### PR TITLE
Вилки смерти и плитки хаоса

### DIFF
--- a/code/game/objects/items/stacks/tiles/plasteel.dm
+++ b/code/game/objects/items/stacks/tiles/plasteel.dm
@@ -6,9 +6,9 @@
 	w_class = 3.0
 	force = 6.0
 	m_amt = 937.5
-	throwforce = 1.0
+	throwforce = 5.0
 	throw_speed = 5
-	throw_range = 20
+	throw_range = 3
 	flags = FPRINT | TABLEPASS | CONDUCT
 	max_amount = 60
 

--- a/code/game/objects/items/stacks/tiles/plasteel.dm
+++ b/code/game/objects/items/stacks/tiles/plasteel.dm
@@ -1,12 +1,12 @@
 /obj/item/stack/tile/plasteel
 	name = "floor tile"
 	singular_name = "floor tile"
-	desc = "Those could work as a pretty decent throwing weapon."
+	desc = "Those could not work as a pretty decent throwing weapon."
 	icon_state = "tile"
 	w_class = 3.0
 	force = 6.0
 	m_amt = 937.5
-	throwforce = 15.0
+	throwforce = 1.0
 	throw_speed = 5
 	throw_range = 20
 	flags = FPRINT | TABLEPASS | CONDUCT

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -17,9 +17,9 @@
  * Utensils
  */
 /obj/item/weapon/kitchen/utensil
-	force = 5.0
+	force = 0
 	w_class = 1.0
-	throwforce = 5.0
+	throwforce = 0
 	throw_speed = 3
 	throw_range = 5
 	flags = FPRINT | TABLEPASS | CONDUCT
@@ -52,8 +52,8 @@
 /obj/item/weapon/kitchen/utensil/fork
 	name = "fork"
 	desc = "Pointy."
+	force = 3
 	icon_state = "fork"
-	sharp = 1
 
 /obj/item/weapon/kitchen/utensil/fork/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	if(!istype(M))
@@ -95,6 +95,7 @@
 	name = "plastic fork"
 	desc = "Yay, no washing up to do."
 	icon_state = "pfork"
+	force = 0
 
 /obj/item/weapon/kitchen/utensil/pfork/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	if(!istype(M))
@@ -128,7 +129,7 @@
 	icon_state = "knife"
 	force = 10.0
 	throwforce = 10.0
-	sharp = 1
+	sharp = 0
 	edge = 1
 
 	suicide_act(mob/user)
@@ -149,8 +150,8 @@
 	name = "plastic knife"
 	desc = "The bluntest of blades."
 	icon_state = "pknife"
-	force = 10.0
-	throwforce = 10.0
+	force = 0
+	throwforce = 0
 
 /obj/item/weapon/kitchen/utensil/knife/attack(target as mob, mob/living/user as mob)
 	if ((CLUMSY in user.mutations) && prob(50))


### PR DESCRIPTION
...или как остановить недоробастеров.

Суть такова - в виду того, что оригинальный разработчик по наивности своей выставил вилкам флаг sharp, и поэтому в каждом втором раунде находится долбоёб, считающий своим святым долго эту вилку в кого-нибудь кинуть. Она из-за этого застревает в теле, но так как её w_class всего лишь 1, то вытащить её без хирургии не представляется возможным. Поэтому это говно было жестоко подправлено вместе с уроном (прощай пластиковый ножик с 10 урона). 

С плитками и всё проще - адовые 15 брута при броске отправляются в пешее эротическое путешествие. 