### PR TITLE
Фикс внутреннего кровотечения в потерянной конечности

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -566,6 +566,10 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(destspawn) return
 	if(override)
 		status |= ORGAN_DESTROYED
+	for(var/datum/wound/W in wounds)
+		if(W.internal)
+			wounds -= W
+			update_damages()
 	if(status & ORGAN_DESTROYED)
 		if(body_part == UPPER_TORSO)
 			return


### PR DESCRIPTION
Должно убирать внутреннее кровотечение в конечности, когда она отрывается