### PR TITLE
Фикс core sampler'a

### DIFF
--- a/code/modules/detectivework/evidence.dm
+++ b/code/modules/detectivework/evidence.dm
@@ -23,6 +23,9 @@
 	if(istype(I, /obj/item/weapon/storage/box/evidence))
 		return
 
+	if(istype(I, /obj/item/device/core_sampler)) //core sampler interacts with evidence bags in another way
+		return
+
 	if(I.w_class > 3)
 		user << "<span class='notice'>[I] won't fit in [src].</span>"
 		return

--- a/code/modules/research/xenoarchaeology/tools/tools_coresampler.dm
+++ b/code/modules/research/xenoarchaeology/tools/tools_coresampler.dm
@@ -38,7 +38,9 @@
 
 /obj/item/device/core_sampler/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W,/obj/item/weapon/evidencebag))
-		if(num_stored_bags < 10)
+		if(W.contents.len)
+			user << "\red This bag has something inside it!"
+		else if(num_stored_bags < 10)
 			qdel(W)
 			num_stored_bags += 1
 			user << "\blue You insert the [W] into the core sampler."


### PR DESCRIPTION
При использовании на нём sample\evidence bag (один и тот же обьект, по сути) одновременно происходило помещение девайса в сумку и удаление самой сумки.
Теперь:
-в сэмплер помещаются только пустые sample bag
-семплер в sample bag поместить нельзя
Да, это костыль, но может пойдёт?