### PR TITLE
Фикс status display

### DIFF
--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -73,6 +73,9 @@
 		set_picture("ai_friend")
 		return
 
+	if(mode == 3 && overlays.len)	//Why we must update diplay if picture is already set?
+		return
+
 	if(overlays.len && !friendc || mode == 4)
 		overlays.Cut()
 
@@ -202,7 +205,8 @@
 		if("supply")
 			if(supply_display)
 				mode = 4
-
+				
+	update()
 
 
 /obj/machinery/ai_status_display

--- a/code/modules/security levels/security levels.dm
+++ b/code/modules/security levels/security levels.dm
@@ -49,10 +49,9 @@
 					world << "<font color='red'>[config.alert_desc_red_downto]</font>"
 				security_level = SEC_LEVEL_RED
 
-				/*	- At the time of commit, setting status displays didn't work properly
 				var/obj/machinery/computer/communications/CC = locate(/obj/machinery/computer/communications,world)
 				if(CC)
-					CC.post_status("alert", "redalert")*/
+					CC.post_status("alert", "redalert")
 
 				for(var/obj/machinery/firealarm/FA in machines)
 					if(FA.z == ZLEVEL_STATION || FA.z == ZLEVEL_ASTEROID)


### PR DESCRIPTION
fixes #381 
Теперь при установке изображения status display не сбрасывается
Бонус: при вводе красного кода все дисплеи отображают, собственно, красный код (было в коде, но было закомментировано в связи с этим багом)