### PR TITLE
Фикс синтетов, исопльзующих закончившиеся ресурсы

### DIFF
--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -7,6 +7,12 @@
 
 /*-------TODOOOOOOOOOO--------*/
 
+/mob/living/silicon/robot/u_equip(obj/W as obj)
+	if(!W)
+		return 0
+	uneq_active()
+	return 1
+
 /mob/living/silicon/robot/proc/uneq_active()
 	if(isnull(module_active))
 		return

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -458,9 +458,14 @@
 		src.emag.name = "Plasma Cutter"
 
 		for(var/T in stacktypes)
-			var/obj/item/stack/sheet/W = new T(src)
-			W.amount = stacktypes[T]
-			src.modules += W
+			if(!iscoil(T))
+				var/obj/item/stack/W = new T(src)
+				W.amount = stacktypes[T]
+				src.modules += W
+			else
+				var/obj/item/weapon/cable_coil/C = new T(src)
+				C.amount = stacktypes[T]
+				src.modules += C
 
 		return
 


### PR DESCRIPTION
Собственно говоря, я не знаю как это пофиксить правильно (поэтому пофиксил как сумел)
Суть проблемы в том, что когда плитка (упоминалась конкретно плитка в ишью) заканчивается, вызывается ей qdel, а юзеру - remove_from_mob
remove_from_mob в свою очередь вызывает у пользователя u_equip (а также делает форс мув, если предмет - айтем (а это таки айтем в данном случае, но не похоже, чтобы это как-то влияло (в данном случае)))
И, что самое главное, у роботов нету своего собственного u_equip. А u_equip мобов им не подходит. Я не был уверен, что u_equip не используеться где-то ещё (он достаточно часто встречается в коде) поэтому u_equip просто вызывает uneq_active у робота.
Так как при израсходовании плитки, она пересатёт отображаться, но продолжает существовать, некоторое время в инвентаре робота продолжает существовать (пока его не заберёт в мир иной сборщик мусора) "пустой" предмет, который занимает место, но который нельзя достать, так как он не имеет иконки. Да, я согласен, что это неправильно, но оставлять его в "руке" мне показалось ещё более неправильным.

fixes #452 
