### PR TITLE
Фикс скамеек на шатле прибытия

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -170,22 +170,28 @@
 	set name = "Rotate Chair"
 	set category = "Object"
 	set src in oview(1)
-
-	if(config.ghost_interaction)
-		src.dir = turn(src.dir, 90)
-		handle_rotation()
-		return
+	
+	if(!istype(src, /obj/structure/stool/bed/chair/schair/wagon))
+		if(config.ghost_interaction)
+			src.dir = turn(src.dir, 90)
+			handle_rotation()
+			return
+		else
+			if(ismouse(usr))
+				return
+			if(!usr || !isturf(usr.loc))
+				return
+			if(usr.incapacitated())
+				return
+			src.dir = turn(src.dir, 90)
+			handle_rotation()
+			return
 	else
-		if(ismouse(usr))
+		if(istype(src, /obj/structure/stool/bed/chair/schair/wagon))
+			usr <<"It's useless"
 			return
-		if(!usr || !isturf(usr.loc))
-			return
-		if(usr.incapacitated())
-			return
-
-		src.dir = turn(src.dir, 90)
-		handle_rotation()
 		return
+	return
 
 /obj/structure/stool/bed/chair/proc/can_flip(mob/living/carbon/human/user)
 	if(!user || !isturf(user.loc) || user.incapacitated() || user.lying || user.a_intent != "hurt"|| !can_flipped)


### PR DESCRIPTION
Из-за того, что спрайт не рассчитан на повороты запад\восток, при повороте они исчезали. Этот фикс просто не позволит игрокам вертеть эти самые скамейки до той поры, пока не придумается более лучшее решение для этого