### PR TITLE
Pretty fast fix of mentors rework and mutes.

### DIFF
--- a/code/modules/admin/DB ban/functions.dm
+++ b/code/modules/admin/DB ban/functions.dm
@@ -449,7 +449,7 @@
 				output += "</tr>"
 				output += "<tr bgcolor='[dcolor]'>"
 				output += "<td align='center' colspan='2' bgcolor=''><b>IP:</b> [ip]</td>"
-				output += "<td align='center' colspan='3' bgcolor=''><b>CIP:</b> [cid]</td>"
+				output += "<td align='center' colspan='3' bgcolor=''><b>CID:</b> [cid]</td>"
 				output += "</tr>"
 				output += "<tr bgcolor='[lcolor]'>"
 				output += "<td align='center' colspan='5'><b>Reason: [(unbanned) ? "" : "(<a href=\"byond://?src=\ref[src];dbbanedit=reason;dbbanid=[banid]\">Edit</a>)"]</b> <cite>\"[reason]\"</cite></td>"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1170,12 +1170,12 @@ var/global/floorIsLava = 0
 		return "<b>(*not an mob*)</b>"
 	switch(detail)
 		if(0)
-			return "<b>[key_name(C, link, name,, reply)]</b>"
+			return "<b>[key_name(C, link, name, 0, reply)]</b>"
 		if(1)
-			return "<b>[key_name(C, link, name,, reply)](<A HREF='?_src_=holder;adminmoreinfo=\ref[M]'>?</A>)</b>"
+			return "<b>[key_name(C, link, name, 1, reply)](<A HREF='?_src_=holder;adminmoreinfo=\ref[M]'>?</A>)</b>"
 		if(2)
 			var/ref_mob = "\ref[M]"
-			return "<b>[key_name(C, link, name,, reply)](<A HREF='?_src_=holder;adminmoreinfo=[ref_mob]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=[ref_mob]'>PP</A>) (<A HREF='?_src_=vars;Vars=[ref_mob]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=[ref_mob]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservejump=[ref_mob]'>JMP</A>) (<A HREF='?_src_=holder;check_antagonist=1'>CA</A>)</b>"
+			return "<b>[key_name(C, link, name, 1, reply)](<A HREF='?_src_=holder;adminmoreinfo=[ref_mob]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=[ref_mob]'>PP</A>) (<A HREF='?_src_=vars;Vars=[ref_mob]'>VV</A>) (<A HREF='?_src_=holder;subtlemessage=[ref_mob]'>SM</A>) (<A HREF='?_src_=holder;adminplayerobservejump=[ref_mob]'>JMP</A>) (<A HREF='?_src_=holder;check_antagonist=1'>CA</A>)</b>"
 
 
 

--- a/code/modules/admin/permissionverbs/permissionedit.dm
+++ b/code/modules/admin/permissionverbs/permissionedit.dm
@@ -194,7 +194,8 @@
 		return
 	if(ment_ckey in admin_datums)
 		remove_admin(ment_ckey)
-	mentor_ckeys |= ment_ckey
+	mentor_ckeys += ment_ckey
+	mentors += directory[ment_ckey]
 	message_admins("[key_name_admin(usr)] added [ment_ckey] to the mentors list")
 	log_admin("[key_name(usr)] added [ment_ckey] to the mentors list")
 
@@ -220,6 +221,7 @@
 		return
 	if(alert("Are you sure you want to remove [ment_ckey] from mentors?","Message","Yes","Cancel") == "Yes")
 		mentor_ckeys -= ment_ckey
+		mentors -= directory[ment_ckey]
 		message_admins("[key_name_admin(usr)] removed [ment_ckey] from the mentors list")
 		log_admin("[key_name(usr)] removed [ment_ckey] from the mentors list")
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1008,20 +1008,26 @@
 				return
 
 	else if(href_list["mute"])
-		if(!check_rights(R_ADMIN))  return
+		if(!check_rights(R_ADMIN))
+			return
 
 		var/mob/M = locate(href_list["mute"])
-		if(!ismob(M))	return
-		if(!M.client)	return
+		if(!ismob(M))
+			return
+		if(!M.client)
+			return
 
 		var/mute_type = href_list["mute_type"]
-		if(istext(mute_type))	mute_type = text2num(mute_type)
-		if(!isnum(mute_type))	return
+		if(istext(mute_type))
+			mute_type = text2num(mute_type)
+		if(!isnum(mute_type))
+			return
 
 		cmd_admin_mute(M, mute_type)
 
 	else if(href_list["c_mode"])
-		if(!check_rights(R_ADMIN))	return
+		if(!check_rights(R_ADMIN))
+			return
 
 		if(ticker && ticker.mode)
 			return alert(usr, "The game has already started.", null, null, null, null)

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -16,6 +16,4 @@
 	if(src.handle_spam_prevention(msg,MUTE_ADMINHELP))
 		return
 
-	adminhelped = 1 //Determines if they get the message to reply by clicking the name.
-
 	staffhelp(msg, help_type = "AH")

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -33,7 +33,7 @@
 	feedback_add_details("admin_verb","APM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_ahelp_reply(whom)
-	if(prefs.muted & MUTE_ADMINHELP)
+	if(prefs.muted & MUTE_ADMINHELP || ((src in mentors) && (prefs.muted & MUTE_MENTORHELP)))
 		src << "<font color='red'>Error: Admin-PM: You are unable to use admin PM-s (muted).</font>"
 		return
 	var/client/C
@@ -59,7 +59,7 @@
 //Fetching a message if needed. src is the sender and C is the target client
 
 /client/proc/cmd_admin_pm(var/client/C, var/msg = null)
-	if(!usr.client.holder && (prefs.muted & MUTE_ADMINHELP))
+	if(prefs.muted & MUTE_ADMINHELP || ((src in mentors) && (prefs.muted & MUTE_MENTORHELP)))
 		src << "<font color='red'>Error: Private-Message: You are unable to use PM-s (muted).</font>"
 		return
 

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -43,15 +43,16 @@
 			src << "<font color='red'>Error: Admin-PM: Client not found.</font>"
 		return
 	if(usr.client in mentors)
-		message_mentors("[key_name_admin(src)] has started replying to [key_name(C, 0, 0)]'s help request.")
+		message_mentors("[key_name(src, 0, 0, 0)] has started replying to [key_name(C, 0, 0, 0)]'s help request.")
 //	if(usr in mentors)
 	message_admins("[key_name_admin(src)] has started replying to [key_name(C, 0, 0)]'s help request.")
 	var/msg = input(src,"Message:", "Private message to [key_name(C, 0, 0)]") as text|null
 	if (!msg)
 		message_admins("[key_name_admin(src)] has cancelled their reply to [key_name(C, 0, 0)]'s help request.")
 		if(usr.client in mentors)
-			message_mentors("[key_name_admin(src)] has cancelled their reply to [key_name(C, 0, 0)]'s help request.")
+			message_mentors("[key_name(src, 0, 0, 0)] has cancelled their reply to [key_name(C, 0, 0, 0)]'s help request.")
 		return
+	msg = sanitize(copytext(msg,1,MAX_MESSAGE_LEN))
 	cmd_admin_pm(whom, msg)
 
 //takes input from cmd_admin_pm_context, cmd_admin_pm_panel or /client/Topic and sends them a PM.
@@ -71,7 +72,7 @@
 
 	//get message text, limit it's length.and clean/escape html
 	if(!msg)
-		msg = input(src,"Message:", "Private message to [key_name(C, 0, holder ? 1 : 0)]") as text|null
+		msg = input(src,"Message:", "Private message to [key_name(C, 0, holder ? 1 : 0, holder ? 1 : 0)]") as text|null
 
 		msg = sanitize(copytext(msg,1,MAX_MESSAGE_LEN))
 
@@ -99,8 +100,8 @@
 
 
 	if(holder)
-		//mod PMs are maroon
-		//PMs sent from admins and mods display their rank
+		//mentor PMs are maroon
+		//PMs sent from admins display their rank
 		if(C.holder && (holder.rights & R_ADMIN))
 			recieve_color = "red"
 		else
@@ -120,7 +121,7 @@
 
 	var/recieve_message = ""
 
-	if(holder && !C.holder)
+	if(((src in mentors) || holder) && !C.holder)
 		recieve_message = "<font color='[recieve_color]' size='3'><b>-- Click the [recieve_pm_type]'s name to reply --</b></font>\n"
 		if(C.adminhelped)
 			C << recieve_message
@@ -162,7 +163,7 @@
 		if(X == C || X == src)
 			continue
 		if(X.key!=key && X.key!=C.key && !C.holder && !src.holder)
-			X << "<B><font color='blue'>PM: [key_name(src, X, 0)]-&gt;[key_name(C, X, 0)]:</B> \blue [msg]</font>" //inform X
+			X << "<B><font color='blue'>PM: [key_name(src, X, 0, 0)]-&gt;[key_name(C, X, 0, 0)]:</B> \blue [msg]</font>" //inform X
 
 /client/proc/cmd_admin_irc_pm()
 	if(prefs.muted & MUTE_ADMINHELP)

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -2,10 +2,15 @@
 	set category = "Special Verbs"
 	set name = "Asay" //Gave this shit a shorter name so you only have to time out "asay" rather than "admin say" to use it --NeoFite
 	set hidden = 1
-	if(!check_rights(R_ADMIN))	return
+	if(!check_rights(R_ADMIN))
+		return
+	if(prefs.muted & MUTE_ADMINHELP)
+		src << "<font color='red'>Error: ASAY: You cannot use asay (Muted).</font>"
+		return
 
 	msg = sanitize(copytext(msg, 1, MAX_MESSAGE_LEN))
-	if(!msg)	return
+	if(!msg)
+		return
 
 	log_admin("[key_name(src)] : [msg]")
 

--- a/code/modules/admin/verbs/staffhelp.dm
+++ b/code/modules/admin/verbs/staffhelp.dm
@@ -35,7 +35,8 @@ client/proc/staffhelp(msg as text, var/help_type = null)
 	var/list/ckeys = list()
 	for(var/mob/M in mob_list)
 		var/list/indexing = list(M.real_name, M.name)
-		if(M.mind)	indexing += M.mind.name
+		if(M.mind)
+			indexing += M.mind.name
 
 		for(var/string in indexing)
 			var/list/L = splittext(string, " ")
@@ -101,7 +102,9 @@ client/proc/staffhelp(msg as text, var/help_type = null)
 			if(isobserver(X.mob))
 				jump = "(<A HREF='?src=\ref[X.mob];ghostplayerobservejump=[ref_mob]'>JMP</A>) "
 			X << 'sound/effects/adminhelp.ogg'
-			X << "<font color=blue><b><font color=[colour]>[prefix]: </font>[key_name(src, 1, 0,, TRUE)][jump]:</b> [original_msg]</font>"
+			X << "<font color=blue><b><font color=[colour]>[prefix]: </font>[key_name(src, 1, 0, 0, TRUE)][jump]:</b> [original_msg]</font>"
+
+	adminhelped = 1 //Determines if they get the message to reply by clicking the name.
 
 	//show it to the person adminhelping too
 	src << "<font color='blue'>PM to-<b>[target_group]</b>: [original_msg]</font>"

--- a/code/modules/mentor/mentor.dm
+++ b/code/modules/mentor/mentor.dm
@@ -29,7 +29,7 @@
 		var/DBQuery/query = dbcon.NewQuery("SELECT ckey FROM erro_mentor")
 		query.Execute()
 		while(query.NextRow())
-			var/ckey = query.item
+			var/ckey = query.item[1]
 			mentor_ckeys += ckey
 			mentors += directory[ckey]
 


### PR DESCRIPTION
Фиксы:
- Добавление и удаление менторов без релоада;
- `reload_mentors` теперь релоадит таки;
- Буква "я" в при ответе на любой из хелпов;
- Должны исчезнуть подсветки ролей менторам;
- Мут админхелпа теперь оставляет без ахелпа, пмок и асэя, как и указанов в файле randomverbs.dm в описании флага.
- Мут менторхелпа теперь оставляет менторов без пмок.