### PR TITLE
Фикс исчезновения исчезающих стёкол на голодеке

### DIFF
--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -144,6 +144,8 @@ turf/simulated/floor/holofloor/update_icon()
 	qdel(src)
 	return
 
+/obj/structure/window/reinforced/holowindow/disappearing
+
 /obj/machinery/door/window/holowindoor/attackby(obj/item/weapon/I as obj, mob/user as mob)
 
 	if (src.operating == 1)
@@ -360,7 +362,7 @@ obj/structure/stool/bed/chair/holochair
 
 	eventstarted = 1
 
-	for(var/obj/structure/window/reinforced/holowindow/W in currentarea)
+	for(var/obj/structure/window/reinforced/holowindow/disappearing/W in currentarea)
 		qdel(W)
 
 	for(var/mob/M in currentarea)


### PR DESCRIPTION
Вероятно, Зве во время оптимизации удалил прок
/obj/structure/window/reinforced/holowindow/disappearing/Destroy()
вместе с аналогичным проком у родителя, что привело к удалению
исчезающих стёкол из билда, что сломало тандер на голодеке.