### PR TITLE
Правка получаемых синд-технологий с хамелеон пистолета и "energy relay"

### DIFF
--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -749,7 +749,7 @@
 	name = "energy relay"
 	desc = "Wirelessly drains energy from any available power channel in area. The performance index is quite low."
 	icon_state = "tesla"
-	origin_tech = "magnets=4;syndicate=2"
+	origin_tech = "magnets=4"
 	equip_cooldown = 10
 	energy_drain = 0
 	range = 0

--- a/code/modules/clothing/under/chameleon.dm
+++ b/code/modules/clothing/under/chameleon.dm
@@ -476,7 +476,7 @@
 	desc = "A fake Desert Eagle with a dial on the side to change the gun's disguise."
 	icon_state = "deagle"
 	w_class = 3.0
-	origin_tech = "combat=2;materials=2;syndicate=8"
+	origin_tech = "combat=2;materials=2;syndicate=3"
 	mag_type = /obj/item/ammo_box/magazine/chameleon
 	var/list/gun_choices = list()
 


### PR DESCRIPTION
Нерф неадекватного апа синди технологий хамелеон пистолетом и убрал с энерджи рилея, т.к для его изучения не нужен нелегал, а вот почему он его поднимает - вопрос.