### PR TITLE
Правки телесаенса и сломавшихся реагентов.

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -1,5 +1,5 @@
 //wrapper
-/proc/do_teleport(ateleatom, adestination, aprecision=0, afteleport=1, aeffectin=null, aeffectout=null, asoundin=null, asoundout=null, adest_checkdensity=null)
+/proc/do_teleport(ateleatom, adestination, aprecision=0, afteleport=1, aeffectin=null, aeffectout=null, asoundin=null, asoundout=null, adest_checkdensity=null, arespect_entrydir=null)
 	var/datum/teleport/instant/science/D = new
 	if(D.start(arglist(args)))
 		return 1
@@ -16,15 +16,15 @@
 	var/force_teleport = 1 //if false, teleport will use Move() proc (dense objects will prevent teleportation)
 	var/dest_checkdensity = TELE_CHECK_NONE //if we can't teleport onto dense atoms (more advanced method of the above).
 	                                        //NONE means - yes, we can! TURFS - yes, if no dense turfs. ALL - no, we can't at all.
-	                                        //Also, cannot teleport onto slim windows.
+	var/respect_entrydir = FALSE            //respects atom entry dir (if we enter from north, then we can exit only from south).
 
 
-/datum/teleport/proc/start(ateleatom, adestination, aprecision=0, afteleport=1, aeffectin=null, aeffectout=null, asoundin=null, asoundout=null, adest_checkdensity=null)
+/datum/teleport/proc/start(ateleatom, adestination, aprecision=0, afteleport=1, aeffectin=null, aeffectout=null, asoundin=null, asoundout=null, adest_checkdensity=null, arespect_entrydir=null)
 	if(!initTeleport(arglist(args)))
 		return 0
 	return 1
 
-/datum/teleport/proc/initTeleport(ateleatom,adestination,aprecision,afteleport,aeffectin,aeffectout,asoundin,asoundout,adest_checkdensity)
+/datum/teleport/proc/initTeleport(ateleatom,adestination,aprecision,afteleport,aeffectin,aeffectout,asoundin,asoundout,adest_checkdensity,arespect_entrydir)
 	if(!setTeleatom(ateleatom))
 		return 0
 	if(!setDestination(adestination))
@@ -33,6 +33,8 @@
 		return 0
 	if(adest_checkdensity)
 		dest_checkdensity = adest_checkdensity
+	if(arespect_entrydir)
+		respect_entrydir = arespect_entrydir
 	setEffects(aeffectin,aeffectout)
 	setForceTeleport(afteleport)
 	setSounds(asoundin,asoundout)
@@ -106,22 +108,16 @@
 		var/turf/center = get_turf(destination)
 		if(!center)
 			return 0
-		for(var/turf/T in RANGE_TURFS(precision,center))
-			if(T == center)
-				continue
-			if(get_dir(T, center) in list(NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST)) //No diagonal teleports!
-				continue
-			if(istype(T, /turf/space) && (T.x <= TRANSITIONEDGE || T.x >= (world.maxx - TRANSITIONEDGE - 1) || T.y <= TRANSITIONEDGE || T.y >= (world.maxy - TRANSITIONEDGE - 1)))
-				continue //No teleports into the void, dunno how to fix that with another method.
-			if(dest_checkdensity)
-				if(T.density)
-					continue
-				if(dest_checkdensity == TELE_CHECK_ALL)
-					for(var/get in T.contents)
-						var/atom/A = get
-						if(A.density)
-							continue
+		if(respect_entrydir)
+			var/turf/T = get_step(destination, teleatom.dir)
+			if(!density_checks(T))
+				return 0
 			posturfs += T
+		else
+			for(var/turf/T in RANGE_TURFS(precision,center))
+				if(!density_checks(T))
+					continue
+				posturfs += T
 		destturf = safepick(posturfs - center)
 	else
 		destturf = get_turf(destination)
@@ -151,6 +147,22 @@
 	if(teleportChecks())
 		return doTeleport()
 	return 0
+
+/datum/teleport/proc/density_checks(turf/T)
+	var/turf/center = get_turf(destination)
+	if(T == center)
+		return FALSE
+	if(get_dir(T, center) in list(NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST)) //No diagonal teleports!
+		return FALSE
+	if(istype(T, /turf/space) && (T.x <= TRANSITIONEDGE || T.x >= (world.maxx - TRANSITIONEDGE - 1) || T.y <= TRANSITIONEDGE || T.y >= (world.maxy - TRANSITIONEDGE - 1)))
+		return FALSE //No teleports into the void, dunno how to fix that with another method.
+	if(dest_checkdensity)
+		if(T.density)
+			return FALSE
+		if(dest_checkdensity == TELE_CHECK_ALL)
+			if(!T.Enter(teleatom))
+				return FALSE
+	return TRUE
 
 /datum/teleport/instant //teleports when datum is created
 

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -28,7 +28,7 @@
 		return
 	return
 
-/obj/effect/portal/proc/teleport(atom/movable/M, density_check = TELE_CHECK_NONE)
+/obj/effect/portal/proc/teleport(atom/movable/M, density_check = TELE_CHECK_NONE, respect_entrydir = FALSE)
 	if (istype(M, /obj/effect)) //sparks don't teleport
 		return FALSE
 	if (M.anchored && istype(M, /obj/mecha))
@@ -41,9 +41,9 @@
 	if (istype(M, /atom/movable))
 		if(prob(failchance)) //oh dear a problem, put em in deep space
 			src.icon_state = "portal1"
-			return do_teleport(M, locate(rand(5, world.maxx - 5), rand(5, world.maxy -5), 3), 0, adest_checkdensity = density_check)
+			return do_teleport(M, locate(rand(5, world.maxx - 5), rand(5, world.maxy -5), 3), 0, adest_checkdensity = density_check, arespect_entrydir = respect_entrydir)
 		else
-			return do_teleport(M, target, 1, adest_checkdensity = density_check) ///You will appear adjacent to the beacon
+			return do_teleport(M, target, 1, adest_checkdensity = density_check, arespect_entrydir = respect_entrydir) ///You will appear adjacent to the beacon
 
 //Telescience wormhole
 /obj/effect/portal/tsci_wormhole
@@ -72,20 +72,25 @@
 
 /obj/effect/portal/tsci_wormhole/Bumped(mob/M)
 	set waitfor = 0
-	if(teleport(M, TELE_CHECK_ALL))
+	if(teleport(M, TELE_CHECK_ALL, TRUE))
 		handle_special_effects(M)
 
 /obj/effect/portal/tsci_wormhole/Crossed(AM)
 	set waitfor = 0
-	if(teleport(AM, TELE_CHECK_ALL))
+	if(teleport(AM, TELE_CHECK_ALL, TRUE))
 		handle_special_effects(AM)
 
 /obj/effect/portal/tsci_wormhole/proc/handle_special_effects(AM)
 	if(ishuman(AM))
 		var/mob/living/carbon/human/H = AM
+		var/bad_effects = 0
 		if(prob(20))
+			bad_effects += 1
 			H.confused += 3
 			var/msg = pick("You feel dizzy.", "Your head starts spinning.")
 			H << "<span class='warning'>[msg]</span>"
 		if(prob(20))
+			bad_effects += 1
 			H.vomit() //No msg required, since vomit() will handle this.
+		if(bad_effects == 2)
+			H.Paralyse(3)

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -28,7 +28,7 @@
 		return
 	return
 
-/obj/effect/portal/proc/teleport(atom/movable/M, density_check = TELE_CHECK_NONE, respect_entrydir = FALSE)
+/obj/effect/portal/proc/teleport(atom/movable/M, density_check = TELE_CHECK_NONE, respect_entrydir = FALSE, use_forceMove = TRUE)
 	if (istype(M, /obj/effect)) //sparks don't teleport
 		return FALSE
 	if (M.anchored && istype(M, /obj/mecha))
@@ -41,9 +41,9 @@
 	if (istype(M, /atom/movable))
 		if(prob(failchance)) //oh dear a problem, put em in deep space
 			src.icon_state = "portal1"
-			return do_teleport(M, locate(rand(5, world.maxx - 5), rand(5, world.maxy -5), 3), 0, adest_checkdensity = density_check, arespect_entrydir = respect_entrydir)
+			return do_teleport(M, locate(rand(5, world.maxx - 5), rand(5, world.maxy -5), 3), 0, use_forceMove, adest_checkdensity = density_check, arespect_entrydir = respect_entrydir)
 		else
-			return do_teleport(M, target, 1, adest_checkdensity = density_check, arespect_entrydir = respect_entrydir) ///You will appear adjacent to the beacon
+			return do_teleport(M, target, 1, use_forceMove, adest_checkdensity = density_check, arespect_entrydir = respect_entrydir)
 
 //Telescience wormhole
 /obj/effect/portal/tsci_wormhole
@@ -72,12 +72,12 @@
 
 /obj/effect/portal/tsci_wormhole/Bumped(mob/M)
 	set waitfor = 0
-	if(teleport(M, TELE_CHECK_ALL, TRUE))
+	if(teleport(M, TELE_CHECK_ALL, TRUE, FALSE))
 		handle_special_effects(M)
 
 /obj/effect/portal/tsci_wormhole/Crossed(AM)
 	set waitfor = 0
-	if(teleport(AM, TELE_CHECK_ALL, TRUE))
+	if(teleport(AM, TELE_CHECK_ALL, TRUE, FALSE))
 		handle_special_effects(AM)
 
 /obj/effect/portal/tsci_wormhole/proc/handle_special_effects(AM)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -65,7 +65,7 @@
 			if(A.density)
 				can_switch = FALSE
 				break
-		if(can_switch)
+		if(can_switch && get_dist(M, src) <= 1)
 			now_pushing = 1
 			//TODO: Make this use Move(). we're pretty much recreating it here.
 			//it could be done by setting one of the locs to null to make Move() work, then setting it back and Move() the other mob

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1531,6 +1531,7 @@ datum
 					return
 				if(toxpwr)
 					M.adjustToxLoss(toxpwr * REM)
+				return TRUE //toxin has many subclasses, so we need return TRUE for them.
 
 		toxin/amatoxin
 			name = "Amatoxin"
@@ -2471,6 +2472,7 @@ datum
 				if(adj_temp)
 					if(M.bodytemperature < 310)//310 is the normal bodytemp. 310.055
 						M.bodytemperature = min(310, M.bodytemperature + (25 * TEMPERATURE_DAMAGE_COEFFICIENT))
+				return TRUE
 
 		drink/orangejuice
 			name = "Orange juice"
@@ -2644,6 +2646,7 @@ datum
 				M.make_jittery(5)
 				if(adj_temp > 0 && holder.has_reagent("frostoil"))
 					holder.remove_reagent("frostoil", 10 * REAGENTS_METABOLISM)
+				return TRUE
 
 		drink/coffee/icecoffee
 			name = "Iced Coffee"
@@ -3073,6 +3076,7 @@ datum
 						if(istype(L))
 							L.take_damage(0.1, 1)
 						H.adjustToxLoss(0.1)
+				return TRUE
 
 			reaction_obj(var/obj/O, var/volume)
 				if(istype(O,/obj/item/weapon/paper))


### PR DESCRIPTION
### Телесаенс
* Исправил баг с телепортом на турфы с плотными объектами, например, можно было залететь на турф с консолью или застрять в окнах с решетками.
* При входе в червоточину учитывается направление атома. Если атом попадает в портал с севера, значит при выходе он вылетит с юга, при условии что турф свободен для прохождения.
* Поправил логику перемещений. Стало возможным выйти на тот турф, где у нас тонкая дверь или стекло или наоборот нельзя, если они повернуты к нам так, что оказываются между порталом и турфом конечным.
* Добавил потерю сознания, если сработало головокружение и тошнота одновременно.
* Можно толкать атомы на противоположной стороне. Сразу не даст войти в портал, сначала произойдет отталкивание кого/чего либо, а потом надо будет еще раз попробовать войти в портал и если конечный турф стал свободным, то переместимся.

### Реагенты
* Тут все просто, если реагент подкласс другого реагента у которого тоже есть прок исполняющий что-то при жизни моба - им обязательно нужно возвращать значение, иначе подкласс думает что родитель всегда говорит нет.
  * Фикс парапена тоже тут.