### PR TITLE
Различные фиксы

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -19,7 +19,7 @@
 
 	if(ismob(A))
 		ai_actual_track(A)
-	else
+	else if (!istype(A, /obj/screen))
 		A.move_camera_by_click()
 
 

--- a/code/game/gamemodes/events/power_failure.dm
+++ b/code/game/gamemodes/events/power_failure.dm
@@ -6,15 +6,13 @@ var/power_fail_event = 0
 
 	if(announce)
 		command_alert("Abnormal activity detected in [station_name()]'s powernet. As a precautionary measure, the station's power will be shut off for an indeterminate duration.", "Critical Power Failure")
-		for(var/mob/M in player_list)
-			M << sound('sound/AI/poweroff.ogg')
-			if(prob(25))
-				sleep(600)
-				M << sound('tauceti/sounds/ambience/hullcreak.ogg')
+		player_list << sound('sound/AI/poweroff.ogg')
+		if(prob(25))
+			addtimer(GLOBAL_PROC, "play_ambience", 600)
 
 	var/list/skipped_areas = list(/area/turret_protected/ai, /area/tcommsat/chamber, /area/tcommsat/chamber)
 
-	for(var/obj/machinery/power/smes/S in world)
+	for(var/obj/machinery/power/smes/S in machines)
 		var/area/current_area = get_area(S)
 		if(current_area.type in skipped_areas ||S.z != ZLEVEL_STATION)
 			continue
@@ -29,9 +27,12 @@ var/power_fail_event = 0
 		S.update_icon()
 		S.power_change()
 
-	for(var/obj/machinery/power/apc/C in world)
+	for(var/obj/machinery/power/apc/C in machines)
 		if(C.cell && C.z == ZLEVEL_STATION)
 			C.cell.charge = 0
+
+/proc/play_ambience()
+	player_list << sound('tauceti/sounds/ambience/hullcreak.ogg')
 
 /proc/power_restore(var/announce = 1, var/badminery = 0)
 	power_fail_event = 0
@@ -39,15 +40,14 @@ var/power_fail_event = 0
 
 	if(announce)
 		command_alert("Power has been restored to [station_name()]. We apologize for the inconvenience.", "Power Systems Nominal")
-		for(var/mob/M in player_list)
-			M << sound('sound/AI/poweron.ogg')
+		player_list << sound('sound/AI/poweron.ogg')
 	if(badminery)
-		for(var/obj/machinery/power/apc/C in world)
+		for(var/obj/machinery/power/apc/C in machines)
 			if(C.cell && C.z == ZLEVEL_STATION)
 				C.cell.charge = C.cell.maxcharge
-	for(var/obj/machinery/power/smes/S in world)
+	for(var/obj/machinery/power/smes/S in machines)
 		var/area/current_area = get_area(S)
-		if(current_area.type in skipped_areas ||S.z != ZLEVEL_STATION)
+		if(current_area.type in skipped_areas || S.z != ZLEVEL_STATION)
 			continue
 		S.RefreshParts()
 		if(badminery)
@@ -61,9 +61,8 @@ var/power_fail_event = 0
 /proc/power_restore_quick(var/announce = 1)
 	if(announce)
 		command_alert("All SMESs on [station_name()] have been recharged. We apologize for the inconvenience.", "Power Systems Nominal")
-		for(var/mob/M in player_list)
-			M << sound('sound/AI/poweron.ogg')
-	for(var/obj/machinery/power/smes/S in world)
+		player_list << sound('sound/AI/poweron.ogg')
+	for(var/obj/machinery/power/smes/S in machines)
 		if(S.z != ZLEVEL_STATION)
 			continue
 		S.RefreshParts()

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -129,6 +129,9 @@
 		return -1 //Transciever Disabled.
 	return ..(freq, level, 1)
 
+/obj/item/device/radio/headset/heads/ai_integrated/emp_act()
+	return
+
 /obj/item/device/radio/headset/heads/rd
 	name = "Research Director's headset"
 	desc = "Headset of the researching God. To access the science channel, use :n. For command, use :c."

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -196,7 +196,7 @@
 		usr.drop_item()
 		if(W)
 			W.forceMove(src.loc)
-	else if(istype(W, /obj/item/weapon/packageWrap))
+	else if(istype(W, /obj/item/weapon/packageWrap) || istype(W, /obj/item/weapon/extraction_pack))
 		return
 	else if(istype(W, /obj/item/weapon/weldingtool))
 		var/obj/item/weapon/weldingtool/WT = W

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -74,7 +74,7 @@
 		user.drop_item()
 		if(W)
 			W.forceMove(src.loc)
-	else if(istype(W, /obj/item/weapon/packageWrap))
+	else if(istype(W, /obj/item/weapon/packageWrap) || istype(W, /obj/item/weapon/extraction_pack))	//OOP? Doesn't heard.
 		return
 	else if(istype(W, /obj/item/weapon/cable_coil))
 		if(rigged)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2298,7 +2298,7 @@
 				feedback_add_details("admin_secrets_fun_used","PB")
 				message_admins("[key_name_admin(usr)] has allowed a prison break", 1)
 				prison_break()
-			if("lightout")
+			if("lighstout")
 				feedback_inc("admin_secrets_fun_used",1)
 				feedback_add_details("admin_secrets_fun_used","LO")
 				message_admins("[key_name_admin(usr)] has broke a lot of lights", 1)

--- a/code/modules/client/character menu/occupation.dm
+++ b/code/modules/client/character menu/occupation.dm
@@ -1,5 +1,5 @@
 /datum/preferences/proc/ShowOccupation(mob/user)
-	var/limit = 18	//The amount of jobs allowed per column. Defaults to 18 to make it look nice.
+	var/limit = 19	//The amount of jobs allowed per column. Defaults to 19 to make it look nice.
 	var/list/splitJobs = list("Chief Medical Officer")	//Allows you split the table by job. You can make different tables for each department by including their heads.
 														//Defaults to CMO to make it look nice.
 	if(!SSjob)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -165,15 +165,11 @@ var/list/slot_equipment_priority = list( \
 		return 0
 
 // Removes an item from inventory and places it in the target atom
-/mob/proc/drop_from_inventory(var/obj/item/W, var/atom/Target = null)
+/mob/proc/drop_from_inventory(var/obj/item/W, var/atom/target = null)
 	if(W)
-		if(!Target)
-			Target = loc
-
-		remove_from_mob(W)
-		if(!W) return 1 // self destroying objects (tk, grabs)
-
-		W.forceMove(Target)
+		remove_from_mob(W, target)
+		if(!(W && W.loc))
+			return 1 // self destroying objects (tk, grabs)
 		update_icons()
 		return 1
 	return 0
@@ -229,7 +225,7 @@ var/list/slot_equipment_priority = list( \
 	return 1
 
 //Attemps to remove an object on a mob.  Will not move it to another area or such, just removes from the mob.
-/mob/proc/remove_from_mob(var/obj/O)
+/mob/proc/remove_from_mob(obj/O, atom/target)
 	if(!O) return
 	src.u_equip(O)
 	if (src.client)
@@ -239,7 +235,10 @@ var/list/slot_equipment_priority = list( \
 	O.screen_loc = null
 	if(istype(O, /obj/item))
 		var/obj/item/I = O
-		I.forceMove(src.loc)
+		if(target)
+			I.forceMove(target)
+		else
+			I.forceMove(loc)
 		I.dropped(src)
 	return 1
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -154,8 +154,8 @@
 /mob/living/carbon/proc/swap_hand()
 	var/obj/item/item_in_hand = src.get_active_hand()
 	if(item_in_hand) //this segment checks if the item in your hand is twohanded.
-		if(istype(item_in_hand,/obj/item/weapon/twohanded))
-			if(item_in_hand:wielded == 1)
+		if(istype(item_in_hand, /obj/item/weapon/twohanded) || istype(item_in_hand, /obj/item/weapon/gun/projectile/automatic/l6_saw))	//OOP? Generics? Hue hue hue hue ...
+			if(item_in_hand:wielded)
 				usr << "<span class='warning'>Your other hand is too busy holding the [item_in_hand.name]</span>"
 				return
 	src.hand = !( src.hand )


### PR DESCRIPTION
С чего-то надо начинать...

- Fixes #471

- Fixes #554 

- Fixes #501 

- Fixes #512 

- Fixes #270 (наверное)
<details> 
  <summary>Почему наверное?</summary>
Потому что нажатие кнопки 'Make all areas unpowered' концептуально не должно возвращать энергию через некоторое время. А 'lights out event' я как раз таки починил.
</details>

- Fixes #177, closes #273

- Fixes #556 

А также небольшая оптимизация кода события 'power_failure'. Заключается она в двух вещах:

1. Конкретное действие (здесь это проигрывание музыки) можно вызвать напрямую на весь список, без необходимости делать циклы.

2. Использование объекта world в циклах типа for...in приводит к тому, что поиск нужных объектов идёт среди ВСЕГО содержимого игрового мира (а это, я вам скажу, очень много всякой всячины). Не нужно так делать, если есть уже готовый список с машинерией.

Кроме того поправил "особый" эмбиенс, которые по идее должен был выпадать с шансом 25%. На практике в цикле для каждого игрока производилась проверка на выпадение шанса и если тот прокал, то на минуту стек вызовов стопился командой sleep(). Если, допустим, шанс прокал у суммарно 10 человек, то само отключение энергии происходило через 10 минут после объявления. Наверное поэтому можно сказать, что это фикс. (шутка ли, но ведь это я написал ¯\_(ツ)_/¯)