### PR TITLE
Фикс проковербов, в которых нужен текст

### DIFF
--- a/code/game/gamemodes/events/holidays/Holidays.dm
+++ b/code/game/gamemodes/events/holidays/Holidays.dm
@@ -115,7 +115,7 @@ var/global/Holiday = null
 				Holiday = "Friday the 13th"
 
 //Allows GA and GM to set the Holiday variable
-/client/proc/Set_Holiday(T)
+/client/proc/Set_Holiday(T as text)
 	set name = ".Set Holiday"
 	set category = "Fun"
 	set desc = "Force-set the Holiday variable to make the game think it's a certain day."

--- a/code/game/json.dm
+++ b/code/game/json.dm
@@ -91,7 +91,7 @@ proc/GetMapInfo()
 //	Just removing these to try and fix the occasional JSON -> WORLD issue.
 //	world << M.name
 //	world << M.mapname
-client/proc/ChangeMap(X)
+client/proc/ChangeMap(X as text)
 	set name = "Change Map"
 	set category  = "Admin"
 	switchmap(X,X)

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -48,7 +48,7 @@
 
 	return
 
-/mob/living/silicon/ai/proc/ai_store_location(loc)
+/mob/living/silicon/ai/proc/ai_store_location(loc as text)
 	set category = "AI Commands"
 	set name = "Store Camera Location"
 	set desc = "Stores your current camera location by the given name."

--- a/code/modules/admin/verbs/adminsay.dm
+++ b/code/modules/admin/verbs/adminsay.dm
@@ -1,4 +1,4 @@
-/client/proc/cmd_admin_say(msg)
+/client/proc/cmd_admin_say(msg as text)
 	set category = "Special Verbs"
 	set name = "Asay" //Gave this shit a shorter name so you only have to time out "asay" rather than "admin say" to use it --NeoFite
 	set hidden = 1


### PR DESCRIPTION
В паре мест потерялись после #686
А вообще процедуры должны быть процедурами, вербы вербами, но видимо от наследия старой ССки мы никогда не избавимся.