### PR TITLE
Доступная гетто хирургия

### DIFF
--- a/code/modules/surgery/appendix.dm
+++ b/code/modules/surgery/appendix.dm
@@ -54,7 +54,7 @@
 	allowed_tools = list(
 	/obj/item/weapon/hemostat = 100,	\
 	/obj/item/weapon/wirecutters = 75,	\
-	/obj/item/weapon/kitchen/utensil/fork = 20
+	/obj/item/weapon/kitchen/utensil/fork = 50
 	)
 
 	min_duration = 60

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -6,7 +6,7 @@
 /datum/surgery_step/glue_bone
 	allowed_tools = list(
 	/obj/item/weapon/bonegel = 100,	\
-	/obj/item/weapon/screwdriver = 75
+	/obj/item/stack/rods = 50
 	)
 	can_infect = 1
 	blood_level = 1
@@ -118,7 +118,7 @@
 /datum/surgery_step/finish_bone
 	allowed_tools = list(
 	/obj/item/weapon/bonegel = 100,	\
-	/obj/item/weapon/screwdriver = 75
+	/obj/item/stack/rods = 50
 	)
 	can_infect = 1
 	blood_level = 1

--- a/code/modules/surgery/braincore.dm
+++ b/code/modules/surgery/braincore.dm
@@ -13,7 +13,8 @@
 /datum/surgery_step/brain/saw_skull
 	allowed_tools = list(
 	/obj/item/weapon/circular_saw = 100, \
-	/obj/item/weapon/hatchet = 75
+	/obj/item/weapon/hatchet = 75,       \
+	/obj/item/weapon/crowbar = 50
 	)
 
 	min_duration = 50
@@ -70,7 +71,8 @@
 /datum/surgery_step/brain/saw_spine
 	allowed_tools = list(
 	/obj/item/weapon/circular_saw = 100, \
-	/obj/item/weapon/hatchet = 75
+	/obj/item/weapon/hatchet = 75,       \
+	/obj/item/weapon/crowbar = 50
 	)
 
 	min_duration = 50
@@ -133,7 +135,7 @@
 	allowed_tools = list(
 	/obj/item/weapon/hemostat = 100, 		\
 	/obj/item/weapon/wirecutters = 75, 		\
-	/obj/item/weapon/kitchen/utensil/fork = 20
+	/obj/item/weapon/kitchen/utensil/fork = 50
 	)
 
 	min_duration = 80
@@ -255,7 +257,8 @@
 /datum/surgery_step/slime/saw_core
 	allowed_tools = list(
 	/obj/item/weapon/circular_saw = 100, \
-	/obj/item/weapon/hatchet = 75
+	/obj/item/weapon/hatchet = 75,       \
+	/obj/item/weapon/crowbar = 50
 	)
 
 	min_duration = 50

--- a/code/modules/surgery/eye.dm
+++ b/code/modules/surgery/eye.dm
@@ -52,7 +52,7 @@
 	allowed_tools = list(
 	/obj/item/weapon/retractor = 100,	        \
 	/obj/item/weapon/kitchen/utensil/fork = 75,	\
-	/obj/item/weapon/crowbar = 50
+	/obj/item/weapon/screwdriver = 50
 	)
 
 	min_duration = 30

--- a/code/modules/surgery/eye.dm
+++ b/code/modules/surgery/eye.dm
@@ -50,8 +50,9 @@
 
 /datum/surgery_step/eye/lift_eyes
 	allowed_tools = list(
-	/obj/item/weapon/retractor = 100,	\
-	/obj/item/weapon/kitchen/utensil/fork = 50
+	/obj/item/weapon/retractor = 100,	        \
+	/obj/item/weapon/kitchen/utensil/fork = 75,	\
+	/obj/item/weapon/crowbar = 50
 	)
 
 	min_duration = 30
@@ -81,8 +82,10 @@
 
 /datum/surgery_step/eye/mend_eyes
 	allowed_tools = list(
-	/obj/item/weapon/hemostat = 100, 	\
-	/obj/item/weapon/cable_coil = 75, 	\
+	/obj/item/weapon/hemostat = 100,             \
+	/obj/item/weapon/cable_coil = 75,            \
+	/obj/item/weapon/wirecutters = 75,           \
+	/obj/item/weapon/kitchen/utensil/fork = 50,  \
 	/obj/item/device/assembly/mousetrap = 10	//I don't know. Don't ask me. But I'm leaving it because hilarity.
 	)
 
@@ -116,7 +119,7 @@
 	/obj/item/weapon/cautery = 100,			\
 	/obj/item/clothing/mask/cigarette = 75,	\
 	/obj/item/weapon/lighter = 50,			\
-	/obj/item/weapon/weldingtool = 25
+	/obj/item/weapon/weldingtool = 50
 	)
 
 	min_duration = 70

--- a/code/modules/surgery/face.dm
+++ b/code/modules/surgery/face.dm
@@ -48,8 +48,10 @@
 
 /datum/surgery_step/face/mend_vocal
 	allowed_tools = list(
-	/obj/item/weapon/hemostat = 100, 	\
-	/obj/item/weapon/cable_coil = 75, 	\
+	/obj/item/weapon/hemostat = 100,             \
+	/obj/item/weapon/cable_coil = 75,            \
+	/obj/item/weapon/wirecutters = 75,           \
+	/obj/item/weapon/kitchen/utensil/fork = 50,  \
 	/obj/item/device/assembly/mousetrap = 10	//I don't know. Don't ask me. But I'm leaving it because hilarity.
 	)
 
@@ -78,8 +80,8 @@
 /datum/surgery_step/face/fix_face
 	allowed_tools = list(
 	/obj/item/weapon/retractor = 100, 	\
-	/obj/item/weapon/crowbar = 55,	\
-	/obj/item/weapon/kitchen/utensil/fork = 75)
+	/obj/item/weapon/kitchen/utensil/fork = 75,	\
+	/obj/item/weapon/crowbar = 50)
 
 	min_duration = 80
 	max_duration = 100
@@ -109,7 +111,7 @@
 	/obj/item/weapon/cautery = 100,			\
 	/obj/item/clothing/mask/cigarette = 75,	\
 	/obj/item/weapon/lighter = 50,			\
-	/obj/item/weapon/weldingtool = 25
+	/obj/item/weapon/weldingtool = 50
 	)
 
 	min_duration = 70

--- a/code/modules/surgery/face.dm
+++ b/code/modules/surgery/face.dm
@@ -81,7 +81,8 @@
 	allowed_tools = list(
 	/obj/item/weapon/retractor = 100, 	\
 	/obj/item/weapon/kitchen/utensil/fork = 75,	\
-	/obj/item/weapon/crowbar = 50)
+	/obj/item/weapon/screwdriver = 50
+	)
 
 	min_duration = 80
 	max_duration = 100

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -182,9 +182,9 @@
 
 /datum/surgery_step/generic/retract_skin
 	allowed_tools = list(
-	/obj/item/weapon/retractor = 100, 	\
-	/obj/item/weapon/crowbar = 75,	\
-	/obj/item/weapon/kitchen/utensil/fork = 50
+	/obj/item/weapon/retractor = 100,           \
+	/obj/item/weapon/kitchen/utensil/fork = 75,	\
+	/obj/item/weapon/screwdriver = 50
 	)
 
 	min_duration = 30

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -145,8 +145,10 @@
 
 /datum/surgery_step/generic/clamp_bleeders
 	allowed_tools = list(
-	/obj/item/weapon/hemostat = 100,	\
-	/obj/item/weapon/cable_coil = 75, 	\
+	/obj/item/weapon/hemostat = 100,             \
+	/obj/item/weapon/cable_coil = 75,            \
+	/obj/item/weapon/wirecutters = 75,           \
+	/obj/item/weapon/kitchen/utensil/fork = 50,  \
 	/obj/item/device/assembly/mousetrap = 20
 	)
 
@@ -238,7 +240,7 @@
 	/obj/item/weapon/cautery = 100,			\
 	/obj/item/clothing/mask/cigarette = 75,	\
 	/obj/item/weapon/lighter = 50,			\
-	/obj/item/weapon/weldingtool = 25
+	/obj/item/weapon/weldingtool = 50
 	)
 
 	min_duration = 70
@@ -273,7 +275,8 @@
 /datum/surgery_step/generic/cut_limb
 	allowed_tools = list(
 	/obj/item/weapon/circular_saw = 100, \
-	/obj/item/weapon/hatchet = 75
+	/obj/item/weapon/hatchet = 75,       \
+	/obj/item/weapon/crowbar = 50
 	)
 
 	min_duration = 110

--- a/code/modules/surgery/headreattach.dm
+++ b/code/modules/surgery/headreattach.dm
@@ -58,8 +58,8 @@
 /datum/surgery_step/head/shape
 	allowed_tools = list(
 	/obj/item/weapon/FixOVein = 100, 	\
-	/obj/item/weapon/cable_coil = 75,	\
-	/obj/item/device/assembly/mousetrap = 10) //ok chinsky
+	/obj/item/weapon/cable_coil = 75
+	)
 
 	min_duration = 80
 	max_duration = 100
@@ -92,7 +92,9 @@
 /datum/surgery_step/head/suture
 	allowed_tools = list(
 	/obj/item/weapon/hemostat = 100, 	\
-	/obj/item/weapon/cable_coil = 60,	\
+	/obj/item/weapon/cable_coil = 75,	\
+	/obj/item/weapon/wirecutters = 75,           \
+	/obj/item/weapon/kitchen/utensil/fork = 50,  \
 	/obj/item/weapon/FixOVein = 80)
 
 	min_duration = 80
@@ -127,7 +129,7 @@
 	/obj/item/weapon/cautery = 100,			\
 	/obj/item/clothing/mask/cigarette = 75,	\
 	/obj/item/weapon/lighter = 50,			\
-	/obj/item/weapon/weldingtool = 25
+	/obj/item/weapon/weldingtool = 50
 	)
 
 	min_duration = 60

--- a/code/modules/surgery/headreattach.dm
+++ b/code/modules/surgery/headreattach.dm
@@ -22,9 +22,9 @@
 
 /datum/surgery_step/head/peel
 	allowed_tools = list(
-	/obj/item/weapon/retractor = 100,		\
-	/obj/item/weapon/crowbar = 75,	\
-	/obj/item/weapon/kitchen/utensil/fork = 50, 		\
+	/obj/item/weapon/retractor = 100,           \
+	/obj/item/weapon/kitchen/utensil/fork = 75, \
+	/obj/item/weapon/screwdriver = 50
 	)
 
 	min_duration = 80

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -74,7 +74,7 @@
 	/obj/item/weapon/cautery = 100,			\
 	/obj/item/clothing/mask/cigarette = 75,	\
 	/obj/item/weapon/lighter = 50,			\
-	/obj/item/weapon/weldingtool = 25
+	/obj/item/weapon/weldingtool = 50
 	)
 
 	min_duration = 60
@@ -161,7 +161,7 @@
 	allowed_tools = list(
 	/obj/item/weapon/hemostat = 100,	\
 	/obj/item/weapon/wirecutters = 75,	\
-	/obj/item/weapon/kitchen/utensil/fork = 20
+	/obj/item/weapon/kitchen/utensil/fork = 50
 	)
 
 	min_duration = 80

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -37,8 +37,7 @@
 /datum/surgery_step/cavity/make_space
 	allowed_tools = list(
 	/obj/item/weapon/surgicaldrill = 100,	\
-	/obj/item/weapon/pen = 75,	\
-	/obj/item/stack/rods = 50
+	/obj/item/weapon/pen = 75
 	)
 
 	min_duration = 60

--- a/code/modules/surgery/lipoplasty.dm
+++ b/code/modules/surgery/lipoplasty.dm
@@ -52,9 +52,9 @@
 
 /datum/surgery_step/lipoplasty/remove_fat
 	allowed_tools = list(
-	/obj/item/weapon/retractor = 100, 	\
-	/obj/item/weapon/crowbar = 75,	\
-	/obj/item/weapon/kitchen/utensil/fork = 50
+	/obj/item/weapon/retractor = 100,           \
+	/obj/item/weapon/kitchen/utensil/fork = 75,	\
+	/obj/item/weapon/screwdriver = 50
 	)
 
 	min_duration = 50

--- a/code/modules/surgery/lipoplasty.dm
+++ b/code/modules/surgery/lipoplasty.dm
@@ -15,7 +15,8 @@
 /datum/surgery_step/lipoplasty/cut_fat
 	allowed_tools = list(
 	/obj/item/weapon/circular_saw = 100, \
-	/obj/item/weapon/hatchet = 75
+	/obj/item/weapon/hatchet = 75,       \
+	/obj/item/weapon/crowbar = 50
 	)
 
 	min_duration = 110
@@ -53,7 +54,7 @@
 	allowed_tools = list(
 	/obj/item/weapon/retractor = 100, 	\
 	/obj/item/weapon/crowbar = 75,	\
-	/obj/item/weapon/kitchen/utensil/fork = 20
+	/obj/item/weapon/kitchen/utensil/fork = 50
 	)
 
 	min_duration = 50

--- a/code/modules/surgery/plastic_surgery.dm
+++ b/code/modules/surgery/plastic_surgery.dm
@@ -20,9 +20,9 @@
 
 /datum/surgery_step/plastic_surgery/retract_face
 	allowed_tools = list(
-	/obj/item/weapon/retractor = 100, 	\
-	/obj/item/weapon/crowbar = 55,	\
-	/obj/item/weapon/kitchen/utensil/fork = 75
+	/obj/item/weapon/retractor = 100,           \
+	/obj/item/weapon/kitchen/utensil/fork = 75, \
+	/obj/item/weapon/crowbar = 50
 	)
 
 	min_duration = 80
@@ -51,6 +51,8 @@
 	allowed_tools = list(
 	/obj/item/weapon/hemostat = 100, 	\
 	/obj/item/weapon/cable_coil = 75, 	\
+	/obj/item/weapon/wirecutters = 75,           \
+	/obj/item/weapon/kitchen/utensil/fork = 50,  \
 	/obj/item/device/assembly/mousetrap = 10
 	)
 
@@ -133,7 +135,7 @@
 	/obj/item/weapon/cautery = 100,			\
 	/obj/item/clothing/mask/cigarette = 75,	\
 	/obj/item/weapon/lighter = 50,			\
-	/obj/item/weapon/weldingtool = 25
+	/obj/item/weapon/weldingtool = 50
 	)
 
 	min_duration = 70

--- a/code/modules/surgery/plastic_surgery.dm
+++ b/code/modules/surgery/plastic_surgery.dm
@@ -22,7 +22,7 @@
 	allowed_tools = list(
 	/obj/item/weapon/retractor = 100,           \
 	/obj/item/weapon/kitchen/utensil/fork = 75, \
-	/obj/item/weapon/crowbar = 50
+	/obj/item/weapon/screwdriver = 50
 	)
 
 	min_duration = 80

--- a/code/modules/surgery/ribcage.dm
+++ b/code/modules/surgery/ribcage.dm
@@ -13,7 +13,8 @@
 /datum/surgery_step/ribcage/saw_ribcage
 	allowed_tools = list(
 	/obj/item/weapon/circular_saw = 100, \
-	/obj/item/weapon/hatchet = 75
+	/obj/item/weapon/hatchet = 75,       \
+	/obj/item/weapon/crowbar = 50
 	)
 
 	min_duration = 50
@@ -48,7 +49,7 @@
 	allowed_tools = list(
 	/obj/item/weapon/retractor = 100, 	\
 	/obj/item/weapon/crowbar = 75,	\
-	/obj/item/weapon/kitchen/utensil/fork = 20
+	/obj/item/weapon/kitchen/utensil/fork = 50
 	)
 
 	min_duration = 30
@@ -88,7 +89,7 @@
 	allowed_tools = list(
 	/obj/item/weapon/retractor = 100, 	\
 	/obj/item/weapon/crowbar = 75,	\
-	/obj/item/weapon/kitchen/utensil/fork = 20
+	/obj/item/weapon/kitchen/utensil/fork = 50
 	)
 
 
@@ -160,7 +161,7 @@
 	allowed_tools = list(
 	/obj/item/weapon/hemostat = 100,	\
 	/obj/item/weapon/wirecutters = 75,	\
-	/obj/item/weapon/kitchen/utensil/fork = 20
+	/obj/item/weapon/kitchen/utensil/fork = 50
 	)
 	blood_level = 2
 

--- a/code/modules/surgery/ribcage.dm
+++ b/code/modules/surgery/ribcage.dm
@@ -47,9 +47,9 @@
 
 /datum/surgery_step/ribcage/retract_ribcage
 	allowed_tools = list(
-	/obj/item/weapon/retractor = 100, 	\
-	/obj/item/weapon/crowbar = 75,	\
-	/obj/item/weapon/kitchen/utensil/fork = 50
+	/obj/item/weapon/retractor = 100,           \
+	/obj/item/weapon/kitchen/utensil/fork = 75,	\
+	/obj/item/weapon/screwdriver = 50
 	)
 
 	min_duration = 30
@@ -87,9 +87,9 @@
 
 /datum/surgery_step/ribcage/close_ribcage
 	allowed_tools = list(
-	/obj/item/weapon/retractor = 100, 	\
-	/obj/item/weapon/crowbar = 75,	\
-	/obj/item/weapon/kitchen/utensil/fork = 50
+	/obj/item/weapon/retractor = 100,           \
+	/obj/item/weapon/kitchen/utensil/fork = 75,	\
+	/obj/item/weapon/screwdriver = 50
 	)
 
 
@@ -129,7 +129,7 @@
 /datum/surgery_step/ribcage/mend_ribcage
 	allowed_tools = list(
 	/obj/item/weapon/bonegel = 100,	\
-	/obj/item/weapon/screwdriver = 75
+	/obj/item/stack/rods = 50
 	)
 
 	min_duration = 20

--- a/code/modules/surgery/robolimbs.dm
+++ b/code/modules/surgery/robolimbs.dm
@@ -59,9 +59,10 @@
 
 /datum/surgery_step/limb/mend
 	allowed_tools = list(
-	/obj/item/weapon/retractor = 100, 	\
-	/obj/item/weapon/crowbar = 75,	\
-	/obj/item/weapon/kitchen/utensil/fork = 50)
+	/obj/item/weapon/retractor = 100,           \
+	/obj/item/weapon/kitchen/utensil/fork = 75,	\
+	/obj/item/weapon/screwdriver = 50
+	)
 
 	min_duration = 80
 	max_duration = 100

--- a/code/modules/surgery/robolimbs.dm
+++ b/code/modules/surgery/robolimbs.dm
@@ -97,7 +97,7 @@
 	/obj/item/weapon/cautery = 100,			\
 	/obj/item/clothing/mask/cigarette = 75,	\
 	/obj/item/weapon/lighter = 50,			\
-	/obj/item/weapon/weldingtool = 25
+	/obj/item/weapon/weldingtool = 50
 	)
 
 	min_duration = 60


### PR DESCRIPTION
Привел в порядок гетто хирургию.

Сподвигло на это то, что для многих операций (лечение внутренних органов, шитья легких, удаление шрапнели и т.д.) нужна циркулярка. Единственным же гетто аналогом был топорик, который доступен лишь ботанику(лежит в запертом ящике).
Основная же идея гетто хирургии, чтобы операцию можно было провести подручными средствами, хоть и с высоким шансом нанести увечья при проведении.

До и после (% - успешность действия инструментом):
![getto](https://cloud.githubusercontent.com/assets/15943769/19760822/d4e3a6d4-9c4c-11e6-889e-ab4c0106a61a.png)




