### PR TITLE
Доступ в техтуннели для парамедиков и СМО

### DIFF
--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -11,10 +11,10 @@
 	req_admin_notify = 1
 	access = list(access_medical, access_morgue, access_genetics, access_heads,
 			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,
-			access_keycard_auth, access_sec_doors, access_psychiatrist)
+			access_keycard_auth, access_sec_doors, access_psychiatrist, access_maint_tunnels)
 	minimal_access = list(access_medical, access_morgue, access_genetics, access_heads,
 			access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,
-			access_keycard_auth, access_sec_doors, access_psychiatrist)
+			access_keycard_auth, access_sec_doors, access_psychiatrist, access_maint_tunnels)
 	minimal_player_age = 10
 	minimal_player_ingame_minutes = 2400
 
@@ -78,13 +78,21 @@
 			if("Emergency Physician")
 				H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/medical(H), slot_w_uniform)
 				H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/fr_jacket(H), slot_wear_suit)
+
+				access += access_maint_tunnels
+				minimal_access += access_maint_tunnels
+				access -= access_surgery
+				minimal_access -= access_surgery
+
 			if("Surgeon")
 				H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/medical/blue(H), slot_w_uniform)
 				H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/labcoat(H), slot_wear_suit)
 				H.equip_to_slot_or_del(new /obj/item/clothing/head/surgery/blue(H), slot_head)
+
 			if("Medical Doctor")
 				H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/medical(H), slot_w_uniform)
 				H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/labcoat(H), slot_wear_suit)
+
 			if("Nurse")
 				if(H.gender == FEMALE)
 					if(prob(50))
@@ -94,6 +102,7 @@
 					H.equip_to_slot_or_del(new /obj/item/clothing/head/nursehat(H), slot_head)
 				else
 					H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/medical/purple(H), slot_w_uniform)
+
 	else
 		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/medical(H), slot_w_uniform)
 		H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/labcoat(H), slot_wear_suit)


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/15943769/20027614/422838ba-a33a-11e6-992b-9f79bf25b8fc.png)

Рассмотрев ваши предложения и заручившись поддержкой директора, предлагаю остановиться на том варианте, что парамедику нужно выдать доступ в теха, так как это соответствует его специализации, как выездного врача и забрать доступ в хирургию. Таким образом у него где-то убыло, где-то прибыло. Если его не в чём не урезать, то все предпочтут парамедика простому доктору, ибо халявный доступ.

Пару дней подержу метку "Не мержить", возможно у вас найдется идея лучше.