### PR TITLE
Максимальное время действия гостевого пропуска 30 минут

### DIFF
--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -127,9 +127,9 @@
 				if(reas)
 					reason = reas
 			if ("duration")
-				var/dur = input("Duration (in minutes) during which pass is valid (up to 10 minutes).", "Duration") as num|null
+				var/dur = input("Duration (in minutes) during which pass is valid (up to 30 minutes).", "Duration") as num|null
 				if (dur)
-					if (dur > 0 && dur <= 10)
+					if (dur > 0 && dur <= 30)
 						duration = dur
 					else
 						usr << "<span class='warning'>Invalid duration.</span>"


### PR DESCRIPTION
**Гостевой пропуск? А что это такое?** 
А это такие невзрачные терминальчики в каждом отделе, позволяющие шарить доступ тем у кого его нет.
![image](https://cloud.githubusercontent.com/assets/15943769/20028062/13f773b6-a349-11e6-8f46-d5be6ade928d.png)
**Кому это нужно?** 
В основном кадетам и ассистентам которые хотят помочь, а хопа нет. А также например можно выдать доступ в генетику врачу, в криминалистскую детективу и прочее.
Раньше пропуск работал до 10 минут, теперь до 30.

