### PR TITLE
Фикс боксерских перчаток

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -55,7 +55,7 @@
 					visible_message("\red <B>[src] has been touched with the stun gloves by [M]!</B>")
 				return
 
-		if(istype(M.gloves , /obj/item/clothing/gloves/boxing/hologlove))
+		if(istype(M.gloves , /obj/item/clothing/gloves/boxing))
 
 			var/damage = rand(0, 9)
 			if(!damage)


### PR DESCRIPTION
В общем новая качалочка привнесла и плохие элементы тоже, так что делаем ее менее кровавой. Теперь можно робастить друг друга сколько угодно, не обмазывая станцию говном и кровью, не проламывая друг другу головы, и не прибавляя итак уже занятым врачам еще больше работы.