### PR TITLE
Изменения в модулях для боргов + Возможность открывать и закрывать шкафчики.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -235,7 +235,7 @@
 	return
 
 /obj/structure/closet/attack_ai(mob/user)
-	if(istype(user, /mob/living/silicon/robot) && Adjacent(user)) //Robots can open/close it, but not the AI
+	if(isrobot(user) && Adjacent(user)) //Robots can open/close it, but not the AI
 		attack_hand(user)
 
 /obj/structure/closet/relaymove(mob/user)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -234,6 +234,10 @@
 	src.add_fingerprint(user)
 	return
 
+/obj/structure/closet/attack_ai(mob/user)
+	if(istype(user, /mob/living/silicon/robot) && Adjacent(user)) //Robots can open/close it, but not the AI
+		attack_hand(user)
+
 /obj/structure/closet/relaymove(mob/user)
 	if(user.stat || !isturf(src.loc))
 		return

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -179,7 +179,7 @@ var/list/robot_verbs_default = list(
 /mob/living/silicon/robot/proc/pick_module()
 	if(module)
 		return
-	var/list/modules = list("Standard", "Engineering", "Construction", "Surgeon", "Crisis", "Miner", "Janitor", "Service", "Clerical", "Security", "Science")
+	var/list/modules = list("Standard", "Engineering", "Surgeon", "Crisis", "Miner", "Janitor", "Service", "Security", "Science")
 	if(crisis && security_level == SEC_LEVEL_RED) //Leaving this in until it's balanced appropriately.
 		src << "\red Crisis mode active. Combat module available."
 		modules+="Combat"
@@ -211,16 +211,6 @@ var/list/robot_verbs_default = list(
 			module_sprites["Drone"] = "drone-service" // How does this even work...? Oh well.
 			module_sprites["Acheron"] = "mechoid-Service"
 			module_sprites["Kodiak"] = "kodiak-service"
-
-		if("Clerical")
-			module = new /obj/item/weapon/robot_module/clerical(src)
-			module_sprites["Waitress"] = "Service"
-			module_sprites["Kent"] = "toiletbot"
-			module_sprites["Bro"] = "Brobot"
-			module_sprites["Rich"] = "maximillion"
-			module_sprites["Default"] = "Service2"
-			module_sprites["Drone"] = "drone-service"
-			module_sprites["Acheron"] = "mechoid-Service"
 
 		if("Science")
 			module = new /obj/item/weapon/robot_module/science(src)
@@ -292,19 +282,6 @@ var/list/robot_verbs_default = list(
 			module_sprites["Drone"] = "drone-engineer"
 			module_sprites["Acheron"] = "mechoid-Engineering"
 			module_sprites["Kodiak"] = "kodiak-eng"
-
-		if("Construction")
-			module = new /obj/item/weapon/robot_module/construction(src)
-			module.channels = list("Engineering" = 1)
-			if(camera && "Robots" in camera.network)
-				camera.add_network("Engineering")
-			module_sprites["Basic"] = "Engineering"
-			module_sprites["Antique"] = "engineerrobot"
-			module_sprites["Custom"] = "custom_astra_t3"
-			module_sprites["Landmate"] = "landmate"
-			module_sprites["Landmate - Treaded"] = "engiborg+tread"
-			module_sprites["Drone"] = "drone-engineer"
-			module_sprites["Acheron"] = "mechoid-Engineering"
 
 		if("Janitor")
 			module = new /obj/item/weapon/robot_module/janitor(src)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -185,6 +185,7 @@
 		src.modules += new /obj/item/weapon/crowbar(src)
 		src.modules += new /obj/item/weapon/wirecutters(src)
 		src.modules += new /obj/item/device/multitool(src)
+		src.modules += new /obj/item/weapon/rcd/borg(src)
 		src.modules += new /obj/item/device/t_scanner(src)
 		src.modules += new /obj/item/device/analyzer(src)
 		src.modules += new /obj/item/taperoll/engineering(src)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -164,25 +164,6 @@
 
 	..()
 
-/obj/item/weapon/robot_module/construction
-	name = "construction robot module"
-
-	stacktypes = list(
-		/obj/item/stack/sheet/metal = 50,
-		/obj/item/stack/sheet/plasteel = 10,
-		/obj/item/stack/sheet/rglass = 50
-		)
-
-	New()
-		src.modules += new /obj/item/device/flash(src)
-		src.modules += new /obj/item/borg/sight/meson(src)
-		src.modules += new /obj/item/weapon/extinguisher(src)
-		src.modules += new /obj/item/weapon/rcd/borg(src)
-		src.modules += new /obj/item/weapon/screwdriver(src)
-		src.modules += new /obj/item/weapon/wrench(src)
-		src.modules += new /obj/item/weapon/crowbar(src)
-		src.modules += new /obj/item/weapon/pickaxe/plasmacutter(src)
-
 /obj/item/weapon/robot_module/engineering
 	name = "engineering robot module"
 
@@ -210,6 +191,7 @@
 		src.modules += new /obj/item/weapon/gripper(src)
 		src.modules += new /obj/item/weapon/matter_decompiler(src)
 
+
 		src.emag = new /obj/item/borg/stun(src)
 
 		var/obj/item/stack/sheet/metal/cyborg/M = new /obj/item/stack/sheet/metal/cyborg(src)
@@ -223,6 +205,14 @@
 		var/obj/item/weapon/cable_coil/W = new /obj/item/weapon/cable_coil(src)
 		W.amount = 50
 		src.modules += W
+
+		var/obj/item/stack/rods/Q = new /obj/item/stack/rods(src)
+		Q.amount = 15
+		src.modules += Q
+
+		var/obj/item/stack/tile/plasteel/F = new /obj/item/stack/tile/plasteel(src)
+		F.amount = 15
+		src.modules += F
 
 		return
 
@@ -284,7 +274,6 @@
 
 	New()
 		src.modules += new /obj/item/device/flash(src)
-		src.modules += new /obj/item/weapon/razor(src)
 		src.modules += new /obj/item/weapon/reagent_containers/food/drinks/cans/beer(src)
 		src.modules += new /obj/item/weapon/reagent_containers/food/condiment/enzyme(src)
 
@@ -300,6 +289,9 @@
 
 		src.modules += new /obj/item/weapon/tray/robotray(src)
 		src.modules += new /obj/item/weapon/reagent_containers/food/drinks/shaker(src)
+		src.modules += new /obj/item/weapon/pen/robopen(src)
+		src.modules += new /obj/item/weapon/razor(src)
+
 		src.emag = new /obj/item/weapon/reagent_containers/food/drinks/cans/beer(src)
 
 		var/datum/reagents/R = new/datum/reagents(50)
@@ -311,27 +303,6 @@
 
 	add_languages(mob/living/silicon/robot/R)
 		//full set of languages
-		R.add_language("Sol Common", 1)
-		R.add_language("Sinta'unathi", 1)
-		R.add_language("Siik'maas", 1)
-		R.add_language("Siik'tajr", 0)
-		R.add_language("Skrellian", 1)
-		R.add_language("Rootspeak", 1)
-		R.add_language("Tradeband", 1)
-		R.add_language("Gutter", 1)
-
-/obj/item/weapon/robot_module/clerical
-	name = "clerical robot module"
-
-	New()
-		src.modules += new /obj/item/device/flash(src)
-		src.modules += new /obj/item/weapon/pen/robopen(src)
-		src.modules += new /obj/item/weapon/form_printer(src)
-		src.modules += new /obj/item/weapon/gripper/paperwork(src)
-
-		src.emag = new /obj/item/weapon/stamp/denied(src)
-
-	add_languages(mob/living/silicon/robot/R)
 		R.add_language("Sol Common", 1)
 		R.add_language("Sinta'unathi", 1)
 		R.add_language("Siik'maas", 1)
@@ -362,7 +333,7 @@
 		src.modules += new /obj/item/weapon/storage/bag/sheetsnatcher/borg(src)
 		src.modules += new /obj/item/device/geoscanner(src)
 		src.modules += new /obj/item/weapon/shovel(src)//Need to buff borgdrill, so it can get sand instead shovel
-		src.emag = new /obj/item/weapon/pickaxe/plasmacutter(src)
+		src.emag = new /obj/item/borg/stun(src)
 		return
 
 /obj/item/weapon/robot_module/syndicate


### PR DESCRIPTION
Конечно же я это ~~накодил~~ портировал с Paradise Station/Baystation12
Просто добавил возможность боргам открывать/закрывать шкафчики. 
![Preview](https://puu.sh/smIyA/e39e78de5f.gif)
До этого борги могли только открывать шкафы, хоть и не совсем корректным способом.

 
Убрал 2 **бесполезных** модуля.
**Clerical** - Вы просто посмотрите на его список вещей, это же просто смешно. 
**Construction** - Единственный **+** данного модуля в том, что у него есть: Plasma Cutter(зачем?) и RCD. RCD можно будет добавить инженерному боргу после нерфоцирка, если вообще нужно добавлять. На данный момент с RCD можно выпилить среднего размера кабинет и потерять максимум ~60% заряда на стандартной батарейке.

Добавил ручку для Service-борга.
Пофиксил отсутствие металлических прутов и плитки у Инженерного борга при выборе модуля. Раньше данные предметы появлялись только после небольшой подзарядки.
Заменил Plasma Cutter у емагнутого шахтерского модуля на наэлектризованную руку. 

И да, у нас даже [WIKI](http://tauceti.ru/wiki/Cyborg) под все эти изменения уже была отредактирована.

