### PR TITLE
Корректировка энергетического оружия.

### DIFF
--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -76,6 +76,7 @@
 	projectile_type = /obj/item/projectile/beam/stun
 	select_name = "stun"
 	fire_sound = 'sound/weapons/taser.ogg'
+	e_cost = 50
 
 /obj/item/ammo_casing/energy/electrode/gun
 	fire_sound = 'sound/weapons/gunshot.ogg'

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -9,6 +9,13 @@
 	origin_tech = "combat=3;magnets=2"
 	ammo_type = list(/obj/item/ammo_casing/energy/laser)
 
+/obj/item/weapon/gun/energy/laser/New()
+	..()
+	if(power_supply)
+		power_supply.maxcharge = 1500
+		power_supply.charge = 1500
+
+
 /obj/item/weapon/gun/energy/laser/isHandgun()
 	return 0
 


### PR DESCRIPTION
Считаю не справедливым, что при стрельбе в различных режимах,
энергетическое оружие расходует одинаковое количество энергии.  Теперь
два выстрела тазерным лучом потребляют как один выстрел в летальном
режиме.