### PR TITLE
Фикс неправильных условий в коде дефибрилятора

### DIFF
--- a/code/game/objects/items/weapons/defibrillator.dm
+++ b/code/game/objects/items/weapons/defibrillator.dm
@@ -118,5 +118,6 @@
 		returnable.tod = null
 		returnable.timeofdeath = 0
 		dead_mob_list -= returnable
+		update_health_hud()
 
 		return

--- a/code/game/objects/items/weapons/defibrillator.dm
+++ b/code/game/objects/items/weapons/defibrillator.dm
@@ -118,6 +118,6 @@
 		returnable.tod = null
 		returnable.timeofdeath = 0
 		dead_mob_list -= returnable
-		update_health_hud()
+		returnable.update_health_hud()
 
 		return

--- a/code/game/objects/items/weapons/defibrillator.dm
+++ b/code/game/objects/items/weapons/defibrillator.dm
@@ -66,15 +66,13 @@
 					if(C.health<=config.health_threshold_crit || prob(10))
 						var/suff = min(C.getOxyLoss(), 20)
 						C.adjustOxyLoss(-suff)
-						C.updatehealth()
-						if(C.stat == DEAD && C.health > config.health_threshold_dead)
-							C.stat = UNCONSCIOUS
 					else
 						C.adjustFireLoss(5)
-						if(C.stat == DEAD && C.health > config.health_threshold_dead)
-							C.stat = CONSCIOUS
-					return_to_body_dialog(C)
-					reanimate_body(C)
+					C.updatehealth()
+					if(C.stat == DEAD && C.health > config.health_threshold_dead)
+						C.stat = UNCONSCIOUS
+						return_to_body_dialog(C)
+						reanimate_body(C)
 
 				if(wet)
 					var/turf/T = get_turf(src)

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -59,9 +59,7 @@
 	jitteriness = 0
 	dog_owner = null
 
-	hud_updateflag |= 1 << HEALTH_HUD
-	hud_updateflag |= 1 << STATUS_HUD
-
+	update_health_hud()
 	handle_hud_list()
 
 	//Handle species-specific deaths.

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -440,8 +440,7 @@
 		if (C.legcuffed && !initial(C.legcuffed))
 			C.drop_from_inventory(C.legcuffed)
 		C.legcuffed = initial(C.legcuffed)
-	hud_updateflag |= 1 << HEALTH_HUD
-	hud_updateflag |= 1 << STATUS_HUD
+	update_health_hud()
 
 /mob/living/proc/rejuvenate()
 
@@ -497,10 +496,12 @@
 
 	// make the icons look correct
 	regenerate_icons()
+	update_health_hud()
+	return
 
+/mob/living/proc/update_health_hud()
 	hud_updateflag |= 1 << HEALTH_HUD
 	hud_updateflag |= 1 << STATUS_HUD
-	return
 
 /mob/living/proc/UpdateDamageIcon()
 	return


### PR DESCRIPTION
В общем, дефибы почему-то пытаются воскресить игрока даже если у него недостаточно здоровья. И ещё не тот флаг устанавливают в одном случае