### PR TITLE
В одном месте убран qdel() на типе client

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -237,8 +237,8 @@ var/world_topic_spam_protect_time = world.timeofday
 				if(C.is_afk(INACTIVITY_KICK))
 					if(!istype(C.mob, /mob/dead))
 						log_access("AFK: [key_name(C)]")
-						to_chat(C, "\red You have been inactive for more than 10 minutes and have been disconnected.")
-						qdel(C)
+						to_chat(C, "<span class='userdanger'>You have been inactive for more than 10 minutes and have been disconnected.</span>")
+						del(C)
 #undef INACTIVITY_KICK
 
 /world/proc/load_stealth_keys()


### PR DESCRIPTION
Тип `client` не является подтипом `datum`, следовательно `qdel()` на нём использовать бессмысленно.