### PR TITLE
Изменён autoclose(), изменено поведение при зажатии дверью, удалён obj/effect/stop

### DIFF
--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -301,12 +301,5 @@ var/global/ManifestJSON
 		user.drop_item()
 		src.throw_at(target, throw_range, throw_speed, user)
 
-/obj/effect/stop
-	var/victim = null
-	icon_state = "empty"
-	name = "Geas"
-	desc = "You can't resist."
-	// name = ""
-
 /obj/effect/spawner
 	name = "object spawner"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1508,13 +1508,6 @@
 		log_admin("[key_name(M)] has been hit by Bluespace Artillery fired by [src.owner]")
 		message_admins("[key_name(M)] has been hit by Bluespace Artillery fired by [src.owner]")
 
-		var/obj/effect/stop/S
-		S = new /obj/effect/stop
-		S.victim = M
-		S.loc = M.loc
-		spawn(20)
-			qdel(S)
-
 		var/turf/simulated/floor/T = get_turf(M)
 		if(istype(T))
 			if(prob(80))	T.break_tile_to_plating()

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -131,12 +131,7 @@
 
 	if(world.time < move_delay)	return
 
-	if(locate(/obj/effect/stop/, mob.loc))
-		for(var/obj/effect/stop/S in mob.loc)
-			if(S.victim == mob)
-				return
-
-	if(mob.stat==2)	return
+	if(mob.stat==DEAD)	return
 
 /*	// handle possible spirit movement
 	if(istype(mob,/mob/spirit))


### PR DESCRIPTION
- Удалён тип `obj/effect/stop`. Практические неиспользуемое "наследие".
- Изменён импакт от зажатия дверью.
  - Добавлено сообщение о том, что тебя зажало
  - Убран спавн крови (пусть льётся сама, если потребуется).
  - Убран обязательный крик (сэйм стори).
  - Убран спавн `obj/effect/stop` (нулевое влияние).
- Изменён прок `autoclose()`. Пофикшено такое явление, как стак таймеров, когда могла быть следующая ситуация: открываешь дверь, сразу её закрываешь и снова открываешь -> дверь в результате закроется слишком быстро, так как после первого откртия на неё уже повесился таймер закрытия (раньше, если что, такое тоже было, только со `spawn()` командой, а следовательно исправить, как сделано здесь, было невозможно).
- `addtimer(src, "close", 60)` для автоматического закрытия двери, если в ней кто-то стоит заменён на `autoclose()`. По мне так это странно, когда дверь закрывается сама с выключенной функцией автозакрытия.