### PR TITLE
Фикс самозакрывающихся емагнутых дверей

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -371,14 +371,14 @@
  */
 
 /obj/machinery/door/proc/open_checks(forced)
-	if(operating != 1 && ticker)
+	if(!operating && ticker)
 		if(!forced)
 			return normal_open_checks()
 		return TRUE
 	return FALSE
 
 /obj/machinery/door/proc/close_checks(forced)
-	if(operating != 1 && ticker)
+	if(!operating && ticker)
 		if(!forced)
 			return normal_close_checks()
 		return TRUE
@@ -459,7 +459,7 @@
 /obj/machinery/door/proc/set_operating(operating)
 	if(operating && !src.operating)
 		src.operating = TRUE
-	else if(!operating && src.operating)
+	else if(!operating && src.operating == 1)
 		src.operating = FALSE
 
 

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -276,7 +276,6 @@
 
 	//Emags and ninja swords? You may pass.
 	if (density && ((istype(I, /obj/item/weapon/card/emag) && hasPower()) || istype(I, /obj/item/weapon/melee/energy/blade)))
-		operating = -1
 		flick("[src.base_state]spark", src)
 		sleep(6)
 		if(istype(I, /obj/item/weapon/melee/energy/blade))
@@ -287,15 +286,14 @@
 			playsound(src.loc, 'sound/weapons/blade1.ogg', 50, 1)
 			visible_message("<span class='warning'> The glass door was sliced open by [user]!</span>")
 			open(1)
-			emagged = 1
-			return 1
+			return
 		open()
-		emagged = 1
-		return 1
+		operating = -1
+		return
 
 	if(!(flags & NODECONSTRUCT))
 		if(istype(I, /obj/item/weapon/screwdriver))
-			if(src.density || src.operating)
+			if(src.density || src.operating == 1)
 				to_chat(user, "<span class='warning'>You need to open the [src.name] to access the maintenance panel.</span>")
 				return
 			playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)


### PR DESCRIPTION
В проверках стояло `operating != 1` из-за этой строчки
https://github.com/TauCetiStation/TauCetiClassic/pull/883/files#diff-55aabf5f63c61eba0d33470dc986158cL44
Но по сути даже там можно было обойтись и `!operating`, переставив
https://github.com/TauCetiStation/TauCetiClassic/compare/master...SpaiR:fix?expand=1#diff-4a5442bbdc61a7575f4e4e1a909ac94eL279
на
https://github.com/TauCetiStation/TauCetiClassic/compare/master...SpaiR:fix?expand=1#diff-4a5442bbdc61a7575f4e4e1a909ac94eR291
что я и сделал.

ps Каким надо быть поехавшим, чтобы хранить состояние емагнутости в переменной, отвечающей за состояние процесса открытия/закрытия, когда у всей машинерии есть переменная `emagged`... 