### PR TITLE
GrafonIsBack

### DIFF
--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -202,7 +202,7 @@
 	sleep(10)
 	enter_allowed = 0
 	if(ticker)
-		//ticker.station_explosion_cinematic(0,null)
+		ticker.station_explosion_cinematic(0,null)
 		if(malf_turf)
 			sleep(20)
 			explosion(malf_turf, 15, 70, 200)

--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -502,7 +502,7 @@ obj/machinery/nuclearbomb/proc/nukehack_win(mob/user)
 			if(syndie_location)
 				ticker.mode:syndies_didnt_escape = (syndie_location.z > ZLEVEL_STATION ? 0 : 1)	//muskets will make me change this, but it will do for now
 			ticker.mode:nuke_off_station = off_station
-		//ticker.station_explosion_cinematic(off_station,null)
+			ticker.station_explosion_cinematic(off_station,null)
 		if(ticker.mode)
 			ticker.mode.explosion_in_progress = 0
 			if(ticker.mode.name == "nuclear emergency")


### PR DESCRIPTION
Возвращаем графон после взрыва нюкабомбы при режиме нюки и самоликвидации ИИ при малфе.
Графона не будет, если взрываем бомбу не при режиме нюки. 
(Когда последний раз взрывали бомбу не во время нюки? Год назад?)
Еще меня терзают сомнения, что графон почему-то убрали специально. Или просто забыли.
Вроде бы научился в ПР.