### PR TITLE
Подсветка для строительства/крафта.

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -45,6 +45,20 @@
 		return
 
 	var/list/modifiers = params2list(params)
+
+	if(client.cob.in_building_mode)
+		var/client/C = client
+		if(C.cob.busy)
+			//do nothing
+		else if(modifiers["left"])
+			if(modifiers["alt"])
+				C.cob.rotate_object()
+			else
+				C.cob.try_to_build(src)
+		else if(modifiers["right"])
+			C.cob.remove_build_overlay(client)
+		return
+
 	if(modifiers["shift"] && modifiers["ctrl"])
 		CtrlShiftClickOn(A)
 		return

--- a/code/datums/cob_highlight.dm
+++ b/code/datums/cob_highlight.dm
@@ -1,0 +1,159 @@
+#define COB_HINT "Rotate (ALT + LMB)\nCancel (RMB)\nAmount [using_this.amount]"
+
+/client/var/datum/craft_or_build/cob
+
+/datum/craft_or_build
+	var
+		in_building_mode = FALSE
+		datum/stack_recipe/from_recipe = null
+		atom/build_this = null
+		obj/item/stack/using_this = null
+		turf/over_this = null
+		busy = FALSE
+		build_direction = NORTH
+		image/b_overlay = null
+		obj/effect/holo_build = null
+
+/datum/craft_or_build/proc/turn_on_build_overlay(client/C, datum/stack_recipe/recipe, using)
+	if(!C.cob.in_building_mode)
+		from_recipe = recipe
+		build_this = recipe.result_type
+		using_this = using
+		add_build_overlay(C)
+
+/datum/craft_or_build/proc/add_build_overlay(client/C)
+	C.show_popup_menus = FALSE
+	b_overlay = image(initial(build_this.icon), initial(build_this.icon_state))
+	b_overlay.alpha = 185
+	b_overlay.dir = build_direction
+	b_overlay.maptext = COB_HINT
+	b_overlay.maptext_width = 128
+	b_overlay.maptext_height = 32
+	b_overlay.maptext_y = -32
+	b_overlay.maptext_x = -16
+	C.images += b_overlay
+	C.cob.in_building_mode = TRUE
+
+/datum/craft_or_build/proc/remove_build_overlay(client/C)
+	C.cob.in_building_mode = FALSE
+	C.show_popup_menus = TRUE
+	C.images -= b_overlay
+	qdel(b_overlay)
+	if(holo_build)
+		qdel(holo_build)
+		holo_build = null
+	b_overlay = null
+	from_recipe = null
+	build_this = null
+	using_this = null
+	over_this = null
+
+/datum/craft_or_build/proc/rotate_object()
+	switch(build_direction)
+		if(NORTH)
+			build_direction = WEST
+		if(WEST)
+			build_direction = SOUTH
+		if(SOUTH)
+			build_direction = EAST
+		if(EAST)
+			build_direction = NORTH
+	b_overlay.dir = build_direction
+
+/datum/craft_or_build/proc/can_build(mob/M, turf/here, turf/origin)
+	. = TRUE
+	if(busy || !using_this || !from_recipe)
+		return FALSE //return, no need to play red animation.
+	else if(using_this.amount < from_recipe.req_amount)
+		. = FALSE
+		to_chat(M, "<span class='notice'>You haven't got enough [using_this.name] to build \the [from_recipe.title]!</span>")
+	else if(from_recipe.one_per_turf && (locate(from_recipe.result_type) in here))
+		. = FALSE
+		to_chat(M, "<span class='warning'> There is another [from_recipe.title] here!</span>")
+	else if(!istype(here, /turf/simulated/floor))
+		. = FALSE
+		to_chat(M, "<span class='warning'>\The [from_recipe.title] must be constructed on the floor!</span>")
+	else if(here.contents.len > 15) //we don't want for() thru tons of atoms.
+		. = FALSE
+	else if(!(origin.CanPass(null, here, 0, 0) && here.CanPass(null, origin, 0, 0)))
+		. = FALSE
+	else
+		for(var/atom/movable/AM in here)
+			if(AM.density)
+				. = FALSE
+				break
+	if(!.)
+		b_overlay.color = "red"
+		animate(b_overlay, time = 5, color = "white")
+
+/datum/craft_or_build/proc/try_to_build(mob/M)
+	if(!can_build(M, over_this, get_turf(M)))
+		return
+
+	var/turf/over_this_saved = over_this
+	if(from_recipe.time)
+		busy = TRUE
+		playsound(M, 'sound/effects/grillehit.ogg', 50, 1)
+		b_overlay.alpha = 0
+		holo_build = new(over_this_saved) //Everyone will see what you trying to build.
+		holo_build.anchored = TRUE
+		holo_build.unacidable = TRUE
+		holo_build.name = "Holo Object"
+		holo_build.icon = initial(build_this.icon)
+		holo_build.icon_state = initial(build_this.icon_state)
+		holo_build.alpha = 160
+		holo_build.color = list(-1,0,0,0,-1,0,0,0,-1,1,1,1)
+		holo_build.mouse_opacity = FALSE
+		to_chat(M, "Building [from_recipe.title] ...")
+		var/failed = FALSE
+		if(!do_after(M, from_recipe.time, target = M))
+			failed = TRUE
+		busy = FALSE
+		if(!in_building_mode)
+			return
+		b_overlay.alpha = 185
+		qdel(holo_build)
+		holo_build = null
+		if(failed)
+			return
+
+	if(!can_build(M, over_this_saved, get_turf(M)))
+		return
+
+	if(over_this_saved && get_dist(M, over_this_saved) <= 1)
+		playsound(M, 'sound/effects/grillehit.ogg', 50, 1)//Yes, 2nd time with timed recipe.
+		var/atom/A = new from_recipe.result_type(over_this_saved)
+		A.dir = build_direction
+		using_this.amount -= from_recipe.req_amount
+		if(using_this.amount <= 0)
+			M.remove_from_mob(using_this)
+			qdel(using_this)
+		A.add_fingerprint(M)
+		b_overlay.maptext = COB_HINT
+
+/turf/MouseEntered(location, control, params)
+	if(usr.client.cob.in_building_mode)
+		if(usr.restrained() || usr.stat || (usr.get_active_hand() != usr.client.cob.using_this && usr.get_inactive_hand() != usr.client.cob.using_this))
+			usr.client.cob.remove_build_overlay(usr.client)
+			return
+		var/turf/T = src
+		if(get_dist(usr, src) > 0)
+			var/direction = get_dir(usr, src)
+			switch(direction)
+				if(NORTHEAST)
+					direction = EAST
+				if(SOUTHEAST)
+					direction = SOUTH
+				if(SOUTHWEST)
+					direction = WEST
+				if(NORTHWEST)
+					direction = NORTH
+
+			T = get_step(usr, direction)
+			if(!T)
+				return
+
+		usr.client.cob.over_this = T
+		usr.client.cob.b_overlay.loc = T
+
+#undef COB_HINT

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -128,8 +128,9 @@
 		if (R.one_per_turf && (locate(R.result_type) in usr.loc))
 			to_chat(usr, "\red There is another [R.title] here!")
 			return
-		if (R.on_floor && !istype(usr.loc, /turf/simulated/floor))
-			to_chat(usr, "\red \The [R.title] must be constructed on the floor!")
+		if (R.on_floor)
+			usr.client.cob.turn_on_build_overlay(usr.client, R, src)
+			usr << browse(null, "window=stack")
 			return
 		if (R.time)
 			to_chat(usr, "\blue Building [R.title] ...")

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -3,7 +3,9 @@ var/list/forbidden_varedit_object_types = list(
 		/datum/configuration,
 		/obj/machinery/blackbox_recorder,  //Prevents people messing with feedback gathering
 		/datum/feedback_variable,          //Prevents people messing with feedback gathering
-		/datum/timedevent                  //Nope.avi
+		/datum/timedevent,                 //Nope.avi
+		/datum/craft_or_build,
+		/datum/stack_recipe
 	)
 
 /client/proc/cmd_modify_ticker_variables()

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -211,11 +211,16 @@
 	if(!tooltips)
 		tooltips = new /datum/tooltip(src)
 
+	if(!cob)
+		cob = new()
+
 	//////////////
 	//DISCONNECT//
 	//////////////
 /client/Del()
 	log_client_ingame_age_to_db()
+	if(cob && cob.in_building_mode)
+		cob.remove_build_overlay(src)
 	if(holder)
 		holder.owner = null
 		admins -= src

--- a/taucetistation.dme
+++ b/taucetistation.dme
@@ -152,6 +152,7 @@
 #include "code\datums\ai_laws.dm"
 #include "code\datums\beam.dm"
 #include "code\datums\browser.dm"
+#include "code\datums\cob_highlight.dm"
 #include "code\datums\computerfiles.dm"
 #include "code\datums\datacore.dm"
 #include "code\datums\datumvars.dm"


### PR DESCRIPTION
Сам не знаю зачем, но тем не менее. Достал фичу из мешочка фич.

Механ/правила создания если и претерпел изменения, то очень минимально. Этот ПР был рассчитан только на саму фичу без каких либо ребалансов.
Собственно все должно быть по старому за исключением шага выбора рецепта из меню.
* Если тип рецепта тот, что мы создаем под собой, то теперь вместо создания, включается режим отображения объекта под курсором или рядом с игроком (дальше чем 1 турф - т.е удаленно от игрока) строить ничего само собой нельзя. Можно конечно как мутацию добавить эту возможность, но ПР не о фичах ребаланса.
* Левым кликом - собственно строим, зажав дополнительно альт - изменяем поворот, а правый клик отменяет этот режим.
* В момент создания объекта и если в нем прописано, что он не делается мгновенно - в этот момент все видят что игрок строит и где, а сам объект принимает инвертированный цвет, поэтому спутать будет сложно.
* В момент начала и окончания действия - это если рецепт без мгновенного создания, иначе один раз - слышен звук удара по грилю - хорошо бы на самом деле вменяемый звук поискать, но сейчас не горю желанием.

* Насчет подсказки что отображается этим ужасным шрифтом под оверлеем- я бы сделал как тултип, но он не имеет поддержки создания в любой точке экрана, разве что через дерзкий хак. Можно еще в чат перенаправить, но чтот не решился, да и тогда нельзя отображать будет кол.во того же металла в реальном времени.

* Баги? Вполне может что и проглядел (пока писал это описание, вспомнил про стекла и подумал - вот он - баг, а они не юзают этот механ, поэтому нововведение окна сейчас не касается).
  * Так что касательно окон - можно их тоже под этот механ закинуть, о них совсем забыл.

![build_6](https://cloud.githubusercontent.com/assets/8426718/21783081/870dfde0-d6be-11e6-84c3-751f952aac56.gif)