### PR TITLE
Интеракции ИИ для админов. 1.

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -39,8 +39,11 @@
 
 // Oh by the way this didn't work with old click code which is why clicking shit didn't spam you
 /atom/proc/attack_ghost(mob/dead/observer/user)
-	if(user.client && user.client.inquisitive_ghost)
-		user.examinate(src)
+	if(user.client)
+		if(check_rights(R_ADMIN, 0) && user.client.AI_Interact)
+			attack_ai(user)
+		if(user.client.inquisitive_ghost)
+			user.examinate(src)
 	return
 
 // ---------------------------------------

--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -101,6 +101,9 @@
 		var/mob/living/silicon/S = M
 		if(src.check_access(S))
 			return TRUE
+	if(IsAdminGhost(M))
+		//Access can't stop the abuse
+		return TRUE
 	else if(istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
 		//if they are holding or wearing a card that has access, that works

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -1409,7 +1409,7 @@ FIRE ALARM
 			update_icon()
 
 /obj/machinery/firealarm/attack_hand(mob/user)
-	if(user.stat || stat & (NOPOWER|BROKEN))
+	if((user.stat && !IsAdminGhost(user)) || stat & (NOPOWER|BROKEN))
 		return
 
 	if (buildstage != 2)
@@ -1594,7 +1594,7 @@ Code shamelessly copied from apc_frame
 	return attack_hand(user)
 
 /obj/machinery/partyalarm/attack_hand(mob/user)
-	if(user.stat || stat & (NOPOWER|BROKEN))
+	if((user.stat && !IsAdminGhost(user)) || stat & (NOPOWER|BROKEN))
 		return
 
 	user.machine = src

--- a/code/game/machinery/computer/power.dm
+++ b/code/game/machinery/computer/power.dm
@@ -43,7 +43,7 @@
 /obj/machinery/computer/monitor/interact(mob/user)
 
 	if ( (get_dist(src, user) > 1 ) || (stat & (BROKEN|NOPOWER)) )
-		if (!istype(user, /mob/living/silicon))
+		if (!(istype(user, /mob/living/silicon) || IsAdminGhost(user)))
 			user.unset_machine()
 			user << browse(null, "window=powcomp")
 			return

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -893,7 +893,7 @@ About the new airlock wires panel:
 	return
 
 /obj/machinery/door/airlock/attack_hand(mob/user)
-	if(!istype(usr, /mob/living/silicon))
+	if(!(istype(user, /mob/living/silicon) || IsAdminGhost(user)))
 		if(src.isElectrified())
 			if(src.shock(user, 100))
 				return
@@ -1029,7 +1029,7 @@ About the new airlock wires panel:
 			R.airlock_wire = null
 			signalers[wirenum] = null
 
-	if(issilicon(usr) && canAIControl())
+	if((istype(usr, /mob/living/silicon) && src.canAIControl()) || IsAdminGhost(usr))
 		//AI
 		//aiDisable - 1 idscan, 2 disrupt main power, 3 disrupt backup power, 4 drop door bolts, 5 un-electrify door, 7 close door, 8 door safties, 9 door speed, 11 lift access override
 		//aiEnable - 1 idscan, 4 raise door bolts, 5 electrify door for 30 seconds, 6 electrify door indefinitely, 7 open door,  8 door safties, 9 door speed, 11 lift access override
@@ -1226,7 +1226,7 @@ About the new airlock wires panel:
 		updateUsrDialog()
 
 /obj/machinery/door/airlock/attackby(C, mob/user)
-	if(!istype(usr, /mob/living/silicon))
+	if(!(istype(usr, /mob/living/silicon) || IsAdminGhost(user)))
 		if(src.isElectrified())
 			if(src.shock(user, 75))
 				return

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -635,7 +635,7 @@ About the new airlock wires panel:
 		to_chat(user, "Airlock AI control wire is cut. Please call the engineer or engiborg to fix this problem.")
 		return
 //##Z1
-	if(!src.canAIControl())
+	if(!(src.canAIControl()) || IsAdminGhost(usr))
 		if(src.canAIHack())
 			src.hack(user)
 			return

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -286,7 +286,7 @@ Class Procs:
 /obj/machinery/attack_hand(mob/user)
 	if(stat & (NOPOWER|BROKEN|MAINT))
 		return 1
-	if(user.lying || user.stat)
+	if((user.lying || user.stat) && !IsAdminGhost(user))
 		return 1
 	if ( ! (istype(usr, /mob/living/carbon/human) || \
 			istype(usr, /mob/living/silicon) || \

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -133,10 +133,10 @@ var/GLOBAL_RADIO_TYPE = 1 // radio type to use
 
 /obj/item/device/radio/Topic(href, href_list)
 	//..()
-	if (usr.stat || !on)
+	if ((usr.stat && !IsAdminGhost(usr)) || !on)
 		return
 
-	if (!(issilicon(usr) || (usr.contents.Find(src) || ( in_range(src, usr) && istype(loc, /turf) ))))
+	if (!(issilicon(usr) || IsAdminGhost(usr) || (usr.contents.Find(src) || ( in_range(src, usr) && istype(loc, /turf) ))))
 		usr << browse(null, "window=radio")
 		return
 	usr.set_machine(src)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -82,7 +82,7 @@
 			if ((M.client && M.machine == src))
 				is_in_use = 1
 				src.attack_hand(M)
-		if (istype(usr, /mob/living/silicon/ai) || istype(usr, /mob/living/silicon/robot))
+		if (istype(usr, /mob/living/silicon/ai) || istype(usr, /mob/living/silicon/robot) || IsAdminGhost(usr))
 			if (!(usr in nearby))
 				if (usr.client && usr.machine==src) // && M.machine == src is omitted because if we triggered this by using the dialog, it doesn't matter if our machine changed in between triggering it and this - the dialog is probably still supposed to refresh.
 					is_in_use = 1

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -81,7 +81,8 @@ var/list/admin_verbs_admin = list(
 	/client/proc/aooc,
 	/client/proc/change_security_level,
 	/client/proc/empty_ai_core_toggle_latejoin,
-	/client/proc/send_fax_message
+	/client/proc/send_fax_message,
+	/client/proc/toggle_AI_interact /*toggle admin ability to interact with machines as an AI*/
 	)
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel
@@ -968,3 +969,12 @@ var/list/admin_verbs_hideable = list(
 			to_chat(M, "<font color='#960018'><span class='ooc'><span class='prefix'>Antag-OOC:</span> <EM>[display_name]:</EM> <span class='message'>[msg]</span></span></font>")
 
 	log_ooc("Antag-OOC: [key] : [msg]")
+
+/client/proc/toggle_AI_interact()
+	set name = "Toggle Admin AI Interact"
+	set category = "Admin"
+	set desc = "Allows you to interact with most machines as an AI would as a ghost"
+
+	AI_Interact = !AI_Interact
+	log_admin("[key_name(usr)] has [AI_Interact ? "activated" : "deactivated"] Admin AI Interact")
+	message_admins("[key_name_admin(usr)] has [AI_Interact ? "activated" : "deactivated"] their AI interaction")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -81,8 +81,7 @@ var/list/admin_verbs_admin = list(
 	/client/proc/aooc,
 	/client/proc/change_security_level,
 	/client/proc/empty_ai_core_toggle_latejoin,
-	/client/proc/send_fax_message,
-	/client/proc/toggle_AI_interact /*toggle admin ability to interact with machines as an AI*/
+	/client/proc/send_fax_message
 	)
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel
@@ -113,7 +112,8 @@ var/list/admin_verbs_fun = list(
 	/client/proc/epileptic_anomaly,
 //	/client/proc/Noir_anomaly,
 	/client/proc/epileptic_anomaly_cancel,
-	/client/proc/achievement
+	/client/proc/achievement,
+	/client/proc/toggle_AI_interact /*toggle admin ability to interact with machines as an AI*/
 	)
 var/list/admin_verbs_spawn = list(
 	/datum/admins/proc/spawn_atom,		/*allows us to spawn instances*/
@@ -972,7 +972,7 @@ var/list/admin_verbs_hideable = list(
 
 /client/proc/toggle_AI_interact()
 	set name = "Toggle Admin AI Interact"
-	set category = "Admin"
+	set category = "Fun"
 	set desc = "Allows you to interact with most machines as an AI would as a ghost"
 
 	AI_Interact = !AI_Interact

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -5,6 +5,7 @@
 	var/datum/admins/holder = null
 	var/datum/admins/deadmin_holder = null
 	var/buildmode		= 0
+	var/AI_Interact		= 0
 
 	var/jobbancache = null //Used to cache this client's jobbans to save on DB queries
 	var/last_message	= "" //Contains the last message sent by this client - used to protect against copy-paste spamming.

--- a/code/modules/mob/dead/observer/login.dm
+++ b/code/modules/mob/dead/observer/login.dm
@@ -1,5 +1,9 @@
 /mob/dead/observer/Login()
 	..()
+
+	if(check_rights(R_ADMIN, 0))
+		has_unlimited_silicon_privilege = 1
+
 	if(ghostimage)
 		ghostimage.icon_state = src.icon_state
 	ghost_orbit = client.prefs.ghost_orbit

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -203,6 +203,8 @@
 
 	var/digitalcamo = 0 // Can they be tracked by the AI?
 
+	var/has_unlimited_silicon_privilege = 0 // Can they interact with station electronics
+
 	var/list/radar_blips = list() // list of screen objects, radar blips
 	var/radar_open = 0 	// nonzero is radar is open
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -339,3 +339,9 @@ var/list/intents = list("help","disarm","grab","hurt")
 			M.show_message("<span class='info'>[bicon(icon)] [message]</span>", 1)
 	for(var/mob/dead/observer/G in player_list) //Ghosts? Why not.
 		G.show_message("<span class='info'>[bicon(icon)] [message]</span>", 1)
+
+/proc/IsAdminGhost(var/mob/user)
+	if(check_rights(R_ADMIN, 0) && istype(user, /mob/dead/observer) && user.client.AI_Interact)
+		return 1
+	else
+		return 0

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -912,6 +912,8 @@
 				src.updateDialog()
 
 /obj/machinery/power/apc/proc/can_use(mob/user, loud = 0) //used by attack_hand() and Topic()
+	if (IsAdminGhost(user))
+		return 1
 	if(!user.client)
 		return 0
 	autoflag = 5


### PR DESCRIPTION
У админов будет возможность взаимодействовать с некоторыми объектами так, как это делает ИИ.

Список того с чем можно взаимодействовать:
- Двери;
- АПЦ (пока только просмотр);
- Firealarm и Airalarm;
- Вендоматы;
- Интеркомы;
- Канистры:
- Эммитеры;
- Рычаги и кнопки.

Также, в панели Admin появится новый пункт. 
"Toggle Admin AI Interact" - позволяет включать и выключать эту возможность, по умолчанию выключена. Кроме этого, включение этой функции оставляет запись в логах. 

Все действия оставляют скрытые отпечатки, которые видно только через ВВ.

Upd by igigin:
Closes #957. (Поправьте меня, если не закрывает.)