### PR TITLE
Убран некорректный to_chat() при выведении звука

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -93,7 +93,7 @@ var/const/FALLOFF_SOUNDS = 0.5
 		S.falloff = (falloff ? falloff : FALLOFF_SOUNDS)
 	if(!is_global)
 		S.environment = 2
-	to_chat(src, S)
+	src << S
 
 /client/proc/playtitlemusic()
 	if(!ticker || !ticker.login_music)	return


### PR DESCRIPTION
Из-за этого кто-то что-то не слышал