### PR TITLE
Инфекции при операциях

### DIFF
--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -49,6 +49,7 @@
 	siemens_coefficient = 0.30
 	permeability_coefficient = 0.01
 	item_color="white"
+	germ_level = 0
 
 /obj/item/clothing/gloves/latex/cmo
 	item_color = "medical"		//Exists for washing machines. Is not different from latex gloves in any way.

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -172,7 +172,6 @@
 		user.visible_message("\blue [user] clamps bleeders in [target]'s [affected.display_name] with \the [tool].",	\
 		"\blue You clamp bleeders in [target]'s [affected.display_name] with \the [tool].")
 		affected.clamp()
-		spread_germs_to_organ(affected, user)
 
 	fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 		var/datum/organ/external/affected = target.get_organ(target_zone)
@@ -263,7 +262,6 @@
 		user.visible_message("\blue [user] cauterizes the incision on [target]'s [affected.display_name] with \the [tool].", \
 		"\blue You cauterize the incision on [target]'s [affected.display_name] with \the [tool].")
 		affected.open = 0
-		affected.germ_level = 0
 		affected.status &= ~ORGAN_BLEEDING
 
 	fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -76,7 +76,8 @@ proc/spread_germs_to_organ(datum/organ/external/E, mob/living/carbon/human/user)
 		germ_level = user.gloves.germ_level
 
 	E.germ_level = max(germ_level,E.germ_level) //as funny as scrubbing microbes out with clean gloves is - no.
-
+	if(E.germ_level)
+		E.owner.bad_external_organs |= E
 proc/do_surgery(mob/living/carbon/M, mob/living/user, obj/item/tool)
 	if(!istype(M))
 		return 0


### PR DESCRIPTION
В текущем варианте на этапе с каутером инфекция на органе полностью удаляется. Это практически полностью обесценивает стерильность при операции. Так как в этом варианте для заметного вреда пациенту нужно заниматься операцией невменяемо долго. Более того, это позволяет лечить таким образом инфекцию на конкретном органе.
Поскольку мы в любом случае требуем от игроков соблюдения стерильности из ролевых соображений, предлагаю сделать возможность заражения инфекцией при операциях сколько-нибудь значимой простым удалением описанной выше механики. Тогда требования стерильности станут более понятны для игроков из-за практического применения. Да и объяснить их необходимости будет гораздо проще.
С предлагаемыми изменениями лечить людей станет немного труднее, зато гораздо реалистичнее. Спейсасилин уже есть в раздатчиках, поэтому даже в худшем случае без наличия химии в раунде с инфекцией можно относительно справиться.
У игроков остается любой из трех (или все вместе) способов избежать опасной для здоровья инфекции:
1. Использовать новые перчатки или помыть старые перед операции.
2. Помыть руки перед операцией (без перчаток тоже сойдет) и желательно несколько раз в процессе.
3. Использовать стерилизин
Также исправлены две сопутствующие проблемы:
Орган с инфекцией в общем случае не попадал в список для обновления https://github.com/TauCetiStation/TauCetiClassic/blob/master/code/modules/organs/organ.dm#L66, в то время как его обновление из-за инфекции предполагается https://github.com/TauCetiStation/TauCetiClassic/blob/master/code/modules/organs/organ_external.dm#L293.
Латексные перчатки были нестерильными к моменту спавна .