### PR TITLE
Исправление - синтеты не могли строекрафтить через механ подсветки.

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -47,16 +47,7 @@
 	var/list/modifiers = params2list(params)
 
 	if(client.cob.in_building_mode)
-		var/client/C = client
-		if(C.cob.busy)
-			//do nothing
-		else if(modifiers["left"])
-			if(modifiers["alt"])
-				C.cob.rotate_object()
-			else
-				C.cob.try_to_build(src)
-		else if(modifiers["right"])
-			C.cob.remove_build_overlay(client)
+		cob_click(client, modifiers)
 		return
 
 	if(modifiers["shift"] && modifiers["ctrl"])
@@ -295,6 +286,7 @@
 
 	Laser Eyes: as the name implies, handles this since nothing else does currently
 	face_atom: turns the mob towards what you clicked on
+	cob_click: handles hotkeys for "craft or build"
 */
 /mob/proc/LaserEyes(atom/A)
 	return
@@ -339,6 +331,17 @@
 		if(dx > 0)	usr.dir = EAST
 		else		usr.dir = WEST
 
+// Craft or Build helper (main file can be found here: code/datums/cob_highlight.dm)
+/mob/proc/cob_click(client/C, list/modifiers)
+	if(C.cob.busy)
+		//do nothing
+	else if(modifiers["left"])
+		if(modifiers["alt"])
+			C.cob.rotate_object()
+		else
+			C.cob.try_to_build(src)
+	else if(modifiers["right"])
+		C.cob.remove_build_overlay(C)
 
 /obj/screen/click_catcher
 	icon = 'icons/mob/screen1_full.dmi'

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -16,6 +16,11 @@
 		return
 
 	var/list/modifiers = params2list(params)
+
+	if(client.cob.in_building_mode)
+		cob_click(client, modifiers)
+		return
+
 	if(modifiers["shift"] && modifiers["ctrl"])
 		CtrlShiftClickOn(A)
 		return

--- a/code/datums/cob_highlight.dm
+++ b/code/datums/cob_highlight.dm
@@ -90,6 +90,8 @@
 	if(!can_build(M, over_this, get_turf(M)))
 		return
 
+	M.face_atom(over_this)
+
 	var/turf/over_this_saved = over_this
 	if(from_recipe.time)
 		busy = TRUE


### PR DESCRIPTION
* Потому что забыл добавить синтетам прок на горячие кнопки!
  * fixes #1039 
* [+] Моб смотрит/поворачивается в ту сторону, где начинает что-то создавать после клика.