### PR TITLE
Фикс мусора, подлёт которого виден по всей станции

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -15,6 +15,7 @@
 	var/mob/pulledby = null
 	var/inertia_dir = 0
 	var/list/client_mobs_in_contents
+	appearance_flags = TILE_BOUND
 
 /atom/movable/New()
 	. = ..()


### PR DESCRIPTION
>**TILE_BOUND**
There are many ways an object may be shifted out of the normal bounds of the tile it's on: a large icon, pixel offsets, step offsets, and transform. Ordinarily it's desirable to be able to see the object if it touches any visible turf. However, in some cases it's more desirable to only show the object if its actual loc is in view. The TILE_BOUND flag will accomplish that.

Падение будут видеть только те у кого мусор находится в прямой видимости. Возможно пофиксится тот баг с плакатами, но не имею ни малейшего представления как его воспроизвести, поэтому это на уровне догадок.