### PR TITLE
Проверка блока щитом для всех типов снарядов

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -21,6 +21,10 @@
 
 				return -1 // complete projectile permutation
 
+	if(check_shields(P.damage, "the [P.name]"))
+		P.on_hit(src, 100, def_zone)
+		return 2
+
 	if(istype(P, /obj/item/projectile/bullet/weakbullet))
 		var/datum/organ/external/select_area = get_organ(def_zone) // We're checking the outside, buddy!
 		if(check_thickmaterial(select_area))
@@ -68,10 +72,6 @@
 		to_chat(src, "\red You have been shot!")
 		qdel(P)
 		return
-
-	if(check_shields(P.damage, "the [P.name]"))
-		P.on_hit(src, 100, def_zone)
-		return 2
 
 	if(istype(P, /obj/item/projectile/bullet))
 		var/obj/item/projectile/bullet/B = P


### PR DESCRIPTION
Идея текущего расположения вызова check_shields() для меня совершенно непонятна, так как исключаются типы снарядов для которых это скорее лишнее. Переместил, чтобы включать все проверяемые типы снарядов