### PR TITLE
Возвращение механа миссов в зависимости от выбранной части тела.

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -38,10 +38,10 @@
 // If "chest" was passed in as zone, then on a "miss" will return "head", "l_arm", or "r_arm"
 // Do not use this if someone is intentionally trying to hit a specific body part.
 // Use get_zone_with_miss_chance() for that.
-/proc/ran_zone(zone, probability)
+/proc/ran_zone(zone, probability = 90)
 	zone = check_zone(zone)
-	if(!probability)	probability = 90
-	if(probability == 100)	return zone
+	if(probability == 100)
+		return zone
 
 	if(zone == "chest")
 		if(prob(probability))	return "chest"
@@ -67,38 +67,49 @@
 			if("head")
 				miss_chance = 30
 			if("l_leg")
-				miss_chance = 20
+				miss_chance = 40
 			if("r_leg")
-				miss_chance = 20
+				miss_chance = 40
 			if("l_arm")
-				miss_chance = 20
+				miss_chance = 40
 			if("r_arm")
-				miss_chance = 20
+				miss_chance = 40
 			if("l_hand")
-				miss_chance = 40
+				miss_chance = 60
 			if("r_hand")
-				miss_chance = 40
+				miss_chance = 60
 			if("l_foot")
-				miss_chance = 40
+				miss_chance = 60
 			if("r_foot")
-				miss_chance = 40
-		miss_chance = max(miss_chance + miss_chance_mod, 0)
-		if(prob(miss_chance))
-			if(prob(80))
+				miss_chance = 60
+		if(prob(max(miss_chance + miss_chance_mod, 0)))
+			if(prob(max(20, (miss_chance/2))))
 				return null
 			else
-				var/t = rand(1, 10)
+				var/t = rand(1, 100)
 				switch(t)
-					if(1)	return "head"
-					if(2)	return "l_arm"
-					if(3)	return "r_arm"
-					if(4) 	return "chest"
-					if(5) 	return "l_foot"
-					if(6)	return "r_foot"
-					if(7)	return "l_hand"
-					if(8)	return "r_hand"
-					if(9)	return "l_leg"
-					if(10)	return "r_leg"
+					if(1 to 50)
+						return "chest"
+					if(51 to 61)
+						return "head"
+					if(62 to 66)
+						return "l_arm"
+					if(67 to 71)
+						return "r_arm"
+					if(72 to 76)
+						return "r_leg"
+					if(77 to 81)
+						return "l_leg"
+					if(82 to 87)
+						return "groin"
+					if(88 to 91)
+						return "l_foot"
+					if(92 to 94)
+						return "r_foot"
+					if(95 to 97)
+						return "l_hand"
+					if(98 to 100)
+						return "r_hand"
 
 	return zone
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -149,8 +149,7 @@
 		if(damage && (distance > 7))
 			if(damage < 55)
 				damage = max(1, damage - round(damage * (((distance-6)*3)/100)))
-		if(istype(src, /obj/item/projectile/beam/sniper))
-			miss_modifier = - 100 // so sniper rifle beam cannot miss
+				miss_modifier = - 100 // so sniper rifle and PTR-rifle projectiles cannot miss
 		if (istype(shot_from,/obj/item/weapon/gun))	//If you aim at someone beforehead, it'll hit more often.
 			var/obj/item/weapon/gun/daddy = shot_from //Kinda balanced by fact you need like 2 seconds to aim
 			if (daddy.target && original in daddy.target) //As opposed to no-delay pew pew

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -145,18 +145,19 @@
 			return 0// nope.avi
 
 		var/distance = get_dist(starting,loc) //More distance = less damage, except for high fire power weapons.
+		var/miss_modifier = 0
 		if(damage && (distance > 7))
 			if(damage < 55)
 				damage = max(1, damage - round(damage * (((distance-6)*3)/100)))
-		//var/miss_modifier = -30
-
-		//if (istype(shot_from,/obj/item/weapon/gun))	//If you aim at someone beforehead, it'll hit more often.
-		//	var/obj/item/weapon/gun/daddy = shot_from //Kinda balanced by fact you need like 2 seconds to aim
-		//	if (daddy.target && original in daddy.target) //As opposed to no-delay pew pew
-		//		miss_modifier += -30
-		//if(distance > 1)
-		//	def_zone = get_zone_with_miss_chance(def_zone, M)
-		def_zone = get_zone_with_probabilty(def_zone)
+		if(istype(src, /obj/item/projectile/beam/sniper))
+			miss_modifier = - 100 // so sniper rifle beam cannot miss
+		if (istype(shot_from,/obj/item/weapon/gun))	//If you aim at someone beforehead, it'll hit more often.
+			var/obj/item/weapon/gun/daddy = shot_from //Kinda balanced by fact you need like 2 seconds to aim
+			if (daddy.target && original in daddy.target) //As opposed to no-delay pew pew
+				miss_modifier += -60
+		if(distance > 1)
+			def_zone = get_zone_with_miss_chance(def_zone, M, miss_modifier)
+		//def_zone = get_zone_with_probabilty(def_zone)
 
 		if(!def_zone)
 			visible_message("<span class = 'notice'>\The [src] misses [M] narrowly!</span>")


### PR DESCRIPTION
В общем-то, я не знаю, как нужно было затравить Зве, или кто занимался балансом, чтобы он убрал миссы (и поставил НЫНЕШНИЙ ПРОК, О ГОСПОДИ), тем самым, открывая путь юным механобобам целиться онли в пятки/запястья.
Теперь же эти парняги могут ПОДУМОТЬ, что им важнее, целиться в менее защищенную часть органа с неплохим шансом промахнуться вовсе, либо же гарантированно стрелять в грудак и свести эти затраты к минимуму (впрочем, по грудаку тоже можно промахнуться).
Да, этот прок используется в мили комбате, но там дело касается простого закликивания и не особо играет роль, да и раньше он как использовался, если мисс прошёл, то он с вероятностью 80% просто промахнётся, сейчас же скорее всего попадёт в цель, но в другую часть тела.
Я не претендую на звание гуру в робасте, (в лучшие свои годы, Ольт равнялся на меня, по его признаниям, екх) поэтому могу выслушать предложения по каким-либо ещё изменениям (либо же уйти в закат из-за тонны критики от Зве) . Например зависимость промаха от расстояния, почему бы и нет (потому что у нас экран 7 тайтлов, что не так уж и много).
Одно я знаю точно, нынешняя система явно требует реворка.
UPD. Сделал поправку на замечание Зве по поводу Птров и всех остальных снайперок.