### PR TITLE
Фиксы неправильно работающих флагов давления на одежде и удаление лишних проверок на них

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -1,9 +1,7 @@
 //PREASSURE_FLAGS BITMASK
-#define STOPS_PRESSUREDMAGE     1    //This flag is used on the flags variable for SUIT and HEAD items which stop pressure damage. Note that the flag 1 was previous used as ONBACK, so it is possible for some code to use (flags & 1) when checking if something can be put on your back. Replace this code with (inv_flags & SLOT_BACK) if you see it anywhere
-                                     //To successfully stop you taking all pressure damage you must have both a suit and head item with this flag.
-                                     //Used against both, high and low pressure.
-#define STOPS_HIGHPRESSUREDMAGE 2
-#define STOPS_LOWPRESSUREDMAGE  4
+#define STOPS_HIGHPRESSUREDMAGE 1    //These flags is used on the flags_pressure variable for SUIT and HEAD items which stop (high/low/all) pressure damage. Note that the flag 1 was previous used as ONBACK, so it is possible for some code to use (flags & 1) when checking if something can be put on your back. Replace this code with (inv_flags & SLOT_BACK) if you see it anywhere
+#define STOPS_LOWPRESSUREDMAGE  2    //To successfully stop you taking all pressure damage you must have both a suit and head item with STOPS_PRESSUREDMAGE flag.
+#define STOPS_PRESSUREDMAGE     3    //Used against both, high and low pressure.
 
 //FLAGS BITMASK
 #define NOBLUDGEON        2    // When an item has this it produces no "X has been hit by Y with Z" message with the default handler.

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -137,29 +137,17 @@
 /mob/living/carbon/human/proc/get_pressure_protection(pressure_check = STOPS_PRESSUREDMAGE)
 	var/pressure_adjustment_coefficient = 1	//Determins how much the clothing you are wearing protects you in percent.
 
-	if((head && (head.flags_pressure & STOPS_PRESSUREDMAGE))&&(wear_suit && (wear_suit.flags_pressure & STOPS_PRESSUREDMAGE)))
+	if((head && (head.flags_pressure & pressure_check))&&(wear_suit && (wear_suit.flags_pressure & pressure_check)))
 		pressure_adjustment_coefficient = 0
 
 		//Handles breaches in your space suit. 10 suit damage equals a 100% loss of pressure reduction.
-		if(wear_suit && (wear_suit.flags_pressure & STOPS_PRESSUREDMAGE))
-			if(istype(wear_suit,/obj/item/clothing/suit/space))
-				var/obj/item/clothing/suit/space/S = wear_suit
-				if(S.can_breach && S.damage)
-					var/pressure_loss = S.damage * 0.1
-					pressure_adjustment_coefficient += pressure_loss
-	else
-		if((head && (head.flags_pressure & pressure_check))&&(wear_suit && (wear_suit.flags_pressure & pressure_check)))
-			pressure_adjustment_coefficient = 0
+		if(istype(wear_suit,/obj/item/clothing/suit/space))
+			var/obj/item/clothing/suit/space/S = wear_suit
+			if(S.can_breach && S.damage)
+				var/pressure_loss = S.damage * 0.1
+				pressure_adjustment_coefficient = pressure_loss
 
-		//Handles breaches in your space suit. 10 suit damage equals a 100% loss of pressure reduction.
-		if(wear_suit && (wear_suit.flags_pressure & pressure_check))
-			if(istype(wear_suit,/obj/item/clothing/suit/space))
-				var/obj/item/clothing/suit/space/S = wear_suit
-				if(S.can_breach && S.damage)
-					var/pressure_loss = S.damage * 0.1
-					pressure_adjustment_coefficient += pressure_loss
-
-	pressure_adjustment_coefficient = min(1,max(pressure_adjustment_coefficient,0)) //So it isn't less than 0 or larger than 1.
+	pressure_adjustment_coefficient = CLAMP01(pressure_adjustment_coefficient) //So it isn't less than 0 or larger than 1.
 
 	return 1 - pressure_adjustment_coefficient	//want 0 to be bad protection, 1 to be good protection
 


### PR DESCRIPTION
Суть проблемы: если космонавтик имеет шлем от скафандра с flags_pressure STOPS_PRESSUREDMAGE и прешшур сьюит с  flags_pressure STOPS_LOWPRESSUREDMAGE, то он спокойно умрёт от низкого давления.
Данный ПР должен пофиксить сей щит.
Проблема может возникнуть, если где-то эти значения захардкожены