### PR TITLE
Файр дорам нечего висеть в процессинге без дела (немного облегчаем жизнь контроллеру).

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -41,7 +41,7 @@
 
 /obj/machinery/door/firedoor/New()
 	. = ..()
-	for(var/obj/machinery/door/firedoor/F in loc)
+	for(var/obj/machinery/door/firedoor/F in loc) // i don't like the way this written ~zve
 		if(F != src)
 			spawn(1)
 				qdel(src)
@@ -263,6 +263,7 @@
 	..()
 	layer = base_layer + FIREDOOR_CLOSED_MOD
 	latetoggle()
+	SSmachine.processing |= src
 
 /obj/machinery/door/firedoor/do_open()
 	..()
@@ -348,3 +349,5 @@
 			changed = 1
 		if(changed)
 			update_icon()
+	else if(!density)
+		return PROCESS_KILL


### PR DESCRIPTION
Для начала в чем суть - файрдоры реально начинают исполнять какой-то процесс только тогда, когда проходят вот это условие `if(density && next_process_time <= world.time)` - т.е основное, это иметь true на density - быть в закрытом состоянии. Поэтому нет смысла их присутствия в листе процессинга машин в иное время.

Касательно самой реализации - иного разрешения ситуации пока не придумал, ну которое меня устроит (пилю же я, а не чужой ПР рассматриваю), если у кого еще какие мысли появятся - пишите, может у вас действительно лучше решение будет о том, когда и как добавлять их в процессинг, но надо учитывать, что это не рефакторинг, это решение на данный момент без перепиливания всего и вся, но с ним точно лучше, чем без него.

Насчет "сломал ли я их работу?" - вроде  нет, начинают процессится те, которые закрыты (закрылись через прок do_close())  и удаляются из списка - когда density теряют.

Тесты проводились так:

1) Компилим билд с двумя картами - 1 и 2 слой (это чисто моя привычка, т.к не вижу смысла поднимать сервер со всеми слоями когда в этом нет необходимости, лишь время на поднятие локалки отнимает).
2) ~Удаляем бипски (раздражает катанием по карте).~
-
2) Даем всем батареям в апц полный заряд (5к), это чтобы снять шум от зарядки (поэтому ds на картинке ниже в обоих случаях 0 - но даже если оставить помеху, все равно результат будет отличаться).
3) Стартуем раунд и наблюдаем.

![mc](https://cloud.githubusercontent.com/assets/8426718/23704971/10ed6c20-0410-11e7-8644-91c942864a1b.png)

В профилировщике вышло как-то так (эти проки как раз висят в самом верху, но замерял чисто ради интереса, т.к тут и так понятно, что сняв с листа около 1к объектов, оно очевидно что будет быстрее):
```
                                                  Profile results (total time)
Proc Name                                                                         Self CPU    Total CPU    Real Time        Calls
-----------------------------------------------------------------------------    ---------    ---------    ---------    ---------
/datum/subsystem/machines/fire                                                       0.348        1.519        1.520           50
/obj/machinery/proc/use_power                                                        0.147        0.235        0.242        73425
/obj/machinery/proc/auto_use_power                                                   0.136        0.554        0.562        74125
/obj/machinery/proc/powered                                                          0.120        0.183        0.189        74125
===========================================================
/datum/subsystem/machines/fire                                                       0.208        1.118        1.118           50
/obj/machinery/proc/auto_use_power                                                   0.105        0.367        0.371        45125
/obj/machinery/proc/powered                                                          0.093        0.128        0.135        45125
/obj/machinery/proc/use_power                                                        0.089        0.140        0.143        44850
```

https://gist.github.com/ZVee/74efb6ab620ed1ccaa21a11c2c801153 - а тут вот полный список того что процессится на текущий момент до этого ПРа. Думаю есть куда двигаться в будущем.