### PR TITLE
Убран фикс на утечки памяти при работе с цветовыми матрицами

### DIFF
--- a/code/modules/lighting/lighting_corner.dm
+++ b/code/modules/lighting/lighting_corner.dm
@@ -85,13 +85,13 @@
 	else if (mx < LIGHTING_SOFT_THRESHOLD)
 		. = 0 // 0 means soft lighting.
 
-	cache_r  = lum_r * . + (rand(1,999)/100000) || LIGHTING_SOFT_THRESHOLD
-	cache_g  = lum_g * . + (rand(1,999)/100000) || LIGHTING_SOFT_THRESHOLD
-	cache_b  = lum_b * . + (rand(1,999)/100000) || LIGHTING_SOFT_THRESHOLD
+	cache_r  = lum_r * . || LIGHTING_SOFT_THRESHOLD
+	cache_g  = lum_g * . || LIGHTING_SOFT_THRESHOLD
+	cache_b  = lum_b * . || LIGHTING_SOFT_THRESHOLD
 	#else
-	cache_r  = lum_r * . + (rand(1,999)/100000)
-	cache_g  = lum_g * . + (rand(1,999)/100000)
-	cache_b  = lum_b * . + (rand(1,999)/100000)
+	cache_r  = lum_r * .
+	cache_g  = lum_g * .
+	cache_b  = lum_b * .
 	#endif
 	cache_mx = mx
 


### PR DESCRIPTION
Это был баг бьёнда, который пофикшен в версии 1377.

@volas Обрати внимание, что при обнове с этим ПРом нужно обновить бьёнд до последней бета версии.