### PR TITLE
Фикс неправильного процесса госта у синтетов

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -220,7 +220,12 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		var/response = alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost, you won't be able to play this round for another 30 minutes! You can't change your mind so choose wisely!)","Are you sure you want to ghost?","Stay in body","Ghost")
 		if(response != "Ghost")
 			return	//didn't want to ghost after-all
-		resting = 1
+
+		if(isrobot(usr))
+			var/mob/living/silicon/robot/robot = usr
+			robot.toggle_all_components()
+		else
+			resting = 1
 		var/mob/dead/observer/ghost = ghostize(can_reenter_corpse = FALSE)						//0 parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
 		ghost.timeofdeath = world.time // Because the living mob won't have a time of death and we want the respawn timer to work properly.
 	return

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -901,13 +901,9 @@
 	set name = "Rest"
 	set category = "IC"
 
-	if(issilicon(usr))
+	if(isrobot(usr))
 		var/mob/living/silicon/robot/R = usr
-		for(var/V in R.components)
-			if(V == "power cell") continue
-			var/datum/robot_component/C = R.components[V]
-			if(C.installed)
-				C.toggled = !C.toggled
+		R.toggle_all_components()
 		to_chat(R, "<span class='notice'>You toggle all your components.</span>")
 		return
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1387,3 +1387,11 @@ var/list/robot_verbs_default = list(
 		used_power_this_tick += amount * CYBORG_POWER_USAGE_MULTIPLIER
 		return 1
 	return 0
+
+/mob/living/silicon/robot/proc/toggle_all_components()
+	for(var/V in components)
+		if(V == "power cell")
+			continue
+		var/datum/robot_component/C = components[V]
+		if(C.installed)
+			C.toggled = !C.toggled


### PR DESCRIPTION
Суть проблемы: при госте у синтетов прописывается resting = 1, но они не используют эту переменную. Вместо реста они выключают модули.
UPD: Если в такого борга вселить педальной магией кого-то, то он сам не встанет уже. Да и искать проблему можно долго.