### PR TITLE
[DNM][TEST ONLY] Эксперимент с клиентским фпс

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -21,6 +21,8 @@
 
 	var/list/client_mobs_in_contents
 
+	glide_size = 8
+
 /atom/movable/New()
 	. = ..()
 

--- a/code/modules/client/client defines.dm
+++ b/code/modules/client/client defines.dm
@@ -66,3 +66,5 @@
 	// Their chat window, sort of important.
 	// See /goon/code/datums/browserOutput.dm
 	var/datum/chatOutput/chatOutput
+
+	fps = 40

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -121,17 +121,23 @@
 
 /client/Move(n, direct)
 	if(!mob)
-		return // Moved here to avoid nullrefs below
+		return 0 // Moved here to avoid nullrefs below
 
-	if(mob.control_object)	Move_object(direct)
+	if(world.time < move_delay)
+		return 0
+	move_delay = world.time + world.tick_lag  // This is here because Move() can now be called mutiple times per tick.
 
-	if(isobserver(mob))	return mob.Move(n,direct)
+	if(mob.control_object)
+		Move_object(direct)
 
-	if(moving)	return 0
+	if(isobserver(mob))
+		return mob.Move(n,direct)
 
-	if(world.time < move_delay)	return
+	if(moving)
+		return 0
 
-	if(mob.stat==DEAD)	return
+	if(mob.stat == DEAD)
+		return 0
 
 /*	// handle possible spirit movement
 	if(istype(mob,/mob/spirit))

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -421,3 +421,23 @@
 	else
 		step(pulling, get_dir(pulling.loc, A))
 	return
+
+/client/verb/moveup()
+	set name = ".moveup"
+	set instant = 1
+	Move(get_step(mob, NORTH), NORTH)
+
+/client/verb/movedown()
+	set name = ".movedown"
+	set instant = 1
+	Move(get_step(mob, SOUTH), SOUTH)
+
+/client/verb/moveright()
+	set name = ".moveright"
+	set instant = 1
+	Move(get_step(mob, EAST), EAST)
+
+/client/verb/moveleft()
+	set name = ".moveleft"
+	set instant = 1
+	Move(get_step(mob, WEST), WEST)

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -29,7 +29,7 @@ macro "macro"
 		is-disabled = false
 	elem "MACRO-WEST+REP"
 		name = "WEST+REP"
-		command = ".west"
+		command = ".moveleft"
 		is-disabled = false
 	elem "MACRO-CTRL+NORTH"
 		name = "CTRL+NORTH"
@@ -37,7 +37,7 @@ macro "macro"
 		is-disabled = false
 	elem "MACRO-NORTH+REP"
 		name = "NORTH+REP"
-		command = ".north"
+		command = ".moveup"
 		is-disabled = false
 	elem "MACRO-CTRL+EAST"
 		name = "CTRL+EAST"
@@ -45,7 +45,7 @@ macro "macro"
 		is-disabled = false
 	elem "MACRO-EAST+REP"
 		name = "EAST+REP"
-		command = ".east"
+		command = ".moveright"
 		is-disabled = false
 	elem "MACRO-CTRL+SOUTH"
 		name = "CTRL+SOUTH"
@@ -53,7 +53,7 @@ macro "macro"
 		is-disabled = false
 	elem "MACRO-SOUTH+REP"
 		name = "SOUTH+REP"
-		command = ".south"
+		command = ".movedown"
 		is-disabled = false
 	elem "MACRO-INSERT"
 		name = "INSERT"
@@ -81,11 +81,11 @@ macro "macro"
 		is-disabled = false
 	elem "MACRO-CTRL+A+REP"
 		name = "CTRL+A+REP"
-		command = ".west"
+		command = ".moveleft"
 		is-disabled = false
 	elem "MACRO-CTRL+D+REP"
 		name = "CTRL+D+REP"
-		command = ".east"
+		command = ".moveright"
 		is-disabled = false
 	elem "MACRO-CTRL+E"
 		name = "CTRL+E"
@@ -109,13 +109,13 @@ macro "macro"
 		is-disabled = false
 	elem "MACRO-CTRL+S+REP"
 		name = "CTRL+S+REP"
-		command = ".south"
+		command = ".movedown"
 		is-disabled = false
 	elem "MACRO-CTRL+W+REP"
 		name = "CTRL+W+REP"
-		command = ".north"
+		command = ".moveup"
 		is-disabled = false
-	elem 
+	elem
 		name = "CTRL+X"
 		command = ".northeast"
 		is-disabled = false
@@ -211,7 +211,7 @@ macro "hotkeymode"
 		is-disabled = false
 	elem "HKMODE-WEST+REP"
 		name = "WEST+REP"
-		command = ".west"
+		command = ".moveleft"
 		is-disabled = false
 	elem "HKMODE-CTRL+NORTH"
 		name = "CTRL+NORTH"
@@ -219,7 +219,7 @@ macro "hotkeymode"
 		is-disabled = false
 	elem "HKMODE-NORTH+REP"
 		name = "NORTH+REP"
-		command = ".north"
+		command = ".moveup"
 		is-disabled = false
 	elem "HKMODE-CTRL+EAST"
 		name = "CTRL+EAST"
@@ -227,7 +227,7 @@ macro "hotkeymode"
 		is-disabled = false
 	elem "HKMODE-EAST+REP"
 		name = "EAST+REP"
-		command = ".east"
+		command = ".moveright"
 		is-disabled = false
 	elem "HKMODE-CTRL+SOUTH"
 		name = "CTRL+SOUTH"
@@ -235,7 +235,7 @@ macro "hotkeymode"
 		is-disabled = false
 	elem "HKMODE-SOUTH+REP"
 		name = "SOUTH+REP"
-		command = ".south"
+		command = ".movedown"
 		is-disabled = false
 	elem "HKMODE-INSERT"
 		name = "INSERT"
@@ -279,19 +279,19 @@ macro "hotkeymode"
 		is-disabled = false
 	elem "HKMODE-A+REP"
 		name = "A+REP"
-		command = ".west"
+		command = ".moveleft"
 		is-disabled = false
 	elem "HKMODE-CTRL+A+REP"
 		name = "CTRL+A+REP"
-		command = ".west"
+		command = ".moveleft"
 		is-disabled = false
 	elem "HKMODE-D+REP"
 		name = "D+REP"
-		command = ".east"
+		command = ".moveright"
 		is-disabled = false
 	elem "HKMODE-CTRL+D+REP"
 		name = "CTRL+D+REP"
-		command = ".east"
+		command = ".moveright"
 		is-disabled = false
 	elem "HKMODE-E"
 		name = "E"
@@ -343,11 +343,11 @@ macro "hotkeymode"
 		is-disabled = false
 	elem "s_key"
 		name = "S+REP"
-		command = ".south"
+		command = ".movedown"
 		is-disabled = false
 	elem "HKMODE-CTRL+S+REP"
 		name = "CTRL+S+REP"
-		command = ".south"
+		command = ".movedown"
 		is-disabled = false
 	elem "HKMODE-T"
 		name = "T"
@@ -355,11 +355,11 @@ macro "hotkeymode"
 		is-disabled = false
 	elem "w_key"
 		name = "W+REP"
-		command = ".north"
+		command = ".moveup"
 		is-disabled = false
 	elem "HKMODE-CTRL+W+REP"
 		name = "CTRL+W+REP"
-		command = ".north"
+		command = ".moveup"
 		is-disabled = false
 	elem "HKMODE-X"
 		name = "X"
@@ -440,7 +440,7 @@ macro "hotkeymode"
 
 
 menu "menu"
-	elem 
+	elem
 		name = "&File"
 		command = ""
 		category = ""
@@ -449,7 +449,7 @@ menu "menu"
 		group = ""
 		is-disabled = false
 		saved-params = "is-checked"
-	elem 
+	elem
 		name = "&Quick screenshot\tF2"
 		command = ".screenshot auto"
 		category = "&File"
@@ -458,7 +458,7 @@ menu "menu"
 		group = ""
 		is-disabled = false
 		saved-params = "is-checked"
-	elem 
+	elem
 		name = "&Save screenshot as...\tShift+F2"
 		command = ".screenshot"
 		category = "&File"
@@ -467,7 +467,7 @@ menu "menu"
 		group = ""
 		is-disabled = false
 		saved-params = "is-checked"
-	elem 
+	elem
 		name = ""
 		command = ""
 		category = "&File"
@@ -476,7 +476,7 @@ menu "menu"
 		group = ""
 		is-disabled = false
 		saved-params = "is-checked"
-	elem 
+	elem
 		name = "&Quit"
 		command = ".quit"
 		category = "&File"
@@ -485,7 +485,7 @@ menu "menu"
 		group = ""
 		is-disabled = false
 		saved-params = "is-checked"
-	elem 
+	elem
 		name = "&Icons"
 		command = ""
 		category = ""
@@ -521,7 +521,7 @@ menu "menu"
 		group = "size"
 		is-disabled = false
 		saved-params = "is-checked"
-	elem 
+	elem
 		name = ""
 		command = ""
 		category = "&Icons"
@@ -539,7 +539,7 @@ menu "menu"
 		group = ""
 		is-disabled = false
 		saved-params = "is-checked"
-	elem 
+	elem
 		name = "&Help"
 		command = ""
 		category = ""
@@ -548,7 +548,7 @@ menu "menu"
 		group = ""
 		is-disabled = false
 		saved-params = "is-checked"
-	elem 
+	elem
 		name = "&Admin help\tF1"
 		command = "adminhelp"
 		category = "&Help"
@@ -557,7 +557,7 @@ menu "menu"
 		group = ""
 		is-disabled = false
 		saved-params = "is-checked"
-	elem 
+	elem
 		name = "&Hotkeys"
 		command = "hotkeys-help"
 		category = "&Help"


### PR DESCRIPTION
В 511 бьёнде клиентам добавилась переменная `fps`. Влияя на неё, можно достичь смузи эффекта, при этом с низким значением фпс на самом сервере. (А любой кодер знает, что чем меньше фпс на сервере - тем быстрее он работает.) Ранее была проблема с перемещением, которая не позволяла эту фичу воплотить. Если не вдаваясь в технические нюансы, заключалась она в том, что из-за разницы фпс сервера и игрока появлялся рассинхрон и можно было отпустить кнопку ходьбы, но при этом пройти ещё несколько тайлов. В данном ПРе эта проблема убрана подсмотренным на ТГ способом (можете почитать в бьёнд референс про `instant` настройку, там это решение даже в качестве примера приводится).

Из преимуществ такого подхода: мы можем уменьшить фпс сервера, дав ему на обработку событий больше времени и увеличить фпс клиента, дав ему визуальный эффект плавности.
Из минусов: чем больше разница фпс - тем выше будет рассинхрон между тем, что игрок видит и тем, что происходит на самом деле.

Короче говоря, нужно посмотреть как всё это работает на живом сервере. На локалке с тиклагом 0.5 смузи получилось вполне себе достойным. 

Глайд сайз на 8, потому что рывки в перемещении на 25 фпс и на 40 чувствуются по-разному, да.

Из-за статического глайдсайза есть проблема с мобцами, которые двигаются быстро (госты, например, или байки пиратов) или медленно. **Я об этом знаю**. Если всё будет работать как и задумано, то можно будет придумать или подсмотреть с ВГ систему динамического глайдсайза. А пока что тест.

@volas **ТИКЛАГ НА 0.5, ЭТО ВАЖНО**

ps Сейчас на сервере 25 фпс. С 0.5 тиклага будет 20 фпс. Поэтому скорость событий (бега, например) может уменьшиться.

pps Да, теоретически можно поставить клиенту 60 фпс, а серверу 10, но нет, это плохая идея.