### PR TITLE
Фикс отсутствия Яна в админ ПП, орбите и фолоу, нерф пузерей, сообщение о заходе.

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -458,6 +458,8 @@ Turf and target are seperate in case you want to teleport some distance from a t
 		moblist.Add(M)
 	for(var/mob/living/carbon/slime/M in sortmob)
 		moblist.Add(M)
+	for(var/mob/living/carbon/ian/M in sortmob)
+		moblist.Add(M)
 	for(var/mob/living/simple_animal/M in sortmob)
 		moblist.Add(M)
 	for(var/mob/camera/M in sortmob)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -587,6 +587,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		break
 
 	if(phoron_dog)
+		message_admins("[src.ckey] joined the game as [phoron_dog] [ADMIN_JMP(phoron_dog)] [ADMIN_FLW(phoron_dog)].")
 		phoron_dog.ckey = src.ckey
 	else
 		to_chat(src, "<span class='notice'><B>Living and available Ian not found.</B></span>")

--- a/code/modules/mob/living/carbon/ian/ian.dm
+++ b/code/modules/mob/living/carbon/ian/ian.dm
@@ -243,9 +243,10 @@
 	addtimer(CALLBACK(src, .proc/pop), end_in + 3)
 
 /obj/effect/bubble_ian/proc/pop()
-	for(var/mob/living/carbon/C in view(1,src))
-		C.Stun(3)
-		C.Weaken(3)
+	if(prob(3)) // There is too many of them!
+		for(var/mob/living/carbon/C in view(1,src))
+			C.Stun(1)
+			C.Weaken(1)
 	playsound(src, 'sound/effects/bubble_pop.ogg', 50, 1)
 	underlays.Cut()
 	qdel(src)


### PR DESCRIPTION
* Добавил 3% шанс стану от пузырей и снизил длительность (было 100% и 3) - если и это не спасет ... (хотел выпилить вообще, но меня просили пересмотреть этот момент). Длительность там все равно огромная с одного мыла.
* Добавил сообщение админам информирующее о том, что кто-то зашел за Яна посредством вайтлистового прока.
* От прока sortmobs() зависит наличие кого либо в ПП, орбите и фолоу, имейте ввиду на будущее.