### PR TITLE
Увеличил силу химических взрывов и сделал отлетание кожуры банана или мыла при подскальзывании

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1168,7 +1168,7 @@ var/global/list/common_tools = list(
 		return 1
 	return 0
 
-proc/is_hot(obj/item/W)
+/proc/is_hot(obj/item/W)
 	switch(W.type)
 		if(/obj/item/weapon/weldingtool)
 			var/obj/item/weapon/weldingtool/WT = W

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -91,7 +91,7 @@
 
 /obj/machinery/atmospherics/unary/cryo_cell/container_resist(mob/user)
 	to_chat(user, "<span class='notice'>You struggle inside the cryotube, kicking the release with your foot... (This will take around 30 seconds.)</span>")
-	//audible_message("<span class='notice'>You hear a thump from [src].</span>")
+	audible_message("<span class='notice'>You hear a thump from [src].</span>")
 	if(do_after(user, 300, target = src))
 		if(occupant == user) // Check they're still here.
 			open_machine()
@@ -355,4 +355,3 @@
 
 /obj/machinery/atmospherics/unary/cryo_cell/can_crawl_through()
 	return //can't ventcrawl in or out of cryo.
-

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -725,26 +725,26 @@ steam.start() -- spawns the effect
 					M.Weaken(rand(1,5))
 			return
 		else
-			var/devastation = -1
-			var/heavy = -1
-			var/light = -1
-			var/flash = -1
+			var/devastation = 0
+			var/heavy = 0
+			var/light = 0
+			var/flash = 0
 
 			// Clamp all values to MAX_EXPLOSION_RANGE
 			if (round(amount/12) > 0)
-				devastation = min (MAX_EXPLOSION_RANGE, devastation + round(amount/12))
+				devastation = min (MAX_EXPLOSION_RANGE, round(amount/12))
 
 			if (round(amount/6) > 0)
-				heavy = min (MAX_EXPLOSION_RANGE, heavy + round(amount/6))
+				heavy = min (MAX_EXPLOSION_RANGE, round(amount/6))
 
 			if (round(amount/3) > 0)
-				light = min (MAX_EXPLOSION_RANGE, light + round(amount/3))
+				light = min (MAX_EXPLOSION_RANGE, round(amount/3))
 
 			if (flash && flashing_factor)
 				flash += (round(amount/4) * flashing_factor)
 
-			for(var/mob/M in viewers(8, location))
-				to_chat(M, "\red The solution violently explodes.")
+			for(var/mob/M in viewers(world.view, location))
+				to_chat(M, "<span class='red'>The solution violently explodes.</span>")
 
 			explosion(location, devastation, heavy, light, flash)
 

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -6,7 +6,7 @@
 	if(dx>=dy)	return dx + (0.5*dy)	//The longest side add half the shortest side approximates the hypotenuse
 	else		return dy + (0.5*dx)
 
-proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, adminlog = 1, z_transfer = 1)
+/proc/explosion(turf/epicenter, devastation_range, heavy_impact_range, light_impact_range, flash_range, adminlog = 1, z_transfer = 1)
 	set waitfor = 0
 	src = null	//so we don't abort once src is deleted
 

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -132,16 +132,16 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	if(!src.lit)
 		src.lit = 1
 		damtype = "fire"
-		if(reagents.get_reagent_amount("phoron")) // the phoron explodes when exposed to fire
+
+		if(reagents.get_reagent_amount("phoron") || reagents.get_reagent_amount("fuel")) // the phoron (fuel also) explodes when exposed to fire
 			var/datum/effect/effect/system/reagents_explosion/e = new()
-			e.set_up(round(reagents.get_reagent_amount("phoron") / 2.5, 1), get_turf(src), 0, 0)
+			var/exploding_reagents = round(reagents.get_reagent_amount("phoron") / 2.5 + reagents.get_reagent_amount("fuel") / 5, 1)
+			e.set_up(exploding_reagents, get_turf(src), 0, 0)
 			e.start()
-			qdel(src)
-			return
-		if(reagents.get_reagent_amount("fuel")) // the fuel explodes, too, but much less violently
-			var/datum/effect/effect/system/reagents_explosion/e = new()
-			e.set_up(round(reagents.get_reagent_amount("fuel") / 5, 1), get_turf(src), 0, 0)
-			e.start()
+			if(ishuman(loc))
+				var/mob/living/carbon/human/wearer = loc
+				if(wearer.wear_mask == src)
+					wearer.adjustBruteLossByPart(10 * exploding_reagents, "head")
 			qdel(src)
 			return
 		flags &= ~NOREACT // allowing reagents to react after being lit

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -5,35 +5,34 @@
  *		Bike Horns
  */
 
+/obj/item/weapon/proc/try_slip_on_me(mob/living/carbon/victim)
+	if(ishuman(victim))
+		var/mob/living/carbon/human/human_victim = victim
+		if(isobj(human_victim.shoes) && (human_victim.shoes.flags & NOSLIP))
+			return FALSE
+
+	victim.stop_pulling()
+	to_chat(victim, "<span class='notice'>You slipped on the [src]!</span>")
+	playsound(loc, 'sound/misc/slip.ogg', 50, 1, -3)
+	victim.Stun(4)
+	victim.Weaken(2)
+	return TRUE
+
 /*
  * Banana Peals
  */
 /obj/item/weapon/bananapeel/Crossed(AM as mob|obj)
-	if (istype(AM, /mob/living/carbon))
-		var/mob/M =	AM
-		if (istype(M, /mob/living/carbon/human) && (isobj(M:shoes) && M:shoes.flags&NOSLIP))
-			return
-
-		M.stop_pulling()
-		to_chat(M, "\blue You slipped on the [name]!")
-		playsound(src.loc, 'sound/misc/slip.ogg', 50, 1, -3)
-		M.Stun(4)
-		M.Weaken(2)
+	if(iscarbon(AM))
+		if(try_slip_on_me(AM))
+			Move(get_step(get_turf(src), pick(cardinal)))
 
 /*
  * Soap
  */
 /obj/item/weapon/soap/Crossed(AM as mob|obj) //EXACTLY the same as bananapeel for now, so it makes sense to put it in the same dm -- Urist
-	if (istype(AM, /mob/living/carbon))
-		var/mob/M =	AM
-		if (istype(M, /mob/living/carbon/human) && ( (isobj(M:shoes) && M:shoes.flags&NOSLIP)) || ((istype(M:wear_suit, /obj/item/clothing/suit/space/rig) && M:wear_suit.flags&NOSLIP)) )
-			return
-
-		M.stop_pulling()
-		to_chat(M, "\blue You slipped on the [name]!")
-		playsound(src.loc, 'sound/misc/slip.ogg', 50, 1, -3)
-		M.Stun(3)
-		M.Weaken(2)
+	if(iscarbon(AM))
+		if(try_slip_on_me(AM))
+			Move(get_step(get_turf(src), pick(cardinal)))
 
 /obj/item/weapon/soap/afterattack(atom/target, mob/user, proximity)
 	if(!proximity) return
@@ -51,7 +50,7 @@
 
 /obj/item/weapon/soap/attack(mob/target, mob/user)
 	if(target && user && ishuman(target) && ishuman(user) && !target.stat && !user.stat && user.zone_sel &&user.zone_sel.selecting == "mouth" )
-		user.visible_message("\red \the [user] washes \the [target]'s mouth out with soap!")
+		user.visible_message("<span class='red'>\the [user] washes \the [target]'s mouth out with soap!</span>")
 		return
 	..()
 

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -5,34 +5,32 @@
  *		Bike Horns
  */
 
-/obj/item/weapon/proc/try_slip_on_me(mob/living/carbon/victim)
+/obj/item/weapon/proc/slip_on_me(mob/living/carbon/victim)
 	if(ishuman(victim))
 		var/mob/living/carbon/human/human_victim = victim
 		if(isobj(human_victim.shoes) && (human_victim.shoes.flags & NOSLIP))
-			return FALSE
+			return
 
 	victim.stop_pulling()
 	to_chat(victim, "<span class='notice'>You slipped on the [src]!</span>")
 	playsound(loc, 'sound/misc/slip.ogg', 50, 1, -3)
 	victim.Stun(4)
 	victim.Weaken(2)
-	return TRUE
+	Move(get_step(get_turf(src), pick(cardinal)))
 
 /*
  * Banana Peals
  */
 /obj/item/weapon/bananapeel/Crossed(AM as mob|obj)
 	if(iscarbon(AM))
-		if(try_slip_on_me(AM))
-			Move(get_step(get_turf(src), pick(cardinal)))
+		slip_on_me(AM)
 
 /*
  * Soap
  */
 /obj/item/weapon/soap/Crossed(AM as mob|obj) //EXACTLY the same as bananapeel for now, so it makes sense to put it in the same dm -- Urist
 	if(iscarbon(AM))
-		if(try_slip_on_me(AM))
-			Move(get_step(get_turf(src), pick(cardinal)))
+		slip_on_me(AM)
 
 /obj/item/weapon/soap/afterattack(atom/target, mob/user, proximity)
 	if(!proximity) return


### PR DESCRIPTION
В чём проблема со взрывами: в некоторых случаях они просто не происходили. Пример: закачиваем в сигарету 15 едениц форона поджигаем и... её нет.
Причина этого в том, что при низком количестве реагентов в прок взрыва попадают отрицательные числа, из-за которых взрыв не происходит.

Мыло: по сути фикс вечного таскания на мыле. Теперь если на нём кто-то подскользнётся, то оно (мыло) отлетит в случайную сторону.

Из другого - добавил пару слешей и раскомментировал прок, который сообщал всем в зоне слышимости криокапсулы, что из неё пытается кто-то выбраться

UPD: побочный эффект изменения взрывов - граната 100 воды * 100 калия выглядит теперь так
![screenshot_20](https://cloud.githubusercontent.com/assets/11941910/23959249/5da54004-09ad-11e7-8c9b-f6d1863d0d5a.png)

UPD2: также баффнул взрыв сигареты во рту. (максимум 60 урона, если сигарету полностью закачать уроном; урон идёт на голову)

fixes #280