### PR TITLE
Фикс и небольшой рефактор ЕД-ботов, убирание спама при стрельбе ботов и турелей

### DIFF
--- a/code/datums/spells/conjure.dm
+++ b/code/datums/spells/conjure.dm
@@ -3,7 +3,7 @@
 	desc = "This spell conjures objs of the specified types in range."
 
 	var/list/summon_type = list() //determines what exactly will be summoned
-	//should be text, like list("/obj/machinery/bot/ed209")
+	//should be text, like list("/obj/machinery/bot/secbot/ed209")
 
 	var/summon_lifespan = 0 // 0=permanent, any other time in deciseconds
 	var/summon_amt = 1 //amount of objects summoned
@@ -58,7 +58,7 @@
 	name = "Dispense Wizard Justice"
 	desc = "This spell dispenses wizard justice."
 
-	summon_type = list(/obj/machinery/bot/ed209)
+	summon_type = list(/obj/machinery/bot/secbot/ed209)
 	summon_amt = 10
 	range = 3
 	newVars = list("emagged" = 1,"name" = "Wizard's Justicebot")

--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -3,12 +3,13 @@
 	desc = "A security robot.  He looks less than thrilled."
 	icon = 'icons/obj/aibots.dmi'
 	icon_state = "ed2090"
+	icon_state_arrest = "ed209-c"
 	health = 100
 	maxhealth = 100
 
 	var/lastfired = 0
 	var/shot_delay = 3 //.3 seconds between shots
-	var/lasercolor = ""
+
 	var/disabled = 0//A holder for if it needs to be disabled, if true it will not seach for targets, shoot at targets, or move, currently only used for lasertag
 	idcheck = 1 //If false, all station IDs are authorized for weapons.
 	check_records = 1 //Does it check security records? Checks arrest status and existence of record

--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -1,39 +1,19 @@
-/obj/machinery/bot/ed209
+/obj/machinery/bot/secbot/ed209
 	name = "ED-209 Security Robot"
 	desc = "A security robot.  He looks less than thrilled."
 	icon = 'icons/obj/aibots.dmi'
 	icon_state = "ed2090"
-	layer = 5.0
-	density = 0
-	anchored = 0
-//	weight = 1.0E7
-	req_one_access = list(access_security, access_forensics_lockers)
 	health = 100
 	maxhealth = 100
-	fire_dam_coeff = 0.7
-	brute_dam_coeff = 0.5
 
 	var/lastfired = 0
 	var/shot_delay = 3 //.3 seconds between shots
 	var/lasercolor = ""
 	var/disabled = 0//A holder for if it needs to be disabled, if true it will not seach for targets, shoot at targets, or move, currently only used for lasertag
-
-	//var/lasers = 0
-
-	var/mob/living/carbon/target
-	var/oldtarget_name
-	var/threatlevel = 0
-	var/target_lastloc //Loc of target when arrested.
-	var/last_found //There's a delay
-	var/frustration = 0
-//var/emagged = 0 //Emagged Secbots view everyone as a criminal
-	var/idcheck = 1 //If false, all station IDs are authorized for weapons.
-	var/check_records = 1 //Does it check security records? Checks arrest status and existence of record
-	var/arrest_type = 0 //If true, don't handcuff
-	var/declare_arrests = 1 //When making an arrest, should it notify everyone wearing sechuds?
+	idcheck = 1 //If false, all station IDs are authorized for weapons.
+	check_records = 1 //Does it check security records? Checks arrest status and existence of record
 	var/projectile = null//Holder for projectile type, to avoid so many else if chains
 
-	var/mode = 0
 #define SECBOT_IDLE 		0		// idle
 #define SECBOT_HUNT 		1		// found target, hunting
 #define SECBOT_PREP_ARREST 	2		// at target, preparing to arrest
@@ -41,24 +21,6 @@
 #define SECBOT_START_PATROL	4		// start patrol
 #define SECBOT_PATROL		5		// patrolling
 #define SECBOT_SUMMON		6		// summoned by PDA
-
-	var/auto_patrol = 0		// set to make bot automatically patrol
-
-	var/beacon_freq = 1445		// navigation beacon frequency
-	var/control_freq = 1447		// bot control frequency
-
-
-	var/turf/patrol_target	// this is turf to navigate to (location of beacon)
-	var/new_destination		// pending new destination (waiting for beacon response)
-	var/destination			// destination description tag
-	var/next_destination	// the next destination in the patrol route
-	var/list/path = new				// list of path turfs
-
-	var/blockcount = 0		//number of times retried a blocked path
-	var/awaiting_beacon	= 0	// count of pticks awaiting a beacon response
-
-	var/nearest_beacon			// the nearest beacon's tag
-	var/turf/nearest_beacon_loc	// the nearest beacon's location
 
 
 /obj/item/weapon/ed209_assembly
@@ -72,55 +34,40 @@
 	var/lasercolor = ""
 
 
-/obj/machinery/bot/ed209/New(loc,created_name,created_lasercolor)
+/obj/machinery/bot/secbot/ed209/New(loc,created_name,created_lasercolor)
 	..()
 	if(created_name)
 		name = created_name
 	if(created_lasercolor)
 		lasercolor = created_lasercolor
-	update_icon()
+		update_icon()
+
 	if(lasercolor)
 		shot_delay = 6		//Longer shot delay because JESUS CHRIST
 		check_records = 0	//Don't actively target people set to arrest
 		arrest_type = 1		//Don't even try to cuff
+		req_one_access.Cut()
 		req_access = list(access_maint_tunnels)
 		arrest_type = 1
 		if((lasercolor == "b") && (name == "ED-209 Security Robot"))//Picks a name if there isn't already a custome one
 			name = pick("BLUE BALLER","SANIC","BLUE KILLDEATH MURDERBOT")
 		if((lasercolor == "r") && (name == "ED-209 Security Robot"))
 			name = pick("RED RAMPAGE","RED ROVER","RED KILLDEATH MURDERBOT")
-	addtimer(CALLBACK(src, .proc/post_creation), 3)
 
 
-/obj/machinery/bot/ed209/proc/post_creation()
-	botcard = new /obj/item/weapon/card/id(src)
-	var/datum/job/detective/J = new/datum/job/detective
-	botcard.access = J.get_access()
-
-	if(radio_controller)
-		radio_controller.add_object(src, control_freq, filter = RADIO_SECBOT)
-		radio_controller.add_object(src, beacon_freq, filter = RADIO_NAVBEACONS)
-
-/obj/machinery/bot/ed209/turn_on()
-	. = ..()
-	mode = SECBOT_IDLE
-	update_icon()
-	updateUsrDialog()
-
-/obj/machinery/bot/ed209/update_icon()
+/obj/machinery/bot/secbot/ed209/update_icon()
 	icon_state = "[lasercolor]ed209[on]"
 
-/obj/machinery/bot/ed209/turn_off()
-	..()
-	target = null
-	oldtarget_name = null
-	anchored = 0
-	mode = SECBOT_IDLE
-	walk_to(src,0)
-	update_icon()
-	updateUsrDialog()
+/obj/machinery/bot/secbot/ed209/is_operational_topic()
+	if(lasercolor && ishuman(usr))
+		var/mob/living/carbon/human/H = usr
+		if((lasercolor == "b") && istype(H.wear_suit, /obj/item/clothing/suit/redtag))//Opposing team cannot operate it
+			return FALSE
+		else if((lasercolor == "r") && istype(H.wear_suit, /obj/item/clothing/suit/bluetag))
+			return FALSE
+	return TRUE
 
-/obj/machinery/bot/ed209/attack_hand(mob/user)
+/obj/machinery/bot/secbot/ed209/attack_hand(mob/user)
 	. = ..()
 	if(.)
 		return
@@ -157,76 +104,21 @@ Auto Patrol: []"},
 	onclose(user, "autosec")
 	return
 
-/obj/machinery/bot/ed209/Topic(href, href_list)
-	. = ..()
-	if(!.)
-		return
 
-	if(lasercolor && ishuman(usr))
-		var/mob/living/carbon/human/H = usr
-		if((lasercolor == "b") && istype(H.wear_suit, /obj/item/clothing/suit/redtag))//Opposing team cannot operate it
-			return FALSE
-		else if((lasercolor == "r") && istype(H.wear_suit, /obj/item/clothing/suit/bluetag))
-			return FALSE
-	if(href_list["power"] && allowed(usr))
-		if(on)
-			turn_off()
-		else
-			turn_on()
+/obj/machinery/bot/secbot/ed209/beingAttacked(obj/item/weapon/W, mob/user)
+	if(!istype(W, /obj/item/weapon/screwdriver) && W.force && !target)
+		target = user
+		mode = SECBOT_HUNT
+		if(lasercolor)//To make up for the fact that lasertag bots don't hunt
+			shootAt(user)
 
-	switch(href_list["operation"])
-		if("idcheck")
-			idcheck = !idcheck
-		if("ignorerec")
-			check_records = !check_records
-		if("switchmode")
-			arrest_type = !arrest_type
-		if("patrol")
-			auto_patrol = !auto_patrol
-			mode = SECBOT_IDLE
-		if("declarearrests")
-			declare_arrests = !declare_arrests
-	updateUsrDialog()
 
-/obj/machinery/bot/ed209/attackby(obj/item/weapon/W, mob/user)
-	if(istype(W, /obj/item/weapon/card/id) || istype(W, /obj/item/device/pda))
-		if(emagged)
-			to_chat(user, "<span class='warning'>ERROR</span>")
-		else if(open)
-			to_chat(user, "<span class='warning'>Please close the access panel before locking it.</span>")
-		else if(allowed(user))
-			locked = !locked
-			to_chat(user, "<span class='notice'>Controls are now [locked ? "locked" : "unlocked"].</span>")
-		else
-			to_chat(user, "<span class='notice'>Access denied.</span>")
-	else
-		..()
-		if(!istype(W, /obj/item/weapon/screwdriver) && W.force && !target)
-			target = user
-			if(lasercolor)//To make up for the fact that lasertag bots don't hunt
-				shootAt(user)
-			mode = SECBOT_HUNT
-
-/obj/machinery/bot/ed209/Emag(mob/user)
+/obj/machinery/bot/secbot/ed209/Emag(mob/user)
 	..()
 	if(open && !locked)
-		if(user)
-			to_chat(user, "<span class='warning'>You short out [src]'s target assessment circuits.</span>")
-		audible_message("<span class='userdanger'><B>[src] buzzes oddly!</span>")
-		target = null
-		if(user)
-			oldtarget_name = user.name
-		last_found = world.time
-		anchored = 0
-		emagged = 2
-		on = 1
 		projectile = null
-		mode = SECBOT_IDLE
-		update_icon()
 
-/obj/machinery/bot/ed209/process()
-	//set background = 1
-
+/obj/machinery/bot/secbot/ed209/process()
 	if(!on)
 		return
 
@@ -251,160 +143,15 @@ Auto Patrol: []"},
 			//speak("selected target: " + t.real_name)
 			shootAt(t)
 
-	switch(mode)
-		if(SECBOT_IDLE)		// idle
-			walk_to(src, 0)
-			look_for_perp()	// see if any criminals are in range
-			if(!mode && auto_patrol)	// still idle, and set to patrol
-				mode = SECBOT_START_PATROL	// switch to patrol mode
+	if((mode == SECBOT_HUNT || mode == SECBOT_PREP_ARREST) && lasercolor) //Lasertag bots do not tase or arrest anyone, just patrol and shoot and whatnot
+		mode = SECBOT_IDLE
+		return
 
-		if(SECBOT_HUNT)		// hunting for perp
-			if(lasercolor)//Lasertag bots do not tase or arrest anyone, just patrol and shoot and whatnot
-				mode = SECBOT_IDLE
-				return
-			// if can't reach perp for long enough, go idle
-			if(frustration >= 8)
-		//		for(var/mob/O in hearers(src, null))
-		//			O << "<span class='game say'><span class='name'>[src]</span> beeps, \"Backup requested! Suspect has evaded arrest.\""
-				target = null
-				last_found = world.time
-				frustration = 0
-				mode = 0
-				walk_to(src,0)
-
-			if(target)		// make sure target exists
-				if(Adjacent(target))		// if right next to perp
-					playsound(loc, 'sound/weapons/Egloves.ogg', 50, 1, -1)
-					icon_state = "[lasercolor]ed209-c"
-					addtimer(CALLBACK(src, .proc/update_icon), 2)
-					var/mob/living/carbon/M = target
-					var/maxstuns = 4
-					if(M.stuttering < 10 && !(HULK in M.mutations))
-						M.stuttering = 10
-					M.Stun(10)
-					M.Weaken(10)
-					maxstuns--
-					if(maxstuns <= 0)
-						target = null
-
-					if(declare_arrests)
-						var/area/location = get_area(src)
-						broadcast_security_hud_message("[name] is [arrest_type ? "detaining" : "arresting"] level [threatlevel] suspect <b>[target]</b> in <b>[location]</b>", src)
-					visible_message("\red <B>[target] has been stunned by [src]!</B>")
-
-					mode = SECBOT_PREP_ARREST
-					anchored = 1
-					target_lastloc = M.loc
-					return
-
-				else								// not next to perp
-					var/turf/olddist = get_dist(src, target)
-					walk_to(src, target, 1, 4)
-					if(get_dist(src, target) >= olddist)
-						frustration++
-					else
-						frustration = 0
-
-		if(SECBOT_PREP_ARREST)		// preparing to arrest target
-			if(lasercolor)
-				mode = SECBOT_IDLE
-				return
-			if(!target)
-				mode = SECBOT_IDLE
-				anchored = 0
-				return
-			// see if he got away
-			if((get_dist(src, target) > 1) || (target.loc != target_lastloc) && (target.weakened < 2))
-				anchored = 0
-				mode = SECBOT_HUNT
-				return
-
-			if(iscarbon(target))
-				if(!target.handcuffed && !arrest_type)
-					playsound(loc, 'sound/weapons/handcuffs.ogg', 30, 1, -2)
-					mode = SECBOT_ARREST
-					visible_message("\red <B>[src] is trying to put handcuffs on [target]!</B>")
-					addtimer(CALLBACK(src, .proc/subprocess, mode), 60)
-
-
-		//					playsound(loc, pick('sound/voice/bgod.ogg', 'sound/voice/biamthelaw.ogg', 'sound/voice/bsecureday.ogg', 'sound/voice/bradio.ogg', 'sound/voice/binsult.ogg', 'sound/voice/bcreep.ogg'), 50, 0)
-		//					var/arrest_message = pick("Have a secure day!","I AM THE LAW.", "God made tomorrow for the crooks we don't catch today.","You can't outrun a radio.")
-		//					speak(arrest_message)
-			else
-				mode = SECBOT_IDLE
-				target = null
-				anchored = 0
-				last_found = world.time
-				frustration = 0
-
-		if(SECBOT_ARREST)		// arresting
-			if(lasercolor)
-				mode = SECBOT_IDLE
-				return
-			if(!target || target.handcuffed)
-				anchored = 0
-				mode = SECBOT_IDLE
-				return
-
-
-		if(SECBOT_START_PATROL)	// start a patrol
-			if(path.len > 0 && patrol_target)	// have a valid path, so just resume
-				mode = SECBOT_PATROL
-				return
-
-			else if(patrol_target)		// has patrol target already
-				INVOKE_ASYNC(src, .proc/subprocess, mode)
-
-			else					// no patrol target, so need a new one
-				find_patrol_target()
-				speak("Engaging patrol mode.")
-
-
-		if(SECBOT_PATROL)		// patrol mode
-			patrol_step()
-			addtimer(CALLBACK(src, .proc/subprocess, mode), 5)
-
-		if(SECBOT_SUMMON)		// summoned to PDA
-			patrol_step()
-			addtimer(CALLBACK(src, .proc/subprocess, mode), 4)
-			addtimer(CALLBACK(src, .proc/subprocess, mode), 8)
-
-/obj/machinery/bot/ed209/proc/subprocess(oldmode)
-	switch(oldmode)
-		if(SECBOT_PREP_ARREST)
-			if(get_dist(src, target) <= 1)
-				if(target.handcuffed)
-					return
-
-				if(iscarbon(target))
-					target.handcuffed = new /obj/item/weapon/handcuffs(target)
-					target.update_inv_handcuffed()	//update handcuff overlays
-
-				mode = SECBOT_IDLE
-				target = null
-				anchored = 0
-				last_found = world.time
-				frustration = 0
-
-		if(SECBOT_START_PATROL)
-			calc_path()		// so just find a route to it
-			if(path.len == 0)
-				patrol_target = 0
-				return
-			mode = SECBOT_PATROL
-
-		if(SECBOT_PATROL)
-			if(mode == SECBOT_PATROL)
-				patrol_step()
-
-		if(SECBOT_SUMMON)
-			if(mode == SECBOT_SUMMON)
-				patrol_step()
+	..()
 
 // perform a single patrol step
 
-/obj/machinery/bot/ed209/proc/patrol_step()
-
+/obj/machinery/bot/secbot/ed209/patrol_step()
 	if(loc == patrol_target)		// reached target
 		at_patrol_target()
 		return
@@ -436,184 +183,11 @@ Auto Patrol: []"},
 	else	// no path, so calculate new one
 		mode = SECBOT_START_PATROL
 
-/obj/machinery/bot/ed209/proc/patrol_substep(turf/next)
-	calc_path(next)
-	if(path.len == 0)
-		find_patrol_target()
-	else
-		blockcount = 0
-
-
-// finds a new patrol target
-/obj/machinery/bot/ed209/proc/find_patrol_target()
-	send_status()
-	if(awaiting_beacon)			// awaiting beacon response
-		awaiting_beacon++
-		if(awaiting_beacon > 5)	// wait 5 secs for beacon response
-			find_nearest_beacon()	// then go to nearest instead
-		return
-
-	if(next_destination)
-		set_destination(next_destination)
-	else
-		find_nearest_beacon()
-
-
-// finds the nearest beacon to self
-// signals all beacons matching the patrol code
-/obj/machinery/bot/ed209/proc/find_nearest_beacon()
-	nearest_beacon = null
-	new_destination = "__nearest__"
-	post_signal(beacon_freq, "findbeacon", "patrol")
-	awaiting_beacon = 1
-	addtimer(CALLBACK(src, .proc/find_nearest_beacon_substep), 10)
-
-/obj/machinery/bot/ed209/proc/find_nearest_beacon_substep()
-	awaiting_beacon = 0
-	if(nearest_beacon)
-		set_destination(nearest_beacon)
-	else
-		auto_patrol = 0
-		mode = SECBOT_IDLE
-		speak("Disengaging patrol mode.")
-		send_status()
-
-
-/obj/machinery/bot/ed209/proc/at_patrol_target()
-	find_patrol_target()
-
-
-// sets the current destination
-// signals all beacons matching the patrol code
-// beacons will return a signal giving their locations
-/obj/machinery/bot/ed209/proc/set_destination(new_dest)
-	new_destination = new_dest
-	post_signal(beacon_freq, "findbeacon", "patrol")
-	awaiting_beacon = 1
-
-
-// receive a radio signal
-// used for beacon reception
-
-/obj/machinery/bot/ed209/receive_signal(datum/signal/signal)
-	if(!on)
-		return
-
-	/*
-	to_chat(world, "rec signal: [signal.source]")
-	for(var/x in signal.data)
-		to_chat(world, "* [x] = [signal.data[x]]")
-	*/
-
-	var/recv = signal.data["command"]
-	// process all-bot input
-	if(recv=="bot_status")
-		send_status()
-
-	// check to see if we are the commanded bot
-	if(signal.data["active"] == src)
-	// process control input
-		switch(recv)
-			if("stop")
-				mode = SECBOT_IDLE
-				auto_patrol = 0
-				return
-
-			if("go")
-				mode = SECBOT_IDLE
-				auto_patrol = 1
-				return
-
-			if("summon")
-				patrol_target = signal.data["target"]
-				next_destination = destination
-				destination = null
-				awaiting_beacon = 0
-				mode = SECBOT_SUMMON
-				calc_path()
-				speak("Responding.")
-				return
-
-
-
-	// receive response from beacon
-	recv = signal.data["beacon"]
-	var/valid = signal.data["patrol"]
-	if(!recv || !valid)
-		return
-
-	if(recv == new_destination)	// if the recvd beacon location matches the set destination
-								// the we will navigate there
-		destination = new_destination
-		patrol_target = signal.source.loc
-		next_destination = signal.data["next_patrol"]
-		awaiting_beacon = 0
-
-	// if looking for nearest beacon
-	else if(new_destination == "__nearest__")
-		var/dist = get_dist(src,signal.source.loc)
-		if(nearest_beacon)
-
-			// note we ignore the beacon we are located at
-			if(dist > 1 && dist < get_dist(src, nearest_beacon_loc))
-				nearest_beacon = recv
-				nearest_beacon_loc = signal.source.loc
-				return
-			else
-				return
-		else if(dist > 1)
-			nearest_beacon = recv
-			nearest_beacon_loc = signal.source.loc
-
-
-// send a radio signal with a single data key/value pair
-/obj/machinery/bot/ed209/proc/post_signal(freq, key, value)
-	post_signal_multiple(freq, list("[key]" = value) )
-
-// send a radio signal with multiple data key/values
-/obj/machinery/bot/ed209/proc/post_signal_multiple(freq, list/keyval)
-	var/datum/radio_frequency/frequency = radio_controller.return_frequency(freq)
-
-	if(!frequency)
-		return
-
-	var/datum/signal/signal = new()
-	signal.source = src
-	signal.transmission_method = 1
-	//for(var/key in keyval)
-	//	signal.data[key] = keyval[key]
-		//world << "sent [key],[keyval[key]] on [freq]"
-	signal.data = keyval
-	if(signal.data["findbeacon"])
-		frequency.post_signal(src, signal, filter = RADIO_NAVBEACONS)
-	else if(signal.data["type"] == "secbot")
-		frequency.post_signal(src, signal, filter = RADIO_SECBOT)
-	else
-		frequency.post_signal(src, signal)
-
-// signals bot status etc. to controller
-/obj/machinery/bot/ed209/proc/send_status()
-	var/list/kv = list(
-		"type" = "secbot",
-		"name" = name,
-		"loca" = loc.loc,	// area
-		"mode" = mode,
-	)
-	post_signal_multiple(control_freq, kv)
-
-
-
-// calculates a path to the current destination
-// given an optional turf to avoid
-/obj/machinery/bot/ed209/proc/calc_path(turf/avoid = null)
-	path = AStar(loc, patrol_target, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 120, id=botcard, exclude=avoid)
-	if(!path)
-		path = list()
 
 
 // look for a criminal in view of the bot
 
-/obj/machinery/bot/ed209/proc/look_for_perp()
+/obj/machinery/bot/secbot/ed209/look_for_perp()
 	if(disabled)
 		return
 	anchored = 0
@@ -646,16 +220,8 @@ Auto Patrol: []"},
 
 //If the security records say to arrest them, arrest them
 //Or if they have weapons and aren't security, arrest them.
-/obj/machinery/bot/ed209/proc/assess_perp(mob/living/carbon/perp)
-	var/threatcount = 0
-
-	if(!istype(perp))
-		return 0
-
-	if(emagged == 2)
-		return 10 //Everyone is a criminal!
-
-	threatcount = perp.assess_perp(src, FALSE, idcheck, FALSE, check_records)
+/obj/machinery/bot/secbot/ed209/assess_perp(mob/living/carbon/perp)
+	var/threatcount = ..()
 
 	if(lasercolor && ishuman(perp))
 		var/mob/living/carbon/human/hperp = perp
@@ -682,20 +248,7 @@ Auto Patrol: []"},
 
 	return threatcount
 
-/obj/machinery/bot/ed209/Bump(atom/M) //Leave no door unopened!
-	if(istype(M, /obj/machinery/door) && !isnull(botcard))
-		var/obj/machinery/door/D = M
-		if(!istype(D, /obj/machinery/door/firedoor) && D.check_access(botcard) && !istype(D,/obj/machinery/door/poddoor))
-			D.open()
-			frustration = 0
-	else if(!anchored && isliving(M))
-		loc = M.loc
-		frustration = 0
-
-/obj/machinery/bot/ed209/proc/speak(message)
-	audible_message("<span class='name'>[src]</span> beeps, \"[message]\"")
-
-/obj/machinery/bot/ed209/explode()
+/obj/machinery/bot/secbot/ed209/explode()
 	walk_to(src, 0)
 	visible_message("\red <B>[src] blows apart!</B>", 1)
 	var/turf/Tsec = get_turf(src)
@@ -739,7 +292,7 @@ Auto Patrol: []"},
 	qdel(src)
 
 
-/obj/machinery/bot/ed209/proc/shootAt(mob/target)
+/obj/machinery/bot/secbot/ed209/proc/shootAt(mob/target)
 	if(lastfired && world.time - lastfired < shot_delay)
 		return
 	lastfired = world.time
@@ -772,18 +325,19 @@ Auto Patrol: []"},
 	A.original = target
 	A.current = T
 	A.starting = T
+	A.fake = TRUE
 	A.yo = U.y - T.y
 	A.xo = U.x - T.x
 	A.process()
 
-/obj/machinery/bot/ed209/attack_alien(mob/living/carbon/alien/user)
+/obj/machinery/bot/secbot/ed209/attack_alien(mob/living/carbon/alien/user)
 	..()
 	if(!isalien(target))
 		target = user
 		mode = SECBOT_HUNT
 
 
-/obj/machinery/bot/ed209/emp_act(severity)
+/obj/machinery/bot/secbot/ed209/emp_act(severity)
 	if(severity == 2 && prob(70))
 		..(severity - 1)
 	else
@@ -935,14 +489,14 @@ Auto Patrol: []"},
 				build_step++
 				to_chat(user, "<span class='notice'>You complete the ED-209.</span>")
 				var/turf/T = get_turf(src)
-				new /obj/machinery/bot/ed209(T, created_name, lasercolor)
+				new /obj/machinery/bot/secbot/ed209(T, created_name, lasercolor)
 				user.drop_item()
 				qdel(W)
 				user.drop_from_inventory(src)
 				qdel(src)
 
 
-/obj/machinery/bot/ed209/bullet_act(obj/item/projectile/Proj)
+/obj/machinery/bot/secbot/ed209/bullet_act(obj/item/projectile/Proj)
 	if(!disabled && ((lasercolor == "b") && istype(Proj, /obj/item/projectile/beam/lastertag/red) \
 				|| (lasercolor == "r") && istype(Proj, /obj/item/projectile/beam/lastertag/blue)))
 		disabled = 1
@@ -950,13 +504,13 @@ Auto Patrol: []"},
 		addtimer(CALLBACK(src, .proc/enable), 100)
 	..()
 
-/obj/machinery/bot/ed209/proc/enable()
+/obj/machinery/bot/secbot/ed209/proc/enable()
 	disabled = 0
 
-/obj/machinery/bot/ed209/bluetag/New()//If desired, you spawn red and bluetag bots easily
-	new /obj/machinery/bot/ed209(get_turf(src), null, "b")
+/obj/machinery/bot/secbot/ed209/bluetag/New()//If desired, you spawn red and bluetag bots easily
+	new /obj/machinery/bot/secbot/ed209(get_turf(src), null, "b")
 	qdel(src)
 
-/obj/machinery/bot/ed209/redtag/New()
-	new /obj/machinery/bot/ed209(get_turf(src), null, "r")
+/obj/machinery/bot/secbot/ed209/redtag/New()
+	new /obj/machinery/bot/secbot/ed209(get_turf(src), null, "r")
 	qdel(src)

--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -12,7 +12,7 @@
 	brute_dam_coeff = 0.5
 
 	req_one_access = list(access_security, access_forensics_lockers)
-	var/mob/living/carbon/target
+	var/mob/living/target
 	var/oldtarget_name
 	var/threatlevel = 0
 	var/target_lastloc //Loc of target when arrested.
@@ -118,10 +118,10 @@
 	dat += text({"
 <TT><B>Automatic Security Unit v1.3</B></TT><BR><BR>
 Status: []<BR>
-Behaviour controls are [src.locked ? "locked" : "unlocked"]<BR>
-Maintenance panel panel is [src.open ? "opened" : "closed"]"},
+Behaviour controls are [locked ? "locked" : "unlocked"]<BR>
+Maintenance panel panel is [open ? "opened" : "closed"]"},
 
-"<A href='?src=\ref[src];power=1'>[src.on ? "On" : "Off"]</A>" )
+"<A href='?src=\ref[src];power=1'>[on ? "On" : "Off"]</A>" )
 
 	if(!locked || issilicon(user))
 		dat += text({"<BR>
@@ -131,10 +131,10 @@ Operating Mode: []<BR>
 Report Arrests: []<BR>
 Auto Patrol: []"},
 
-"<A href='?src=\ref[src];operation=idcheck'>[src.idcheck ? "Yes" : "No"]</A>",
-"<A href='?src=\ref[src];operation=ignorerec'>[src.check_records ? "Yes" : "No"]</A>",
-"<A href='?src=\ref[src];operation=switchmode'>[src.arrest_type ? "Detain" : "Arrest"]</A>",
-"<A href='?src=\ref[src];operation=declarearrests'>[src.declare_arrests ? "Yes" : "No"]</A>",
+"<A href='?src=\ref[src];operation=idcheck'>[idcheck ? "Yes" : "No"]</A>",
+"<A href='?src=\ref[src];operation=ignorerec'>[check_records ? "Yes" : "No"]</A>",
+"<A href='?src=\ref[src];operation=switchmode'>[arrest_type ? "Detain" : "Arrest"]</A>",
+"<A href='?src=\ref[src];operation=declarearrests'>[declare_arrests ? "Yes" : "No"]</A>",
 "<A href='?src=\ref[src];operation=patrol'>[auto_patrol ? "On" : "Off"]</A>" )
 
 
@@ -190,6 +190,14 @@ Auto Patrol: []"},
 		target = user
 		mode = SECBOT_HUNT
 
+/obj/machinery/bot/secbot/proc/forgetCurrentTarget()
+	target = null
+	last_found = world.time
+	mode = SECBOT_IDLE
+	walk_to(src, 0)
+	frustration = 0
+	anchored = FALSE
+
 /obj/machinery/bot/secbot/Emag(mob/user)
 	..()
 	if(open && !locked)
@@ -230,13 +238,7 @@ Auto Patrol: []"},
 		if(SECBOT_HUNT)		// hunting for perp
 			// if can't reach perp for long enough, go idle
 			if(frustration >= 8)
-		//		for(var/mob/O in hearers(src, null))
-		//			O << "<span class='game say'><span class='name'>[src]</span> beeps, \"Backup requested! Suspect has evaded arrest.\""
-				target = null
-				last_found = world.time
-				frustration = 0
-				mode = 0
-				walk_to(src, 0)
+				forgetCurrentTarget()
 
 			if(target)		// make sure target exists
 				if(Adjacent(target))		// if right next to perp
@@ -256,28 +258,27 @@ Auto Patrol: []"},
 
 						if(declare_arrests)
 							var/area/location = get_area(src)
-							broadcast_security_hud_message("[src.name] is [arrest_type ? "detaining" : "arresting"] level [threatlevel] suspect <b>[target]</b> in <b>[location]</b>", src)
-						visible_message("\red <B>[src.target] has been stunned by [src]!</B>")
+							broadcast_security_hud_message("[name] is [arrest_type ? "detaining" : "arresting"] level [threatlevel] suspect <b>[target]</b> in <b>[location]</b>", src)
+						visible_message("<span class='danger'>[target] has been stunned by [src]!</span>")
 
 						mode = SECBOT_PREP_ARREST
 						anchored = 1
 						target_lastloc = M.loc
 						return
 
-					else if(istype(target, /mob/living/simple_animal))
+					else
 						//just harmbaton them until dead
 						if(world.time > next_harm_time)
 							next_harm_time = world.time + 15
 							playsound(loc, 'sound/weapons/Egloves.ogg', 50, 1, -1)
-							visible_message("\red <B>[src] beats [src.target] with the stun baton!</B>")
+							visible_message("<span class='danger'>[src] beats [target] with the stun baton!</span>")
 							icon_state = "secbot-c"
 							addtimer(CALLBACK(src, .proc/update_icon), 2)
-							var/mob/living/simple_animal/S = target
-							S.AdjustStunned(10)
-							S.adjustBruteLoss(15)
-							if(S.stat)
-								frustration = 8
-								playsound(src.loc, pick('sound/voice/bgod.ogg', 'sound/voice/biamthelaw.ogg', 'sound/voice/bsecureday.ogg', 'sound/voice/bradio.ogg', 'sound/voice/bcreep.ogg'), 50, 0)
+							target.AdjustStunned(10)
+							target.adjustBruteLoss(15)
+							if(target.stat)
+								forgetCurrentTarget()
+								playsound(loc, pick('sound/voice/bgod.ogg', 'sound/voice/biamthelaw.ogg', 'sound/voice/bsecureday.ogg', 'sound/voice/bradio.ogg', 'sound/voice/bcreep.ogg'), 50, 0)
 
 				else								// not next to perp
 					var/turf/olddist = get_dist(src, target)
@@ -290,9 +291,8 @@ Auto Patrol: []"},
 				frustration = 8
 
 		if(SECBOT_PREP_ARREST)		// preparing to arrest target
-
 			// see if he got away
-			if((get_dist(src, src.target) > 1) || ((target.loc != target_lastloc) && (target.weakened < 2)))
+			if((get_dist(src, target) > 1) || ((target.loc != target_lastloc) && (target.weakened < 2)))
 				anchored = 0
 				mode = SECBOT_HUNT
 				return
@@ -302,28 +302,19 @@ Auto Patrol: []"},
 				if(!C.handcuffed && !arrest_type)
 					playsound(loc, 'sound/weapons/handcuffs.ogg', 30, 1, -2)
 					mode = SECBOT_ARREST
-					visible_message("\red <B>[src] is trying to put handcuffs on [src.target]!</B>")
+					visible_message("\red <B>[src] is trying to put handcuffs on [target]!</B>")
 					addtimer(CALLBACK(src, .proc/subprocess, SECBOT_PREP_ARREST), 60)
 
 			else
-				mode = SECBOT_IDLE
-				target = null
-				anchored = 0
-				last_found = world.time
-				frustration = 0
+				forgetCurrentTarget()
 
 		if(SECBOT_ARREST)		// arresting
 			if(!target || !iscarbon(target))
-				anchored = 0
-				mode = SECBOT_IDLE
-				return
+				forgetCurrentTarget()
 			else
 				var/mob/living/carbon/C = target
-				if(!C.handcuffed)
-					anchored = 0
-					mode = SECBOT_IDLE
-					return
-
+				if(C.handcuffed)
+					forgetCurrentTarget()
 
 		if(SECBOT_START_PATROL)	// start a patrol
 			if(path.len > 0 && patrol_target)	// have a valid path, so just resume
@@ -356,12 +347,8 @@ Auto Patrol: []"},
 					if(!mob_carbon.handcuffed)
 						mob_carbon.handcuffed = new /obj/item/weapon/handcuffs(target)
 						mob_carbon.update_inv_handcuffed()	//update the handcuffs overlay
-				mode = SECBOT_IDLE
-				target = null
-				anchored = 0
-				last_found = world.time
-				frustration = 0
-				playsound(src.loc, pick('sound/voice/bgod.ogg', 'sound/voice/biamthelaw.ogg', 'sound/voice/bsecureday.ogg', 'sound/voice/bradio.ogg', 'sound/voice/binsult.ogg', 'sound/voice/bcreep.ogg'), 50, 0)
+				forgetCurrentTarget()
+				playsound(loc, pick('sound/voice/bgod.ogg', 'sound/voice/biamthelaw.ogg', 'sound/voice/bsecureday.ogg', 'sound/voice/bradio.ogg', 'sound/voice/binsult.ogg', 'sound/voice/bcreep.ogg'), 50, 0)
 
 		if(SECBOT_START_PATROL)
 			calc_path()		// so just find a route to it
@@ -567,7 +554,7 @@ Auto Patrol: []"},
 
 // signals bot status etc. to controller
 /obj/machinery/bot/secbot/proc/send_status()
-	if(!(src && src.loc && src.loc.loc))
+	if(!(src && loc && loc.loc))
 		return
 	var/list/kv = list(
 	"type" = "secbot",
@@ -582,7 +569,7 @@ Auto Patrol: []"},
 // calculates a path to the current destination
 // given an optional turf to avoid
 /obj/machinery/bot/secbot/proc/calc_path(turf/avoid = null)
-	path = AStar(src.loc, patrol_target, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 120, id=botcard, exclude=avoid)
+	path = AStar(loc, patrol_target, /turf/proc/CardinalTurfsWithAccess, /turf/proc/Distance, 0, 120, id=botcard, exclude=avoid)
 	if(!path)
 		path = list()
 
@@ -590,29 +577,26 @@ Auto Patrol: []"},
 
 /obj/machinery/bot/secbot/proc/look_for_perp()
 	anchored = 0
-	for(var/mob/living/M in view(7, src)) //Let's find us a criminal
-		if(iscarbon(M))
-			var/mob/living/carbon/C = M
-			if(C.stat || C.handcuffed)
+	for(var/mob/living/L in view(7, src)) //Let's find us a criminal
+		if(L.stat)
+			continue
+
+		if(iscarbon(L))
+			var/mob/living/carbon/C = L
+			if(C.handcuffed)
 				continue
 
-			if((C.name == src.oldtarget_name) && (world.time < src.last_found + 100))
-				continue
+		if((L.name == oldtarget_name) && (world.time < last_found + 100))
+			continue
 
-			threatlevel = assess_perp(C)
+		threatlevel = assess_perp(L)
 
-		else if(istype(M, /mob/living/simple_animal/hostile))
-			if(M.stat == DEAD)
-				continue
-			else
-				threatlevel = 4
-
-		if(src.threatlevel >= 4)
-			target = M
-			oldtarget_name = M.name
+		if(threatlevel >= 4)
+			target = L
+			oldtarget_name = L.name
 			speak("Level [threatlevel] infraction alert!")
 			playsound(loc, pick('sound/voice/bcriminal.ogg', 'sound/voice/bjustice.ogg', 'sound/voice/bfreeze.ogg'), 50, 0)
-			visible_message("<b>[src]</b> points at [M.name]!")
+			visible_message("<b>[src]</b> points at [L.name]!")
 			mode = SECBOT_HUNT
 			process() // ensure bot quickly responds to a perp
 			break
@@ -622,7 +606,7 @@ Auto Patrol: []"},
 
 //If the security records say to arrest them, arrest them
 //Or if they have weapons and aren't security, arrest them.
-/obj/machinery/bot/secbot/proc/assess_perp(mob/living/carbon/perp)
+/obj/machinery/bot/secbot/proc/assess_perp(mob/living/perp)
 	var/threatcount = 0
 
 	if(!istype(perp))
@@ -632,13 +616,12 @@ Auto Patrol: []"},
 		return 10 //Everyone is a criminal!
 
 	threatcount = perp.assess_perp(src, FALSE, idcheck, FALSE, check_records)
-
 	return threatcount
 
 /obj/machinery/bot/secbot/Bump(atom/M) //Leave no door unopened!
 	if(istype(M, /obj/machinery/door) && !isnull(botcard))
 		var/obj/machinery/door/D = M
-		if(!istype(D, /obj/machinery/door/firedoor) && D.check_access(src.botcard) && !istype(D,/obj/machinery/door/poddoor))
+		if(!istype(D, /obj/machinery/door/firedoor) && D.check_access(botcard) && !istype(D,/obj/machinery/door/poddoor))
 			D.open()
 			frustration = 0
 	else if(isliving(M) && !anchored)
@@ -682,7 +665,7 @@ Auto Patrol: []"},
 //Secbot Construction
 
 /obj/item/clothing/head/helmet/attackby(obj/item/device/assembly/signaler/S, mob/user)
-	if(!issignaler(S) || src.type != /obj/item/clothing/head/helmet || !S.secured) //Eh, but we don't want people making secbots out of space helmets.
+	if(!issignaler(S) || !istype(src, /obj/item/clothing/head/helmet) || !S.secured) //Eh, but we don't want people making secbots out of space helmets.
 		..()
 		return
 
@@ -698,8 +681,8 @@ Auto Patrol: []"},
 	if(istype(W, /obj/item/weapon/weldingtool) && !build_step)
 		var/obj/item/weapon/weldingtool/WT = W
 		if(WT.remove_fuel(0, user))
-			src.build_step++
-			src.overlays += image('icons/obj/aibots.dmi', "hs_hole")
+			build_step++
+			overlays += image('icons/obj/aibots.dmi', "hs_hole")
 			to_chat(user, "You weld a hole in [src]!")
 
 	else if(isprox(W) && build_step == 1)
@@ -718,7 +701,7 @@ Auto Patrol: []"},
 		overlays += image('icons/obj/aibots.dmi', "hs_arm")
 		qdel(W)
 
-	else if(istype(W, /obj/item/weapon/melee/baton) && (src.build_step >= 3))
+	else if(istype(W, /obj/item/weapon/melee/baton) && (build_step >= 3))
 		user.drop_item()
 		build_step++
 		to_chat(user, "You complete the Securitron! Beep boop.")
@@ -729,7 +712,7 @@ Auto Patrol: []"},
 		qdel(src)
 
 	else if(istype(W, /obj/item/weapon/pen))
-		var/t = copytext(stripped_input(user, "Enter new robot name", src.name, src.created_name),1,MAX_NAME_LEN)
+		var/t = copytext(stripped_input(user, "Enter new robot name", name, created_name),1,MAX_NAME_LEN)
 		if(!t)
 			return
 		if(!in_range(src, usr) && loc != usr)

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -663,6 +663,7 @@ var/list/turret_icons
 	A.original = target
 	A.current = T
 	A.starting = T
+	A.fake = TRUE
 	A.yo = U.y - T.y
 	A.xo = U.x - T.x
 	A.process()

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -191,7 +191,7 @@
 					if(!fake)
 						msg_admin_attack("[firer.name] ([firer.ckey]) shot [M.name] ([M.ckey]) with a [src] [ADMIN_JMP(firer)] [ADMIN_FLW(firer)]") //BS12 EDIT ALG
 				else
-					M.attack_log += "\[[time_stamp()]\] <b>UNKNOWN SUBJECT (No longer exists)</b> shot <b>[M]/[M.ckey]</b> with a <b>[src]</b>"
+					M.attack_log += "\[[time_stamp()]\] <b>UNKNOWN SUBJECT</b> shot <b>[M]/[M.ckey]</b> with a <b>[src]</b>"
 					if(!fake)
 						msg_admin_attack("UNKNOWN shot [M.name] ([M.ckey]) with a [src] [ADMIN_JMP(M)] [ADMIN_FLW(M)]") //BS12 EDIT ALG
 


### PR DESCRIPTION
Фикс:
Я прошлым обновлением сломал ЕДботам надевание наручников на задержанных. К счастью, с бипскаями я немного не разобрался и сделал им другой прок, поэтому это их не зацепило

Изменения:
- ЕДботы тепепрь наследуются от бипскаев - выпилил часть кода, но нужно ещё немного доделать, так как они используют разные типы таргетов
- Турели и ЕДботы при стрельбе теперь не спамят админам (запись в атаклог осталась)