### PR TITLE
Фиксы отображения "я" на экране подключения.

### DIFF
--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -64,7 +64,7 @@ world/IsBanned(key,address,computer_id)
 			if(text2num(duration) > 0)
 				expires = " The ban is for [duration] minutes and expires on [expiration] (server time)."
 
-			var/desc = "\nReason: You, or another user of this computer or connection ([pckey]) is banned from playing here. The ban reason is:\n[sanitize_alt(reason)]\nThis ban was applied by [ackey] on [bantime], [expires]"
+			var/desc = "\nReason: You, or another user of this computer or connection ([pckey]) is banned from playing here. The ban reason is:\n[replacetext(reason, LETTER_255,"ÿ")] \nThis ban was applied by [ackey] on [bantime], [expires]"
 
 			return list("reason"="[bantype]", "desc"="[desc]")
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -92,7 +92,7 @@
 		var/bancid = href_list["dbbanaddcid"]
 		var/banduration = text2num(href_list["dbbaddduration"])
 		var/banjob = href_list["dbbanaddjob"]
-		var/banreason = href_list["dbbanreason"]
+		var/banreason = sanitize_simple(href_list["dbbanreason"])
 
 		banckey = ckey(banckey)
 


### PR DESCRIPTION
<details><summary>Весьма костыльным способом фиксит вот это</summary>

![image](https://cloud.githubusercontent.com/assets/17473163/24074577/01303804-0c3e-11e7-8d43-14e7f2b37c17.png)

</details>

<br>

Также, раз уж у нас с каких-то пор санитайзы дошли до БД и ризоны банов из ПП стали хранить букву `я` как `¶`, сделал то же самое с ризонами в анбан-панели.

----

Алсо, если кто-то знает как это лучше исправить и почему тут не работают переносы строк, то жду ваших советов.