### PR TITLE
Various runtimes fixes

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -33,7 +33,7 @@
 	var/turf/loc = get_turf(O)
 	if(loc)
 		var/area/res = loc.loc
-		.= res
+		. = res
 
 /proc/get_area_name(N) //get area by its name
 	for(var/area/A in all_areas)

--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -114,7 +114,7 @@ var/datum/subsystem/throwing/SSthrowing
 	set waitfor = 0
 	SSthrowing.processing -= thrownthing
 	//done throwing, either because it hit something or it finished moving
-	if (thrownthing.throwing)
+	if (!QDELETED(thrownthing) && thrownthing.throwing)
 		thrownthing.throwing = FALSE
 		if (!hit)
 			for (var/thing in get_turf(thrownthing)) //looking for our target on the turf we land on.

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -6,7 +6,7 @@ var/datum/subsystem/ticker/ticker
 	name = "Ticker"
 
 	priority = SS_PRIORITY_TICKER
-	
+
 	flags = SS_FIRE_IN_LOBBY | SS_KEEP_TIMING
 
 	var/const/restart_timeout = 600
@@ -463,7 +463,7 @@ var/datum/subsystem/ticker/ticker
 			ai_completions += "<BR>[robo.write_laws()]"
 
 		if(dronecount)
-			to_chat(ai_completions, "<B>There [dronecount>1 ? "were" : "was"] [dronecount] industrious maintenance [dronecount>1 ? "drones" : "drone"] this round.</B>")
+			ai_completions += "<B>There [dronecount>1 ? "were" : "was"] [dronecount] industrious maintenance [dronecount>1 ? "drones" : "drone"] this round.</B>"
 
 		ai_completions += "<HR>"
 

--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -259,9 +259,7 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 				if(!possible_targets.len)
 					break
 				if(target_ignore_prev)
-					var/target = pick(possible_targets)
-					possible_targets -= target
-					targets += target
+					targets += pick_n_take(possible_targets)
 				else
 					targets += pick(possible_targets)
 

--- a/code/datums/spells/horsemask.dm
+++ b/code/datums/spells/horsemask.dm
@@ -19,7 +19,12 @@
 		to_chat(user, "<span class='notice'>No target found in range.</span>")
 		return
 
-	var/mob/living/carbon/target = targets[1]
+	var/mob/living/carbon/target
+	while(targets.len)
+		target = targets[targets.len]
+		targets -= target
+		if(istype(target))
+			break
 
 	if(!(target.type in compatible_mobs))
 		to_chat(user, "<span class='notice'>It'd be stupid to curse [target] with a horse's head!</span>")

--- a/code/game/gamemodes/autotraitor/autotraitor.dm
+++ b/code/game/gamemodes/autotraitor/autotraitor.dm
@@ -10,7 +10,7 @@
 
 	votable = 0
 
-	var/list/possible_traitors = null
+	var/list/possible_traitors = list()
 	var/num_players = 0
 
 /datum/game_mode/traitor/autotraitor/announce()

--- a/code/game/machinery/computer/specops_shuttle.dm
+++ b/code/game/machinery/computer/specops_shuttle.dm
@@ -133,7 +133,8 @@ var/specops_shuttle_timeleft = 0
 	specops_shuttle_moving_to_centcom = 0
 
 	specops_shuttle_at_station = 1
-	if (specops_shuttle_moving_to_station || specops_shuttle_moving_to_centcom) return
+	if (specops_shuttle_moving_to_station || specops_shuttle_moving_to_centcom)
+		return
 
 	if (!specops_can_move())
 		to_chat(usr, "\red The Special Operations shuttle is unable to leave.")

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -172,9 +172,11 @@
 	desc = initial(desc)
 
 	var/location = get_step(src,(dir))
-	var/obj/item/I = new D.build_path(location)
-	I.materials[MAT_METAL] = get_resource_cost_w_coeff(D,MAT_METAL)
-	I.materials[MAT_GLASS] = get_resource_cost_w_coeff(D,MAT_GLASS)
+	var/I = new D.build_path(location)
+	if(istype(I, /obj/item))
+		var/obj/item/Item = I
+		Item.materials[MAT_METAL] = get_resource_cost_w_coeff(D,MAT_METAL)
+		Item.materials[MAT_GLASS] = get_resource_cost_w_coeff(D,MAT_GLASS)
 	visible_message("[bicon(src)] <b>\The [src]</b> beeps, \"\The [I] is complete.\"")
 	being_built = null
 

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -884,7 +884,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		empulse(P.loc, 3, 6, 1)
 		message += "Your [P] emits a wave of electromagnetic energy!"
 	if(i>=25 && i<=40) //Smoke
-		var/datum/effect/effect/system/smoke_spread/sleepy/S = new /datum/effect/effect/system/smoke_spread/sleepy
+		var/datum/effect/effect/system/smoke_spread/S = new /datum/effect/effect/system/smoke_spread
 		S.attach(P.loc)
 		S.set_up(n = 10, c = 0, loca = P.loc, direct = 0)
 		playsound(P.loc, 'sound/effects/smoke.ogg', 50, 1, -3)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -884,9 +884,9 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		empulse(P.loc, 3, 6, 1)
 		message += "Your [P] emits a wave of electromagnetic energy!"
 	if(i>=25 && i<=40) //Smoke
-		var/datum/effect/effect/system/smoke_spread/chem/S = new /datum/effect/effect/system/smoke_spread/chem
+		var/datum/effect/effect/system/smoke_spread/sleepy/S = new /datum/effect/effect/system/smoke_spread/sleepy
 		S.attach(P.loc)
-		S.set_up(carry = null, n = 10, c = 0, loca = P.loc, direct = 0)
+		S.set_up(n = 10, c = 0, loca = P.loc, direct = 0)
 		playsound(P.loc, 'sound/effects/smoke.ogg', 50, 1, -3)
 		S.start()
 		message += "Large clouds of smoke billow forth from your [P]!"
@@ -907,7 +907,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 		message += "Your [P] flashes with a blinding white light! You feel weaker."
 	if(i>=85) //Sparks
 		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
-		s.set_up(n = 2, c = 1, loc = P.loc)
+		s.set_up(n = 2, c = 1, loca = P.loc)
 		s.start()
 		message += "Your [P] begins to spark violently!"
 	if(i>45 && i<65 && prob(50)) //Nothing happens

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -211,7 +211,8 @@
 /obj/item/weapon/cartridge/proc/post_status(command, data1, data2)
 
 	var/datum/radio_frequency/frequency = radio_controller.return_frequency(1435)
-	if(!frequency) return
+	if(!frequency)
+		return
 
 	var/datum/signal/status_signal = new
 	status_signal.source = src
@@ -224,11 +225,21 @@
 			status_signal.data["msg2"] = data2
 			if(loc)
 				var/obj/item/PDA = loc
-				var/mob/user = PDA.fingerprintslast
+				var/mob/user = null
 				if(istype(PDA.loc,/mob/living))
-					name = PDA.loc
-				log_admin("STATUS: [user] set status screen with [PDA]. Message: [data1] [data2]")
-				message_admins("STATUS: [user] set status screen with [PDA]. Message: [data1] [data2] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
+					user = PDA.loc
+				else if(PDA.fingerprintslast)
+					var/client/user_client = directory[PDA.fingerprintslast]
+					if(user_client && user_client.mob)
+						user = user_client.mob
+
+				if(user)
+					log_admin("STATUS: [user] set status screen with [PDA]. Message: [data1] [data2]")
+					message_admins("STATUS: [user] set status screen with [PDA]. Message: [data1] [data2] [ADMIN_FLW(user)]")
+				else
+					var/turf/PDA_turf = get_turf(PDA)
+					log_admin("STATUS: UNKNOWN set status screen with [PDA]. Message: [data1] [data2]")
+					message_admins("STATUS: UNKNOWN set status screen with [PDA]. Message: [data1] [data2] [PDA.loc ? "[ADMIN_JMP(PDA_turf)]" : ""] ")
 
 		if("alert")
 			status_signal.data["picture_state"] = data1

--- a/code/game/objects/items/devices/suit_cooling.dm
+++ b/code/game/objects/items/devices/suit_cooling.dm
@@ -59,13 +59,14 @@
 		turn_off()
 
 /obj/item/device/suit_cooling_unit/proc/get_environment_temperature()
-	if (ishuman(loc))
+	if(ishuman(loc))
 		var/mob/living/carbon/human/H = loc
 		if(istype(H.loc, /obj/mecha))
-			var/obj/mecha/M = loc
+			var/obj/mecha/M = H.loc
 			return M.return_temperature()
 		else if(istype(H.loc, /obj/machinery/atmospherics/unary/cryo_cell))
-			return H.loc:air_contents.temperature
+			var/obj/machinery/atmospherics/unary/cryo_cell/cryo = H.loc
+			return cryo.air_contents.temperature
 
 	var/turf/T = get_turf(src)
 	if(istype(T, /turf/space))

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -48,7 +48,7 @@
 	if(user)
 		var/obj/item/weapon/twohanded/O = user.get_inactive_hand()
 		if(istype(O))
-			O.unwield()
+			user.drop_from_inventory(O)
 	return	unwield()
 
 /obj/item/weapon/twohanded/update_icon()
@@ -58,7 +58,7 @@
 	unwield()
 
 /obj/item/weapon/twohanded/attack_self(mob/user)
-	if( istype(user,/mob/living/carbon/monkey) )
+	if(istype(user,/mob/living/carbon/monkey))
 		to_chat(user, "<span class='warning'>It's too heavy for you to wield fully.</span>")
 		return
 
@@ -75,8 +75,8 @@
 			playsound(src.loc, unwieldsound, 50, 1)
 
 		var/obj/item/weapon/twohanded/offhand/O = user.get_inactive_hand()
-		if(O && istype(O))
-			O.unwield()
+		if(istype(O))
+			user.drop_from_inventory(O)
 		return
 
 	else //Trying to wield it
@@ -105,11 +105,11 @@
 	icon_state = "offhand"
 	name = "offhand"
 
-	unwield()
-		qdel(src)
+/obj/item/weapon/twohanded/offhand/unwield()
+	qdel(src)
 
-	wield()
-		qdel(src)
+/obj/item/weapon/twohanded/offhand/wield()
+	qdel(src)
 
 /*
  * Fireaxe

--- a/code/modules/client/geoip.dm
+++ b/code/modules/client/geoip.dm
@@ -25,6 +25,9 @@ var/global/list/geoip_ckey_updated = list()
 	if(!try_update_geoip(C, addr))
 		return
 
+	if(!C)
+		return
+
 	if(status == "updated")
 		if(proxy == "true")
 			var/reason = "No proxy allowed"

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -26,9 +26,9 @@
  // Maybe some people are okay with that.
 
 		for(var/mob/M in player_list)
-			if (!M.client)
+			if(!M.client)
 				continue //skip monkeys and leavers
-			if (istype(M, /mob/new_player))
+			if(istype(M, /mob/new_player))
 				continue
 			if(findtext(message," snores.")) //Because we have so many sleeping people.
 				break

--- a/code/modules/mob/living/silicon/ai/latejoin.dm
+++ b/code/modules/mob/living/silicon/ai/latejoin.dm
@@ -21,6 +21,9 @@ var/global/list/empty_playable_ai_cores = list()
 	if(istype(loc,/obj/item/device/aicard))
 		to_chat(usr, "<span class='danger'>Unable to establish connection with Repository. Wiping isn't possible at now.</span>")
 		return
+	if(stat)
+		to_chat(usr, "<span class='danger'>Connection with Repository is corrupted. Wiping isn't possible at now.</span>")
+		return
 
 	// Guard against misclicks, this isn't the sort of thing we want happening accidentally
 	if(alert("WARNING: This will immediately wipe your core and ghost you, removing your character from the round permanently (similar to cryo and robotic storage). Are you entirely sure you want to do this?",

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -72,11 +72,12 @@
 
 
 /mob/living/simple_animal/mouse/proc/splat()
-	src.health = 0
-	src.stat = DEAD
-	src.icon_dead = "mouse_[body_color]_splat"
-	src.icon_state = "mouse_[body_color]_splat"
+	health = 0
+	stat = DEAD
+	icon_dead = "mouse_[body_color]_splat"
+	icon_state = "mouse_[body_color]_splat"
 	layer = MOB_LAYER
+	timeofdeath = world.time
 	if(client)
 		client.time_died_as_mouse = world.time
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -466,7 +466,7 @@
 	src << browse(null, "window=playersetup") //closes the player setup window
 
 /mob/new_player/proc/has_admin_rights()
-	return client.holder.rights & R_ADMIN
+	return (client && client.holder && (client.holder.rights & R_ADMIN))
 
 /mob/new_player/proc/is_species_whitelisted(datum/species/S)
 	if(!S)

--- a/code/modules/musical_instruments/guitar.dm
+++ b/code/modules/musical_instruments/guitar.dm
@@ -282,6 +282,9 @@
 			spawn()
 				var/list/lines = splittext(t, "\n")
 				var/tempo = 5
+				if(lines.len <= 1) //One line with BPM and at least one line with song
+					to_chat(usr, "Aaaand... Where is song?")
+					return
 				if(copytext(lines[1],1,6) == "BPM: ")
 					tempo = 600 / text2num(copytext(lines[1],6))
 					lines.Cut(1,2)
@@ -304,4 +307,3 @@
 		if((M.client && M.machine == src))
 			attack_self(M)
 	return
-

--- a/code/modules/power/tesla/energy_ball.dm
+++ b/code/modules/power/tesla/energy_ball.dm
@@ -131,17 +131,17 @@ var/list/blacklisted_tesla_types = typecacheof(list(/obj/machinery/atmospherics,
 	dust_mobs(A)
 
 /obj/singularity/energy_ball/orbit(obj/singularity/energy_ball/target)
-	if (istype(target))
+	if(istype(target))
 		target.orbiting_balls += src
 		poi_list -= src
 	. = ..()
 
 /obj/singularity/energy_ball/stop_orbit()
-	if (orbiting && istype(orbiting.orbiting, /obj/singularity/energy_ball))
+	if(orbiting && istype(orbiting.orbiting, /obj/singularity/energy_ball))
 		var/obj/singularity/energy_ball/orbitingball = orbiting.orbiting
 		orbitingball.orbiting_balls -= src
 	..()
-	if (!loc)
+	if(!loc && !QDELETED(src))
 		qdel(src)
 
 /obj/singularity/energy_ball/proc/dust_mobs(atom/A)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -129,7 +129,7 @@
 	starting = starting_loc
 	current = starting_loc
 	if(new_firer)
-		firer = src
+		firer = new_firer
 
 	yo = new_y - starting_loc.y
 	xo = new_x - starting_loc.x

--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -545,12 +545,10 @@
 
 		if(talkative)
 			new_item.talking_atom = new()
-			talking_atom.holder_atom = new_item
-			talking_atom.init()
+			talking_atom.init(new_item)
 
 		qdel(src)
 
 	else if(talkative)
 		src.talking_atom = new()
-		talking_atom.holder_atom = src
-		talking_atom.init()
+		talking_atom.init(src)

--- a/code/modules/research/xenoarchaeology/finds/finds_talkingitem.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds_talkingitem.dm
@@ -14,7 +14,8 @@
 	var/talk_interval = 50
 	var/talk_chance = 10
 
-/datum/talking_atom/proc/init()
+/datum/talking_atom/proc/init(atom/holder = null)
+	holder_atom = holder
 	if(holder_atom)
 		START_PROCESSING(SSobj, src)
 


### PR DESCRIPTION
Total unique runtimes: 54
Total runtimes: 885

Upd: мейнтейнеры (кроме Зве) видели список рантаймов. На данный момент я не знаю как пофиксить (а не просто заглушить)

- proc name: cancelAlarm (/mob/living/silicon/proc/cancelAlarm)
- proc name: doneLoading (/datum/chatOutput/proc/doneLoading) (хотя оно только при старте сревера, ЕМНИП)
- runtime error: Cannot read null.chat_toggles
- proc name: shake camera (/proc/shake_camera) (совершенно не понимаю, что там происходит)
- proc name: New (/datum/geoip_data/New) (там есть проверка на первый аргумент, но почему-то она не срабатывает)
- runtime error: pick() from empty list (там несколько разных ошибок этого рода)
- runtime error: Cannot read null.dir proc name: start (/datum/effect/effect/system/ion_trail_follow/start)

И так далее

fixes #540