### PR TITLE
Fixed "ERROR: Loadout - Missing display name: /datum/gear/gear"

### DIFF
--- a/code/modules/client/character menu/loadout/loadout_general.dm
+++ b/code/modules/client/character menu/loadout/loadout_general.dm
@@ -27,7 +27,7 @@ datum/gear/zippo
 	path = /obj/item/weapon/lighter/zippo
 	cost = 2
 
-/datum/gear/gear/paicard
+/datum/gear/paicard
 	display_name = "PAI device"
 	path = /obj/item/device/paicard
 	cost = 2


### PR DESCRIPTION
Fixes #1205.