### PR TITLE
Ports tgstation's cid randomizer detector.

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -283,9 +283,8 @@
 	var/admin_rank = "Player"
 	if (src.holder)
 		admin_rank = src.holder.rank
-	else
-		if (check_randomizer(connectiontopic))
-			return
+	else if (check_randomizer(connectiontopic))
+		return
 
 	//Just the standard check to see if it's actually a number
 	if(sql_id)
@@ -334,7 +333,7 @@
 			tokens[ckey] = cid_check_reconnect()
 
 			sleep(10) //browse is queued, we don't want them to disconnect before getting the browse() command.
-			qdel(src)
+			del(src)
 			return TRUE
 
 		if (oldcid != computer_id) //IT CHANGED!!!
@@ -345,9 +344,9 @@
 
 			if (!cidcheck_failedckeys[ckey])
 				message_admins("<span class='adminnotice'>[key_name(src)] has been detected as using a cid randomizer. Connection rejected.</span>")
-				send2slack_logs(key_name(usr), "has been detected as using a cid randomizer. Connection rejected.", "(CidRandomizer)")
+				send2slack_logs(key_name(src), "has been detected as using a cid randomizer. Connection rejected.", "(CidRandomizer)")
 				cidcheck_failedckeys[ckey] = TRUE
-				note_randomizer_user()
+				notes_add(ckey, "Detected as using a cid randomizer.")
 
 			log_access("Failed Login: [key] [computer_id] [address] - CID randomizer confirmed (oldcid: [oldcid])")
 
@@ -356,7 +355,7 @@
 		else
 			if (cidcheck_failedckeys[ckey])
 				message_admins("<span class='adminnotice'>[key_name_admin(src)] has been allowed to connect after showing they removed their cid randomizer</span>")
-				send2slack_logs(key_name(usr), "has been allowed to connect after showing they removed their cid randomizer.", "(CidRandomizer)")
+				send2slack_logs(key_name(src), "has been allowed to connect after showing they removed their cid randomizer.", "(CidRandomizer)")
 				cidcheck_failedckeys -= ckey
 			if (cidcheck_spoofckeys[ckey])
 				message_admins("<span class='adminnotice'>[key_name_admin(src)] has been allowed to connect after appearing to have attempted to spoof a cid randomizer check because it <i>appears</i> they aren't spoofing one this time</span>")
@@ -387,10 +386,6 @@
 	//special javascript to make them reconnect under a new window.
 	src << browse("<a id='link' href='byond://[url]?token=[token]'>byond://[url]?token=[token]</a><script type='text/javascript'>document.getElementById(\"link\").click();window.location=\"byond://winset?command=.quit\"</script>", "border=0;titlebar=0;size=1x1")
 	to_chat(src, "<a href='byond://[url]?token=[token]'>You will be automatically taken to the game, if not, click here to be taken manually</a>")
-
-/client/proc/note_randomizer_user()
-	notes_add(ckey, "Detected as using a cid randomizer.")
-
 
 /client/proc/log_client_ingame_age_to_db()
 	if ( IsGuestKey(src.key) )


### PR DESCRIPTION
<!--
Работа с чейнджлогом:

ВАЖНО! Чейнджлог должен быть в КОНЦЕ описания вашего ПРа. Всё что идёт после :cl: (эмодзи значка) будет парсится как чейнджлог.
Изменения должны описываться в формате списка. Используйте шаблон ниже.

Просьба писать чейнджлог с большой буквы и хотя бы с минимальным количеством знаков препинания, типа точки в конце предложения.

Шаблон для чейнджлога:
:cl: Здесь вы можете вставить свой/чужой ник (Необязательно. При пустом поле в чейнджлог пойдёт ник из гитхаба.)
 - bugfix: Фиксы описываются тут.
 - rscadd: Разные добавления и новшества (например фичи).
 - rscdel: Откаты фичь, удаление старого и т.д.
 - image: Изменения со спрайтами и изображениями.
 - sound: Звуки и всё что с ними связано.
 - spellcheck: Небольшие или не очень исправления в тексте.
 - tweak: Небольшие изменения (что-то формата "Добавил возможность сминать жестяные банки").
 - balance: Изменения связанные с балансом.
 - map: Изменения на карте.
 - performance: Производительность, скорость работы и т.д.
 - experiment: Экспериментальные изменения, шанс отката которых выше обычного.
 
Если изменений много, то вы можете ограничиться парой слов и добавить метку [link]. С ней, в конец строчки чейнджлога, будет автоматически добавлена ссылка на ваш ПР.
Пример:
:cl:
 - bugfix: Какой-то фикс. (Ссылка добавлена не будет.)
 - performance[link]: Огромные изменения, слов не хватит описать. (Будет добавлена ссылка, текст в игре будет выглядеть так: "Огромные изменения, слов не хватит описать. - подробнее -", где '- подробнее -' будет ссылкой на ПР.)
 
Чейнджлог генерируется автоматически сразу после мержа вашего ПРа.
-->
Я там слышал что набеги участились, наверно пора и к нам это утянуть, вдруг усложнит жизнь.

Собственно порт отсюда - https://github.com/tgstation/tgstation/pull/20058 и https://github.com/tgstation/tgstation/pull/21226

Что не так как у них:
* они используют мускул для нотесов, поэтому выдрал этот код и оставил только добавление записи
* гунчат не дает выводится сообщениям которые пользователь ловит в первые секунды захода еще до того, как он-чат загрузится, поэтому набегатель получит белый экран без информационных сообщений которые должны его информировать.
* Еще убрал опцию из конфига, т.к мы любим по дефолту всякое такое использовать.

Ченжлог не пишу, так как опять штука которая в нем не нужна.

А, еще забыл об одном - у администраторов иммун на это, а остальным не стоит пересаживаться на другой ПК в рамках одного раунда. Более чем уверен, что пересаживание с одного ПК на другой будет расценено как нарушение, но думаю такие случаи крайне редки и стоит просто потерпеть пока закончится раунд.
Ну и система не банит, только отключает клиента и не дает ему зайти в текущий раунд, максимум - получите нотисы от бота (и несуществующий бан на раунд который спадает если вы опять зайдете с предыдущего ПК в случае пересаживания).