### PR TITLE
Фиксы для конфетного батончика

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -807,11 +807,11 @@
 	product_ads = "The healthiest!;Award-winning chocolate bars!;Mmm! So good!;Oh my god it's so juicy!;Have a snack.;Snacks are good for you!;Have some more Getmore!;Best quality snacks straight from mars.;We love chocolate!;Try our new jerky!"
 	icon_state = "snack"
 	light_color = "#d00023"
-	products = list(/obj/item/weapon/reagent_containers/food/snacks/candy = 6,/obj/item/weapon/reagent_containers/food/drinks/dry_ramen = 6,/obj/item/weapon/reagent_containers/food/snacks/chips =6,
+	products = list(/obj/item/weapon/reagent_containers/food/snacks/candy/candybar = 6,/obj/item/weapon/reagent_containers/food/drinks/dry_ramen = 6,/obj/item/weapon/reagent_containers/food/snacks/chips =6,
 					/obj/item/weapon/reagent_containers/food/snacks/sosjerky = 6,/obj/item/weapon/reagent_containers/food/snacks/no_raisin = 6,/obj/item/weapon/reagent_containers/food/snacks/spacetwinkie = 6,
 					/obj/item/weapon/reagent_containers/food/snacks/cheesiehonkers = 6)
 	contraband = list(/obj/item/weapon/reagent_containers/food/snacks/syndicake = 6)
-	prices = list(/obj/item/weapon/reagent_containers/food/snacks/candy = 1,/obj/item/weapon/reagent_containers/food/drinks/dry_ramen = 5,/obj/item/weapon/reagent_containers/food/snacks/chips = 1,
+	prices = list(/obj/item/weapon/reagent_containers/food/snacks/candy/candybar = 1,/obj/item/weapon/reagent_containers/food/drinks/dry_ramen = 5,/obj/item/weapon/reagent_containers/food/snacks/chips = 1,
 					/obj/item/weapon/reagent_containers/food/snacks/sosjerky = 2,/obj/item/weapon/reagent_containers/food/snacks/no_raisin = 1,/obj/item/weapon/reagent_containers/food/snacks/spacetwinkie = 1,
 					/obj/item/weapon/reagent_containers/food/snacks/cheesiehonkers = 1)
 	refill_canister = /obj/item/weapon/vending_refill/snack

--- a/code/game/objects/random/random_foods.dm
+++ b/code/game/objects/random/random_foods.dm
@@ -22,7 +22,7 @@
 	icon_state = "grapesoda"
 /obj/random/foods/food_snack/item_to_spawn()
 		return pick(\
-						prob(2);/obj/item/weapon/reagent_containers/food/snacks/candy,\
+						prob(2);/obj/item/weapon/reagent_containers/food/snacks/candy/candybar,\
 						prob(2);/obj/item/weapon/reagent_containers/food/drinks/dry_ramen,\
 						prob(2);/obj/item/weapon/reagent_containers/food/snacks/chips,\
 						prob(2);/obj/item/weapon/reagent_containers/food/snacks/sosjerky,\

--- a/code/modules/food/recipes_candymaker.dm
+++ b/code/modules/food/recipes_candymaker.dm
@@ -484,7 +484,7 @@
 		/obj/item/weapon/reagent_containers/food/snacks/candy/candybar,
 		/obj/item/weapon/reagent_containers/food/snacks/candy/caramel,
 	)
-	result = /obj/item/weapon/reagent_containers/food/snacks/candy/candybar/caramel
+	result = /obj/item/weapon/reagent_containers/food/snacks/candy/malper
 
 /datum/recipe/candy/toolerone
 	reagents = list()
@@ -492,7 +492,7 @@
 		/obj/item/weapon/reagent_containers/food/snacks/candy/candybar,
 		/obj/item/weapon/reagent_containers/food/snacks/candy/nougat,
 	)
-	result = /obj/item/weapon/reagent_containers/food/snacks/candy/candybar/nougat
+	result = /obj/item/weapon/reagent_containers/food/snacks/candy/toolerone
 
 /datum/recipe/candy/yumbaton
 	reagents = list()
@@ -500,14 +500,14 @@
 		/obj/item/weapon/reagent_containers/food/snacks/candy/candybar,
 		/obj/item/weapon/reagent_containers/food/snacks/candy/toffee,
 	)
-	result = /obj/item/weapon/reagent_containers/food/snacks/candy/candybar/toffee
+	result = /obj/item/weapon/reagent_containers/food/snacks/candy/yumbaton
 
 /datum/recipe/candy/crunch
 	reagents = list("rice" = 5)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/candy/candybar,
 	)
-	result = /obj/item/weapon/reagent_containers/food/snacks/candy/candybar/rice
+	result = /obj/item/weapon/reagent_containers/food/snacks/candy/rice
 
 /datum/recipe/candy/toxinstest
 	reagents = list()
@@ -516,4 +516,4 @@
 		/obj/item/weapon/reagent_containers/food/snacks/candy/caramel,
 		/obj/item/weapon/reagent_containers/food/snacks/candy/nougat,
 	)
-	result = /obj/item/weapon/reagent_containers/food/snacks/candy/candybar/caramel_nougat
+	result = /obj/item/weapon/reagent_containers/food/snacks/candy/caramel_nougat

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -269,7 +269,6 @@
 /obj/item/weapon/reagent_containers/food/snacks/candy
 	name = "candy"
 	desc = "Nougat, love it or hate it."
-	icon_state = "candy"
 	filling_color = "#7D5F46"
 
 	New()
@@ -3734,32 +3733,39 @@
 // CANDYBARS! :3
 ///////////////////////////////////////////
 
-/obj/item/weapon/reagent_containers/food/snacks/candy/candybar/rice
+/obj/item/weapon/reagent_containers/food/snacks/candy/candybar
+	name = "candy bar"
+	desc = "Nougat, love it or hate it."
+	icon_state = "candy"
+	trash = /obj/item/trash/candy
+	filling_color = "#7D5F46"
+
+/obj/item/weapon/reagent_containers/food/snacks/candy/rice
 	name = "Asteroid Crunch Bar"
 	desc = "Crunchy rice deposits in delicious chocolate! A favorite of miners galaxy-wide."
 	icon_state = "asteroidcrunch"
 	trash = /obj/item/trash/candy
 	filling_color = "#7D5F46"
 
-/obj/item/weapon/reagent_containers/food/snacks/candy/candybar/toffee
+/obj/item/weapon/reagent_containers/food/snacks/candy/yumbaton
 	name = "Yum-baton Bar"
 	desc = "Chocolate and toffee in the shape of a baton. Security sure knows how to pound these down!"
 	icon_state = "yumbaton"
 	filling_color = "#7D5F46"
 
-/obj/item/weapon/reagent_containers/food/snacks/candy/candybar/caramel
+/obj/item/weapon/reagent_containers/food/snacks/candy/malper
 	name = "Malper Bar"
 	desc = "A chocolate syringe filled with a caramel injection. Just what the doctor ordered!"
 	icon_state = "malper"
 	filling_color = "#7D5F46"
 
-/obj/item/weapon/reagent_containers/food/snacks/candy/candybar/caramel_nougat
+/obj/item/weapon/reagent_containers/food/snacks/candy/caramel_nougat
 	name = "Toxins Test Bar"
 	desc = "An explosive combination of chocolate, caramel, and nougat. Research has never been so tasty!"
 	icon_state = "toxinstest"
 	filling_color = "#7D5F46"
 
-/obj/item/weapon/reagent_containers/food/snacks/candy/candybar/nougat
+/obj/item/weapon/reagent_containers/food/snacks/candy/toolerone
 	name = "Tool-erone Bar"
 	desc = "Chocolate-covered nougat, shaped like a wrench. Great for an engineer on the go!"
 	icon_state = "toolerone"


### PR DESCRIPTION
- Пофикшена невозможность использовать конфеты из автомата в рецептах кухни.
Косяк был в том, что в атоматах продавался базовый класс /candy, тогда как в рецептах использовался /candybar.
fixes #1338 
- Пофикшено отсутствие мусора у конфеты
Легитимный фикс бага описанного здесь #991 
- Немного поигрался с путями сладостей
Подкласс /candybar имел нулевую смысловую нагрузку и даже не имел имплементации. Все свойства сладостей брались из класса /candy. Поэтому /candybar я превратил в полноценный класс с конфетной, а из остальных путей батончиков он был убран. Названия некоторых батончиков были изменены из-за того, что иначе бы они были идентичны некоторым ингредиентам из которых они делаются (кто так вообще делает?!).
В классе /candy я намеренно убрал icon_state, чтобы отсутствие спрайта намекало на невалидность использования данного объекта.

:cl:
 - bugfix: Конфету покупаемую в автоматах нельзя было использовать в рецептах кухни.
 - bugfix: Из конфеты не выпадал мусор.

