### PR TITLE
Lying grab fix

### DIFF
--- a/code/game/gamemodes/changeling/powers/Whip.dm
+++ b/code/game/gamemodes/changeling/powers/Whip.dm
@@ -85,7 +85,7 @@
 		T.throw_at(host, get_dist(host, T) - 1, 1, spin = FALSE, callback = CALLBACK(src, .proc/end_whipping, T))
 
 /obj/item/projectile/changeling_whip/proc/end_whipping(atom/movable/T)
-	if(in_range(T, host) && !host.get_inactive_hand())
+	if(in_range(T, host) && !host.get_inactive_hand() && !host.lying)
 		if(iscarbon(T))
 			var/obj/item/weapon/grab/G = new(host,T)
 			host.put_in_inactive_hand(G)

--- a/code/modules/mob/living/carbon/alien/alien_defense.dm
+++ b/code/modules/mob/living/carbon/alien/alien_defense.dm
@@ -39,7 +39,7 @@ This is what happens, when we attack aliens.
 				help_shake_act(M)
 
 		if ("grab")
-			if (M == src || anchored)
+			if (M == src || anchored || M.lying)
 				return
 			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src)
 

--- a/code/modules/mob/living/carbon/alien/human_attackalien.dm
+++ b/code/modules/mob/living/carbon/alien/human_attackalien.dm
@@ -49,7 +49,7 @@ This is what happens, when alien attack.
 		if ("help")
 			visible_message(text("\blue [M] caresses [src] with its scythe like arm."))
 		if ("grab")
-			if(M == src || anchored)
+			if(M == src || anchored || M.lying)
 				return
 			if (w_uniform)
 				w_uniform.add_fingerprint(M)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -111,7 +111,7 @@
 			return 1
 
 		if("grab")
-			if(M == src || anchored)
+			if(M == src || anchored || M.lying)
 				return 0
 			for(var/obj/item/weapon/grab/G in src.grabbed_by)
 				if(G.assailant == M)

--- a/code/modules/mob/living/carbon/ian/ian.dm
+++ b/code/modules/mob/living/carbon/ian/ian.dm
@@ -407,7 +407,7 @@
 			updatehealth()
 
 		if("grab")
-			if(M == src || anchored)
+			if(M == src || anchored || M.lying)
 				return
 
 			for(var/obj/item/weapon/grab/G in grabbed_by)
@@ -625,9 +625,9 @@
 				playsound(loc, 'sound/weapons/slashmiss.ogg', 25, 1, -1)
 				visible_message("<span class='danger'>has attempted to lunge at [name]!</span>")
 		if ("grab")
-			if (M == src)
+			if (M == src || anchored || M.lying)
 				return
-			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab( M, M, src )
+			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src)
 			M.put_in_active_hand(G)
 			grabbed_by += G
 			G.synch()

--- a/code/modules/mob/living/carbon/metroid/metroid.dm
+++ b/code/modules/mob/living/carbon/metroid/metroid.dm
@@ -451,9 +451,9 @@
 			help_shake_act(M)
 
 		if ("grab")
-			if (M == src)
+			if (M == src || M.lying)
 				return
-			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab( M, src )
+			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src)
 
 			M.put_in_active_hand(G)
 
@@ -542,9 +542,9 @@
 						O.show_message(text("\red <B>[] has attempted to lunge at [name]!</B>", M), 1)
 
 		if ("grab")
-			if (M == src)
+			if (M == src || M.lying)
 				return
-			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab( M, M, src )
+			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src)
 
 			M.put_in_active_hand(G)
 

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -249,10 +249,10 @@
 						O.show_message(text("\red <B>[] has attempted to punch [name]!</B>", M), 1)
 		else
 			if (M.a_intent == "grab")
-				if (M == src || anchored)
+				if (M == src || anchored || M.lying)
 					return
 
-				var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src )
+				var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src)
 
 				M.put_in_active_hand(G)
 
@@ -319,9 +319,9 @@
 						O.show_message(text("\red <B>[] has attempted to lunge at [name]!</B>", M), 1)
 
 		if ("grab")
-			if (M == src)
+			if (M == src || anchored || M.lying)
 				return
-			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab( M, M, src )
+			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src)
 
 			M.put_in_active_hand(G)
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -854,9 +854,9 @@ var/list/robot_verbs_default = list(
 					O.show_message(text("\blue [M] caresses [src]'s plating with its scythe-like arm."), 1)
 
 		if ("grab")
-			if (M == src)
+			if (M == src || anchored || M.lying)
 				return
-			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab( M, M, src )
+			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src)
 
 			M.put_in_active_hand(G)
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -240,18 +240,17 @@
 						O.show_message("\blue [M] [response_help] [src]")
 
 		if("grab")
-			if (M == src)
+			if (M == src || anchored || M.lying)
 				return
 			if (!(status_flags & CANPUSH))
 				return
 
-			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab( M, M, src )
+			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src)
 
 			M.put_in_active_hand(G)
 
 			grabbed_by += G
 			G.synch()
-			G.affecting = src
 			LAssailant = M
 
 			for(var/mob/O in viewers(src, null))
@@ -277,18 +276,17 @@
 				if ((O.client && !( O.blinded )))
 					O.show_message(text("\blue [M] caresses [src] with its scythe like arm."), 1)
 		if ("grab")
-			if(M == src)
+			if(M == src || anchored || M.lying)
 				return
 			if(!(status_flags & CANPUSH))
 				return
 
-			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab( M, M, src )
+			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src)
 
 			M.put_in_active_hand(G)
 
 			grabbed_by += G
 			G.synch()
-			G.affecting = src
 			LAssailant = M
 
 			playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -61,8 +61,10 @@
 	if(affecting)
 		if(assailant.r_hand == src)
 			hud.screen_loc = ui_rhand
-		else
+		else if(assailant.l_hand == src)
 			hud.screen_loc = ui_lhand
+		else
+			qdel(src)
 
 
 /obj/item/weapon/grab/process()


### PR DESCRIPTION
<!--
Работа с чейнджлогом:

ВАЖНО! Чейнджлог должен быть в КОНЦЕ описания вашего ПРа. Всё что идёт после :cl: (эмодзи значка) будет парсится как чейнджлог.
Изменения должны описываться в формате списка. Используйте шаблон ниже.

Просьба писать чейнджлог с большой буквы и хотя бы с минимальным количеством знаков препинания, типа точки в конце предложения.

Шаблон для чейнджлога:
:cl: Здесь вы можете вставить свой/чужой ник (Необязательно. При пустом поле в чейнджлог пойдёт ник из гитхаба.)
 - bugfix: Фиксы описываются тут.
 - rscadd: Разные добавления и новшества (например фичи).
 - rscdel: Откаты фичь, удаление старого и т.д.
 - image: Изменения со спрайтами и изображениями.
 - sound: Звуки и всё что с ними связано.
 - spellcheck: Небольшие или не очень исправления в тексте.
 - tweak: Небольшие изменения (что-то формата "Добавил возможность сминать жестяные банки").
 - balance: Изменения связанные с балансом.
 - map: Изменения на карте.
 - performance: Производительность, скорость работы и т.д.
 - experiment: Экспериментальные изменения, шанс отката которых выше обычного.
 
Если изменений много, то вы можете ограничиться парой слов и добавить метку [link]. С ней, в конец строчки чейнджлога, будет автоматически добавлена ссылка на ваш ПР.
Пример:
:cl:
 - bugfix: Какой-то фикс. (Ссылка добавлена не будет.)
 - performance[link]: Огромные изменения, слов не хватит описать. (Будет добавлена ссылка, текст в игре будет выглядеть так: "Огромные изменения, слов не хватит описать. - подробнее -", где '- подробнее -' будет ссылкой на ПР.)
 
Чейнджлог генерируется автоматически сразу после мержа вашего ПРа.
-->
Также добавил немного переносов строк для кода инвентаря
Кто-нибудь знает, какой сакральный смысл в том, что каждый раз при создании нового граба вместо вызова его конструктора мы также вызываем несколько совершенно левых проков, которые могли бы быть в конструкторе?

fixes #1298 
:cl:
 - bugfix: Можно было грабнуть кого-либо лёжа.