### PR TITLE
Этот предмет не повысит уровень исследовний. Хотите разобрать?

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -244,8 +244,17 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			if(linked_destroy.busy)
 				to_chat(usr, "\red The destructive analyzer is busy at the moment.")
 			else
-				var/choice = input("Proceeding will destroy loaded item.") in list("Proceed", "Cancel")
-				if(choice == "Cancel" || !linked_destroy) return
+				var/list/temp_tech = linked_destroy.ConvertReqString2List(linked_destroy.loaded_item.origin_tech)
+				var/cancontinue = FALSE
+				for(var/T in temp_tech)
+					if(files.IsTechHigher(T, temp_tech[T]))
+						cancontinue = TRUE
+						break
+				if(!cancontinue)
+					var/choice = input("This item does not raise tech levels. Proceed destroying loaded item anyway?") in list("Proceed", "Cancel")
+					if(choice == "Cancel")
+						return
+
 				linked_destroy.busy = 1
 				screen = 0.1
 				updateUsrDialog()
@@ -259,7 +268,6 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 								screen = 1.0
 								return
 							if((linked_destroy.loaded_item.reliability >= 99 - (linked_destroy.decon_mod * 3)) || linked_destroy.loaded_item.crit_fail)
-								var/list/temp_tech = linked_destroy.ConvertReqString2List(linked_destroy.loaded_item.origin_tech)
 								for(var/T in temp_tech)
 									if(prob(linked_destroy.loaded_item.reliability))               //If deconstructed item is not reliable enough its just being wasted, else it is pocessed
 										files.UpdateTech(T, temp_tech[T])                          //Check if deconstructed item has research levels higher/same/one less than current ones

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -252,7 +252,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 						break
 				if(!cancontinue)
 					var/choice = input("This item does not raise tech levels. Proceed destroying loaded item anyway?") in list("Proceed", "Cancel")
-					if(choice == "Cancel")
+					if(choice == "Cancel" || !linked_destroy)
 						return
 
 				linked_destroy.busy = 1

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -154,6 +154,13 @@ research holder datum.
 				KT.level = max((KT.level + 1), (level - 1))
 	return
 
+//Checks if the origin level can raise current tech levels
+//Input: Tech's ID and Level; Output: TRUE for yes, FALSE for no
+/datum/research/proc/IsTechHigher(ID, level)
+	for(var/datum/tech/KT in known_tech)
+		if(KT.id == ID)
+			return KT.level <= level
+
 /datum/research/proc/UpdateDesigns(obj/item/I, list/temp_tech)
 	for(var/T in temp_tech)
 		if(temp_tech[T] - 1 >= known_tech[T])


### PR DESCRIPTION
![afa941e44c9e4c399ad47fb4b26d857a](https://cloud.githubusercontent.com/assets/15943769/25310029/787d48da-27f4-11e7-8f2f-235eeb0fd5d9.jpg)

Деструктивный анализ подразумевает уничтожение предметов для их изучения.Ученый это знает.
Следовательно, после того как он:
• Засунул предмет в дестуктор
• Выбрал в меню подменю деструктора
• Нажал кнопку "разрушить предмет"
каждый раз предупреждать
"Это действие разрушит предмет" 
"Разрушить"  "Отмена" 
немного попахивает идиотизмом.

:cl:
 - tweak: Деструктор РНД теперь уведомит вас, если разбираемая вещь не повысит уровень исследований.