### PR TITLE
Фикс рокетлаунчера для мехов

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -236,7 +236,7 @@
 	var/missile_range = 30
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/Fire(atom/movable/AM, atom/target, turf/aimloc)
-	AM.throw_at(target,missile_range, missile_speed, chassis)
+	AM.throw_at(target, missile_range, missile_speed, spin = FALSE)
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/explosive
 	name = "SRM-8 Missile Rack"


### PR DESCRIPTION
Из-за того, что передавался chassis в качестве источника броска прок throw_at рантаймил, т.к. пытался найти в нём переменную с клиентом.

fixes #1379 

:cl:
 - bugfix: Рокетлаунчер у мехов не запускал ракету при выстреле.