### PR TITLE
Дестрои телепада и консоли к нему корректно обрабатывают свой дестрой

### DIFF
--- a/code/modules/telesci/telepad.dm
+++ b/code/modules/telesci/telepad.dm
@@ -9,6 +9,7 @@
 	idle_power_usage = 200
 	active_power_usage = 5000
 	var/efficiency
+	var/obj/machinery/computer/telescience/computer
 
 /obj/machinery/telepad/New()
 	..()
@@ -20,6 +21,12 @@
 	component_parts += new /obj/item/weapon/stock_parts/console_screen(null)
 	component_parts += new /obj/item/weapon/cable_coil/random(null, 1)
 	RefreshParts()
+
+/obj/machinery/telepad/Destroy()
+	if(computer)
+		computer.close_wormhole()
+		computer.telepad = null
+	return ..()
 
 /obj/machinery/telepad/RefreshParts()
 	var/E

--- a/code/modules/telesci/telepad.dm
+++ b/code/modules/telesci/telepad.dm
@@ -26,6 +26,7 @@
 	if(computer)
 		computer.close_wormhole()
 		computer.telepad = null
+		computer = null
 	return ..()
 
 /obj/machinery/telepad/RefreshParts()

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -97,6 +97,9 @@
 	else if(istype(W, /obj/item/device/multitool))
 		var/obj/item/device/multitool/M = W
 		if(M.buffer && istype(M.buffer, /obj/machinery/telepad))
+			if(telepad)
+				telepad.computer = null
+				close_wormhole()
 			telepad = M.buffer
 			telepad.computer = src
 			M.buffer = null

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -43,6 +43,7 @@
 		inserted_gps = null
 	if(telepad)
 		telepad.computer = null
+		telepad = null
 	close_wormhole()
 	return ..()
 

--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -41,6 +41,9 @@
 	if(inserted_gps)
 		inserted_gps.loc = loc
 		inserted_gps = null
+	if(telepad)
+		telepad.computer = null
+	close_wormhole()
 	return ..()
 
 /obj/machinery/computer/telescience/examine(mob/user)
@@ -95,6 +98,7 @@
 		var/obj/item/device/multitool/M = W
 		if(M.buffer && istype(M.buffer, /obj/machinery/telepad))
 			telepad = M.buffer
+			telepad.computer = src
 			M.buffer = null
 			to_chat(user, "<span class='notice'>You upload the data from the [W.name]'s buffer.</span>")
 	else


### PR DESCRIPTION
fixes #1396 
:cl:
 - bugfix: При разборке телепада или его консоли, червоточина не закрывалась.

