### PR TITLE
Deleting atoms from VV

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -281,6 +281,8 @@ datum/proc/on_varedit(modified_var) //called whenever a var is edited
 			body += "<option value='?_src_=vars;makeslime=\ref[D]'>Make slime</option>"
 		body += "<option value>---</option>"
 		body += "<option value='?_src_=vars;gib=\ref[D]'>Gib</option>"
+	if(isatom(D))
+		body += "<option value='?_src_=vars;delthis=\ref[D]'>Delete this object</option>"
 	if(isobj(D))
 		body += "<option value='?_src_=vars;delall=\ref[D]'>Delete all of type</option>"
 	if(isobj(D) || ismob(D) || isturf(D))
@@ -571,6 +573,11 @@ body
 
 		if(usr.client)
 			usr.client.cmd_assume_direct_control(M)
+
+	else if(href_list["delthis"])
+		//Rights check are in cmd_admin_delete() proc
+		var/atom/A = locate(href_list["delthis"])
+		cmd_admin_delete(A)
 
 	else if(href_list["delall"])
 		if(!check_rights(R_DEBUG|R_SERVER))	return


### PR DESCRIPTION
Собственно, возможность удалять предмет не только через ПКМ, но и через ВВ этого предмета.
Что касается предметов внутри других предметов - при удалении дыхательной маски из коробки, которая была в рюкзаке, который висел на кукле, контентс очистился, инвентарь (персонаж "смотрел в коробку") частично обновился, никаких отладочных сообщений, что сборщик мусора не смог собрать предмет и его пришлось удалить, не было получено.

:cl:
 - rscadd: У админов в ВВ панели появилась кнопка Delete this object для удаления конкретного объекта.