### PR TITLE
Добавлена задержка при надувании надувных стен и дверей

### DIFF
--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -6,12 +6,14 @@
 	w_class = 3.0
 
 	attack_self(mob/user)
-		playsound(loc, 'sound/items/zip.ogg', 75, 1)
-		to_chat(user, "\blue You inflate [src].")
-		var/obj/structure/inflatable/R = new /obj/structure/inflatable(user.loc)
-		src.transfer_fingerprints_to(R)
-		R.add_fingerprint(user)
-		qdel(src)
+		to_chat(user, "<span class='notice'>You start inflating the wall...</span>")
+		if(do_after(user, 40, target = user.loc))
+			playsound(loc, 'sound/items/zip.ogg', 75, 1)
+			to_chat(user, "\blue You inflate [src].")
+			var/obj/structure/inflatable/R = new /obj/structure/inflatable(user.loc)
+			src.transfer_fingerprints_to(R)
+			R.add_fingerprint(user)
+			qdel(src)
 
 /obj/structure/inflatable
 	name = "inflatable wall"
@@ -158,12 +160,14 @@
 	icon_state = "folded_door"
 
 	attack_self(mob/user)
-		playsound(loc, 'sound/items/zip.ogg', 75, 1)
-		to_chat(user, "\blue You inflate [src].")
-		var/obj/structure/inflatable/door/R = new /obj/structure/inflatable/door(user.loc)
-		src.transfer_fingerprints_to(R)
-		R.add_fingerprint(user)
-		qdel(src)
+		to_chat(user, "<span class='notice'>You start inflating the door...</span>")
+		if(do_after(user, 40, target = user.loc))
+			playsound(loc, 'sound/items/zip.ogg', 75, 1)
+			to_chat(user, "\blue You inflate [src].")
+			var/obj/structure/inflatable/door/R = new /obj/structure/inflatable/door(user.loc)
+			src.transfer_fingerprints_to(R)
+			R.add_fingerprint(user)
+			qdel(src)
 
 /obj/structure/inflatable/door //Based on mineral door code
 	name = "inflatable door"

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -4,13 +4,20 @@
 	icon = 'icons/obj/inflatable.dmi'
 	icon_state = "folded_wall"
 	w_class = 3.0
+	var/inflatable_type = /obj/structure/inflatable
 
 	attack_self(mob/user)
-		to_chat(user, "<span class='notice'>You start inflating the wall...</span>")
-		if(do_after(user, 40, target = user.loc))
+		user.visible_message(
+			"<span class='notice'>[user] starts inflating \the [src]...</span>",
+			"<span class='notice'>You start inflating \the [src]...</span>"
+		)
+		if(do_after(user, 40, target = user))
 			playsound(loc, 'sound/items/zip.ogg', 75, 1)
-			to_chat(user, "\blue You inflate [src].")
-			var/obj/structure/inflatable/R = new /obj/structure/inflatable(user.loc)
+			user.visible_message(
+				"<span class='notice'>[user] inflated \the [src].</span>",
+				"<span class='notice'>You inflate \the [src].</span>"
+			)
+			var/obj/structure/inflatable/R = new inflatable_type(user.loc)
 			src.transfer_fingerprints_to(R)
 			R.add_fingerprint(user)
 			qdel(src)
@@ -158,16 +165,7 @@
 	desc = "A folded membrane which rapidly expands into a simple door on activation."
 	icon = 'icons/obj/inflatable.dmi'
 	icon_state = "folded_door"
-
-	attack_self(mob/user)
-		to_chat(user, "<span class='notice'>You start inflating the door...</span>")
-		if(do_after(user, 40, target = user.loc))
-			playsound(loc, 'sound/items/zip.ogg', 75, 1)
-			to_chat(user, "\blue You inflate [src].")
-			var/obj/structure/inflatable/door/R = new /obj/structure/inflatable/door(user.loc)
-			src.transfer_fingerprints_to(R)
-			R.add_fingerprint(user)
-			qdel(src)
+	inflatable_type = /obj/structure/inflatable/door
 
 /obj/structure/inflatable/door //Based on mineral door code
 	name = "inflatable door"


### PR DESCRIPTION
Недавно со мной многие согласились, что мгновенный спавн надувных стен и дверей может абузиться. Ну и вот что-то вроде фикса. Теперь вылезает простой прогресс бар и длится это несколько секунд. Потому что почему нет.

![dreamseeker_2017-04-16_14-22-32](https://cloud.githubusercontent.com/assets/6051766/25557856/2f25912c-2d23-11e7-8505-cb8f98464528.png)


:cl:
 - tweak: Появилась задержка при надувании надувных стен и дверей.