### PR TITLE
Фиксы двуручного оружия

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -46,9 +46,9 @@
 /obj/item/weapon/twohanded/dropped(mob/user)
 	//handles unwielding a twohanded weapon when dropped as well as clearing up the offhand
 	if(user)
-		var/obj/item/weapon/twohanded/O = user.get_inactive_hand()
+		var/obj/item/weapon/twohanded/offhand/O = user.get_inactive_hand()
 		if(istype(O))
-			user.drop_from_inventory(O)
+			O.unwield()
 	return	unwield()
 
 /obj/item/weapon/twohanded/update_icon()

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -112,7 +112,7 @@
 /obj/item/weapon/gun/projectile/automatic/l6_saw/dropped(mob/user)
 	//handles unwielding a twohanded weapon when dropped as well as clearing up the offhand
 	if(user)
-		var/obj/item/weapon/gun/projectile/automatic/l6_saw/O = user.get_inactive_hand()
+		var/obj/item/weapon/twohanded/offhand/O = user.get_inactive_hand()
 		if(istype(O))
 			O.unwield()
 	return	unwield()

--- a/code/modules/projectiles/guns/projectile/rocket.dm
+++ b/code/modules/projectiles/guns/projectile/rocket.dm
@@ -37,7 +37,7 @@
 /obj/item/weapon/gun/projectile/revolver/rocketlauncher/dropped(mob/user)
 	//handles unwielding a twohanded weapon when dropped as well as clearing up the offhand
 	if(user)
-		var/obj/item/weapon/gun/projectile/revolver/rocketlauncher/O = user.get_inactive_hand()
+		var/obj/item/weapon/twohanded/offhand/O = user.get_inactive_hand()
 		if(istype(O))
 			O.unwield()
 	return	unwield()


### PR DESCRIPTION
<!--
Работа с чейнджлогом:

ВАЖНО! Чейнджлог должен быть в КОНЦЕ описания вашего ПРа. Всё что идёт после :cl: (эмодзи значка) будет парсится как чейнджлог.
Изменения должны описываться в формате списка. Используйте шаблон ниже.

Просьба писать чейнджлог с большой буквы и хотя бы с минимальным количеством знаков препинания, типа точки в конце предложения.

Шаблон для чейнджлога:
:cl: Здесь вы можете вставить свой/чужой ник (Необязательно. При пустом поле в чейнджлог пойдёт ник из гитхаба.)
 - bugfix: Фиксы описываются тут.
 - rscadd: Разные добавления и новшества (например фичи).
 - rscdel: Откаты фичь, удаление старого и т.д.
 - image: Изменения со спрайтами и изображениями.
 - sound: Звуки и всё что с ними связано.
 - spellcheck: Небольшие или не очень исправления в тексте.
 - tweak: Небольшие изменения (что-то формата "Добавил возможность сминать жестяные банки").
 - balance: Изменения связанные с балансом.
 - map: Изменения на карте.
 - performance: Производительность, скорость работы и т.д.
 - experiment: Экспериментальные изменения, шанс отката которых выше обычного.
 
Если изменений много, то вы можете ограничиться парой слов и добавить метку [link]. С ней, в конец строчки чейнджлога, будет автоматически добавлена ссылка на ваш ПР.
Пример:
:cl:
 - bugfix: Какой-то фикс. (Ссылка добавлена не будет.)
 - performance[link]: Огромные изменения, слов не хватит описать. (Будет добавлена ссылка, текст в игре будет выглядеть так: "Огромные изменения, слов не хватит описать. - подробнее -", где '- подробнее -' будет ссылкой на ПР.)
 
Чейнджлог генерируется автоматически сразу после мержа вашего ПРа.
-->
Пофикшено удаление offhand'a у двуручных оружий, не находящихся в классе twohanded
Теперь при дропе одного оружия класса twohanded из второй руки оружие класса twohanded не выпадает

:cl:
- bugfix: При дропе двуручных пушек вторая рука оставалась занятой.
- bugfix: При дропе двуручного оружия из одной руки двуручное оружие из другой руки также выпадало.