### PR TITLE
RnD dupe fix

### DIFF
--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -158,37 +158,33 @@ Note: Must be placed west/left of and R&D console to function.
 	if(max_material_storage - TotalMaterials() < (amount*stack.perunit))//Can't overfill
 		amount = min(stack.amount, round((max_material_storage-TotalMaterials())/stack.perunit))
 
-	src.overlays += "protolathe_[stack.name]"
-	sleep(10)
-	src.overlays -= "protolathe_[stack.name]"
-
-	icon_state = "protolathe"
-	busy = 1
-	use_power(max(1000, (3750*amount/10)))
-	var/stacktype = stack.type
+	busy = TRUE
 	stack.use(amount)
-	if (do_after(user, 16, target = src))
-		to_chat(user, "\blue You add [amount] sheets to the [src.name].")
-		icon_state = "protolathe"
-		switch(stacktype)
-			if(/obj/item/stack/sheet/metal)
-				m_amount += amount * 3750
-			if(/obj/item/stack/sheet/glass)
-				g_amount += amount * 3750
-			if(/obj/item/stack/sheet/mineral/gold)
-				gold_amount += amount * 2000
-			if(/obj/item/stack/sheet/mineral/silver)
-				silver_amount += amount * 2000
-			if(/obj/item/stack/sheet/mineral/phoron)
-				phoron_amount += amount * 2000
-			if(/obj/item/stack/sheet/mineral/uranium)
-				uranium_amount += amount * 2000
-			if(/obj/item/stack/sheet/mineral/diamond)
-				diamond_amount += amount * 2000
-			if(/obj/item/stack/sheet/mineral/clown)
-				clown_amount += amount * 2000
-	else
-		new stacktype(src.loc, amount)
-	busy = 0
-	src.updateUsrDialog()
-	return
+	to_chat(user, "<span class='notice'>You add [amount] sheets to the [name].</span>")
+
+	overlays += "protolathe_[stack.name]"
+	sleep(10)
+	overlays -= "protolathe_[stack.name]"
+
+	use_power(max(1000, (3750 * amount / 10)))
+
+	switch(stack.type)
+		if(/obj/item/stack/sheet/metal)
+			m_amount += amount * 3750
+		if(/obj/item/stack/sheet/glass)
+			g_amount += amount * 3750
+		if(/obj/item/stack/sheet/mineral/gold)
+			gold_amount += amount * 2000
+		if(/obj/item/stack/sheet/mineral/silver)
+			silver_amount += amount * 2000
+		if(/obj/item/stack/sheet/mineral/phoron)
+			phoron_amount += amount * 2000
+		if(/obj/item/stack/sheet/mineral/uranium)
+			uranium_amount += amount * 2000
+		if(/obj/item/stack/sheet/mineral/diamond)
+			diamond_amount += amount * 2000
+		if(/obj/item/stack/sheet/mineral/clown)
+			clown_amount += amount * 2000
+
+	busy = FALSE
+	updateUsrDialog()


### PR DESCRIPTION
Rip in pepperoni.

Помимо прочего, убрал `do_after` задержку, т.к. не вижу в ней никакого смысла с наличием слипа между добавлением/убиранием оверлея "вставки" ресурса. Ну и немного подправил код, убрав ненужные выставления `icon_state`.

fixes #1487 

:cl:
 - bugfix: Прикрыта лавочка с дюпом ресурсов в РнД через протолат и фабрикатор мехов.