### PR TITLE
Изменение лога `noob notify` и новые дефайны для админских операций

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -46,3 +46,5 @@
 #define ADMIN_QUE(user) "(<a href='?_src_=holder;adminmoreinfo=\ref[user]'>?</a>)"
 #define ADMIN_FLW(target) "(<a href='?_src_=holder;adminplayerobservefollow=\ref[target]'>FLW</a>)"
 #define ADMIN_JMP(target) "(<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[target.x];Y=[target.y];Z=[target.z]'>JMP</a>)"
+#define ADMIN_VV(target) "(<a href='?_src_=vars;Vars=\ref[target]'>VV</a>)"
+#define ADMIN_PP(user)  "(<a href='?_src_=holder;adminplayeropts=\ref[user]'>PP</a>)"

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -502,7 +502,12 @@ proc/isInSight(atom/A, atom/B)
 		var/player_assigned_role = (M.mind.assigned_role ? " ([M.mind.assigned_role])" : "")
 		var/player_byond_profile = "http://www.byond.com/members/[M.ckey]"
 
-		message_admins("<b>New player notify:</b> [M.ckey] join to the game as [M.mind.name][player_assigned_role] - <a href='[player_byond_profile]'>Byond Profile</a>, [M.ckey] ip: [M.lastKnownIP] [ADMIN_FLW(M)]")
+		var/msg = {"New player notify
+					Player '[M.ckey]' joined to the game as [M.mind.name][player_assigned_role] [ADMIN_FLW(M)] [ADMIN_PP(M)] [ADMIN_VV(M)]
+					Byond profile: <a href='[player_byond_profile]'>open</a>
+					IP: [M.lastKnownIP]"}
+
+		message_admins(msg)
 
 //============VG PORTS============
 /proc/recursive_type_check(atom/O, type = /atom)

--- a/goon/browserassets/js/browserOutput.js
+++ b/goon/browserassets/js/browserOutput.js
@@ -86,7 +86,7 @@ if (typeof String.prototype.trim !== 'function') {
 
 //Shit fucking piece of crap that doesn't work god fuckin damn it
 function linkify(text) {
-	var rex = /((?:<a|<iframe|<img)(?:.*?(?:src="|href=").*?))?(?:(?:https?:\/\/)|(?:www\.))+(?:[^ ]*?\.[^ ]*?)+[-A-Za-z0-9+&@#\/%?=~_|$!:,.;]+/ig;
+	var rex = /((?:<a|<iframe|<img)(?:.*?(?:src|href)=(?:'|").*?))?(?:(?:https?:\/\/)|(?:www\.))+(?:[^ ]*?\.[^ ]*?)+[-A-Za-z0-9+&@#\/%?=~_|$!:,.;]+/ig;
 	return text.replace(rex, function ($0, $1) {
 		if(/^https?:\/\/.+/i.test($0)) {
 			return $1 ? $0: '<a href="'+$0+'">'+$0+'</a>';


### PR DESCRIPTION
- Поправил реджекс в `linkify`, чтобы тот парсил ссылки не только с двойными ковычками, но и с одинарными. (fix #1495)
- Изменил выведение лога в чат, чтобы тот был более заметными и понятным. Добавил кнопки для VV и PP.
- Добавил новые дефайны для админских операций: ADIMN_VV и ADMIN_PP.

Было:
![bandicam 2017-05-21 16-49-36-602](https://cloud.githubusercontent.com/assets/12721311/26284535/5750285e-3e46-11e7-9b78-156f4c8eac19.jpg)

Стало:
![bandicam 2017-05-21 16-36-49-766](https://cloud.githubusercontent.com/assets/12721311/26284537/5d05e7f2-3e46-11e7-8606-73315865acd8.jpg)
