### PR TITLE
Убираем синди тулбокс из космоса у спутника ИИ

### DIFF
--- a/maps/z1.dmm
+++ b/maps/z1.dmm
@@ -6988,7 +6988,7 @@
 "cEB" = (/obj/machinery/flasher{id = "AI"; pixel_x = 0; pixel_y = 24},/obj/structure/cable{icon_state = "2-8"; d1 = 2; d2 = 8},/turf/simulated/floor/whitegreed,/area/turret_protected/ai)
 "cEC" = (/obj/structure/window/reinforced{dir = 4},/turf/space,/area/space)
 "cED" = (/obj/machinery/light/small{dir = 1},/obj/structure/stool/bed/chair/schair/wagon{dir = 4},/turf/simulated/shuttle/floor/erokez{icon_state = "floor"},/area/shuttle/escape_pod5/station)
-"cEE" = (/obj/structure/window/reinforced{dir = 1; pixel_y = 0},/obj/structure/window/reinforced{dir = 4},/obj/item/weapon/storage/toolbox/syndicate,/turf/space,/area/space)
+"cEE" = (/obj/structure/window/reinforced{dir = 1; pixel_y = 0},/obj/structure/window/reinforced{dir = 4},/turf/space,/area/space)
 "cEF" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/whitegreed,/area/turret_protected/ai)
 "cEG" = (/obj/machinery/flasher{id = "AI"; pixel_x = 0; pixel_y = 24},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/whitegreed,/area/turret_protected/ai)
 "cEH" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9},/turf/simulated/floor/whitegreed,/area/turret_protected/ai)


### PR DESCRIPTION
<!--
Работа с чейнджлогом:

ВАЖНО! Чейнджлог должен быть в КОНЦЕ описания вашего ПРа. Всё что идёт после :cl: (эмодзи значка) будет парсится как чейнджлог.
Изменения должны описываться в формате списка. Используйте шаблон ниже.

Просьба писать чейнджлог с большой буквы и хотя бы с минимальным количеством знаков препинания, типа точки в конце предложения.

Шаблон для чейнджлога:
:cl: Здесь вы можете вставить свой/чужой ник (Необязательно. При пустом поле в чейнджлог пойдёт ник из гитхаба.)
 - bugfix: Фиксы описываются тут.
 - rscadd: Разные добавления и новшества (например фичи).
 - rscdel: Откаты фичь, удаление старого и т.д.
 - image: Изменения со спрайтами и изображениями.
 - sound: Звуки и всё что с ними связано.
 - spellcheck: Небольшие или не очень исправления в тексте.
 - tweak: Преимущественно небольшие изменение чего-то готового.
 - balance: Изменения связанные с балансом.
 - map: Изменения на карте.
 - performance: Производительность, скорость работы и т.д.
 - experiment: Экспериментальные изменения, шанс отката которых выше обычного.
 
Если изменений много, то вы можете ограничиться парой слов и добавить метку [link]. С ней, в конец строчки чейнджлога, будет автоматически добавлена ссылка на ваш ПР.
Пример:
:cl:
 - bugfix: Какой-то фикс. (Ссылка добавлена не будет.)
 - performance[link]: Огромные изменения, слов не хватит описать. (Будет добавлена ссылка, текст в игре будет выглядеть так: "Огромные изменения, слов не хватит описать. - подробнее -", где '- подробнее -' будет ссылкой на ПР.)
 
Чейнджлог генерируется автоматически, сразу после мержа вашего ПРа.
-->

HERE WE GO AGAIN

Удален синдитулбокс из спеса 

Почему убрать? Ну потому что наличие этого нелогично, глупо, и постоянно абузится (причем нарушая правила) разными игроками, так что лучше сделать сделать небольшое изменение, дабы не провоцировать игроков на метагейм.

:cl: 
 - map: Убрана синдикатовская коробка с инструментами из космоса у спутника ИИ