### PR TITLE
Фикс защиты глаз шлема от "космического скафандра"

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -805,7 +805,7 @@
 	if(istype(src.head, /obj/item/clothing/head/welding))
 		if(!src.head:up)
 			number += 2
-	if(istype(src.head, /obj/item/clothing/head/helmet/space))
+	if(istype(src.head, /obj/item/clothing/head/helmet/space) && !istype(src.head, /obj/item/clothing/head/helmet/space/sk))
 		number += 2
 	if(istype(src.glasses, /obj/item/clothing/glasses/thermal))
 		number -= 1
@@ -821,8 +821,6 @@
 			number += 2
 	if(istype(src.glasses, /obj/item/clothing/glasses/night/shadowling))
 		number -= 1
-	if(istype(src.head, /obj/item/clothing/head/helmet/space/sk))
-		number = 0
 	return number
 
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -821,6 +821,8 @@
 			number += 2
 	if(istype(src.glasses, /obj/item/clothing/glasses/night/shadowling))
 		number -= 1
+	if(istype(src.head, /obj/item/clothing/head/helmet/space/sk))
+		number = 0
 	return number
 
 


### PR DESCRIPTION
:cl:
 - balance: Шлем от "космического скафандра", из синих аварийных шкафчиков, больше не защищает глаза от сварки и флешек