### PR TITLE
Фикс вечного цикла в турелях и фикс воздействия тазеров на мехов

### DIFF
--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -459,7 +459,7 @@
 	return
 
 /obj/machinery/bot/medbot/bullet_act(obj/item/projectile/Proj)
-	if(Proj.flag == "taser")
+	if(is_type_in_list(Proj, taser_projectiles)) //taser_projectiles defined in projectile.dm
 		src.stunned = min(stunned+10,20)
 	..()
 

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -499,7 +499,7 @@
 		src.log_append_to_last("Armor saved.")
 		return
 	var/ignore_threshold
-	if(Proj.flag == "taser")
+	if(is_type_in_list(Proj, taser_projectiles)) //taser_projectiles defined in projectile.dm
 		use_power(200)
 		return
 	if(istype(Proj, /obj/item/projectile/beam/pulse))

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -266,9 +266,14 @@
 
 		if(!bumped && !isturf(original))
 			if(loc == get_turf(original))
-				if(!(original in permutated))
-					if(Bump(original))
-						return
+				if(isturf(original.loc))
+					if(!(original in permutated))
+						if(Bump(original))
+							return
+				else//if target is in mecha/crate/MULE/etc
+					if(!(original.loc in permutated))
+						if(Bump(original.loc))
+							return
 
 		if(first_step)
 			muzzle_effect(effect_transform)
@@ -355,14 +360,15 @@
 	if(istype(A, /obj/item/projectile))
 		return
 	if(istype(A, /mob/living))
-		result = 2 //We hit someone, return 1!
+		result = 2 //We hit someone, return 1 (in process() 2 will be decremented to 1)!
+		bumped = TRUE
 		return
 	if(checkpass(PASSGLASS) && istype(A, /obj/structure/window))
 		return
 	if(checkpass(PASSGRILLE) && istype(A, /obj/structure/grille))
 		return
 	result = 1
-	return
+	bumped = TRUE
 
 /obj/item/projectile/test/process()
 	var/turf/curloc = get_turf(src)
@@ -371,8 +377,8 @@
 		return 0
 	yo = targloc.y - curloc.y
 	xo = targloc.x - curloc.x
-	target = targloc
 	original = target
+	target = targloc
 	starting = curloc
 
 	//plot the initial trajectory
@@ -381,26 +387,31 @@
 	while(src) //Loop on through!
 		if(result)
 			return (result - 1)
-		if((!( target ) || loc == target))
+		if(!target || loc == target)
 			target = locate(min(max(x + xo, 1), world.maxx), min(max(y + yo, 1), world.maxy), z) //Finding the target turf at map edge
+		if(x == 1 || x == world.maxx || y == 1 || y == world.maxy || kill_count-- < 1)
+			qdel(src)
+			return 0
 
 		trajectory.increment()	// increment the current location
 		location = trajectory.return_location(location)		// update the locally stored location data
+		if(!location)
+			qdel(src)
+			return 0
 
 		Move(location.return_turf())
 
-		var/mob/living/M = locate() in get_turf(src)
-		if(istype(M)) //If there is someting living...
-			return 1 //Return 1
-		else
-			M = locate() in get_step(src,target)
-			if(istype(M))
-				return 1
+		if(!bumped && !isturf(original) && loc == get_turf(original))
+			if(isturf(original.loc))
+				Bump(original)
+			else
+				Bump(original.loc) //if target is in mecha/crate/MULE/etc
 
 /obj/item/projectile/test/dummy/Bump(atom/A) //Another test projectile with increased checklist
 	..()
 	if(result != 1)
 		return
+	//bumped is already set to TRUE
 	if(is_type_in_list(A, list(/obj/structure/closet, /obj/mecha, /obj/machinery/bot/mulebot)))
 		result = 2
 	return
@@ -410,3 +421,8 @@
 
 /obj/item/projectile/Process_Spacemove(movement_dir = 0)
 	return 1 //Bullets don't drift in space
+
+var/static/list/taser_projectiles = list(
+	/obj/item/projectile/beam/stun,
+	/obj/item/ammo_casing/energy/electrode
+)


### PR DESCRIPTION
<!--
Описание ПРа:
Пожалуйста, опишите в теле ПРа суть изменений, причину и чего вы хотите добиться.

Работа с чейнджлогом:

ВАЖНО! Чейнджлог должен быть в КОНЦЕ описания вашего ПРа. Всё что идёт после :cl: (эмодзи значка) будет парсится как чейнджлог.
Изменения должны описываться в формате списка. Используйте шаблон ниже.

Просьба писать чейнджлог с большой буквы и хотя бы с минимальным количеством знаков препинания, типа точки в конце предложения.

Шаблон для чейнджлога:
:cl: Здесь вы можете вставить свой/чужой ник (Необязательно. При пустом поле в чейнджлог пойдёт ник из гитхаба.)
 - bugfix: Фиксы описываются тут.
 - rscadd: Разные добавления и новшества (например фичи).
 - rscdel: Откаты фичь, удаление старого и т.д.
 - image: Изменения со спрайтами и изображениями.
 - sound: Звуки и всё что с ними связано.
 - spellcheck: Небольшие или не очень исправления в тексте.
 - tweak: Преимущественно небольшие изменение чего-то готового.
 - balance: Изменения связанные с балансом.
 - map: Изменения на карте.
 - performance: Производительность, скорость работы и т.д.
 - experiment: Экспериментальные изменения, шанс отката которых выше обычного.
 
Если изменений много, то вы можете ограничиться парой слов и добавить метку [link]. С ней, в конец строчки чейнджлога, будет автоматически добавлена ссылка на ваш ПР.
Важно: [link] - это маркер для обработчика, которая даёт ему понять, что нужно вставить ссылку на ваш ПР. В саму метку НИЧЕГО помещать не надо, ссылка получается АВТОМАТИЧЕСКИ обработчиком в процессе генерации чейнджлога.

Пример:
:cl:
 - bugfix: Какой-то фикс. (Ссылка добавлена не будет.)
 - performance[link]: Огромные изменения, слов не хватит описать. (Будет добавлена ссылка, текст в игре будет выглядеть так: "Огромные изменения, слов не хватит описать. - подробнее -", где '- подробнее -' будет ссылкой на ПР.)
 
Чейнджлог генерируется автоматически, сразу после мержа вашего ПРа.
-->
Ну, с турелями понятно, если поместить меха на турф с турелью, то процесс тестового проджектайла уйдёт в вечный цикл, так как прожектайл никуда не двигается, таким образом бамп не вызывается и лайвингов на турфе с турелью нет.
Также пофиксил поведение в этой же ситуации для других прожектайлов. Суть: если прожектайл ни с чем не взаимодействовал, то происходит проверка на то, не является ли цель турфом и находится ли он с целью на одном и том же турфе. Вернее, проверка не на цель, а на то, куда человек кликает при стрельбе (original), но если говорить про те же турели, то там ориджинал - таки вполне себе моб. Получается так, что даже если моб находится в каком-либо контейнере, для него вызывается бамп этого проджектайла. По моему скромному мнению, переход на один уровень вверх (если лок цели - не турф) - приемлемое решение. 
Также заметил, что у мехов и медботов есть интересная проверка на то, имеет ли проджектайл, который попал по ним, флаг "тазер". Если имеет, у меха списывается некоторое количество энергии, а медбот выключается на некоторое время. Но есть небольшая загвоздка в том, что в билде нету проджектайлов с флагом "тазер". У тазера-луча флаг "лазер", а у стансферы - "энерджи". Поэтому я решил, что стоит здесь заменить проверку флага на проверку соответствия типа проджектайла какому-либо из этих двух тазеров, так как этот код не был выпилен,, а только лишь сломан. 
:cl:
 - bugfix: Попадание из тазера по меху не снижало заряд его батареи.