### PR TITLE
Теперь боковые южные части гейтвея так же проходимы.

### DIFF
--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -15,8 +15,8 @@
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/gateway/atom_init_late()
-	if(dir == 2)
-		density = 0
+	if(dir & SOUTH)
+		density = FALSE
 	if(!transit_loc)
 		transit_loc = locate(/obj/effect/landmark/gateway_transit) in landmarks_list
 


### PR DESCRIPTION
Бьонда на компухтере нет, так что на локалочке не проверял. Но изменения мизерные, так что проблем возникнуть не должно. Сделал из-за выкриков в чятике из-за узкого проёма гейвея. 

:cl: Phantom Kurshan
 - tweak: Теперь боковые южные части гейтвея не препятствуют движению объектов. 