### PR TITLE
Фикс кровотечения в отсутствующих органах при их отрубании

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -644,7 +644,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		if(BP.parent == src)
 			BP.droplimb(null, clean, disintegrate)
 
-	if(parent && disintegrate != DROPLIMB_BURN)
+	if(parent && !(parent.status & ORGAN_DESTROYED) && disintegrate != DROPLIMB_BURN)
 		if(clean)
 			if(prob(10))
 				parent.sever_artery()


### PR DESCRIPTION
<!--
Подробно про оформление ПРов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies

Там же написано про то, как сделать чейнджлог. Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment.
-->
fixes #1651 
:cl:
 - bugfix: В некоторых случаях отрезанная часть тела получала артериальное кровотечение.