### PR TITLE
Твики проверок состояния ног

### DIFF
--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -9,14 +9,14 @@
 	if(findtext(act,"s",-1) && !findtext(act,"_",-2))//Removes ending s's unless they are prefixed with a '_'
 		act = copytext(act,1,length(act))
 
-	var/muzzled = istype(src.wear_mask, /obj/item/clothing/mask/muzzle)
+	var/muzzled = istype(wear_mask, /obj/item/clothing/mask/muzzle)
 	//var/m_type = 1
 
 	for (var/obj/item/weapon/implant/I in src)
 		if (I.implanted)
 			I.trigger(act, src)
 
-	if(src.stat == DEAD && (act != "deathgasp"))
+	if(stat == DEAD && (act != "deathgasp"))
 		return
 	switch(act)
 		if ("airguitar")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -332,13 +332,15 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 	return
 
 
-/mob/living/carbon/human/restrained()
-	if (handcuffed)
-		return 1
+/mob/living/carbon/human/restrained(check_type = HANDS)
+	if ((check_type & HANDS) && handcuffed)
+		return TRUE
+	if ((check_type & LEGS) && legcuffed)
+		return TRUE
 	if (istype(wear_suit, /obj/item/clothing/suit/straight_jacket))
-		return 1
+		return TRUE
 	if (istype(buckled, /obj/structure/stool/bed/nest))
-		return 1
+		return TRUE
 	return 0
 
 
@@ -1466,7 +1468,7 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 		to_chat(src, "<span class='notice'>It is unsafe to leap without gravity!</span>")
 		return
 
-	if(incapacitated() || buckled || pinned.len || stance_damage >= 4)
+	if(incapacitated(LEGS) || buckled || pinned.len || stance_damage >= 4) //because you need !restrained legs to leap
 		to_chat(src, "<span class='warning'>You cannot leap in your current state.</span>")
 		return
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1466,7 +1466,7 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 		to_chat(src, "<span class='notice'>It is unsafe to leap without gravity!</span>")
 		return
 
-	if(stat || stunned || lying)
+	if(incapacitated() || buckled || pinned.len || stance_damage >= 4)
 		to_chat(src, "<span class='warning'>You cannot leap in your current state.</span>")
 		return
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -81,6 +81,8 @@
 	if(bodytemperature < 283.222)
 		tally += (283.222 - bodytemperature) / 10 * 1.75
 
+	tally += max(2 * stance_damage, 0) //damaged/missing feet or legs is slow
+
 	return (tally + config.human_delay)
 
 /mob/living/carbon/human/Process_Spacemove(movement_dir = 0)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -294,6 +294,6 @@
 			//hud_used.SetButtonCoords(hud_used.hide_actions_toggle,button_number+1)
 		client.screen += hud_used.hide_actions_toggle
 
-/mob/living/incapacitated()
-	if(stat || paralysis || stunned || weakened || restrained())
+/mob/living/incapacitated(restrained_type = HANDS)
+	if(stat || paralysis || stunned || weakened || restrained(restrained_type))
 		return 1

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -125,7 +125,7 @@
 	set waitfor = 0
 	return
 
-/mob/proc/incapacitated()
+/mob/proc/incapacitated(restrained_type = HANDS)
 	return
 
 /mob/proc/restrained()

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -216,7 +216,7 @@
 	var/alien_talk_understand = 0
 
 	var/has_limbs = 1 //Whether this mob have any limbs he can move with
-	var/can_stand = 1 //Whether this mob have ability to stand
+	var/stance_damage = 1 //Whether this mob's ability to stand has been affected
 
 	var/immune_to_ssd = 0
 

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -83,7 +83,6 @@
 // Takes care of bodypart and their organs related updates, such as broken and missing limbs
 /mob/living/carbon/human/proc/handle_bodyparts()
 	number_wounds = 0
-	var/leg_tally = 2
 	var/force_process = 0
 	var/damage_this_tick = getBruteLoss() + getFireLoss() + getToxLoss()
 	if(damage_this_tick > last_dam)
@@ -97,6 +96,8 @@
 	//processing organs is pretty cheap, do that first.
 	for(var/obj/item/organ/internal/IO in organs)
 		IO.process()
+
+	handle_stance()
 
 	if(!force_process && !bad_bodyparts.len)
 		return
@@ -124,23 +125,51 @@
 						if (W.infection_check())
 							W.germ_level += 1
 
-			if((BP.body_zone in list(BP_L_LEG , BP_L_FOOT , BP_R_LEG , BP_R_FOOT)) && !lying)
-				if (!BP.is_usable() || BP.is_malfunctioning() || (BP.is_broken() && !(BP.status & ORGAN_SPLINTED)))
-					leg_tally--			// let it fail even if just foot&leg
+/mob/living/carbon/human/proc/handle_stance()
+	// Don't need to process any of this if they aren't standing anyways
+	// unless their stance is damaged, and we want to check if they should stay down
+	if(!stance_damage && (lying || resting) && (life_tick % 4) != 0)
+		return
+
+	stance_damage = 0
+
+	// Buckled to a bed/chair. Stance damage is forced to 0 since they're sitting on something solid
+	if(istype(buckled, /obj/structure/stool))
+		return
+
+	for(var/limb_tag in list(BP_L_LEG, BP_R_LEG, BP_L_FOOT, BP_R_FOOT))
+		var/obj/item/organ/external/E = bodyparts_by_name[limb_tag]
+		if(!E || !E.is_usable())
+			stance_damage += 2 // let it fail even if just foot&leg
+		else if(E.is_malfunctioning())
+			//malfunctioning only happens intermittently so treat it as a missing limb when it procs
+			stance_damage += 2
+			if(prob(10))
+				visible_message("\The [src]'s [E.name] [pick("twitches", "shudders")] and sparks!")
+				var/datum/effect/effect/system/spark_spread/spark_system = new ()
+				spark_system.set_up(5, 0, src)
+				spark_system.attach(src)
+				spark_system.start()
+				spawn(10)
+					qdel(spark_system)
+		else if(E.is_broken())
+			if(!(E.status & ORGAN_SPLINTED))
+				stance_damage += 1
+			else
+				stance_damage += 0.5
+
+	// Canes and crutches help you stand (if the latter is ever added)
+	// One cane mitigates a broken leg+foot, or a missing foot.
+	// Two canes are needed for a lost leg. If you are missing both legs, canes aren't gonna help you.
+	if (l_hand && istype(l_hand, /obj/item/weapon/cane))
+		stance_damage -= 2
+	if (r_hand && istype(r_hand, /obj/item/weapon/cane))
+		stance_damage -= 2
 
 	// standing is poor
-	if(leg_tally <= 0 && !paralysis && !(lying || resting) && prob(5))
-		if(species && species.flags[NO_PAIN])
-			emote("scream",,, 1)
-		emote("collapse")
-		paralysis = 10
-
-	//Check arms and legs for existence
-	can_stand = 2 //can stand on both legs
-	var/obj/item/organ/external/BP = bodyparts_by_name[BP_L_FOOT]
-	if(BP.status & ORGAN_DESTROYED)
-		can_stand--
-
-	BP = bodyparts_by_name[BP_R_FOOT]
-	if(BP.status & ORGAN_DESTROYED)
-		can_stand--
+	if(stance_damage >= 4 || (stance_damage >= 2 && prob(5)))
+		if(!(lying || resting))
+			if(species && !species.flags[NO_PAIN])
+				emote("scream", auto = TRUE)
+			emote("collapse")
+		Weaken(5) //can't emote while weakened, apparently.


### PR DESCRIPTION
<!--
Подробно про оформление ПРов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies

Там же написано про то, как сделать чейнджлог. Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment.
-->
fixes #1946 
:cl:
 - bugfix: Люди без ног могли ходить.
 - tweak: При повреждении ног уменьшается скорость передвижения. Трость(-и) и кресло-каталка помогут исправить это (но они не убирают штраф на скорость от травматического шока).