### PR TITLE
Фиксы к ПРу с изменениями уровней машинерии и контейнеров

### DIFF
--- a/code/__DEFINES/_planes+layers.dm
+++ b/code/__DEFINES/_planes+layers.dm
@@ -83,28 +83,28 @@ What is the naming convention for planes or layers?
 #define ABOVE_HUD_LAYER   20
 
 //efine TURF_LAYER                 2 // For easy recordkeeping; this is a byond define
-#define ABOVE_NORMAL_TURF_LAYER    2.08	// Currently used only by /obj/structure/fans/tiny
+#define ABOVE_NORMAL_TURF_LAYER    2.08 // Currently used only by /obj/structure/fans/tiny
 #define GAS_PIPE_HIDDEN_LAYER      2.35
 #define GAS_SCRUBBER_LAYER         2.46
 #define GAS_PIPE_VISIBLE_LAYER     2.47
 #define GAS_FILTER_LAYER           2.48
 #define GAS_PUMP_LAYER             2.49
-#define LOW_OBJ_LAYER              2.491// Currently used only by unused machinery
+#define LOW_OBJ_LAYER              2.491 // Currently used only by unused machinery
 #define FIREDOOR_LAYER             2.5
-#define BELOW_CONTAINERS_LAYER     2.7	// Below closets, crates...
-#define CONTAINER_STRUCTURE_LAYER  2.8	// Layer for closets, crates, bags, racks, tables
+#define BELOW_CONTAINERS_LAYER     2.7 // Below closets, crates...
+#define CONTAINER_STRUCTURE_LAYER  2.8 // Layer for closets, crates, bags, racks, tables
 #define DOOR_LAYER                 2.82
-#define BELOW_MACHINERY_LAYER      2.83	// Currently for grilles only, because they should be below machinery
-#define DEFAULT_MACHINERY_LAYER    2.85	// Every /obj/machinery by default have this layer
+#define BELOW_MACHINERY_LAYER      2.83 // Currently for grilles only, because they should be below machinery
+#define DEFAULT_MACHINERY_LAYER    2.85 // Every /obj/machinery by default have this layer
 //efine OBJ_LAYER                  3 // For easy recordkeeping; this is a byond define
-#define SHUTTERS_LAYER      3.1
+#define SHUTTERS_LAYER             3.1
 #define ABOVE_WINDOW_LAYER         3.3
-#define BELOW_MOB_LAYER            3.7	//Currently used only by fluff struct in bluespace shelter
+#define BELOW_MOB_LAYER            3.7 //Currently used only by fluff struct in bluespace shelter
 //efine MOB_LAYER                  4 // For easy recordkeeping; this is a byond define
 //efine FLY_LAYER                  5 // For easy recordkeeping; this is a byond define
 
 
 //modifiers for /obj/machinery/door (and subtypes) layers
-#define DOOR_CLOSED_MOD     0.3	//how much the layer is increased when the door is closed
+#define DOOR_CLOSED_MOD     0.3 //how much the layer is increased when the door is closed
 #define PODDOOR_CLOSED_MOD  0.3
 #define FIREDOOR_CLOSED_MOD 0.31

--- a/code/__DEFINES/_planes+layers.dm
+++ b/code/__DEFINES/_planes+layers.dm
@@ -83,17 +83,28 @@ What is the naming convention for planes or layers?
 #define ABOVE_HUD_LAYER   20
 
 //efine TURF_LAYER                 2 // For easy recordkeeping; this is a byond define
+#define ABOVE_NORMAL_TURF_LAYER    2.08	// Currently used only by /obj/structure/fans/tiny
 #define GAS_PIPE_HIDDEN_LAYER      2.35
 #define GAS_SCRUBBER_LAYER         2.46
 #define GAS_PIPE_VISIBLE_LAYER     2.47
 #define GAS_FILTER_LAYER           2.48
 #define GAS_PUMP_LAYER             2.49
-#define LOW_OBJ_LAYER              2.5
-#define BELOW_CONTAINERS_LAYER     2.7
-#define CONTAINER_STRUCTURE_LAYER  2.8
-#define BELOW_MACHINERY_LAYER      2.83
-#define DEFAULT_MACHINERY_LAYER    2.85
+#define LOW_OBJ_LAYER              2.491// Currently used only by unused machinery
+#define FIREDOOR_LAYER             2.5
+#define BELOW_CONTAINERS_LAYER     2.7	// Below closets, crates...
+#define CONTAINER_STRUCTURE_LAYER  2.8	// Layer for closets, crates, bags, racks, tables
+#define DOOR_LAYER                 2.82
+#define BELOW_MACHINERY_LAYER      2.83	// Currently for grilles only, because they should be below machinery
+#define DEFAULT_MACHINERY_LAYER    2.85	// Every /obj/machinery by default have this layer
 //efine OBJ_LAYER                  3 // For easy recordkeeping; this is a byond define
+#define SHUTTERS_LAYER      3.1
 #define ABOVE_WINDOW_LAYER         3.3
+#define BELOW_MOB_LAYER            3.7	//Currently used only by fluff struct in bluespace shelter
 //efine MOB_LAYER                  4 // For easy recordkeeping; this is a byond define
 //efine FLY_LAYER                  5 // For easy recordkeeping; this is a byond define
+
+
+//modifiers for /obj/machinery/door (and subtypes) layers
+#define DOOR_CLOSED_MOD     0.3	//how much the layer is increased when the door is closed
+#define PODDOOR_CLOSED_MOD  0.3
+#define FIREDOOR_CLOSED_MOD 0.31

--- a/code/__DEFINES/_planes+layers.dm
+++ b/code/__DEFINES/_planes+layers.dm
@@ -91,6 +91,7 @@ What is the naming convention for planes or layers?
 #define LOW_OBJ_LAYER              2.5
 #define BELOW_CONTAINERS_LAYER     2.7
 #define CONTAINER_STRUCTURE_LAYER  2.8
+#define BELOW_MACHINERY_LAYER      2.83
 #define DEFAULT_MACHINERY_LAYER    2.85
 //efine OBJ_LAYER                  3 // For easy recordkeeping; this is a byond define
 #define ABOVE_WINDOW_LAYER         3.3

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -63,16 +63,6 @@
 // Doors!
 #define DOOR_CRUSH_DAMAGE 10
 
-#define DOOR_LAYER          2.82
-#define DOOR_CLOSED_MOD     0.3 //how much the layer is increased when the door is closed
-
-#define PODDOOR_CLOSED_MOD  0.3
-
-#define SHUTTERS_LAYER      3.1
-
-#define FIREDOOR_LAYER      2.5
-#define FIREDOOR_CLOSED_MOD 0.31
-
 #define FIREDOOR_MAX_PRESSURE_DIFF 25 // kPa
 
 #define FIREDOOR_MAX_TEMP 50 // °C
@@ -176,9 +166,6 @@
 #define MANIFEST_ERROR_CONTENTS		2
 #define MANIFEST_ERROR_ITEM			4
 
-// from /tg/
-#define ABOVE_NORMAL_TURF_LAYER 2.08
-#define BELOW_MOB_LAYER 3.7
 
 //teleport checks
 #define TELE_CHECK_NONE 0

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -6,7 +6,7 @@
 	density = 1
 	anchored = 1
 	flags = CONDUCT
-	layer = 2.9
+	layer = BELOW_MACHINERY_LAYER
 	explosion_resistance = 5
 	var/health = 10
 	var/destroyed = 0

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -81,7 +81,7 @@
 		playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 		src.connected = new /obj/structure/m_tray( src.loc )
 		step(src.connected, src.dir)
-		src.connected.layer = OBJ_LAYER
+		src.connected.layer = BELOW_CONTAINERS_LAYER
 		var/turf/T = get_step(src, src.dir)
 		if (T.contents.Find(src.connected))
 			src.connected.connected = src
@@ -120,7 +120,7 @@
 		return
 	src.connected = new /obj/structure/m_tray( src.loc )
 	step(src.connected, src.dir)
-	src.connected.layer = OBJ_LAYER
+	src.connected.layer = BELOW_CONTAINERS_LAYER
 	var/turf/T = get_step(src, src.dir)
 	if (T.contents.Find(src.connected))
 		src.connected.connected = src
@@ -269,7 +269,7 @@
 		playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 		src.connected = new /obj/structure/c_tray( src.loc )
 		step(src.connected, SOUTH)
-		src.connected.layer = OBJ_LAYER
+		src.connected.layer = BELOW_CONTAINERS_LAYER
 		var/turf/T = get_step(src, SOUTH)
 		if (T.contents.Find(src.connected))
 			src.connected.connected = src
@@ -303,7 +303,7 @@
 		return
 	src.connected = new /obj/structure/c_tray( src.loc )
 	step(src.connected, SOUTH)
-	src.connected.layer = OBJ_LAYER
+	src.connected.layer = BELOW_CONTAINERS_LAYER
 	var/turf/T = get_step(src, SOUTH)
 	if (T.contents.Find(src.connected))
 		src.connected.connected = src


### PR DESCRIPTION
<!--
Подробно про оформление ПРов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies

Там же написано про то, как сделать чейнджлог. Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment.
-->
(нет, бластдуры/провода/трубы не окажутся внезапно над решетками)
:cl:
 - bugfix: Некоторая машинерия отображалась под решетками.
 - bugfix: Стеллажи в морге и крематории были над мешками с трупами.