### PR TITLE
Пистолет больше не ест обоймы

### DIFF
--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -58,7 +58,7 @@
 /obj/item/weapon/gun/projectile/sigi/attackby(obj/item/A, mob/user)
 	if (istype(A, /obj/item/ammo_box/magazine))
 		var/obj/item/ammo_box/magazine/AM = A
-		if ((!magazine && istype(AM, mag_type) || istype(AM, mag_type2)))
+		if ((!magazine && (istype(AM, mag_type) || istype(AM, mag_type2))))
 			user.remove_from_mob(AM)
 			magazine = AM
 			magazine.loc = src


### PR DESCRIPTION
<!--
Подробно про оформление ПРов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies

Там же написано про то, как сделать чейнджлог. Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment.
-->
Fixes #1653 

:cl: Martinelli
 - bugfix: Пистолет "съедал" летальные обоймы, если он уже был заряжен.