### PR TITLE
Грязные трейторы не смогут сбегать в смирительных рубашках.

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -388,7 +388,7 @@ datum/objective/escape
 		if(istype(location, /turf/simulated/shuttle/floor4)) // Fails traitors if they are in the shuttle brig -- Polymorph
 			if(istype(owner.current, /mob/living/carbon))
 				var/mob/living/carbon/C = owner.current
-				if (!C.handcuffed)
+				if (!C.restrained())
 					return 1
 			return 0
 


### PR DESCRIPTION
Fixes #1800

Насколько я понял - старая проверка не включала в себя наличие
смирительной рубашки на игроке, следовательно, задание ошибочно
засчитывалось как выполненное.

:cl: 
- bugfix: Трейторы больше не будут выполнять задание на побег, находясь в смирительной рубашке и в красной зоне шаттла. 