### PR TITLE
Из граба стало возможно выбраться. Так же теперь нельзя мгновенно про…

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -749,7 +749,7 @@
 
 	if(!isliving(usr) || usr.next_move > world.time)
 		return
-	usr.next_move = world.time + 20
+	usr.SetNextMove(20)
 
 	var/mob/living/L = usr
 
@@ -809,7 +809,7 @@
 
 	//resisting grabs (as if it helps anyone...)
 	if (!L.stat && !L.restrained())
-		if(L.stunned > 2 || L.weakened)
+		if(L.stunned > 2 || L.weakened > 2)
 			return
 		var/resisting = 0
 		for(var/obj/O in L.requests)
@@ -822,7 +822,7 @@
 				if(GRAB_PASSIVE)
 					qdel(G)
 				if(GRAB_AGGRESSIVE)
-					if(prob(60)) //same chance of breaking the grab as disarm
+					if(prob(50 - (L.lying ? 35 : 0)))
 						L.visible_message("<span class='danger'>[L] has broken free of [G.assailant]'s grip!</span>")
 						qdel(G)
 				if(GRAB_NECK)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -27,6 +27,7 @@
 
 	if(affecting.anchored)
 		return INITIALIZE_HINT_QDEL
+	last_action = world.time - 10
 
 	hud = new /obj/screen/grab(src)
 	hud.icon_state = "reinforce"


### PR DESCRIPTION
…апгрейдить его до АГРЕССИВНОГО состояния.

У нас до этого изменения из синего граба вообще нельзя было выбраться. Да и из красного тоже потому что каждый тик граба накидывал weakened, который препятствовал всякому резисту. Я бы сказал, что это багфикс в какой-то степени. Но тема с грабом слишком скользкая и подобрать правильные тайминги на локалочке у меня не получится. Так что потребуется короткий тестмерж, чтобы народ попробовал и (не)оценил.

:cl:
 - balance: Было установлено время, которое требуется, чтобы взять человека в усиленный захват (синяя иконка). 
 - bugfix: У людей практически не было возможности сопротивляться при втором и последующих грабах.

  