### PR TITLE
Правки сканера растений и генератора поля

### DIFF
--- a/code/defines/obj/hydro.dm
+++ b/code/defines/obj/hydro.dm
@@ -4,6 +4,10 @@
 	name = "plant analyzer"
 	desc = "A hand-held scanner which reports condition of the plant."
 	icon = 'icons/obj/device.dmi'
+	w_class = 1.0
+	m_amt = 200
+	g_amt = 50
+	origin_tech = "materials=1;biotech=1"
 	icon_state = "hydro"
 	item_state = "plantanalyzer"
 

--- a/code/game/machinery/IDpainter.dm
+++ b/code/game/machinery/IDpainter.dm
@@ -80,6 +80,8 @@
 	set name = "Eject ID"
 	set category = "Object"
 	set src in oview(1)
+	if(!usr.canmove || usr.stat || usr.restrained())
+		return
 
 	if(storedcard)
 		storedcard.loc = get_turf(src.loc)

--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -89,6 +89,8 @@
 	set name = "Eject PDA"
 	set category = "Object"
 	set src in oview(1)
+	if(!usr.canmove || usr.stat || usr.restrained())
+		return
 
 	if(storedpda)
 		storedpda.loc = get_turf(src.loc)

--- a/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
+++ b/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
@@ -4,9 +4,7 @@
 	icon = 'icons/obj/xenoarchaeology.dmi'
 	icon_state = "suspension2"
 	density = 1
-	req_access = list(access_research)
 	var/obj/item/weapon/stock_parts/cell/cell
-	var/obj/item/weapon/card/id/auth_card
 	var/locked = 1
 	var/open = 0
 	var/screwed = 1
@@ -18,158 +16,6 @@
 /obj/machinery/suspension_gen/atom_init()
 	cell = new/obj/item/weapon/stock_parts/cell/high(src)
 	. = ..()
-
-/obj/machinery/suspension_gen/process()
-	//set background = 1
-
-	if (suspension_field)
-		cell.charge -= power_use
-
-		var/turf/T = get_turf(suspension_field)
-		if(field_type == "carbon")
-			for(var/mob/living/carbon/M in T)
-				M.weakened = max(M.weakened, 3)
-				cell.charge -= power_use
-				if(prob(5))
-					to_chat(M, "\blue [pick("You feel tingly.","You feel like floating.","It is hard to speak.","You can barely move.")]")
-
-		if(field_type == "iron")
-			for(var/mob/living/silicon/M in T)
-				M.weakened = max(M.weakened, 3)
-				cell.charge -= power_use
-				if(prob(5))
-					to_chat(M, "\blue [pick("You feel tingly.","You feel like floating.","It is hard to speak.","You can barely move.")]")
-
-		for(var/obj/item/I in T)
-			if(!suspension_field.contents.len)
-				suspension_field.icon_state = "energynet"
-				suspension_field.overlays += "shield2"
-			I.loc = suspension_field
-
-		for(var/mob/living/simple_animal/M in T)
-			M.weakened = max(M.weakened, 3)
-			cell.charge -= power_use
-			if(prob(5))
-				to_chat(M, "\blue [pick("You feel tingly.","You feel like floating.","It is hard to speak.","You can barely move.")]")
-
-		if(cell.charge <= 0)
-			deactivate()
-
-/obj/machinery/suspension_gen/ui_interact(mob/user)
-	var/dat = "<b>Multi-phase mobile suspension field generator MK II \"Steadfast\"</b><br>"
-	if(cell)
-		var/colour = "red"
-		if(cell.charge / cell.maxcharge > 0.66)
-			colour = "green"
-		else if(cell.charge / cell.maxcharge > 0.33)
-			colour = "orange"
-		dat += "<b>Energy cell</b>: <font color='[colour]'>[100 * cell.charge / cell.maxcharge]%</font><br>"
-	else
-		dat += "<b>Energy cell</b>: None<br>"
-	if(auth_card)
-		dat += "<A href='?src=\ref[src];ejectcard=1'>\[[auth_card]\]<a><br>"
-		if(!locked)
-			dat += "<b><A href='?src=\ref[src];toggle_field=1'>[suspension_field ? "Disable" : "Enable"] field</a></b><br>"
-		else
-			dat += "<br>"
-	else
-		dat += "<A href='?src=\ref[src];insertcard=1'>\[------\]<a><br>"
-		if(!locked)
-			dat += "<b><A href='?src=\ref[src];toggle_field=1'>[suspension_field ? "Disable" : "Enable"] field</a></b><br>"
-		else
-			dat += "Enter your ID to begin.<br>"
-
-	dat += "<hr>"
-	if(!locked)
-		dat += "<b>Select field mode</b><br>"
-		dat += "[field_type=="carbon"?"<b>":""			]<A href='?src=\ref[src];select_field=carbon'>Diffracted carbon dioxide laser</A></b><br>"
-		dat += "[field_type=="nitrogen"?"<b>":""		]<A href='?src=\ref[src];select_field=nitrogen'>Nitrogen tracer field</A></b><br>"
-		dat += "[field_type=="potassium"?"<b>":""		]<A href='?src=\ref[src];select_field=potassium'>Potassium refrigerant cloud</A></b><br>"
-		dat += "[field_type=="mercury"?"<b>":""	]<A href='?src=\ref[src];select_field=mercury'>Mercury dispersion wave</A></b><br>"
-		dat += "[field_type=="iron"?"<b>":""		]<A href='?src=\ref[src];select_field=iron'>Iron wafer conduction field</A></b><br>"
-		dat += "[field_type=="calcium"?"<b>":""	]<A href='?src=\ref[src];select_field=calcium'>Calcium binary deoxidiser</A></b><br>"
-		dat += "[field_type=="phoron"?"<b>":""	]<A href='?src=\ref[src];select_field=chlorine'>Chlorine diffusion emissions</A></b><br>"
-		dat += "[field_type=="phoron"?"<b>":""	]<A href='?src=\ref[src];select_field=phoron'>Phoron saturated field</A></b><br>"
-	else
-		dat += "<br>"
-		dat += "<br>"
-		dat += "<br>"
-		dat += "<br>"
-		dat += "<br>"
-		dat += "<br>"
-		dat += "<br>"
-		dat += "<br>"
-	dat += "<hr>"
-	dat += "<font color='blue'><b>Always wear safety gear and consult a field manual before operation.</b></font><br>"
-	if(!locked)
-		dat += "<A href='?src=\ref[src];lock=1'>Lock console</A><br>"
-	else
-		dat += "<br>"
-	dat += "<A href='?src=\ref[src];refresh=1'>Refresh console</A><br>"
-	dat += "<A href='?src=\ref[src];close=1'>Close console</A>"
-	user << browse(dat, "window=suspension;size=500x400")
-	onclose(user, "suspension")
-
-/obj/machinery/suspension_gen/is_operational_topic()
-	return TRUE
-
-/obj/machinery/suspension_gen/Topic(href, href_list)
-	if(href_list["close"])
-		usr.unset_machine()
-		usr << browse(null, "window=suspension")
-		return FALSE
-
-	. = ..()
-	if(!.)
-		return
-
-	if(href_list["toggle_field"])
-		if(!suspension_field)
-			if(cell.charge > 0)
-				if(anchored)
-					activate()
-				else
-					to_chat(usr, "<span class='warning'>You are unable to activate [src] until it is properly secured on the ground.</span>")
-		else
-			deactivate()
-	if(href_list["select_field"])
-		field_type = href_list["select_field"]
-	else if(href_list["insertcard"])
-		var/obj/item/I = usr.get_active_hand()
-		if (istype(I, /obj/item/weapon/card))
-			usr.drop_item()
-			I.loc = src
-			auth_card = I
-			if(attempt_unlock(I))
-				to_chat(usr, "<span class='info'>You insert [I], the console flashes \'<i>Access granted.</a>\'</span>")
-			else
-				to_chat(usr, "<span class='warning'>You insert [I], the console flashes \'<i>Access denied.</a>\'</span>")
-	else if(href_list["ejectcard"])
-		if(auth_card)
-			if(ishuman(usr))
-				auth_card.loc = usr.loc
-				if(!usr.get_active_hand())
-					usr.put_in_hands(auth_card)
-				auth_card = null
-			else
-				auth_card.loc = loc
-				auth_card = null
-	else if(href_list["lock"])
-		locked = 1
-
-	updateUsrDialog()
-
-/obj/machinery/suspension_gen/interact(mob/user)
-	if(!open)
-		..()
-	else if(cell)
-		cell.loc = loc
-		cell.add_fingerprint(user)
-		cell.updateicon()
-
-		icon_state = "suspension0"
-		cell = null
-		to_chat(user, "<span class='info'>You remove the power cell</span>")
 
 /obj/machinery/suspension_gen/attackby(obj/item/weapon/W, mob/user)
 	if (istype(W, /obj/item/weapon/screwdriver))
@@ -218,27 +64,135 @@
 				cell = W
 				to_chat(user, "<span class='info'>You insert the power cell.</span>")
 				icon_state = "suspension1"
-	else if(istype(W, /obj/item/weapon/card))
-		var/obj/item/weapon/card/I = W
-		if(!auth_card)
-			if(attempt_unlock(I))
-				to_chat(user, "<span class='info'>You swipe [I], the console flashes \'<i>Access granted.</i>\'</span>")
-			else
-				to_chat(user, "<span class='warning'>You swipe [I], console flashes \'<i>Access denied.</i>\'</span>")
+	else if(istype(W, /obj/item/weapon/card/id))
+		var/obj/item/weapon/card/id/sci = W
+		if(access_xenoarch in sci.access)
+			src.locked = !src.locked
+			to_chat(user, "Controls are now [src.locked ? "locked." : "unlocked."]")
+			updateDialog()
 		else
-			to_chat(user, "<span class='warning'>Remove [auth_card] first.</span>")
+			to_chat(user, "\red Access denied.")
+	else if(istype(W, /obj/item/weapon/card/emag))
+		user.SetNextMove(CLICK_CD_INTERACT)
+		if(prob(75))
+			src.locked = !src.locked
+			to_chat(user, "Controls are now [src.locked ? "locked." : "unlocked."]")
+			updateDialog()
+		var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+		s.set_up(5, 1, src)
+		s.start()
 
-/obj/machinery/suspension_gen/proc/attempt_unlock(obj/item/weapon/card/C)
+/obj/machinery/suspension_gen/ui_interact(mob/user)
+	var/dat = "<b>Multi-phase mobile suspension field generator MK II \"Steadfast\"</b><br>"
+	if(cell)
+		var/colour = "red"
+		if(cell.charge / cell.maxcharge > 0.66)
+			colour = "green"
+		else if(cell.charge / cell.maxcharge > 0.33)
+			colour = "orange"
+		dat += "<b>Energy cell</b>: <font color='[colour]'>[100 * cell.charge / cell.maxcharge]%</font><br>"
+	else
+		dat += "<b>Energy cell</b>: None<br>"
+		dat += "<hr>"
+	if(locked && !isobserver(user))
+		dat += "<i>Swipe your ID card to begin.</i>"
+	else
+		dat += "Suspension field generator is: [suspension_field ? "<font color=green>Enable</font>" : "<font color=red>Disable</font>" ] <br><b><A href='?src=\ref[src];toggle_field=1'>[suspension_field ? "\[Disable field\]" : "\[Enable field\]"]</a></b><br>"
+		dat += "<b>Select field mode</b><br>"
+		dat += "[field_type=="carbon"?"<b>":""			]<A href='?src=\ref[src];select_field=carbon'>Diffracted carbon dioxide laser</A></b><br>"
+		dat += "[field_type=="nitrogen"?"<b>":""		]<A href='?src=\ref[src];select_field=nitrogen'>Nitrogen tracer field</A></b><br>"
+		dat += "[field_type=="potassium"?"<b>":""		]<A href='?src=\ref[src];select_field=potassium'>Potassium refrigerant cloud</A></b><br>"
+		dat += "[field_type=="mercury"?"<b>":""	]<A href='?src=\ref[src];select_field=mercury'>Mercury dispersion wave</A></b><br>"
+		dat += "[field_type=="iron"?"<b>":""		]<A href='?src=\ref[src];select_field=iron'>Iron wafer conduction field</A></b><br>"
+		dat += "[field_type=="calcium"?"<b>":""	]<A href='?src=\ref[src];select_field=calcium'>Calcium binary deoxidiser</A></b><br>"
+		dat += "[field_type=="chlorine"?"<b>":""	]<A href='?src=\ref[src];select_field=chlorine'>Chlorine diffusion emissions</A></b><br>"
+		dat += "[field_type=="phoron"?"<b>":""	]<A href='?src=\ref[src];select_field=phoron'>Phoron saturated field</A></b><br>"
+		dat += "<hr>"
+		dat += "<font color='blue'><b>Always wear safety gear and consult a field manual before operation.</b></font><br>"
+		dat += "<A href='?src=\ref[src];lock=1'>Lock console</A><br>"
+	dat += "<hr>"
+	dat += "<A href='?src=\ref[src]'> Refresh console </A><BR>"
+	dat += "<A href='?src=\ref[src];close=1'> Close console </A><BR>"
+	user << browse(dat, "window=suspension;size=500x400")
+	onclose(user, "suspension")
+
+/obj/machinery/suspension_gen/process()
+	//set background = 1
+
+	if (suspension_field)
+		cell.charge -= power_use
+
+		var/turf/T = get_turf(suspension_field)
+		if(field_type == "carbon")
+			for(var/mob/living/carbon/M in T)
+				M.weakened = max(M.weakened, 3)
+				cell.charge -= power_use
+				if(prob(5))
+					to_chat(M, "\blue [pick("You feel tingly.","You feel like floating.","It is hard to speak.","You can barely move.")]")
+
+		if(field_type == "iron")
+			for(var/mob/living/silicon/M in T)
+				M.weakened = max(M.weakened, 3)
+				cell.charge -= power_use
+				if(prob(5))
+					to_chat(M, "\blue [pick("You feel tingly.","You feel like floating.","It is hard to speak.","You can barely move.")]")
+
+		for(var/obj/item/I in T)
+			if(!suspension_field.contents.len)
+				suspension_field.icon_state = "energynet"
+				suspension_field.overlays += "shield2"
+			I.loc = suspension_field
+
+		for(var/mob/living/simple_animal/M in T)
+			M.weakened = max(M.weakened, 3)
+			cell.charge -= power_use
+			if(prob(5))
+				to_chat(M, "\blue [pick("You feel tingly.","You feel like floating.","It is hard to speak.","You can barely move.")]")
+
+		if(cell.charge <= 0)
+			deactivate()
+
+/obj/machinery/suspension_gen/is_operational_topic()
+	return TRUE
+
+/obj/machinery/suspension_gen/Topic(href, href_list)
+	if(href_list["close"])
+		usr.unset_machine()
+		usr << browse(null, "window=suspension")
+		return FALSE
+
+	. = ..()
+	if(!.)
+		return
+
+	if(href_list["toggle_field"])
+		if(!suspension_field)
+			if(cell.charge > 0)
+				if(anchored)
+					activate()
+				else
+					to_chat(usr, "<span class='warning'>You are unable to activate [src] until it is properly secured on the ground.</span>")
+		else
+			deactivate()
+	if(href_list["select_field"])
+		field_type = href_list["select_field"]
+
+	if(href_list["lock"])
+		locked = 1
+
+	updateDialog()
+
+/obj/machinery/suspension_gen/interact(mob/user)
 	if(!open)
-		if(istype(C, /obj/item/weapon/card/emag) && cell.charge > 0)
-			//put sparks here
-			if(prob(95))
-				locked = 0
-		else if(istype(C, /obj/item/weapon/card/id) && check_access(C))
-			locked = 0
+		..()
+	else if(cell)
+		cell.loc = loc
+		cell.add_fingerprint(user)
+		cell.updateicon()
 
-		if(!locked)
-			return 1
+		icon_state = "suspension0"
+		cell = null
+		to_chat(user, "<span class='info'>You remove the power cell</span>")
 
 //checks for whether the machine can be activated or not should already have occurred by this point
 /obj/machinery/suspension_gen/proc/activate()
@@ -341,23 +295,6 @@
 		to_chat(usr, "\red You cannot rotate [src], it has been firmly fixed to the floor.")
 	else
 		dir = turn(dir, -90)
-
-/obj/machinery/suspension_gen/verb/ejectid()
-	set name = "Eject ID"
-	set category = "Object"
-	set src in oview(1)
-	if(!usr.canmove || usr.stat || usr.restrained())
-		return
-
-	if(auth_card)
-		auth_card.loc = get_turf(src.loc)
-		auth_card = null
-		update_icon()
-		to_chat(usr, "<span class='notice'>Card is removed from [src].</span>")
-		return
-
-	else
-		to_chat(usr, "<span class='notice'>The [src] is empty.</span>")
 
 /obj/effect/suspension_field
 	name = "energy field"

--- a/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
+++ b/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
@@ -164,6 +164,10 @@
 	. = ..()
 	if(!.)
 		return
+	
+	if(locked)
+		to_chat(usr, "<span class='warning'>Console locked!</span>")
+		return
 
 	if(href_list["toggle_field"])
 		if(!suspension_field)

--- a/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
+++ b/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
@@ -346,11 +346,16 @@
 	set name = "Eject ID"
 	set category = "Object"
 	set src in oview(1)
+	if(!usr.canmove || usr.stat || usr.restrained())
+		return
 
 	if(auth_card)
 		auth_card.loc = get_turf(src.loc)
 		auth_card = null
 		update_icon()
+		to_chat(usr, "<span class='notice'>Card is removed from [src].</span>")
+		return
+
 	else
 		to_chat(usr, "<span class='notice'>The [src] is empty.</span>")
 

--- a/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
+++ b/code/modules/research/xenoarchaeology/tools/suspension_generator.dm
@@ -342,6 +342,18 @@
 	else
 		dir = turn(dir, -90)
 
+/obj/machinery/suspension_gen/verb/ejectid()
+	set name = "Eject ID"
+	set category = "Object"
+	set src in oview(1)
+
+	if(auth_card)
+		auth_card.loc = get_turf(src.loc)
+		auth_card = null
+		update_icon()
+	else
+		to_chat(usr, "<span class='notice'>The [src] is empty.</span>")
+
 /obj/effect/suspension_field
 	name = "energy field"
 	icon = 'icons/effects/effects.dmi'


### PR DESCRIPTION
Сканер для растений теперь требует 250 единиц металла и 50 единиц стекла для создания. Из генератора можно вынуть карту, не имея доступа к нему.

<!--
Подробно про оформление ПРов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
Там же написано про то, как сделать чейнджлог. 

!!!
Если авторство не полностью ваше, вы делаете порт с другого билда - укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
!!!

Для копипаста:
Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment.

Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
- 200 единиц металла.
- 50 единиц стекла.
Из генератора поля можно достать карту.
![honeycam 2018-01-11 19-33-19](https://user-images.githubusercontent.com/20359322/34835921-62309cc0-f707-11e7-9feb-c6c3ce8c915c.gif)

Fix #2136 
Fix #2132 

:cl:
- bugfix: Анализатор для растений не требовал материала для создания.
- bugfix: Из генератора поля для ксеноархеологии нельзя было извлечь карту доступа.
- bugfix: Нельзя было активировать предпоследний тип поля для Хлорина в генераторе.
- bugfix: Из оборудования ХоПа призраки больше не могут вынимать карты и КПК