### PR TITLE
Небольшие изменениея в трейторских вещах.

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -347,4 +347,4 @@
 	new /obj/item/weapon/FixOVein(src)
 	new /obj/item/clothing/suit/straight_jacket(src)
 	new /obj/item/clothing/mask/muzzle(src)
-	new /obj/item/device/mmi(src)
+	new /obj/item/stack/medical/advanced/bruise_pack(src)

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -80,6 +80,6 @@
 	new /obj/item/weapon/wrench(src)
 	new /obj/item/weapon/weldingtool(src)
 	new /obj/item/weapon/crowbar(src)
-	new /obj/item/stack/cable_coil/random(src)
+	new /obj/item/clothing/gloves/combat(src)
 	new /obj/item/weapon/wirecutters(src)
 	new /obj/item/device/multitool(src)

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -80,6 +80,6 @@
 	new /obj/item/weapon/wrench(src)
 	new /obj/item/weapon/weldingtool(src)
 	new /obj/item/weapon/crowbar(src)
-	new /obj/item/clothing/gloves/combat(src)
 	new /obj/item/weapon/wirecutters(src)
 	new /obj/item/device/multitool(src)
+	new /obj/item/clothing/gloves/combat(src)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -143,6 +143,8 @@
 	. = ..()
 	new /obj/item/clothing/suit/space/syndicate(src)
 	new /obj/item/clothing/head/helmet/space/syndicate(src)
+	new /obj/item/clothing/mask/breath(src)
+	new /obj/item/weapon/tank/emergency_oxygen/engi(src)
 
 /obj/item/weapon/storage/box/syndie_kit/chameleon
 	name = "Chameleon Kit"


### PR DESCRIPTION
<!--
Подробно про оформление ПРов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
Там же написано про то, как сделать чейнджлог. 

!!!
Если авторство не полностью ваше, вы делаете порт с другого билда - укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
!!!

Для копипаста:
Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment.

Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
Так как с них сняли защиту, можно и добавить в ящик, почему бы и нет, провода в них я считаю бесполезными. ~~хотя и мерж с удалением защиты на тесте~~
Вопрос в том, стоит ли менять цену ящику или нет.
~~Теперь у нюкеров будет по две пары~~
Теперь трейторы получат балон и маску при покупке набора со скафандром. Невероятная щедрость.
В сумку с хирургическим набором добавлен бинтик для операций на органы вместо ММИ, так как у нас изменилось задание, а бинтик для операций очень будет к месту.
:cl:
- tweak: В подозрительный ящик с инструментами добавлены изолляционные перчатки. В комплект подозрительного скафандра добавлен баллон и маска. В хирургическую сумку добавлен бинтик для операций на органы.