### PR TITLE
Фикс риг шлемов

### DIFF
--- a/code/modules/clothing/spacesuits/rig.dm
+++ b/code/modules/clothing/spacesuits/rig.dm
@@ -142,7 +142,7 @@
 	else if(H.equip_to_slot_if_possible(helmet, slot_head))
 		helmet.loc = H
 		helmet.canremove = 0
-		to_chat(H, "<span class='notice'> You deploy your hardsuit helmet, sealing you off from the world.</span>")
+		to_chat(H, "<span class='notice'>You deploy your hardsuit helmet, sealing you off from the world.</span>")
 		return
 
 /obj/item/clothing/suit/space/rig/verb/toggle_magboots()

--- a/code/modules/clothing/spacesuits/rig.dm
+++ b/code/modules/clothing/spacesuits/rig.dm
@@ -140,14 +140,9 @@
 		to_chat(H, "\blue You retract your hardsuit helmet.")
 
 	else if(H.equip_to_slot_if_possible(helmet, slot_head))
-		if(H.head != helmet)
-			to_chat(H, "\red You cannot deploy your helmet while wearing another helmet.")
-			return
-		//TODO: Species check, skull damage for forcing an unfitting helmet on?
 		helmet.loc = H
-		H.equip_to_slot(helmet, slot_head)
 		helmet.canremove = 0
-		to_chat(H, "\blue You deploy your hardsuit helmet, sealing you off from the world.")
+		to_chat(H, "<span class='notice'> You deploy your hardsuit helmet, sealing you off from the world.</span>")
 		return
 
 /obj/item/clothing/suit/space/rig/verb/toggle_magboots()

--- a/code/modules/clothing/spacesuits/rig.dm
+++ b/code/modules/clothing/spacesuits/rig.dm
@@ -115,6 +115,24 @@
 				H.drop_from_inventory(boots)
 				boots.loc = src
 
+/obj/item/clothing/suit/space/rig/proc/helmetonhead()
+
+	var/mob/living/carbon/human/H = usr
+	if(H.head == helmet)
+		helmet.canremove = 1
+		H.drop_from_inventory(helmet)
+		helmet.loc = src
+		to_chat(H, "\blue You retract your hardsuit helmet.")
+	else
+		if(H.head)
+			to_chat(H, "\red You cannot deploy your helmet while wearing another helmet.")
+			return
+		//TODO: Species check, skull damage for forcing an unfitting helmet on?
+		helmet.loc = H
+		H.equip_to_slot(helmet, slot_head)
+		helmet.canremove = 0
+		to_chat(H, "\blue You deploy your hardsuit helmet, sealing you off from the world.")
+
 /obj/item/clothing/suit/space/rig/verb/toggle_helmet()
 
 	set name = "Toggle Helmet"
@@ -133,20 +151,23 @@
 	if(H.stat) return
 	if(H.wear_suit != src) return
 
-	if(H.head == helmet)
-		helmet.canremove = 1
-		H.drop_from_inventory(helmet)
-		helmet.loc = src
-		to_chat(H, "\blue You retract your hardsuit helmet.")
-	else
-		if(H.head)
-			to_chat(H, "\red You cannot deploy your helmet while wearing another helmet.")
+	if(H.species)
+		var/wearable = null
+		var/exclusive = null
+		if("exclude" in helmet.species_restricted)
+			exclusive = 1
+		if(exclusive)
+			if(!(H.species.name in helmet.species_restricted))
+				wearable = 1
+		else if(!exclusive)
+			if(H.species.name in helmet.species_restricted)
+				wearable = 1
+		if(!wearable)
+			to_chat(H, "\red Your species cannot wear [src].")
 			return
-		//TODO: Species check, skull damage for forcing an unfitting helmet on?
-		helmet.loc = H
-		H.equip_to_slot(helmet, slot_head)
-		helmet.canremove = 0
-		to_chat(H, "\blue You deploy your hardsuit helmet, sealing you off from the world.")
+		else if(wearable)
+			helmetonhead()
+		return
 
 /obj/item/clothing/suit/space/rig/verb/toggle_magboots()
 

--- a/code/modules/clothing/spacesuits/rig.dm
+++ b/code/modules/clothing/spacesuits/rig.dm
@@ -140,7 +140,6 @@
 		to_chat(H, "\blue You retract your hardsuit helmet.")
 
 	else if(H.equip_to_slot_if_possible(helmet, slot_head))
-		helmet.loc = H
 		helmet.canremove = 0
 		to_chat(H, "<span class='notice'>You deploy your hardsuit helmet, sealing you off from the world.</span>")
 		return

--- a/code/modules/clothing/spacesuits/rig.dm
+++ b/code/modules/clothing/spacesuits/rig.dm
@@ -115,24 +115,6 @@
 				H.drop_from_inventory(boots)
 				boots.loc = src
 
-/obj/item/clothing/suit/space/rig/proc/helmetonhead()
-
-	var/mob/living/carbon/human/H = usr
-	if(H.head == helmet)
-		helmet.canremove = 1
-		H.drop_from_inventory(helmet)
-		helmet.loc = src
-		to_chat(H, "\blue You retract your hardsuit helmet.")
-	else
-		if(H.head)
-			to_chat(H, "\red You cannot deploy your helmet while wearing another helmet.")
-			return
-		//TODO: Species check, skull damage for forcing an unfitting helmet on?
-		helmet.loc = H
-		H.equip_to_slot(helmet, slot_head)
-		helmet.canremove = 0
-		to_chat(H, "\blue You deploy your hardsuit helmet, sealing you off from the world.")
-
 /obj/item/clothing/suit/space/rig/verb/toggle_helmet()
 
 	set name = "Toggle Helmet"
@@ -151,22 +133,21 @@
 	if(H.stat) return
 	if(H.wear_suit != src) return
 
-	if(H.species)
-		var/wearable = null
-		var/exclusive = null
-		if("exclude" in helmet.species_restricted)
-			exclusive = 1
-		if(exclusive)
-			if(!(H.species.name in helmet.species_restricted))
-				wearable = 1
-		else if(!exclusive)
-			if(H.species.name in helmet.species_restricted)
-				wearable = 1
-		if(!wearable)
-			to_chat(H, "\red Your species cannot wear [src].")
+	if(H.head == helmet)
+		helmet.canremove = 1
+		H.drop_from_inventory(helmet)
+		helmet.loc = src
+		to_chat(H, "\blue You retract your hardsuit helmet.")
+
+	else if(H.equip_to_slot_if_possible(helmet, slot_head))
+		if(H.head != helmet)
+			to_chat(H, "\red You cannot deploy your helmet while wearing another helmet.")
 			return
-		else if(wearable)
-			helmetonhead()
+		//TODO: Species check, skull damage for forcing an unfitting helmet on?
+		helmet.loc = H
+		H.equip_to_slot(helmet, slot_head)
+		helmet.canremove = 0
+		to_chat(H, "\blue You deploy your hardsuit helmet, sealing you off from the world.")
 		return
 
 /obj/item/clothing/suit/space/rig/verb/toggle_magboots()


### PR DESCRIPTION
Небольшой фикс, который теперь не позволит одевать шлемы предназначенные для других рас через кнопку Toggle Helmet, когда к нему пристегнут шлем.

Closes #2147

forcodeer: добавлены проверки, которые раньше отсутствовали, позволяя так делать. Так же само действие перенесено в прок для избежания ненужных веток проверок и для удобного использования в будущем, возможно.

🆑 Miracler

- bugfix: Исправлена возможность одевать шлемы рига через кнопку Toggle Helmet не для своей расы
