### PR TITLE
Изменил описание Ak74, заменил в мусорных кучах, А28 на АК74

### DIFF
--- a/code/game/objects/random/random_syndie.dm
+++ b/code/game/objects/random/random_syndie.dm
@@ -7,7 +7,7 @@
 	prob(2);/obj/item/weapon/gun/projectile/automatic/l6_saw,\
 	prob(3);/obj/item/weapon/antag_spawner/borg_tele,\
 	prob(3);/obj/item/weapon/gun/projectile/revolver/rocketlauncher,\
-	prob(4);/obj/item/weapon/gun/projectile/automatic/a28,\
+	prob(4);/obj/item/weapon/gun/projectile/automatic/a74,\
 	prob(5);/obj/item/weapon/storage/box/syndie_kit/imp_uplink,\
 	prob(5);/obj/item/weapon/storage/box/syndicate,\
 	prob(5);/obj/item/toy/syndicateballoon,\
@@ -24,12 +24,11 @@
 	prob(10);/obj/item/ammo_casing/caseless/rocket/emp,\
 	prob(12);/obj/item/weapon/melee/powerfist,\
 	prob(12);/obj/item/weapon/gun/projectile/revolver ,\
-	prob(12);/obj/item/ammo_box/magazine/m556/incendiary,\
 	prob(14);/obj/item/weapon/gun/projectile/automatic/c20r,\
 	prob(14);/obj/item/weapon/implanter/storage,\
 	prob(14);/obj/item/weapon/gun/energy/crossbow,\
 	prob(14);/obj/item/weapon/melee/energy/sword,\
-	prob(14);/obj/item/ammo_box/magazine/m556,\
+	prob(14);/obj/item/ammo_box/magazine/a74mm,\
 	prob(14);/obj/item/weapon/grenade/spawnergrenade/manhacks,\
 	prob(14);/obj/item/device/healthanalyzer/rad_laser,\
 	prob(16);/obj/item/weapon/gun/projectile/automatic/pistol,\

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -472,6 +472,7 @@
 
 /obj/item/weapon/gun/projectile/automatic/a74
 	name = "A74 assault rifle"
+	desc = "Stradi and Practican Maid Bai Spess soviets corporation, bazed he original design of 20 centuriyu fin about baars and vodka vile patrimonial it, saunds of balalaika place minvile, yuzes 7.62 caliber"
 	mag_type = /obj/item/ammo_box/magazine/a74mm
 	w_class = 3.0
 	icon_state = "a74"


### PR DESCRIPTION
fixes #2056
Изменил описания АК74 на более каноничное
Убрал спавн А28 в синдикучах и патронов к нему, заменив на АК74 и патроны к нему

:cl: Olt1771
 - bugfix: Добавлено собственное описание АК74.
 - bugfix: В синдикучах спавнился А28 и патроны к нему.