### PR TITLE
[Обсуждение/тест/WIP] Ладошки и прочее

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -4,17 +4,15 @@
 		health = maxHealth
 		stat = CONSCIOUS
 		return
-
 	var/total_burn = 0
 	var/total_brute = 0
 	for(var/obj/item/organ/external/BP in bodyparts) // hardcoded to streamline things a bit
 		if((BP.status & ORGAN_ROBOT) && !BP.vital)
 			continue // *non-vital* robot limbs don't count towards shock and crit
-		total_brute += BP.brute_dam
-		total_burn += BP.burn_dam
+		total_brute += BP.brute_dam * BP.damage_coefficient
+		total_burn += BP.burn_dam * BP.damage_coefficient
 
 	health = maxHealth - getOxyLoss() - getToxLoss() - getCloneLoss() - total_burn - total_brute
-
 	//TODO: fix husking
 	if( ((maxHealth - total_burn) < config.health_threshold_dead) && stat == DEAD)
 		ChangeToHusk()
@@ -64,7 +62,7 @@
 	for(var/obj/item/organ/external/BP in bodyparts)
 		if((BP.status & ORGAN_ROBOT) && !BP.vital)
 			continue // robot limbs don't count towards shock and crit
-		amount += BP.brute_dam
+		amount += BP.brute_dam * BP.damage_coefficient
 	return amount
 
 /mob/living/carbon/human/adjustBruteLoss(amount)
@@ -80,7 +78,7 @@
 	for(var/obj/item/organ/external/BP in bodyparts)
 		if((BP.status & ORGAN_ROBOT) && !BP.vital)
 			continue // robot limbs don't count towards shock and crit
-		amount += BP.burn_dam
+		amount += BP.burn_dam * BP.damage_coefficient
 	return amount
 
 /mob/living/carbon/human/adjustFireLoss(amount)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -41,10 +41,11 @@
 
 	if(istype(P, /obj/item/projectile/energy/electrode) || istype(P, /obj/item/projectile/beam/stun) || istype(P, /obj/item/projectile/bullet/stunslug))
 		var/obj/item/organ/external/BP = get_bodypart(def_zone) // We're checking the outside, buddy!
-		P.agony *= get_siemens_coefficient_organ(BP)
-		P.stun *= get_siemens_coefficient_organ(BP)
-		P.weaken *= get_siemens_coefficient_organ(BP)
-		P.stutter *= get_siemens_coefficient_organ(BP)
+		var/organ_siemens_coefficient = get_siemens_coefficient_organ(BP)
+		P.agony *= organ_siemens_coefficient
+		P.stun *= organ_siemens_coefficient
+		P.weaken *= organ_siemens_coefficient
+		P.stutter *= organ_siemens_coefficient
 
 		if(P.agony) // No effect against full protection.
 			if(prob(max(P.agony, 20)))
@@ -173,10 +174,10 @@
 				var/turf/T = get_turf(src)
 				var/obj/effect/fluid/F = locate() in T
 				if(F)
-					F.electrocute_act(60)
+					F.electrocute_act(60)//why is it HERE???
 			siemens_coefficient *= C.siemens_coefficient
 
-	return siemens_coefficient
+	return siemens_coefficient*BP.siemens_coefficient
 
 //this proc returns the armour value for a particular external organ.
 /mob/living/carbon/human/proc/getarmor_organ(obj/item/organ/external/BP, type)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -100,7 +100,7 @@
 
 	handle_stasis_bag()
 
-	if(life_tick > 5 && timeofdeath && (timeofdeath < 5 || world.time - timeofdeath > 6000))	//We are long dead, or we're junk mobs spawned like the clowns on the clown shuttle
+	if(life_tick > 5 && stat == DEAD && timeofdeath && (timeofdeath < 5 || world.time - timeofdeath > 6000))	//We are long dead, or we're junk mobs spawned like the clowns on the clown shuttle
 		return											//We go ahead and process them 5 times for HUD images and other stuff though.
 
 	//Handle temperature/pressure differences between body and environment
@@ -1438,8 +1438,8 @@
 			else
 				healthdoll.icon_state = "healthdoll_OVERLAY"
 				for(var/obj/item/organ/external/BP in bodyparts)
-					var/damage = BP.burn_dam + BP.brute_dam
-					var/comparison = (BP.max_damage / 5)
+					var/damage = (BP.burn_dam + BP.brute_dam) * BP.damage_coefficient
+					var/comparison = (BP.max_damage / 5) * BP.damage_coefficient
 					var/icon_num = 0
 					if(damage)
 						icon_num = 1

--- a/code/modules/mob/living/carbon/shock.dm
+++ b/code/modules/mob/living/carbon/shock.dm
@@ -33,15 +33,14 @@
 		var/mob/living/carbon/human/M = src
 		for(var/obj/item/organ/external/BP in M.bodyparts)
 			if((BP.status & ORGAN_DESTROYED) && !BP.amputated)
-				src.traumatic_shock += 60
+				src.traumatic_shock += 60 * BP.shock_coefficient
 			else if((BP.status & ORGAN_BROKEN) || BP.open)
-				src.traumatic_shock += 30
+				src.traumatic_shock += 30 * BP.shock_coefficient
 				if(BP.status & ORGAN_SPLINTED)
-					src.traumatic_shock -= 25
+					src.traumatic_shock -= 25 * BP.shock_coefficient
 
 	if(src.traumatic_shock < 0)
 		src.traumatic_shock = 0
-
 	return src.traumatic_shock
 
 

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -47,6 +47,10 @@
 	var/limb_layer = 0
 	var/damage_msg = "\red You feel an intense pain"
 
+	siemens_coefficient = 1.0 //only for balance purpose, to prevent abuse of shooting on the heels
+	var/damage_coefficient = 1.0
+	var/shock_coefficient = 1.0
+
 /obj/item/organ/external/insert_organ()
 	..()
 
@@ -1073,6 +1077,10 @@ Note that amputating the affected organ does in fact remove the infection from t
 	min_broken_damage = 30
 	w_class = ITEM_SIZE_NORMAL
 
+	siemens_coefficient = 0.75
+	damage_coefficient = 0.75
+	shock_coefficient = 0.75
+
 /obj/item/organ/external/l_arm/process()
 	..()
 	process_grasp(owner.l_hand, "left hand")
@@ -1092,6 +1100,10 @@ Note that amputating the affected organ does in fact remove the infection from t
 	min_broken_damage = 30
 	w_class = ITEM_SIZE_NORMAL
 
+	siemens_coefficient = 0.75
+	damage_coefficient = 0.75
+	shock_coefficient = 0.75
+
 /obj/item/organ/external/r_arm/process()
 	..()
 	process_grasp(owner.r_hand, "right hand")
@@ -1110,6 +1122,10 @@ Note that amputating the affected organ does in fact remove the infection from t
 	min_broken_damage = 15
 	w_class = ITEM_SIZE_SMALL
 
+	siemens_coefficient = 0.5
+	damage_coefficient = 0.25
+	shock_coefficient = 0.25
+
 /obj/item/organ/external/l_hand/process()
 	..()
 	process_grasp(owner.l_hand, "left hand")
@@ -1127,6 +1143,10 @@ Note that amputating the affected organ does in fact remove the infection from t
 	max_damage = 30
 	min_broken_damage = 15
 	w_class = ITEM_SIZE_SMALL
+
+	siemens_coefficient = 0.5
+	damage_coefficient = 0.25
+	shock_coefficient = 0.25
 
 /obj/item/organ/external/r_hand/process()
 	..()
@@ -1148,6 +1168,10 @@ Note that amputating the affected organ does in fact remove the infection from t
 	min_broken_damage = 30
 	w_class = ITEM_SIZE_NORMAL
 
+	siemens_coefficient = 0.75
+	damage_coefficient = 0.75
+	shock_coefficient = 0.75
+
 
 /obj/item/organ/external/r_leg
 	name = "right leg"
@@ -1165,6 +1189,10 @@ Note that amputating the affected organ does in fact remove the infection from t
 	min_broken_damage = 30
 	w_class = ITEM_SIZE_NORMAL
 
+	siemens_coefficient = 0.75
+	damage_coefficient = 0.75
+	shock_coefficient = 0.75
+
 
 /obj/item/organ/external/l_foot
 	name = "left foot"
@@ -1179,6 +1207,10 @@ Note that amputating the affected organ does in fact remove the infection from t
 	max_damage = 30
 	min_broken_damage = 15
 	w_class = ITEM_SIZE_SMALL
+
+	siemens_coefficient = 0.5
+	damage_coefficient = 0.25
+	shock_coefficient = 0.25
 
 
 /obj/item/organ/external/r_foot
@@ -1195,6 +1227,9 @@ Note that amputating the affected organ does in fact remove the infection from t
 	min_broken_damage = 15
 	w_class = ITEM_SIZE_SMALL
 
+	siemens_coefficient = 0.5
+	damage_coefficient = 0.25
+	shock_coefficient = 0.25
 
 /obj/item/organ/external/head/take_damage(brute, burn, damage_flags, used_weapon)
 	if(!disfigured)


### PR DESCRIPTION
Обсуждалось как альтернатива #2113 

На данный момент это 3 коэффициента к внешним органам, модифицирующие влияние на состояние моба:
damage_coefficient - модификатор для урона персонажу, ладони/ступни 0.25 и руки/ноги 0.75
влияет только на расчет общего здоровья персонажа, от которого зависит состояние и накапливаемый шок
siemens_coefficient - теперь и у органов. Влияет на применяемые эффекты вроде стана. Возможно не совсем реалистично, хотя со всякими тазерами ирл вроде как тоже различная эффективность от места применения, но точно не узнавал.
Соответственно как выше, 0.5 и 0.75. СБшный бронежилет к примеру имеет коэффициент 0.4, более-менее нивелируется эта разница. Бронежилет всё еще эффективней, но если его нету - лучше стрелять в пузо.
shock_coefficient - 0.5 и 0.75 - модификатор для накапливаемого шока. Раньше не было разницы, сломалась ступня или нога.

Значения подбирал практически от балды на своё усмотрение, нужно будет смотреть по фидбеку.
Для головы/туловища/гроина значения везде 1, хотя можно допустим повысить на голову.

Пока что никак не решается проблема с переломом ладоней, возможно как писал перекину на них ковер с органов-родителей и обновлю коэффициенты, либо еще что... 