### PR TITLE
[WIP]Время объявления войны продлено с 6 минут до 10

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -1,5 +1,5 @@
 #define CHALLENGE_TELECRYSTALS 200
-#define CHALLENGE_TIME_LIMIT 4000
+#define CHALLENGE_TIME_LIMIT 6000
 #define CHALLENGE_MIN_PLAYERS 30
 
 var/global/obj/item/device/nuclear_challenge/Challenge


### PR DESCRIPTION
В связи с тем, что декларации войны из доступности в самом начале, переехала за створку:
- аутистам-нюкерам нужно договориться,
- дозвониться педалям,
- педали должны решить уместна нюка или нет, и нажать кнопку,

окно объявления было увеличено на 4 минуты.

:cl:
 - tweak: Время объявления войны продлено с 6 минут до 10

