### PR TITLE
Фикс пропавшей платы для гиротрона.

### DIFF
--- a/code/modules/power/fusion/fusion_circuits.dm
+++ b/code/modules/power/fusion/fusion_circuits.dm
@@ -103,3 +103,12 @@
 	req_tech = list("powerstorage" = 4, "engineering" = 5, "materials" = 5)
 	build_type = IMPRINTER
 	materials = list(MAT_GLASS = 2000, "sacid" = 20)
+
+/datum/design/fusion/emitter/gyrotron
+	name = "Circuit Board (Gyrotron)"
+	id = "gyrotron"
+	build_path = /obj/item/weapon/circuitboard/emitter/gyrotron
+	req_tech = list ("powerstorage" = 6, "engineering" = 5, "programming" = 6)
+	build_type = IMPRINTER
+	materials = list(MAT_GLASS = 2000, "sacid" = 20)
+


### PR DESCRIPTION
<!--
Подробно про оформление ПРов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
Там же написано про то, как сделать чейнджлог. 

!!!
Если авторство не полностью ваше, вы делаете порт с другого билда - укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
!!!

Для копипаста:
остальных случаях можете указать исходный ПР.
!!!

Для копипаста:
Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment.

Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
Быстро фикс пропавшей платы гиротрона.

:cl:
- bugfix:  Плата гиротрона отсутствовала в принтере плат, была возвращена.