### PR TITLE
Хим диспансер выплевывает колбы прямо в руки

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -144,8 +144,8 @@
 			energy = max(energy - min(amount, energy * 10, space) / 10, 0)
 
 	if(href_list["ejectBeaker"])
-		if(beaker)			
-			if(!usr.hand && usr.r_hand && usr.l_hand)
+		if(beaker)				
+			if(usr.r_hand && usr.l_hand)
 				var/obj/item/weapon/reagent_containers/B = beaker
 				B.loc = loc
 				beaker = null

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -144,10 +144,14 @@
 			energy = max(energy - min(amount, energy * 10, space) / 10, 0)
 
 	if(href_list["ejectBeaker"])
-		if(beaker)
-			var/obj/item/weapon/reagent_containers/B = beaker
-			B.loc = loc
-			beaker = null
+		if(beaker)			
+			if(!usr.hand && usr.r_hand && usr.l_hand)
+				var/obj/item/weapon/reagent_containers/B = beaker
+				B.loc = loc
+				beaker = null
+			else						
+				usr.put_in_hands(beaker)
+				beaker = null
 
 
 /obj/machinery/chem_dispenser/attackby(obj/item/weapon/reagent_containers/B, mob/user)


### PR DESCRIPTION
Хим диспансер выплевывает колбы прямо в руки. Если руки заняты выплевывает над хим диспансером как и раньше.

<!--
Подробно про оформление ПРов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
Там же написано про то, как сделать чейнджлог. 

!!!
Если авторство не полностью ваше, вы делаете порт с другого билда - укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
!!!

Для копипаста:
Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment.

Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
:cl:
 - tweak: Хим диспансер выплевывает колбы прямо в руки.