### PR TITLE
Fixes #2256

### DIFF
--- a/code/game/machinery/bots/farmbot.dm
+++ b/code/game/machinery/bots/farmbot.dm
@@ -534,9 +534,9 @@
 
 	A.loc = src.loc
 	to_chat(user, "You add the robot arm to the [src]")
-	qdel(src)
 	user.remove_from_mob(S)
 	qdel(S)
+	qdel(src)
 
 /obj/item/weapon/farmbot_arm_assembly/attackby(obj/item/weapon/W, mob/user)
 	..()

--- a/code/game/machinery/bots/farmbot.dm
+++ b/code/game/machinery/bots/farmbot.dm
@@ -534,7 +534,7 @@
 
 	A.loc = src.loc
 	to_chat(user, "You add the robot arm to the [src]")
-	src.loc = A //Place the water tank into the assembly, it will be needed for the finished bot
+	qdel(src)
 	user.remove_from_mob(S)
 	qdel(S)
 
@@ -565,9 +565,6 @@
 		src.build_step++
 		to_chat(user, "You complete the Farmbot! Beep boop.")
 		var/obj/machinery/bot/farmbot/S = new /obj/machinery/bot/farmbot
-		for ( var/obj/structure/reagent_dispensers/watertank/wTank in src.contents )
-			wTank.loc = S
-			S.tank = wTank
 		S.loc = get_turf(src)
 		S.name = src.created_name
 		user.remove_from_mob(W)


### PR DESCRIPTION
Починка бага #2256

<!--
Подробно про оформление ПРов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
Там же написано про то, как сделать чейнджлог. 

!!!
Если авторство не полностью ваше, вы делаете порт с другого билда - укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
!!!

Для копипаста:
Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment.

Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
Собственно, баг был описан в #2256. Теперь же, будет спавниться один ватертанк, вместо трех. 

:cl: 
 - bugfix: починен баг, связанный с излишним спавном ватертанков. 