### PR TITLE
Добавление профессии АВД в консоль ХоПа

### DIFF
--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -189,7 +189,7 @@
 				var/n = text2num(x)
 				if(n)
 					req_one_access += n
-	
+
 	if(!req_access.len && !req_one_access.len)
 		return TRUE
 	if(!islist(L))
@@ -362,7 +362,7 @@
 		if(access_library)
 			return "Library"
 		if(access_lawyer)
-			return "Law Office"
+			return "IAA Office"
 		if(access_robotics)
 			return "Robotics"
 		if(access_virology)

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -97,7 +97,7 @@ var/list/civilian_positions = list(
 	"Cargo Technician",
 	"Shaft Miner",
 	"Recycler",
-	"Lawyer",
+	"Internal Affairs Agent",
 	"Chaplain",
 	"Test Subject",
 	"Clown",


### PR DESCRIPTION
С момента ввода АВД забыли добавить его в консоль ХоПа, а старая профа "Lawyer"а выдавала ошибку. Пофиксил это.
Так же сменил название Law office на IAA оffice в списке доступов консоли. 
:cl:
 - tweak: Добавлена профессия АВД в консоль ХоПа