### PR TITLE
Отныне учитывается желание глав играть в РП-революцию

### DIFF
--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -9,6 +9,7 @@
 #define ROLE_WIZARD            "Wizard"
 #define ROLE_MALF              "Malf AI"
 #define ROLE_REV               "Revolutionary"
+#define ROLE_REV_HEAD          "Head of Staff in Rev."
 #define ROLE_ALIEN             "Xenomorph"
 #define ROLE_PAI               "pAI"
 #define ROLE_CULTIST           "Cultist"
@@ -35,6 +36,7 @@ var/global/list/special_roles = list(
 	ROLE_WIZARD = IS_MODE_COMPILED("wizard"),            //3
 	ROLE_MALF = IS_MODE_COMPILED("malfunction"),         //4
 	ROLE_REV = IS_MODE_COMPILED("revolution"),           //5
+	ROLE_REV_HEAD = ROLE_REV,                            //5.1
 	ROLE_ALIEN = 1,                                      //6
 	ROLE_PAI = 1,                                        //7
 	ROLE_CULTIST = IS_MODE_COMPILED("cult"),             //8

--- a/code/game/gamemodes/revolution/rp_revolution.dm
+++ b/code/game/gamemodes/revolution/rp_revolution.dm
@@ -26,8 +26,8 @@
 /datum/game_mode/revolution/rp_revolution/pre_setup()
 
 	for(var/mob/dead/new_player/player in player_list) //check if all heads want a revolution
-		if((player.mind.assigned_role in command_positions) && (ROLE_REV_HEAD in player.client.prefs.be_role))
-				return FALSE
+		if((player.mind.assigned_role in command_positions) && !(ROLE_REV_HEAD in player.client.prefs.be_role))
+			return FALSE
 
 	if(config.protect_roles_from_antagonist)
 		restricted_jobs += protected_jobs

--- a/code/game/gamemodes/revolution/rp_revolution.dm
+++ b/code/game/gamemodes/revolution/rp_revolution.dm
@@ -25,6 +25,10 @@
 ///////////////////////////////////////////////////////////////////////////////
 /datum/game_mode/revolution/rp_revolution/pre_setup()
 
+	for(var/mob/dead/new_player/player in player_list) //check if all heads want a revolution
+		if((player.mind.assigned_role in command_positions) && (ROLE_REV_HEAD in player.client.prefs.be_role))
+				return FALSE
+
 	if(config.protect_roles_from_antagonist)
 		restricted_jobs += protected_jobs
 
@@ -50,9 +54,9 @@
 		head_revolutionaries += lenin
 
 	if((head_revolutionaries.len==0)||(!head_check))
-		return 0
+		return FALSE
 
-	return 1
+	return TRUE
 
 
 /datum/game_mode/revolution/rp_revolution/post_setup()


### PR DESCRIPTION
По заказу донатеров и вайнов в дедчате. С этого момента для начала революции у выбранных глав должен быть включен специальный преференс. Сделано это для того, чтобы игроки желающие поиграть на главах могли спокойно насладиться игрой. Это нужно как новичкам, которые впервые играют за глав, так и игрокам, чьим персонажам несвойственно поведение кровавого тирана, которого требует режим РП-революция для этого самого РП.

Бтв, там ещё в БД чё-то подкрутить надо вроде, но это уже не ко мне.
:cl: Sakuya Izayoi
- tweak: Нынче для начала РП-революции требуется наличие преференса "Head of Staff in Rev." у глав.
