### PR TITLE
Фиксы карандашика.

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -141,7 +141,7 @@
 				to_chat(user, "<span class = 'notice'>You finish [instant ? "spraying" : "drawing"] a letter on the [target.name].</span>")
 			else
 				to_chat(user, "<span class = 'notice'>You finish [instant ? "spraying" : "drawing"] [drawtype] on the [target.name].</span>")
-
+			if(instant<0)
 				playsound(user.loc, 'sound/effects/spray.ogg', 5, 1, 5)
 			uses = max(0,uses-1)
 			if(!uses)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -73,16 +73,15 @@
 	if(istype(target, /obj/effect/decal/cleanable))
 		target = target.loc
 	if(is_type_in_list(target,validSurfaces))
-		var/temp
 		var/drawtype = input("Choose what you'd like to draw.", "Crayon scribbles") in list("graffiti","rune","letter")
 		switch(drawtype)
 			if("letter")
 				drawtype = input("Choose the letter.", "Crayon scribbles") in list("a","b","c","d","e","f","g","h","i","j","k","l","m","n","o","p","q","r","s","t","u","v","w","x","y","z")
-				to_chat(user, "You start drawing a letter on the [target.name].")
+				to_chat(user, "<span class = 'notice'>You start [instant ? "spraying" : "drawing"] a letter on the [target.name].</span>")
 			if("graffiti")
-				to_chat(user, "You start drawing graffiti on the [target.name].")
+				to_chat(user, "<span class = 'notice'>You start [instant ? "spraying" : "drawing"] graffiti on the [target.name].</span>")
 			if("rune")
-				to_chat(user, "You start drawing a rune on the [target.name].")
+				to_chat(user, "<span class = 'notice'>You start [instant ? "spraying" : "drawing"] a rune on the [target.name].</span>")
 
 		////////////////////////// GANG FUNCTIONS
 		var/area/territory
@@ -90,10 +89,8 @@
 		if(gang)
 			//Determine gang affiliation
 			if(user.mind in (ticker.mode.A_bosses | ticker.mode.A_gang))
-				temp = "[gang_name("A")] gang tag"
 				gangID = "A"
 			else if(user.mind in (ticker.mode.B_bosses | ticker.mode.B_gang))
-				temp = "[gang_name("B")] gang tag"
 				gangID = "B"
 
 			//Check area validity. Reject space, player-created areas, and non-station z-levels.
@@ -119,8 +116,9 @@
 					return
 		/////////////////////////////////////////
 
-
-		to_chat(user, "You start [instant ? "spraying" : "drawing"] a [temp] on the [target.name].")
+		if(!in_range(user, target))
+			to_chat(user, "<span class = 'notice'>You must stay close to your drawing if you want to draw something.</span>")
+			return
 		if(instant)
 			playsound(user.loc, 'sound/effects/spray.ogg', 5, 1, 5)
 		if(instant > 0 || (!user.is_busy(src) && do_after(user, 50, target = target)))
@@ -139,8 +137,11 @@
 			else
 				new /obj/effect/decal/cleanable/crayon(target,colour,shadeColour,drawtype)
 
-			to_chat(user, "You finish [instant ? "spraying" : "drawing"] [temp].")
-			if(instant<0)
+			if(drawtype in list("a","b","c","d","e","f","g","h","i","j","k","l","m","n","o","p","q","r","s","t","u","v","w","x","y","z"))
+				to_chat(user, "<span class = 'notice'>You finish [instant ? "spraying" : "drawing"] a letter on the [target.name].</span>")
+			else
+				to_chat(user, "<span class = 'notice'>You finish [instant ? "spraying" : "drawing"] [drawtype] on the [target.name].</span>")
+
 				playsound(user.loc, 'sound/effects/spray.ogg', 5, 1, 5)
 			uses = max(0,uses-1)
 			if(!uses)


### PR DESCRIPTION
Closes #1813. В пару мест закинул спанов. Убрал бесполезное отображение того для какой банды игрок помечает территорию (т.к. это просто выглядело убого из-за кривой реализации, да и было не к месту т.к. ганг вроде как не всегда является гейммодом а фиксить по другому мне это лень, с учётом что я могу превратить это в фичу) и заменил его на вывод того что игрок нарисовал. Исправил отображение двух сообщений о том что игрок начал рисовать вещи хотя должно быть одно.

<!--
Подробно про оформление ПРов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
Там же написано про то, как сделать чейнджлог. 

!!!
Если авторство не полностью ваше, вы делаете порт с другого билда - укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
!!!

Для копипаста:
Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment.

Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
:cl: LLIIkolnik
- bugfix: Карандаш больше не может рисовать издалека. 