### PR TITLE
Fix runtime on old character saves

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -2,7 +2,7 @@
 #define SAVEFILE_VERSION_MIN 8
 
 //This is the current version, anything below this will attempt to update (if it's not obsolete)
-#define SAVEFILE_VERSION_MAX 18
+#define SAVEFILE_VERSION_MAX 19
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -50,18 +50,23 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		aooccolor = ooccolor
 
 /datum/preferences/proc/update_character(current_version, savefile/S)
-	if(current_version < 18)
-		ResetJobs()
-		if(language && species && language != "None")
-			var/datum/language/lang = all_languages[language]
-			if(!(species in lang.allowed_species))
-				language = "None"
-				S["language"] << language
 	if(current_version < 17)
 		for(var/organ_name in organ_data)
 			if(organ_name in list("r_hand", "l_hand", "r_foot", "l_foot"))
 				organ_data -= organ_name
 				S["organ_data"] -= organ_name
+	if(current_version < 18)
+		ResetJobs()
+
+		if(language && species && language != "None")
+			if(!istext(language))
+				var/atom/A = language
+				language = A.name
+
+			var/datum/language/lang = all_languages[language]
+			if(!(species in lang.allowed_species))
+				language = "None"
+				S["language"] << language
 
 /datum/preferences/proc/load_path(ckey, filename = "preferences.sav")
 	if(!ckey)


### PR DESCRIPTION
```
[13:47:51]Cannot read null.allowed_species
[13:47:51]proc name: update character (/datum/preferences/proc/update_character)
[13:47:51]  source file: preferences_savefile.dm,57
[13:47:51]  usr: null
[13:47:51]  src: /datum/preferences (/datum/preferences)
[13:47:51]  call stack:
[13:47:51]/datum/preferences (/datum/preferences): update character(15, data/player_saves/l/lexakr/pre... (/savefile))
[13:47:51]/datum/preferences (/datum/preferences): load saved character("/character5")
[13:47:51]/datum/preferences (/datum/preferences): load character(5)
[13:47:51]/datum/preferences (/datum/preferences): New(Lexakr (/client))
```

Как понимаю, в старых сейвах это был датум, а сейчас однозначно текст