### PR TITLE
Бюрократический апдейт

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -301,7 +301,7 @@
 	t = replacetext(t, "\[/bh\]", "</h3>")
 
 	// blockquote
-	t = replacetext(t, "\[quote\]", "<blockquote style=\"line-height:normal; margin-bottom:10px; font-style:italic; text-align:right;\">");
+	t = replacetext(t, "\[quote\]", "<blockquote style=\"line-height:normal; margin-bottom:10px; font-style:italic; letter-spacing: 1.25px; text-align:right;\">");
 	t = replacetext(t, "\[/quote\]", "</blockquote>");
 
 	// div

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -282,6 +282,32 @@
 	t = replacetext(t, "\[/large\]", "</font>")
 	t = replacetext(t, "\[field\]", "<span class=\"paper_field\"></span>")
 
+	// tables
+	t = replacetext(t, "\[table\]", "<table border=3px cellpadding=5px bordercolor=\"black\">");
+	t = replacetext(t, "\[/table\]", "</table>");
+	t = replacetext(t, "\[tr\]", "<tr>");
+	t = replacetext(t, "\[/tr\]", "</tr>");
+	t = replacetext(t, "\[td\]", "<td>");
+	t = replacetext(t, "\[/td\]", "</td>");
+	t = replacetext(t, "\[th\]", "<th>");
+	t = replacetext(t, "\[/th\]", "</th>");
+
+	// standart head
+	t = replacetext(t, "\[h\]", "<h2 style=\"font-family: Arial; text-align:center;\">");
+	t = replacetext(t, "\[/h\]", "</h2>");
+
+	// bordered head;
+	t = replacetext(t, "\[bh\]", "<h2 style=\"border-width: 4px; border-style: solid; font-family: Arial; padding: 10px; text-align:center;\">");
+	t = replacetext(t, "\[/bh\]", "</h2>")
+
+	// blockquote
+	t = replacetext(t, "\[quote\]", "<blockquote style=\"line-height:normal; margin-bottom:10px; font-style:italic; text-align:right;\">");
+	t = replacetext(t, "\[/quote\]", "</blockquote>");
+
+	// div
+	t = replacetext(t, "\[block\]", "<div style=\"border-width: 4px; border-style: dashed;\">");
+	t = replacetext(t, "\[/block\]", "</div>");
+
 	if(!iscrayon)
 		t = replacetext(t, "\[*\]", "<li>")
 		t = replacetext(t, "\[hr\]", "<HR>")
@@ -426,7 +452,6 @@
 
 /obj/item/weapon/paper/attackby(obj/item/weapon/P, mob/user)
 	..()
-	user.SetNextMove(CLICK_CD_INTERACT)
 	var/clown = 0
 	if(user.mind && (user.mind.assigned_role == "Clown"))
 		clown = 1

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -452,6 +452,7 @@
 
 /obj/item/weapon/paper/attackby(obj/item/weapon/P, mob/user)
 	..()
+	user.SetNextMove(CLICK_CD_INTERACT)
 	var/clown = 0
 	if(user.mind && (user.mind.assigned_role == "Clown"))
 		clown = 1

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -293,12 +293,12 @@
 	t = replacetext(t, "\[/th\]", "</th>");
 
 	// standart head
-	t = replacetext(t, "\[h\]", "<h2 style=\"font-family: Arial; text-align:center;\">");
-	t = replacetext(t, "\[/h\]", "</h2>");
+	t = replacetext(t, "\[h\]", "<h3 style=\"font-family: Arial; text-align:center;\">");
+	t = replacetext(t, "\[/h\]", "</h3>");
 
 	// bordered head;
-	t = replacetext(t, "\[bh\]", "<h2 style=\"border-width: 4px; border-style: solid; font-family: Arial; padding: 10px; text-align:center;\">");
-	t = replacetext(t, "\[/bh\]", "</h2>")
+	t = replacetext(t, "\[bh\]", "<h3 style=\"border-width: 4px; border-style: solid; font-family: Arial; padding: 10px; text-align:center;\">");
+	t = replacetext(t, "\[/bh\]", "</h3>")
 
 	// blockquote
 	t = replacetext(t, "\[quote\]", "<blockquote style=\"line-height:normal; margin-bottom:10px; font-style:italic; text-align:right;\">");
@@ -418,7 +418,7 @@
 
 		var last_fields_value = fields
 
-		t = sanitize_alt(t, list("\n"="\[br\]","ÿ"=LETTER_255))
+		t = sanitize_alt(t, list("\n"="\[br\]","Ã¿"=LETTER_255))
 
 		// check for exploits
 		for(var/bad in paper_blacklist)


### PR DESCRIPTION
Решил сделать небольшой апдейт для бюрократов (для работы с формами, бумагами и т.д.).

В обновлении добавлены 4 основные возможности:

1. Таблицы
2. Заголовки
3. Цитаты
4. Блок

О каждой далее по-порядку.

**Таблицы**

У игроков будет возможность создавать таблицы на бумаге. Собственно, для таблицы внедрены 4 основных тега: table (основание таблицы), th (главная ячейка столбца), tr (строка), td (обычная ячейка таблицы). Таблица немного отформатирована: добавлены рамки и небольшое отступление от контента ячейки к её рамки для большей удобности. 

Пример таблицы:

`[table][tr][th]Член экипажа[/th][th]Должность[/th][th]Зарплата[/th][/tr][tr][td]Willy Jackson[/td][td]RD[/td][td]PERMA[/td][/tr][/table]`

Вид: http://prntscr.com/iz0ce1

**Заголовки**

У игроков будет возможность более просто создавать заголовки для рапортов и чего-либо еще. 
[center][large][b]Отдел поставок КСН "ИСХОД"[/b][/large][/center] - забудьте про это, теперь это будет так: [h]Отдел поставок КСН "ИСХОД"[/h]. Так же есть [bh], тогда будут добавлены рамки до заголовка. 

Пример заголовков: http://prntscr.com/iz0i4t

**Цитаты**

У игроков будет возможность быстро записывать цитаты на бумагу. Если нужно указать автора, достаточно перейти на новую строчку и написать что-то, вроде: "- Гарри".

Пример цитаты: http://prntscr.com/iz0xkz

**Блок**

У игроков будет возможность выделить какой-то фрагмент всего их текста в один блок с рамкой с пропусками. 

Пример: http://prntscr.com/iz0j7h

**_Бонус: я готов обновить статью по бюрократии на википедии._**
:cl:
 - rscadd[link]: апдейт бюрократии: добавлены таблицы, заголовки, цитаты, блок с рамкой с пропусками. Добавлены следующие теги: h, bh, table, tr, td, th, quote, block.
