### PR TITLE
Багфиксы к генокрадам.

### DIFF
--- a/code/game/gamemodes/changeling/powers/absorb.dm
+++ b/code/game/gamemodes/changeling/powers/absorb.dm
@@ -121,19 +121,19 @@
 	if(T)
 		if(!ishuman(T))
 			to_chat(U, "<span class='warning'>[T] is too simple for absorption.</span>")
-			return 0
+			return FALSE
 
-		if(NOCLONE in T.mutations || HUSK in T.mutations)
+		if((NOCLONE in T.mutations) || (HUSK in T.mutations))
 			to_chat(U, "<span class='warning'>DNA of [T] is ruined beyond usability!</span>")
-			return 0
+			return FALSE
 
 		if(T:species.flags[IS_SYNTHETIC] || T:species.flags[IS_PLANT])
 			to_chat(U, "<span class='warning'>[T] is not compatible with our biology.</span>")
-			return 0
+			return FALSE
 
 		if(T:species.flags[NO_SCAN])
 			to_chat(src, "<span class='warning'>We do not know how to parse this creature's DNA!</span>")
-			return 0
+			return FALSE
 
 		for(var/datum/dna/D in absorbed_dna)
 			if(T.dna.uni_identity == D.uni_identity)
@@ -141,113 +141,5 @@
 					if(T.dna.real_name == D.real_name)
 						if(T.dna.mutantrace == D.mutantrace)
 							to_chat(U, "<span class='warning'>We already have that DNA in storage.</span>")
-							return 0
-	return 1
-/*
-/obj/effect/proc_holder/changeling/absorbDNA/can_sting(mob/living/carbon/user)
-	if(!..())
-		return
-
-	var/datum/changeling/changeling = user.mind.changeling
-	if(changeling.isabsorbing)
-		to_chat(user, "<span class='warning'>We are already absorbing!</span>")
-		return
-
-	var/obj/item/weapon/grab/G = user.get_active_hand()
-	if(!istype(G))
-		to_chat(user, "<span class='warning'>We must be grabbing a creature in our active hand to absorb them.</span>")
-		return
-	if(!G.state == GRAB_KILL)
-		to_chat(user, "<span class='warning'>We must have a tighter grip to absorb this creature.</span>")
-		return
-
-	var/mob/living/carbon/target = G.affecting
-	return changeling.can_absorb_dna(user,target)
-
-/obj/effect/proc_holder/changeling/absorbDNA/sting_action(mob/user)
-	var/datum/changeling/changeling = user.mind.changeling
-	var/obj/item/weapon/grab/G = user.get_active_hand()
-	var/mob/living/carbon/human/target = G.affecting
-	for(var/stage = 1, stage<=3, stage++)
-		switch(stage)
-			if(1)
-				to_chat(user, "<span class='notice'>This creature is compatible. We must hold still...</span>")
-			if(2)
-				to_chat(user, "<span class='notice'>We extend a proboscis.</span>")
-				user.visible_message("<span class='warning'>[user] extends a proboscis!</span>")
-			if(3)
-				to_chat(user, "<span class='notice'>We stab [target] with the proboscis.</span>")
-				user.visible_message("<span class='danger'>[user] stabs [target] with the proboscis!</span>")
-				to_chat(target, "<span class='danger'>You feel a sharp stabbing pain!</span>")
-				target.take_overall_damage(40)
-
-		feedback_add_details("changeling_powers","A[stage]")
-		if(!do_mob(user, target, 150))
-			to_chat(user, "<span class='warning'>Our absorption of [target] has been interrupted!</span>")
-			changeling.isabsorbing = 0
-			return
-
-	to_chat(user, "<span class='notice'>We have absorbed [target]!</span>")
-	user.visible_message("<span class='danger'>[user] sucks the fluids from [target]!</span>")
-	to_chat(target, "<span class='danger'>You have been absorbed by the changeling!</span>")
-
-//	changeling.absorb_dna(target)
-	target.dna.real_name = target.real_name //Set this again, just to be sure that it's properly set.
-	changeling.absorbed_dna |= target.dna
-
-	//Steal all of their languages!
-	for(var/language in target.languages)
-		if(!(language in changeling.absorbed_languages))
-			changeling.absorbed_languages += language
-
-	var/mob/living/carbon/C = src
-	C.changeling_update_languages(changeling.absorbed_languages)
-
-	//Steal their species!
-	if(target.species && !(target.species.name in changeling.absorbed_species))
-		changeling.absorbed_species += target.species.name
-
-	if(user.nutrition < 400) user.nutrition = min((user.nutrition + target.nutrition), 400)
-	if(target.mind)//if the victim has got a mind
-		target.mind.show_memory(src, 0) //I can read your mind, kekeke. Output all their notes.
-		if(target.mind.changeling)//If the target was a changeling, suck out their extra juice and objective points!
-			if(target.mind.changeling.absorbed_dna)
-				for(var/dna_data in target.mind.changeling.absorbed_dna)	//steal all their loot
-					if(dna_data in changeling.absorbed_dna)
-						continue
-					changeling.absorbed_dna += dna_data
-
-/*		if(T.mind.changeling.purchasedpowers)
-			for(var/datum/power/changeling/Tp in T.mind.changeling.purchasedpowers)
-				if(Tp in changeling.purchasedpowers)
-					continue
-				else
-					changeling.purchasedpowers += Tp
-
-					if(!Tp.isVerb)
-						call(Tp.verbpath)()
-					else
-						src.make_changeling() */
-
-
-				changeling.chem_charges += min(target.mind.changeling.chem_charges, changeling.chem_storage)
-				changeling.absorbedcount += target.mind.changeling.absorbedcount
-				changeling.geneticpoints += target.mind.changeling.geneticpoints
-
-				target.mind.changeling.absorbed_dna.len = 1
-				target.mind.changeling.absorbedcount = 0
-				target.mind.changeling.chem_charges = 0
-				target.mind.changeling.geneticpoints = 0
-
-		else
-			changeling.chem_charges += 10
-
-	changeling.geneticpoints += 2
-	changeling.isabsorbing = 0
-//	changeling.canrespec = 1
-
-	target.death(0)
-	target.Drain()
-	return 1
-
- */
+							return FALSE
+	return TRUE

--- a/code/game/gamemodes/changeling/powers/essences.dm
+++ b/code/game/gamemodes/changeling/powers/essences.dm
@@ -1,6 +1,7 @@
 /mob/living/parasite/essence
 	alpha = 127
 	icon = 'icons/mob/human.dmi'
+	stat = DEAD
 	var/datum/changeling/changeling
 	var/flags_allowed = (ESSENCE_HIVEMIND | ESSENCE_PHANTOM | ESSENCE_POINT | ESSENCE_SPEAK_TO_HOST)
 	var/obj/effect/essence_phantom/phantom

--- a/code/modules/mob/emote.dm
+++ b/code/modules/mob/emote.dm
@@ -28,7 +28,7 @@
 				if(isnewplayer(M))
 					continue
 				if(M.stat == DEAD && (M.client.prefs.chat_toggles & CHAT_GHOSTSIGHT) && !(M in viewers(src, null)))
-					M.show_message(message, show_to_parasites = FALSE)
+					M.show_message(message)
 
 
 		// Type 1 (Visual) emotes are sent to anyone in view of the item

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -141,5 +141,5 @@
 	if(fake_death)
 		fake_death = 0
 	ChangeToHusk()
-	mutations |= NOCLONE
+	mutations.Add(NOCLONE)
 	return


### PR DESCRIPTION
Мама, я убери этот огромный лист рантаймов.
:cl:
 - bugfix: Генокрады могли повторно иссушать тело, если оно ранее было иссушено другим.
 - bugfix: Иссушенные жертвы генокрадов не засчитывались убитыми при цели на убийство.