### PR TITLE
TILE_BOUND для объектов

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1,5 +1,6 @@
 /atom/movable
 	layer = 3
+	appearance_flags = TILE_BOUND
 	var/last_move = null
 	var/anchored = 0
 	var/move_speed = 10

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -6,6 +6,7 @@
 	anchored = 1
 	density = 1
 	layer = 6
+	appearance_flags = 0
 	//light_range = 6
 	unacidable = 1 //Don't comment this out.
 	var/current_size = 1

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -18,6 +18,7 @@
 	anchored = 1 //There's a reason this is here, Mport. God fucking damn it -Agouri. Find&Fix by Pete. The reason this is here is to stop the curving of emitter shots.
 	pass_flags = PASSTABLE
 	mouse_opacity = 0
+	appearance_flags = 0
 	var/bumped = 0		//Prevents it from hitting more than one guy at once
 	var/def_zone = ""	//Aiming at
 	var/mob/firer = null//Who shot it


### PR DESCRIPTION
Добавил флаг TILE_BOUND для объектов, исключения - синга и прожектайлы, теперь нет проблем со смещением объектов на стенках (и еще каких-то, может быть, тоже не будет)
:cl:
 - bugfix: Сейфы, кнопки и другие объекты на стенках больше не видно из неположенных мест (со стороны тоннелей, из коридора...)
