### PR TITLE
Исправления в разделывании тушек

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -19,6 +19,10 @@
 		return
 	user.SetNextMove(CLICK_CD_MELEE)
 
+	if(user.a_intent == "help" && istype(I, /obj/item/weapon/kitchenknife) || istype(I, /obj/item/weapon/butch))
+		if(attempt_harvest(I, user))
+			return
+
 	if(user.zone_sel && user.zone_sel.selecting)
 		I.attack(src, user, user.zone_sel.selecting)
 	else
@@ -35,9 +39,6 @@
 		if(istype(H.wear_suit, /obj/item/clothing/suit))
 			var/obj/item/clothing/suit/V = H.wear_suit
 			V.attack_reaction(src, REACTION_ATACKED, user)
-
-	if(attempt_harvest(I, user))
-		return
 
 // Proximity_flag is 1 if this afterattack was called on something adjacent, in your square, or on your person.
 // Click parameters is the params string from byond Click() code, see that documentation.

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -19,10 +19,6 @@
 		return
 	user.SetNextMove(CLICK_CD_MELEE)
 
-	if(user.a_intent == "help" && istype(I, /obj/item/weapon/kitchenknife) || istype(I, /obj/item/weapon/butch))
-		if(attempt_harvest(I, user))
-			return
-
 	if(user.zone_sel && user.zone_sel.selecting)
 		I.attack(src, user, user.zone_sel.selecting)
 	else

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -139,6 +139,11 @@
 							"\red <b>[user] is slitting \his stomach open with the [src.name]! It looks like \he's trying to commit seppuku.</b>"))
 		return (BRUTELOSS)
 
+/obj/item/weapon/kitchenknife/attack(mob/living/carbon/M, mob/living/carbon/user)
+	if(user.a_intent == "help" && M.attempt_harvest(src, user))
+		return
+	return ..()
+
 /obj/item/weapon/kitchenknife/plastic
 	name = "plastic knife"
 	desc = "The bluntest of blades."
@@ -174,6 +179,8 @@
 	edge = 1
 
 /obj/item/weapon/butch/attack(mob/living/carbon/M, mob/living/carbon/user)
+	if(user.a_intent == "help" && M.attempt_harvest(src, user))
+		return
 	playsound(loc, 'sound/weapons/bladeslice.ogg', 50, 1, -1)
 	return ..()
 

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -178,8 +178,8 @@
 	sharp = 1
 	edge = 1
 
-/obj/item/weapon/butch/attack(mob/living/carbon/M, mob/living/carbon/user)
-	if(user.a_intent == "help" && M.attempt_harvest(src, user))
+/obj/item/weapon/butch/attack(mob/living/M, mob/living/user)
+	if(user.a_intent == I_HELP && M.attempt_harvest(src, user))
 		return
 	playsound(loc, 'sound/weapons/bladeslice.ogg', 50, 1, -1)
 	return ..()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1122,8 +1122,9 @@
 	floating = 0
 
 /mob/living/proc/attempt_harvest(obj/item/I, mob/user)
-	if(stat == DEAD && !isnull(butcher_results) && istype(src.buckled, /obj/structure/kitchenspike)) //can we butcher it? Mob must be buckled to a meatspike to butcher it
-		if(user.is_busy()) return
+	if(stat == DEAD && istype(buckled, /obj/structure/kitchenspike)) //can we butcher it? Mob must be buckled to a meatspike to butcher it
+		if(user.is_busy())
+			return
 		to_chat(user, "<span class='notice'>You begin to butcher [src]...</span>")
 		playsound(loc, 'sound/weapons/slice.ogg', 50, 1, -1)
 		if(do_mob(user, src, 80))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1122,7 +1122,7 @@
 	floating = 0
 
 /mob/living/proc/attempt_harvest(obj/item/I, mob/user)
-	if(stat == DEAD && istype(buckled, /obj/structure/kitchenspike)) //can we butcher it? Mob must be buckled to a meatspike to butcher it
+	if(stat == DEAD && butcher_results && istype(buckled, /obj/structure/kitchenspike)) //can we butcher it? Mob must be buckled to a meatspike to butcher it
 		if(user.is_busy())
 			return
 		to_chat(user, "<span class='notice'>You begin to butcher [src]...</span>")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1122,14 +1122,13 @@
 	floating = 0
 
 /mob/living/proc/attempt_harvest(obj/item/I, mob/user)
-	if(stat == DEAD && !isnull(butcher_results) && !ishuman(src)) //can we butcher it?
-		if(istype(I, /obj/item/weapon/kitchenknife) || istype(I, /obj/item/weapon/butch))
-			if(user.is_busy()) return
-			to_chat(user, "<span class='notice'>You begin to butcher [src]...</span>")
-			playsound(loc, 'sound/weapons/slice.ogg', 50, 1, -1)
-			if(do_mob(user, src, 80))
-				harvest(user)
-			return TRUE
+	if(stat == DEAD && !isnull(butcher_results) && istype(src.buckled, /obj/structure/kitchenspike)) //can we butcher it? Mob must be buckled to a meatspike to butcher it
+		if(user.is_busy()) return
+		to_chat(user, "<span class='notice'>You begin to butcher [src]...</span>")
+		playsound(loc, 'sound/weapons/slice.ogg', 50, 1, -1)
+		if(do_mob(user, src, 80))
+			harvest(user)
+		return TRUE
 
 /mob/living/proc/harvest(mob/user)
 	if(QDELETED(src))

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -345,8 +345,10 @@
 		else
 			to_chat(user, "<span class='notice'> this [src] is dead, medical items won't bring it back to life.</span>")
 	user.SetNextMove(CLICK_CD_MELEE)
-	if(attempt_harvest(O, user))
-		return
+
+	if(user.a_intent == "help" && istype(O, /obj/item/weapon/kitchenknife) || istype(O, /obj/item/weapon/butch))
+		if(attempt_harvest(O, user))
+			return
 	..()
 
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -345,10 +345,6 @@
 		else
 			to_chat(user, "<span class='notice'> this [src] is dead, medical items won't bring it back to life.</span>")
 	user.SetNextMove(CLICK_CD_MELEE)
-
-	if(user.a_intent == "help" && istype(O, /obj/item/weapon/kitchenknife) || istype(O, /obj/item/weapon/butch))
-		if(attempt_harvest(O, user))
-			return
 	..()
 
 


### PR DESCRIPTION
<!--
Подробно про оформление ПРов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
Там же написано про то, как сделать чейнджлог. 

!!!
Если авторство не полностью ваше, вы делаете порт с другого билда - укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
!!!

Для копипаста:
Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment.

Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
Fixes #2374 
:cl: Trogwar
- bugfix: Поправлено разделывание тушек. Разделывание хуманов и их респрайтов на мясном крюке снова доступно. Мобов теперь можно разделывать только на крюке. Разделывание происходит на help-интенте и все еще требует, чтобы жертва была мертва.
