### PR TITLE
Изменение размера гейм-кита.

### DIFF
--- a/code/game/objects/game_kit.dm
+++ b/code/game/objects/game_kit.dm
@@ -12,7 +12,7 @@
 	m_amt = 2000
 	g_amt = 1000
 	item_state = "sheet-metal"
-	w_class = 5.0
+	w_class = ITEM_SIZE_NORMAL
 
 /obj/item/weapon/game_kit/red
 	icon_state = "game_kit_red"


### PR DESCRIPTION
Для увеличения популярности, всяким @Zap-zapper -ам посвящается.

:cl: Luduk
- tweak: Гейм-киты можно поместить в рюкзак, в связи с уменьшением их размера.