### PR TITLE
Фикс Accounts uplink terminal.

### DIFF
--- a/code/modules/economy/Accounts_DB.dm
+++ b/code/modules/economy/Accounts_DB.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/computer.dmi'
 	icon_state = "aiupload"
 	density = 1
+	anchored = TRUE
 	req_one_access = list(access_hop, access_captain, access_cent_captain)
 	allowed_checks = ALLOWED_CHECK_NONE
 	var/receipt_num


### PR DESCRIPTION
Ранее эту консоль возможно было двигать пуллом и телепатией из-за переменной Anchored = 0
Исправил путём добавления переменной TRUE