### PR TITLE
Синта'Унати, Сиик'Мейс всем!

### DIFF
--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -71,7 +71,7 @@
 	exclaim_verb = "roars"
 	colour = "soghun"
 	key = list("o", "ù")
-	allowed_species = list(IPC)
+	allowed_species = list(IPC, HUMAN, DIONA, SKRELL, TAJARAN)
 	syllables = list("ss","ss","ss","ss","skak","seeki","resh","las","esi","kor","sh")
 
 /datum/language/tajaran
@@ -81,7 +81,7 @@
 	ask_verb = "mrowls"
 	exclaim_verb = "yowls"
 	colour = "tajaran"
-	allowed_species = list(IPC)
+	allowed_species = list(IPC, HUMAN, DIONA, SKRELL, UNATHI)
 	key = list("j", "î")
 	syllables = list("rr","rr","tajr","kir","raj","kii","mir","kra","ahk","nal","vah","khaz","jri","ran","darr", \
 	"mi","jri","dynh","manq","rhe","zar","rrhaz","kal","chur","eech","thaa","dra","jurl","mah","sanu","dra","ii'r", \


### PR DESCRIPTION
То что не понял Куршан, понял я. Абсолютно все ксеносы должны мочь говорить на этих языках, в связи с их относительной простотой.

:cl: Luduk
- tweak: Кукла любой расы может выбрать Синта'Унати и Сиик'Мейс, как языки для разговора.