### PR TITLE
Antag objectives tweaks

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -103,15 +103,15 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 
 	switch(rand(1,100))
 		if(1 to 80)
-			if (!(locate(/datum/objective/escape) in changeling.objectives))
-				var/datum/objective/escape/escape_objective = new
-				escape_objective.owner = changeling
-				changeling.objectives += escape_objective
-		else
 			if (!(locate(/datum/objective/survive) in changeling.objectives))
 				var/datum/objective/survive/survive_objective = new
 				survive_objective.owner = changeling
 				changeling.objectives += survive_objective
+		else
+			if (!(locate(/datum/objective/escape) in changeling.objectives))
+				var/datum/objective/escape/escape_objective = new
+				escape_objective.owner = changeling
+				changeling.objectives += escape_objective
 	return
 
 /datum/game_mode/proc/greet_changeling(datum/mind/changeling, you_are=1)

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -101,11 +101,17 @@
 			objectives_count--
 
 		switch(rand(1,120))
-			if(1 to 119)
+			if(1 to 60)
 				if (!(locate(/datum/objective/escape) in traitor.objectives))
 					var/datum/objective/escape/escape_objective = new
 					escape_objective.owner = traitor
 					traitor.objectives += escape_objective
+
+			if(61 to 119)
+				if (!(locate(/datum/objective/survive) in traitor.objectives))
+					var/datum/objective/survive/survive_objective = new
+					survive_objective.owner = traitor
+					traitor.objectives += survive_objective
 
 			else
 				if (!(locate(/datum/objective/hijack) in traitor.objectives))

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -68,22 +68,23 @@
 			kill_objective.find_target()
 			wizard.objectives += kill_objective
 
-			if (!(locate(/datum/objective/escape) in wizard.objectives))
-				var/datum/objective/escape/escape_objective = new
-				escape_objective.owner = wizard
-				wizard.objectives += escape_objective
+			if (!(locate(/datum/objective/survive) in wizard.objectives))
+				var/datum/objective/survive/survive_objective = new
+				survive_objective.owner = wizard
+				wizard.objectives += survive_objective
+		
 		if(31 to 60)
 			var/datum/objective/steal/steal_objective = new
 			steal_objective.owner = wizard
 			steal_objective.find_target()
 			wizard.objectives += steal_objective
 
-			if (!(locate(/datum/objective/escape) in wizard.objectives))
-				var/datum/objective/escape/escape_objective = new
-				escape_objective.owner = wizard
-				wizard.objectives += escape_objective
+			if (!(locate(/datum/objective/survive) in wizard.objectives))
+				var/datum/objective/survive/survive_objective = new
+				survive_objective.owner = wizard
+				wizard.objectives += survive_objective
 
-		if(61 to 100)
+		if(61 to 99)
 			var/datum/objective/assassinate/kill_objective = new
 			kill_objective.owner = wizard
 			kill_objective.find_target()


### PR DESCRIPTION
Пока обсуждение?

Зачем: уменьшить принуждение антагов к вылету на шаттле, так как это не всегда логично (например маги) и часто излишне конфликтно для конца раунда

Обсуждение на форуме расползлось на несколько тем:
http://tauceti.ru/forums/index.php?topic=6589.0
http://tauceti.ru/forums/index.php?topic=6591.0
http://tauceti.ru/forums/index.php?topic=6584.0

:cl:
 - tweak: Задачи мага на побег на шаттле были заменены на обычное выживание. В качестве бонуса вернулся небольшой шанс в 1% на похищения шаттла (hijack)
 - tweak: Генокраду шансы на эскейп/сурвайвл были изменены на 20/80 соответственно (было 80/20)
 - tweak: Трейторам был дан равнозначный задаче на эскейп шанс на сурвайвл