### PR TITLE
Logs

### DIFF
--- a/code/__HELPERS/logging.dm
+++ b/code/__HELPERS/logging.dm
@@ -116,3 +116,36 @@
 		return "[A.loc] [COORD(T)] ([A.loc.type])"
 	else if(A.loc)
 		return "[A.loc] (0, 0, 0) ([A.loc.type])"
+
+//Print a list of antagonists to the server log
+/proc/antagonist_announce()
+	var/text = "ANTAG LIST:\n"
+	var/objectives
+	var/temprole
+	var/list/total_antagonists = list()
+	//Look into all mobs in world, dead or alive
+	for(var/datum/mind/Mind in ticker.minds)
+		temprole = Mind.special_role
+		objectives = ""
+		if(temprole)							//if they are an antagonist of some sort.
+			if(Mind.objectives.len)
+				for(var/datum/objective/O in Mind.objectives)
+					if(length(objectives))
+						objectives += " | "
+					objectives += "[O.explanation_text]"
+				objectives = " \[[objectives]\]"
+
+			if(temprole in total_antagonists)	//If the role exists already, add the name to it
+				total_antagonists[temprole] += "\n, [Mind.name]([Mind.key])[objectives]"
+			else
+				total_antagonists.Add(temprole) //If the role doesnt exist in the list, create it and add the mob
+				total_antagonists[temprole] += ": [Mind.name]([Mind.key])[objectives]"
+
+	//Now print them all into the log!
+	if(total_antagonists.len)
+		for(var/i in total_antagonists)
+			text += "[i]s[total_antagonists[i]]."
+	else
+		text += "no antagonists this moment"
+
+	log_game(text)

--- a/code/__HELPERS/logging.dm
+++ b/code/__HELPERS/logging.dm
@@ -1,3 +1,6 @@
+#define LOG_CLEANING(text) \
+  replace_characters(text, list("\proper"="","\improper"="", JA_CODE=JA_PLACEHOLDER, JA_CODE_ASCII=JA_PLACEHOLDER, JA_CHARACTER=JA_PLACEHOLDER))
+
 //print an error message to world.log
 
 
@@ -24,7 +27,7 @@
 /proc/log_admin(text)
 	admin_log.Add(text)
 	if (config.log_admin)
-		diary << "\[[time_stamp()]]ADMIN: [reset_ja(text)][log_end]"
+		diary << "\[[time_stamp()]]ADMIN: [LOG_CLEANING(text)][log_end]"
 
 
 /proc/log_debug(text)
@@ -42,7 +45,7 @@
 
 /proc/log_vote(text)
 	if (config.log_vote)
-		diary << "\[[time_stamp()]]VOTE: [reset_ja(text)][log_end]"
+		diary << "\[[time_stamp()]]VOTE: [LOG_CLEANING(text)][log_end]"
 
 /proc/log_access(text)
 	if (config.log_access)
@@ -50,19 +53,19 @@
 
 /proc/log_say(text)
 	if (config.log_say)
-		diary << "\[[time_stamp()]]SAY: [reset_ja(text)][log_end]"
+		diary << "\[[time_stamp()]]SAY: [LOG_CLEANING(text)][log_end]"
 
 /proc/log_ooc(text)
 	if (config.log_ooc)
-		diary << "\[[time_stamp()]]OOC: [reset_ja(text)][log_end]"
+		diary << "\[[time_stamp()]]OOC: [LOG_CLEANING(text)][log_end]"
 
 /proc/log_whisper(text)
 	if (config.log_whisper)
-		diary << "\[[time_stamp()]]WHISPER: [reset_ja(text)][log_end]"
+		diary << "\[[time_stamp()]]WHISPER: [LOG_CLEANING(text)][log_end]"
 
 /proc/log_emote(text)
 	if (config.log_emote)
-		diary << "\[[time_stamp()]]EMOTE: [reset_ja(text)][log_end]"
+		diary << "\[[time_stamp()]]EMOTE: [LOG_CLEANING(text)][log_end]"
 
 /proc/log_attack(text)
 	if (config.log_attack)
@@ -71,15 +74,15 @@
 /proc/log_adminsay(text, say_type)
 	admin_log.Add(text)
 	if (config.log_adminchat)
-		diary << "\[[time_stamp()]][say_type]: [reset_ja(text)][log_end]"
+		diary << "\[[time_stamp()]][say_type]: [LOG_CLEANING(text)][log_end]"
 
 /proc/log_adminwarn(text)
 	if (config.log_adminwarn)
-		diary << "\[[time_stamp()]]ADMINWARN: [reset_ja(text)][log_end]"
+		diary << "\[[time_stamp()]]ADMINWARN: [LOG_CLEANING(text)][log_end]"
 
 /proc/log_pda(text)
 	if (config.log_pda)
-		diary << "\[[time_stamp()]]PDA: [reset_ja(text)][log_end]"
+		diary << "\[[time_stamp()]]PDA: [LOG_CLEANING(text)][log_end]"
 
 /proc/log_misc(text)
 	diary << "\[[time_stamp()]]MISC: [text][log_end]"
@@ -98,7 +101,7 @@
 
 /proc/log_fax(text)
 	if (config.log_fax)
-		diary << "\[[time_stamp()]]FAX: [reset_ja(text)][log_end]"
+		diary << "\[[time_stamp()]]FAX: [LOG_CLEANING(text)][log_end]"
 
 /proc/datum_info_line(datum/D)
 	if(!istype(D))
@@ -149,3 +152,5 @@
 		text += "no antagonists this moment"
 
 	log_game(text)
+
+#undef LOG_CLEANING

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -244,6 +244,9 @@ var/datum/subsystem/ticker/ticker
 
 		SSvote.started_time = world.time
 
+		//Print a list of antagonists to the server log
+		antagonist_announce()
+
 		/*var/admins_number = 0 //For slack maybe?
 		for(var/client/C)
 			if(C.holder)
@@ -481,21 +484,7 @@ var/datum/subsystem/ticker/ticker
 			ai_completions += "[call(mode, handler)()]"
 
 	//Print a list of antagonists to the server log
-	var/list/total_antagonists = list()
-	//Look into all mobs in world, dead or alive
-	for(var/datum/mind/Mind in minds)
-		var/temprole = Mind.special_role
-		if(temprole)							//if they are an antagonist of some sort.
-			if(temprole in total_antagonists)	//If the role exists already, add the name to it
-				total_antagonists[temprole] += ", [Mind.name]([Mind.key])"
-			else
-				total_antagonists.Add(temprole) //If the role doesnt exist in the list, create it and add the mob
-				total_antagonists[temprole] += ": [Mind.name]([Mind.key])"
-
-	//Now print them all into the log!
-	log_game("Antagonists at round end were...")
-	for(var/i in total_antagonists)
-		log_game("[i]s[total_antagonists[i]].")
+	antagonist_announce()
 
 	if(SSjunkyard)
 		SSjunkyard.save_stats()

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -2,23 +2,6 @@
 	if(achievements.len)
 		completions += "<br>[achievement_declare_completion()]"
 
-	//Print a list of antagonists to the server log
-	var/list/total_antagonists = list()
-	//Look into all mobs in world, dead or alive
-	for(var/datum/mind/Mind in minds)
-		var/temprole = Mind.special_role
-		if(temprole)							//if they are an antagonist of some sort.
-			if(temprole in total_antagonists)	//If the role exists already, add the name to it
-				total_antagonists[temprole] += ", [Mind.name]([Mind.key])"
-			else
-				total_antagonists.Add(temprole) //If the role doesnt exist in the list, create it and add the mob
-				total_antagonists[temprole] += ": [Mind.name]([Mind.key])"
-
-	//Now print them all into the log!
-	log_game("Antagonists at round end were...")
-	for(var/i in total_antagonists)
-		log_game("[i]s[total_antagonists[i]].")
-
 	// Score Calculation and Display
 
 	// Who is alive/dead, who escaped

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -189,7 +189,7 @@
 		speech_sound = sound('sound/voice/shriek1.ogg')
 		sound_vol = 50
 
-	..(message, speaking, verb, alt_name, italics, message_range, used_radios, speech_sound, sound_vol, sanitize = 0)	//ohgod we should really be passing a datum here.
+	..(message, speaking, verb, alt_name, italics, message_range, used_radios, speech_sound, sound_vol, sanitize = FALSE, message_mode = message_mode)	//ohgod we should really be passing a datum here.
 
 /mob/living/carbon/human/say_understands(mob/other,datum/language/speaking = null)
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -106,7 +106,7 @@ var/list/department_radio_keys = list(
 		if(dongle.translate_binary)
 			return 1
 
-/mob/living/say(message, datum/language/speaking = null, verb="says", alt_name="", italics=0, message_range = world.view, list/used_radios = list(), sound/speech_sound, sound_vol, sanitize = 1)
+/mob/living/say(message, datum/language/speaking = null, verb="says", alt_name="", italics=FALSE, message_range = world.view, list/used_radios = list(), sound/speech_sound, sound_vol, sanitize = TRUE, message_mode = FALSE)
 	if (src.client)
 		if(client.prefs.muted & MUTE_IC)
 			to_chat(src, "You cannot send IC messages (muted).")
@@ -198,7 +198,8 @@ var/list/department_radio_keys = list(
 			if(O) //It's possible that it could be deleted in the meantime.
 				O.hear_talk(src, message, verb, speaking)
 
-	log_say("[name]/[key] : [message]")
+	var/area/A = get_area(src)
+	log_say("[name]/[key] : \[[A.name][message_mode?"/[message_mode]":""]\]: [message]")
 	return 1
 
 /mob/living/proc/say_signlang(var/message, var/verb="gestures", var/datum/language/language)

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -84,16 +84,18 @@
 		verb = speaking.speech_verb
 		message = trim(copytext(message,2+length(speaking.key)))
 
+	var/area/A = get_area(src)
+
 	switch(message_mode)
 		if("department")
 			switch(bot_type)
 				if(IS_AI)
 					return AI.holopad_talk(message, verb, speaking)
 				if(IS_ROBOT)
-					log_say("[key_name(src)] : [message]")
+					log_say("[name]/[key] : \[[A.name][message_mode?"/[message_mode]":""]\]: [message]")
 					R.radio.talk_into(src,message,message_mode,verb,speaking)
 				if(IS_PAI)
-					log_say("[key_name(src)] : [message]")
+					log_say("[name]/[key] : \[[A.name][message_mode?"/[message_mode]":""]\]]: [message]")
 					P.radio.talk_into(src,message,message_mode,verb,speaking)
 			return 1
 
@@ -120,13 +122,13 @@
 						to_chat(src, "\red System Error - Transceiver Disabled")
 						return
 					else
-						log_say("[key_name(src)] : [message]")
+						log_say("[name]/[key] : \[[A.name][message_mode?"/[message_mode]":""]\]]: [message]")
 						AI.aiRadio.talk_into(src,message,null,verb,speaking)
 				if(IS_ROBOT)
-					log_say("[key_name(src)] : [message]")
+					log_say("[name]/[key] : \[[A.name][message_mode?"/[message_mode]":""]\]]: [message]")
 					R.radio.talk_into(src,message,null,verb,speaking)
 				if(IS_PAI)
-					log_say("[key_name(src)] : [message]")
+					log_say("[name]/[key] : \[[A.name][message_mode?"/[message_mode]":""]\]]: [message]")
 					P.radio.talk_into(src,message,null,verb,speaking)
 			return 1
 
@@ -138,13 +140,13 @@
 							to_chat(src, "\red System Error - Transceiver Disabled")
 							return
 						else
-							log_say("[key_name(src)] : [message]")
+							log_say("[name]/[key] : \[[A.name][message_mode?"/[message_mode]":""]\]]: [message]")
 							AI.aiRadio.talk_into(src,message,message_mode,verb,speaking)
 					if(IS_ROBOT)
-						log_say("[key_name(src)] : [message]")
+						log_say("[name]/[key] : \[[A.name][message_mode?"/[message_mode]":""]\]]: [message]")
 						R.radio.talk_into(src,message,message_mode,verb,speaking)
 					if(IS_PAI)
-						log_say("[key_name(src)] : [message]")
+						log_say("[name]/[key] : \[[A.name][message_mode?"/[message_mode]":""]\]]: [message]")
 						P.radio.talk_into(src,message,message_mode,verb,speaking)
 				return 1
 
@@ -192,12 +194,13 @@
 
 /mob/living/proc/robot_talk(message)
 
-	log_say("[key_name(src)] : [message]")
-
 	message = trim(message)
 
 	if (!message)
 		return
+	
+	var/area/A = get_area(src)
+	log_say("[name]/[key] : \[[A.name]/binary\]: [message]")
 
 	var/verb = say_quote(message)
 


### PR DESCRIPTION
Я когда-нибудь перепишу логи, но не сегодня. Пока пара маленьких облегчающих жизнь изменений:
* Лист антагонистов выводится кроме окончания еще при старте раунда, включает задачи (отчасти дублирует инфу из статистики раунда)
* Say-логи включают в себя локацию человека и какое-то обозначение радио, если есть (с радио всё сложно, но хоть что-то)
``[06:32:07]SAY: Louis Mills/VolAs [Operation Observation Room/department]: test``
* Пофиксил потерянные байт-символы в логах ("служебный" 255 символ постоянно напоминает о себе)

админфигня, так что без чеинжлога