### PR TITLE
Experimental Welding Tool регенерирует топливо

### DIFF
--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -264,7 +264,8 @@
 				src.icon_state = initial(src.icon_state)
 				src.welding = 0
 			set_light(0)
-			STOP_PROCESSING(SSobj, src)
+			if (!istype(src, /obj/item/weapon/weldingtool/experimental)) 
+				STOP_PROCESSING(SSobj, src)
 			return
 		//Welders left on now use up fuel, but lets not have them run out quite that fast
 		if(1)
@@ -367,7 +368,8 @@
 			src.force = 15
 			src.damtype = "fire"
 			src.icon_state = initial(src.icon_state) + "1"
-			START_PROCESSING(SSobj, src)
+			if (!istype(src, /obj/item/weapon/weldingtool/experimental))
+				START_PROCESSING(SSobj, src)
 		else
 			to_chat(usr, "<span class='info'>Need more fuel!</span>")
 			src.welding = 0
@@ -399,7 +401,8 @@
 			src.force = 15
 			src.damtype = "fire"
 			src.icon_state = initial(src.icon_state) + "1"
-			START_PROCESSING(SSobj, src)
+			if (!istype(src, /obj/item/weapon/weldingtool/experimental))
+				START_PROCESSING(SSobj, src)
 		else
 			to_chat(usr, "<span class='info'>Need more fuel!</span>")
 			src.welding = 0
@@ -490,15 +493,18 @@
 	m_amt = 70
 	g_amt = 120
 	origin_tech = "materials=4;engineering=4;bluespace=2;phorontech=3"
-	var/last_gen = 0
+	var/nextrefueltick = 0
 
+/obj/item/weapon/weldingtool/experimental/atom_init()
+	.=..()
+	nextrefueltick = (world.time + 25)
+	START_PROCESSING(SSobj, src)
 
-
-/obj/item/weapon/weldingtool/experimental/proc/fuel_gen()//Proc to make the experimental welder generate fuel, optimized as fuck -Sieve
-	var/gen_amount = ((world.time-last_gen)/25)
-	reagents += (gen_amount)
-	if(reagents > max_fuel)
-		reagents = max_fuel
+/obj/item/weapon/weldingtool/experimental/process()
+	..()
+	if((get_fuel() < max_fuel) && (nextrefueltick < world.time) && (welding == 0))
+		nextrefueltick = world.time + 25
+		reagents.add_reagent("fuel", 1)
 
 /*
  * Crowbar

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -494,13 +494,12 @@
 	var/next_refuel_tick = 0
 
 /obj/item/weapon/weldingtool/experimental/atom_init()
-	.=..()
-	next_refuel_tick = (world.time + 25)
+	. = ..()
 
 /obj/item/weapon/weldingtool/experimental/process()
 	..()
 	if((get_fuel() < max_fuel) && (next_refuel_tick < world.time) && !welding)
-		next_refuel_tick = world.time + 25
+		next_refuel_tick = world.time + 2.5 SECONDS
 		reagents.add_reagent("fuel", 1)
 	if(!welding && (get_fuel() == max_fuel))
 		STOP_PROCESSING(SSobj, src)

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -264,11 +264,8 @@
 				src.icon_state = initial(src.icon_state)
 				src.welding = 0
 			set_light(0)
-			if (!istype(src, /obj/item/weapon/weldingtool/experimental)) 
+			if (!istype(src, /obj/item/weapon/weldingtool/experimental)||(get_fuel() == max_fuel)) 
 				STOP_PROCESSING(SSobj, src)
-			else 
-				if(get_fuel() == max_fuel)
-					STOP_PROCESSING(SSobj, src)
 			return
 		//Welders left on now use up fuel, but lets not have them run out quite that fast
 		if(1)
@@ -494,16 +491,16 @@
 	m_amt = 70
 	g_amt = 120
 	origin_tech = "materials=4;engineering=4;bluespace=2;phorontech=3"
-	var/nextrefueltick = 0
+	var/next_refuel_tick = 0
 
 /obj/item/weapon/weldingtool/experimental/atom_init()
 	.=..()
-	nextrefueltick = (world.time + 25)
+	next_refuel_tick = (world.time + 25)
 
 /obj/item/weapon/weldingtool/experimental/process()
 	..()
-	if((get_fuel() < max_fuel) && (nextrefueltick < world.time) && (welding == 0))
-		nextrefueltick = world.time + 25
+	if((get_fuel() < max_fuel) && (next_refuel_tick < world.time) && !welding)
+		next_refuel_tick = world.time + 25
 		reagents.add_reagent("fuel", 1)
 
 /*

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -264,7 +264,7 @@
 				src.icon_state = initial(src.icon_state)
 				src.welding = 0
 			set_light(0)
-			if (!istype(src, /obj/item/weapon/weldingtool/experimental)||(get_fuel() == max_fuel)) 
+			if (!istype(src, /obj/item/weapon/weldingtool/experimental))
 				STOP_PROCESSING(SSobj, src)
 			return
 		//Welders left on now use up fuel, but lets not have them run out quite that fast
@@ -502,7 +502,8 @@
 	if((get_fuel() < max_fuel) && (next_refuel_tick < world.time) && !welding)
 		next_refuel_tick = world.time + 25
 		reagents.add_reagent("fuel", 1)
-
+	if(!welding && (get_fuel() == max_fuel))
+		STOP_PROCESSING(SSobj, src)
 /*
  * Crowbar
  */

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -493,9 +493,6 @@
 	origin_tech = "materials=4;engineering=4;bluespace=2;phorontech=3"
 	var/next_refuel_tick = 0
 
-/obj/item/weapon/weldingtool/experimental/atom_init()
-	. = ..()
-
 /obj/item/weapon/weldingtool/experimental/process()
 	..()
 	if((get_fuel() < max_fuel) && (next_refuel_tick < world.time) && !welding)

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -266,6 +266,9 @@
 			set_light(0)
 			if (!istype(src, /obj/item/weapon/weldingtool/experimental)) 
 				STOP_PROCESSING(SSobj, src)
+			else 
+				if(get_fuel() == max_fuel)
+					STOP_PROCESSING(SSobj, src)
 			return
 		//Welders left on now use up fuel, but lets not have them run out quite that fast
 		if(1)
@@ -368,8 +371,7 @@
 			src.force = 15
 			src.damtype = "fire"
 			src.icon_state = initial(src.icon_state) + "1"
-			if (!istype(src, /obj/item/weapon/weldingtool/experimental))
-				START_PROCESSING(SSobj, src)
+			START_PROCESSING(SSobj, src)
 		else
 			to_chat(usr, "<span class='info'>Need more fuel!</span>")
 			src.welding = 0
@@ -401,8 +403,7 @@
 			src.force = 15
 			src.damtype = "fire"
 			src.icon_state = initial(src.icon_state) + "1"
-			if (!istype(src, /obj/item/weapon/weldingtool/experimental))
-				START_PROCESSING(SSobj, src)
+			START_PROCESSING(SSobj, src)
 		else
 			to_chat(usr, "<span class='info'>Need more fuel!</span>")
 			src.welding = 0
@@ -498,7 +499,6 @@
 /obj/item/weapon/weldingtool/experimental/atom_init()
 	.=..()
 	nextrefueltick = (world.time + 25)
-	START_PROCESSING(SSobj, src)
 
 /obj/item/weapon/weldingtool/experimental/process()
 	..()


### PR DESCRIPTION
Перенес функцию регенерации топлива экспериментальной горелки из tgstation. Немного уменьшил скорость генерации топлива по сравнению с tgstation. Топливо генерируется только тогда, когда горелка отключена. Частично закрывает этот issue - Fixes #1599 . Судя по всему, то что экспериментальную горелку нельзя поместить в пояс с инструментами - сделано специально для внутриигрового баланса, поэтому я не стал это менять.
:cl: Klpghf
 - bugfix: Экспериментальная горелка теперь регенерирует топливо.
