### PR TITLE
[DNM] Преференсы для глав на реву v2.0

### DIFF
--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -46,6 +46,6 @@ var/global/list/special_roles = list(
 	ROLE_MEME = IS_MODE_COMPILED("meme"),                //13
 	ROLE_MUTINEER = IS_MODE_COMPILED("mutiny"),          //14
 	ROLE_SHADOWLING = IS_MODE_COMPILED("shadowling"),    //15
-	ROLE_ABDUCTOR = IS_MODE_COMPILED("abduction")        //16
-	ROLE_REV_HOS = IS_MODE_COMPILED("revolution"),       //17
+	ROLE_ABDUCTOR = IS_MODE_COMPILED("abduction"),       //16
+	ROLE_REV_HOS = IS_MODE_COMPILED("revolution")        //17
 )

--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -9,6 +9,7 @@
 #define ROLE_WIZARD            "Wizard"
 #define ROLE_MALF              "Malf AI"
 #define ROLE_REV               "Revolutionary"
+#define ROLE_REV_HOS           "Head of Staff in Rev."
 #define ROLE_ALIEN             "Xenomorph"
 #define ROLE_PAI               "pAI"
 #define ROLE_CULTIST           "Cultist"
@@ -46,4 +47,5 @@ var/global/list/special_roles = list(
 	ROLE_MUTINEER = IS_MODE_COMPILED("mutiny"),          //14
 	ROLE_SHADOWLING = IS_MODE_COMPILED("shadowling"),    //15
 	ROLE_ABDUCTOR = IS_MODE_COMPILED("abduction")        //16
+	ROLE_REV_HOS = IS_MODE_COMPILED("revolution"),       //17
 )

--- a/code/game/gamemodes/revolution/rp_revolution.dm
+++ b/code/game/gamemodes/revolution/rp_revolution.dm
@@ -33,7 +33,7 @@
 
 	var/head_check = 0
 	for(var/mob/dead/new_player/player in player_list)
-		if(player.mind.assigned_role in command_positions)
+		if((player.mind.assigned_role in command_positions) && (ROLE_REV_HOS in player.client.prefs.be_role)) //check is there any heads of staff that want to play rev
 			head_check = 1
 			break
 


### PR DESCRIPTION
При поддержке вайнов в дедчате и убитого джеф сквадом невиновного персонала, встречайте, преференсы для глав на реву v2.0.

### Как это работает
В панели настройки персонажа у вас появится специальный пункт. В основном он ничего не меняет и если вы не играете на главах, то он ничего и не сделает. Однако, если вы глава, то этот преференс поможет вам избежать раунда ревы когда вы этого не хотите. Если система определила раунд как рп-революцию и у хоть одного главы данный преференс будет отключен, то рева не начнётся.

### Зачем это сдеано
Большинству игроков рева либо не по нраву как режим, либо не подходит их персонажам. После мержа этой фичи игрокам больше не надо будет гостаться за глав при режиме рп-ревы -- этого режима просто не будет.

Свои мнения и замечания оставляйте в комментариях под этим ПРом.

:cl: Getup1
 - tweak[link]: Преференсы главам на реву.