### PR TITLE
Исправление для недвижимого стержня (Immovable Rod)

### DIFF
--- a/code/game/gamemodes/events/clang.dm
+++ b/code/game/gamemodes/events/clang.dm
@@ -16,9 +16,10 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	density = 1
 	anchored = 1
 
-/obj/effect/immovablerod/atom_init(mapload, turf/start, turf/end)
+/obj/effect/immovablerod/atom_init(mapload, turf/end)
 	. = ..()
-	INVOKE_ASYNC(src, .proc/check_location, start, end)
+	INVOKE_ASYNC(src, .proc/check_location, mapload, end)
+
 
 /obj/effect/immovablerod/proc/check_location(turf/start, turf/end)
 	var/z_original = z
@@ -34,17 +35,29 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	if(istype(clong, /turf/simulated/shuttle) || clong == src) //Skip shuttles without actually deleting the rod
 		return
 	playsound(src, 'sound/effects/bang.ogg', 50, 1)
-	visible_message("<span class='danger'>CLANG</span>")
 	if((istype(clong, /turf/simulated) || isobj(clong)) && clong.density)
 		clong.ex_act(2)
+		for (var/mob/O in hearers(src, null))
+			O.show_message("CLANG", 2)
 	else if(isliving(clong))
 		var/mob/living/M = clong
 		M.adjustBruteLoss(rand(10,40))
 		if(prob(60))
 			step(src, get_dir(src, M))
-
+	else if (istype(clong, /obj))
+		if(clong.density)
+			clong.ex_act(2)
+			for (var/mob/O in hearers(src, null))
+				O.show_message("CLANG", 2)
+	else
+		qdel(src)
+	
 /obj/effect/immovablerod/ex_act(severity, target)
 	return 0
+
+/obj/effect/immovablerod/Destroy()
+	walk(src, 0) // Because we might have called walk_towards, we must stop the walk loop or BYOND keeps an internal reference to us forever.
+	return ..()
 
 /proc/immovablerod()
 	var/turf/start
@@ -52,17 +65,17 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	var/startside = pick(cardinal)
 	switch(startside)
 		if(NORTH)
-			start = locate(rand(41, 199), 187, 1)
+			start = locate(rand(41, 199), 205, 1)
 			end = locate(rand(41, 199), 38, 1)
 		if(EAST)
-			start = locate(199, rand(38, 187), 1)
-			end = locate(41, rand(38, 187), 1)
+			start = locate(199, rand(38, 205), 1)
+			end = locate(41, rand(38, 205), 1)
 		if(SOUTH)
 			start = locate(rand(41, 199), 38, 1)
-			end = locate(rand(41, 199), 187, 1)
+			end = locate(rand(41, 199), 205, 1)
 		if(WEST)
-			start = locate(41, rand(38, 187), 1)
-			end = locate(199, rand(38, 187), 1)
+			start = locate(41, rand(38, 205), 1)
+			end = locate(199, rand(38, 205), 1)
 	//rod time!
 	var/obj/effect/immovablerod/Imm = new(start, end)
 	message_admins("Immovable Rod has spawned at [Imm.x],[Imm.y],[Imm.z] [ADMIN_JMP(Imm)] [ADMIN_FLW(Imm)].")


### PR DESCRIPTION
Исправление сломанного во время предыдущей оптимизации Immovable Rod. Также немного увеличена граница полета стержня по y-оси (из-за роста станции самые северные помещения отдела службы безопасности стали безопасной зоной). Немного скопировано кода с baystation 12 - теперь сообщение "Clang" появляется, когда удар стержня слышно (раньше его нужно было видеть).

Основное изменение заключается в том, что теперь параметры функции check_location внутри init_atom передаются правильно.

:cl: Klpghf
 - bugfix: Теперь immovable rod вновь ломает станцию.
