### PR TITLE
Сделать Fossil Satchel более полезным

### DIFF
--- a/code/modules/research/xenoarchaeology/tools/tools.dm
+++ b/code/modules/research/xenoarchaeology/tools/tools.dm
@@ -33,4 +33,6 @@
 	storage_slots = 50
 	max_combined_w_class = 200 //Doesn't matter what this is, so long as it's more or equal to storage_slots * ore.w_class
 	max_w_class = 3
-	can_hold = list("/obj/item/weapon/fossil")
+	can_hold = list(
+ 		"/obj/item/weapon/fossil",
+ 		"/obj/item/weapon/ore/strangerock")


### PR DESCRIPTION
Fossil Satchel - Сумка Для Ископаемых ксеноархеолога, но в нее можно класть лишь Окаменелости животных и растений, что зачастую не является целью раскопок. С другой стороны, часто Ксеноархеологам просто-напросто не хватает места в инвентаре на их находки. Я предлагаю сделать так, чтобы Сумка вмещала в себя также Странные Камни(Продукт раскопок).
Для чего нужно - Чтобы сделать процесс раскопок удобнее, а также изменить тот факт, что Fossil Satchel практически бесполезен.

Проверено на локалке, работает.

:cl: Richard Jones
- rscadd: Fossil Satchel теперь может содержать в себе "Strange rock".