### PR TITLE
Фикс хлыста, неприменяющего эффекты.

### DIFF
--- a/code/game/gamemodes/changeling/powers/Whip.dm
+++ b/code/game/gamemodes/changeling/powers/Whip.dm
@@ -81,7 +81,7 @@
 			grab_chance = 90
 		if(!T.anchored && prob(grab_chance))
 			T.throw_at(host, get_dist(host, T) - 1, 1, spin = FALSE, callback = CALLBACK(src, .proc/end_whipping, T))
-	 return ..()
+	return ..()
 
 /obj/item/projectile/changeling_whip/proc/end_whipping(atom/movable/T)
 	if(in_range(T, host) && !host.get_inactive_hand() && !host.lying)


### PR DESCRIPTION
:cl: Luduk
- bugfix: Хлыст генокрада работает как и задумано в режимах Хелпа, и Дизарма.