### PR TITLE
Добавление флешки в начальное снаряжение АВД.

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -357,6 +357,7 @@
 	if(visualsOnly)
 		return
 
+	H.equip_to_slot_or_del(new /obj/item/device/flash(H), slot_r_store)
 	H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_sec(H), slot_l_ear)
 	H.equip_to_slot_or_del(new /obj/item/device/pda/lawyer(H), slot_belt)
 


### PR DESCRIPTION
На форуме велась дискуссия по поводу этого, вроде бы все согласны были. АВД не должен угрожать кому-либо, сохраняя нейтралитет, но такому члену экипажа(С имплантом лояльности!) сто процентов нужна хоть какая-то защита.
Проверено на локалке, работает. Флеш появляется в правом кармане.

:cl: Richard Jones
 - tweak: В начальное снаряжение АВД добавлен флеш.