### PR TITLE
Мед. пояс теперь вмещает масс-спектрометр и сканнер реагентов

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -70,7 +70,9 @@
 		"/obj/item/clothing/mask/surgical",
 		"/obj/item/clothing/gloves/latex",
 	    "/obj/item/weapon/reagent_containers/hypospray",
-	    "/obj/item/device/sensor_device"
+	    "/obj/item/device/sensor_device",
+	    "/obj/item/device/mass_spectrometer",
+	    "/obj/item/device/reagent_scanner"
 	    )
 /obj/item/weapon/storage/belt/medical/surg
 	name = "Surgery belt"


### PR DESCRIPTION
fixes#2542


:cl: Dred1792
 - bugfix: Масс-спектрометр и сканер реагентов не вмещались в мед. пояс.
