### PR TITLE
Add shuttle ETA to PDA

### DIFF
--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -13,9 +13,12 @@ proc/time_stamp()
 
 /proc/shuttleeta2text()
 	var/timeleft = SSshuttle.timeleft()
-	if (timeleft < 0)
+	if(timeleft < 0)
 		timeleft = 0
 	return "[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]"
+
+/proc/shuttleminutes2text()
+	return "[round(SSshuttle.timeleft()/60)]"
 
 var/next_duration_update = 0
 var/last_round_duration = 0

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -11,6 +11,12 @@ proc/worldtime2text(time = world.time)
 proc/time_stamp()
 	return time2text(world.timeofday, "hh:mm:ss")
 
+/proc/shuttleeta2text()
+	var/timeleft = SSshuttle.timeleft()
+	if (timeleft < 0)
+		timeleft = 0
+	return "[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]"
+
 var/next_duration_update = 0
 var/last_round_duration = 0
 

--- a/code/controllers/subsystem/voting.dm
+++ b/code/controllers/subsystem/voting.dm
@@ -143,7 +143,7 @@ var/datum/subsystem/vote/SSvote
 		if(!SSshuttle.online && SSshuttle.location == 0)
 			SSshuttle.shuttlealert(1)
 			SSshuttle.incall()
-			captain_announce("A crew transfer has been initiated. The shuttle has been called. It will arrive in [round(SSshuttle.timeleft()/60)] minutes.")
+			captain_announce("A crew transfer has been initiated. The shuttle has been called. It will arrive in [shuttleminutes2text()] minutes.")
 			message_admins("A crew transfer vote has passed, calling the shuttle.")
 			log_admin("A crew transfer vote has passed, calling the shuttle.")
 

--- a/code/game/gamemodes/abduction/abduction.dm
+++ b/code/game/gamemodes/abduction/abduction.dm
@@ -257,7 +257,7 @@
 			var/datum/objective/objective = team_objectives[team_number]
 			if (con.experiment.points >= objective.target_amount)
 				SSshuttle.incall(0.5)
-				captain_announce("The emergency shuttle has been called. It will arrive in [round(SSshuttle.timeleft()/60)] minutes.")
+				captain_announce("The emergency shuttle has been called. It will arrive in [shuttleminutes2text()] minutes.")
 				world << sound('sound/AI/shuttlecalled.ogg')
 				finished = 1
 				return ..()

--- a/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
@@ -161,7 +161,7 @@ var/list/possibleShadowlingNames = list("U'ruan", "Y`shej", "Nex", "Hel-uae", "N
 			sleep(50)
 			if(!ticker.mode.shadowling_ascended)
 				SSshuttle.incall(0.3)
-				captain_announce("The emergency shuttle has been called. It will arrive in [round(SSshuttle.timeleft()/60)] minutes.")
+				captain_announce("The emergency shuttle has been called. It will arrive in [shuttleminutes2text()] minutes.")
 				world << sound('sound/AI/shuttlecalled.ogg')
 			ticker.mode.shadowling_ascended = 1
 			qdel(usr)

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -273,9 +273,8 @@
 		return
 
 	var/dat = "<head><title>Communications Console</title></head><body>"
-	if (SSshuttle.online && SSshuttle.location==0)
-		var/timeleft = SSshuttle.timeleft()
-		dat += "<B>Emergency shuttle</B>\n<BR>\nETA: [timeleft / 60 % 60]:[add_zero(num2text(timeleft % 60), 2)]<BR>"
+	if (SSshuttle.online && SSshuttle.location == 0)
+		dat += "<B>Emergency shuttle</B>\n<BR>\nETA: [shuttleeta2text()]<BR>"
 
 	if (issilicon(user))
 		var/dat2 = src.interact_ai(user) // give the AI a different interact proc to limit its access
@@ -435,7 +434,7 @@
 	SSshuttle.incall()
 	log_game("[key_name(user)] has called the shuttle.")
 	message_admins("[key_name_admin(user)] has called the shuttle. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
-	captain_announce("The emergency shuttle has been called. It will arrive in [round(SSshuttle.timeleft()/60)] minutes.")
+	captain_announce("The emergency shuttle has been called. It will arrive in [shuttleminutes2text()] minutes.")
 	world << sound('sound/AI/shuttlecalled.ogg')
 
 	make_maint_all_access(FALSE)
@@ -476,7 +475,7 @@
 	SSshuttle.incall()
 	log_game("[key_name(user)] has called the shuttle.")
 	message_admins("[key_name_admin(user)] has called the shuttle. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
-	captain_announce("A crew transfer has been initiated. The shuttle has been called. It will arrive in [round(SSshuttle.timeleft()/60)] minutes.")
+	captain_announce("A crew transfer has been initiated. The shuttle has been called. It will arrive in [shuttleminutes2text()] minutes.")
 
 	return
 
@@ -542,7 +541,7 @@
 	SSshuttle.incall(2)
 	log_game("All the AIs, comm consoles and boards are destroyed. Shuttle called.")
 	message_admins("All the AIs, comm consoles and boards are destroyed. Shuttle called.")
-	captain_announce("The emergency shuttle has been called. It will arrive in [round(SSshuttle.timeleft()/60)] minutes.")
+	captain_announce("The emergency shuttle has been called. It will arrive in [shuttleminutes2text()] minutes.")
 	world << sound('sound/AI/shuttlecalled.ogg')
 
 	return ..()
@@ -567,7 +566,7 @@
 	SSshuttle.incall(2)
 	log_game("All the AIs, comm consoles and boards are destroyed. Shuttle called.")
 	message_admins("All the AIs, comm consoles and boards are destroyed. Shuttle called.")
-	captain_announce("The emergency shuttle has been called. It will arrive in [round(SSshuttle.timeleft()/60)] minutes.")
+	captain_announce("The emergency shuttle has been called. It will arrive in [shuttleminutes2text()] minutes.")
 	world << sound('sound/AI/shuttlecalled.ogg')
 
 	return ..()

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -58,7 +58,11 @@ var/global/list/obj/item/device/pda/PDAs = list()
 /obj/item/device/pda/examine(mob/user)
 	..()
 	if(src in user)
-		to_chat(user, "The time [worldtime2text()] is displayed in the corner of the screen.")
+		if (SSshuttle.online)
+			to_chat(user, "The time [worldtime2text()] and shuttle ETA [shuttleeta2text()] are displayed in the corner of the screen.")
+		else
+			to_chat(user, "The time [worldtime2text()] is displayed in the corner of the screen.")
+
 
 /obj/item/device/pda/medical
 	default_cartridge = /obj/item/weapon/cartridge/medical
@@ -431,8 +435,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	data["stationTime"] = worldtime2text()
 	data["new_Message"] = newmessage
 	if (SSshuttle.online)
-		var/timeleft = SSshuttle.timeleft()
-		data["shuttle_eta"] = "[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]"
+		data["shuttle_eta"] = shuttleeta2text()
 
 	if(mode==2)
 		var/convopdas[0]

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -430,6 +430,9 @@ var/global/list/obj/item/device/pda/PDAs = list()
 
 	data["stationTime"] = worldtime2text()
 	data["new_Message"] = newmessage
+	if (SSshuttle.online)
+		var/timeleft = SSshuttle.timeleft()
+		data["shuttle_eta"] = "[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]"
 
 	if(mode==2)
 		var/convopdas[0]

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -391,13 +391,12 @@
 		if (!SSshuttle.online)
 			dat += "<a href='?src=\ref[src];call_shuttle=1'>Call Shuttle</a><br>"
 		else
-			var/timeleft = SSshuttle.timeleft()
 			switch(SSshuttle.location)
 				if(0)
-					dat += "ETA: <a href='?src=\ref[src];edit_shuttle_time=1'>[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]</a><BR>"
+					dat += "ETA: <a href='?src=\ref[src];edit_shuttle_time=1'>[shuttleeta2text()]</a><BR>"
 					dat += "<a href='?src=\ref[src];call_shuttle=2'>Send Back</a><br>"
 				if(1)
-					dat += "ETA: <a href='?src=\ref[src];edit_shuttle_time=1'>[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]</a><BR>"
+					dat += "ETA: <a href='?src=\ref[src];edit_shuttle_time=1'>[shuttleeta2text()]</a><BR>"
 		dat += "<a href='?src=\ref[src];delay_round_end=1'>[ticker.delay_end ? "End Round Normally" : "Delay Round End"]</a><br>"
 		if(ticker.mode.syndicates.len)
 			dat += "<br><table cellspacing=5><tr><td><B>Syndicates</B></td><td></td></tr>"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -207,7 +207,7 @@
 				if ((!( ticker ) || SSshuttle.location))
 					return
 				SSshuttle.incall()
-				captain_announce("The emergency shuttle has been called. It will arrive in [round(SSshuttle.timeleft()/60)] minutes.")
+				captain_announce("The emergency shuttle has been called. It will arrive in [shuttleminutes2text()] minutes.")
 				world << sound('sound/AI/shuttlecalled.ogg')
 				log_admin("[key_name(usr)] called the Emergency Shuttle")
 				message_admins("\blue [key_name_admin(usr)] called the Emergency Shuttle to the station")
@@ -219,7 +219,7 @@
 				switch(SSshuttle.direction)
 					if(-1)
 						SSshuttle.incall()
-						captain_announce("The emergency shuttle has been called. It will arrive in [round(SSshuttle.timeleft()/60)] minutes.")
+						captain_announce("The emergency shuttle has been called. It will arrive in [shuttleminutes2text()] minutes.")
 						log_admin("[key_name(usr)] called the Emergency Shuttle")
 						message_admins("\blue [key_name_admin(usr)] called the Emergency Shuttle to the station")
 						make_maint_all_access(FALSE)
@@ -239,7 +239,7 @@
 
 		SSshuttle.settimeleft( input("Enter new shuttle duration (seconds):","Edit Shuttle Timeleft", SSshuttle.timeleft() ) as num )
 		log_admin("[key_name(usr)] edited the Emergency Shuttle's timeleft to [SSshuttle.timeleft()]")
-		captain_announce("The emergency shuttle has been called. It will arrive in [round(SSshuttle.timeleft()/60)] minutes.")
+		captain_announce("The emergency shuttle has been called. It will arrive in [shuttleminutes2text()] minutes.")
 		message_admins("\blue [key_name_admin(usr)] edited the Emergency Shuttle's timeleft to [SSshuttle.timeleft()]")
 		href_list["secretsadmin"] = "check_antagonist"
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -938,11 +938,11 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(type == "Crew transfer")
 		SSshuttle.shuttlealert(1)
 		SSshuttle.incall()
-		captain_announce("A crew transfer has been initiated. The shuttle has been called. It will arrive in [round(SSshuttle.timeleft()/60)] minutes.")
+		captain_announce("A crew transfer has been initiated. The shuttle has been called. It will arrive in [shuttleminutes2text()] minutes.")
 	else
 		var/eaccess = alert(src, "Grant acces to maints for everyone?", "Confirm", "Yes", "No")
 		SSshuttle.incall()
-		captain_announce("The emergency shuttle has been called. It will arrive in [round(SSshuttle.timeleft()/60)] minutes.")
+		captain_announce("The emergency shuttle has been called. It will arrive in [shuttleminutes2text()] minutes.")
 		world << sound('sound/AI/shuttlecalled.ogg')
 
 		if(eaccess == "Yes")

--- a/code/modules/mob/living/silicon/ai/death.dm
+++ b/code/modules/mob/living/silicon/ai/death.dm
@@ -47,7 +47,7 @@
 		SSshuttle.incall(2)
 		log_game("All the AIs, comm consoles and boards are destroyed. Shuttle called.")
 		message_admins("All the AIs, comm consoles and boards are destroyed. Shuttle called.")
-		captain_announce("The emergency shuttle has been called. It will arrive in [round(SSshuttle.timeleft()/60)] minutes.")
+		captain_announce("The emergency shuttle has been called. It will arrive in [shuttleminutes2text()] minutes.")
 		world << sound('sound/AI/shuttlecalled.ogg')
 
 	if(explosive)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -105,9 +105,7 @@
 		stat(null, "Station Time: [worldtime2text()]")
 
 		if(SSshuttle.online && SSshuttle.location < 2)
-			var/timeleft = SSshuttle.timeleft()
-			if (timeleft)
-				stat(null, "ETA-[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]")
+			stat(null, "ETA-[shuttleeta2text()]")
 
 		if(stat == CONSCIOUS)
 			stat(null, text("System integrity: [round((health / maxHealth) * 100)]%"))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -651,9 +651,7 @@ note dizziness decrements automatically in the mob's Life() proc.
 					if(GM.malf_mode_declared)
 						stat(null, "Time left: [max(GM.AI_win_timeleft / (GM.apcs / APC_MIN_TO_MALF_DECLARE), 0)]")
 				if(SSshuttle.online && SSshuttle.location < 2)
-					var/timeleft = SSshuttle.timeleft()
-					if(timeleft)
-						stat(null, "ETA-[(timeleft / 60) % 60]:[add_zero(num2text(timeleft % 60), 2)]")
+					stat(null, "ETA-[shuttleeta2text()]")
 
 	if(client && client.holder)
 		if((client.holder.rights & R_ADMIN))

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -24,7 +24,17 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
 			<span class="average">{{:data.stationTime}}</span>
 		</div>
 	</div>
-	<br>
+    {{if data.shuttle_eta}}
+        <div class="item">
+            <div class="itemLabelNarrow">
+                <b>Shuttle ETA</b>:
+            </div>
+            <div class="itemContent">
+                <span class="average">{{:data.shuttle_eta}}</span>
+            </div>
+        </div>
+    {{/if}}
+    <br>
 
 
 	{{if data.mode == 0}} <!-- Main Menu -->


### PR DESCRIPTION
<!--
Подробно про оформление ПРов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
Там же написано про то, как сделать чейнджлог. 

!!!
Если авторство не полностью ваше, вы делаете порт с другого билда - укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
!!!

Для копипаста:
Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment.

Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
closes #2822
![](https://i.imgur.com/36KvtJe.png)
:cl:
 - tweak: В PDA теперь отображается время до прибытия шаттла.