### PR TITLE
Фикс выделяющегося цвета АВД в setup character

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -338,7 +338,7 @@
 	total_positions = 2
 	spawn_positions = 2
 	supervisors = "The Central Command"
-	selection_color = "#2b2b2b"
+	selection_color = "#dddddd"
 	idtype = /obj/item/weapon/card/id/int
 	access = list(access_lawyer, access_court, access_sec_doors, access_medical, access_research, access_mailsorting, access_engine, access_engine_equip)
 	minimal_player_ingame_minutes = 1560


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/39438947/50057246-b2dc5c00-0178-11e9-8b23-932e89e4a4fb.png)

Ченжлог же не нужен?