### PR TITLE
Gateway refactoring

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -86,15 +86,9 @@
 	if(target)
 		user.loc = get_turf(target)
 
-/obj/machinery/gateway/centerstation/attack_ghost(mob/user)
-	if(awaygate)
-		user.loc = awaygate.loc
-	else
-		to_chat(user, "[src] has no destination.")
-
-/obj/machinery/gateway/centeraway/attack_ghost(mob/user)
-	if(stationgate)
-		user.loc = stationgate.loc
+/obj/machinery/gateway/center/attack_ghost(mob/user)
+	if(destination)
+		user.loc = destination.loc
 	else
 		to_chat(user, "[src] has no destination.")
 

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -139,7 +139,7 @@
 	var/simultaneous_pm_warning_timeout = 100
 
 	var/assistant_maint = 0 //Do assistants get maint access?
-	var/gateway_delay = 18000 //How long the gateway takes before it activates. Default is half an hour.
+	var/gateway_enabled = 0
 	var/ghost_interaction = 0
 
 	var/comms_password = ""
@@ -492,8 +492,8 @@
 				if("assistant_maint")
 					config.assistant_maint = 1
 
-				if("gateway_delay")
-					config.gateway_delay = text2num(value)
+				if("gateway_enabled")
+					config.gateway_enabled = 1
 
 				if("continuous_rounds")
 					config.continous_rounds = 1

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -32,6 +32,9 @@
 		if("airtunnel_bottom")
 			airtunnel_bottom = y
 
+		if ("awaystart")
+			awaydestinations += src
+
 		if("monkey")
 			monkeystart += loc
 			return INITIALIZE_HINT_QDEL

--- a/code/game/objects/items/devices/gateway_locker.dm
+++ b/code/game/objects/items/devices/gateway_locker.dm
@@ -6,7 +6,7 @@
 	icon_state = "recaller"
 	item_state = "walkietalkie"
 	w_class = 2
-	var/obj/machinery/gateway/centerstation/stationgate
+	var/obj/machinery/gateway/center/stationgate
 	var/used = FALSE
 	var/opened = FALSE
 
@@ -15,7 +15,7 @@
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/item/device/gateway_locker/atom_init_late()
-	stationgate = locate(/obj/machinery/gateway/centerstation)
+	stationgate = locate(/obj/machinery/gateway/center/station/)
 
 /obj/item/device/gateway_locker/attack_self(mob/user)
 	if(!stationgate)
@@ -53,19 +53,17 @@
 		G.hacked = TRUE
 		G.update_icon()
 
-
 /obj/item/device/gateway_locker/proc/perform_gate(turf/turf, obj/item/device/radio/intercom/radio)
 	new /obj/effect/effect/sparks(turf)
-	var/obj/machinery/gateway/centeraway/Gate = new(turf)
+	var/obj/machinery/gateway/center/Gate = new(turf)
 	Gate.detect()
 	for(var/obj/machinery/gateway/G in Gate.linked)
 		G.hacked = TRUE
 		G.update_icon()
 	Gate.hacked = TRUE
 	Gate.update_icon()
-	Gate.stationgate = stationgate
-	stationgate.awaygate = Gate
-	Gate.stationgate.wait = 0
+	Gate.destination = stationgate
+	stationgate.destination = Gate
 	opened = TRUE
 	radio.autosay("Access was granted, It's Nice day to die, Crew.", "Gateway Message System", "Common")
 	qdel(radio)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -116,7 +116,7 @@ var/list/admin_verbs_fun = list(
 	/client/proc/achievement,
 	/client/proc/toggle_AI_interact, /*toggle admin ability to interact with machines as an AI*/
 	/client/proc/centcom_barriers_toggle,
-	/client/proc/gateway_fix
+	/client/proc/gateway_toggle
 	)
 var/list/admin_verbs_spawn = list(
 	/datum/admins/proc/spawn_atom,		/*allows us to spawn instances*/
@@ -1058,18 +1058,17 @@ var/list/admin_verbs_hideable = list(
 // Gateway
 //////////////////////////////
 
-/client/proc/gateway_fix()
+/client/proc/gateway_toggle()
 	set category = "Event"
-	set name = "Connect Gateways"
+	set name = "Toggle Station Gateway"
 
 	if(!check_rights(R_FUN))
 		return
 
-	for(var/obj/machinery/gateway/G in machines)
-		G.atom_init()
+	config.gateway_enabled = !config.gateway_enabled
 
-	log_admin("[key_name(src)] connected gates")
-	message_admins("\blue [key_name_admin(src)] connected gates")
+	log_admin("[key_name(src)] toggle [config.gateway_enabled ? "on" : "off"] station gateway")
+	message_admins("[key_name(src)] toggle [config.gateway_enabled ? "on" : "off"] station gateway")
 
 //////////////////////////////
 // Velocity\Centcomm barriers

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -388,6 +388,12 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 	set category = "Debug"
 	set name = "Load Junkyard"
 	SSjunkyard.populate_junkyard()
+
+	//todo: safe gate ref in map datum
+	for(var/obj/machinery/gateway/center/G in gateways_list)
+		if (G.name == "Junkyard Gateway")
+			G.toggleon()
+
 	log_admin("[key_name(src)] pupulated junkyard. SSjunkyard.populate_junkyard() called.")
 	message_admins("[key_name_admin(src)] pupulated junkyard. SSjunkyard.populate_junkyard() called.")
 	feedback_add_details("admin_verb","PPJYD") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/awaymissions/zlevel.dm
+++ b/code/modules/awaymissions/zlevel.dm
@@ -1,5 +1,5 @@
 proc/createRandomZlevel()
-	if(awaydestinations.len)	//crude, but it saves another var!
+	if(awaydestinations.len)	//crude, but it saves another var! //todo: need new var for this
 		return
 
 	var/list/potentialRandomZlevels = list()
@@ -41,11 +41,6 @@ proc/createRandomZlevel()
 		var/file = file(map)
 		if(isfile(file))
 			maploader.load_map(file)
-
-		for(var/obj/effect/landmark/L in landmarks_list)
-			if (L.name != "awaystart")
-				continue
-			awaydestinations.Add(L)
 
 		to_chat(world, "\red \b Away mission loaded.")
 

--- a/maps/RandomZLevels/Academy.dmm
+++ b/maps/RandomZLevels/Academy.dmm
@@ -4010,8 +4010,8 @@
 /area/awaymission/academy/academygate)
 "kd" = (
 /obj/structure/cable,
-/obj/machinery/gateway/centeraway{
-	calibrated = 0
+/obj/machinery/gateway/center{
+	name = "Academy Gateway"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/academy/academygate)

--- a/maps/RandomZLevels/arcticwaste.dmm
+++ b/maps/RandomZLevels/arcticwaste.dmm
@@ -158,8 +158,8 @@
 /turf/simulated/floor/plating,
 /area/awaymission)
 "D" = (
-/obj/machinery/gateway/centeraway{
-	calibrated = 0
+/obj/machinery/gateway/center{
+	name = "Arctic Gateway"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission)

--- a/maps/RandomZLevels/beach.dmm
+++ b/maps/RandomZLevels/beach.dmm
@@ -37,7 +37,10 @@
 /turf/unsimulated/beach/sand,
 /area/awaymission/beach)
 "h" = (
-/obj/machinery/gateway/centeraway,
+/obj/machinery/gateway/center{
+	name = "Beach Gateway",
+	active = 1
+	},
 /turf/unsimulated/beach/sand,
 /area/awaymission/beach)
 "i" = (

--- a/maps/RandomZLevels/blackmarketpackers.dmm
+++ b/maps/RandomZLevels/blackmarketpackers.dmm
@@ -490,7 +490,7 @@
 /area/awaymission/BMPship1)
 "bB" = (
 /obj/machinery/gateway/centeraway{
-	calibrated = 0
+	name = "Black Market Gateway"
 	},
 /obj/structure/cable{
 	d2 = 4;

--- a/maps/RandomZLevels/example.dmm
+++ b/maps/RandomZLevels/example.dmm
@@ -120,7 +120,7 @@
 	icon_state = "0-2";
 	pixel_y = 1
 	},
-/obj/machinery/gateway/centeraway,
+/obj/machinery/gateway/center,
 /turf/simulated/floor,
 /area/awaymission/example)
 "ap" = (

--- a/maps/RandomZLevels/jungle.dmm
+++ b/maps/RandomZLevels/jungle.dmm
@@ -822,7 +822,9 @@
 /turf/unsimulated/floor,
 /area/jungle)
 "dc" = (
-/obj/machinery/gateway/centeraway,
+/obj/machinery/gateway/center{
+	name = "Jungle Gateway"
+	},
 /turf/unsimulated/floor,
 /area/jungle)
 "dd" = (

--- a/maps/RandomZLevels/listeningpost.dmm
+++ b/maps/RandomZLevels/listeningpost.dmm
@@ -297,7 +297,7 @@
 	},
 /area/mine/explored)
 "R" = (
-/obj/machinery/gateway/centeraway,
+/obj/machinery/gateway/center,
 /turf/simulated/floor/airless{
 	icon_state = "gcircuit"
 	},

--- a/maps/RandomZLevels/spacebattle.dmm
+++ b/maps/RandomZLevels/spacebattle.dmm
@@ -1503,8 +1503,8 @@
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/cruiser)
 "eq" = (
-/obj/machinery/gateway/centeraway{
-	calibrated = 0
+/obj/machinery/gateway/center{
+	name = "NMV Daedalus Gateway"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/spacebattle/cruiser)

--- a/maps/RandomZLevels/stationCollision.dmm
+++ b/maps/RandomZLevels/stationCollision.dmm
@@ -3959,9 +3959,7 @@
 	icon_state = "0-2";
 	pixel_y = 1
 	},
-/obj/machinery/gateway/centeraway{
-	calibrated = 0
-	},
+/obj/machinery/gateway/center,
 /turf/simulated/floor,
 /area/awaymission/gateroom)
 "kp" = (

--- a/maps/RandomZLevels/wildwest.dmm
+++ b/maps/RandomZLevels/wildwest.dmm
@@ -115,9 +115,7 @@
 	},
 /area/awaymission/wwvault)
 "av" = (
-/obj/machinery/gateway/centeraway{
-	calibrated = 0
-	},
+/obj/machinery/gateway/center,
 /turf/simulated/shuttle/plating{
 	icon_state = "gcircuitoff"
 	},

--- a/maps/RandomZLevels/zresearchlabs.dmm
+++ b/maps/RandomZLevels/zresearchlabs.dmm
@@ -2103,7 +2103,7 @@
 	},
 /area/awaymission/labs/gateway)
 "fq" = (
-/obj/machinery/gateway/centeraway,
+/obj/machinery/gateway/center,
 /turf/simulated/floor,
 /area/awaymission/labs/gateway)
 "fr" = (

--- a/maps/testmap.dmm
+++ b/maps/testmap.dmm
@@ -87,7 +87,7 @@
 	},
 /area/centcom)
 "n" = (
-/obj/machinery/gateway/centerstation,
+/obj/machinery/gateway/center/station,
 /turf/unsimulated/floor{
 	dir = 5;
 	icon_state = "vault"

--- a/maps/z1.dmm
+++ b/maps/z1.dmm
@@ -72120,7 +72120,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "hLb" = (
-/obj/machinery/gateway/centerstation,
+/obj/machinery/gateway/center/station,
 /turf/simulated/floor{
 	dir = 2;
 	icon_state = "darkblue"

--- a/maps/z7.dmm
+++ b/maps/z7.dmm
@@ -137,8 +137,8 @@
 /turf/simulated/floor/plating,
 /area/awaymission/junkyard)
 "A" = (
-/obj/machinery/gateway/centeraway{
-	calibrated = 0
+/obj/machinery/gateway/center{
+	name = "Junkyard Gateway"
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/junkyard)


### PR DESCRIPTION
:cl:
 - tweak: Гейтвей корректно работает при множественных подгруженных в игру вратах. Изменилась суть калибровки - её нужно проводить и на Вратах станции (по клику мультитулом по воротам можно выбрать точку назначения).
 - rscadd: Отдельный параметр конфига, отвечающий за включение Ворот станции. На нашем сервере по дефолту ворота выключены, экипаж должен делать запрос на ЦК/админам.
 - rscadd: При загруженной свалке и одобрении ЦК экипаж может пойти устроить экспансию на свалку, больше никаких костылей!