### PR TITLE
Звоночки и глотание таблеток из бутылки больше не показывают аттак_мессенжи

### DIFF
--- a/code/game/objects/items/weapons/bell.dm
+++ b/code/game/objects/items/weapons/bell.dm
@@ -5,6 +5,7 @@
 	desc = "A bell to ring to get people's attention. Don't break it."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "bell"
+	flags = NOBLUDGEON
 	hitsound = 'sound/items/oneding.ogg'
 	m_amt = 75
 

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -113,6 +113,7 @@
 	icon_state = "pill_canister"
 	icon = 'icons/obj/chemical.dmi'
 	item_state = "contsolid"
+	flags = NOBLUDGEON
 	w_class = ITEM_SIZE_SMALL
 	max_storage_space = 21
 	can_hold = list("/obj/item/weapon/reagent_containers/pill","/obj/item/weapon/dice","/obj/item/weapon/paper")


### PR DESCRIPTION
В чатик не будут выводиться аттак сообщения, когда бьешь по кому-нибудь звоночком или глотаешь таблетки из пилл_боттла (когда бьешь пилл_боттлом тоже не будет, но а зачем надо?)