### PR TITLE
Инициализация сабсистем более не ждет появления первого клиента.

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -75,8 +75,6 @@
 
 	. = ..()
 
-	sleep_offline = 1
-
 	spawn(3000)		//so we aren't adding to the round-start lag
 		if(config.kick_inactive)
 			KickInactiveClients()


### PR DESCRIPTION
Контроллер выставляет тоже самое после выполнения инициализации - https://github.com/TauCetiStation/TauCetiClassic/blob/master/code/controllers/master.dm#L146