### PR TITLE
Небольшой ребаланс магов

### DIFF
--- a/code/datums/spells/mind_transfer.dm
+++ b/code/datums/spells/mind_transfer.dm
@@ -3,7 +3,7 @@
 	desc = "This spell allows the user to switch bodies with a target."
 
 	school = "transmutation"
-	charge_max = 600
+	charge_max = 1800
 	clothes_req = 0
 	invocation = "GIN'YU CAPAN"
 	invocation_type = "whisper"
@@ -53,6 +53,18 @@ Also, you never added distance checking after target is selected. I've went ahea
 
 	if(target.mind.special_role in protected_roles)
 		to_chat(user, "Their mind is resisting your spell.")
+		return
+
+	//If target has mindshield/loyalty implant we break it, adding some brainloss
+	if(ismindshielded(target))
+		to_chat(user, "Their mind seems to be protected, so you only manage to break it")
+		to_chat(target, "You feel a flash of pain in your head")
+		for(var/obj/item/weapon/implant/mindshield/L in target)
+			if(L.implanted)
+				qdel(L)
+		target.adjustBrainLoss(15)
+		user.Paralyse(paralysis_amount_caster)
+		target.Paralyse(paralysis_amount_victim)
 		return
 
 	var/mob/living/victim = target//The target of the spell whos body will be transferred to.

--- a/code/datums/spells/mind_transfer.dm
+++ b/code/datums/spells/mind_transfer.dm
@@ -60,7 +60,7 @@ Also, you never added distance checking after target is selected. I've went ahea
 		to_chat(user, "Their mind seems to be protected, so you only manage to break it")
 		to_chat(target, "You feel a flash of pain in your head")
 		for(var/obj/item/weapon/implant/mindshield/L in target)
-			if(L.implanted)
+			if(L.implanted && L.imp_in == target)
 				qdel(L)
 		target.adjustBrainLoss(15)
 		user.Paralyse(paralysis_amount_caster)

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -149,8 +149,8 @@
 	var/wizard_name = "Grand Magus"
 	if(wizard)
 		wizard_name = wizard.name
-	if(M.mind.special_role == "Traitor")
-		to_chat(M, "<span class='notice'>You succeed in getting those precious powers from that fool. Now it's time to show [master] what you are realy after. And remember - no witnesses </span>")
+	if(M.mind.special_role == "traitor")
+		to_chat(M, "<span class='notice'>You succeed in getting those precious powers from that fool. Now it's time to show [master] what you are realy after.</span>")
 	else  	
 		to_chat(M, "<span class='notice'>You are [master]'s apprentice! You are bound by magic contract to follow their orders and help them in accomplishing their goals.</span>")
 	switch(type)
@@ -159,30 +159,30 @@
 				free_school_flags &= ~SCHOOL_DESTRUCTION
 				M.AddSpell(new /obj/effect/proc_holder/spell/targeted/projectile/magic_missile(M))
 				M.AddSpell(new /obj/effect/proc_holder/spell/in_hand/fireball(M))
-				to_chat(M, "<span class='notice'>Your service has not gone unrewarded, however. Studying under [wizard_name], you have learned powerful, destructive spells. You are able to cast magic missile and fireball.</span>")
+				to_chat(M, "<span class='notice'>Studying under [wizard_name], you have learned powerful, destructive spells. You are able to cast magic missile and fireball.</span>")
 		if("bluespace")
 			if(free_school_flags & SCHOOL_BLUESPACE)
 				free_school_flags &= ~SCHOOL_BLUESPACE
 				M.AddSpell(new /obj/effect/proc_holder/spell/targeted/area_teleport/teleport(M))
 				M.AddSpell(new /obj/effect/proc_holder/spell/targeted/ethereal_jaunt(M))
 				M.AddSpell(new /obj/effect/proc_holder/spell/targeted/forcewall(M))
-				to_chat(M, "<span class='notice'>Your service has not gone unrewarded, however. Studying under [wizard_name], you have learned reality bending mobility spells. You are able to cast teleport and ethereal jaunt, forcewall.</span>")
+				to_chat(M, "<span class='notice'>Studying under [wizard_name], you have learned reality bending mobility spells. You are able to cast teleport and ethereal jaunt, forcewall.</span>")
 		if("healing")
 			if(free_school_flags & SCHOOL_HEAL)
 				free_school_flags &= ~SCHOOL_HEAL
 				M.AddSpell(new /obj/effect/proc_holder/spell/targeted/charge(M))
 				M.AddSpell(new /obj/effect/proc_holder/spell/in_hand/res_touch(M))
 				M.AddSpell(new /obj/effect/proc_holder/spell/in_hand/heal(M))
-				to_chat(M, "<span class='notice'>Your service has not gone unrewarded, however. Studying under [wizard_name], you have learned livesaving survival spells. You are able to cast charge, resurrection and heal.</span>")
+				to_chat(M, "<span class='notice'>Studying under [wizard_name], you have learned livesaving survival spells. You are able to cast charge, resurrection and heal.</span>")
 		if("robeless")
 			if(free_school_flags & SCHOOL_ROBELESS)
 				free_school_flags &= ~SCHOOL_ROBELESS
 				M.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/knock(M))
 				M.AddSpell(new /obj/effect/proc_holder/spell/targeted/mind_transfer(M))
-				to_chat(M, "<span class='notice'>Your service has not gone unrewarded, however. Studying under [wizard_name], you have learned stealthy, robeless spells. You are able to cast knock and mindswap.</span>")
+				to_chat(M, "<span class='notice'>Studying under [wizard_name], you have learned stealthy, robeless spells. You are able to cast knock and mindswap.</span>")
 	equip_apprentice(M)
 	if(wizard && wizard.current)
-		if(M.mind.special_role == "Traitor")  //Because traitors gonna trait. Besides, mage with dualsaber and revolver is a bit too OP for this station
+		if(M.mind.special_role == "traitor")  //Because traitors gonna trait. Besides, mage with dualsaber and revolver is a bit too OP for this station
 			var/datum/objective/protect/new_objective = new /datum/objective/assassinate
 			new_objective.explanation_text = "Assassinate [wizard.current.real_name], the wizard."
 			new_objective.owner = M.mind

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -124,6 +124,11 @@
 	if(H.mind.special_role == "Wizard")
 		to_chat(H, "<span class='danger'>Your school years have long passed.</span>")
 		return
+
+	if(ismindshielded(H))
+		to_chat(H, "<span class='notice'>Something prevents you from becoming a magic girl that you've allways dreamed of</span>")
+		return
+
 	for(var/datum/mind/mind in previous_users)
 		if(H.mind == mind)
 			to_chat(H, "<span class='notice'>Not so fast, self-confident fulmar</span>")
@@ -144,7 +149,10 @@
 	var/wizard_name = "Grand Magus"
 	if(wizard)
 		wizard_name = wizard.name
-	to_chat(M, "<span class='notice'>You are [master]'s apprentice! You are bound by magic contract to follow their orders and help them in accomplishing their goals.</span>")
+	if(M.mind.special_role == "Traitor")
+		to_chat(M, "<span class='notice'>You succeed in getting those precious powers from that fool. Now it's time to show [master] what you are realy after. And remember - no witnesses </span>")
+	else  	
+		to_chat(M, "<span class='notice'>You are [master]'s apprentice! You are bound by magic contract to follow their orders and help them in accomplishing their goals.</span>")
 	switch(type)
 		if("destruction")
 			if(free_school_flags & SCHOOL_DESTRUCTION)
@@ -174,11 +182,18 @@
 				to_chat(M, "<span class='notice'>Your service has not gone unrewarded, however. Studying under [wizard_name], you have learned stealthy, robeless spells. You are able to cast knock and mindswap.</span>")
 	equip_apprentice(M)
 	if(wizard && wizard.current)
-		var/datum/objective/protect/new_objective = new /datum/objective/protect
-		new_objective.owner = M.mind
-		new_objective.target = wizard
-		new_objective.explanation_text = "Protect [wizard.current.real_name], the wizard."
-		M.mind.objectives += new_objective
+		if(M.mind.special_role == "Traitor")  //Because traitors gonna trait. Besides, mage with dualsaber and revolver is a bit too OP for this station
+			var/datum/objective/protect/new_objective = new /datum/objective/assassinate
+			new_objective.explanation_text = "Assassinate [wizard.current.real_name], the wizard."
+			new_objective.owner = M.mind
+			new_objective.target = wizard
+			M.mind.objectives += new_objective
+		else	
+			var/datum/objective/protect/new_objective = new /datum/objective/protect
+			new_objective.explanation_text = "Protect [wizard.current.real_name], the wizard."
+			new_objective.owner = M.mind
+			new_objective.target = wizard
+			M.mind.objectives += new_objective
 	uses--
 	previous_users += M.mind
 	playsound(M, 'sound/effects/magic.ogg', 100, 1)

--- a/code/game/objects/items/weapons/implants/mindshield.dm
+++ b/code/game/objects/items/weapons/implants/mindshield.dm
@@ -18,7 +18,7 @@
 	if(!ishuman(M))
 		return FALSE
 	var/mob/living/carbon/human/H = M
-	if(H.mind && (H.mind in (ticker.mode.head_revolutionaries | ticker.mode.A_bosses | ticker.mode.B_bosses)) || is_shadow_or_thrall(H))
+	if(H.mind && (H.mind in (ticker.mode.head_revolutionaries | ticker.mode.A_bosses | ticker.mode.B_bosses)) || is_shadow_or_thrall(H)|| H.mind.special_role == "Wizard")
 		M.visible_message("<span class='warning'>[M] seems to resist the implant!</span>", "<span class='warning'>You feel something interfering with your mental conditioning, but you resist it!</span>")
 		return FALSE
 


### PR DESCRIPTION
Собственно, в свете последних событий и споров по поводу взаимодействия заклинания смены разума и имплантов лояльности/щита было принято решение поставить в этом вопросе точку при помощи механа.
:cl:
 - balance: Маг не может быть имплантирован лояльностью/щитом.
 - balance: Применение обмена сознаниями (mindswap) на тело с установленным имплантом при первом применении ломает имплант и наносит небольшие повреждения мозгу цели.
 - balance: Перезарядка заклинания обмена сознаниями была увеличена
 - balance: Невозможно принять контракт ученичества у мага, находясь под действием импланта лояльности/щита
 - tweak: У предателей теперь свое мнение относительно тех, кто решит обучать их магии..