### PR TITLE
Исправление на некорректный цвет глаз ксеносов, поинт то верба и сохранение выбранного скалирования.

### DIFF
--- a/code/__DEFINES/colors.dm
+++ b/code/__DEFINES/colors.dm
@@ -72,3 +72,8 @@
 #define LIGHT_COLOR_FIRE       "#FAA019" // Warm orange color, leaning strongly towards yellow. rgb(250, 160, 25)
 #define LIGHT_COLOR_FLARE      "#F93C2F" // Bright, non-saturated red. Leaning slightly towards pink for visibility. rgb(250, 100, 75)
 #define LIGHT_COLOR_GHOST_CANDLE      "#a2fad1" // Used by ghost candles. rgb(162, 250, 209)
+
+//Human organ color mods
+#define HULK_SKIN_TONE rgb(48, 224, 40) // human
+#define HULK_SKIN_COLOR RGB_CONTRAST(35, 121, 11) // xenos
+#define NECROSIS_COLOR_MOD list(0.33,0.33,0.33, 0.59,0.59,0.59, 0.11,0.11,0.11)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -137,11 +137,6 @@ Please contact me on #coderbus IRC. ~Carn x
 #define TOTAL_LIMB_LAYERS		7
 //////////////////////////////////
 
-//Human organ color mods//////////
-#define HULK_SKIN_TONE rgb(48, 224, 40) // human
-#define HULK_SKIN_COLOR RGB_CONTRAST(35, 121, 11) // xenos
-#define NECROSIS_COLOR_MOD list(0.33,0.33,0.33, 0.59,0.59,0.59, 0.11,0.11,0.11)
-
 /mob/living/carbon/human
 	var/list/overlays_standing[TOTAL_LAYERS]
 	var/list/overlays_damage[TOTAL_LIMB_LAYERS]
@@ -189,10 +184,7 @@ Please contact me on #coderbus IRC. ~Carn x
 	remove_overlay(BODY_LAYER)
 	var/list/standing = list()
 
-	var/husk = (HUSK in mutations)
 	var/fat = (FAT in mutations) ? "fat" : null
-	var/hulk = (HULK in mutations)
-
 	var/g = (gender == FEMALE ? "f" : "m")
 
 	var/mutable_appearance/base_icon = mutable_appearance(null, null, -BODY_LAYER)
@@ -212,20 +204,6 @@ Please contact me on #coderbus IRC. ~Carn x
 			temp = BP.get_icon(race_icon, deform_icon, g)
 		else
 			temp = BP.get_icon(race_icon, deform_icon)
-
-		if(!husk)
-			if(BP.status & ORGAN_DEAD)
-				temp.color = NECROSIS_COLOR_MOD
-			else if (species.flags[HAS_SKIN_COLOR])
-				if(!hulk)
-					temp.color = RGB_CONTRAST(r_skin, g_skin, b_skin)
-				else
-					temp.color = HULK_SKIN_COLOR
-			else if(species.flags[HAS_SKIN_TONE])
-				if(!hulk)
-					temp.color = RGB_CONTRAST(s_tone, s_tone, s_tone)
-				else
-					temp.color = HULK_SKIN_TONE
 
 		base_icon.overlays += temp
 
@@ -965,7 +943,3 @@ Please contact me on #coderbus IRC. ~Carn x
 #undef TARGETED_LAYER
 #undef FIRE_LAYER
 #undef TOTAL_LAYERS
-
-#undef HULK_SKIN_TONE
-#undef HULK_SKIN_COLOR
-#undef NECROSIS_COLOR_MOD

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -321,6 +321,7 @@
 	var/obj/P = new /obj/effect/decal/point(tile)
 	P.pixel_x = A.pixel_x
 	P.pixel_y = A.pixel_y
+	P.plane = GAME_PLANE
 
 	QDEL_IN(P, 20)
 

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -923,6 +923,21 @@ Note that amputating the affected organ does in fact remove the infection from t
 			return 1
 	return 0
 
+/obj/item/organ/external/proc/apply_body_color(mutable_appearance/MA)
+	if(status & ORGAN_DEAD)
+		MA.color = NECROSIS_COLOR_MOD
+	else if (owner.species.flags[HAS_SKIN_COLOR])
+		if(!(HULK in owner.mutations))
+			MA.color = RGB_CONTRAST(owner.r_skin, owner.g_skin, owner.b_skin)
+		else
+			MA.color = HULK_SKIN_COLOR
+	else if(owner.species.flags[HAS_SKIN_TONE])
+		if(!(HULK in owner.mutations))
+			MA.color = RGB_CONTRAST(owner.s_tone, owner.s_tone, owner.s_tone)
+		else
+			MA.color = HULK_SKIN_TONE
+	return MA
+
 /obj/item/organ/external/get_icon(icon/race_icon, icon/deform_icon, gender = "", fat = "")
 	if (!owner)
 		return
@@ -931,15 +946,15 @@ Note that amputating the affected organ does in fact remove the infection from t
 		gender = ""
 
 	if (status & ORGAN_ROBOT && !owner.species.flags[IS_SYNTHETIC])
-		return mutable_appearance('icons/mob/human_races/robotic.dmi', "[body_zone][gender ? "_[gender]" : ""]")
-
-	if ((HUSK in owner.mutations) && !owner.species.flags[IS_SYNTHETIC])
+		. = mutable_appearance('icons/mob/human_races/robotic.dmi', "[body_zone][gender ? "_[gender]" : ""]")
+	else if ((HUSK in owner.mutations) && !owner.species.flags[IS_SYNTHETIC])
 		return mutable_appearance('icons/mob/human_races/husk.dmi', "[body_zone]")
+	else if (status & ORGAN_MUTATED)
+		. = mutable_appearance(deform_icon, "[body_zone][gender ? "_[gender]" : ""][fat ? "_[fat]" : ""]")
+	else
+		. = mutable_appearance(race_icon, "[body_zone][gender ? "_[gender]" : ""][fat ? "_[fat]" : ""]")
 
-	if (status & ORGAN_MUTATED)
-		return mutable_appearance(deform_icon, "[body_zone][gender ? "_[gender]" : ""][fat ? "_[fat]" : ""]")
-
-	return mutable_appearance(race_icon, "[body_zone][gender ? "_[gender]" : ""][fat ? "_[fat]" : ""]")
+	apply_body_color(.)
 
 /obj/item/organ/external/head/get_icon(icon/race_icon, icon/deform_icon, gender = "")
 	if (!owner)
@@ -951,12 +966,12 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if (!owner.species.has_gendered_icons)
 		gender = ""
 
-	if(status & ORGAN_MUTATED)
-		. = mutable_appearance(deform_icon, "[body_zone][gender ? "_[gender]" : ""]")
-	else
-		. = mutable_appearance(race_icon, "[body_zone][gender ? "_[gender]" : ""]")
+	. = list()
 
-	var/mutable_appearance/MA = .
+	if(status & ORGAN_MUTATED)
+		. += apply_body_color(mutable_appearance(deform_icon, "[body_zone][gender ? "_[gender]" : ""]"))
+	else
+		. += apply_body_color(mutable_appearance(race_icon, "[body_zone][gender ? "_[gender]" : ""]"))
 
 	//Eyes
 	if(owner.species.eyes)
@@ -965,13 +980,13 @@ Note that amputating the affected organ does in fact remove the infection from t
 			img_eyes_s.color = rgb(owner.r_eyes, owner.g_eyes, owner.b_eyes)
 		else
 			img_eyes_s.color = "#ff0000"
-		MA.overlays += img_eyes_s
+		. += img_eyes_s
 
 	//Mouth	(lipstick!)
 	if(owner.lip_style && owner.species.flags[HAS_LIPS]) // skeletons are allowed to wear lipstick no matter what you think, agouri.
 		var/mutable_appearance/lips = mutable_appearance('icons/mob/human_face.dmi', "lips_[owner.lip_style]_s")
 		lips.color = owner.lip_color
-		MA.overlays += lips
+		. += lips
 
 
 

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -503,9 +503,36 @@ menu "menu"
 		group = "size"
 		is-disabled = false
 		saved-params = "is-checked"
+	elem "icon128"
+		name = "&128x128 (4x)"
+		command = ".winset \"mapwindow.map.icon-size=128\""
+		category = "&Icons"
+		is-checked = false
+		can-check = true
+		group = "size"
+		is-disabled = false
+		saved-params = "is-checked"
+	elem "icon96"
+		name = "&96x96 (3x)"
+		command = ".winset \"mapwindow.map.icon-size=96\""
+		category = "&Icons"
+		is-checked = false
+		can-check = true
+		group = "size"
+		is-disabled = false
+		saved-params = "is-checked"
 	elem "icon64"
 		name = "&64x64 (2x)"
 		command = ".winset \"mapwindow.map.icon-size=64\""
+		category = "&Icons"
+		is-checked = false
+		can-check = true
+		group = "size"
+		is-disabled = false
+		saved-params = "is-checked"
+	elem "icon48"
+		name = "&48x48 (1.5x)"
+		command = ".winset \"mapwindow.map.icon-size=48\""
 		category = "&Icons"
 		is-checked = false
 		can-check = true

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -552,7 +552,7 @@ menu "menu"
 		name = "&Nearest Neighbor"
 		command = ".winset \"mapwindow.map.zoom-mode=distort\""
 		category = "&Scaling Mode"
-		is-checked = true
+		is-checked = false
 		can-check = true
 		group = "scaling"
 		is-disabled = false
@@ -561,7 +561,7 @@ menu "menu"
 		name = "&Point Sampling"
 		command = ".winset \"mapwindow.map.zoom-mode=normal\""
 		category = "&Scaling Mode"
-		is-checked = false
+		is-checked = true
 		can-check = true
 		group = "scaling"
 		is-disabled = false
@@ -1231,7 +1231,7 @@ window "mapwindow"
 		border = none
 		drop-zone = true
 		right-click = false
-		saved-params = "icon-size"
+		saved-params = "icon-size;zoom-mode"
 		on-size = ""
 		icon-size = 0
 		text-mode = false
@@ -1240,7 +1240,6 @@ window "mapwindow"
 		on-show = ".winset\"mainwindow.mainvsplit.left=mapwindow\""
 		on-hide = ".winset\"mainwindow.mainvsplit.left=\""
 		style = ""
-		zoom-mode = distort
 
 window "outputwindow"
 	elem "outputwindow"


### PR DESCRIPTION
* Скалирование: решил вернуть дефолт обратно к тому что всегда и было.
* Дотащил "зум" для карты 1.5х, 3х, 4х (это хотел притащить еще когда выбор скалирования делал).
* fixes #3018 (стрелочка от point to отображается ниже большинства вещей).

:cl:
 - bugfix: scaling mode возвращался к дефолту после дисконнекта, несмотря на то что выбор говорил обратное.
 - bugfix: цвет тела влиял на цвет глаз в той или иной мере.
 - tweak: во вкладку icons добавлены режимы 48х48, 96х96, 128х128.