### PR TITLE
Фиксит баг с перчатками

### DIFF
--- a/code/modules/clothing/gloves/stungloves.dm
+++ b/code/modules/clothing/gloves/stungloves.dm
@@ -62,7 +62,6 @@
 			user.visible_message("\red [user] cuts the fingertips off of the [src].","\red You cut the fingertips off of the [src].")
 
 			clipped = TRUE
-			protect_fingers = FALSE
 			name = "mangled [name]"
 			desc = "[desc]<br>They have had the fingertips cut off of them."
 			if("exclude" in species_restricted)


### PR DESCRIPTION
Мой косяк. Я забыл убрать в одном месте смену переменной, из-за чего fingerless gloves, созданные в процессе раунда, не защищали от порезов при копании в мусоре.