### PR TITLE
[WiP]Твики химии (химия с бея на минималках)

### DIFF
--- a/code/__DEFINES/chemistry.dm
+++ b/code/__DEFINES/chemistry.dm
@@ -1,0 +1,15 @@
+// How many units of reagent are consumed per tick, by default.
+#define REAGENTS_METABOLISM 0.2
+
+// By defining the effect multiplier this way, it'll exactly adjust
+// all effects according to how they originally were with the 0.4 metabolism
+#define REM REAGENTS_METABOLISM / 0.4
+
+#define FOOD_METABOLISM   0.4
+#define DRINK_METABOLISM  0.8
+
+#define SOLID 1
+#define LIQUID 2
+#define GAS 3
+
+#define REAGENTS_OVERDOSE 30

--- a/code/__DEFINES/mob.dm
+++ b/code/__DEFINES/mob.dm
@@ -90,13 +90,6 @@
 #define NUTRITION_LEVEL_HUNGRY 250
 #define NUTRITION_LEVEL_STARVING 150
 
-// How many units of reagent are consumed per tick, by default.
-#define REAGENTS_METABOLISM 0.2
-
-// By defining the effect multiplier this way, it'll exactly adjust
-// all effects according to how they originally were with the 0.4 metabolism
-#define REAGENTS_EFFECT_MULTIPLIER REAGENTS_METABOLISM / 0.4
-
 // Factor of how fast mob nutrition decreases
 #define METABOLISM_FACTOR 1 // standart (for humans, other)
 #define SKRELL_METABOLISM_FACTOR 2 // Twice the speed for half the sense!

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -20,8 +20,8 @@
 	var/recharged = 0
 	var/recharge_delay = 15
 	var/hackedcheck = 0
-	var/list/dispensable_reagents = list("hydrogen","lithium","carbon","nitrogen","oxygen","fluorine",
-	"sodium","aluminum","silicon","phosphorus","sulfur","chlorine","potassium","iron",
+	var/list/dispensable_reagents = list("hydrazine","lithium","carbon","ammonia","acetone",
+	"sodium","aluminum","silicon","phosphorus","sulfur","hacid","potassium","iron",
 	"copper","mercury","radium","water","ethanol","sugar","sacid","tungsten")
 
 /obj/machinery/chem_dispenser/proc/recharge()

--- a/code/modules/reagents/Chemistry-Reagents-Antidepressants.dm
+++ b/code/modules/reagents/Chemistry-Reagents-Antidepressants.dm
@@ -24,7 +24,7 @@
 	name = "Methylphenidate"
 	id = "methylphenidate"
 	result = "methylphenidate"
-	required_reagents = list("mindbreaker" = 1, "hydrogen" = 1)
+	required_reagents = list("mindbreaker" = 1, "lithium" = 1)
 	result_amount = 3
 
 /datum/reagent/antidepressant/citalopram
@@ -82,5 +82,5 @@
 	name = "Paroxetine"
 	id = "paroxetine"
 	result = "paroxetine"
-	required_reagents = list("mindbreaker" = 1, "oxygen" = 1, "inaprovaline" = 1)
+	required_reagents = list("mindbreaker" = 1, "acetone" = 1, "inaprovaline" = 1)
 	result_amount = 3

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -1,11 +1,3 @@
-#define SOLID 1
-#define LIQUID 2
-#define GAS 3
-#define FOOD_METABOLISM 0.4
-#define DRINK_METABOLISM 0.8
-#define REAGENTS_OVERDOSE 30
-#define REM REAGENTS_EFFECT_MULTIPLIER
-
 //The reaction procs must ALWAYS set src = null, this detaches the proc from the object (the reagent)
 //so that it can continue working when the reagent is deleted while the proc is still active.
 

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -57,7 +57,7 @@ datum
 			name = "Silicate"
 			id = "silicate"
 			result = "silicate"
-			required_reagents = list("aluminum" = 1, "silicon" = 1, "oxygen" = 1)
+			required_reagents = list("aluminum" = 1, "silicon" = 1, "acetone" = 1)
 			result_amount = 3
 */
 		stoxin
@@ -71,35 +71,35 @@ datum
 			name = "Sterilizine"
 			id = "sterilizine"
 			result = "sterilizine"
-			required_reagents = list("ethanol" = 1, "anti_toxin" = 1, "chlorine" = 1)
+			required_reagents = list("ethanol" = 1, "anti_toxin" = 1, "hacid" = 1)
 			result_amount = 3
 
 		inaprovaline
 			name = "Inaprovaline"
 			id = "inaprovaline"
 			result = "inaprovaline"
-			required_reagents = list("oxygen" = 1, "carbon" = 1, "sugar" = 1)
+			required_reagents = list("acetone" = 1, "carbon" = 1, "sugar" = 1)
 			result_amount = 3
 
 		anti_toxin
 			name = "Anti-Toxin (Dylovene)"
 			id = "anti_toxin"
 			result = "anti_toxin"
-			required_reagents = list("silicon" = 1, "potassium" = 1, "nitrogen" = 1)
+			required_reagents = list("silicon" = 1, "potassium" = 1, "ammonia" = 1)
 			result_amount = 3
 
 		mutagen
 			name = "Unstable mutagen"
 			id = "mutagen"
 			result = "mutagen"
-			required_reagents = list("radium" = 1, "phosphorus" = 1, "chlorine" = 1)
+			required_reagents = list("radium" = 1, "phosphorus" = 1, "hacid" = 1)
 			result_amount = 3
 
 		tramadol
 			name = "Tramadol"
 			id = "tramadol"
 			result = "tramadol"
-			required_reagents = list("inaprovaline" = 1, "ethanol" = 1, "oxygen" = 1)
+			required_reagents = list("inaprovaline" = 1, "ethanol" = 1, "acetone" = 1)
 			result_amount = 3
 
 		paracetamol
@@ -121,28 +121,21 @@ datum
 		//	name = "Cyanide"
 		//	id = "cyanide"
 		//	result = "cyanide"
-		//	required_reagents = list("hydrogen" = 1, "carbon" = 1, "nitrogen" = 1)
+		//	required_reagents = list("hydrazine" = 1, "carbon" = 1, "ammonia" = 1)
 		//	result_amount = 1
-
-		water //I can't believe we never had this.
-			name = "Water"
-			id = "water"
-			result = "water"
-			required_reagents = list("oxygen" = 2, "hydrogen" = 1)
-			result_amount = 1
 
 		thermite
 			name = "Thermite"
 			id = "thermite"
 			result = "thermite"
-			required_reagents = list("aluminum" = 1, "iron" = 1, "oxygen" = 1)
+			required_reagents = list("aluminum" = 1, "iron" = 1, "acetone" = 1)
 			result_amount = 3
 
 		lexorin
 			name = "Lexorin"
 			id = "lexorin"
 			result = "lexorin"
-			required_reagents = list("phoron" = 1, "hydrogen" = 1, "nitrogen" = 1)
+			required_reagents = list("phoron" = 1, "hydrazine" = 1, "ammonia" = 1)
 			result_amount = 3
 
 		space_drugs
@@ -156,14 +149,14 @@ datum
 			name = "Space Lube"
 			id = "lube"
 			result = "lube"
-			required_reagents = list("water" = 1, "silicon" = 1, "oxygen" = 1)
+			required_reagents = list("water" = 1, "silicon" = 1, "acetone" = 1)
 			result_amount = 4
 
 		pacid
 			name = "Polytrinic acid"
 			id = "pacid"
 			result = "pacid"
-			required_reagents = list("sacid" = 1, "chlorine" = 1, "potassium" = 1)
+			required_reagents = list("sacid" = 1, "hacid" = 1, "potassium" = 1)
 			result_amount = 3
 
 		synaptizine
@@ -184,14 +177,14 @@ datum
 			name = "Arithrazine"
 			id = "arithrazine"
 			result = "arithrazine"
-			required_reagents = list("hyronalin" = 1, "hydrogen" = 1)
+			required_reagents = list("hyronalin" = 1, "hacid" = 1)
 			result_amount = 2
 
 		impedrezene
 			name = "Impedrezene"
 			id = "impedrezene"
 			result = "impedrezene"
-			required_reagents = list("mercury" = 1, "oxygen" = 1, "sugar" = 1)
+			required_reagents = list("mercury" = 1, "acetone" = 1, "sugar" = 1)
 			result_amount = 2
 
 		kelotane
@@ -228,7 +221,7 @@ datum
 			name = "Cryptobiolin"
 			id = "cryptobiolin"
 			result = "cryptobiolin"
-			required_reagents = list("potassium" = 1, "oxygen" = 1, "sugar" = 1)
+			required_reagents = list("potassium" = 1, "acetone" = 1, "sugar" = 1)
 			result_amount = 3
 
 		tricordrazine
@@ -242,14 +235,14 @@ datum
 			name = "Alkysine"
 			id = "alkysine"
 			result = "alkysine"
-			required_reagents = list("chlorine" = 1, "nitrogen" = 1, "anti_toxin" = 1)
+			required_reagents = list("hacid" = 1, "ammonia" = 1, "anti_toxin" = 1)
 			result_amount = 2
 
 		dexalin
 			name = "Dexalin"
 			id = "dexalin"
 			result = "dexalin"
-			required_reagents = list("oxygen" = 2, "phoron" = 0.1)
+			required_reagents = list("acetone" = 2, "phoron" = 0.1)
 			required_catalysts = list("phoron" = 5)
 			result_amount = 1
 
@@ -257,7 +250,7 @@ datum
 			name = "Dermaline"
 			id = "dermaline"
 			result = "dermaline"
-			required_reagents = list("oxygen" = 1, "phosphorus" = 1, "kelotane" = 1)
+			required_reagents = list("acetone" = 1, "phosphorus" = 1, "kelotane" = 1)
 			result_amount = 3
 
 		dexalinp
@@ -299,7 +292,7 @@ datum
 			name = "Cryoxadone"
 			id = "cryoxadone"
 			result = "cryoxadone"
-			required_reagents = list("dexalin" = 1, "water" = 1, "oxygen" = 1)
+			required_reagents = list("dexalin" = 1, "water" = 1, "acetone" = 1)
 			result_amount = 3
 
 		clonexadone
@@ -321,15 +314,22 @@ datum
 			name = "imidazoline"
 			id = "imidazoline"
 			result = "imidazoline"
-			required_reagents = list("carbon" = 1, "hydrogen" = 1, "anti_toxin" = 1)
+			required_reagents = list("carbon" = 1, "hydrazine" = 1, "anti_toxin" = 1)
 			result_amount = 2
 
 		ethylredoxrazine
 			name = "Ethylredoxrazine"
 			id = "ethylredoxrazine"
 			result = "ethylredoxrazine"
-			required_reagents = list("oxygen" = 1, "anti_toxin" = 1, "carbon" = 1)
+			required_reagents = list("acetone" = 1, "anti_toxin" = 1, "carbon" = 1)
 			result_amount = 3
+
+		noexcutite
+			name = "Noexcutite"
+			id = "noexcutite"
+			result = "noexcutite"
+			required_reagents = list("oxycodone" = 1, "anti_toxin" = 1)
+			result_amount = 1
 
 		ethanoloxidation
 			name = "ethanoloxidation"	//Kind of a placeholder in case someone ever changes it so that chemicals
@@ -369,7 +369,7 @@ datum
 			name = "Sodium Chloride"
 			id = "sodiumchloride"
 			result = "sodiumchloride"
-			required_reagents = list("sodium" = 1, "chlorine" = 1)
+			required_reagents = list("sodium" = 1, "hacid" = 1)
 			result_amount = 2
 
 		flash_powder
@@ -464,7 +464,7 @@ datum
 			name = "Chloral Hydrate"
 			id = "chloralhydrate"
 			result = "chloralhydrate"
-			required_reagents = list("ethanol" = 1, "chlorine" = 3, "water" = 1)
+			required_reagents = list("ethanol" = 1, "hacid" = 3, "water" = 1)
 			result_amount = 1
 
 		mutetoxin //i'll just fit this in here snugly between other unfun chemicals :v @ TG Port
@@ -513,7 +513,7 @@ datum
 			name = "Mindbreaker Toxin"
 			id = "mindbreaker"
 			result = "mindbreaker"
-			required_reagents = list("silicon" = 1, "hydrogen" = 1, "anti_toxin" = 1)
+			required_reagents = list("silicon" = 1, "hydrazine" = 1, "anti_toxin" = 1)
 			result_amount = 3
 
 		lipozine
@@ -548,7 +548,7 @@ datum
 			name = "Virus Food"
 			id = "virusfood"
 			result = "virusfood"
-			required_reagents = list("water" = 5, "milk" = 5, "oxygen" = 5)
+			required_reagents = list("water" = 5, "milk" = 5, "acetone" = 5)
 			result_amount = 15
 /*
 		mix_virus
@@ -604,7 +604,7 @@ datum
 			name = "Foam surfactant"
 			id = "foam surfactant"
 			result = "fluorosurfactant"
-			required_reagents = list("fluorine" = 2, "carbon" = 2, "sacid" = 1)
+			required_reagents = list("hydrazine" = 2, "carbon" = 2, "sacid" = 1)
 			result_amount = 5
 
 
@@ -677,22 +677,12 @@ datum
 				s.start()
 				return
 
-
-
 		foaming_agent
 			name = "Foaming Agent"
 			id = "foaming_agent"
 			result = "foaming_agent"
-			required_reagents = list("lithium" = 1, "hydrogen" = 1)
+			required_reagents = list("lithium" = 1, "hydrazine" = 1)
 			result_amount = 1
-
-		// Synthesizing these three chemicals is pretty complex in real life, but fuck it, it's just a game!
-		ammonia
-			name = "Ammonia"
-			id = "ammonia"
-			result = "ammonia"
-			required_reagents = list("hydrogen" = 3, "nitrogen" = 1)
-			result_amount = 3
 
 		diethylamine
 			name = "Diethylamine"
@@ -2253,7 +2243,7 @@ datum
 /datum/chemical_reaction/deuterium
 	name = "Deuterium"
 	result = null
-	required_reagents = list("water" = 70, "oxygen" = 30)
+	required_reagents = list("water" = 70, "acetone" = 30)
 	result_amount = 1
 
 /datum/chemical_reaction/deuterium/on_reaction(datum/reagents/holder, created_volume)
@@ -2291,7 +2281,7 @@ TODO: Convert everything to custom hair dye,
 	name = "Green Hair Dye"
 	id = "greenhairdye"
 	result = "greenhairdye"
-	required_reagents = list("hairdye" = 1, "chlorine" = 1)
+	required_reagents = list("hairdye" = 1, "hacid" = 1)
 	result_amount = 1
 
 /datum/chemical_reaction/hair_dye/black

--- a/code/modules/reagents/reagent_types/Chemistry-Core.dm
+++ b/code/modules/reagents/reagent_types/Chemistry-Core.dm
@@ -222,7 +222,13 @@
 	custom_metabolism = REAGENTS_METABOLISM * 0.2
 
 /datum/reagent/acetone/on_general_digest(mob/living/M)
-	M.adjustToxLoss(REAGENTS_METABOLISM * 0.7) //Default toxin damage
+	M.adjustToxLoss(REAGENTS_METABOLISM * 0.2) // Low toxic
+
+/datum/reagent/acetone/on_vox_digest(mob/living/M)
+	..()
+	M.adjustToxLoss(REAGENTS_METABOLISM)
+	holder.remove_reagent(id, REAGENTS_METABOLISM) //By default it slowly disappears.
+	return FALSE
 
 /datum/reagent/aluminum
 	name = "Aluminum"
@@ -243,16 +249,21 @@
 	overdose = 5
 
 /datum/reagent/ammonia/on_general_digest(mob/living/M)
-	M.adjustToxLoss(REAGENTS_METABOLISM * 0.35)
-
-/datum/reagent/ammonia/on_diona_digest(mob/living/M)
-	..()
-	M.nutrition += 1 * REM
-	return FALSE
+	M.adjustToxLoss(REAGENTS_METABOLISM * 0.2) // Low toxic
 
 /datum/reagent/ammonia/on_vox_digest(mob/living/M)
 	..()
-	M.adjustOxyLoss(-2 * REAGENTS_METABOLISM)
+	M.adjustOxyLoss(-2 * REM)
+	holder.remove_reagent(id, REAGENTS_METABOLISM) //By default it slowly disappears.
+	return FALSE
+
+/datum/reagent/ammonia/on_diona_digest(mob/living/M)
+	..()
+	M.adjustBruteLoss(-REM)
+	M.adjustOxyLoss(-REM)
+	M.adjustToxLoss(-REM)
+	M.adjustFireLoss(-REM)
+	M.nutrition += REM
 	return FALSE
 
 /datum/reagent/carbon
@@ -317,9 +328,6 @@
 	taste_message = "sweet tasting metal"
 	reagent_state = LIQUID
 	color = "#808080"
-
-/datum/reagent/fuel/hydrazine/on_general_digest(mob/living/M)
-	M.adjustToxLoss(1.5)
 
 /datum/reagent/iron
 	name = "Iron"
@@ -498,11 +506,3 @@
 			var/obj/effect/decal/cleanable/greenglow/glow = locate(/obj/effect/decal/cleanable/greenglow, T)
 			if(!glow)
 				new /obj/effect/decal/cleanable/greenglow(T)
-
-/datum/reagent/hydrogen
-	name = "Hydrogen"
-	id = "hydrogen"
-	description = "A colorless, odorless, nonmetallic, tasteless, highly combustible diatomic gas."
-	reagent_state = GAS
-	color = "#808080"
-	taste_message = null

--- a/code/modules/reagents/reagent_types/Chemistry-Core.dm
+++ b/code/modules/reagents/reagent_types/Chemistry-Core.dm
@@ -212,97 +212,48 @@
 		var/obj/item/weapon/storage/fancy/black_candle_box/G = O
 		G.teleporter_delay += volume
 
-/datum/reagent/oxygen
-	name = "Oxygen"
-	id = "oxygen"
-	description = "A colorless, odorless gas."
-	reagent_state = GAS
-	color = "#808080" // rgb: 128, 128, 128
-	taste_message = null
-	custom_metabolism = 0.01
-
-/datum/reagent/oxygen/on_vox_digest(mob/living/M)
-	..()
-	M.adjustToxLoss(REAGENTS_METABOLISM)
-	holder.remove_reagent(id, REAGENTS_METABOLISM) //By default it slowly disappears.
-	return FALSE
-
-/datum/reagent/copper
-	name = "Copper"
-	id = "copper"
-	description = "A highly ductile metal."
-	color = "#6E3B08" // rgb: 110, 59, 8
-	taste_message = null
-	custom_metabolism = 0.01
-
-/datum/reagent/nitrogen
-	name = "Nitrogen"
-	id = "nitrogen"
-	description = "A colorless, odorless, tasteless gas."
-	reagent_state = GAS
-	color = "#808080" // rgb: 128, 128, 128
-	taste_message = null
-	custom_metabolism = 0.01
-
-/datum/reagent/nitrogen/on_diona_digest(mob/living/M)
-	..()
-	M.adjustBruteLoss(-REM)
-	M.adjustOxyLoss(-REM)
-	M.adjustToxLoss(-REM)
-	M.adjustFireLoss(-REM)
-	M.nutrition += REM
-	return FALSE
-
-/datum/reagent/nitrogen/on_vox_digest(mob/living/M)
-	..()
-	M.adjustOxyLoss(-2 * REM)
-	holder.remove_reagent(id, REAGENTS_METABOLISM) //By default it slowly disappears.
-	return FALSE
-
-/datum/reagent/hydrogen
-	name = "Hydrogen"
-	id = "hydrogen"
-	description = "A colorless, odorless, nonmetallic, tasteless, highly combustible diatomic gas."
-	reagent_state = GAS
-	color = "#808080" // rgb: 128, 128, 128
-	taste_message = null
-	custom_metabolism = 0.01
-
-/datum/reagent/potassium
-	name = "Potassium"
-	id = "potassium"
-	description = "A soft, low-melting solid that can easily be cut with a knife. Reacts violently with water."
-	reagent_state = SOLID
-	color = "#A0A0A0" // rgb: 160, 160, 160
-	taste_message = "bad ideas"
-	custom_metabolism = 0.01
-
-/datum/reagent/mercury
-	name = "Mercury"
-	id = "mercury"
-	description = "A chemical element."
+/datum/reagent/acetone
+	name = "Acetone"
+	id = "acetone"
+	description = "A colorless liquid solvent used in chemical synthesis."
+	taste_message = "acid"
 	reagent_state = LIQUID
-	color = "#484848" // rgb: 72, 72, 72
-	overdose = REAGENTS_OVERDOSE
-	taste_message = "druggie poison"
-	restrict_species = list(IPC, DIONA)
+	color = "#808080"
+	custom_metabolism = REAGENTS_METABOLISM * 0.2
 
-/datum/reagent/mercury/on_general_digest(mob/living/M)
-	..()
-	if(M.canmove && !M.restrained() && istype(M.loc, /turf/space))
-		step(M, pick(cardinal))
-	if(prob(5))
-		M.emote(pick("twitch","drool","moan"))
-	M.adjustBrainLoss(2)
+/datum/reagent/acetone/on_general_digest(mob/living/M)
+	M.adjustToxLoss(REAGENTS_METABOLISM * 0.7) //Default toxin damage
 
-/datum/reagent/sulfur
-	name = "Sulfur"
-	id = "sulfur"
-	description = "A chemical element with a pungent smell."
+/datum/reagent/aluminum
+	name = "Aluminum"
+	id = "aluminum"
+	description = "A silvery white and ductile member of the boron group of chemical elements."
 	reagent_state = SOLID
-	color = "#BF8C00" // rgb: 191, 140, 0
-	taste_message = "impulsive decisions"
-	custom_metabolism = 0.01
+	color = "#A8A8A8"
+	taste_message = "metal"
+
+/datum/reagent/ammonia
+	name = "Ammonia"
+	id = "ammonia"
+	taste_message = "mordant"
+	description = "A caustic substance commonly used in fertilizer or household cleaners."
+	reagent_state = LIQUID
+	color = "#404030"
+	custom_metabolism = REAGENTS_METABOLISM * 0.5
+	overdose = 5
+
+/datum/reagent/ammonia/on_general_digest(mob/living/M)
+	M.adjustToxLoss(REAGENTS_METABOLISM * 0.35)
+
+/datum/reagent/ammonia/on_diona_digest(mob/living/M)
+	..()
+	M.nutrition += 1 * REM
+	return FALSE
+
+/datum/reagent/ammonia/on_vox_digest(mob/living/M)
+	..()
+	M.adjustOxyLoss(-2 * REAGENTS_METABOLISM)
+	return FALSE
 
 /datum/reagent/carbon
 	name = "Carbon"
@@ -323,58 +274,62 @@
 		else
 			dirtoverlay.alpha = min(dirtoverlay.alpha + volume * 30, 255)
 
-/datum/reagent/chlorine
-	name = "Chlorine"
-	id = "chlorine"
-	description = "A chemical element with a characteristic odour."
-	reagent_state = GAS
-	color = "#808080" // rgb: 128, 128, 128
-	overdose = REAGENTS_OVERDOSE
-	taste_message = "characteristic taste"
-
-/datum/reagent/chlorine/on_general_digest(mob/living/M)
-	..()
-	M.take_bodypart_damage(1 * REM, 0)
-
-/datum/reagent/fluorine
-	name = "Fluorine"
-	id = "fluorine"
-	description = "A highly-reactive chemical element."
-	reagent_state = GAS
-	color = "#808080" // rgb: 128, 128, 128
-	overdose = REAGENTS_OVERDOSE
-	taste_message = "toothpaste"
-
-/datum/reagent/fluorine/on_general_digest(mob/living/M)
-	..()
-	M.adjustToxLoss(REM)
-
-/datum/reagent/sodium
-	name = "Sodium"
-	id = "sodium"
-	description = "A chemical element, readily reacts with water."
-	reagent_state = SOLID
-	color = "#808080" // rgb: 128, 128, 128
-	taste_message = "horrible misjudgement"
+/datum/reagent/copper
+	name = "Copper"
+	id = "copper"
+	description = "A highly ductile metal."
+	color = "#6E3B08"
+	taste_message = "copper"
 	custom_metabolism = 0.01
 
-/datum/reagent/phosphorus
-	name = "Phosphorus"
-	id = "phosphorus"
-	description = "A chemical element, the backbone of biological energy carriers."
-	reagent_state = SOLID
-	color = "#832828" // rgb: 131, 40, 40
-	taste_message = "misguided choices"
-	custom_metabolism = 0.01
+/datum/reagent/fuel
+	name = "Welding fuel"
+	id = "fuel"
+	description = "Required for welders. Flamable."
+	reagent_state = LIQUID
+	color = "#660000"
+	overdose = REAGENTS_OVERDOSE
+	taste_message = "motor oil"
 
-/datum/reagent/phosphorus/on_diona_digest(mob/living/M)
+/datum/reagent/fuel/reaction_obj(obj/O, volume)
+	var/turf/the_turf = get_turf(O)
+	if(!the_turf)
+		return //No sense trying to start a fire if you don't have a turf to set on fire. --NEO
+	new /obj/effect/decal/cleanable/liquid_fuel(the_turf, volume)
+
+/datum/reagent/fuel/reaction_turf(turf/T, volume)
+	new /obj/effect/decal/cleanable/liquid_fuel(T, volume)
+
+/datum/reagent/fuel/on_general_digest(mob/living/M)
 	..()
-	M.adjustBruteLoss(-REM)
-	M.adjustOxyLoss(-REM)
-	M.adjustToxLoss(-REM)
-	M.adjustFireLoss(-REM)
-	M.nutrition += REM
-	return FALSE
+	M.adjustToxLoss(1)
+
+/datum/reagent/fuel/reaction_mob(mob/living/M, method=TOUCH, volume)//Splashing people with welding fuel to make them easy to ignite!
+	if(!istype(M, /mob/living))
+		return
+	if(method == TOUCH)
+		M.adjust_fire_stacks(volume / 10)
+
+/datum/reagent/fuel/hydrazine
+	name = "Hydrazine"
+	id = "hydrazine"
+	description = "A toxic, colorless, flammable liquid with a strong ammonia-like odor, in hydrate form."
+	taste_message = "sweet tasting metal"
+	reagent_state = LIQUID
+	color = "#808080"
+
+/datum/reagent/fuel/hydrazine/on_general_digest(mob/living/M)
+	M.adjustToxLoss(1.5)
+
+/datum/reagent/iron
+	name = "Iron"
+	id = "iron"
+	description = "Pure iron is a metal."
+	reagent_state = SOLID
+	color = "#C8A5DC"
+	overdose = REAGENTS_OVERDOSE
+	taste_message = "metal"
+	restrict_species = list(IPC, DIONA)
 
 /datum/reagent/lithium
 	name = "Lithium"
@@ -393,17 +348,49 @@
 	if(prob(5))
 		M.emote(pick("twitch","drool","moan"))
 
-/datum/reagent/sugar
-	name = "Sugar"
-	id = "sugar"
-	description = "The organic compound commonly known as table sugar and sometimes called saccharose. This white, odorless, crystalline powder has a pleasing, sweet taste."
-	reagent_state = SOLID
-	color = "#FFFFFF" // rgb: 255, 255, 255
-	taste_message = "sweetness"
+/datum/reagent/mercury
+	name = "Mercury"
+	id = "mercury"
+	description = "A chemical element."
+	reagent_state = LIQUID
+	color = "#484848"
+	overdose = REAGENTS_OVERDOSE
+	taste_message = "druggie poison"
+	restrict_species = list(IPC, DIONA)
 
-/datum/reagent/sugar/on_general_digest(mob/living/M)
+/datum/reagent/mercury/on_general_digest(mob/living/M)
 	..()
+	if(M.canmove && !M.restrained() && istype(M.loc, /turf/space))
+		step(M, pick(cardinal))
+	if(prob(5))
+		M.emote(pick("twitch","drool","moan"))
+	M.adjustBrainLoss(2)
+
+/datum/reagent/phosphorus
+	name = "Phosphorus"
+	id = "phosphorus"
+	description = "A chemical element, the backbone of biological energy carriers."
+	reagent_state = SOLID
+	color = "#832828"
+	taste_message = "vinegar"
+	custom_metabolism = REAGENTS_METABOLISM * 0.5
+
+/datum/reagent/phosphorus/on_diona_digest(mob/living/M)
+	..()
+	M.adjustBruteLoss(-REM)
+	M.adjustOxyLoss(-REM)
+	M.adjustToxLoss(-REM)
+	M.adjustFireLoss(-REM)
 	M.nutrition += REM
+	return FALSE
+
+/datum/reagent/potassium
+	name = "Potassium"
+	id = "potassium"
+	description = "A soft, low-melting solid that can easily be cut with a knife. Reacts violently with water."
+	reagent_state = SOLID
+	color = "#A0A0A0"
+	taste_message = "sweetness"
 
 /datum/reagent/radium
 	name = "Radium"
@@ -440,14 +427,41 @@
 			if(!glow)
 				new /obj/effect/decal/cleanable/greenglow(T)
 
-/datum/reagent/iron
-	name = "Iron"
-	id = "iron"
-	description = "Pure iron is a metal."
+/datum/reagent/silicon
+	name = "Silicon"
+	id = "silicon"
+	description = "A tetravalent metalloid, silicon is less reactive than its chemical analog carbon."
 	reagent_state = SOLID
-	color = "#C8A5DC" // rgb: 200, 165, 220
-	overdose = REAGENTS_OVERDOSE
-	taste_message = "metal"
+	color = "#A8A8A8"
+	taste_message = "a CPU"
+
+/datum/reagent/sodium
+	name = "Sodium"
+	id = "sodium"
+	description = "A chemical element, readily reacts with water."
+	reagent_state = SOLID
+	color = "#808080"
+	taste_message = "salty metal"
+
+/datum/reagent/sugar
+	name = "Sugar"
+	id = "sugar"
+	description = "The organic compound commonly known as table sugar and sometimes called saccharose. This white, odorless, crystalline powder has a pleasing, sweet taste."
+	reagent_state = SOLID
+	color = "#FFFFFF"
+	taste_message = "sweetness"
+
+/datum/reagent/sugar/on_general_digest(mob/living/M)
+	..()
+	M.nutrition += REM
+
+/datum/reagent/sulfur
+	name = "Sulfur"
+	id = "sulfur"
+	description = "A chemical element with a pungent smell."
+	reagent_state = SOLID
+	color = "#BF8C00"
+	taste_message = "old eggs"
 
 /datum/reagent/gold
 	name = "Gold"
@@ -455,7 +469,7 @@
 	description = "Gold is a dense, soft, shiny metal and the most malleable and ductile metal known."
 	reagent_state = SOLID
 	color = "#F7C430" // rgb: 247, 196, 48
-	taste_message = "bling"
+	taste_message = "expensive metal"
 
 /datum/reagent/silver
 	name = "Silver"
@@ -463,7 +477,7 @@
 	description = "A soft, white, lustrous transition metal, it has the highest electrical conductivity of any element and the highest thermal conductivity of any metal."
 	reagent_state = SOLID
 	color = "#D0D0D0" // rgb: 208, 208, 208
-	taste_message = "sub-par bling"
+	taste_message = "expensive yet reasonable metal"
 
 /datum/reagent/uranium
 	name ="Uranium"
@@ -471,7 +485,7 @@
 	description = "A silvery-white metallic chemical element in the actinide series, weakly radioactive."
 	reagent_state = SOLID
 	color = "#B8B8C0" // rgb: 184, 184, 192
-	taste_message = "bonehurting juice"
+	taste_message = "the inside of a reactor"
 
 /datum/reagent/uranium/on_general_digest(mob/living/M)
 	..()
@@ -485,18 +499,10 @@
 			if(!glow)
 				new /obj/effect/decal/cleanable/greenglow(T)
 
-/datum/reagent/aluminum
-	name = "Aluminum"
-	id = "aluminum"
-	description = "A silvery white and ductile member of the boron group of chemical elements."
-	reagent_state = SOLID
-	color = "#A8A8A8" // rgb: 168, 168, 168
+/datum/reagent/hydrogen
+	name = "Hydrogen"
+	id = "hydrogen"
+	description = "A colorless, odorless, nonmetallic, tasteless, highly combustible diatomic gas."
+	reagent_state = GAS
+	color = "#808080"
 	taste_message = null
-
-/datum/reagent/silicon
-	name = "Silicon"
-	id = "silicon"
-	description = "A tetravalent metalloid, silicon is less reactive than its chemical analog carbon."
-	reagent_state = SOLID
-	color = "#A8A8A8" // rgb: 168, 168, 168
-	taste_message = "a CPU"

--- a/code/modules/reagents/reagent_types/Chemistry-Medicine.dm
+++ b/code/modules/reagents/reagent_types/Chemistry-Medicine.dm
@@ -1,37 +1,3 @@
-/datum/reagent/srejuvenate
-	name = "Soporific Rejuvenant"
-	id = "stoxin2"
-	description = "Put people to sleep, and heals them."
-	reagent_state = LIQUID
-	color = "#c8a5dc" // rgb: 200, 165, 220
-	custom_metabolism = REAGENTS_METABOLISM * 0.5
-	overdose = REAGENTS_OVERDOSE
-	restrict_species = list(IPC, DIONA)
-
-/datum/reagent/srejuvenate/on_general_digest(mob/living/M)
-	..()
-	if(M.losebreath >= 10)
-		M.losebreath = max(10, M.losebreath-10)
-	if(!data)
-		data = 1
-	data++
-	switch(data)
-		if(1 to 15)
-			M.eye_blurry = max(M.eye_blurry, 10)
-		if(15 to 25)
-			M.drowsyness  = max(M.drowsyness, 20)
-		if(25 to INFINITY)
-			M.sleeping += 1
-			M.adjustOxyLoss(-M.getOxyLoss())
-			M.SetWeakened(0)
-			M.SetStunned(0)
-			M.SetParalysis(0)
-			M.dizziness = 0
-			M.drowsyness = 0
-			M.stuttering = 0
-			M.confused = 0
-			M.jitteriness = 0
-
 /datum/reagent/inaprovaline
 	name = "Inaprovaline"
 	id = "inaprovaline"
@@ -46,6 +12,11 @@
 	..()
 	if(M.losebreath >= 10)
 		M.losebreath = max(10, M.losebreath-5)
+	if(volume > overdose)
+		if(prob(5))
+			M.slurring = max(M.slurring, 10)
+		if(prob(2))
+			M.drowsyness = max(M.drowsyness, 5)
 
 /datum/reagent/inaprovaline/on_vox_digest(mob/living/M)
 	..()
@@ -72,44 +43,64 @@
 	description = "Most probably know this as Tylenol, but this chemical is a mild, simple painkiller."
 	reagent_state = LIQUID
 	color = "#c8a5dc"
-	overdose = 60
+	overdose = REAGENTS_OVERDOSE * 2
 	restrict_species = list(IPC, DIONA)
 
 /datum/reagent/paracetamol/on_general_digest(mob/living/M)
 	..()
 	if(volume > overdose)
 		M.hallucination = max(M.hallucination, 2)
+		M.druggy = max(M.druggy, 2)
 
 /datum/reagent/tramadol
 	name = "Tramadol"
 	id = "tramadol"
-	description = "A simple, yet effective painkiller."
+	description = "A simple, yet effective painkiller. Don't mix with alcohol."
 	reagent_state = LIQUID
 	color = "#cb68fc"
-	overdose = 30
-	custom_metabolism = 0.025
+	custom_metabolism = 0.05
 	restrict_species = list(IPC, DIONA)
 
 /datum/reagent/tramadol/on_general_digest(mob/living/M)
 	..()
-	if(volume > overdose)
+	if(volume  > 0.5 * overdose)
+		if(prob(1))
+			M.slurring = max(M.slurring, 10)
+	if(volume  > 0.75 * overdose)
+		if(prob(5))
+			M.slurring = max(M.slurring, 20)
+	if(volume  > overdose)
 		M.hallucination = max(M.hallucination, 2)
+		M.druggy = max(M.druggy, 10)
+		M.slurring = max(M.slurring, 30)
+		if(prob(1))
+			M.Weaken(2)
+			M.drowsyness = max(M.drowsyness, 5)
+	var/boozed = isboozed(M)
+	if(boozed)
+		M.adjustToxLoss(1)
+		M.adjustOxyLoss(REAGENTS_METABOLISM * 10) //drinking and opiating makes breathing kinda hard
 
-/datum/reagent/oxycodone
+/datum/reagent/tramadol/proc/isboozed(mob/living/M)
+	. = 0
+	var/list/pool = M.reagents.reagent_list
+	for(var/datum/reagent/consumable/ethanol in pool)
+		. = 1
+
+/datum/reagent/tramadol/oxycodone
 	name = "Oxycodone"
 	id = "oxycodone"
-	description = "An effective and very addictive painkiller."
+	description = "An effective and very addictive painkiller. Don't mix with alcohol."
 	reagent_state = LIQUID
 	color = "#800080"
 	overdose = 20
-	custom_metabolism = 0.025
+	custom_metabolism = 0.1
 	restrict_species = list(IPC, DIONA)
 
-/datum/reagent/oxycodone/on_general_digest(mob/living/M)
+/datum/reagent/tramadol/oxycodone/on_general_digest(mob/living/M)
 	..()
 	if(volume > overdose)
-		M.druggy = max(M.druggy, 10)
-		M.hallucination = max(M.hallucination, 3)
+		M.hallucination = max(M.hallucination, 4)
 
 /datum/reagent/sterilizine
 	name = "Sterilizine"
@@ -210,7 +201,7 @@
 	M.adjustOxyLoss(-M.getOxyLoss())
 
 	if(holder.has_reagent("lexorin"))
-		holder.remove_reagent("lexorin", 2 * REM)
+		holder.remove_reagent("lexorin", 3 * REM)
 
 /datum/reagent/dexalinp/on_vox_digest(mob/living/M) // Now dexalin plus does not remove lexarin from Vox. For the better or the worse.
 	..()
@@ -263,33 +254,7 @@
 
 /datum/reagent/adminordrazine/on_general_digest(mob/living/M)
 	..()
-	M.reagents.remove_all_type(/datum/reagent/toxin, 5 * REM, 0, 1)
-	M.setCloneLoss(0)
-	M.setOxyLoss(0)
-	M.radiation = 0
-	M.heal_bodypart_damage(5,5)
-	M.adjustToxLoss(-5)
-	M.hallucination = 0
-	M.setBrainLoss(0)
-	M.disabilities = 0
-	M.sdisabilities = 0
-	M.eye_blurry = 0
-	M.eye_blind = 0
-	M.SetWeakened(0)
-	M.SetStunned(0)
-	M.SetParalysis(0)
-	M.silent = 0
-	M.dizziness = 0
-	M.drowsyness = 0
-	M.stuttering = 0
-	M.confused = 0
-	M.sleeping = 0
-	M.jitteriness = 0
-	for(var/datum/disease/D in M.viruses)
-		D.spread = "Remissive"
-		D.stage--
-		if(D.stage < 1)
-			D.cure()
+	M.rejuvenate()
 
 /datum/reagent/synaptizine
 	name = "Synaptizine"
@@ -332,9 +297,8 @@
 	id = "arithrazine"
 	description = "Arithrazine is an unstable medication used for the most extreme cases of radiation poisoning."
 	reagent_state = LIQUID
-	color = "#008000" // rgb: 200, 165, 220
-	custom_metabolism = 0.05
-	overdose = REAGENTS_OVERDOSE
+	color = "#008000"
+	custom_metabolism = REAGENTS_METABOLISM * 0.25
 	taste_message = null
 
 /datum/reagent/arithrazine/on_general_digest(mob/living/M)
@@ -349,22 +313,22 @@
 	id = "alkysine"
 	description = "Alkysine is a drug used to lessen the damage to neurological tissue after a catastrophic injury. Can heal brain tissue."
 	reagent_state = LIQUID
-	color = "#8b00ff" // rgb: 200, 165, 220
-	custom_metabolism = 0.05
-	overdose = REAGENTS_OVERDOSE
+	color = "#8b00ff"
+	custom_metabolism = REAGENTS_METABOLISM * 0.25
 	taste_message = null
 
 /datum/reagent/alkysine/on_general_digest(mob/living/M)
 	..()
 	M.adjustBrainLoss(-3 * REM)
+	M.confused++
+	M.drowsyness++
 
 /datum/reagent/imidazoline
 	name = "Imidazoline"
 	id = "imidazoline"
 	description = "Heals eye damage"
 	reagent_state = LIQUID
-	color = "#a0dbff" // rgb: 200, 165, 220
-	overdose = REAGENTS_OVERDOSE
+	color = "#a0dbff"
 	taste_message = "carrot"
 	restrict_species = list(IPC, DIONA)
 
@@ -433,14 +397,19 @@
 	id = "bicaridine"
 	description = "Bicaridine is an analgesic medication and can be used to treat blunt trauma."
 	reagent_state = LIQUID
-	color = "#bf0000" // rgb: 200, 165, 220
-	overdose = REAGENTS_OVERDOSE
+	color = "#bf0000"
 	taste_message = null
 	restrict_species = list(IPC, DIONA)
 
 /datum/reagent/bicaridine/on_general_digest(mob/living/M, alien)
 	..()
 	M.heal_bodypart_damage(2 * REM, 0)
+	if(volume > overdose)
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			for(var/obj/item/organ/external/IO in H.organs)
+				if(IO.status & ORGAN_ARTERY_CUT && prob(2))
+					IO.status &= ~ORGAN_ARTERY_CUT
 
 /datum/reagent/hyperzine
 	name = "Hyperzine"
@@ -463,8 +432,9 @@
 	id = "cryoxadone"
 	description = "A chemical mixture with almost magical healing powers. Its main limitation is that the targets body temperature must be under 170K for it to metabolise correctly."
 	reagent_state = LIQUID
-	color = "#80bfff" // rgb: 200, 165, 220
-	taste_message = null
+	color = "#80bfff"
+	taste_message = "sludge"
+
 
 /datum/reagent/cryoxadone/on_general_digest(mob/living/M)
 	..()
@@ -479,8 +449,8 @@
 	id = "clonexadone"
 	description = "A liquid compound similar to that used in the cloning process. Can be used to 'finish' the cloning process when used in conjunction with a cryo tube."
 	reagent_state = LIQUID
-	color = "#8080ff" // rgb: 200, 165, 220
-	taste_message = null
+	color = "#8080ff"
+	taste_message = "slime"
 
 /datum/reagent/clonexadone/on_general_digest(mob/living/M)
 	..()
@@ -493,29 +463,20 @@
 /datum/reagent/rezadone
 	name = "Rezadone"
 	id = "rezadone"
-	description = "A powder derived from fish toxin, this substance can effectively treat genetic damage in humanoids, though excessive consumption has side effects."
+	description = "A powder with almost magical properties, this substance can effectively treat genetic damage in humanoids, though excessive consumption has side effects."
 	reagent_state = SOLID
 	color = "#669900" // rgb: 102, 153, 0
-	overdose = REAGENTS_OVERDOSE
-	taste_message = null
+	taste_message = "sickness"
 
 /datum/reagent/rezadone/on_general_digest(mob/living/M)
 	..()
-	if(!data)
-		data = 1
-	data++
-	switch(data)
-		if(1 to 15)
-			M.adjustCloneLoss(-1)
-			M.heal_bodypart_damage(1, 1)
-		if(15 to 35)
-			M.adjustCloneLoss(-2)
-			M.heal_bodypart_damage(2, 1)
-			M.status_flags &= ~DISFIGURED
-		if(35 to INFINITY)
-			M.adjustToxLoss(1)
-			M.make_dizzy(5)
-			M.make_jittery(5)
+	M.adjustCloneLoss(-2)
+	M.adjustOxyLoss(-2)
+	M.heal_bodypart_damage(2, 2)
+	M.adjustToxLoss(-2)
+	if(volume > 10)
+		M.make_dizzy(5)
+		M.make_jittery(5)
 
 /datum/reagent/spaceacillin
 	name = "Spaceacillin"
@@ -580,3 +541,18 @@
 	..()
 	M.nutrition = max(M.nutrition - nutriment_factor, 0)
 	M.overeatduration = 0
+
+/datum/reagent/noexcutite
+	name = "Noexcutite"
+	id = "noexcutite"
+	description = "A thick, syrupy liquid that has a lethargic effect. Used to cure cases of jitteriness."
+	taste_message = "numbing coldness"
+	reagent_state = LIQUID
+	color = "#bc018a"
+	overdose = REAGENTS_OVERDOSE
+	restrict_species = list(IPC, DIONA)
+
+/datum/reagent/noexcutite/on_general_digest(mob/living/M)
+	..()
+	M.make_jittery(-50)
+

--- a/code/modules/reagents/reagent_types/Chemistry-Medicine.dm
+++ b/code/modules/reagents/reagent_types/Chemistry-Medicine.dm
@@ -58,6 +58,7 @@
 	description = "A simple, yet effective painkiller. Don't mix with alcohol."
 	reagent_state = LIQUID
 	color = "#cb68fc"
+	overdose = REAGENTS_OVERDOSE
 	custom_metabolism = 0.05
 	restrict_species = list(IPC, DIONA)
 
@@ -214,6 +215,7 @@
 	description = "Tricordrazine is a highly potent stimulant, originally derived from cordrazine. Can be used to treat a wide range of injuries."
 	reagent_state = LIQUID
 	color = "#00b080" // rgb: 200, 165, 220
+	overdose = REAGENTS_OVERDOSE * 3 // Abuse prevention
 	taste_message = null
 	restrict_species = list(IPC, DIONA)
 
@@ -233,7 +235,7 @@
 	id = "anti_toxin"
 	description = "Dylovene is a broad-spectrum antitoxin."
 	reagent_state = LIQUID
-	color = "#00a000" // rgb: 200, 165, 220
+	color = "#00a000"
 	taste_message = null
 	restrict_species = list(IPC, DIONA)
 
@@ -249,7 +251,7 @@
 	id = "adminordrazine"
 	description = "It's magic. We don't have to explain it."
 	reagent_state = LIQUID
-	color = "#C8A5DC" // rgb: 200, 165, 220
+	color = "#C8A5DC"
 	taste_message = "admin abuse"
 
 /datum/reagent/adminordrazine/on_general_digest(mob/living/M)
@@ -261,7 +263,7 @@
 	id = "synaptizine"
 	description = "Synaptizine is used to treat various diseases."
 	reagent_state = LIQUID
-	color = "#99ccff" // rgb: 200, 165, 220
+	color = "#99ccff"
 	custom_metabolism = 0.01
 	overdose = REAGENTS_OVERDOSE
 	restrict_species = list(IPC, DIONA)
@@ -298,6 +300,7 @@
 	description = "Arithrazine is an unstable medication used for the most extreme cases of radiation poisoning."
 	reagent_state = LIQUID
 	color = "#008000"
+	overdose = REAGENTS_OVERDOSE
 	custom_metabolism = REAGENTS_METABOLISM * 0.25
 	taste_message = null
 
@@ -314,6 +317,7 @@
 	description = "Alkysine is a drug used to lessen the damage to neurological tissue after a catastrophic injury. Can heal brain tissue."
 	reagent_state = LIQUID
 	color = "#8b00ff"
+	overdose = REAGENTS_OVERDOSE
 	custom_metabolism = REAGENTS_METABOLISM * 0.25
 	taste_message = null
 
@@ -329,6 +333,7 @@
 	description = "Heals eye damage"
 	reagent_state = LIQUID
 	color = "#a0dbff"
+	overdose = REAGENTS_OVERDOSE
 	taste_message = "carrot"
 	restrict_species = list(IPC, DIONA)
 
@@ -348,7 +353,7 @@
 	id = "peridaxon"
 	description = "Used to encourage recovery of organs and nervous systems. Medicate cautiously."
 	reagent_state = LIQUID
-	color = "#561ec3" // rgb: 200, 165, 220
+	color = "#561ec3"
 	overdose = 10
 	taste_message = null
 	restrict_species = list(IPC, DIONA)
@@ -368,7 +373,7 @@
 	id = "kyphotorin"
 	description = "Used nanites to encourage recovery of body parts and bones. Medicate cautiously."
 	reagent_state = LIQUID
-	color = "#551a8b" // rgb: 85, 26, 139
+	color = "#551a8b"
 	overdose = 5.1
 	custom_metabolism = 0.07
 	taste_message = "machines"
@@ -398,6 +403,7 @@
 	description = "Bicaridine is an analgesic medication and can be used to treat blunt trauma."
 	reagent_state = LIQUID
 	color = "#bf0000"
+	overdose = REAGENTS_OVERDOSE
 	taste_message = null
 	restrict_species = list(IPC, DIONA)
 
@@ -466,17 +472,28 @@
 	description = "A powder with almost magical properties, this substance can effectively treat genetic damage in humanoids, though excessive consumption has side effects."
 	reagent_state = SOLID
 	color = "#669900" // rgb: 102, 153, 0
+	overdose = REAGENTS_OVERDOSE
 	taste_message = "sickness"
 
 /datum/reagent/rezadone/on_general_digest(mob/living/M)
 	..()
-	M.adjustCloneLoss(-2)
-	M.adjustOxyLoss(-2)
-	M.heal_bodypart_damage(2, 2)
-	M.adjustToxLoss(-2)
-	if(volume > 10)
-		M.make_dizzy(5)
-		M.make_jittery(5)
+	if(!data)
+		data = 1
+	data++
+	switch(data)
+		if(1 to 15)
+			M.adjustCloneLoss(-1)
+			M.adjustOxyLoss(-1)
+			M.adjustToxLoss(-1)
+			M.heal_bodypart_damage(1, 1)
+		if(15 to 35)
+			M.adjustCloneLoss(-2)
+			M.heal_bodypart_damage(2, 2)
+			M.status_flags &= ~DISFIGURED
+		if(35 to INFINITY)
+			M.adjustToxLoss(1)
+			M.make_dizzy(5)
+			M.make_jittery(5)
 
 /datum/reagent/spaceacillin
 	name = "Spaceacillin"
@@ -488,12 +505,12 @@
 	overdose = REAGENTS_OVERDOSE
 	taste_message = null
 
-/datum/reagent/ethylredoxrazine // FUCK YOU, ALCOHOL
+/datum/reagent/ethylredoxrazine
 	name = "Ethylredoxrazine"
 	id = "ethylredoxrazine"
 	description = "A powerful oxidizer that reacts with ethanol."
 	reagent_state = SOLID
-	color = "#605048" // rgb: 96, 80, 72
+	color = "#605048"
 	overdose = REAGENTS_OVERDOSE
 	taste_message = null
 
@@ -510,7 +527,7 @@
 	id = "vitamin"
 	description = "All the best vitamins, minerals, and carbohydrates the body needs in pure form."
 	reagent_state = SOLID
-	color = "#664330" // rgb: 102, 67, 48
+	color = "#664330"
 	taste_message = null
 
 /datum/reagent/vitamin/on_general_digest(mob/living/M)
@@ -554,5 +571,5 @@
 
 /datum/reagent/noexcutite/on_general_digest(mob/living/M)
 	..()
-	M.make_jittery(-50)
+	M.make_jittery(-20)
 

--- a/code/modules/reagents/reagent_types/Chemistry-Miscellaneous.dm
+++ b/code/modules/reagents/reagent_types/Chemistry-Miscellaneous.dm
@@ -319,14 +319,6 @@
 			M.drowsyness = min(40, (M.drowsyness + 2))
 	return TRUE
 
-/datum/reagent/ammonia
-	name = "Ammonia"
-	id = "ammonia"
-	description = "A caustic substance commonly used in fertilizer or household cleaners."
-	reagent_state = GAS
-	color = "#404030" // rgb: 64, 64, 48
-	taste_message = "floor cleaner"
-
 /datum/reagent/ultraglue
 	name = "Ultra Glue"
 	id = "glue"

--- a/code/modules/reagents/reagent_types/Chemistry-Miscellaneous.dm
+++ b/code/modules/reagents/reagent_types/Chemistry-Miscellaneous.dm
@@ -189,34 +189,6 @@
 	M.adjustToxLoss(2 * REM)
 	return FALSE
 
-/datum/reagent/fuel
-	name = "Welding fuel"
-	id = "fuel"
-	description = "Required for welders. Flamable."
-	reagent_state = LIQUID
-	color = "#660000" // rgb: 102, 0, 0
-	overdose = REAGENTS_OVERDOSE
-	taste_message = "motor oil"
-
-/datum/reagent/fuel/reaction_obj(obj/O, volume)
-	var/turf/the_turf = get_turf(O)
-	if(!the_turf)
-		return //No sense trying to start a fire if you don't have a turf to set on fire. --NEO
-	new /obj/effect/decal/cleanable/liquid_fuel(the_turf, volume)
-
-/datum/reagent/fuel/reaction_turf(turf/T, volume)
-	new /obj/effect/decal/cleanable/liquid_fuel(T, volume)
-
-/datum/reagent/fuel/on_general_digest(mob/living/M)
-	..()
-	M.adjustToxLoss(1)
-
-/datum/reagent/fuel/reaction_mob(mob/living/M, method=TOUCH, volume)//Splashing people with welding fuel to make them easy to ignite!
-	if(!istype(M, /mob/living))
-		return
-	if(method == TOUCH)
-		M.adjust_fire_stacks(volume / 10)
-
 /datum/reagent/space_cleaner
 	name = "Space cleaner"
 	id = "cleaner"

--- a/code/modules/reagents/reagent_types/Chemistry-Toxic.dm
+++ b/code/modules/reagents/reagent_types/Chemistry-Toxic.dm
@@ -461,8 +461,8 @@
 	taste_message = "stomach acid"
 	reagent_state = LIQUID
 	color = "#808080"
-	toxpwr = 1
-	meltprob = 5
+	toxpwr = 0.5
+	meltprob = 20
 
 /datum/reagent/toxin/acid/polyacid
 	name = "Polytrinic acid"

--- a/code/modules/reagents/reagent_types/Chemistry-Toxic.dm
+++ b/code/modules/reagents/reagent_types/Chemistry-Toxic.dm
@@ -378,6 +378,7 @@
 	description = "A very corrosive mineral acid with the molecular formula H2SO4."
 	reagent_state = LIQUID
 	color = "#DB5008" // rgb: 219, 80, 8
+	taste_message = "acid"
 	toxpwr = 1
 	var/meltprob = 10
 
@@ -452,6 +453,16 @@
 			for(var/mob/M in viewers(5, O))
 				to_chat(M, "<span class='warning'>\the [O] melts.</span>")
 			qdel(O)
+
+/datum/reagent/toxin/acid/hydrochloric //Like sulfuric, but less toxic and more acidic.
+	name = "Hydrochloric Acid"
+	id = "hacid"
+	description = "A very corrosive mineral acid with the molecular formula HCl."
+	taste_message = "stomach acid"
+	reagent_state = LIQUID
+	color = "#808080"
+	toxpwr = 1
+	meltprob = 5
 
 /datum/reagent/toxin/acid/polyacid
 	name = "Polytrinic acid"
@@ -646,7 +657,7 @@
 	reagent_state = LIQUID
 	color = "#60a584" // rgb: 96, 165, 132
 	custom_metabolism = REAGENTS_METABOLISM * 0.5
-	overdose = REAGENTS_OVERDOSE
+	overdose = REAGENTS_OVERDOSE / 3
 	restrict_species = list(IPC, DIONA)
 
 /datum/reagent/space_drugs/on_general_digest(mob/living/M)

--- a/code/modules/research/xenoarchaeology/chemistry.dm
+++ b/code/modules/research/xenoarchaeology/chemistry.dm
@@ -50,7 +50,7 @@ datum
 			name = "Lithium Sodium Tungstate"
 			id = "lithiumsodiumtungstate"
 			result = "lithiumsodiumtungstate"
-			required_reagents = list("lithium" = 1, "sodium" = 2, "tungsten" = 1, "oxygen" = 4)
+			required_reagents = list("lithium" = 1, "sodium" = 2, "tungsten" = 1, "acetone" = 4)
 			result_amount = 8
 
 		density_separated_liquid
@@ -100,12 +100,12 @@ obj/item/weapon/reagent_containers/glass/solution_tray/attackby(obj/item/weapon/
 	reagents.add_reagent("tungsten",50)
 	update_icon()
 
-/obj/item/weapon/reagent_containers/glass/beaker/oxygen
-	name = "beaker 'oxygen'"
+/obj/item/weapon/reagent_containers/glass/beaker/acetone
+	name = "beaker 'acetone'"
 
-/obj/item/weapon/reagent_containers/glass/beaker/oxygen/atom_init()
+/obj/item/weapon/reagent_containers/glass/beaker/acetone/atom_init()
 	. = ..()
-	reagents.add_reagent("oxygen",50)
+	reagents.add_reagent("acetone",50)
 	update_icon()
 
 /obj/item/weapon/reagent_containers/glass/beaker/sodium

--- a/code/modules/research/xenoarchaeology/machinery/coolant.dm
+++ b/code/modules/research/xenoarchaeology/machinery/coolant.dm
@@ -10,7 +10,7 @@
 	name = "Coolant"
 	id = "coolant"
 	result = "coolant"
-	required_reagents = list("tungsten" = 1, "oxygen" = 1, "water" = 1)
+	required_reagents = list("tungsten" = 1, "acetone" = 1, "water" = 1)
 	result_amount = 3
 
 /obj/structure/reagent_dispensers/coolanttank

--- a/taucetistation.dme
+++ b/taucetistation.dme
@@ -25,6 +25,7 @@
 #include "code\__DEFINES\atmos.dm"
 #include "code\__DEFINES\atmospherics.dm"
 #include "code\__DEFINES\callbacks.dm"
+#include "code\__DEFINES\chemistry.dm"
 #include "code\__DEFINES\clothing.dm"
 #include "code\__DEFINES\colors.dm"
 #include "code\__DEFINES\combat.dm"


### PR DESCRIPTION
Выпилены реагенты: воздух, водород, азот, хлор и фтор. Вместо них теперь ацетон, аммиак (он и был, но теперь это базовый реагент), соляная кислота и гидразин. Зачем? Воздух и тд в жидкой форме - очень странно, а еще, когда кто-нибудь будет рефакторить химию полностью, не придется этим заниматься.

Новый препарат с бея noexcutite - успокаивает персонажа и тот перестает трястись

Удалил не использующийся srejuvenate, админордрацин теперь просто ревайвает

Макросы, связанные с химикатами вынесены в отдельный файл. Убрал юзелес дефайн `REAGENTS_EFFECT_MULTIPLIER`, вместе него теперь просто `REM`, т.к это попросту одно и то же.
Кор-реагенты отсортированы в алфавитном порядке (сортировать остальное не стал, нужно ли?)

Некоторые лекарства получили дополнительные эффекты, некоторые забафал, некоторые занерфал, например:
Дексп быстрее убирает лексорин, бикардин при передозировке лечит артерии (вроде не лечит, тут нужна помощь), трамадол и оксикодон стал давать больше интересных эффектов, а при применении их вместе с алкоголем начинается гипоксия, резадон стал эффективнее (его не станут варить чаще, но все же)

Попозже, если и когда дело пойдет к моржу, распишу все игровые изменения подробнее, чтобы люди могли посмотреть чо поменялось, не залезая в код, пока вики не обновят
:cl:
 - balance: Трамадол и оксикодон нельзя принимать вместе с алкоголем!
 - rscadd: Препарат noexcutite, успокаивающий трясущихся людей (ксеносов тоже).
 - rscadd: Передозировка бикардином лечит артерии.
 - tweak[link]: Часть базовых реагентов в химии заменена на ацетон, аммиак, гидразин и соляную кислоту. Некоторые препараты обзавелись новыми эффектами.