### PR TITLE
Указание авторства спрайтов для флафа

### DIFF
--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -10,6 +10,7 @@
 	body_parts_covered = UPPER_TORSO|ARMS
 	allowed = list(/obj/item/device/analyzer,/obj/item/stack/medical,/obj/item/weapon/dnainjector,/obj/item/weapon/reagent_containers/dropper,/obj/item/weapon/reagent_containers/syringe,/obj/item/weapon/reagent_containers/hypospray,/obj/item/device/healthanalyzer,/obj/item/device/flashlight/pen,/obj/item/weapon/reagent_containers/glass/bottle,/obj/item/weapon/reagent_containers/glass/beaker,/obj/item/weapon/reagent_containers/pill,/obj/item/weapon/storage/pill_bottle,/obj/item/weapon/paper)
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 50, rad = 0)
+	var/base_icon_state = null // used for fluff labcoats
 
 /obj/item/clothing/suit/storage/labcoat/verb/toggle()
 	set name = "Toggle Labcoat Buttons"
@@ -23,7 +24,10 @@
 		return 0
 
 	if(!src.is_button_up)
-		src.icon_state = initial(icon_state)
+		if(base_icon_state)
+			icon_state = base_icon_state
+		else
+			icon_state = initial(icon_state)
 		to_chat(usr, "You button up your labcoat.")
 		src.is_button_up = 1
 	else

--- a/code/modules/fluff/customitems.dm
+++ b/code/modules/fluff/customitems.dm
@@ -231,6 +231,7 @@ var/savefile/customItemsCache = new /savefile("data/customItemsCache.sav")
 				var/obj/item/clothing/suit/storage/labcoat/custom/labcoat = new /obj/item/clothing/suit/storage/labcoat/custom()
 				if(!("[custom_item_info.icon_state]_open" in icon_states(custom_item_info.icon)))
 					labcoat.can_button_up = FALSE
+				labcoat.base_icon_state = custom_item_info.icon_state
 				item = labcoat
 
 		if(!item)

--- a/code/modules/fluff/customitems.dm
+++ b/code/modules/fluff/customitems.dm
@@ -53,6 +53,9 @@ var/savefile/customItemsCache = new /savefile("data/customItemsCache.sav")
 	var/status // submitted accepted rejected
 	var/moderator_message
 
+	var/sprite_author
+	var/info
+
 /client/proc/get_custom_items_slot_count()
 	customItemsCache.cd = "/"
 	var/list/slots = null
@@ -234,6 +237,8 @@ var/savefile/customItemsCache = new /savefile("data/customItemsCache.sav")
 			continue
 		item.name = custom_item_info.name
 		item.desc = custom_item_info.desc
+		if(custom_item_info.sprite_author)
+			item.desc = "[item.desc]<br><small><span style='color:#00BFFF;'><i>sprite author:</i> [custom_item_info.sprite_author]</span></small>"
 		item.icon = custom_item_info.icon
 		item.icon_custom = custom_item_info.icon
 		item.icon_state = custom_item_info.icon_state

--- a/code/modules/fluff/fluffmenu.dm
+++ b/code/modules/fluff/fluffmenu.dm
@@ -84,7 +84,7 @@ var/list/editing_item_oldname_list = list()
 
 	dat += "<table cellspacing='0' width='100%'>"
 	dat += "<tr>"
-	dat += "<td>Type</td>"
+	dat += "<td width=110>Type</td>"
 	dat += "<td>[readonly?"<b>[editing_item.item_type]</b>":"<a class='small' href='?_src_=prefs;preference=fluff;change_type=1'>[editing_item.item_type]</a>"]</td>"
 	dat += "</tr>"
 	dat += "<tr>"
@@ -104,6 +104,14 @@ var/list/editing_item_oldname_list = list()
 	dat += "<td>Icon name</td>"
 	dat += "<td>[readonly?"<b>[editing_item.icon_state]</b>":"<a class='small' href='?_src_=prefs;preference=fluff;change_iconname=1'>[editing_item.icon_state]</a>"]</td>"
 	dat += "</tr>"
+	dat += "<tr>"
+	dat += "<td>Sprite author<a class='small' href='?_src_=prefs;preference=fluff;author_info=1'>\[?\]</a></td>"
+	dat += "<td>[readonly?"<b>[editing_item.sprite_author ? editing_item.sprite_author : "no author"]</b>":"<a class='small' href='?_src_=prefs;preference=fluff;change_author=1'>[editing_item.sprite_author ? editing_item.sprite_author : "no author"]</a>"]</td>"
+	dat += "</tr>"
+	dat += "<tr>"
+	dat += "<td>OOC Info<a class='small' href='?_src_=prefs;preference=fluff;ooc_info=1'>\[?\]</a></td>"
+	dat += "<td>[readonly?"<b>[editing_item.info ? editing_item.info : "no info"]</b>":"<a class='small' href='?_src_=prefs;preference=fluff;change_oocinfo=1'>[editing_item.info ? editing_item.info : "no info"]</a>"]</td>"
+	dat += "</tr>"
 	dat += "</table></div>"
 
 	if(!readonly)
@@ -116,7 +124,7 @@ var/list/editing_item_oldname_list = list()
 		dat += " <a class='small' href='?_src_=prefs;preference=fluff;download=1'>Download icon</a>"
 
 	dat += "</body></html>"
-	user << browse(entity_ja(dat), "window=edit_custom_item;size=400x500;can_minimize=0;can_maximize=0;can_resize=0")
+	user << browse(entity_ja(dat), "window=edit_custom_item;size=400x600;can_minimize=0;can_maximize=0;can_resize=0")
 
 /datum/preferences/proc/process_link_fluff(mob/user, list/href_list)
 	var/datum/custom_item/editing_item = editing_item_list[user.client.ckey]
@@ -197,6 +205,44 @@ var/list/editing_item_oldname_list = list()
 		edit_custom_item_panel(src, user)
 		return
 
+	if(href_list["author_info"])
+		alert(user, "If you are submitting sprites from another build or made by another person you must first ask their permission and then give them credit by putting their name here", "Info", "OK")
+		return
+
+	if(href_list["change_author"])
+		var/new_sprite_author = sanitize(input("Enter sprite author:", "Text")  as text|null)
+		if(!editing_item)
+			return
+
+		if(!new_sprite_author)
+			editing_item.sprite_author = null
+		else if(length(new_sprite_author) > 100)
+			return
+		else
+			editing_item.sprite_author = new_sprite_author
+
+		edit_custom_item_panel(src, user)
+		return
+
+	if(href_list["ooc_info"])
+		alert(user, "Not shown ingame. You may put here anything that you think is important about your item. Will only be visible here to you and premoderation admins", "Info", "OK")
+		return
+
+	if(href_list["change_oocinfo"])
+		var/new_ooc_info = sanitize(input("Enter item ooc information:", "Text")  as text|null)
+		if(!editing_item)
+			return
+
+		if(!new_ooc_info)
+			editing_item.info = null
+		else if(length(new_ooc_info) > 500)
+			return
+		else
+			editing_item.info = new_ooc_info
+
+		edit_custom_item_panel(src, user)
+		return
+
 	if(href_list["submit"])
 		if(!editing_item || !editing_item.icon || !editing_item.icon_state)
 			return
@@ -246,6 +292,7 @@ var/list/editing_item_oldname_list = list()
 			return
 
 		usr << ftp(editing_item.icon)
+		return
 
 	if(href_list["upload_icon"])
 		var/new_item_icon = input("Pick icon:","Icon") as null|icon


### PR DESCRIPTION
Добавляем возможность указывать оригинального автора используемого спрайта и добавлять OOC информацию о предмете для принимающих админов
![default](https://user-images.githubusercontent.com/14040378/52110068-8f7a4d00-2610-11e9-8bc8-d6c18695fde0.png)
![default](https://user-images.githubusercontent.com/14040378/52110104-a620a400-2610-11e9-98a2-722e96784fce.png)

also fixes #3060 
:cl:
- tweak: Возможность указать оригинального автора спрайта для флафа и ooc информацию