### PR TITLE
Небольшие изменения касательно ingame age

### DIFF
--- a/code/__DEFINES/varedit.dm
+++ b/code/__DEFINES/varedit.dm
@@ -1,0 +1,33 @@
+/* protected types */
+
+#define VE_PROTECTED_TYPES list(\
+		/datum/admins,\
+		/datum/configuration,\
+		/obj/machinery/blackbox_recorder,\
+		/datum/feedback_variable,\
+		/datum/timedevent,\
+		/datum/craft_or_build,\
+		/datum/stack_recipe,\
+		/datum/events,\
+		/obj/effect/bmode/,\
+	)
+
+
+/* protected variables */
+
+#define VE_ICONS \
+	list("resize") // R_DEBUG|R_EVENT required
+#define VE_DEBUG \
+	list("vars", "virus", "viruses", "mutantrace", "summon_type", "AI_Interact", "key", "ckey", "client")
+#define VE_FULLY_LOCKED \
+	list("holder", "player_next_age_tick", "player_ingame_age", "resize_rev", "step_x", "step_y")
+
+
+/* massmodify protected */
+
+#define VE_MASS_ICONS \
+	list("icon", "icon_state", "resize") // R_DEBUG|R_EVENT required
+#define VE_MASS_DEBUG \
+	list("vars", "virus", "viruses", "mutantrace", "summon_type", "AI_Interact")
+#define VE_MASS_FULLY_LOCKED \
+	list("holder", "player_next_age_tick", "player_ingame_age", "resize_rev", "step_x", "step_y", "key", "ckey", "client")

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -139,6 +139,8 @@
 	var/ban_legacy_system = 0	//Defines whether the server uses the legacy banning system with the files in /data or the SQL system. Config option in config.txt
 	var/use_age_restriction_for_jobs = 0 //Do jobs use account age restrictions? --requires database
 	var/use_ingame_minutes_restriction_for_jobs = 0 //Do jobs use in-game minutes instead account age for restrictions?
+	
+	var/add_player_age_value = 4000 //default minuts added with admin "Increase player age" button
 
 	var/byond_version_min = 0
 	var/byond_version_recommend = 0
@@ -243,6 +245,9 @@
 
 				if ("use_ingame_minutes_restriction_for_jobs")
 					config.use_ingame_minutes_restriction_for_jobs = 1
+
+				if ("add_player_age_value")
+					config.add_player_age_value = text2num(value)
 
 				if ("log_ooc")
 					config.log_ooc = 1

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -175,7 +175,8 @@ var/list/admin_verbs_debug = list(
 	/client/proc/toggledebuglogs,
 	/client/proc/view_runtimes,
 	/client/proc/cmd_display_del_log,
-	/client/proc/cmd_display_init_log
+	/client/proc/cmd_display_init_log,
+	/client/proc/add_player_age,
 	)
 var/list/admin_verbs_possess = list(
 	/proc/possess,
@@ -269,6 +270,7 @@ var/list/admin_verbs_hideable = list(
 	/client/proc/cmd_debug_tog_aliens,
 	/client/proc/cmd_debug_tog_vcounter,
 	/client/proc/enable_debug_verbs,
+	/client/proc/add_player_age,
 	/proc/possess,
 	/proc/release
 	)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -86,7 +86,8 @@ var/list/admin_verbs_log = list(
 	/client/proc/investigate_show,		/*various admintools for investigation. Such as a singulo grief-log*/
 	)
 var/list/admin_verbs_variables = list(
-	/client/proc/debug_variables 		/*allows us to -see- the variables of any instance in the game. +VAREDIT needed to modify*/
+	/client/proc/debug_variables,
+	/client/proc/add_player_age, 		/*allows us to -see- the variables of any instance in the game. +VAREDIT needed to modify*/
 	)
 var/list/admin_verbs_ban = list(
 	/client/proc/unban_panel
@@ -176,7 +177,6 @@ var/list/admin_verbs_debug = list(
 	/client/proc/view_runtimes,
 	/client/proc/cmd_display_del_log,
 	/client/proc/cmd_display_init_log,
-	/client/proc/add_player_age,
 	)
 var/list/admin_verbs_possess = list(
 	/proc/possess,

--- a/code/modules/admin/verbs/buildmode.dm
+++ b/code/modules/admin/verbs/buildmode.dm
@@ -162,15 +162,14 @@
 					if(ispath(objholder,/mob) && !check_rights(R_DEBUG,0))
 						objholder = /obj/structure/closet
 			if(3)
-				var/list/locked = list("vars", "key", "ckey", "client", "virus", "viruses", "icon", "icon_state")
-				var/list/fully_locked = list("resize", "resize_rev")
-
 				master.buildmode.varholder = sanitize(input(usr,"Enter variable name:" ,"Name", "name"))
-				if(master.buildmode.varholder in fully_locked)
-					to_chat(usr, "\red It is forbidden to edit this variable.")
+				if(master.buildmode.varholder in VE_MASS_FULLY_LOCKED)
+					to_chat(usr, "<span class='warning'>It is forbidden to edit this variable.</span>")
 					return
-				if(master.buildmode.varholder in locked && !check_rights(R_DEBUG,0))
-					return 1
+				if((master.buildmode.varholder in VE_MASS_DEBUG) && !check_rights(R_DEBUG))
+					return
+				if((master.buildmode.varholder in VE_MASS_ICONS) && !check_rights(R_DEBUG|R_EVENT))
+					return
 				var/thetype = input(usr,"Select variable type:" ,"Type") in list("text","number","mob-reference","obj-reference","turf-reference")
 				if(!thetype) return 1
 				switch(thetype)

--- a/code/modules/admin/verbs/massmodvar.dm
+++ b/code/modules/admin/verbs/massmodvar.dm
@@ -26,11 +26,7 @@
 /client/proc/massmodify_variables(atom/O, var_name = "", method = 0)
 	if(!check_rights(R_VAREDIT))	return
 
-	var/list/icons_modifying = list("icon", "icon_state", "resize")
-	var/list/locked = list("vars", "summon_type")
-	var/list/fully_locked = list("holder", "key", "ckey", "client", "player_next_age_tick", "player_ingame_age", "resize_rev", "step_x", "step_y")
-
-	if(is_type_in_list(O, forbidden_varedit_object_types))
+	if(is_type_in_list(O, VE_PROTECTED_TYPES))
 		to_chat(usr, "\red It is forbidden to edit this object's variables.")
 		return
 
@@ -54,14 +50,14 @@
 	var/var_value = O.vars[variable]
 	var/dir
 
-	if(variable in fully_locked)
+	if(variable in VE_MASS_FULLY_LOCKED)
 		to_chat(usr, "\red It is forbidden to edit this variable.")
 		return
 
-	if((variable in locked) && !check_rights(R_DEBUG))
+	if((variable in VE_MASS_DEBUG) && !check_rights(R_DEBUG))
 		return
 
-	if((variable in icons_modifying) && !check_rights(R_DEBUG|R_EVENT))
+	if((variable in VE_MASS_ICONS) && !check_rights(R_DEBUG|R_EVENT))
 		return
 
 	if(isnull(var_value))

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -1,14 +1,3 @@
-var/list/forbidden_varedit_object_types = list(
-		/datum/admins,                     //Admins editing their own admin-power object? Yup, sounds like a good idea.
-		/datum/configuration,
-		/obj/machinery/blackbox_recorder,  //Prevents people messing with feedback gathering
-		/datum/feedback_variable,          //Prevents people messing with feedback gathering
-		/datum/timedevent,                 //Nope.avi
-		/datum/craft_or_build,
-		/datum/stack_recipe,
-		/datum/events,
-	)
-
 /client/proc/cmd_modify_ticker_variables()
 	set category = "Debug"
 	set name = "Edit Ticker Variables"
@@ -271,12 +260,7 @@ var/list/forbidden_varedit_object_types = list(
 /client/proc/modify_variables(atom/O, param_var_name = null, autodetect_class = 0)
 	if(!check_rights(R_VAREDIT))	return
 
-	var/list/icons_modifying = list("resize")
-	var/list/locked = list("vars", "key", "ckey", "client", "virus", "viruses", "mutantrace", "player_ingame_age", "summon_type", "AI_Interact")
-	var/list/typechange_locked = list("player_next_age_tick","player_ingame_age")
-	var/list/fully_locked = list("holder", "player_next_age_tick", "resize_rev", "step_x", "step_y")
-
-	if(is_type_in_list(O, forbidden_varedit_object_types))
+	if(is_type_in_list(O, VE_PROTECTED_TYPES))
 		to_chat(usr, "\red It is forbidden to edit this object's variables.")
 		return
 
@@ -289,17 +273,14 @@ var/list/forbidden_varedit_object_types = list(
 			to_chat(src, "A variable with this name ([param_var_name]) doesn't exist in this atom ([O])")
 			return
 
-		if(param_var_name in fully_locked)
+		if(param_var_name in VE_FULLY_LOCKED)
 			to_chat(usr, "\red It is forbidden to edit this variable.")
 			return
 
-		if(!autodetect_class && (param_var_name in typechange_locked))
+		if((param_var_name in VE_DEBUG) && !check_rights(R_DEBUG))
 			return
 
-		if((param_var_name in locked) && !check_rights(R_DEBUG))
-			return
-
-		if((param_var_name in icons_modifying) && !check_rights(R_DEBUG|R_EVENT))
+		if((param_var_name in VE_ICONS) && !check_rights(R_DEBUG|R_EVENT))
 			return
 
 		variable = param_var_name
@@ -356,7 +337,7 @@ var/list/forbidden_varedit_object_types = list(
 		if(!variable)	return
 		var_value = O.vars[variable]
 
-		if(variable == "holder" || (variable in locked))
+		if(variable == "holder" || (variable in VE_DEBUG))
 			if(!check_rights(R_DEBUG))	return
 
 	if(!autodetect_class)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1108,3 +1108,24 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	feedback_add_details("admin_verb","FAXMESS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	message_admins("Fax message was created by [key_name_admin(usr)] and sent to [department]")
 	send2slack_custommsg("Fax message was created by [key_name_admin(usr)] and sent to [department]: [sent_text]")
+
+/client/proc/add_player_age()
+	set category = "Debug"
+	set name = "Increase player age"
+	set desc = "Allow a new player to skip the job time limits."
+
+	if(!check_rights(R_DEBUG))
+		return
+
+	var/client/target = input("Select player to increase his in-game age to [config.add_player_age_value] minutes") as null|anything in clients
+
+	if(!target)
+		return
+
+	if(target.player_ingame_age < config.add_player_age_value)
+		log_admin("[key_name(usr)] increased [key_name(target)] in-game age from [target.player_ingame_age] to [config.add_player_age_value]")
+		message_admins("[key_name_admin(usr)] increased [key_name_admin(target)] in-game age from [target.player_ingame_age] to [config.add_player_age_value]")
+
+		target.player_ingame_age = config.add_player_age_value
+	else
+		to_chat(src, "This player already has more minutes than [config.add_player_age_value]!")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1110,11 +1110,11 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	send2slack_custommsg("Fax message was created by [key_name_admin(usr)] and sent to [department]: [sent_text]")
 
 /client/proc/add_player_age()
-	set category = "Debug"
+	set category = "Server"
 	set name = "Increase player age"
 	set desc = "Allow a new player to skip the job time restrictions."
 
-	if(!check_rights(R_DEBUG))
+	if(!check_rights(R_VAREDIT))
 		return
 
 	if(!config.use_ingame_minutes_restriction_for_jobs)
@@ -1125,10 +1125,19 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!target)
 		return
 
-	if(target.player_ingame_age < config.add_player_age_value)
-		log_admin("[key_name(usr)] increased [key_name(target)] in-game age from [target.player_ingame_age] to [config.add_player_age_value]")
-		message_admins("[key_name_admin(usr)] increased [key_name_admin(target)] in-game age from [target.player_ingame_age] to [config.add_player_age_value]")
+	var/value = config.add_player_age_value
+	if(check_rights(R_PERMISSIONS,0) && alert("As +PERMISSIONS user you can set custom value. Set custom?", "Custom age?", "Yes", "No") == "Yes")
+		value = input("Enter custom in-game age value") as num|null
 
-		target.player_ingame_age = config.add_player_age_value
+	if(!value)
+		return
+
+	if(target.player_ingame_age < value)
+		notes_add(target.ckey, "PLAYERAGE: increased in-game age from [target.player_ingame_age] to [value]", src)
+
+		log_admin("[key_name(usr)] increased [key_name(target)] in-game age from [target.player_ingame_age] to [value]")
+		message_admins("[key_name_admin(usr)] increased [key_name_admin(target)] in-game age from [target.player_ingame_age] to [value]")
+
+		target.player_ingame_age = value
 	else
-		to_chat(src, "This player already has more minutes than [config.add_player_age_value]!")
+		to_chat(src, "This player already has more minutes than [value]!")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1112,9 +1112,12 @@ Traitors and the like can also be revived with the previous role mostly intact.
 /client/proc/add_player_age()
 	set category = "Debug"
 	set name = "Increase player age"
-	set desc = "Allow a new player to skip the job time limits."
+	set desc = "Allow a new player to skip the job time restrictions."
 
 	if(!check_rights(R_DEBUG))
+		return
+
+	if(!config.use_ingame_minutes_restriction_for_jobs)
 		return
 
 	var/client/target = input("Select player to increase his in-game age to [config.add_player_age_value] minutes") as null|anything in clients

--- a/code/modules/client/character menu/occupation.dm
+++ b/code/modules/client/character menu/occupation.dm
@@ -8,13 +8,16 @@
 
 	switch(alternate_option)
 		if(GET_RANDOM_JOB)
-			. += "<u><a href='?_src_=prefs;preference=job;task=random'><font color=green>Get random job if preferences unavailable</font></a></u>"
+			. += "<u><a href='?_src_=prefs;preference=job;task=random'><font color=green>\[Get random job if preferences unavailable\]</font></a></u>"
 		if(BE_ASSISTANT)
-			. += "<u><a href='?_src_=prefs;preference=job;task=random'><font color=red>Be assistant if preference unavailable</font></a></u>"
+			. += "<u><a href='?_src_=prefs;preference=job;task=random'><font color=red>\[Be assistant if preference unavailable\]</font></a></u>"
 		if(RETURN_TO_LOBBY)
-			. += "<u><a href='?_src_=prefs;preference=job;task=random'><font color=purple>Return to lobby if preference unavailable</font></a></u>"
+			. += "<u><a href='?_src_=prefs;preference=job;task=random'><font color=purple>\[Return to lobby if preference unavailable\]</font></a></u>"
 
 	. += "<br><a href='?_src_=prefs;preference=job;task=reset'>\[Reset\]</a>"
+
+	if(config.use_ingame_minutes_restriction_for_jobs && config.add_player_age_value && user.client.player_ingame_age < config.add_player_age_value)
+		. += "<br><span style='color: red; font-style: italic; font-size: 12px;'>If you are experienced SS13 player, you can ask admins about the possibility of skipping minutes restriction for jobs.</span>"
 
 	. += "<table width='100%' cellpadding='1' cellspacing='0' style='margin-top:10px'><tr><td width='20%'>" // Table within a table for alignment, also allows you to easily add more colomns.
 	. += "<table width='100%' cellpadding='1' cellspacing='0'>"

--- a/code/modules/fluff/customitems.dm
+++ b/code/modules/fluff/customitems.dm
@@ -69,7 +69,7 @@ var/savefile/customItemsCache = new /savefile("data/customItemsCache.sav")
 	if(supporter)
 		ammount += 1
 
-	if(holder)
+	if(ckey in admin_datums)
 		ammount += 1
 
 	if(player_ingame_age >= config.customitem_slot_by_time)

--- a/code/modules/fluff/customitems.dm
+++ b/code/modules/fluff/customitems.dm
@@ -69,6 +69,9 @@ var/savefile/customItemsCache = new /savefile("data/customItemsCache.sav")
 	if(supporter)
 		ammount += 1
 
+	if(holder)
+		ammount += 1
+
 	if(player_ingame_age >= config.customitem_slot_by_time)
 		ammount += 1
 

--- a/taucetistation.dme
+++ b/taucetistation.dme
@@ -52,6 +52,7 @@
 #include "code\__DEFINES\subsystem.dm"
 #include "code\__DEFINES\tick.dm"
 #include "code\__DEFINES\traits.dm"
+#include "code\__DEFINES\varedit.dm"
 #include "code\__DEFINES\zas.dm"
 #include "code\__HELPERS\atmospherics.dm"
 #include "code\__HELPERS\cmp.dm"


### PR DESCRIPTION
* Добавление флафф-слота для админов (обоснование в чеинжлоге, можно вынести на обсуждение)
* Запрет на свободное редактирование игрового времени игрока
* Отдельная кнопка для увеличения ингейм времени до 4к, что бы опытные игроки могли пропустить джоб лимиты. "4к" выбрано потому, что при вводе системы с ингейм временем всем старым игрокам по дефолту накидывалось именно столько же минут.
* Небольшие правки к VV-протекту

Извиняюсь за многообразие, не знаю как так получилось.

:cl:
 - rscadd: Опытные игроки Спесс Стейшен 13 без игрового времени на нашем конкретном сервере могут попросить админа о пропуске лимитов на профессии. Не каждая просьба будет одобрена, зависит от игрока.
 - rscadd: Один флафф-слот для админов. Кое-кто сильно жаловался, что ему не хватает времени на игру, что бы получить свой флафф за игровой возраст, а время администрирования не засчитывается.