### PR TITLE
loadout fix

### DIFF
--- a/code/modules/client/character menu/loadout/loadout_clothing.dm
+++ b/code/modules/client/character menu/loadout/loadout_clothing.dm
@@ -141,7 +141,7 @@
 /datum/gear/under/pants/New()
 	..()
 	var/list/pants = list()
-	for(var/pant in typesof(/obj/item/clothing/under/pants) - /obj/item/clothing/under/pants)
+	for(var/pant in subtypesof(/obj/item/clothing/under/pants))
 		var/obj/item/clothing/under/pants/pant_type = pant
 		pants[initial(pant_type.name)] = pant_type
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(pants))

--- a/code/modules/client/character menu/loadout/loadout_clothing.dm
+++ b/code/modules/client/character menu/loadout/loadout_clothing.dm
@@ -141,7 +141,7 @@
 /datum/gear/under/pants/New()
 	..()
 	var/list/pants = list()
-	for(var/pant in typesof(/obj/item/clothing/under/pants))
+	for(var/pant in typesof(/obj/item/clothing/under/pants) - /obj/item/clothing/under/pants)
 		var/obj/item/clothing/under/pants/pant_type = pant
 		pants[initial(pant_type.name)] = pant_type
 	gear_tweaks += new/datum/gear_tweak/path(sortAssoc(pants))


### PR DESCRIPTION
Убрал из списка родительский тип, которого там быть не должно. Ватлер при мне вчера словил этот баг.

:cl: Richard Jones
 - bugfix: Из лодаута пропала возможность выбрать "under" в pants selection, который не имел спрайта.
