### PR TITLE
Удаляет очки у офицера нравов

### DIFF
--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -65,7 +65,6 @@
 			if("Vice Officer")
 				H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/vice	(H), slot_w_uniform)
 				H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
-				H.equip_to_slot_or_del(new /obj/item/clothing/glasses/sunglasses(H), slot_glasses)
 			if("Paranormal Investigator")
 				H.equip_to_slot_or_del(new /obj/item/clothing/under/fluff/indiana	(H), slot_w_uniform)
 				H.equip_to_slot_or_del(new /obj/item/clothing/shoes/brown(H), slot_shoes)

--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -41,7 +41,6 @@
 				H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/mecha_operator(H), slot_w_uniform)
 				H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), slot_shoes)
 				H.equip_to_slot_or_del(new /obj/item/clothing/gloves/fingerless(H), slot_gloves)
-				H.equip_to_slot_or_del(new /obj/item/clothing/glasses/sunglasses(H), slot_glasses)
 			if("Private Eye")
 				H.equip_to_slot_or_del(new /obj/item/clothing/under/color/black(H), slot_w_uniform)
 				H.equip_to_slot_or_del(new /obj/item/clothing/shoes/jackboots(H), slot_shoes)


### PR DESCRIPTION
<!--
Подробно про оформление ПРов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
Там же написано про то, как сделать чейнджлог. 

!!!
Если авторство не полностью ваше, вы делаете порт с другого билда - укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
!!!

Для копипаста:
Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment.

Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
Офицера нравов использовали как замену ассистенту ради санглассесов со старта, дабы всякие роли и офицеры их не пожрали. Удаляю очки, потому что только из-за них и выбирают эту недооцененную подпрофу.
:cl: 
- balance: Офицер нравов и оператор мехов спавнятся без очков.