### PR TITLE
Изменения кнопки смеха

### DIFF
--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -225,8 +225,7 @@
 			)
 
 		for(var/mob/M in viewers(user, null))
-			if(M.client && M.ear_deaf <= 0)
-				M << sound(laugh, volume = 50)
+			M.playsound_local(null, laugh, 50, 2)
 
 		flick("laugh_button_down",src)
 		icon_state = "laugh_button_off"

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -217,12 +217,17 @@
 	if(!cooldown)
 		user.visible_message("<span class='notice'>[bicon(src)] \the [user] presses \the [src]</span>")
 		playsound(src, 'sound/items/buttonclick.ogg', 50, 1)
+
 		var/laugh = pick(
 			'sound/voice/fake_laugh/laugh1.ogg',
 			'sound/voice/fake_laugh/laugh2.ogg',
 			'sound/voice/fake_laugh/laugh3.ogg',
 			)
-		playsound(src, laugh, 50, 1)
+
+		for(var/mob/M in viewers(user, null))
+			if(M.client && M.ear_deaf <= 0)
+				M << sound(laugh, volume = 50)
+
 		flick("laugh_button_down",src)
 		icon_state = "laugh_button_off"
 		cooldown = TRUE


### PR DESCRIPTION
Была проблема с кнопкой смеха, о которой сообщили игроки. Смех был хорошо слышен тому, кто нажимает кнопку, НО все остальные слышали его ужасно тихо. Причем если стоишь не на соседнем тайле то вообще почти не слышно. Поэтому я решил немного переделать код, чтобы звук для всех был одинаковой громкости (прямо как в ситкомах, ха)

:cl: Richard Jones
 - tweak: "Кнопка смеха" теперь проигрывает смех с одинаковой для всех слышащих её громкостью.
