### PR TITLE
Fix goonchat scroll problem when reaching a msg limit

### DIFF
--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -12,8 +12,8 @@ html, body {
 body {
 	background: #fff;
 	font-family: Verdana, "Helvetica Neue", Helvetica, Arial, sans-serif;
-	font-size: 9pt;
-	line-height: 1.2;
+	font-size: 14px;
+	line-height: 18px;
 	overflow-x: hidden;
 	overflow-y: scroll;
 	word-wrap: break-word;
@@ -22,7 +22,6 @@ body {
 img {
 	margin: 0;
 	padding: 0;
-	line-height: 1;
 	/* -ms-interpolation-mode: nearest-neighbor; */
 	/* image-rendering: pixelated; */
 }
@@ -87,7 +86,7 @@ a.popt {text-decoration: none;}
 	background: #ddd;
 	text-decoration: none;
 	font-variant: small-caps;
-	font-size: 1.1em;
+	font-size: 16px;
 	font-weight: bold;
 	color: #333;
 }
@@ -106,7 +105,7 @@ a.popt {text-decoration: none;}
 #ping .ms {
 	display: block;
 	text-align: center;
-	font-size: 8pt;
+	font-size: 10px;
 	padding-top: 2px;
 }
 #userBar {


### PR DESCRIPTION
Первая проблема заключалась в отсутствии компенсации для скролла высоты удаленного сообщения - причем, раньше оно у нас было, но я скопипастил баг с /tg/
Вторая проблема с не целыми размерами высоты сообщений и тем, как оно рендерилось в IE - сообщения немного могли скакать вверх/вниз при перерисовке DOM.