### PR TITLE
Фикс щитка ХоСа

### DIFF
--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -78,6 +78,7 @@
 	throw_speed = 3
 	throw_range = 4
 	block_chance = 50
+	w_class = 3
 	var/active = 0
 
 /obj/item/weapon/shield/riot/tele/Get_shield_chance()

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -78,7 +78,7 @@
 	throw_speed = 3
 	throw_range = 4
 	block_chance = 50
-	w_class = 3
+	w_class = ITEM_SIZE_NORMAL
 	var/active = 0
 
 /obj/item/weapon/shield/riot/tele/Get_shield_chance()


### PR DESCRIPTION
fixes #3158
:cl: Getup1
- bugfix: Телескопический щит ХоСа невозможно было положить в пояс в исходном состоянии.