### PR TITLE
Возможность просмотра ВВ была подвязана к флагу R_LOG ..

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -8,11 +8,13 @@
 	set name = "View Variables"
 	//set src in world
 
-
 	if(!usr.client || !usr.client.holder)
-		to_chat(usr, "\red You need to be an administrator to access this.")
+		to_chat(usr, "<span class='warning'>You need to be an administrator to access this.</span>")
 		return
 
+	if(!check_rights(R_DEBUG|R_VAREDIT|R_LOG)) // Since client.holder still doesn't mean we have permissions...
+		to_chat(usr, "<span class='warning'>You need to be an administrator to access this.</span>")
+		return
 
 	var/title = ""
 	var/body = ""
@@ -424,7 +426,7 @@ body
 		debug_variables(locate(href_list["Vars"]))
 
 	else if(href_list["view_flags"])
-		if(!check_rights(R_DEBUG|R_ADMIN))
+		if(!check_rights(R_DEBUG|R_VAREDIT|R_LOG))
 			return
 		view_flags_variables(href_list["view_flags"])
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -76,7 +76,8 @@ var/list/admin_verbs_admin = list(
 	/client/proc/aooc,
 	/client/proc/change_security_level,
 	/client/proc/empty_ai_core_toggle_latejoin,
-	/client/proc/send_fax_message
+	/client/proc/send_fax_message,
+	/client/proc/debug_variables 		/*allows us to -see- the variables of any instance in the game. +VAREDIT needed to modify*/
 	)
 var/list/admin_verbs_log = list(
 	/datum/admins/proc/view_txt_log,	/*shows the server log (diary) for today*/
@@ -84,7 +85,6 @@ var/list/admin_verbs_log = list(
 	/client/proc/giveruntimelog,		/*allows us to give access to runtime logs to somebody*/
 	/client/proc/getserverlog,			/*allows us to fetch server logs (diary) for other days*/
 	/client/proc/investigate_show,		/*various admintools for investigation. Such as a singulo grief-log*/
-	/client/proc/debug_variables 		/*allows us to -see- the variables of any instance in the game. +VAREDIT needed to modify*/
 	)
 var/list/admin_verbs_variables = list(
 	/client/proc/debug_variables 		/*allows us to -see- the variables of any instance in the game. +VAREDIT needed to modify*/

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -84,6 +84,7 @@ var/list/admin_verbs_log = list(
 	/client/proc/giveruntimelog,		/*allows us to give access to runtime logs to somebody*/
 	/client/proc/getserverlog,			/*allows us to fetch server logs (diary) for other days*/
 	/client/proc/investigate_show,		/*various admintools for investigation. Such as a singulo grief-log*/
+	/client/proc/debug_variables 		/*allows us to -see- the variables of any instance in the game. +VAREDIT needed to modify*/
 	)
 var/list/admin_verbs_variables = list(
 	/client/proc/debug_variables 		/*allows us to -see- the variables of any instance in the game. +VAREDIT needed to modify*/

--- a/code/modules/admin/verbs/library.dm
+++ b/code/modules/admin/verbs/library.dm
@@ -1,7 +1,7 @@
 /client/proc/library_debug_remove()
 	set category = "Debug"
 	set name = "Library: Remove by id"
-	if(!check_rights(R_PERMISSIONS))	return
+	if(!check_rights(R_DEBUG))	return
 
 	establish_old_db_connection()
 	if(!dbcon_old.IsConnected())
@@ -32,7 +32,7 @@
 /client/proc/library_debug_read()
 	set category = "Debug"
 	set name = "Library: Read by id"
-	if(!check_rights(R_PERMISSIONS))	return
+	if(!check_rights(R_DEBUG))	return
 
 	establish_old_db_connection()
 	if(!dbcon_old.IsConnected())


### PR DESCRIPTION
создавать отдельный флаг для такого - маразм. Этот функционал все так же доспен и из под флага R_VAREDIT.  Это было сделано по просьбе директора и ноющих. Все претензии в их огород.

Манипуляции с БД библиотеки были вынесены из под пермишенсов под дебаг, по просьбе все того же директора.

<!--
Подробно про оформление ПРов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
Там же написано про то, как сделать чейнджлог. 

!!!
Если авторство не полностью ваше, вы делаете порт с другого билда - укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
!!!

Если есть форумное обсуждение на тему изменений PR-а - укажите ссылку.

Для копипаста:
Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment.

Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
