### PR TITLE
Waddling при ходьбе у клоуна

### DIFF
--- a/code/datums/components/waddle.dm
+++ b/code/datums/components/waddle.dm
@@ -1,0 +1,31 @@
+/datum/component/waddle
+	var/waddle_height
+	var/list/waddle_angles
+
+/datum/component/waddle/Initialize(_waddle_height, _waddle_angles, list/waddle_on)
+	if(!istype(parent, /atom/movable))
+		return COMPONENT_INCOMPATIBLE
+
+	waddle_height = _waddle_height
+	waddle_angles = _waddle_angles
+
+	if(ismob(parent))
+		RegisterSignal(parent, waddle_on, .proc/waddle_mob)
+	else if(isobj(parent))
+		RegisterSignal(parent, waddle_on, .proc/waddle_obj)
+
+/datum/component/waddle/proc/waddle_mob(atom/movable/AM, dir)
+	var/mob/M = parent
+	if(!M.incapacitated() && !M.crawling && !M.notransform && !M.anchored)
+		var/matrix/old_transform = M.transform
+		animate(M, pixel_z = waddle_height, time = 0)
+		animate(pixel_z = 0, transform = turn(M.transform, pick(waddle_angles)), time=2)
+		animate(pixel_z = 0, transform = old_transform, time = 0)
+
+/datum/component/waddle/proc/waddle_obj(atom/movable/AM, dir)
+	var/obj/O = parent
+	if(!O.anchored)
+		var/matrix/old_transform = O.transform
+		animate(O, pixel_z = waddle_height, time = 0)
+		animate(pixel_z = 0, transform = turn(O.transform, pick(waddle_angles)), time=2)
+		animate(pixel_z = 0, transform = old_transform, time = 0)

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -198,16 +198,30 @@
 	attack_verb = list("HONKED")
 	var/cooldown = FALSE
 
+/obj/item/weapon/bikehorn/proc/honk(mob/user)
+	playsound(src, 'sound/items/bikehorn.ogg', VOL_EFFECTS_MISC)
+	if(!user.notransform)
+		return
+
+	animate(user, pixel_z = rand(2, 6), time = 0)
+	var/matrix/old_transform = user.transform
+	animate(pixel_z = 0, transform = turn(old_transform, pick(-8, 0, 8)), time=2)
+	animate(pixel_z = 0, transform = old_transform, time = 0)
+
 /obj/item/weapon/bikehorn/attack(mob/target, mob/user, def_zone)
 	. = ..()
-	playsound(src, 'sound/items/bikehorn.ogg', VOL_EFFECTS_MISC)
+	honk(user)
 
 /obj/item/weapon/bikehorn/attack_self(mob/user)
 	if(cooldown <= world.time)
 		cooldown = world.time + 8
-		playsound(src, 'sound/items/bikehorn.ogg', VOL_EFFECTS_MISC)
+		honk(user)
 		src.add_fingerprint(user)
-	return
+
+/obj/item/weapon/bikehorn/Crossed(mob/living/carbon/C)
+	if(cooldown <= world.time)
+		cooldown = world.time + 8
+		honk(C)
 
 /obj/item/weapon/bikehorn/dogtoy
 	name = "dog toy"

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -107,10 +107,15 @@
 	name = "clown shoes"
 	icon_state = "clown"
 	item_state = "clown_shoes"
-	slowdown = SHOES_SLOWDOWN+1
+	slowdown = SHOES_SLOWDOWN + 0.5
 	item_color = "clown"
-//	var/footstep = 1	//used for squeeks whilst walking
 	species_restricted = null
+
+/obj/item/clothing/shoes/clown_shoes/equipped(mob/user, slot)
+	user.AddComponent(/datum/component/waddle, 4, list(-14, 0, 14), list(COMSIG_MOVABLE_MOVED))
+
+/obj/item/clothing/shoes/clown_shoes/dropped(mob/user)
+	qdel(user.GetComponent(/datum/component/waddle))
 
 /obj/item/clothing/shoes/clown_shoes/play_unique_footstep_sound()
 	..()

--- a/taucetistation.dme
+++ b/taucetistation.dme
@@ -205,6 +205,7 @@
 #include "code\datums\components\_component.dm"
 #include "code\datums\components\footstep.dm"
 #include "code\datums\components\slippery.dm"
+#include "code\datums\components\waddle.dm"
 #include "code\datums\diseases\appendicitis.dm"
 #include "code\datums\diseases\brainrot.dm"
 #include "code\datums\diseases\cold.dm"


### PR DESCRIPTION
- Делает ботинки клоуна чу-у-у-уточку быстрее, ибо ну совсем в них тяжело ходить.

- При ходьбе в ботинках клоуна будет эффект "подпрыгивания". https://youtu.be/QOwa0NM3imI

- При ходьбе ПО байкхорну он тоже будет  издавать звук

- При использовании байкхорна кукла немного подпрыгивает, почти как при ходьбе клоуна

Единственная проблема - странные контуры у спрайта куклы при повороте. Видны в видео.

:cl: Richard Jones
 - tweak: При ходьбе в ботинках клоуна персонаж "подпрыгивает".
 - tweak: Если на гудок встать, им бить, или использовать - кукла подпрыгивает как при ходьбе клоуна.
 - balance: Ботинки клоуна стали чуточку быстрее.
