### PR TITLE
Предупреждение админам о смерти игрока

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -110,6 +110,9 @@
 //		world.log << "k"
 		sql_report_death(src)
 		ticker.mode.check_win()		//Calls the rounds wincheck, mainly for wizard, malf, and changeling now
+
+	message_admins("[key_name_admin(src)] (<A HREF='?_src_=holder;adminmoreinfo=\ref[src]'>?</A>) (<A HREF='?_src_=holder;adminplayeropts=\ref[src]'>PP</A>) (<A HREF='?_src_=vars;Vars=\ref[src]'>VV</A>) died @ [src.x], [src.y], [src.z] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>)")
+
 	return ..(gibbed)
 
 /mob/living/carbon/human/proc/makeSkeleton()

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1321,9 +1321,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 		name = "[H.real_name]'s head"
 
-		H.stat = DEAD
 		H.death()
-		brainmob.stat = DEAD
 		brainmob.death()
 		if(brainmob && brainmob.mind && brainmob.mind.changeling) //cuz fuck runtimes
 			var/datum/changeling/Host = brainmob.mind.changeling


### PR DESCRIPTION
Теперь администраторы с выключенными атаклогами не пропустят смерть игрока.
