### PR TITLE
Халкам нельзя давать маленькие предметы

### DIFF
--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -20,6 +20,10 @@
 	if(I.flags & (ABSTRACT | DROPDEL))
 		to_chat(usr, "<span class='red'>You can't give this to [name]</span>")
 		return
+	if(HULK in src.mutations)
+		if(I.w_class < ITEM_SIZE_LARGE)
+			to_chat(usr, "<span class='red'>[I] is too small for [name] to hold.</span>")
+			return
 	if(!src.get_active_hand() || !src.get_inactive_hand())
 		switch(alert(src,"[usr] wants to give you \a [I]?",,"Yes","No"))
 			if("Yes")


### PR DESCRIPTION
fixes #281
Халк не может поднимать предметы с w_class < 4, но мог принимать их с помощью верба give. Теперь нет.

:cl: Richard Jones
- bugfix: Халк больше не может принимать не предназначенные ему по весу предметы с помощью верба give.