### PR TITLE
Исправление неработающих бросков при низких значениях в некоторых слу…

### DIFF
--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -79,7 +79,7 @@ var/datum/subsystem/throwing/SSthrowing
 	var/atom/step
 
 	//calculate how many tiles to move, making up for any missed ticks.
-	var/tilestomove = round(min(((((world.time + world.tick_lag) - start_time) * speed) - (dist_travelled ? dist_travelled : -1)), speed * MAX_TICKS_TO_MAKE_UP) * (world.tick_lag * SSthrowing.wait))
+	var/tilestomove = ceil(min(((((world.time + world.tick_lag) - start_time) * speed) - (dist_travelled ? dist_travelled : -1)), speed * MAX_TICKS_TO_MAKE_UP) * (world.tick_lag * SSthrowing.wait))
 	while (tilestomove-- > 0)
 		if ((dist_travelled >= maxrange || AM.loc == target_turf) && has_gravity(AM, AM.loc))
 			finialize()


### PR DESCRIPTION
…чаях.

Вполне возможно исправляет еще что-нибудь из такого. Речь идет про использование throw_at со значением скорости 1 например, как это было в коде плетки.

:cl:
 - bugfix: Organic Whip у changeling в режиме граба не притягивала предметы и мобов.