### PR TITLE
Чистка граба и его хелперы.

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -55,16 +55,14 @@
 #define MOB_STATUS_FLAGS_DEFAULT (CANSTUN | CANWEAKEN | CANPARALYSE | CANPUSH)
 
 //Grab levels
-#define GRAB_PASSIVE	1
-#define GRAB_AGGRESSIVE	2
-#define GRAB_NECK		3
-#define GRAB_UPGRADING	4
-#define GRAB_KILL		5
+#define GRAB_NONE         0
+#define GRAB_PASSIVE      1
+#define GRAB_AGGRESSIVE   2
+#define GRAB_NECK         3
+#define GRAB_KILL         4
 
 #define HOSTILE_STANCE_IDLE 	 1
 #define HOSTILE_STANCE_ALERT 	 2
 #define HOSTILE_STANCE_ATTACK 	 3
 #define HOSTILE_STANCE_ATTACKING 4
 #define HOSTILE_STANCE_TIRED 	 5
-
-#define UPGRADE_COOLDOWN	40

--- a/code/__DEFINES/mob.dm
+++ b/code/__DEFINES/mob.dm
@@ -121,3 +121,5 @@
 #define CLICK_CD_INTERACT 4
 #define CLICK_CD_RAPID 2
 #define CLICK_CD_AI 9
+#define CLICK_CD_GRAB 40
+#define CLICK_CD_ACTION 20 // used in grab actions

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -51,7 +51,7 @@
 	// Knifing
 	if(edge)
 		for(var/obj/item/weapon/grab/G in M.grabbed_by)
-			if(G.assailant == user && G.state >= GRAB_NECK && world.time >= (G.last_action + 20) && def_zone == BP_HEAD)
+			if(G.assailant == user && G.state >= GRAB_NECK && def_zone == BP_HEAD)
 				var/protected = 0
 				if(ishuman(M))
 					var/mob/living/carbon/human/AH = M
@@ -66,7 +66,7 @@
 					M.adjustOxyLoss(60) // Brain lacks oxygen immediately, pass out
 					playsound(loc, 'sound/effects/throat_cutting.ogg', 50, 1, 1)
 					flick(G.hud.icon_state, G.hud)
-					G.last_action = world.time
+					user.SetNextMove(CLICK_CD_ACTION)
 					user.visible_message("<span class='danger'>[user] slit [M]'s throat open with \the [name]!</span>")
 					user.attack_log += "\[[time_stamp()]\]<font color='red'> Knifed [M.name] ([M.ckey]) with [name] (INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(damtype)])</font>"
 					M.attack_log += "\[[time_stamp()]\]<font color='orange'> Got knifed by [user.name] ([user.ckey]) with [name] (INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(damtype)])</font>"

--- a/code/datums/spells/area_teleport.dm
+++ b/code/datums/spells/area_teleport.dm
@@ -60,7 +60,7 @@
 	else
 		teleport_place = T
 	var/list/returned = list()
-	for(var/obj/item/weapon/grab/G in list(U.get_active_hand(), U.get_inactive_hand()))
+	for(var/obj/item/weapon/grab/G in U.GetGrabs())
 		returned += G.affecting
 		G.affecting.forceMove(teleport_place)
 	if(length(returned))

--- a/code/game/gamemodes/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/abduction/abduction_gear.dm
@@ -611,19 +611,7 @@
 	if(!istype(C))
 		return
 	C.SetNextMove(CLICK_CD_MELEE)
-
-	if(istype(C.get_active_hand(),/obj/item/weapon/grab))
-		var/obj/item/weapon/grab/G = C.get_active_hand()
-		if(istype(C.l_hand, G))
-			C.drop_l_hand()
-		else
-			C.drop_r_hand()
-	if(istype(C.get_inactive_hand(),/obj/item/weapon/grab))
-		var/obj/item/weapon/grab/G = C.get_inactive_hand()
-		if(istype(C.l_hand, G))
-			C.drop_l_hand()
-		else
-			C.drop_r_hand()
+	C.StopGrabs()
 
 	holding = !holding
 

--- a/code/game/gamemodes/abduction/machinery/pad.dm
+++ b/code/game/gamemodes/abduction/machinery/pad.dm
@@ -46,20 +46,9 @@
 	if(target)
 
 		//prevent from teleporting victim though the grab on neck
-		if(istype(target.get_active_hand(), /obj/item/weapon/grab))
-			var/obj/item/weapon/grab/G = target.get_active_hand()
+		for(var/obj/item/weapon/grab/G in target.GetGrabs())
 			if(G.state >= GRAB_PASSIVE)
-				if(istype(target.l_hand, G))
-					target.drop_l_hand()
-				else
-					target.drop_r_hand()
-		if(istype(target.get_inactive_hand(), /obj/item/weapon/grab))
-			var/obj/item/weapon/grab/G = target.get_inactive_hand()
-			if(G.state >= GRAB_PASSIVE)
-				if(istype(target.l_hand, G))
-					target.drop_l_hand()
-				else
-					target.drop_r_hand()
+				qdel(G)
 		target.forceMove(loc)
 
 /obj/machinery/abductor/pad/proc/Send()

--- a/code/game/gamemodes/changeling/powers/Whip.dm
+++ b/code/game/gamemodes/changeling/powers/Whip.dm
@@ -86,11 +86,7 @@
 /obj/item/projectile/changeling_whip/proc/end_whipping(atom/movable/T)
 	if(in_range(T, host) && !host.get_inactive_hand() && !host.lying)
 		if(iscarbon(T))
-			var/obj/item/weapon/grab/G = new(host,T)
-			host.put_in_inactive_hand(G)
-			G.state = GRAB_AGGRESSIVE
-			G.icon_state = "grabbed1"
-			G.synch()
+			host.Grab(T, GRAB_AGGRESSIVE, FALSE)
 		else if(istype(T, /obj/item))
 			host.put_in_inactive_hand(T)
 

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -137,10 +137,11 @@
 		return
 
 	if (istype(W, /obj/item/weapon/grab))
-		if(iscarbon(W:affecting))
-			take_victim(W:affecting,usr)
+		var/obj/item/weapon/grab/G = W
+		if(iscarbon(G.affecting))
+			take_victim(G.affecting, usr)
 			user.SetNextMove(CLICK_CD_MELEE)
-			qdel(W)
+			qdel(G)
 			return
 	user.drop_item()
 	if(W && W.loc)

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -664,7 +664,7 @@ steam.start() -- spawns the effect
 
 	if (istype(I, /obj/item/weapon/grab))
 		var/obj/item/weapon/grab/G = I
-		G.affecting.loc = src.loc
+		G.affecting.forceMove(loc)
 		for(var/mob/O in viewers(src))
 			if (O.client)
 				to_chat(O, "\red [G.assailant] smashes [G.affecting] through the foamed metal wall.")

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -187,7 +187,8 @@
 /obj/structure/closet/attackby(obj/item/weapon/W, mob/user)
 	if(src.opened)
 		if(istype(W, /obj/item/weapon/grab))
-			src.MouseDrop_T(W:affecting, user)      //act like they were dragged onto the closet
+			var/obj/item/weapon/grab/G = W
+			MouseDrop_T(G.affecting, user)      //act like they were dragged onto the closet
 		if(istype(W,/obj/item/tk_grab))
 			return 0
 		if(istype(W, /obj/item/weapon/weldingtool))

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -45,7 +45,8 @@
 /obj/structure/closet/secure_closet/personal/attackby(obj/item/weapon/W, mob/user)
 	if (src.opened)
 		if (istype(W, /obj/item/weapon/grab))
-			src.MouseDrop_T(W:affecting, user)      //act like they were dragged onto the closet
+			var/obj/item/weapon/grab/G = W
+			MouseDrop_T(G.affecting, user)      //act like they were dragged onto the closet
 		user.drop_item()
 		if (W) W.forceMove(src.loc)
 	else if(istype(W, /obj/item/weapon/card/id))

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -66,7 +66,8 @@
 	if(src.opened)
 		if(istype(W, /obj/item/weapon/grab))
 			if(src.large)
-				src.MouseDrop_T(W:affecting, user)	//act like they were dragged onto the closet
+				var/obj/item/weapon/grab/G = W
+				MouseDrop_T(G.affecting, user)	//act like they were dragged onto the closet
 			else
 				to_chat(user, "<span class='notice'>The locker is too small to stuff [W:affecting] into!</span>")
 		if(isrobot(user))

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -375,9 +375,7 @@
 					to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
 					return
 			else
-				if(world.time < (G.last_action + UPGRADE_COOLDOWN))
-					return
-				G.affecting.loc = src.loc
+				G.affecting.forceMove(loc)
 				G.affecting.Weaken(5)
 				visible_message("<span class='danger'>[G.assailant] puts [G.affecting] on \the [src].</span>")
 				M.attack_log += "\[[time_stamp()]\] <font color='orange'>Was laied by [A.name] on \the [src]([A.ckey])</font>"

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -306,6 +306,12 @@ var/list/slot_equipment_priority = list(
 		I.dropped(src)
 	return 1
 
+/mob/proc/get_hand_slots()
+	return list(l_hand, r_hand)
+
+/mob/living/carbon/ian/get_hand_slots()
+	return list(mouth)
+
 //Returns the item equipped to the specified slot, if any.
 /mob/proc/get_equipped_item(var/slot)
 	return null

--- a/code/modules/mob/living/carbon/alien/alien_defense.dm
+++ b/code/modules/mob/living/carbon/alien/alien_defense.dm
@@ -39,21 +39,7 @@ This is what happens, when we attack aliens.
 				help_shake_act(M)
 
 		if ("grab")
-			if (M == src || anchored || M.lying)
-				return
-			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src)
-
-			M.put_in_active_hand(G)
-
-			grabbed_by += G
-			G.synch()
-
-			LAssailant = M
-
-			playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-			for(var/mob/O in viewers(src, null))
-				if ((O.client && !( O.blinded )))
-					O.show_message(text("\red [] has grabbed [] passively!", M, src), 1)
+			M.Grab(src)
 
 		if ("hurt")
 			var/damage = rand(1, 9)

--- a/code/modules/mob/living/carbon/alien/human_attackalien.dm
+++ b/code/modules/mob/living/carbon/alien/human_attackalien.dm
@@ -53,21 +53,7 @@ This is what happens, when alien attack.
 		if ("help")
 			visible_message(text("\blue [M] caresses [src] with its scythe like arm."))
 		if ("grab")
-			if(M == src || anchored || M.lying)
-				return
-			if (w_uniform)
-				w_uniform.add_fingerprint(M)
-			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src)
-
-			M.put_in_active_hand(G)
-
-			grabbed_by += G
-			G.synch()
-			LAssailant = M
-
-			playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-			visible_message(text("\red [] has grabbed [] passively!", M, src))
-
+			M.Grab(src)
 		if("hurt")
 			M.do_attack_animation(src)
 			if (w_uniform)

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -47,10 +47,6 @@
 	handle_regular_status_updates()
 	update_canmove()
 
-	// Grabbing
-	for(var/obj/item/weapon/grab/G in src)
-		G.process()
-
 	if(client)
 		handle_regular_hud_updates()
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1649,30 +1649,7 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 			L.Weaken(5)
 			sleep(2) // Runtime prevention (infinite bump() calls on hulks)
 			step_towards(src, L)
-
-			if(restrained()) //You can leap when you hands are cuffed, but you can't grab
-				return
-
-			var/use_hand = "left"
-			if(l_hand)
-				if(r_hand)
-					to_chat(src, "<span class='warning'>You need to have one hand free to grab someone.</span>")
-					return
-				else
-					use_hand = "right"
-
-			visible_message("<span class='warning'><b>\The [src]</b> seizes [L] aggressively!</span>")
-
-			var/obj/item/weapon/grab/G = new(src, L)
-			if(use_hand == "left")
-				l_hand = G
-			else
-				r_hand = G
-
-			G.state = GRAB_AGGRESSIVE
-			G.icon_state = "grabbed1"
-			G.synch()
-			L.grabbed_by += G
+			Grab(L, GRAB_AGGRESSIVE)
 
 	else if(A.density)
 		visible_message("<span class='danger'>[src] smashes into [A]!</span>", "<span class='danger'>You smashes into [A]!</span>")

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -111,27 +111,7 @@
 				return 1
 
 		if("grab")
-			if(M == src || anchored || M.lying)
-				return 0
-			for(var/obj/item/weapon/grab/G in src.grabbed_by)
-				if(G.assailant == M)
-					to_chat(M, "<span class='notice'>You already grabbed [src].</span>")
-					return
-			if(w_uniform)
-				w_uniform.add_fingerprint(M)
-
-			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src)
-			if(buckled)
-				to_chat(M, "<span class='notice'>You cannot grab [src], \he is buckled in!</span>")
-			if(!G)	//the grab will delete itself in New if affecting is anchored
-				return
-			M.put_in_active_hand(G)
-			grabbed_by += G
-			G.synch()
-			LAssailant = M
-
-			playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-			visible_message("<span class='warning'>[M] has grabbed [src] passively!</span>")
+			M.Grab(src)
 			return 1
 
 		if("hurt")
@@ -220,20 +200,11 @@
 					stop_pulling()
 
 				//BubbleWrap: Disarming also breaks a grab - this will also stop someone being choked, won't it?
-				if(istype(l_hand, /obj/item/weapon/grab))
-					var/obj/item/weapon/grab/lgrab = l_hand
-					if(lgrab.affecting)
-						visible_message("\red <b>[M] has broken [src]'s grip on [lgrab.affecting]!</B>")
+				for(var/obj/item/weapon/grab/G in GetGrabs())
+					if(G.affecting)
+						visible_message("\red <b>[M] has broken [src]'s grip on [G.affecting]!</B>")
 						talked = 1
-					spawn(1)
-						qdel(lgrab)
-				if(istype(r_hand, /obj/item/weapon/grab))
-					var/obj/item/weapon/grab/rgrab = r_hand
-					if(rgrab.affecting)
-						visible_message("\red <b>[M] has broken [src]'s grip on [rgrab.affecting]!</B>")
-						talked = 1
-					spawn(1)
-						qdel(rgrab)
+					qdel(G)
 				//End BubbleWrap
 
 				if(!talked)	//BubbleWrap

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -127,10 +127,6 @@
 
 	pulse = handle_pulse()
 
-	// Grabbing
-	for(var/obj/item/weapon/grab/G in src)
-		G.process()
-
 
 //Much like get_heat_protection(), this returns a 0 - 1 value, which corresponds to the percentage of protection based on what you're wearing and what you're exposed to.
 /mob/living/carbon/human/proc/get_pressure_protection(pressure_check = STOPS_PRESSUREDMAGE)

--- a/code/modules/mob/living/carbon/ian/ian.dm
+++ b/code/modules/mob/living/carbon/ian/ian.dm
@@ -409,26 +409,8 @@
 			updatehealth()
 
 		if("grab")
-			if(M == src || anchored || M.lying)
-				return
+			M.Grab(src)
 
-			for(var/obj/item/weapon/grab/G in grabbed_by)
-				if(G.assailant == M)
-					to_chat(M, "<span class='notice'>You already grabbed [src].</span>")
-					return
-
-			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src)
-			if(buckled)
-				to_chat(M, "<span class='notice'>You cannot grab [src], \he is buckled in!</span>")
-			if(!G)
-				return
-			M.put_in_active_hand(G)
-			grabbed_by += G
-			G.synch()
-			LAssailant = M
-
-			playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-			visible_message("<span class='warning'>[M] has grabbed [src] passively!</span>")
 		if("disarm")
 			M.do_attack_animation(src)
 			M.attack_log += text("\[[time_stamp()]\] <font color='red'>Disarmed [src.name] ([src.ckey])</font>")
@@ -451,12 +433,11 @@
 						visible_message("<span class='danger'>[M] has broken [src]'s grip on [pulling]!</span>")
 						talked = 1
 						stop_pulling()
-					if(istype(mouth, /obj/item/weapon/grab))
-						var/obj/item/weapon/grab/grab = l_hand
-						if(grab.affecting)
-							visible_message("<span class='danger'>[M] has broken [src]'s grip on [grab.affecting]!</span>")
+					for(var/obj/item/weapon/grab/G in GetGrabs())
+						if(G.affecting)
+							visible_message("<span class='danger'>[M] has broken [src]'s grip on [G.affecting]!</span>")
 							talked = 1
-							qdel(grab)
+							qdel(G)
 					if(!talked)
 						drop_item()
 						visible_message("<span class='danger'>[M] has disarmed [src]!</span>")
@@ -471,13 +452,7 @@
 			if(stat != DEAD)
 				if(FH == src)
 					return
-				var/obj/item/weapon/fh_grab/G = new /obj/item/weapon/fh_grab(FH, src)
-				FH.put_in_active_hand(G)
-				grabbed_by += G
-				G.last_upgrade = world.time - 20
-				G.synch()
-				LAssailant = FH
-				visible_message("<span class='red'>[FH] atempts to leap at [src] face!</span>")
+				new /obj/item/weapon/fh_grab(FH, src)
 			else
 				to_chat(FH, "<span class='red'>looks dead.</span>")
 
@@ -627,15 +602,7 @@
 				playsound(loc, 'sound/weapons/slashmiss.ogg', 25, 1, -1)
 				visible_message("<span class='danger'>has attempted to lunge at [name]!</span>")
 		if ("grab")
-			if (M == src || anchored || M.lying)
-				return
-			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src)
-			M.put_in_active_hand(G)
-			grabbed_by += G
-			G.synch()
-			LAssailant = M
-			playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-			visible_message("<span class='red'>has grabbed [name] passively!</span>")
+			M.Grab(src)
 		if ("disarm")
 			playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
 			if(is_armored(M, 35))

--- a/code/modules/mob/living/carbon/metroid/metroid.dm
+++ b/code/modules/mob/living/carbon/metroid/metroid.dm
@@ -450,21 +450,7 @@
 			help_shake_act(M)
 
 		if ("grab")
-			if (M == src || M.lying)
-				return
-			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src)
-
-			M.put_in_active_hand(G)
-
-			grabbed_by += G
-			G.synch()
-
-			LAssailant = M
-
-			playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-			for(var/mob/O in viewers(src, null))
-				if ((O.client && !( O.blinded )))
-					O.show_message(text("\red [] has grabbed [] passively!", M, src), 1)
+			M.Grab(src)
 
 		else
 
@@ -541,20 +527,7 @@
 						O.show_message(text("\red <B>[] has attempted to lunge at [name]!</B>", M), 1)
 
 		if ("grab")
-			if (M == src || M.lying)
-				return
-			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src)
-
-			M.put_in_active_hand(G)
-
-			grabbed_by += G
-			G.synch()
-
-			LAssailant = M
-
-			playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-			for(var/mob/O in viewers(src, null))
-				O.show_message(text("\red [] has grabbed [name] passively!", M), 1)
+			M.Grab(src)
 
 		if ("disarm")
 			playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -60,10 +60,6 @@
 	if(client)
 		handle_regular_hud_updates()
 
-	// Grabbing
-	for(var/obj/item/weapon/grab/G in src)
-		G.process()
-
 	if(!client && stat == CONSCIOUS)
 
 		if(prob(33) && canmove && isturf(loc) && !pulledby) //won't move if being pulled

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -265,21 +265,7 @@
 						O.show_message(text("\red <B>[] has attempted to punch [name]!</B>", M), 1)
 		else
 			if (M.a_intent == "grab")
-				if (M == src || anchored || M.lying)
-					return
-
-				var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src)
-
-				M.put_in_active_hand(G)
-
-				grabbed_by += G
-				G.synch()
-
-				LAssailant = M
-
-				playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-				for(var/mob/O in viewers(src, null))
-					O.show_message(text("\red [] has grabbed [name] passively!", M), 1)
+				M.Grab(src)
 			else
 				if (!( paralysis ))
 					if (prob(25))
@@ -335,20 +321,7 @@
 						O.show_message(text("\red <B>[] has attempted to lunge at [name]!</B>", M), 1)
 
 		if ("grab")
-			if (M == src || anchored || M.lying)
-				return
-			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src)
-
-			M.put_in_active_hand(G)
-
-			grabbed_by += G
-			G.synch()
-
-			LAssailant = M
-
-			playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-			for(var/mob/O in viewers(src, null))
-				O.show_message(text("\red [] has grabbed [name] passively!", M), 1)
+			M.Grab(src)
 
 		if ("disarm")
 			playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -797,18 +797,7 @@
 					O.show_message(text("\blue [M] caresses [src]'s plating with its scythe-like arm."), 1)
 
 		if ("grab")
-			if (M == src || anchored || M.lying)
-				return
-			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src)
-
-			M.put_in_active_hand(G)
-
-			grabbed_by += G
-			G.synch()
-			playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-			for(var/mob/O in viewers(src, null))
-				if ((O.client && !( O.blinded )))
-					O.show_message(text("\red [] has grabbed [] passively!", M, src), 1)
+			M.Grab(src)
 
 		if ("hurt")
 			M.do_attack_animation(src)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -237,22 +237,7 @@
 						O.show_message("\blue [M] [response_help] [src]")
 
 		if("grab")
-			if (M == src || anchored || M.lying)
-				return
-			if (!(status_flags & CANPUSH))
-				return
-
-			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src)
-
-			M.put_in_active_hand(G)
-
-			grabbed_by += G
-			G.synch()
-			LAssailant = M
-
-			for(var/mob/O in viewers(src, null))
-				if ((O.client && !( O.blinded )))
-					O.show_message(text("\red [] has grabbed [] passively!", M, src), 1)
+			M.Grab(src)
 
 		if("hurt", "disarm")
 			M.do_attack_animation(src)
@@ -273,23 +258,7 @@
 				if ((O.client && !( O.blinded )))
 					O.show_message(text("\blue [M] caresses [src] with its scythe like arm."), 1)
 		if ("grab")
-			if(M == src || anchored || M.lying)
-				return
-			if(!(status_flags & CANPUSH))
-				return
-
-			var/obj/item/weapon/grab/G = new /obj/item/weapon/grab(M, src)
-
-			M.put_in_active_hand(G)
-
-			grabbed_by += G
-			G.synch()
-			LAssailant = M
-
-			playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-			for(var/mob/O in viewers(src, null))
-				if ((O.client && !( O.blinded )))
-					O.show_message(text("\red [] has grabbed [] passively!", M, src), 1)
+			M.Grab(src)
 
 		if("hurt", "disarm")
 			var/damage = rand(15, 30)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -169,7 +169,8 @@
 	return
 
 /mob/proc/ret_grab(obj/effect/list_container/mobl/L, flag)
-	if(!(istype(l_hand, /obj/item/weapon/grab) || istype(r_hand, /obj/item/weapon/grab)))
+	var/list/grabs = GetGrabs()
+	if(!LAZYLEN(grabs))
 		if(!L)
 			return null
 		else
@@ -179,17 +180,10 @@
 			L = new /obj/effect/list_container/mobl(null)
 			L.container += src
 			L.master = src
-		if(istype(l_hand, /obj/item/weapon/grab))
-			var/obj/item/weapon/grab/G = l_hand
+		for(var/obj/item/weapon/grab/G in grabs)
 			if(!L.container.Find(G.affecting))
 				L.container += G.affecting
 				if (G.affecting)
-					G.affecting.ret_grab(L, 1)
-		if(istype(r_hand, /obj/item/weapon/grab))
-			var/obj/item/weapon/grab/G = r_hand
-			if(!L.container.Find(G.affecting))
-				L.container += G.affecting
-				if(G.affecting)
 					G.affecting.ret_grab(L, 1)
 		if(!flag)
 			if(L.master == src)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -1,3 +1,12 @@
+///Process_Grab()
+///Called by client/Move()
+///Checks to see if you are grabbing anything and if moving will affect your grab.
+/client/proc/Process_Grab()
+	for(var/obj/item/weapon/grab/G in mob.GetGrabs())
+		if(G.state == GRAB_KILL) //no wandering across the station/asteroid while choking someone
+			mob.visible_message("<span class='warning'>[mob] lost \his tight grip on [G.affecting]'s neck!</span>")
+			G.set_state(GRAB_NECK)
+
 /obj/item/weapon/grab
 	name = "grab"
 	icon = 'icons/mob/screen1.dmi'
@@ -6,10 +15,9 @@
 	var/obj/screen/grab/hud = null
 	var/mob/living/affecting = null
 	var/mob/living/carbon/human/assailant = null
-	var/state = GRAB_PASSIVE
+	var/state = GRAB_NONE
 
 	var/allow_upgrade = 1
-	var/last_action = 0
 	var/last_hit_zone = 0
 	var/force_down //determines if the affecting mob will be pinned to the ground
 	var/dancing //determines if assailant and affecting keep looking at each other. Basically a wrestling position
@@ -19,21 +27,59 @@
 	item_state = "nothing"
 	w_class = 5.0
 
+/mob/proc/Grab(atom/movable/target, force_state, show_warnings = TRUE)
+	if(QDELETED(src) || QDELETED(target))
+		return
+	if(lying || target == src || target.anchored)
+		return
+	if(!isturf(target.loc) || restrained())
+		return
+	for(var/obj/item/weapon/grab/G in GetGrabs())
+		if(G.affecting == target)
+			if(show_warnings)
+				to_chat(src, "<span class='warning'>You already grabbed [target]</span>")
+			return
+	if(!target.Adjacent(src))
+		return
+	if(get_active_hand() && get_inactive_hand())
+		if(show_warnings)
+			to_chat(src, "<span class='warning'>You are holding too many stuff already.</span>")
+		return
+	if(ismob(target))
+		var/mob/M = target
+		if(!(M.status_flags & CANPUSH))
+			return
+		if(M.buckled)
+			if(show_warnings)
+				to_chat(src, "<span class='notice'>You cannot grab [M], \he is buckled in!</span>")
+			return
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			if(H.w_uniform)
+				H.w_uniform.add_fingerprint(src)
+			if(H.pull_damage())
+				if(show_warnings)
+					to_chat(src, "<span class='danger'>Grabbing \the [H] in their current condition would probably be a bad idea.</span>")
+		M.inertia_dir = 0
 
-/obj/item/weapon/grab/atom_init(mapload, mob/victim)
+	new /obj/item/weapon/grab(src, target, force_state)
+
+/obj/item/weapon/grab/atom_init(mapload, mob/victim, initial_state = GRAB_PASSIVE)
 	. = ..()
 	assailant = loc
 	affecting = victim
 
 	if(affecting.anchored)
 		return INITIALIZE_HINT_QDEL
-	last_action = world.time - 10
 
 	hud = new /obj/screen/grab(src)
-	hud.icon_state = "reinforce"
-	icon_state = "grabbed"
-	hud.name = "reinforce grab"
 	hud.master = src
+
+	victim.grabbed_by += src
+	victim.LAssailant = assailant
+
+	set_state(initial_state)
+	assailant.put_in_hands(src)
 
 	//check if assailant is grabbed by victim as well
 	if(assailant.grabbed_by)
@@ -42,7 +88,16 @@
 				G.dancing = 1
 				G.adjust_position()
 				dancing = 1
-	adjust_position()
+
+	synch()
+	playsound(victim, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+
+	if(state == GRAB_PASSIVE)
+		assailant.visible_message("<span class='red'>[assailant] has grabbed [affecting] passively!</span>")
+	else if(state == GRAB_AGGRESSIVE)
+		visible_message("<span class='warning'><b>\The [assailant]</b> seizes [affecting] aggressively!</span>")
+
+	START_PROCESSING(SSobj, src)
 
 //Used by throw code to hand over the mob, instead of throwing the grab. The grab is then deleted by the throw code.
 /obj/item/weapon/grab/proc/throw_held()
@@ -65,6 +120,35 @@
 		else
 			qdel(src)
 
+/obj/item/weapon/grab/proc/set_state(_state)
+	assailant.SetNextMove(CLICK_CD_GRAB)
+
+	if(_state != state)
+		state = _state
+		switch(state)
+			if(GRAB_PASSIVE)
+				hud.name = "reinforce grab ([affecting])"
+				hud.icon_state = "reinforce"
+				icon_state = "grabbed"
+			if(GRAB_AGGRESSIVE)
+				hud.icon_state = "reinforce1"
+				icon_state = "grabbed1"
+			if(GRAB_NECK)
+				hud.name = "kill ([affecting])"
+				hud.icon_state = "kill"
+				icon_state = "grabbed+1"
+			if(GRAB_KILL)
+				hud.icon_state = "kill1"
+		adjust_position()
+
+/mob/proc/StopGrabs()
+	for(var/obj/item/weapon/grab/G in get_hand_slots())
+		qdel(G)
+
+/mob/proc/GetGrabs()
+	. = list()
+	for(var/obj/item/weapon/grab/G in get_hand_slots())
+		. += G
 
 /obj/item/weapon/grab/process()
 	confirm()
@@ -186,7 +270,7 @@
 				assailant.set_dir(get_dir(assailant, affecting))
 		if(GRAB_AGGRESSIVE)
 			shift = 12
-		if(GRAB_NECK, GRAB_UPGRADING)
+		if(GRAB_NECK)
 			shift = -10
 			adir = assailant.dir
 			affecting.set_dir(assailant.dir)
@@ -213,17 +297,11 @@
 		return
 	if(!assailant)
 		return
-	if(state == GRAB_UPGRADING)
-		return
 	if(assailant.next_move > world.time)
-		return
-	if(world.time < (last_action + UPGRADE_COOLDOWN))
 		return
 	if(!assailant.canmove || assailant.lying)
 		qdel(src)
 		return
-
-	last_action = world.time
 
 	if(state < GRAB_AGGRESSIVE)
 		if(!allow_upgrade)
@@ -237,46 +315,36 @@
 			step_to(assailant, affecting)
 			assailant.set_dir(EAST) //face the victim
 			affecting.set_dir(SOUTH) //face up
-		state = GRAB_AGGRESSIVE
-		icon_state = "grabbed1"
-		hud.icon_state = "reinforce1"
+		set_state(GRAB_AGGRESSIVE)
 
 	else if(state < GRAB_NECK)
 		if(isslime(affecting))
 			to_chat(assailant, "<span class='notice'>You squeeze [affecting], but nothing interesting happens.</span>")
 			return
-
 		assailant.visible_message("<span class='warning'>[assailant] has reinforced \his grip on [affecting] (now neck)!</span>")
-		state = GRAB_NECK
-		icon_state = "grabbed+1"
 		assailant.set_dir(get_dir(assailant, affecting))
 		affecting.attack_log += "\[[time_stamp()]\] <font color='orange'>Has had their neck grabbed by [assailant.name] ([assailant.ckey])</font>"
 		assailant.attack_log += "\[[time_stamp()]\] <font color='red'>Grabbed the neck of [affecting.name] ([affecting.ckey])</font>"
 		msg_admin_attack("[key_name(assailant)] grabbed the neck of [key_name(affecting)] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[assailant.x];Y=[assailant.y];Z=[assailant.z]'>JMP</A>)")
-		hud.icon_state = "kill"
-		hud.name = "kill"
 		affecting.Stun(10) //10 ticks of ensured grab
+		set_state(GRAB_NECK)
 
-	else if(state < GRAB_UPGRADING)
+	else if(state < GRAB_KILL)
 		if(ishuman(affecting))
 			var/mob/living/carbon/human/AH = affecting
 			if(AH.is_in_space_suit())
 				to_chat(assailant, "<span class='notice'>You can't strangle him, because space helmet covers [affecting]'s neck.</span>")
 				return
-		assailant.visible_message("<span class='danger'>[assailant] starts to tighten \his grip on [affecting]'s neck!</span>")
-		hud.icon_state = "kill1"
 
-		state = GRAB_KILL
 		assailant.visible_message("<span class='danger'>[assailant] has tightened \his grip on [affecting]'s neck!</span>")
 		affecting.attack_log += "\[[time_stamp()]\] <font color='orange'>Has been strangled (kill intent) by [assailant.name] ([assailant.ckey])</font>"
 		assailant.attack_log += "\[[time_stamp()]\] <font color='red'>Strangled (kill intent) [affecting.name] ([affecting.ckey])</font>"
 		msg_admin_attack("[key_name(assailant)] strangled (kill intent) [key_name(affecting)]")
 
-		assailant.next_move = world.time + 10
 		affecting.losebreath += 1
 		affecting.set_dir(WEST)
-	adjust_position()
 
+		set_state(GRAB_KILL)
 
 //This is used to make sure the victim hasn't managed to yackety sax away before using the grab.
 /obj/item/weapon/grab/proc/confirm()
@@ -299,14 +367,11 @@
 	if(!affecting)
 		return
 
-	if(world.time < (last_action + 20))
-		return
-
 	if(!M.Adjacent(user))
 		qdel(src)
 		return
 
-	last_action = world.time
+	assailant.SetNextMove(CLICK_CD_ACTION)
 
 	if(M == affecting)
 		if(ishuman(M))

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -159,8 +159,7 @@
 					if(s.zoom)
 						s.zoom()
 
-	if(Process_Grab())
-		return
+	Process_Grab()
 
 	if(istype(mob.buckled, /obj/vehicle))
 		//manually set move_delay for vehicles so we don't inherit any mob movement penalties
@@ -265,7 +264,7 @@
 		else
 			. = mob.SelfMove(n, direct)
 
-		for (var/obj/item/weapon/grab/G in mob)
+		for (var/obj/item/weapon/grab/G in mob.GetGrabs())
 			if (G.state == GRAB_NECK)
 				mob.set_dir(reverse_dir[direct])
 			G.adjust_position()
@@ -297,16 +296,6 @@
 		return FALSE
 
 	return ..()
-
-///Process_Grab()
-///Called by client/Move()
-///Checks to see if you are grabbing anything and if moving will affect your grab.
-/client/proc/Process_Grab()
-	for(var/obj/item/weapon/grab/G in list(mob.l_hand, mob.r_hand))
-		if(G.state == GRAB_KILL) //no wandering across the station/asteroid while choking someone
-			mob.visible_message("<span class='warning'>[mob] lost \his tight grip on [G.affecting]'s neck!</span>")
-			G.hud.icon_state = "kill"
-			G.state = GRAB_NECK
 
 ///Process_Incorpmove
 ///Called by client/Move()


### PR DESCRIPTION
* Кулдауны граба перешли на общую систему задержек клика. Это значит что действия связанные с грабом будут влиять на возможность выполнять клики, как и прочие задержки после кликов будут влиять на граб. Если еще более подробно расписать - то нажав скажем на улучшение граба что имеет задержку в 40 тиков, нельзя будет и любые другие клики выполнять пока не пройдет задержка после граба. Вероятно сделает выполнение граба довольно рискованным шагом, а игрока сделает беззащитным перед окружающими на время задержки.
* Хелперы для граба Grab() - избавляет от написания всех нужных проверок и прописывания `new` для создания (также можно выставить начальную стадию граба, но надо помнить что она не содержит тех механик что есть в проке `s_click()`), StopGrabs() - прерывает все грабы у src (думаю очевидно), GetGrabs() - возвращает лист с грабами которые есть в руке у src. Для получения грабов цели не стал писать хелперы сейчас.

В грабах есть еще что чистить, но остановлюсь тут.

:cl:
 - balance: В связи с тем что задержки на действия граба перешли на общую систему задержек на клики, вероятность того что граб будет ощущаться иначе в стычках довольно высока.
