### PR TITLE
Чистка z1 слоя от ненужных и ошибочных переменных (и фиксы опять)

### DIFF
--- a/code/game/machinery/hydroponics.dm
+++ b/code/game/machinery/hydroponics.dm
@@ -7,7 +7,6 @@
 	density = TRUE
 	anchored = 1
 	interact_offline = TRUE
-	pixel_y = 8
 
 	var/waterlevel = 100             //The amount of water in the tray (max 100)
 	var/maxwater = 100               //The maximum amount of water in the tray

--- a/maps/z1.dmm
+++ b/maps/z1.dmm
@@ -57,8 +57,7 @@
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -76,8 +75,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -98,8 +96,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/brigdoor{
@@ -128,9 +125,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 0
-	},
+/obj/machinery/recharger,
 /obj/item/weapon/paper{
 	info = "Directions:<br><i>First you'll want to make sure there is a target stake in the center of the magnetic platform. Next, take an aluminum target from the crates back there and slip it into the stake. Make sure it clicks! Next, there should be a control console mounted on the wall somewhere in the room.<br><br> This control console dictates the behaviors of the magnetic platform, which can move your firing target around to simulate real-world combat situations. From here, you can turn off the magnets or adjust their electromagnetic levels and magnetic fields. The electricity level dictates the strength of the pull - you will usually want this to be the same value as the speed. The magnetic field level dictates how far the magnetic pull reaches.<br><br>Speed and path are the next two settings. Speed is associated with how fast the machine loops through the designated path. Paths dictate where the magnetic field will be centered at what times. There should be a pre-fabricated path input already. You can enable moving to observe how the path affects the way the stake moves. To script your own path, look at the following key:</i><br><br>N: North<br>S: South<br>E: East<br>W: West<br>C: Center<br>R: Random (results may vary)<br>; or &: separators. They are not necessary but can make the path string better visible.";
 	name = "Firing Range Instructions"
@@ -214,8 +209,7 @@
 "aay" = (
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/structure/table,
 /obj/machinery/power/apc{
@@ -237,8 +231,7 @@
 /obj/item/clothing/ears/earmuffs,
 /obj/machinery/camera{
 	c_tag = "Firing Range East";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
@@ -413,8 +406,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -430,8 +422,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
 	dir = 2;
@@ -485,8 +476,7 @@
 /obj/structure/sink{
 	dir = 8;
 	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
+	pixel_x = -12
 	},
 /obj/structure/mirror{
 	pixel_x = -28
@@ -557,8 +547,7 @@
 "aaX" = (
 /obj/machinery/camera{
 	c_tag = "Firing Range West";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
@@ -578,7 +567,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -670,7 +658,6 @@
 	frequency = 1475;
 	listening = 1;
 	name = "Station Intercom (Security)";
-	pixel_x = 0;
 	pixel_y = 27
 	},
 /obj/structure/table,
@@ -691,8 +678,7 @@
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/security/main)
@@ -700,12 +686,9 @@
 /obj/item/device/radio/intercom{
 	desc = "Talk... listen through this.";
 	name = "Station Intercom (Brig Radio)";
-	pixel_x = 0;
 	pixel_y = -28
 	},
-/obj/machinery/hydroponics/constructable{
-	pixel_y = 0
-	},
+/obj/machinery/hydroponics/constructable,
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
 	dir = 1;
@@ -743,8 +726,7 @@
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/security/main)
@@ -756,9 +738,7 @@
 	},
 /area/security/execution)
 "abp" = (
-/obj/machinery/hydroponics/constructable{
-	pixel_y = 0
-	},
+/obj/machinery/hydroponics/constructable,
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
 	dir = 1;
@@ -785,8 +765,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
@@ -800,9 +779,7 @@
 	network = list("SS13","Prison");
 	pixel_x = 22
 	},
-/obj/machinery/hydroponics/constructable{
-	pixel_y = 0
-	},
+/obj/machinery/hydroponics/constructable,
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
 	dir = 1;
@@ -844,10 +821,7 @@
 /area/security/main)
 "abw" = (
 /obj/structure/table,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/machinery/light{
 	dir = 1
@@ -861,8 +835,7 @@
 /obj/machinery/computer/station_alert,
 /obj/machinery/camera{
 	c_tag = "Security Office North-West";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -883,8 +856,7 @@
 "abz" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/machinery/camera{
 	c_tag = "Xenobiology Module North";
@@ -945,8 +917,7 @@
 "abG" = (
 /obj/machinery/camera{
 	c_tag = "Secure Armory West";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/deployable/barrier,
 /turf/simulated/floor{
@@ -1061,7 +1032,6 @@
 /obj/machinery/door/window/brigdoor{
 	dir = 2;
 	name = "Weapons locker";
-	req_access = null;
 	req_access_txt = "3"
 	},
 /obj/structure/closet/wardrobe/tactical,
@@ -1113,7 +1083,6 @@
 /obj/machinery/door/window/brigdoor{
 	dir = 2;
 	name = "Weapons locker";
-	req_access = null;
 	req_access_txt = "3"
 	},
 /obj/structure/closet/wardrobe/tactical,
@@ -1135,30 +1104,12 @@
 	name = "Weapons locker";
 	req_access_txt = "3"
 	},
-/obj/item/clothing/suit/storage/flak/bulletproof{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/suit/storage/flak/bulletproof{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/suit/storage/flak/bulletproof{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/bulletproof{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/bulletproof{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/bulletproof{
-	pixel_x = -3;
-	pixel_y = 3
-	},
+/obj/item/clothing/suit/storage/flak/bulletproof,
+/obj/item/clothing/suit/storage/flak/bulletproof,
+/obj/item/clothing/suit/storage/flak/bulletproof,
+/obj/item/clothing/head/helmet/bulletproof,
+/obj/item/clothing/head/helmet/bulletproof,
+/obj/item/clothing/head/helmet/bulletproof,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "vault"
@@ -1177,7 +1128,6 @@
 /obj/machinery/door/window/brigdoor{
 	dir = 2;
 	name = "Weapons locker";
-	req_access = null;
 	req_access_txt = "3"
 	},
 /obj/structure/closet/wardrobe/tactical,
@@ -1212,8 +1162,7 @@
 /obj/structure/rack,
 /obj/machinery/camera{
 	c_tag = "Secure Armory East";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/structure/window/reinforced{
 	dir = 1
@@ -1226,30 +1175,12 @@
 	name = "Weapons locker";
 	req_access_txt = "3"
 	},
-/obj/item/clothing/suit/armor/laserproof{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/suit/armor/laserproof{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/suit/armor/laserproof{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/laserproof{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/laserproof{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/laserproof{
-	pixel_x = -3;
-	pixel_y = 3
-	},
+/obj/item/clothing/suit/armor/laserproof,
+/obj/item/clothing/suit/armor/laserproof,
+/obj/item/clothing/suit/armor/laserproof,
+/obj/item/clothing/head/helmet/laserproof,
+/obj/item/clothing/head/helmet/laserproof,
+/obj/item/clothing/head/helmet/laserproof,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "vault"
@@ -1259,8 +1190,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -1271,8 +1201,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1287,6 +1216,11 @@
 "aca" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -1335,8 +1269,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1469,9 +1402,7 @@
 "act" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -22
 	},
 /obj/machinery/flasher/portable,
 /turf/simulated/floor{
@@ -1509,8 +1440,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
@@ -1599,8 +1529,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -1621,8 +1550,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1695,8 +1623,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -1717,8 +1644,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Security Office APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -1740,8 +1666,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -1758,8 +1683,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -1775,8 +1699,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -1788,12 +1711,9 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
-/obj/machinery/recharger{
-	pixel_y = 0
-	},
+/obj/machinery/recharger,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "redfull"
@@ -1841,8 +1761,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -1857,15 +1776,13 @@
 "acY" = (
 /obj/machinery/door/airlock/security{
 	name = "Execution Chamber";
-	req_access = null;
 	req_access_txt = "1"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1883,7 +1800,6 @@
 "ada" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/engine{
@@ -1906,8 +1822,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -1966,15 +1881,10 @@
 	},
 /area/security/armoury)
 "adh" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1985,10 +1895,7 @@
 "adi" = (
 /obj/structure/window/reinforced,
 /obj/structure/table,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/packageWrap,
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -2013,14 +1920,20 @@
 	},
 /area/security/main)
 "adk" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	icon_state = "closed";
+	id_tag = "satellite_aux_inner";
+	locked = 1;
+	name = "Satellite External Access";
+	req_access_txt = "13";
+	req_one_access_txt = "11;24"
 	},
-/turf/simulated/floor,
-/area/security/main)
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/aisat)
 "adl" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 4
@@ -2046,8 +1959,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2062,8 +1974,7 @@
 /area/security/main)
 "adp" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2091,8 +2002,7 @@
 /obj/machinery/requests_console{
 	department = "Security";
 	departmentType = 5;
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
@@ -2122,8 +2032,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2195,7 +2104,6 @@
 	id_tag = "solar_tool_inner";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "13"
 	},
 /obj/structure/cable{
@@ -2224,7 +2132,6 @@
 /obj/machinery/embedded_controller/radio/airlock_controller{
 	frequency = 1379;
 	id_tag = "solar_tool_airlock";
-	pixel_x = 0;
 	pixel_y = 28;
 	req_access_txt = "13";
 	tag_airpump = "solar_tool_pump";
@@ -2287,8 +2194,7 @@
 	frequency = 1475;
 	listening = 1;
 	name = "Station Intercom (Security)";
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -2299,8 +2205,7 @@
 "adG" = (
 /obj/machinery/camera{
 	c_tag = "Armory";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/rack,
 /obj/structure/window/reinforced{
@@ -2315,16 +2220,11 @@
 	req_access_txt = "3"
 	},
 /obj/item/weapon/gun/energy/gun{
-	pixel_x = 3;
-	pixel_y = -3
+	pixel_y = 4
 	},
+/obj/item/weapon/gun/energy/gun,
 /obj/item/weapon/gun/energy/gun{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/weapon/gun/energy/gun{
-	pixel_x = 3;
-	pixel_y = -3
+	pixel_y = -4
 	},
 /turf/simulated/floor{
 	icon_state = "delivery"
@@ -2365,8 +2265,7 @@
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
@@ -2381,12 +2280,10 @@
 	req_access_txt = "3"
 	},
 /obj/item/weapon/gun/energy/ionrifle{
-	pixel_x = -3;
 	pixel_y = 3
 	},
 /obj/item/weapon/gun/energy/ionrifle{
-	pixel_x = -3;
-	pixel_y = 3
+	pixel_y = -3
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -2453,9 +2350,7 @@
 "adR" = (
 /obj/structure/window/reinforced,
 /obj/structure/table,
-/obj/item/device/taperecorder{
-	pixel_y = 0
-	},
+/obj/item/device/taperecorder,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "redcorner"
@@ -2465,12 +2360,10 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2481,6 +2374,10 @@
 	},
 /area/security/brig)
 "adT" = (
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "red"
@@ -2525,12 +2422,10 @@
 	req_access_txt = "3"
 	},
 /obj/item/weapon/gun/projectile/automatic/l10c{
-	pixel_x = -3;
-	pixel_y = 3
+	pixel_y = 2
 	},
 /obj/item/weapon/gun/projectile/automatic/l10c{
-	pixel_x = -3;
-	pixel_y = 3
+	pixel_y = -2
 	},
 /turf/simulated/floor{
 	icon_state = "delivery"
@@ -2547,16 +2442,11 @@
 	req_access_txt = "3"
 	},
 /obj/item/weapon/gun/energy/laser{
-	pixel_x = -3;
 	pixel_y = 3
 	},
+/obj/item/weapon/gun/energy/laser,
 /obj/item/weapon/gun/energy/laser{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/weapon/gun/energy/laser{
-	pixel_x = -3;
-	pixel_y = 3
+	pixel_y = -3
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -2567,11 +2457,12 @@
 /area/security/warden)
 "adZ" = (
 /obj/structure/table,
-/obj/item/weapon/storage/box/teargas,
+/obj/item/weapon/storage/box/teargas{
+	pixel_y = 3
+	},
 /obj/item/weapon/storage/box/teargas,
 /obj/item/weapon/storage/box/flashbangs{
-	pixel_x = -2;
-	pixel_y = -2
+	pixel_y = -3
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -2584,9 +2475,7 @@
 	pixel_y = 24
 	},
 /obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 0
-	},
+/obj/machinery/recharger,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "bot"
@@ -2594,8 +2483,7 @@
 /area/security/warden)
 "aeb" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/disposalpipe/sortjunction/flipped{
 	dir = 1;
@@ -2610,8 +2498,7 @@
 /area/security/main)
 "aec" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/closet/secure_closet/security,
 /turf/simulated/floor{
@@ -2662,8 +2549,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -2731,8 +2617,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2753,8 +2638,7 @@
 	cell_type = 5000;
 	dir = 8;
 	name = "Warden APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -2819,8 +2703,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor,
@@ -2912,7 +2795,6 @@
 	id_tag = "solar_tool_outer";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "10;13"
 	},
 /obj/structure/cable{
@@ -2997,8 +2879,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/security/glass{
 	name = "Solitary Confinement";
@@ -3103,8 +2984,7 @@
 /obj/structure/sink{
 	dir = 8;
 	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
+	pixel_x = -12
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -3114,9 +2994,7 @@
 "aeS" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -22
 	},
 /turf/simulated/floor,
 /area/security/warden)
@@ -3129,8 +3007,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -3156,8 +3033,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -3171,8 +3047,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3201,8 +3076,7 @@
 /obj/machinery/flasher_button{
 	id = "solitary1";
 	name = "Solitary Confinement flash";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -3222,7 +3096,6 @@
 "afc" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/structure/closet{
@@ -3272,8 +3145,7 @@
 "afh" = (
 /obj/machinery/camera{
 	c_tag = "Security Office South";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/newscaster{
 	pixel_x = 30
@@ -3304,8 +3176,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/security/warden)
@@ -3313,8 +3184,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -3362,8 +3232,7 @@
 "afq" = (
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -3375,8 +3244,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -3413,8 +3281,10 @@
 	name = "Weapons locker";
 	req_access_txt = "3"
 	},
+/obj/item/weapon/gun/projectile/m79{
+	pixel_y = 6
+	},
 /obj/item/weapon/gun/grenadelauncher,
-/obj/item/weapon/gun/projectile/m79,
 /turf/simulated/floor{
 	icon_state = "delivery"
 	},
@@ -3452,13 +3322,9 @@
 	req_access_txt = "3"
 	},
 /obj/item/weapon/gun/projectile/shotgun{
-	pixel_x = -3;
-	pixel_y = 3
+	pixel_y = 4
 	},
-/obj/item/weapon/gun/projectile/shotgun{
-	pixel_x = -3;
-	pixel_y = 3
-	},
+/obj/item/weapon/gun/projectile/shotgun,
 /turf/simulated/floor{
 	icon_state = "delivery"
 	},
@@ -3475,7 +3341,6 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Fore Port Solar APC";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/machinery/camera{
@@ -3508,10 +3373,10 @@
 /area/crew_quarters/captain)
 "afA" = (
 /obj/structure/rack,
+/obj/item/clothing/shoes/magboots,
 /obj/item/clothing/suit/space/rig/security,
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/head/helmet/space/rig/security,
-/obj/item/clothing/shoes/magboots,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "bot"
@@ -3565,8 +3430,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
@@ -3589,8 +3453,7 @@
 "afI" = (
 /obj/machinery/camera{
 	c_tag = "Brig Northwest";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3630,8 +3493,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
@@ -3678,8 +3540,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3708,13 +3569,11 @@
 /obj/structure/rack,
 /obj/item/weapon/storage/lockbox/mind_shields,
 /obj/item/weapon/storage/box/chemimp{
-	pixel_x = 4;
 	pixel_y = 3
 	},
 /obj/item/weapon/storage/box/cdeathalarm_kit,
 /obj/item/weapon/storage/box/trackimp{
-	pixel_x = -2;
-	pixel_y = -2
+	pixel_y = -3
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -3732,8 +3591,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/security/warden)
@@ -3743,7 +3601,6 @@
 "afW" = (
 /obj/machinery/door/airlock/security{
 	name = "Security Checkpoint";
-	req_access = null;
 	req_access_txt = "1"
 	},
 /obj/machinery/door/firedoor,
@@ -3815,8 +3672,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -3843,8 +3699,7 @@
 /area/shuttle/escape_pod3/station)
 "agf" = (
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/structure/table,
 /obj/item/device/radio/off,
@@ -3874,8 +3729,7 @@
 /obj/machinery/flasher_button{
 	id = "solitary2";
 	name = "Solitary Confinement flash";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -3944,7 +3798,6 @@
 "agq" = (
 /obj/machinery/door/airlock/security{
 	name = "Evidence Storage";
-	req_access = null;
 	req_access_txt = "1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3980,8 +3833,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4013,8 +3865,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -4121,11 +3972,10 @@
 	layer = 4.1
 	},
 /obj/item/device/megaphone,
-/obj/item/weapon/storage/box/handcuffs,
-/obj/item/weapon/storage/box/seccarts{
-	pixel_x = 3;
-	pixel_y = 2
+/obj/item/weapon/storage/box/handcuffs{
+	pixel_y = 3
 	},
+/obj/item/weapon/storage/box/seccarts,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -4136,8 +3986,7 @@
 /area/rnd/mixing)
 "agF" = (
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/simulated/floor{
 	dir = 2;
@@ -4151,8 +4000,7 @@
 	frequency = 1475;
 	listening = 1;
 	name = "Station Intercom (Security)";
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/structure/window/reinforced,
 /obj/structure/closet/wardrobe/red,
@@ -4288,8 +4136,10 @@
 "agT" = (
 /obj/machinery/camera{
 	c_tag = "Security Processing";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
+	},
+/obj/machinery/alarm{
+	pixel_y = 26
 	},
 /turf/simulated/floor{
 	dir = 9;
@@ -4300,20 +4150,15 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
 	freerange = 0;
 	frequency = 1475;
 	listening = 1;
 	name = "Station Intercom (Security)";
-	pixel_x = 30;
-	pixel_y = 4
+	pixel_y = 27
 	},
-/obj/machinery/alarm{
-	frequency = 1600;
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "darkred"
@@ -4323,8 +4168,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4354,8 +4198,7 @@
 /area/rnd/lab)
 "agY" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -4390,8 +4233,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -4445,8 +4287,7 @@
 /area/rnd/mixing)
 "ahg" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -4528,8 +4369,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/red,
 /area/security/hos)
@@ -4537,8 +4377,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -4612,8 +4451,7 @@
 /area/solar/auxstarboard)
 "ahw" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -4647,7 +4485,6 @@
 	department = "Head of Security's Desk";
 	departmentType = 5;
 	name = "Head of Security RC";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/structure/disposalpipe/trunk{
@@ -4691,8 +4528,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4756,9 +4592,7 @@
 /area/security/brig)
 "ahJ" = (
 /obj/machinery/door/window/westright{
-	name = "Reception Door";
-	req_access = null;
-	req_access_txt = "0"
+	name = "Reception Door"
 	},
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
@@ -4769,8 +4603,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -4790,8 +4623,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -4803,8 +4635,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4821,8 +4652,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -4841,8 +4671,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4858,8 +4687,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -4891,8 +4719,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -4950,8 +4777,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -5008,9 +4834,7 @@
 	pixel_y = 2
 	},
 /obj/structure/table/woodentable,
-/obj/item/device/taperecorder{
-	pixel_y = 0
-	},
+/obj/item/device/taperecorder,
 /obj/item/weapon/cartridge/detective,
 /obj/structure/cable{
 	d2 = 8;
@@ -5038,8 +4862,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -5067,7 +4890,6 @@
 "aif" = (
 /obj/structure/closet/crate/freezer,
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -27
 	},
 /turf/simulated/floor,
@@ -5079,8 +4901,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor{
@@ -5113,8 +4934,7 @@
 	},
 /obj/machinery/light{
 	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -5146,8 +4966,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -5177,14 +4996,12 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 12;
-	pixel_y = 0
+	pixel_x = 12
 	},
 /obj/machinery/power/apc{
 	dir = 2;
 	level = 2;
 	name = "Operating 1 APC";
-	pixel_x = 0;
 	pixel_y = -25
 	},
 /obj/structure/cable{
@@ -5206,18 +5023,14 @@
 /area/maintenance/fpmaint)
 "air" = (
 /obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 0
-	},
+/obj/machinery/recharger,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
 /area/security/warden)
 "ais" = (
 /obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 0
-	},
+/obj/machinery/recharger,
 /obj/item/weapon/reagent_containers/spray/cleaner,
 /turf/simulated/floor{
 	dir = 8;
@@ -5229,7 +5042,6 @@
 /obj/random/tools/tech_supply,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/random/tools/tech_supply,
@@ -5312,14 +5124,10 @@
 "aiA" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/table/woodentable,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/folder/red,
 /obj/item/weapon/pen,
 /turf/simulated/floor{
@@ -5384,8 +5192,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -5409,8 +5216,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -5453,10 +5259,7 @@
 /area/shuttle/escape_pod3/station)
 "aiM" = (
 /obj/structure/table,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/hand_labeler,
 /obj/machinery/light,
 /turf/simulated/floor{
@@ -5488,13 +5291,9 @@
 /obj/item/device/camera{
 	desc = "A one use - polaroid camera. 30 photos left.";
 	name = "detectives camera";
-	pictures_left = 30;
-	pixel_x = 0;
-	pixel_y = 0
+	pictures_left = 30
 	},
-/obj/item/device/taperecorder{
-	pixel_y = 0
-	},
+/obj/item/device/taperecorder,
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "darkred"
@@ -5503,7 +5302,6 @@
 "aiQ" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/computer/security,
@@ -5551,18 +5349,14 @@
 	frequency = 1475;
 	listening = 1;
 	name = "Station Intercom (Security)";
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/structure/table,
 /obj/item/weapon/book/manual/wiki/security_space_law{
 	pixel_x = -3;
 	pixel_y = 5
 	},
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/item/weapon/folder/red,
 /obj/machinery/light{
@@ -5583,14 +5377,10 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Security Equipment South";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/table,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/machinery/light,
 /turf/simulated/floor{
@@ -5641,8 +5431,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -5699,7 +5488,6 @@
 /area/security/hos)
 "ajg" = (
 /obj/machinery/keycard_auth{
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/light,
@@ -5725,8 +5513,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5823,9 +5610,7 @@
 /obj/item/device/camera{
 	desc = "A one use - polaroid camera. 30 photos left.";
 	name = "detectives camera";
-	pictures_left = 30;
-	pixel_x = 0;
-	pixel_y = 0
+	pictures_left = 30
 	},
 /obj/item/weapon/storage/photo_album{
 	pixel_y = -10
@@ -5841,8 +5626,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -5852,7 +5636,6 @@
 /area/storage/primary)
 "aju" = (
 /obj/machinery/recharger/wallcharger{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/structure/cable{
@@ -5870,7 +5653,6 @@
 /area/security/main)
 "ajv" = (
 /obj/machinery/recharger/wallcharger{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/structure/table,
@@ -5908,8 +5690,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -6006,8 +5787,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Storage";
 	dir = 8;
-	network = list("SS13","Medical");
-	pixel_x = 0
+	network = list("SS13","Medical")
 	},
 /obj/item/weapon/storage/box/gloves,
 /obj/structure/table/glass,
@@ -6030,8 +5810,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
@@ -6072,8 +5851,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/solar/auxstarboard)
@@ -6108,8 +5886,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/solar/auxstarboard)
@@ -6146,8 +5923,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -6184,7 +5960,6 @@
 /area/hallway/secondary/exit)
 "ajS" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "10;63"
 	},
 /obj/structure/cable{
@@ -6209,8 +5984,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -6222,8 +5996,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6264,8 +6037,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
@@ -6288,8 +6060,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6307,14 +6078,12 @@
 /area/security/brig)
 "ajY" = (
 /obj/machinery/alarm{
-	frequency = 1600;
 	pixel_y = 26
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6338,8 +6107,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6359,8 +6127,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6416,14 +6183,12 @@
 /area/security/brig)
 "akc" = (
 /obj/item/device/radio/intercom{
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -6451,8 +6216,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -6484,8 +6248,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6502,8 +6265,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6520,8 +6282,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -6543,8 +6304,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -6573,8 +6333,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6594,8 +6353,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6610,14 +6368,12 @@
 /area/security/brig)
 "akl" = (
 /obj/machinery/alarm{
-	frequency = 1600;
 	pixel_y = 26
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -6634,8 +6390,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -6655,7 +6410,6 @@
 	frequency = 1475;
 	listening = 0;
 	name = "Station Intercom (Security)";
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/machinery/camera{
@@ -6665,8 +6419,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -6747,8 +6500,7 @@
 "aks" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -6796,8 +6548,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -6847,8 +6598,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/solar/auxstarboard)
@@ -6879,8 +6629,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -6901,16 +6650,12 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "akI" = (
-/obj/item/weapon/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
+/obj/item/weapon/storage/toolbox/mechanical,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "akJ" = (
@@ -6923,8 +6668,7 @@
 "akK" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -6939,8 +6683,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/landmark/start{
 	name = "Test Subject"
@@ -6966,8 +6709,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
@@ -6983,7 +6725,6 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Brig APC";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/cable,
@@ -6996,8 +6737,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7009,7 +6749,6 @@
 "akQ" = (
 /obj/machinery/door_timer/cell_1{
 	dir = 2;
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor{
@@ -7040,8 +6779,7 @@
 /area/storage/primary)
 "akS" = (
 /obj/machinery/door_timer/cell_2{
-	dir = 2;
-	pixel_x = 0
+	dir = 2
 	},
 /turf/simulated/floor{
 	dir = 2;
@@ -7054,7 +6792,6 @@
 	id = "cell1";
 	name = "Cell 1 Doors";
 	normaldoorcontrol = 0;
-	pixel_x = 0;
 	pixel_y = -30;
 	range = 10;
 	req_access_txt = "2"
@@ -7069,8 +6806,7 @@
 /area/security/brig)
 "akU" = (
 /obj/machinery/door_timer/cell_3{
-	dir = 2;
-	pixel_x = 0
+	dir = 2
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -7086,7 +6822,6 @@
 	id = "cell2";
 	name = "Cell 2 Doors";
 	normaldoorcontrol = 0;
-	pixel_x = 0;
 	pixel_y = -30;
 	range = 10;
 	req_access_txt = "2"
@@ -7102,7 +6837,6 @@
 	id = "cell3";
 	name = "Cell 3 Doors";
 	normaldoorcontrol = 0;
-	pixel_x = 0;
 	pixel_y = -30;
 	range = 10;
 	req_access_txt = "2"
@@ -7178,11 +6912,7 @@
 "alb" = (
 /obj/machinery/camera{
 	c_tag = "Security Warden Office";
-	dir = 2;
-	network = list("SS13")
-	},
-/obj/structure/sign/warning/securearea{
-	pixel_y = 32
+	dir = 2
 	},
 /obj/structure/filingcabinet/chestdrawer/black,
 /turf/simulated/floor{
@@ -7235,8 +6965,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -7364,8 +7093,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -7443,8 +7171,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7455,8 +7182,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
@@ -7469,8 +7195,7 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/simulated/floor{
 	dir = 2;
@@ -7513,8 +7238,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -7522,8 +7246,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating{
 	dir = 8;
@@ -7542,8 +7265,7 @@
 /area/security/detectives_office)
 "aly" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -7553,13 +7275,11 @@
 "alz" = (
 /obj/structure/table,
 /obj/item/weapon/kitchen/rollingpin,
-/obj/machinery/light{
-	dir = 4;
-	light_power = 0.9;
-	light_range = 8
-	},
 /obj/structure/sign/warning/nosmoking/circle{
 	pixel_x = 32
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -7630,8 +7350,7 @@
 /obj/machinery/flasher_button{
 	id = "entryflash";
 	name = "Entry flash";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 4
@@ -7645,8 +7364,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -7697,7 +7415,6 @@
 "alI" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -7731,8 +7448,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -7782,8 +7498,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -7803,15 +7518,13 @@
 /turf/simulated/floor,
 /area/security/prison)
 "alS" = (
-/obj/machinery/alarm{
-	dir = 2;
-	locked = 0;
-	pixel_y = 25
-	},
 /obj/structure/flora/plant/random,
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1"
+	},
+/obj/machinery/alarm{
+	pixel_y = 23
 	},
 /turf/simulated/floor{
 	dir = 9;
@@ -7825,15 +7538,16 @@
 /turf/simulated/floor,
 /area/security/prison)
 "alU" = (
-/obj/machinery/power/terminal{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/structure/cable,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/security/brig)
 "alV" = (
@@ -7959,8 +7673,7 @@
 /obj/item/device/flash,
 /obj/item/clothing/glasses/sunglasses,
 /obj/machinery/light_switch{
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/item/weapon/handcuffs,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -7997,7 +7710,6 @@
 	desc = "Used for watching Prison Wing holding areas.";
 	name = "Prison Monitor";
 	network = list("Prison");
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8009,8 +7721,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -8019,6 +7730,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/obj/machinery/flasher{
+	id = "entryflash"
 	},
 /turf/simulated/floor{
 	icon_state = "delivery"
@@ -8032,12 +7746,7 @@
 	cell_type = 2500;
 	dir = 4;
 	name = "Prison Wing APC";
-	pixel_x = 24;
-	pixel_y = 0
-	},
-/obj/machinery/flasher{
-	id = "entryflash";
-	pixel_x = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -8148,8 +7857,7 @@
 "amy" = (
 /obj/machinery/camera{
 	c_tag = "Brig Southwest";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -8192,8 +7900,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -8201,14 +7908,16 @@
 /turf/simulated/floor/plating,
 /area/security/prison)
 "amD" = (
-/obj/machinery/power/smes,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/power/smes{
+	chargemode = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Security Substation";
 	dir = 2
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/security/brig)
@@ -8216,8 +7925,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -8257,7 +7965,6 @@
 	layer = 4;
 	name = "Observation Screen";
 	network = list("Interrogation");
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/structure/stool/bed/chair/metal/red,
@@ -8396,7 +8103,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Interrogation Observervation";
-	req_access = null;
 	req_access_txt = "63"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -8425,8 +8131,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "red"
@@ -8437,7 +8142,6 @@
 	desc = "Used for watching Prison Wing holding areas.";
 	name = "Prison Monitor";
 	network = list("Prison");
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/machinery/computer/station_alert,
@@ -8499,8 +8203,7 @@
 "amX" = (
 /obj/machinery/flasher{
 	id = "Cell 1";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/stool/bed,
 /turf/simulated/floor{
@@ -8524,8 +8227,7 @@
 /obj/machinery/flasher{
 	id = "Cell 2";
 	pass_flags = 0;
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/stool/bed,
 /turf/simulated/floor{
@@ -8550,8 +8252,7 @@
 /obj/machinery/flasher{
 	id = "Cell 3";
 	pass_flags = 0;
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/simulated/floor{
 	icon_state = "red"
@@ -8623,10 +8324,7 @@
 /area/security/prison)
 "ani" = (
 /obj/structure/table,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/stack/medical/bruise_pack{
 	pixel_x = 10;
 	pixel_y = 2
@@ -8741,8 +8439,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -8998,7 +8695,6 @@
 "anG" = (
 /obj/structure/closet/crate/freezer,
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -27
 	},
 /turf/simulated/floor,
@@ -9096,9 +8792,7 @@
 /obj/structure/stool,
 /obj/machinery/vending/wallmed1{
 	name = "NanoMed";
-	pixel_x = 0;
-	pixel_y = 30;
-	req_access_txt = "0"
+	pixel_y = 30
 	},
 /obj/machinery/light{
 	dir = 1
@@ -9302,7 +8996,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Interrogation";
-	req_access = null;
 	req_access_txt = "63"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -9325,15 +9018,13 @@
 	pixel_x = 5
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/item/weapon/reagent_containers/food/condiment/peppermill{
 	pixel_x = 3
 	},
 /obj/item/weapon/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 0
+	pixel_x = -3
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -9387,8 +9078,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/security/prison)
@@ -9431,8 +9121,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -9468,8 +9157,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -9482,10 +9170,7 @@
 /area/security/lobby)
 "aoC" = (
 /obj/structure/table/reinforced,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/item/weapon/hand_labeler,
 /obj/item/weapon/storage/secure/safe{
@@ -9508,35 +9193,20 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "red"
 	},
 /area/security/prison)
-"aoF" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "redcorner"
-	},
-/area/security/lobby)
 "aoG" = (
 /obj/machinery/flasher{
-	id = "permflash";
-	pixel_x = 0
+	id = "permflash"
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -9584,8 +9254,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -9615,8 +9284,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -9645,15 +9313,13 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/security/prison)
 "aoU" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -9773,8 +9439,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -9804,8 +9469,7 @@
 	},
 /obj/structure/dryer{
 	dir = 4;
-	pixel_x = -6;
-	pixel_y = 0
+	pixel_x = -6
 	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
@@ -9869,8 +9533,7 @@
 	opacity = 0
 	},
 /obj/machinery/door/airlock/security/glass{
-	name = "Security Lobby";
-	req_access_txt = "0"
+	name = "Security Lobby"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -9904,8 +9567,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 12;
-	pixel_y = 0
+	pixel_x = 12
 	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
@@ -9956,9 +9618,7 @@
 	icon_state = "table"
 	},
 /obj/item/device/flashlight/lamp,
-/obj/item/device/taperecorder{
-	pixel_y = 0
-	},
+/obj/item/device/taperecorder,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -10046,7 +9706,6 @@
 	frequency = 1475;
 	listening = 0;
 	name = "Station Intercom (Security)";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/structure/table,
@@ -10123,8 +9782,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
@@ -10157,8 +9815,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10187,7 +9844,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/cable,
@@ -10210,8 +9866,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -10274,8 +9929,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10424,8 +10078,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10441,8 +10094,6 @@
 	id_tag = "security_inner";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
-	req_access_txt = "0";
 	req_one_access_txt = "13;45;1"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -10453,14 +10104,12 @@
 "aqq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "11;12"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10475,8 +10124,7 @@
 	opacity = 0
 	},
 /obj/machinery/door/airlock/security/glass{
-	name = "Security Lobby";
-	req_access_txt = "0"
+	name = "Security Lobby"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10601,8 +10249,7 @@
 /area/security/prison)
 "aqB" = (
 /obj/machinery/door/airlock{
-	name = "Brig Restroom";
-	req_access_txt = "0"
+	name = "Brig Restroom"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -10641,8 +10288,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -10670,8 +10316,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -10729,8 +10374,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -10774,8 +10418,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
@@ -10810,12 +10453,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 29
 	},
 /turf/simulated/floor/plating,
@@ -10841,14 +10482,12 @@
 	id_tag = "solar_chapel_outer";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "10;13"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
@@ -10862,10 +10501,7 @@
 	name = "Internal Affairs Desk";
 	req_access_txt = "38"
 	},
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/item/weapon/folder/white,
 /obj/machinery/door/poddoor{
@@ -10885,7 +10521,6 @@
 /obj/machinery/door_control{
 	id = "xenobio6";
 	name = "Containment Blast Doors";
-	pixel_x = 0;
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
@@ -10926,8 +10561,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "warning"
@@ -10952,8 +10586,7 @@
 /area/rnd/xenobiology)
 "arg" = (
 /obj/machinery/newscaster{
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/simulated/floor,
 /area/security/prison)
@@ -10966,7 +10599,6 @@
 "ari" = (
 /obj/machinery/door/window/westright{
 	name = "Kitchen Maintenance";
-	req_access = null;
 	req_access_txt = "28"
 	},
 /obj/structure/window/reinforced{
@@ -10998,13 +10630,7 @@
 "arm" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light{
-	dir = 4;
-	light_power = 0.9;
-	light_range = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -11030,9 +10656,7 @@
 "arr" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light{
-	dir = 4;
-	light_power = 0.9;
-	light_range = 8
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -11099,7 +10723,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/camera/xray{
@@ -11118,8 +10741,7 @@
 /obj/item/device/destTagger,
 /obj/machinery/camera{
 	c_tag = "Cargo mail";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor{
 	dir = 2;
@@ -11139,8 +10761,7 @@
 	frequency = 1475;
 	listening = 0;
 	name = "Station Intercom (Security)";
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -11244,8 +10865,7 @@
 /area/security/prison)
 "arM" = (
 /obj/machinery/flasher{
-	id = "permflash";
-	pixel_x = 0
+	id = "permflash"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11284,8 +10904,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11307,8 +10926,7 @@
 /area/maintenance/asmaint2)
 "arQ" = (
 /obj/machinery/door/airlock{
-	name = "Toilet";
-	req_access_txt = "0"
+	name = "Toilet"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -11458,8 +11076,7 @@
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -11481,8 +11098,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -11511,8 +11127,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11530,7 +11145,6 @@
 	name = "exterior access button";
 	pixel_x = -20;
 	pixel_y = -20;
-	req_access_txt = "0";
 	req_one_access_txt = "13;45;1"
 	},
 /turf/simulated/floor/plating/airless,
@@ -11539,8 +11153,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11561,8 +11174,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11606,8 +11218,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11625,8 +11236,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/cryofeed/right,
@@ -11638,8 +11248,7 @@
 /area/security/prison)
 "ast" = (
 /obj/machinery/flasher{
-	id = "permflash";
-	pixel_x = 0
+	id = "permflash"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -11650,8 +11259,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11672,8 +11280,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -11780,7 +11387,6 @@
 	name = "interior access button";
 	pixel_x = 20;
 	pixel_y = 20;
-	req_access_txt = "0";
 	req_one_access_txt = "13;45;1"
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible{
@@ -11792,9 +11398,7 @@
 /obj/machinery/embedded_controller/radio/airlock_controller{
 	frequency = 1379;
 	id_tag = "security_airlock";
-	pixel_x = 0;
 	pixel_y = 25;
-	req_access_txt = "0";
 	req_one_access_txt = "13;45;1";
 	tag_airpump = "security_pump";
 	tag_chamber_sensor = "security_sensor";
@@ -11887,8 +11491,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -11983,7 +11586,6 @@
 	pixel_y = -2
 	},
 /obj/item/weapon/reagent_containers/syringe/inaprovaline{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/item/weapon/reagent_containers/syringe/inaprovaline{
@@ -12048,8 +11650,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -12107,8 +11708,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -12177,7 +11777,6 @@
 /area/hallway/primary/fore)
 "atv" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "11;12"
 	},
 /turf/simulated/floor/plating,
@@ -12186,8 +11785,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -12222,8 +11820,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -12242,7 +11839,6 @@
 	id_tag = "solar_chapel_inner";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "13"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
@@ -12271,8 +11867,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -12347,8 +11942,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -12486,18 +12080,13 @@
 "atY" = (
 /obj/structure/rack,
 /obj/item/weapon/storage/briefcase/centcomm{
-	pixel_x = -2;
-	pixel_y = -5
+	pixel_y = 8
 	},
-/obj/item/weapon/storage/briefcase/centcomm{
-	pixel_x = 3;
-	pixel_y = 0
-	},
+/obj/item/weapon/storage/briefcase/centcomm,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -12550,8 +12139,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -12564,8 +12152,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -12655,12 +12242,10 @@
 /obj/structure/sink{
 	dir = 8;
 	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 0
+	pixel_x = -12
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -24
 	},
 /obj/structure/sign/chinese{
@@ -12673,14 +12258,12 @@
 /area/garden)
 "auo" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/door_control{
 	id = "xenobio4";
 	name = "Containment Blast Doors";
-	pixel_x = 0;
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
@@ -12729,7 +12312,6 @@
 "auv" = (
 /obj/machinery/door/window/westright{
 	name = "Hydroponics Maintenance";
-	req_access = null;
 	req_access_txt = "35"
 	},
 /obj/structure/window/reinforced{
@@ -12775,7 +12357,6 @@
 /area/shuttle/mining/station)
 "auA" = (
 /obj/machinery/alarm{
-	frequency = 1600;
 	pixel_y = 26
 	},
 /turf/simulated/floor{
@@ -12807,8 +12388,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
@@ -12818,9 +12398,7 @@
 "auF" = (
 /obj/structure/closet,
 /obj/machinery/light{
-	dir = 4;
-	light_power = 0.9;
-	light_range = 8
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -12915,8 +12493,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -12972,8 +12549,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -13052,8 +12628,7 @@
 "avh" = (
 /obj/structure/sign/poster{
 	official = 1;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plating{
 	icon_state = "platingdmg3"
@@ -13098,8 +12673,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -13161,8 +12735,7 @@
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -13179,7 +12752,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/plating,
@@ -13257,8 +12829,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -13313,8 +12884,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -13324,7 +12894,6 @@
 "avE" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor{
@@ -13341,8 +12910,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
@@ -13367,8 +12935,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -13382,8 +12949,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -13393,14 +12959,12 @@
 /area/rnd/xenobiology)
 "avK" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/door_control{
 	id = "xenobio5";
 	name = "Containment Blast Doors";
-	pixel_x = 0;
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
@@ -13420,8 +12984,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Module SE";
 	dir = 2;
-	network = list("SS13","Research");
-	pixel_x = 0
+	network = list("SS13","Research")
 	},
 /obj/structure/table/glass,
 /turf/simulated/floor{
@@ -13483,8 +13046,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -13528,8 +13090,7 @@
 /area/garden)
 "avY" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1
@@ -13611,8 +13172,7 @@
 /obj/machinery/vending/chinese,
 /obj/machinery/alarm{
 	dir = 1;
-	locked = 0;
-	pixel_y = -24
+	pixel_y = -22
 	},
 /turf/simulated/floor/wood,
 /area/garden)
@@ -13703,8 +13263,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -13733,8 +13292,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -13753,8 +13311,7 @@
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/simulated/floor{
 	dir = 6;
@@ -13770,8 +13327,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 12;
-	pixel_y = 0
+	pixel_x = 12
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -13800,14 +13356,12 @@
 	})
 "awy" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/door_control{
 	id = "xenobio7";
 	name = "Containment Blast Doors";
-	pixel_x = 0;
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
@@ -13871,7 +13425,6 @@
 "awH" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/hologram/holopad,
@@ -13928,8 +13481,7 @@
 	},
 /obj/item/weapon/paper/hydroponics,
 /obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/structure/table/glass,
 /obj/item/weapon/book/manual/wiki/hydroponics,
@@ -13980,8 +13532,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -13993,8 +13544,7 @@
 /obj/machinery/camera{
 	c_tag = "Misc Test Chamber North";
 	dir = 1;
-	network = list("SS13","Research");
-	pixel_x = 0
+	network = list("SS13","Research")
 	},
 /turf/simulated/floor/engine,
 /area/rnd/misc_lab)
@@ -14032,10 +13582,7 @@
 	},
 /area/lawoffice)
 "awY" = (
-/obj/item/weapon/paper_bin{
-	pixel_x = -5;
-	pixel_y = 10
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/folder/blue,
 /obj/item/weapon/pen{
 	layer = 3.1
@@ -14071,8 +13618,7 @@
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_y = 0
+	name = "HIGH VOLTAGE"
 	},
 /turf/simulated/wall,
 /area/security/range)
@@ -14192,8 +13738,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -14291,8 +13836,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 12;
-	pixel_y = 0
+	pixel_x = 12
 	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
@@ -14375,7 +13919,6 @@
 	name = "interior access button";
 	pixel_x = -20;
 	pixel_y = -20;
-	req_access_txt = "0";
 	req_one_access_txt = "13;45;1"
 	},
 /turf/simulated/floor/plating,
@@ -14428,8 +13971,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -14467,7 +14009,6 @@
 "axW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "11;12"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -14512,10 +14053,6 @@
 	icon_state = "warning"
 	},
 /area/rnd/telesci)
-"ayc" = (
-/obj/machinery/door/airlock/external,
-/turf/simulated/floor/plating,
-/area/shuttle/escape_pod1/station)
 "ayd" = (
 /obj/structure/table,
 /obj/random/tools/tech_supply,
@@ -14565,8 +14102,7 @@
 /area/ai_monitored/storage/eva)
 "ayh" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Showers";
-	req_access_txt = "0"
+	name = "Unisex Showers"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -14624,17 +14160,14 @@
 /area/maintenance/fpmaint)
 "ayn" = (
 /obj/structure/mirror{
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 12;
-	pixel_y = 0
+	pixel_x = 12
 	},
 /obj/machinery/alarm{
-	frequency = 1600;
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -14767,8 +14300,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -14905,8 +14437,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Dormitory APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -14970,9 +14501,6 @@
 	icon_state = "white"
 	},
 /area/rnd/telesci)
-"ayQ" = (
-/turf/simulated/wall/r_wall,
-/area/shuttle/escape_pod1/station)
 "ayR" = (
 /obj/machinery/monkey_recycler,
 /turf/simulated/floor{
@@ -14986,7 +14514,6 @@
 	dir = 1
 	},
 /obj/structure/sign/warning/deathsposal{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/light,
@@ -15047,8 +14574,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/camera{
 	c_tag = "Hydroponics Pasture"
@@ -15070,8 +14596,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Holodeck East";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/fitness)
@@ -15109,8 +14634,6 @@
 	id_tag = "security_outer";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
-	req_access_txt = "0";
 	req_one_access_txt = "13;45;1"
 	},
 /turf/simulated/floor/plating,
@@ -15127,8 +14650,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /mob/living/simple_animal/cow{
 	name = "Betsy"
@@ -15158,8 +14680,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -15190,8 +14711,7 @@
 /obj/item/weapon/storage/box/monkeycubes,
 /obj/item/weapon/storage/box/monkeycubes,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/item/weapon/extinguisher,
 /turf/simulated/floor{
@@ -15237,8 +14757,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -15262,10 +14781,7 @@
 /area/hallway/primary/starboard)
 "azn" = (
 /obj/structure/table,
-/obj/item/weapon/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
+/obj/item/weapon/storage/toolbox/mechanical,
 /obj/item/device/flashlight,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -15319,7 +14835,6 @@
 	department = "Science";
 	departmentType = 2;
 	name = "Science Requests Console";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/light,
@@ -15331,8 +14846,7 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -15351,11 +14865,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "azw" = (
-/obj/machinery/newscaster/security_unit{
-	pixel_x = -30;
-	pixel_y = 30
-	},
 /obj/machinery/photocopier,
+/obj/machinery/newscaster/security_unit{
+	pixel_y = 32
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "vault"
@@ -15390,8 +14903,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -15414,8 +14926,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -15448,8 +14959,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -15504,8 +15014,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -15530,7 +15039,6 @@
 "azQ" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor{
@@ -15554,7 +15062,6 @@
 	layer = 4;
 	name = "Test Chamber Telescreen";
 	network = list("Toxins Test Area");
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/simulated/floor{
@@ -15572,7 +15079,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
 	name = "E.V.A.";
-	req_access_txt = "0";
 	req_one_access_txt = "1;5;11;18;24"
 	},
 /turf/simulated/floor{
@@ -15590,15 +15096,13 @@
 	layer = 4;
 	name = "Test Chamber Telescreen";
 	network = list("Toxins Test Area");
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/machinery/driver_button{
 	dir = 2;
 	id = "toxinsdriver";
 	layer = 4;
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -15640,8 +15144,7 @@
 /obj/structure/sink{
 	dir = 8;
 	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
+	pixel_x = -12
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -15659,8 +15162,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -15754,8 +15256,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
@@ -15774,8 +15275,7 @@
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_y = 0
+	name = "HIGH VOLTAGE"
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/auxsolarstarboard)
@@ -15798,8 +15298,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -15816,8 +15315,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -15837,7 +15335,6 @@
 /obj/machinery/door_control{
 	id = "heads_meeting";
 	name = "Security Shutters";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -15891,7 +15388,6 @@
 /obj/item/weapon/bedsheet/green,
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -15909,8 +15405,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -15968,8 +15463,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15988,8 +15482,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -16014,14 +15507,12 @@
 "aAz" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -16041,8 +15532,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Dormitory Maintenance";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -16116,8 +15606,7 @@
 /obj/structure/flora/plant/random,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /turf/simulated/floor{
 	icon_state = "bot"
@@ -16161,8 +15650,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -16221,8 +15709,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
@@ -16344,8 +15831,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -16371,8 +15857,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -16403,14 +15888,12 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
 "aBf" = (
 /obj/machinery/alarm{
-	frequency = 1600;
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -16425,8 +15908,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -16443,8 +15925,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -16477,8 +15958,7 @@
 "aBj" = (
 /obj/machinery/camera{
 	c_tag = "EVA Maintenance";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/decal/cleanable/blood/oil,
 /obj/machinery/light/small{
@@ -16555,8 +16035,7 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -16630,8 +16109,7 @@
 /obj/structure/sink{
 	dir = 8;
 	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
+	pixel_x = -12
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -16649,8 +16127,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -16681,8 +16158,7 @@
 /obj/structure/closet/l3closet/scientist,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/simulated/floor{
 	dir = 6;
@@ -16776,8 +16252,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -16793,9 +16268,7 @@
 "aBN" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/machinery/alarm{
-	dir = 2;
-	locked = 0;
-	pixel_y = 25
+	pixel_y = 23
 	},
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
@@ -16807,8 +16280,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -16828,23 +16300,17 @@
 "aBQ" = (
 /obj/machinery/requests_console{
 	department = "EVA";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/toolbox/electrical{
-	pixel_x = -3;
-	pixel_y = 4
+	pixel_y = 6
 	},
-/obj/item/weapon/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
+/obj/item/weapon/storage/toolbox/mechanical,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -16874,14 +16340,10 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/structure/table,
-/obj/item/device/camera{
-	pixel_x = 3;
-	pixel_y = -4
-	},
+/obj/item/device/camera,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -16947,14 +16409,12 @@
 	amount = 50
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
 	dir = 4
@@ -16975,8 +16435,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -17003,7 +16462,6 @@
 	name = "exterior access button";
 	pixel_x = 20;
 	pixel_y = 20;
-	req_access_txt = "0";
 	req_one_access_txt = "13;45;1"
 	},
 /turf/space,
@@ -17011,8 +16469,7 @@
 "aCb" = (
 /obj/machinery/camera{
 	c_tag = "Security Maintenance";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint)
@@ -17029,8 +16486,6 @@
 	id_tag = "arrival_dock_inner";
 	locked = 1;
 	name = "Arrival Dock External Access";
-	req_access = null;
-	req_access_txt = "0";
 	req_one_access_txt = "13;45;1"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
@@ -17236,8 +16691,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -17294,8 +16748,7 @@
 /area/hallway/primary/fore)
 "aCI" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Showers";
-	req_access_txt = "0"
+	name = "Unisex Showers"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -17319,7 +16772,6 @@
 	frequency = 1379;
 	id_tag = "arrival_dock_airlock";
 	pixel_x = 25;
-	req_access_txt = "0";
 	req_one_access_txt = "13;45;1";
 	tag_airpump = "arrival_dock_pump";
 	tag_chamber_sensor = "arrival_dock_sensor";
@@ -17338,8 +16790,6 @@
 	id_tag = "toxin_test_inner";
 	locked = 1;
 	name = "Garden External Access";
-	req_access = null;
-	req_access_txt = "0";
 	req_one_access_txt = "13;45;1"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -17389,8 +16839,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -17449,8 +16898,6 @@
 	id_tag = "toxin_test_outer";
 	locked = 1;
 	name = "Garden External Access";
-	req_access = null;
-	req_access_txt = "0";
 	req_one_access_txt = "13;45;1"
 	},
 /turf/simulated/floor/plating,
@@ -17463,7 +16910,6 @@
 	name = "exterior access button";
 	pixel_x = -20;
 	pixel_y = -20;
-	req_access_txt = "0";
 	req_one_access_txt = "13;45;1"
 	},
 /turf/simulated/floor/plating,
@@ -17490,8 +16936,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -17544,7 +16989,6 @@
 	dir = 2;
 	name = "Medical Monitor";
 	network = list("Medical");
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/simulated/floor{
@@ -17573,8 +17017,6 @@
 	id_tag = "arrival_dock_outer";
 	locked = 1;
 	name = "Arrival Dock External Access";
-	req_access = null;
-	req_access_txt = "0";
 	req_one_access_txt = "13;45;1"
 	},
 /turf/simulated/floor/plating,
@@ -17638,8 +17080,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -17669,8 +17110,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -17716,7 +17156,6 @@
 	},
 /obj/machinery/cryopod/right,
 /obj/machinery/alarm{
-	frequency = 1600;
 	pixel_y = 26
 	},
 /turf/simulated/floor{
@@ -17775,8 +17214,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -17861,10 +17299,10 @@
 /area/ai_monitored/storage/eva)
 "aDF" = (
 /obj/structure/rack,
+/obj/item/clothing/shoes/magboots,
 /obj/item/clothing/suit/space/rig/medical,
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/head/helmet/space/rig/medical,
-/obj/item/clothing/shoes/magboots,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "vault"
@@ -17927,8 +17365,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -17942,14 +17379,12 @@
 /area/crew_quarters/toilet)
 "aDM" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Restrooms";
-	req_access_txt = "0"
+	name = "Unisex Restrooms"
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -17964,10 +17399,10 @@
 /area/crew_quarters/toilet)
 "aDN" = (
 /obj/structure/rack,
+/obj/item/clothing/shoes/magboots,
 /obj/item/clothing/suit/space/rig/security,
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/head/helmet/space/rig/security,
-/obj/item/clothing/shoes/magboots,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "vault"
@@ -17977,8 +17412,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Dormitory Bathrooms APC";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -17997,7 +17431,6 @@
 "aDP" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor{
@@ -18041,8 +17474,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Science Maintenance APC";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -18066,8 +17498,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
@@ -18201,8 +17632,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -18219,9 +17649,7 @@
 /obj/structure/sign/poster{
 	pixel_y = 32
 	},
-/obj/machinery/hydroponics/constructable{
-	pixel_y = 0
-	},
+/obj/machinery/hydroponics/constructable,
 /turf/simulated/floor/plating{
 	dir = 10;
 	icon_state = "warnplate"
@@ -18230,9 +17658,7 @@
 "aEr" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/machinery/light{
-	dir = 4;
-	light_power = 0.9;
-	light_range = 8
+	dir = 4
 	},
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
@@ -18244,8 +17670,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -18260,8 +17685,7 @@
 /area/hallway/secondary/entry)
 "aEu" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -18272,8 +17696,7 @@
 /obj/structure/sink{
 	dir = 8;
 	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
+	pixel_x = -12
 	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
@@ -18310,8 +17733,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -18347,8 +17769,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -18359,8 +17780,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -18382,8 +17802,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -18467,8 +17886,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18496,8 +17914,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
@@ -18507,7 +17924,6 @@
 	master_tag = "xeno_airlock_control";
 	name = "Xenobiology Access Button";
 	pixel_x = -24;
-	pixel_y = 0;
 	req_access_txt = "55"
 	},
 /turf/simulated/floor{
@@ -18524,8 +17940,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18540,8 +17955,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18559,8 +17973,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18596,8 +18009,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18611,8 +18023,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -18649,8 +18060,7 @@
 "aEZ" = (
 /obj/machinery/camera{
 	c_tag = "Fore Primary Hallway";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/power/apc{
 	dir = 8;
@@ -18675,8 +18085,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -18729,7 +18138,6 @@
 /obj/machinery/camera{
 	c_tag = "Garden East";
 	dir = 8;
-	pixel_x = 0;
 	pixel_y = -22
 	},
 /turf/simulated/floor/grass,
@@ -18754,8 +18162,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18789,8 +18196,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -18832,15 +18238,13 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/briefcase/inflatable{
-	pixel_x = 3;
-	pixel_y = 3
+	pixel_y = 4
 	},
 /obj/item/weapon/storage/briefcase/inflatable,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -18860,8 +18264,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -18921,8 +18324,7 @@
 /obj/structure/sink{
 	dir = 8;
 	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
+	pixel_x = -12
 	},
 /obj/structure/mirror{
 	pixel_x = -28
@@ -19090,8 +18492,7 @@
 /obj/structure/sink{
 	dir = 8;
 	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
+	pixel_x = -12
 	},
 /obj/structure/mirror{
 	pixel_x = -28
@@ -19117,8 +18518,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -19145,8 +18545,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating{
 	icon_state = "platingdmg3"
@@ -19159,8 +18558,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /turf/simulated/floor{
@@ -19176,7 +18574,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor,
@@ -19257,9 +18654,9 @@
 /area/crew_quarters/fitness)
 "aGb" = (
 /obj/structure/rack,
+/obj/item/clothing/shoes/magboots,
 /obj/item/device/suit_cooling_unit,
 /obj/item/weapon/tank/jetpack/carbondioxide,
-/obj/item/clothing/shoes/magboots,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "vault"
@@ -19306,8 +18703,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Dormitory APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -19321,8 +18717,7 @@
 /obj/structure/sink{
 	dir = 8;
 	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
+	pixel_x = -12
 	},
 /obj/structure/mirror{
 	pixel_x = -28
@@ -19363,8 +18758,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -19380,8 +18774,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "wooden-2"
@@ -19391,8 +18784,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -19443,9 +18835,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 4;
-	light_power = 0.9;
-	light_range = 8
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "boxing"
@@ -19532,8 +18922,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -19600,8 +18989,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -19638,8 +19026,7 @@
 /area/storage/emergency3)
 "aGJ" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -19681,8 +19068,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -19772,8 +19158,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Escape Hallway APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -19794,8 +19179,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -19812,8 +19196,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -19869,8 +19252,7 @@
 /obj/machinery/door_control{
 	id = "Medical_Surgery2";
 	name = "Privacy Shutters";
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /turf/simulated/floor{
 	dir = 2;
@@ -19905,12 +19287,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock{
-	name = "Unisex Restrooms";
-	req_access_txt = "0"
+	name = "Unisex Restrooms"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -19943,9 +19323,7 @@
 	pixel_y = 5
 	},
 /obj/item/weapon/reagent_containers/spray/plantbgone,
-/obj/machinery/hydroponics/constructable{
-	pixel_y = 0
-	},
+/obj/machinery/hydroponics/constructable,
 /turf/simulated/floor/plating{
 	dir = 1;
 	icon_state = "warnplate"
@@ -19966,8 +19344,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -20038,8 +19415,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
@@ -20052,8 +19428,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -20122,8 +19497,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -20178,8 +19552,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -20282,8 +19655,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 12;
-	pixel_y = 0
+	pixel_x = 12
 	},
 /obj/structure/dryer{
 	pixel_y = 24
@@ -20365,8 +19737,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -20431,8 +19802,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
@@ -20447,8 +19817,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -20463,8 +19832,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -20478,8 +19846,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -20543,8 +19910,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/orange,
 /area/maintenance/fpmaint)
@@ -20561,9 +19927,7 @@
 "aIu" = (
 /obj/item/weapon/hatchet,
 /obj/item/weapon/minihoe,
-/obj/machinery/hydroponics/constructable{
-	pixel_y = 0
-	},
+/obj/machinery/hydroponics/constructable,
 /obj/item/seeds/wheatseed,
 /turf/simulated/floor/plating{
 	dir = 1;
@@ -20617,9 +19981,7 @@
 /area/maintenance/fsmaint2)
 "aIA" = (
 /obj/item/weapon/storage/bag/plants,
-/obj/machinery/hydroponics/constructable{
-	pixel_y = 0
-	},
+/obj/machinery/hydroponics/constructable,
 /turf/simulated/floor/plating{
 	dir = 2;
 	icon_state = "warnplate"
@@ -20633,8 +19995,7 @@
 /obj/machinery/door_control{
 	id = "Medical_Surgery1";
 	name = "Privacy Shutters";
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -20688,8 +20049,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -20711,8 +20071,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -20735,8 +20094,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -20917,8 +20275,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
@@ -20956,8 +20313,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/flora/plant/random,
 /turf/simulated/floor{
@@ -21019,7 +20375,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Toxins Lab APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -21074,7 +20429,6 @@
 "aJq" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/science{
-	pixel_x = 0;
 	pixel_y = 1
 	},
 /obj/item/device/multitool{
@@ -21094,7 +20448,6 @@
 /obj/machinery/door_control{
 	id = "disvent";
 	name = "Incinerator Vent Control";
-	pixel_x = 0;
 	pixel_y = -24;
 	req_access_txt = "12"
 	},
@@ -21158,8 +20511,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
@@ -21182,8 +20534,6 @@
 /area/rnd/misc_lab)
 "aJy" = (
 /obj/structure/closet,
-/obj/random/tools/tech_supply,
-/obj/random/tools/tech_supply,
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
 "aJz" = (
@@ -21214,8 +20564,7 @@
 "aJC" = (
 /obj/structure/sign/poster{
 	official = 1;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/closet,
 /turf/simulated/floor{
@@ -21309,7 +20658,6 @@
 /area/chapel/office)
 "aJN" = (
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -21321,9 +20669,7 @@
 /area/chapel/office)
 "aJO" = (
 /obj/machinery/light{
-	dir = 4;
-	light_power = 0.9;
-	light_range = 8
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 6;
@@ -21389,16 +20735,13 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
 "aJV" = (
 /obj/item/seeds/watermelonseed,
-/obj/machinery/hydroponics/constructable{
-	pixel_y = 0
-	},
+/obj/machinery/hydroponics/constructable,
 /turf/simulated/floor/plating{
 	dir = 1;
 	icon_state = "warnplate"
@@ -21435,9 +20778,7 @@
 /area/maintenance/fpmaint)
 "aKa" = (
 /obj/item/seeds/berryseed,
-/obj/machinery/hydroponics/constructable{
-	pixel_y = 0
-	},
+/obj/machinery/hydroponics/constructable,
 /turf/simulated/floor/plating{
 	dir = 1;
 	icon_state = "warnplate"
@@ -21503,8 +20844,7 @@
 /obj/item/clothing/under/bathrobe,
 /obj/machinery/alarm{
 	dir = 1;
-	locked = 0;
-	pixel_y = -24
+	pixel_y = -22
 	},
 /turf/simulated/floor{
 	dir = 2;
@@ -21530,8 +20870,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Gym East";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "wooden-2"
@@ -21547,8 +20886,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/orange,
 /area/maintenance/fpmaint)
@@ -21565,8 +20903,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -21586,24 +20923,12 @@
 "aKm" = (
 /obj/structure/dresser,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
 /area/crew_quarters/fitness)
-"aKn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint)
 "aKo" = (
 /obj/machinery/power/apc{
 	dir = 2;
@@ -21618,13 +20943,11 @@
 /obj/structure/sink{
 	dir = 8;
 	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
+	pixel_x = -12
 	},
 /obj/structure/mirror{
 	dir = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -21660,8 +20983,7 @@
 "aKw" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -21682,8 +21004,7 @@
 "aKy" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -21740,8 +21061,7 @@
 "aKE" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -21808,8 +21128,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -21947,8 +21266,7 @@
 /obj/structure/stool,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -22047,8 +21365,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -22066,8 +21383,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -22088,8 +21404,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -22105,8 +21420,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -22143,10 +21457,7 @@
 /area/rnd/mixing)
 "aLo" = (
 /obj/structure/table,
-/obj/item/weapon/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
+/obj/item/weapon/storage/toolbox/mechanical,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "warning"
@@ -22168,7 +21479,6 @@
 "aLq" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor{
@@ -22255,8 +21565,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -22347,8 +21656,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -22374,14 +21682,10 @@
 	base_state = "right";
 	dir = 1;
 	icon_state = "right";
-	name = "Mailing Room";
-	req_access_txt = "0"
+	name = "Mailing Room"
 	},
 /obj/structure/table/reinforced,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/item/weapon/paper_bin,
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
@@ -22402,8 +21706,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -22434,8 +21737,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -22454,8 +21756,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -22480,8 +21781,7 @@
 "aLV" = (
 /obj/machinery/alarm{
 	dir = 1;
-	locked = 0;
-	pixel_y = -24
+	pixel_y = -22
 	},
 /turf/simulated/floor{
 	icon_state = "wooden-2"
@@ -22489,7 +21789,6 @@
 /area/crew_quarters/gym)
 "aLW" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/simulated/floor{
@@ -22520,7 +21819,6 @@
 "aMa" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/machinery/light{
@@ -22567,7 +21865,6 @@
 "aMf" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Hardsuits";
-	req_access_txt = "0";
 	req_one_access_txt = "11;24"
 	},
 /obj/machinery/door/firedoor,
@@ -22618,8 +21915,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
@@ -22692,8 +21988,7 @@
 	pixel_y = 3
 	},
 /obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/simulated/floor{
 	dir = 9;
@@ -22704,8 +21999,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -22774,8 +22068,7 @@
 /area/rnd/storage)
 "aMy" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector,
 /turf/simulated/floor{
@@ -22856,8 +22149,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 10;
@@ -22874,8 +22166,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 6;
@@ -22901,7 +22192,6 @@
 /obj/machinery/atmospherics/components/binary/valve,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor{
@@ -22962,8 +22252,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/door/firedoor,
@@ -22981,8 +22270,7 @@
 "aMT" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -23074,9 +22362,7 @@
 /area/maintenance/fpmaint)
 "aNe" = (
 /obj/item/seeds/ambrosiavulgarisseed,
-/obj/machinery/hydroponics/constructable{
-	pixel_y = 0
-	},
+/obj/machinery/hydroponics/constructable,
 /turf/simulated/floor/plating{
 	dir = 1;
 	icon_state = "warnplate"
@@ -23088,8 +22374,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -23099,8 +22384,7 @@
 "aNg" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -23159,8 +22443,7 @@
 /area/hallway/primary/central)
 "aNo" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -23202,8 +22485,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -23220,7 +22502,6 @@
 /obj/machinery/requests_console{
 	department = "Crew Quarters";
 	pixel_x = 32;
-	pixel_y = 0;
 	pixel_z = 0
 	},
 /obj/structure/cable{
@@ -23247,10 +22528,7 @@
 /area/toxins/brainstorm_center)
 "aNv" = (
 /obj/structure/table/glass,
-/obj/item/weapon/paper_bin{
-	pixel_x = -5;
-	pixel_y = 10
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /turf/simulated/floor{
 	icon_state = "white"
@@ -23268,10 +22546,7 @@
 /area/crew_quarters/locker)
 "aNx" = (
 /obj/structure/rack,
-/obj/item/weapon/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
+/obj/item/weapon/storage/toolbox/mechanical,
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
 "aNy" = (
@@ -23521,7 +22796,6 @@
 /area/bridge)
 "aNW" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/simulated/floor{
@@ -23659,8 +22933,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -23668,8 +22941,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -23688,8 +22960,7 @@
 /obj/machinery/requests_console{
 	department = "Security";
 	departmentType = 5;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -23771,8 +23042,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/storage/tools)
@@ -23795,8 +23065,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -23816,8 +23085,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -23858,8 +23126,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -23884,8 +23151,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -23921,9 +23187,7 @@
 /obj/item/weapon/folder/yellow,
 /obj/item/weapon/clipboard,
 /obj/item/weapon/stamp{
-	name = "Quartermaster's stamp";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "Quartermaster's stamp"
 	},
 /turf/simulated/floor,
 /area/quartermaster/qm)
@@ -23971,8 +23235,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -23998,8 +23261,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -24031,8 +23293,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -24133,8 +23394,7 @@
 "aPf" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/brigdoor{
-	dir = 4;
-	req_access_txt = "0"
+	dir = 4
 	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
@@ -24180,8 +23440,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24240,8 +23499,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
@@ -24263,8 +23521,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -24318,7 +23575,6 @@
 	name = "interior access button";
 	pixel_x = 20;
 	pixel_y = -20;
-	req_access_txt = "0";
 	req_one_access_txt = "13;45;1"
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible,
@@ -24337,8 +23593,6 @@
 	id_tag = "chapel_inner";
 	locked = 1;
 	name = "Chapel External Access";
-	req_access = null;
-	req_access_txt = "0";
 	req_one_access_txt = "13;45;1"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -24428,9 +23682,7 @@
 "aPH" = (
 /obj/item/weapon/folder/white,
 /obj/item/device/radio/headset/headset_medsci,
-/obj/item/device/flashlight/pen{
-	pixel_x = 0
-	},
+/obj/item/device/flashlight/pen,
 /obj/item/device/flashlight/pen{
 	pixel_x = 4;
 	pixel_y = 3
@@ -24448,14 +23700,12 @@
 /obj/item/weapon/storage/box/mousetraps,
 /obj/item/weapon/storage/box/mousetraps,
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/simulated/floor,
 /area/janitor)
 "aPJ" = (
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/structure/closet/wardrobe/red,
@@ -24525,8 +23775,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 2;
@@ -24546,8 +23795,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -24598,8 +23846,7 @@
 "aPY" = (
 /obj/machinery/light{
 	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -24616,10 +23863,7 @@
 /area/quartermaster/office)
 "aQa" = (
 /obj/structure/table,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/device/megaphone,
 /obj/item/weapon/pen{
 	pixel_x = 4;
@@ -24738,8 +23982,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
@@ -24761,7 +24004,6 @@
 "aQm" = (
 /obj/machinery/requests_console{
 	department = "Locker Room";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor,
@@ -24833,7 +24075,6 @@
 /area/crew_quarters/hor)
 "aQu" = (
 /obj/machinery/alarm{
-	frequency = 1600;
 	pixel_y = 26
 	},
 /turf/simulated/floor{
@@ -24849,8 +24090,7 @@
 	department = "Research Director's Desk";
 	departmentType = 5;
 	name = "Research Director RC";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -24862,8 +24102,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -24896,9 +24135,7 @@
 "aQA" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -22
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -24934,9 +24171,7 @@
 	dir = 4
 	},
 /obj/machinery/alarm{
-	dir = 2;
-	locked = 0;
-	pixel_y = 25
+	pixel_y = 23
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -24974,6 +24209,11 @@
 "aQI" = (
 /obj/structure/stool/bed/chair/comfy/black{
 	dir = 8
+	},
+/obj/item/device/radio/intercom{
+	dir = 2;
+	name = "Station Intercom (General)";
+	pixel_x = 31
 	},
 /turf/simulated/floor{
 	dir = 9;
@@ -25052,8 +24292,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
@@ -25083,8 +24322,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/storage/primary)
@@ -25092,7 +24330,6 @@
 /obj/structure/table,
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/random/tools/tech_supply,
@@ -25172,8 +24409,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -25189,8 +24425,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Medbay Storage APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable,
 /turf/simulated/floor{
@@ -25210,8 +24445,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -25233,8 +24467,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -25256,8 +24489,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fsmaint2)
@@ -25386,8 +24618,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/machinery/camera{
 	c_tag = "Toxins Lab South";
@@ -25491,7 +24722,6 @@
 "aRC" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/alarm{
-	frequency = 1600;
 	pixel_y = 26
 	},
 /turf/simulated/floor/carpet/green,
@@ -25535,8 +24765,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
@@ -25558,19 +24787,15 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/glass,
 /obj/item/weapon/storage/belt/medical{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/item/weapon/storage/belt/medical{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/item/weapon/storage/belt/medical{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/item/weapon/storage/belt/medical{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/item/clothing/accessory/stethoscope,
@@ -25676,10 +24901,7 @@
 	},
 /obj/machinery/light,
 /obj/structure/table/glass,
-/obj/item/weapon/storage/box/bodybags{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/weapon/storage/box/bodybags,
 /turf/simulated/floor{
 	dir = 2;
 	icon_state = "whiteblue"
@@ -25761,8 +24983,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/noticeboard{
 	dir = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/door/window/eastright{
 	base_state = "left";
@@ -25796,8 +25017,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -25859,7 +25079,6 @@
 	frequency = 1485;
 	listening = 1;
 	name = "Station Intercom (Medbay)";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /turf/simulated/floor/carpet/green,
@@ -25877,7 +25096,6 @@
 	dir = 9
 	},
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -25
 	},
 /turf/simulated/floor/wood,
@@ -25956,10 +25174,7 @@
 /area/storage/primary)
 "aSu" = (
 /obj/structure/table/woodentable,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/pen/invisible,
 /turf/simulated/floor{
 	dir = 2;
@@ -25997,8 +25212,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/crew_quarters/playroom)
@@ -26048,8 +25262,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26064,8 +25277,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -26088,7 +25300,6 @@
 /obj/structure/table/woodentable/poker,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor{
@@ -26133,8 +25344,7 @@
 "aSO" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -26154,17 +25364,13 @@
 	pixel_x = 7;
 	pixel_y = 1
 	},
-/obj/item/weapon/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/weapon/reagent_containers/glass/beaker/cryoxadone,
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
 	freerange = 0;
 	frequency = 1485;
 	listening = 1;
 	name = "Station Intercom (Medbay)";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/table,
@@ -26270,8 +25476,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -26328,8 +25533,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -26346,8 +25550,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -26378,8 +25581,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -26401,7 +25603,6 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/alarm{
-	frequency = 1600;
 	pixel_y = 26
 	},
 /turf/simulated/floor,
@@ -26438,7 +25639,6 @@
 "aTm" = (
 /obj/structure/table/reinforced,
 /obj/item/device/assembly/prox_sensor{
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/item/device/assembly/prox_sensor{
@@ -26477,8 +25677,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -26501,8 +25700,7 @@
 	},
 /obj/machinery/light{
 	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -26519,8 +25717,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -26546,7 +25743,6 @@
 "aTv" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -24
 	},
 /turf/simulated/floor{
@@ -26616,9 +25812,7 @@
 /obj/item/weapon/shard,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -22
 	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
@@ -26632,10 +25826,7 @@
 /area/maintenance/fsmaint2)
 "aTE" = (
 /obj/structure/table/reinforced,
-/obj/item/weapon/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /turf/simulated/floor{
 	dir = 8;
@@ -26706,8 +25897,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -26726,8 +25916,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/landmark/start{
 	name = "Test Subject"
@@ -26766,8 +25955,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Play Room APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -26782,7 +25970,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/flora/plant/random,
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -25
 	},
 /turf/simulated/floor/carpet/green,
@@ -26817,9 +26004,7 @@
 /obj/machinery/embedded_controller/radio/airlock_controller{
 	frequency = 1379;
 	id_tag = "chapel_airlock";
-	pixel_x = 0;
 	pixel_y = 25;
-	req_access_txt = "0";
 	req_one_access_txt = "13;45;1";
 	tag_airpump = "chapel_maint";
 	tag_chamber_sensor = "chapel_sensor";
@@ -27028,8 +26213,7 @@
 	},
 /obj/machinery/light{
 	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -27043,8 +26227,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/light_switch{
 	pixel_x = -27
@@ -27058,8 +26241,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Locker Room";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/simulated/floor,
 /area/crew_quarters/locker)
@@ -27148,8 +26330,7 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -27216,8 +26397,7 @@
 /obj/structure/closet/wardrobe/chaplain_black,
 /obj/machinery/camera{
 	c_tag = "Chapel Office";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/requests_console{
 	department = "Chapel";
@@ -27242,8 +26422,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel North";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -27334,8 +26513,7 @@
 "aUX" = (
 /obj/machinery/light{
 	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor,
 /area/quartermaster/office)
@@ -27371,7 +26549,6 @@
 /obj/item/device/radio/off,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor{
@@ -27399,7 +26576,6 @@
 	frequency = 1485;
 	listening = 1;
 	name = "Station Intercom (Medbay)";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/machinery/light_switch{
@@ -27432,7 +26608,6 @@
 	dir = 1
 	},
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -25
 	},
 /turf/simulated/floor{
@@ -27463,7 +26638,6 @@
 	dir = 1
 	},
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -25
 	},
 /turf/simulated/floor{
@@ -27492,8 +26666,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/effect/landmark/start{
 	name = "Test Subject"
@@ -27508,8 +26681,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/effect/landmark/start{
 	name = "Test Subject"
@@ -27526,8 +26698,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -27638,8 +26809,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 12;
-	pixel_y = 0
+	pixel_x = 12
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -27686,13 +26856,11 @@
 "aVH" = (
 /obj/machinery/camera{
 	c_tag = "Chief Engineer's Office";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -27752,8 +26920,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -27808,8 +26975,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -27868,8 +27034,7 @@
 	},
 /obj/structure/cable,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/hor)
@@ -27894,8 +27059,7 @@
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -27972,8 +27136,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
 	name = "Gateway";
-	req_access_txt = "62";
-	req_one_access_txt = "0"
+	req_access_txt = "62"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -27990,15 +27153,13 @@
 	pixel_y = 5
 	},
 /obj/item/device/assembly/signaler{
-	pixel_x = 0;
 	pixel_y = 8
 	},
 /obj/machinery/requests_console{
 	department = "Science";
 	departmentType = 2;
 	name = "Science Requests Console";
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/item/device/assembly/timer{
 	pixel_x = 6;
@@ -28065,8 +27226,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -28087,8 +27247,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
@@ -28099,8 +27258,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -28118,8 +27276,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -28139,10 +27296,7 @@
 /area/chapel/office)
 "aWo" = (
 /obj/structure/table/woodentable,
-/obj/item/weapon/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/item/device/eftpos{
 	eftpos_name = "Chapel EFTPOS scanner"
@@ -28159,8 +27313,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28429,8 +27582,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/landmark/start{
 	name = "Test Subject"
@@ -28497,8 +27649,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -28608,8 +27759,7 @@
 /obj/structure/flora/plant/random,
 /obj/machinery/light{
 	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -28623,8 +27773,7 @@
 "aXl" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -28658,8 +27807,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -28719,8 +27867,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "RD Office APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -28796,8 +27943,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -28819,8 +27965,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -28994,8 +28139,7 @@
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /turf/simulated/floor,
 /area/gateway)
@@ -29027,8 +28171,7 @@
 "aXY" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -29046,8 +28189,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -29124,9 +28266,7 @@
 /area/hallway/secondary/entry)
 "aYi" = (
 /obj/structure/table/woodentable,
-/obj/machinery/computer/forensic_scanning/detective{
-	req_access = null
-	},
+/obj/machinery/computer/forensic_scanning/detective,
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "aYj" = (
@@ -29286,8 +28426,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -29311,8 +28450,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -29344,8 +28482,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
@@ -29356,8 +28493,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
@@ -29365,8 +28501,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -29540,7 +28675,6 @@
 /obj/machinery/disposal,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/disposalpipe/trunk,
@@ -29551,8 +28685,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Security Office North-East";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -29587,8 +28720,7 @@
 "aZf" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -29600,8 +28732,7 @@
 "aZg" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -29620,8 +28751,7 @@
 /area/crew_quarters/playroom)
 "aZi" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/grille,
@@ -29632,8 +28762,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -29710,8 +28839,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -29735,8 +28863,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Bay";
@@ -29749,8 +28876,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light,
 /turf/simulated/floor,
@@ -29767,7 +28893,6 @@
 	id = "Gateway_shutters";
 	name = "Gateway Shutters";
 	pixel_x = -5;
-	pixel_y = 0;
 	req_access_txt = "57"
 	},
 /obj/item/weapon/paper/pamphlet{
@@ -29789,8 +28914,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -29819,8 +28943,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -29873,16 +28996,14 @@
 "aZB" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -29893,16 +29014,14 @@
 "aZC" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -29913,8 +29032,7 @@
 "aZD" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -29924,8 +29042,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -30019,8 +29136,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/quartermaster/office)
@@ -30098,8 +29214,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -30112,8 +29227,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -30248,7 +29362,6 @@
 /obj/machinery/camera{
 	c_tag = "Gateway";
 	dir = 8;
-	pixel_x = 0;
 	pixel_y = -22
 	},
 /turf/simulated/floor{
@@ -30268,7 +29381,6 @@
 "bam" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor{
@@ -30300,8 +29412,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -30322,8 +29433,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30379,7 +29489,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor{
@@ -30613,7 +29722,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/simulated/floor{
@@ -30641,8 +29749,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -30679,8 +29786,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/quartermaster/qm)
@@ -30717,8 +29823,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -30729,14 +29834,12 @@
 "bbc" = (
 /obj/machinery/door/airlock/command{
 	name = "Conference Room";
-	req_access = null;
 	req_access_txt = "19"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -30777,7 +29880,6 @@
 "bbh" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor{
@@ -30832,8 +29934,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -30869,8 +29970,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 2;
@@ -30898,7 +29998,6 @@
 	},
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor{
@@ -30932,7 +30031,6 @@
 	buildable_sign = 0;
 	dir = 1;
 	icon_state = "direction_evac";
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -30966,8 +30064,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -30984,8 +30081,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -31063,7 +30159,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/disposalpipe/segment{
@@ -31082,7 +30177,6 @@
 	dir = 4
 	},
 /obj/machinery/alarm{
-	frequency = 1600;
 	pixel_y = 26
 	},
 /turf/simulated/floor{
@@ -31093,14 +30187,12 @@
 "bbL" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Office";
-	req_access = null;
 	req_access_txt = "20"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/wood,
@@ -31114,8 +30206,7 @@
 "bbN" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -31131,8 +30222,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -31154,7 +30244,6 @@
 	dir = 4
 	},
 /obj/machinery/alarm{
-	frequency = 1600;
 	pixel_y = 26
 	},
 /turf/simulated/floor{
@@ -31342,7 +30431,6 @@
 "bcj" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -31382,7 +30470,6 @@
 "bcm" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod 5";
-	req_access = null;
 	req_access_txt = null;
 	req_one_access_txt = null
 	},
@@ -31411,8 +30498,7 @@
 "bcq" = (
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway 5";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/structure/sign/warning/pods{
 	pixel_y = 32
@@ -31454,8 +30540,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -31555,15 +30640,9 @@
 	},
 /area/quartermaster/storage)
 "bcD" = (
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/clipboard,
-/obj/item/weapon/pen/red{
-	pixel_x = 2;
-	pixel_y = 6
-	},
+/obj/item/weapon/pen/red,
 /obj/structure/table,
 /turf/simulated/floor,
 /area/quartermaster/office)
@@ -31578,9 +30657,7 @@
 "bcG" = (
 /obj/machinery/vending/wallmed1{
 	name = "Emergency NanoMed";
-	pixel_x = 28;
-	pixel_y = 0;
-	req_access_txt = "0"
+	pixel_x = 28
 	},
 /turf/simulated/floor{
 	dir = 2;
@@ -31675,8 +30752,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -31700,8 +30776,7 @@
 /obj/item/weapon/aiModule/paladin,
 /obj/item/weapon/aiModule/robocop,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -31738,8 +30813,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/whitegreed,
 /area/turret_protected/ai_upload)
@@ -31765,8 +30839,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -31879,7 +30952,6 @@
 	frequency = 1379;
 	id_tag = "satellite_aux_airlock";
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = 25;
 	req_access_txt = "66";
 	tag_airpump = "satellite_aux_pump";
@@ -32012,8 +31084,7 @@
 "bdz" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA";
-	pixel_y = 0
+	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/wall,
 /area/hallway/secondary/entry)
@@ -32070,8 +31141,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -32116,8 +31186,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -32128,8 +31197,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -32151,8 +31219,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -32167,8 +31234,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -32194,15 +31260,11 @@
 /area/security/vacantoffice)
 "bdT" = (
 /obj/structure/table/woodentable,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/item/device/megaphone,
 /turf/simulated/floor/wood,
@@ -32224,8 +31286,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
@@ -32239,8 +31300,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
@@ -32254,8 +31314,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
@@ -32263,8 +31322,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -32302,7 +31360,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/camera{
@@ -32357,8 +31414,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
@@ -32368,8 +31424,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -32416,8 +31471,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
@@ -32429,8 +31483,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
@@ -32476,8 +31529,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
@@ -32488,21 +31540,18 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/captain)
 "beB" = (
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -32511,14 +31560,12 @@
 /area/crew_quarters/captain)
 "beC" = (
 /obj/machinery/status_display{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -32557,8 +31604,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
@@ -32567,8 +31613,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -32587,8 +31632,7 @@
 	},
 /obj/item/clothing/under/lawyer/oldman,
 /obj/item/clothing/under/suit_jacket/really_black{
-	pixel_x = -2;
-	pixel_y = 0
+	pixel_x = -2
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -32631,8 +31675,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /obj/item/device/radio/intercom{
@@ -32649,8 +31692,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
 	dir = 4
@@ -32663,7 +31705,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor{
@@ -32685,8 +31726,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -32697,8 +31737,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -32708,8 +31747,7 @@
 "beS" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint2)
@@ -32767,8 +31805,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -32779,8 +31816,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/quartermaster/office)
@@ -32788,7 +31824,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/camera{
@@ -32804,8 +31839,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -32824,7 +31858,6 @@
 /obj/structure/noticeboard{
 	dir = 1;
 	icon_state = "nboard00";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -32833,8 +31866,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -32868,7 +31900,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -24
 	},
 /obj/machinery/vending/clothing,
@@ -32878,8 +31909,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -32935,8 +31965,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -32968,14 +31997,12 @@
 /area/hallway/primary/central)
 "bfr" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -33097,8 +32124,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -33114,8 +32140,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -33139,8 +32164,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -33156,8 +32180,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -33170,10 +32193,7 @@
 /area/rnd/hallway)
 "bfM" = (
 /obj/structure/rack,
-/obj/item/weapon/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
+/obj/item/weapon/storage/toolbox/mechanical,
 /obj/item/device/flashlight,
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -33181,8 +32201,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -33221,8 +32240,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -33252,8 +32270,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -33310,8 +32327,7 @@
 	},
 /obj/structure/dryer{
 	dir = 4;
-	pixel_x = -6;
-	pixel_y = 0
+	pixel_x = -6
 	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
@@ -33338,8 +32354,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -33395,7 +32410,6 @@
 "bgr" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/simulated/floor{
@@ -33479,8 +32493,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -33660,7 +32673,6 @@
 /area/crew_quarters/captain)
 "bgT" = (
 /obj/machinery/keycard_auth{
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -33675,8 +32687,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -33737,8 +32748,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -33789,7 +32799,6 @@
 /area/hallway/secondary/entry)
 "bhh" = (
 /obj/machinery/atm{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -33867,10 +32876,7 @@
 /turf/simulated/floor/wood,
 /area/bridge/meeting_room)
 "bhy" = (
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet/blue2,
@@ -33903,7 +32909,6 @@
 "bhE" = (
 /obj/machinery/flasher{
 	id = "AI";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/computer/aiupload,
@@ -33936,7 +32941,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/table,
@@ -33984,21 +32988,6 @@
 "bhL" = (
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/captain)
-"bhM" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fpmaint)
 "bhN" = (
 /obj/structure/table/woodentable,
 /obj/machinery/recharger{
@@ -34050,7 +33039,6 @@
 "bhV" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor{
@@ -34136,8 +33124,7 @@
 /area/rnd/hallway)
 "big" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/simulated/floor{
 	dir = 9;
@@ -34153,8 +33140,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -34202,10 +33188,7 @@
 	pixel_x = 3;
 	pixel_y = 4
 	},
-/obj/item/weapon/storage/box/masks{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/weapon/storage/box/masks,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -34269,9 +33252,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Morgue";
 	dir = 2;
-	network = list("SS13","Medical");
-	pixel_x = 0;
-	pixel_y = 0
+	network = list("SS13","Medical")
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -34291,8 +33272,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -34304,8 +33284,7 @@
 	dir = 8;
 	level = 4;
 	name = "Chemistry APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -34323,7 +33302,6 @@
 "biy" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/closet/secure_closet/chemical,
@@ -34360,8 +33338,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/door/firedoor,
@@ -34370,8 +33347,7 @@
 "biE" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/door/firedoor,
@@ -34403,8 +33379,7 @@
 "biJ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -34423,8 +33398,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -34485,22 +33459,18 @@
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "biQ" = (
-/obj/machinery/ai_status_display{
-	pixel_y = 0
-	},
+/obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai_upload)
 "biR" = (
 /obj/machinery/door/airlock/command{
 	name = "Server Room";
-	req_access = null;
 	req_access_txt = "30"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -34540,7 +33510,6 @@
 /area/security/vacantoffice)
 "biV" = (
 /obj/machinery/alarm{
-	frequency = 1600;
 	pixel_y = 26
 	},
 /turf/simulated/floor/wood{
@@ -34614,8 +33583,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -34728,8 +33696,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -34788,8 +33755,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -34805,8 +33771,7 @@
 	},
 /obj/item/weapon/pen,
 /obj/machinery/light_switch{
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/simulated/floor{
 	dir = 6;
@@ -34876,10 +33841,7 @@
 /area/chapel/main)
 "bjT" = (
 /obj/structure/table,
-/obj/item/weapon/storage/firstaid/regular{
-	pixel_x = 6;
-	pixel_y = -5
-	},
+/obj/item/weapon/storage/firstaid/regular,
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Cargo Office APC";
@@ -34895,8 +33857,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -34930,8 +33891,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -34944,8 +33904,7 @@
 "bka" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA";
-	pixel_y = 0
+	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/wall,
 /area/space)
@@ -34956,8 +33915,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -34967,8 +33925,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -35000,7 +33957,6 @@
 /area/bridge/meeting_room)
 "bkm" = (
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/faxmachine{
@@ -35084,8 +34040,7 @@
 	department = "Captain's Desk";
 	departmentType = 5;
 	name = "Captain RC";
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/structure/filingcabinet,
 /turf/simulated/floor/wood,
@@ -35131,7 +34086,6 @@
 /obj/item/weapon/melee/chainofcommand,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor/wood,
@@ -35231,8 +34185,7 @@
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -35307,10 +34260,7 @@
 /area/security/vacantoffice)
 "bkX" = (
 /obj/structure/table,
-/obj/item/weapon/paper_bin{
-	pixel_x = -2;
-	pixel_y = 5
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/pen/blue{
 	pixel_x = -3;
 	pixel_y = 2
@@ -35390,8 +34340,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
@@ -35412,8 +34361,7 @@
 /obj/structure/window/reinforced/tinted,
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -35506,8 +34454,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -35527,8 +34474,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -35545,8 +34491,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -35556,8 +34501,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -35573,8 +34517,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -35594,8 +34537,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/captain)
@@ -35607,8 +34549,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -35668,8 +34609,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -35700,8 +34640,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -35833,13 +34772,11 @@
 /obj/machinery/camera{
 	c_tag = "Research Division Server Room";
 	dir = 2;
-	network = list("SS13","Research");
-	pixel_x = 0
+	network = list("SS13","Research")
 	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Server Room APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
@@ -35860,7 +34797,6 @@
 "blI" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -35894,17 +34830,12 @@
 /obj/machinery/requests_console{
 	department = "Private Office";
 	name = "Private Office RC";
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/item/weapon/storage/briefcase/centcomm{
-	pixel_x = 3;
-	pixel_y = 0
+	pixel_y = 6
 	},
-/obj/item/weapon/storage/briefcase{
-	pixel_x = -2;
-	pixel_y = -5
-	},
+/obj/item/weapon/storage/briefcase,
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "blP" = (
@@ -35932,8 +34863,7 @@
 /area/hallway/primary/central)
 "blS" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/simulated/floor{
 	icon_state = "bluecorner"
@@ -36038,8 +34968,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -36054,8 +34983,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
@@ -36095,7 +35023,6 @@
 /obj/machinery/door_control{
 	id = "kitchen";
 	name = "Kitchen Shutters Control";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access_txt = "28"
 	},
@@ -36154,9 +35081,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Foyer-East";
 	dir = 8;
-	network = list("SS13","Medical");
-	pixel_x = 0;
-	pixel_y = 0
+	network = list("SS13","Medical")
 	},
 /turf/simulated/floor{
 	dir = 2;
@@ -36276,20 +35201,6 @@
 	icon_state = "whitegreen"
 	},
 /area/medical/hallway)
-"bna" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "whitegreen"
-	},
-/area/medical/hallway)
 "bnb" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plating,
@@ -36314,8 +35225,7 @@
 /obj/structure/stool/bed/chair/metal/yellow,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -36346,7 +35256,6 @@
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
 	departmentType = 2;
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/item/stack/sheet/glass{
@@ -36366,7 +35275,6 @@
 "bnl" = (
 /obj/machinery/autolathe,
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor{
@@ -36421,8 +35329,7 @@
 /area/medical/patients_rooms)
 "bnr" = (
 /obj/machinery/door/airlock{
-	name = "Toilet";
-	req_access_txt = "0"
+	name = "Toilet"
 	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
@@ -36449,8 +35356,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/whitegreed,
 /area/turret_protected/ai_upload)
@@ -36465,8 +35371,7 @@
 /obj/machinery/computer/monitor,
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -36497,8 +35402,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -36546,8 +35450,7 @@
 /area/shuttle/escape_pod1/station)
 "bnG" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/simulated/floor{
 	dir = 2;
@@ -36609,8 +35512,7 @@
 "bnR" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor{
 	dir = 2;
@@ -36621,9 +35523,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Foyer-west";
 	dir = 5;
-	network = list("SS13","Medical");
-	pixel_x = 0;
-	pixel_y = 0
+	network = list("SS13","Medical")
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -36662,7 +35562,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Vault APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -36696,8 +35595,7 @@
 /obj/item/clothing/suit/armor/captain,
 /obj/item/clothing/head/helmet/space/capspace,
 /obj/machinery/newscaster/security_unit{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
@@ -36716,8 +35614,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -36734,8 +35631,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -36803,8 +35699,7 @@
 "bok" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -36862,8 +35757,7 @@
 /obj/machinery/door/window/northleft{
 	dir = 8;
 	icon_state = "left";
-	name = "Reception Window";
-	req_access_txt = "0"
+	name = "Reception Window"
 	},
 /obj/machinery/door/window/brigdoor{
 	base_state = "rightsecure";
@@ -36897,8 +35791,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -36940,8 +35833,7 @@
 "boD" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -36996,8 +35888,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /turf/simulated/floor{
 	icon_state = "delivery"
@@ -37020,10 +35911,7 @@
 /area/medical/storage)
 "boK" = (
 /obj/structure/table/woodentable,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/folder/red,
 /obj/item/weapon/pen,
 /turf/simulated/floor/wood,
@@ -37253,7 +36141,6 @@
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/machinery/alarm{
-	frequency = 1600;
 	pixel_y = 26
 	},
 /turf/simulated/floor{
@@ -37280,8 +36167,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
@@ -37336,8 +36222,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/captain)
@@ -37359,8 +36244,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
@@ -37369,8 +36253,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
@@ -37400,8 +36283,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -37460,8 +36342,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -37484,8 +36365,7 @@
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/Podbay)
@@ -37497,27 +36377,11 @@
 	frequency = 1485;
 	listening = 1;
 	name = "Station Intercom (Medbay)";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "whitegreen"
-	},
-/area/medical/hallway)
-"bpQ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor{
-	dir = 8;
 	icon_state = "whitegreen"
 	},
 /area/medical/hallway)
@@ -37531,7 +36395,6 @@
 	department = "Genetics";
 	departmentType = 0;
 	name = "Genetics Requests Console";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/machinery/light{
@@ -37553,8 +36416,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Kitchen APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -37591,8 +36453,7 @@
 "bqa" = (
 /obj/machinery/vending/cigarette,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -37635,7 +36496,6 @@
 /obj/machinery/door_control{
 	id = "Bar_Privacy1";
 	name = "Privacy Shutters";
-	pixel_x = 0;
 	pixel_y = -25
 	},
 /turf/simulated/floor/carpet/blue,
@@ -37852,8 +36712,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -37983,15 +36842,14 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "bqZ" = (
 /obj/structure/rack,
-/obj/item/weapon/tank/emergency_oxygen,
+/obj/item/weapon/tank/emergency_oxygen/engi,
 /turf/simulated/floor/plating,
 /area/maintenance/maintcentral)
 "bra" = (
@@ -38007,8 +36865,7 @@
 "brc" = (
 /obj/machinery/camera{
 	c_tag = "Vault";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/closet/crate{
 	name = "Gold Crate"
@@ -38134,8 +36991,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/quartermaster/storage)
@@ -38152,8 +37008,7 @@
 "bru" = (
 /obj/machinery/alarm/server{
 	dir = 4;
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -22
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -38249,8 +37104,7 @@
 	dir = 8
 	},
 /obj/machinery/newscaster{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/simulated/floor{
 	icon_state = "delivery"
@@ -38259,10 +37113,7 @@
 "brJ" = (
 /obj/structure/table,
 /obj/item/weapon/pen,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/item/device/megaphone,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -38372,8 +37223,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/teleporter)
@@ -38384,8 +37234,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -38400,8 +37249,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -38412,8 +37260,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -38442,8 +37289,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -38455,8 +37301,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -38493,8 +37338,7 @@
 "bsk" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -38506,8 +37350,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -38621,25 +37464,10 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/Podbay)
-"bsx" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "whitegreen"
-	},
-/area/medical/hallway)
 "bsy" = (
 /obj/machinery/light{
 	dir = 8
@@ -38651,8 +37479,7 @@
 	id = "Genetics";
 	name = "Genetics";
 	normaldoorcontrol = 1;
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/structure/closet/secure_closet/personal/patient,
 /turf/simulated/floor{
@@ -38711,8 +37538,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -38737,8 +37563,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Vacant Office APC";
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /obj/structure/table/woodentable,
 /obj/item/weapon/book/manual/wiki/security_space_law,
@@ -38821,10 +37646,7 @@
 /area/crew_quarters/bar)
 "bsT" = (
 /obj/structure/table/woodentable,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/item/weapon/paper_bin,
 /turf/simulated/floor/carpet/black,
 /area/security/vacantoffice)
 "bsU" = (
@@ -38832,8 +37654,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -38879,7 +37700,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor{
@@ -38901,8 +37721,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -38939,8 +37758,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -38957,8 +37775,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -38976,8 +37793,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -39093,8 +37909,7 @@
 "btB" = (
 /obj/machinery/camera{
 	c_tag = "Recycler office";
-	dir = 1;
-	network = list("ss13")
+	dir = 1
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -39112,8 +37927,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -39130,8 +37944,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/captain)
@@ -39139,7 +37952,6 @@
 /obj/structure/table,
 /obj/item/weapon/storage/belt/utility,
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -39177,8 +37989,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -39193,8 +38004,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -39211,8 +38021,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -39248,8 +38057,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -39275,8 +38083,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/effect/landmark/start{
 	name = "Cyborg"
@@ -39303,8 +38110,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -39321,8 +38127,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -39392,7 +38197,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor{
@@ -39431,8 +38235,7 @@
 "bue" = (
 /obj/structure/noticeboard{
 	dir = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -39500,8 +38303,7 @@
 	department = "Science";
 	departmentType = 2;
 	name = "Science Requests Console";
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -39527,8 +38329,7 @@
 "bus" = (
 /obj/structure/morgue,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "delivery"
@@ -39557,21 +38358,11 @@
 	},
 /obj/item/stack/cable_coil/red,
 /obj/item/weapon/storage/toolbox/electrical{
-	pixel_x = 1;
-	pixel_y = 6
+	pixel_y = 4
 	},
-/obj/item/weapon/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
-/obj/item/clothing/head/welding{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/item/clothing/head/welding{
-	pixel_x = -3;
-	pixel_y = 5
-	},
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/clothing/head/welding,
+/obj/item/clothing/head/welding,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
@@ -39705,8 +38496,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/Podbay)
@@ -39757,7 +38547,6 @@
 	dir = 4
 	},
 /obj/machinery/alarm{
-	frequency = 1600;
 	pixel_y = 26
 	},
 /turf/simulated/floor{
@@ -39824,8 +38613,7 @@
 "bvm" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -39869,8 +38657,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -39917,8 +38704,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -39947,8 +38733,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -40016,8 +38801,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -40034,8 +38818,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -40055,8 +38838,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -40083,8 +38865,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -40119,8 +38900,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -40143,8 +38923,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -40155,8 +38934,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -40181,8 +38959,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/crew_quarters/bar)
@@ -40205,8 +38982,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/green,
 /area/medical/patients_rooms)
@@ -40220,8 +38996,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -40240,8 +39015,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -40271,8 +39045,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
 	dir = 2;
@@ -40295,8 +39068,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -40314,8 +39086,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -40325,8 +39096,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door_control{
 	id = "Bar_Privacy1";
@@ -40417,8 +39187,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -40434,8 +39203,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -40451,8 +39219,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -40473,8 +39240,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -40497,8 +39263,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -40514,8 +39279,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -40533,8 +39297,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -40552,8 +39315,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -40601,8 +39363,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -40621,8 +39382,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/crew_quarters/heads)
@@ -40630,8 +39390,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/heads)
@@ -40645,8 +39404,7 @@
 "bwP" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -40660,8 +39418,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -40691,8 +39448,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -40708,8 +39464,7 @@
 "bwT" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -40728,7 +39483,6 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Genetics Cloning APC";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/cable,
@@ -40755,14 +39509,8 @@
 /area/rnd/lab)
 "bwZ" = (
 /obj/item/weapon/folder/white,
-/obj/item/weapon/disk/tech_disk{
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/obj/item/weapon/disk/tech_disk{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/weapon/disk/tech_disk,
+/obj/item/weapon/disk/tech_disk,
 /obj/item/weapon/disk/design_disk,
 /obj/item/weapon/disk/design_disk,
 /obj/item/weapon/reagent_containers/dropper{
@@ -40825,8 +39573,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -40851,11 +39598,7 @@
 /area/maintenance/aft)
 "bxm" = (
 /obj/structure/rack,
-/obj/item/device/flashlight,
-/obj/item/weapon/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
+/obj/item/weapon/storage/toolbox/mechanical,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "bxn" = (
@@ -40863,8 +39606,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -40879,8 +39621,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -40902,8 +39643,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -40940,8 +39680,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Medbay West APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -40967,8 +39706,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -41025,8 +39763,7 @@
 "bxE" = (
 /obj/structure/table,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/item/device/mmi,
 /obj/item/device/mmi,
@@ -41042,8 +39779,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/item/device/flash/synthetic,
 /obj/item/device/flash/synthetic,
@@ -41092,7 +39828,6 @@
 /area/assembly/chargebay)
 "bxL" = (
 /obj/machinery/alarm{
-	frequency = 1600;
 	pixel_y = 26
 	},
 /turf/simulated/floor,
@@ -41117,7 +39852,6 @@
 	name = "exterior access button";
 	pixel_x = -20;
 	pixel_y = -20;
-	req_access_txt = "0";
 	req_one_access_txt = "13;45;1"
 	},
 /turf/simulated/floor/plating/airless,
@@ -41146,8 +39880,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -41191,8 +39924,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -41326,8 +40058,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -41378,7 +40109,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Messaging Server APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -41394,8 +40124,7 @@
 "byx" = (
 /obj/machinery/camera{
 	c_tag = "Pre Vault";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -41408,8 +40137,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 10;
@@ -41504,8 +40232,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/teleporter)
@@ -41523,8 +40250,7 @@
 "byJ" = (
 /obj/machinery/camera{
 	c_tag = "Chapel South";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -41567,8 +40293,7 @@
 	department = "Kitchen";
 	departmentType = 2;
 	name = "Kitchen RC";
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -41603,8 +40328,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -41616,8 +40340,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -41639,8 +40362,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/central)
@@ -41802,7 +40524,6 @@
 /obj/item/device/radio/intercom{
 	dir = 0;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 27
 	},
 /turf/simulated/floor{
@@ -41835,8 +40556,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -41851,8 +40571,7 @@
 /area/toxins/server)
 "bzx" = (
 /obj/machinery/newscaster{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -41867,8 +40586,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -41885,8 +40603,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -42004,8 +40721,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -42031,8 +40747,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/central)
@@ -42174,7 +40889,6 @@
 "bAj" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/structure/disposalpipe/segment{
@@ -42202,7 +40916,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Treatment Center APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -42288,8 +41001,7 @@
 	opacity = 0
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -42353,8 +41065,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42380,8 +41091,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/aft)
@@ -42471,8 +41181,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -42505,7 +41214,6 @@
 /obj/machinery/door_control{
 	id = "Medical_Psychiatry";
 	name = "Privacy Shutters";
-	pixel_x = 0;
 	pixel_y = -25
 	},
 /obj/structure/cable{
@@ -42740,8 +41448,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -42780,8 +41487,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -42803,8 +41509,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -42834,7 +41539,6 @@
 "bBI" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/light/small,
@@ -42848,8 +41552,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -42861,8 +41564,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -42874,8 +41576,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/aft)
@@ -42883,6 +41584,10 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor{
 	icon_state = "bot"
@@ -42903,8 +41608,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/janitor)
@@ -42912,8 +41616,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -42923,7 +41626,6 @@
 "bBQ" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/recharge_station,
@@ -43005,8 +41707,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -43119,13 +41820,9 @@
 /area/garden)
 "bCq" = (
 /obj/item/weapon/storage/toolbox/mechanical{
-	pixel_x = 2;
-	pixel_y = 3
+	pixel_y = 4
 	},
-/obj/item/weapon/storage/toolbox/mechanical{
-	pixel_x = -2;
-	pixel_y = -1
-	},
+/obj/item/weapon/storage/toolbox/mechanical,
 /obj/structure/table,
 /turf/simulated/floor{
 	dir = 8;
@@ -43210,7 +41907,6 @@
 /obj/machinery/door_control{
 	id = "teles_blast2";
 	name = "Door Bolt Control";
-	pixel_x = 0;
 	pixel_y = 25;
 	req_access_txt = "7"
 	},
@@ -43223,8 +41919,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -43241,8 +41936,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -43256,8 +41950,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -43278,8 +41971,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -43313,7 +42005,6 @@
 	desc = "Used for watching the RD's goons from the safety of his office.";
 	name = "Research Monitor";
 	network = list("Research","Toxins Test Area","Robots","Anomaly Isolation");
-	pixel_x = 0;
 	pixel_y = 2
 	},
 /obj/structure/table,
@@ -43361,7 +42052,6 @@
 "bCQ" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -43441,12 +42131,10 @@
 /obj/machinery/disposal,
 /obj/machinery/camera{
 	c_tag = "Security Equipment North";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 4
@@ -43486,8 +42174,6 @@
 	id_tag = "chapel_outer";
 	locked = 1;
 	name = "Chapel External Access";
-	req_access = null;
-	req_access_txt = "0";
 	req_one_access_txt = "13;45;1"
 	},
 /turf/simulated/floor/plating,
@@ -43495,8 +42181,7 @@
 "bDi" = (
 /obj/machinery/camera{
 	c_tag = "Escape Hallway";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -43531,8 +42216,7 @@
 /obj/item/device/flashlight/lamp/green,
 /obj/structure/sign/poster{
 	official = 1;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
@@ -43578,10 +42262,7 @@
 /area/quartermaster/office)
 "bDs" = (
 /obj/structure/table/woodentable,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/book/manual/wiki/security_space_law,
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
@@ -43632,8 +42313,7 @@
 /obj/structure/sink{
 	dir = 8;
 	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 0
+	pixel_x = -12
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -43667,7 +42347,6 @@
 /obj/item/weapon/bedsheet/captain,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/carpet/blue,
@@ -43696,8 +42375,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -43719,8 +42397,7 @@
 "bDH" = (
 /obj/structure/sign/poster{
 	official = 1;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor{
 	dir = 10;
@@ -43745,8 +42422,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -43776,8 +42452,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -43796,8 +42471,7 @@
 "bDP" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Bay Entrance";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
@@ -43811,8 +42485,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -43926,8 +42599,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
@@ -43980,8 +42652,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -44031,8 +42702,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -44086,8 +42756,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 2;
@@ -44120,8 +42789,7 @@
 /obj/structure/sink{
 	dir = 8;
 	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 0
+	pixel_x = -12
 	},
 /turf/simulated/floor{
 	dir = 10;
@@ -44137,8 +42805,7 @@
 "bEJ" = (
 /obj/structure/sign/poster{
 	official = 1;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -44164,10 +42831,7 @@
 /area/security/vacantoffice)
 "bEM" = (
 /obj/structure/table/woodentable,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/hand_labeler,
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
@@ -44175,8 +42839,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -44197,21 +42860,18 @@
 /area/hallway/primary/aft)
 "bEO" = (
 /obj/structure/table/woodentable,
-/obj/machinery/newscaster{
-	layer = 3.3;
-	pixel_x = 0;
-	pixel_y = -27
-	},
 /obj/item/device/taperecorder,
 /obj/item/device/camera,
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "bEP" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -44232,8 +42892,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44253,8 +42912,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -44294,8 +42952,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44312,8 +42969,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
@@ -44347,8 +43003,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -44417,8 +43072,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44542,10 +43196,7 @@
 /area/maintenance/fsmaint2)
 "bFB" = (
 /obj/structure/table,
-/obj/item/weapon/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/item/device/megaphone,
 /turf/simulated/floor{
@@ -44643,8 +43294,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -44659,8 +43309,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /turf/simulated/floor{
 	dir = 10;
@@ -44697,7 +43346,6 @@
 "bFV" = (
 /obj/machinery/requests_console{
 	department = "Tech storage";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plating,
@@ -44712,8 +43360,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -44779,8 +43426,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -44841,7 +43487,6 @@
 	frequency = 1485;
 	listening = 1;
 	name = "Psychologist Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor/carpet/green,
@@ -44860,9 +43505,7 @@
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/captain)
 "bGk" = (
-/obj/machinery/recharger{
-	pixel_y = 0
-	},
+/obj/machinery/recharger,
 /obj/item/weapon/handcuffs,
 /obj/structure/cable{
 	d1 = 1;
@@ -44895,9 +43538,7 @@
 /obj/machinery/door_control{
 	id = "Patients";
 	name = "Privacy Shutters";
-	pixel_x = -28;
-	pixel_y = 0;
-	req_access_txt = 0
+	pixel_x = -28
 	},
 /obj/item/weapon/storage/fancy/donut_box,
 /obj/structure/table/glass,
@@ -44994,7 +43635,6 @@
 	layer = 4;
 	name = "Singularity Engine Telescreen";
 	network = list("Singularity");
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/structure/stool/bed/chair/office/dark{
@@ -45004,8 +43644,7 @@
 /area/engine/break_room)
 "bGM" = (
 /obj/machinery/newscaster/security_unit{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/machinery/light_switch{
 	pixel_y = -25
@@ -45071,8 +43710,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 8;
@@ -45102,8 +43740,7 @@
 "bGT" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -45285,9 +43922,7 @@
 /obj/item/device/radio/intercom{
 	pixel_y = 25
 	},
-/obj/machinery/hydroponics/constructable{
-	pixel_y = 0
-	},
+/obj/machinery/hydroponics/constructable,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
@@ -45301,8 +43936,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "bluecorner"
@@ -45315,9 +43949,7 @@
 /area/crew_quarters/locker)
 "bHv" = (
 /obj/machinery/door/window/westright{
-	name = "Reception Door";
-	req_access = null;
-	req_access_txt = "0"
+	name = "Reception Door"
 	},
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
@@ -45348,7 +43980,6 @@
 "bHy" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/closet/emcloset,
@@ -45370,8 +44001,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -45391,8 +44021,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -45423,7 +44052,6 @@
 	},
 /obj/structure/table,
 /obj/machinery/alarm{
-	frequency = 1600;
 	pixel_y = 26
 	},
 /turf/simulated/floor{
@@ -45432,7 +44060,7 @@
 /area/crew_quarters/bar)
 "bHE" = (
 /obj/machinery/alarm{
-	pixel_y = 25
+	pixel_y = 23
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -45463,7 +44091,6 @@
 "bHH" = (
 /obj/machinery/disposal,
 /obj/machinery/recharger/wallcharger{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/structure/disposalpipe/trunk,
@@ -45524,8 +44151,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -45563,9 +44189,7 @@
 /obj/machinery/camera{
 	c_tag = "Patient's Room";
 	dir = 4;
-	network = list("SS13","Medical");
-	pixel_x = 0;
-	pixel_y = 0
+	network = list("SS13","Medical")
 	},
 /turf/simulated/floor/carpet/green,
 /area/medical/patients_rooms)
@@ -45595,8 +44219,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/stool/bed/chair/comfy/black{
 	dir = 4
@@ -45675,7 +44298,6 @@
 /obj/item/weapon/storage/belt/utility,
 /obj/item/clothing/gloves/latex,
 /obj/item/clothing/glasses/science{
-	pixel_x = 0;
 	pixel_y = 1
 	},
 /turf/simulated/floor{
@@ -45770,8 +44392,7 @@
 "bIh" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -45908,8 +44529,7 @@
 	frequency = 1485;
 	listening = 1;
 	name = "Station Intercom (Medbay)";
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/item/weapon/storage/box/cups,
 /turf/simulated/floor{
@@ -45946,8 +44566,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -45985,8 +44604,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -46022,8 +44640,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -46044,7 +44661,6 @@
 /obj/structure/table/glass,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/simulated/floor{
@@ -46068,8 +44684,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -46132,8 +44747,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -46155,8 +44769,7 @@
 /obj/machinery/camera{
 	c_tag = "Brainstorm Center";
 	dir = 4;
-	network = list("SS13","Research");
-	pixel_x = 0
+	network = list("SS13","Research")
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -46176,8 +44789,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
@@ -46260,8 +44872,7 @@
 "bJn" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -46298,7 +44909,6 @@
 "bJs" = (
 /obj/machinery/recharge_station,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/machinery/camera{
@@ -46348,14 +44958,12 @@
 /area/assembly/chargebay)
 "bJx" = (
 /obj/machinery/light_switch{
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Mech Bay APC";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -46428,9 +45036,7 @@
 /turf/simulated/floor,
 /area/hallway/secondary/entry)
 "bJI" = (
-/obj/machinery/hydroponics/constructable{
-	pixel_y = 0
-	},
+/obj/machinery/hydroponics/constructable,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -46444,8 +45050,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -46456,8 +45061,7 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -46491,8 +45095,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -46546,8 +45149,7 @@
 /area/medical/patient_b)
 "bKd" = (
 /obj/machinery/newscaster{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -46601,7 +45203,6 @@
 "bKi" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /obj/structure/disposalpipe/segment,
@@ -46659,8 +45260,7 @@
 /obj/item/device/flash,
 /obj/item/device/flash,
 /obj/machinery/ai_status_display{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -46694,8 +45294,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -46709,8 +45308,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -46809,14 +45407,12 @@
 "bKE" = (
 /obj/machinery/camera{
 	c_tag = "Central Hallway East";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -46878,12 +45474,10 @@
 /obj/structure/sink{
 	dir = 8;
 	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 0
+	pixel_x = -12
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor{
@@ -46910,7 +45504,6 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Break Room APC";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/structure/cable,
@@ -47067,8 +45660,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -47106,8 +45698,7 @@
 "bLo" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -47161,8 +45752,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -47192,8 +45782,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -47286,8 +45875,7 @@
 "bLH" = (
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -47319,8 +45907,7 @@
 "bLN" = (
 /obj/machinery/washing_machine,
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -47359,8 +45946,7 @@
 	frequency = 1485;
 	listening = 1;
 	name = "Station Intercom (Medbay)";
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/structure/disposalpipe/segment,
 /obj/item/weapon/storage/firstaid/o2{
@@ -47382,8 +45968,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
 	name = "Mech Bay";
-	req_access_txt = "29";
-	req_one_access_txt = "0"
+	req_access_txt = "29"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/poddoor{
@@ -47460,8 +46045,7 @@
 "bMb" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -47506,8 +46090,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
-	name = "Pod Bay";
-	req_access_txt = "0"
+	name = "Pod Bay"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/Podbay)
@@ -47554,8 +46137,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/janitor)
@@ -47582,14 +46164,12 @@
 /obj/structure/sink{
 	dir = 8;
 	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 0
+	pixel_x = -12
 	},
 /obj/machinery/power/apc{
 	dir = 2;
 	level = 2;
 	name = "Operating 2 APC";
-	pixel_x = 0;
 	pixel_y = -25
 	},
 /obj/structure/cable{
@@ -47632,14 +46212,12 @@
 "bMr" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel";
-	req_access = null;
 	req_access_txt = "57"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
@@ -47653,8 +46231,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/construction)
@@ -47676,7 +46253,6 @@
 /area/hallway/primary/starboard)
 "bMw" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/machinery/light,
@@ -47690,8 +46266,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -47713,26 +46288,6 @@
 	icon_state = "whitehall"
 	},
 /area/medical/surgery)
-"bMz" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	desc = "Pipe for transfer more fuel.";
-	dir = 4;
-	name = "filling pipe"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
 "bMA" = (
 /obj/machinery/light,
 /turf/simulated/floor{
@@ -47769,8 +46324,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -47829,9 +46383,7 @@
 /turf/simulated/floor/engine,
 /area/rnd/misc_lab)
 "bML" = (
-/obj/machinery/hydroponics/constructable{
-	pixel_y = 0
-	},
+/obj/machinery/hydroponics/constructable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
@@ -47844,8 +46396,7 @@
 /obj/structure/table,
 /obj/structure/sign/poster{
 	official = 1;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/item/device/flashlight,
 /obj/item/weapon/stock_parts/cell/high{
@@ -47895,8 +46446,7 @@
 "bMW" = (
 /obj/machinery/alarm{
 	dir = 1;
-	locked = 0;
-	pixel_y = -24
+	pixel_y = -22
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -47907,8 +46457,7 @@
 /obj/machinery/vending/cola,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/machinery/light{
 	dir = 4
@@ -47945,14 +46494,12 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
 	name = "Bar Maintenance";
-	req_access_txt = "0";
 	req_one_access_txt = "12;25;28"
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/bar)
@@ -47999,9 +46546,7 @@
 /area/quartermaster/miningoffice)
 "bNi" = (
 /obj/structure/disposalpipe/segment{
-	desc = "Pipe for transfer more fuel.";
-	dir = 4;
-	name = "filling pipe"
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -48031,8 +46576,7 @@
 "bNm" = (
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway 2";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -48047,8 +46591,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -48074,8 +46617,7 @@
 "bNs" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/simulated/floor{
 	icon_state = "bar"
@@ -48130,13 +46672,11 @@
 "bNA" = (
 /obj/structure/rack,
 /obj/item/weapon/circuitboard/pandemic{
-	pixel_x = -3;
-	pixel_y = 3
+	pixel_y = 8
 	},
 /obj/item/weapon/circuitboard/rdconsole,
 /obj/item/weapon/circuitboard/rdserver{
-	pixel_x = 3;
-	pixel_y = -3
+	pixel_y = 4
 	},
 /obj/item/weapon/circuitboard/destructive_analyzer,
 /obj/item/weapon/circuitboard/protolathe,
@@ -48145,28 +46685,23 @@
 "bNB" = (
 /obj/structure/rack,
 /obj/item/weapon/circuitboard/autolathe{
-	pixel_x = 3;
-	pixel_y = -3
+	pixel_y = 4
 	},
-/obj/item/weapon/circuitboard/security{
-	name = "Circuit board (Mining Monitor)";
-	network = list("MINE")
-	},
+/obj/item/weapon/circuitboard/security,
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "bNC" = (
 /obj/structure/rack,
-/obj/item/weapon/circuitboard/arcade,
-/obj/item/weapon/circuitboard/message_monitor{
-	pixel_y = -5
+/obj/item/weapon/circuitboard/arcade{
+	pixel_y = 4
 	},
+/obj/item/weapon/circuitboard/message_monitor,
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "bND" = (
 /obj/machinery/door_control{
 	id = "atmos";
 	name = "Atmospherics Lockdown";
-	pixel_x = 0;
 	pixel_y = -24;
 	req_access_txt = "24"
 	},
@@ -48195,10 +46730,7 @@
 /area/atmos)
 "bNH" = (
 /obj/structure/table,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /turf/simulated/floor,
 /area/janitor)
@@ -48228,8 +46760,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 2;
@@ -48272,8 +46803,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -48356,8 +46886,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -48381,8 +46910,7 @@
 /obj/machinery/disposal,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -48611,8 +47139,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
@@ -48625,8 +47152,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Bar West";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "grimy"
@@ -48673,8 +47199,7 @@
 /obj/structure/stool/bed/chair/comfy/black,
 /obj/machinery/camera{
 	c_tag = "Bar East";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -48751,8 +47276,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -48844,8 +47368,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 2;
@@ -48978,8 +47501,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -49061,8 +47583,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/starboard)
@@ -49079,8 +47600,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/starboard)
@@ -49097,8 +47617,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -49124,8 +47643,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -49150,8 +47668,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -49178,8 +47695,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -49219,8 +47735,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -49253,8 +47768,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -49294,8 +47808,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -49316,8 +47829,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -49342,16 +47854,14 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "bQb" = (
 /obj/machinery/door/window/eastleft{
 	dir = 8;
-	name = "interior door";
-	req_access_txt = "0"
+	name = "interior door"
 	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor2"
@@ -49371,8 +47881,7 @@
 /obj/item/weapon/bedsheet/medical,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -49404,8 +47913,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
@@ -49477,8 +47985,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/starboard)
@@ -49493,13 +48000,12 @@
 "bQq" = (
 /obj/structure/rack,
 /obj/item/weapon/circuitboard/cloning{
-	pixel_x = 0
+	pixel_y = 8
 	},
-/obj/item/weapon/circuitboard/med_data{
-	pixel_x = 3;
-	pixel_y = -3
+/obj/item/weapon/circuitboard/med_data,
+/obj/item/weapon/circuitboard/clonescanner{
+	pixel_y = 4
 	},
-/obj/item/weapon/circuitboard/clonescanner,
 /obj/item/weapon/circuitboard/clonepod,
 /obj/item/weapon/circuitboard/scan_consolenew,
 /turf/simulated/floor/plating,
@@ -49507,37 +48013,24 @@
 "bQr" = (
 /obj/structure/rack,
 /obj/item/weapon/circuitboard/secure_data{
-	pixel_x = -2;
-	pixel_y = 2
+	pixel_y = 8
 	},
 /obj/item/weapon/circuitboard/security{
-	pixel_x = 1;
-	pixel_y = -1
+	pixel_y = 4
 	},
-/obj/item/weapon/circuitboard/skills{
-	pixel_x = 4;
-	pixel_y = -3
-	},
+/obj/item/weapon/circuitboard/skills,
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "bQs" = (
 /obj/structure/rack,
 /obj/item/weapon/circuitboard/powermonitor{
-	pixel_x = -2;
-	pixel_y = 2
+	pixel_y = 8
 	},
-/obj/item/weapon/circuitboard/stationalert{
-	pixel_x = 1;
-	pixel_y = -1
-	},
+/obj/item/weapon/circuitboard/stationalert,
 /obj/item/weapon/circuitboard/atmos_alert{
-	pixel_x = 3;
-	pixel_y = -3
+	pixel_y = 4
 	},
-/obj/item/weapon/circuitboard/security{
-	name = "Circuit board (Engineering Monitor)";
-	network = list("Engineering","Power Alarms","Atmosphere Alarms","Fire Alarms")
-	},
+/obj/item/weapon/circuitboard/security,
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "bQt" = (
@@ -49560,8 +48053,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -49649,8 +48141,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -49697,8 +48188,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -49799,7 +48289,6 @@
 "bQV" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/sleeper{
@@ -49947,8 +48436,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 2;
@@ -49958,8 +48446,7 @@
 "bRh" = (
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -49976,26 +48463,22 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
 "bRj" = (
 /obj/structure/closet/secure_closet/hydroponics,
-/obj/machinery/alarm{
-	dir = 2;
-	locked = 0;
-	pixel_y = 25
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/camera{
 	c_tag = "Hydroponics Storage"
+	},
+/obj/machinery/alarm{
+	pixel_y = 23
 	},
 /turf/simulated/floor{
 	dir = 2;
@@ -50108,8 +48591,7 @@
 "bRz" = (
 /obj/structure/table,
 /obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/simulated/floor{
 	icon_state = "grimy"
@@ -50142,7 +48624,6 @@
 /obj/structure/table/woodentable,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/item/weapon/reagent_containers/food/condiment/saltshaker,
@@ -50170,9 +48651,7 @@
 	pixel_y = -29
 	},
 /obj/structure/disposalpipe/segment{
-	desc = "Pipe for transfer more fuel.";
-	dir = 4;
-	name = "filling pipe"
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 2;
@@ -50181,13 +48660,10 @@
 /area/hallway/primary/starboard)
 "bRG" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/structure/disposalpipe/segment{
-	desc = "Pipe for transfer more fuel.";
-	dir = 4;
-	name = "filling pipe"
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 2;
@@ -50207,8 +48683,7 @@
 "bRI" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Access";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 6
@@ -50469,8 +48944,7 @@
 	},
 /obj/machinery/light{
 	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor{
 	dir = 2;
@@ -50498,8 +48972,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
@@ -50571,8 +49044,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -50652,17 +49124,13 @@
 /obj/item/device/multitool,
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "bSJ" = (
 /obj/structure/rack,
-/obj/item/weapon/storage/toolbox/electrical{
-	pixel_x = 1;
-	pixel_y = -1
-	},
+/obj/item/weapon/storage/toolbox/electrical,
 /obj/item/clothing/gloves/yellow,
 /obj/item/device/t_scanner,
 /obj/item/clothing/glasses/meson,
@@ -50671,10 +49139,7 @@
 /area/storage/tech)
 "bSK" = (
 /obj/structure/rack,
-/obj/item/weapon/storage/toolbox/electrical{
-	pixel_x = 1;
-	pixel_y = -1
-	},
+/obj/item/weapon/storage/toolbox/electrical,
 /obj/item/device/multitool,
 /obj/item/clothing/glasses/meson,
 /turf/simulated/floor/plating,
@@ -50719,7 +49184,6 @@
 /area/hallway/primary/starboard)
 "bSR" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/structure/closet/secure_closet/atmos_personal,
@@ -50822,7 +49286,6 @@
 	},
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
-	req_access_txt = "0";
 	req_one_access_txt = "11;24"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -50957,7 +49420,6 @@
 /obj/machinery/door_control{
 	id = "Medical_Room2";
 	name = "Privacy Shutters";
-	pixel_x = 0;
 	pixel_y = -25
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -51020,7 +49482,6 @@
 /obj/machinery/door_control{
 	id = "Medical_Room1";
 	name = "Privacy Shutters";
-	pixel_x = 0;
 	pixel_y = -25
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -51219,8 +49680,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/status_display{
 	pixel_y = -30
@@ -51243,8 +49703,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
@@ -51286,8 +49745,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -51303,7 +49761,6 @@
 	frequency = 1485;
 	listening = 1;
 	name = "Station Intercom (Medbay)";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor{
@@ -51315,8 +49772,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -51437,8 +49893,7 @@
 /obj/item/weapon/paper_bin,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/item/weapon/packageWrap,
 /turf/simulated/floor{
@@ -51554,8 +50009,7 @@
 "bUG" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /obj/machinery/newscaster{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -51592,8 +50046,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -51603,8 +50056,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -51624,8 +50076,7 @@
 /obj/machinery/airlock_sensor{
 	id_tag = "tox_airlock_sensor";
 	master_tag = "tox_airlock_control";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1
@@ -51639,8 +50090,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 2;
@@ -51682,7 +50132,6 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Medbay Reception APC";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/door/window/southright{
@@ -51732,8 +50181,7 @@
 "bVa" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -51780,8 +50228,7 @@
 "bVg" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -51794,7 +50241,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
 	name = "Morgue";
-	req_access_txt = 0;
 	req_one_access_txt = "6;28"
 	},
 /turf/simulated/floor{
@@ -51856,7 +50302,6 @@
 /obj/structure/closet/l3closet/scientist,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/light{
@@ -51932,8 +50377,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -51944,8 +50388,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -51956,8 +50399,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/aft)
@@ -51965,8 +50407,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -51984,14 +50425,12 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
-	req_access_txt = "0";
 	req_one_access_txt = "11;24"
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/engine/break_room)
@@ -52097,8 +50536,7 @@
 /area/atmos)
 "bVT" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -52218,7 +50656,6 @@
 "bWe" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/structure/flora/plant/random,
@@ -52263,15 +50700,13 @@
 /area/atmos)
 "bWj" = (
 /obj/machinery/door/airlock{
-	name = "Starboard Emergency Storage";
-	req_access_txt = "0"
+	name = "Starboard Emergency Storage"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -52315,8 +50750,7 @@
 /area/maintenance/asmaint)
 "bWr" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/grille,
@@ -52452,16 +50886,13 @@
 /obj/item/weapon/storage/toolbox/mechanical,
 /obj/item/device/t_scanner,
 /obj/item/weapon/tank/emergency_oxygen{
-	pixel_x = -8;
-	pixel_y = 0
+	pixel_x = -8
 	},
 /obj/item/weapon/tank/emergency_oxygen{
-	pixel_x = -8;
-	pixel_y = 0
+	pixel_x = -8
 	},
 /obj/item/clothing/mask/breath{
-	pixel_x = 4;
-	pixel_y = 0
+	pixel_x = 4
 	},
 /turf/simulated/floor,
 /area/engine/break_room)
@@ -52475,8 +50906,7 @@
 	department = "Atmospherics";
 	departmentType = 4;
 	name = "Atmos RC";
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -52547,8 +50977,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -52569,8 +50998,7 @@
 "bWU" = (
 /obj/machinery/light{
 	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/structure/filingcabinet,
 /turf/simulated/floor{
@@ -52653,8 +51081,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -52691,8 +51118,7 @@
 /area/hydroponics)
 "bXg" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -52716,9 +51142,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -22
 	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
@@ -52784,7 +51208,6 @@
 /obj/structure/sign/poster{
 	dir = 2;
 	official = 0;
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor{
@@ -52793,8 +51216,7 @@
 /area/crew_quarters/bar)
 "bXo" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/structure/flora/plant/floorleaf,
 /turf/simulated/floor{
@@ -52854,10 +51276,8 @@
 	id = "MedbayFoyer";
 	name = "Medbay Doors Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = 28;
-	range = 8;
-	req_access_txt = 0
+	range = 8
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay West-North";
@@ -52905,8 +51325,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -52988,8 +51407,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -53094,7 +51512,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/computer/libraryconsole,
@@ -53139,8 +51556,7 @@
 	icon_state = "closed";
 	locked = 1;
 	name = "Assembly Line (KEEP OUT)";
-	req_access_txt = "32";
-	req_one_access_txt = "0"
+	req_access_txt = "32"
 	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
@@ -53343,8 +51759,7 @@
 /area/atmos)
 "bYG" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -53422,7 +51837,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
-	req_access_txt = "0";
 	req_one_access_txt = "11;24"
 	},
 /turf/simulated/floor,
@@ -53506,8 +51920,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
@@ -53582,7 +51995,6 @@
 "bZu" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor{
@@ -53601,8 +52013,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Incinerator APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -53625,15 +52036,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
-"bZA" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "bZB" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
@@ -53644,8 +52046,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/construction)
@@ -53669,8 +52070,7 @@
 /area/atmos)
 "bZH" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -53696,10 +52096,7 @@
 	pixel_y = 30
 	},
 /obj/structure/table,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /turf/simulated/floor,
 /area/engine/engineering)
@@ -53757,14 +52154,12 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
-	req_access_txt = "0";
 	req_one_access_txt = "11;24"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -53813,8 +52208,7 @@
 "bZX" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics East";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	dir = 4
@@ -53853,18 +52247,15 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
 "cad" = (
 /obj/item/weapon/reagent_containers/spray/plantbgone{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/item/weapon/reagent_containers/spray/plantbgone{
-	pixel_x = 0;
 	pixel_y = 3
 	},
 /obj/item/weapon/reagent_containers/spray/plantbgone{
@@ -54008,8 +52399,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
@@ -54073,8 +52463,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/bar)
@@ -54125,8 +52514,7 @@
 /obj/item/weapon/storage/box/gloves,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -54171,8 +52559,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/holosign_switch{
 	id = "op1";
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -54191,8 +52578,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/holosign_switch{
 	id = "op2";
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -54251,7 +52637,6 @@
 	frequency = 1485;
 	listening = 1;
 	name = "Station Intercom (Medbay)";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor{
@@ -54268,8 +52653,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
@@ -54278,7 +52662,6 @@
 	frequency = 1485;
 	listening = 1;
 	name = "Station Intercom (Medbay)";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -54302,8 +52685,7 @@
 /obj/machinery/camera{
 	c_tag = "Genetics Research";
 	dir = 4;
-	network = list("SS13","Research");
-	pixel_x = 0
+	network = list("SS13","Research")
 	},
 /obj/machinery/light_switch{
 	pixel_x = -27
@@ -54482,8 +52864,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -54497,7 +52878,6 @@
 	frequency = 1379;
 	id_tag = "robotics_solar_airlock";
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access_txt = "13";
 	tag_airpump = "robotics_solar_pump";
@@ -54540,7 +52920,6 @@
 	dir = 1;
 	name = "Medical Monitor";
 	network = list("Medical");
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/machinery/door/window/southright{
@@ -54600,8 +52979,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -54625,8 +53003,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -54642,8 +53019,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -54659,8 +53035,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -54691,8 +53066,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -54725,7 +53099,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/item/clothing/ears/earmuffs{
@@ -54772,8 +53145,7 @@
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -54792,8 +53164,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -54812,8 +53183,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -54853,8 +53223,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light/small{
@@ -54883,8 +53252,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/construction)
@@ -54946,8 +53314,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -54973,7 +53340,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
@@ -55056,9 +53422,7 @@
 "ccN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
-	dir = 4;
-	light_power = 0.9;
-	light_range = 8
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -55299,7 +53663,6 @@
 "cdH" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/disposalpipe/segment{
@@ -55350,8 +53713,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
@@ -55362,8 +53724,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
 	dir = 1
@@ -55378,8 +53739,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
@@ -55399,8 +53759,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -55439,8 +53798,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4
@@ -55465,8 +53823,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
@@ -55656,8 +54013,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -55694,8 +54050,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -55709,8 +54064,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -55788,10 +54142,7 @@
 	},
 /obj/item/clothing/head/chefhat,
 /obj/item/clothing/under/rank/chef,
-/obj/item/weapon/storage/box/mousetraps{
-	pixel_x = 5;
-	pixel_y = 5
-	},
+/obj/item/weapon/storage/box/mousetraps,
 /obj/item/weapon/storage/box/mousetraps,
 /obj/item/clothing/under/waiter,
 /obj/item/clothing/under/waiter,
@@ -55816,8 +54167,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -55831,27 +54181,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"ceW" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "ceX" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -55879,8 +54213,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55897,8 +54230,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56068,8 +54400,7 @@
 "cfm" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics South West";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor,
@@ -56105,8 +54436,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -56183,7 +54513,6 @@
 	layer = 4;
 	name = "Singularity Engine Telescreen";
 	network = list("Singularity");
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -56210,8 +54539,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/storage/emergency3)
@@ -56222,8 +54550,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/storage/emergency3)
@@ -56231,8 +54558,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Starboard Emergency Storage APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -56260,8 +54586,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -56370,18 +54695,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/engine/engineering)
-"cfX" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "cfY" = (
 /turf/simulated/floor/plating/airless{
 	dir = 6;
@@ -56401,8 +54714,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating{
 	icon_state = "platingdmg1"
@@ -56466,8 +54778,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 1;
@@ -56479,8 +54790,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/embedded_controller/radio/airlock_controller{
 	frequency = 1379;
@@ -56622,8 +54932,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -56711,8 +55020,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -56728,8 +55036,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
 	dir = 4
@@ -56817,8 +55124,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -56858,8 +55164,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -56883,7 +55188,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor,
@@ -56904,7 +55208,6 @@
 /obj/item/clothing/head/helmet/space/rig/atmos,
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor,
@@ -57069,8 +55372,7 @@
 "chu" = (
 /obj/structure/closet/radiation,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /turf/simulated/floor{
 	dir = 9;
@@ -57100,10 +55402,7 @@
 "chx" = (
 /obj/machinery/camera{
 	c_tag = "Engineering SMES";
-	dir = 8;
-	network = list("SS13");
-	pixel_x = 0;
-	pixel_y = 0
+	dir = 8
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -57126,15 +55425,18 @@
 /turf/simulated/floor/plating/airless,
 /area/atmos)
 "chC" = (
-/obj/structure/rack,
-/obj/item/weapon/extinguisher{
-	pixel_x = 7;
-	pixel_y = 3
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/weapon/extinguisher,
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/storage/emergency3)
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/medical/morgue)
 "chD" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -57146,20 +55448,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
-"chE" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/engine/drone_fabrication)
 "chF" = (
 /obj/machinery/ai_status_display{
 	layer = 4;
@@ -57308,24 +55596,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "chY" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+/obj/structure/rack,
+/obj/item/weapon/extinguisher{
+	pixel_y = 6
 	},
-/obj/structure/sink{
-	dir = 8;
-	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
-	},
-/obj/item/device/radio/intercom{
-	dir = 2;
-	name = "Station Intercom (General)";
-	pixel_y = 20
-	},
-/turf/simulated/floor,
-/area/engine/break_room)
+/obj/item/weapon/extinguisher,
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/storage/emergency3)
 "chZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57425,8 +55703,7 @@
 "cik" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics West";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor,
@@ -57512,7 +55789,6 @@
 	id = "Singularity";
 	name = "Shutters Control";
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access_txt = "10"
 	},
 /obj/structure/cable/yellow{
@@ -57616,8 +55892,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -57705,8 +55980,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
@@ -57785,9 +56059,7 @@
 /area/engine/drone_fabrication)
 "cjd" = (
 /obj/structure/disposalpipe/segment{
-	desc = "Pipe for transfer more fuel.";
-	dir = 4;
-	name = "filling pipe"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -57800,9 +56072,7 @@
 "cje" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
-	desc = "Pipe for transfer more fuel.";
-	dir = 4;
-	name = "filling pipe"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -57887,8 +56157,7 @@
 /obj/structure/sink{
 	dir = 8;
 	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
+	pixel_x = -12
 	},
 /obj/structure/mirror{
 	pixel_x = -28
@@ -57928,8 +56197,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 8
@@ -57985,9 +56253,7 @@
 /area/rnd/mixing)
 "cjD" = (
 /obj/structure/disposalpipe/segment{
-	desc = "Pipe for transfer more fuel.";
-	dir = 4;
-	name = "filling pipe"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -58027,14 +56293,7 @@
 /area/engine/engineering)
 "cjG" = (
 /obj/machinery/light{
-	dir = 4;
-	light_power = 0.9;
-	light_range = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Library North";
-	dir = 8;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor/carpet,
 /area/library)
@@ -58141,8 +56400,7 @@
 /area/crew_quarters/theatre)
 "cjW" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -58237,8 +56495,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -58283,8 +56540,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -58328,8 +56584,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -58407,9 +56662,7 @@
 /area/rnd/xenobiology)
 "ckE" = (
 /obj/structure/disposalpipe/segment{
-	desc = "Pipe for transfer more fuel.";
-	dir = 4;
-	name = "filling pipe"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -58428,8 +56681,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -58472,9 +56724,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering passage";
 	dir = 2;
-	network = list("SS13");
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -58535,8 +56785,7 @@
 /area/maintenance/asmaint2)
 "ckQ" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -58562,19 +56811,22 @@
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "ckT" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	icon_state = "closed";
-	id_tag = "engineering_aux_inner";
-	locked = 1;
-	name = "Engineering External Access";
-	req_access = null;
-	req_access_txt = "13";
-	req_one_access_txt = "11;24"
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23
 	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/plating,
-/area/engine/engineering)
+/obj/structure/sink{
+	dir = 8;
+	icon_state = "sink";
+	pixel_x = -12
+	},
+/obj/item/device/radio/intercom{
+	dir = 2;
+	name = "Station Intercom (General)";
+	pixel_y = 20
+	},
+/turf/simulated/floor,
+/area/engine/break_room)
 "ckW" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -58591,8 +56843,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/garden)
@@ -58651,8 +56902,7 @@
 /area/crew_quarters/theatre)
 "clk" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -58737,8 +56987,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/grille{
@@ -58801,7 +57050,6 @@
 	id_tag = "engineering_aux_airlock";
 	layer = 3.3;
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access_txt = "13";
 	tag_airpump = "engineering_aux_pump";
 	tag_chamber_sensor = "engineering_aux_sensor";
@@ -58943,8 +57191,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -58961,7 +57208,6 @@
 "clR" = (
 /obj/machinery/flasher{
 	id = "AI";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -59057,7 +57303,6 @@
 /obj/machinery/door_control{
 	id = "xenobio3";
 	name = "Containment Blast Doors";
-	pixel_x = 0;
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
@@ -59073,8 +57318,7 @@
 /obj/structure/sink{
 	dir = 8;
 	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 0
+	pixel_x = -12
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -59084,7 +57328,6 @@
 "cmf" = (
 /obj/machinery/flasher{
 	id = "AI";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -59104,8 +57347,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -59244,8 +57486,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -59292,8 +57533,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -59359,8 +57599,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -59546,8 +57785,7 @@
 /obj/structure/sink{
 	dir = 8;
 	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 2
+	pixel_x = -12
 	},
 /turf/simulated/floor/wood,
 /area/crew_quarters/bar)
@@ -59594,7 +57832,6 @@
 "cns" = (
 /obj/machinery/door/window/westright{
 	name = "Bar Maintenance";
-	req_access = null;
 	req_access_txt = "25"
 	},
 /obj/structure/window/reinforced{
@@ -59660,8 +57897,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -59680,8 +57916,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -59693,7 +57928,6 @@
 	cell_type = 2500;
 	dir = 1;
 	name = "MiniSat Antechamber Power APC";
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/machinery/camera/motion{
@@ -59719,8 +57953,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -59768,8 +58001,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/binary/pump/on,
 /obj/machinery/atmospherics/pipe/manifold/visible/scrubbers{
@@ -59783,8 +58015,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 9
@@ -59829,8 +58060,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -59851,8 +58081,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/aft)
@@ -59870,8 +58099,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/crew_quarters/fitness)
@@ -59885,9 +58113,7 @@
 /area/aisat)
 "cnT" = (
 /obj/structure/disposalpipe/segment{
-	desc = "Pipe for transfer more fuel.";
-	dir = 4;
-	name = "filling pipe"
+	dir = 4
 	},
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/refined_scrap,
@@ -59908,9 +58134,7 @@
 /area/rnd/xenobiology)
 "cnV" = (
 /obj/structure/disposalpipe/segment{
-	desc = "Pipe for transfer more fuel.";
-	dir = 4;
-	name = "filling pipe"
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "bot"
@@ -59918,9 +58142,7 @@
 /area/quartermaster/storage)
 "cnW" = (
 /obj/structure/disposalpipe/segment{
-	desc = "Pipe for transfer more fuel.";
-	dir = 4;
-	name = "filling pipe"
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -59939,7 +58161,6 @@
 "cnX" = (
 /obj/machinery/door/airlock/command{
 	name = "Captain's Quarters";
-	req_access = null;
 	req_access_txt = "20"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -60087,10 +58308,7 @@
 /area/crew_quarters/bar)
 "con" = (
 /obj/structure/table/glass,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/machinery/light_switch{
 	pixel_y = 28
@@ -60148,8 +58366,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -60223,8 +58440,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/engine/break_room)
@@ -60275,8 +58491,7 @@
 /obj/machinery/alarm{
 	dir = 4;
 	frequency = 1439;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -60315,7 +58530,6 @@
 /obj/structure/stool/bed/chair/comfy/black,
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/wood,
@@ -60367,8 +58581,7 @@
 "coS" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -60382,9 +58595,7 @@
 /area/library)
 "coT" = (
 /obj/structure/disposalpipe/segment{
-	desc = "Pipe for transfer more fuel.";
-	dir = 4;
-	name = "filling pipe"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -60396,9 +58607,7 @@
 /area/garden)
 "coU" = (
 /obj/structure/disposalpipe/segment{
-	desc = "Pipe for transfer more fuel.";
-	dir = 4;
-	name = "filling pipe"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -60485,8 +58694,7 @@
 "cpi" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -60522,8 +58730,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/structure/table,
 /obj/item/stack/sheet/mineral/phoron{
@@ -60539,7 +58746,6 @@
 	cell_type = 2500;
 	dir = 2;
 	name = "MiniSat External Power APC";
-	pixel_x = 0;
 	pixel_y = -25
 	},
 /obj/structure/cable,
@@ -60549,7 +58755,6 @@
 /area/aisat)
 "cpm" = (
 /obj/machinery/ai_status_display{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/turretid/stun/AI_special{
@@ -60614,7 +58819,6 @@
 	cell_type = 2500;
 	dir = 2;
 	name = "MiniSat Internal Power APC";
-	pixel_x = 0;
 	pixel_y = -25
 	},
 /obj/structure/cable{
@@ -60630,8 +58834,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -60692,8 +58895,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -60729,8 +58931,7 @@
 /obj/item/weapon/wrench,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -60765,9 +58966,7 @@
 /area/ai_monitored/storage/secure)
 "cpE" = (
 /obj/structure/disposalpipe/segment{
-	desc = "Pipe for transfer more fuel.";
-	dir = 4;
-	name = "filling pipe"
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 2;
@@ -60786,7 +58985,6 @@
 	id_tag = "robotics_solar_outer";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "10;13"
 	},
 /turf/simulated/floor/plating,
@@ -60829,7 +59027,6 @@
 	id_tag = "robotics_solar_inner";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "13"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -60858,7 +59055,6 @@
 /obj/machinery/door_control{
 	id = "xenobio2";
 	name = "Containment Blast Doors";
-	pixel_x = 0;
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
@@ -60878,8 +59074,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -60950,8 +59145,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced{
@@ -60975,10 +59169,8 @@
 	id = "MedbayFoyer1";
 	name = "Medbay Doors Control";
 	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = 28;
-	range = 8;
-	req_access_txt = 0
+	range = 8
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -60988,13 +59180,9 @@
 "cpY" = (
 /obj/structure/rack,
 /obj/item/weapon/circuitboard/borgupload{
-	pixel_x = -1;
-	pixel_y = 1
+	pixel_y = 4
 	},
-/obj/item/weapon/circuitboard/aiupload{
-	pixel_x = 2;
-	pixel_y = -2
-	},
+/obj/item/weapon/circuitboard/aiupload,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "vault"
@@ -61003,8 +59191,7 @@
 "cqa" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/machinery/camera{
 	c_tag = "MiniSat Teleporter";
@@ -61078,8 +59265,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -61203,8 +59389,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering Storage";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/closet/secure_closet/engineering_personal,
 /turf/simulated/floor,
@@ -61299,8 +59484,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10
@@ -61311,8 +59495,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -61362,8 +59545,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/grille,
 /obj/structure/cable{
@@ -61390,8 +59572,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
@@ -61498,9 +59679,7 @@
 /area/rnd/xenobiology)
 "cqV" = (
 /obj/structure/disposalpipe/segment{
-	desc = "Pipe for transfer more fuel.";
-	dir = 4;
-	name = "filling pipe"
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 2;
@@ -61573,9 +59752,7 @@
 /turf/simulated/floor/plating,
 /area/hydroponics)
 "crd" = (
-/obj/machinery/hydroponics/constructable{
-	pixel_y = 0
-	},
+/obj/machinery/hydroponics/constructable,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -61590,14 +59767,12 @@
 "cri" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
@@ -61611,13 +59786,10 @@
 /turf/simulated/floor,
 /area/hydroponics)
 "crm" = (
-/obj/machinery/hydroponics/constructable{
-	pixel_y = 0
-	},
+/obj/machinery/hydroponics/constructable,
 /obj/machinery/requests_console{
 	department = "Hydroponics";
 	departmentType = 2;
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/simulated/floor{
@@ -61724,8 +59896,7 @@
 	},
 /obj/machinery/alarm/server{
 	dir = 4;
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -22
 	},
 /turf/simulated/floor/bluegrid{
 	icon_state = "dark";
@@ -61775,8 +59946,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -61923,13 +60093,11 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering Storage";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/simulated/floor,
 /area/engine/break_room)
@@ -62001,17 +60169,12 @@
 "csa" = (
 /obj/structure/rack,
 /obj/item/weapon/circuitboard/crew{
-	pixel_x = -1;
-	pixel_y = 1
+	pixel_y = 8
 	},
 /obj/item/weapon/circuitboard/card{
-	pixel_x = 2;
-	pixel_y = -2
+	pixel_y = 4
 	},
-/obj/item/weapon/circuitboard/communications{
-	pixel_x = 5;
-	pixel_y = -5
-	},
+/obj/item/weapon/circuitboard/communications,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -62099,8 +60262,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/grille{
 	density = 0;
@@ -62141,8 +60303,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -62152,7 +60313,6 @@
 "css" = (
 /obj/machinery/status_display{
 	density = 0;
-	pixel_x = 0;
 	pixel_y = 32;
 	supply_display = 1
 	},
@@ -62190,8 +60350,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -62229,8 +60388,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -62356,8 +60514,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/bluegrid{
 	icon_state = "dark";
@@ -62382,8 +60539,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/bluegrid{
@@ -62403,8 +60559,7 @@
 	cell_type = 5000;
 	dir = 4;
 	name = "Telecoms Sat. Central Compartment APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -62468,8 +60623,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -62513,8 +60667,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/engine/break_room)
@@ -62525,8 +60678,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/engine/break_room)
@@ -62646,8 +60798,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -62663,7 +60814,6 @@
 "ctx" = (
 /obj/machinery/flasher{
 	id = "HoP_flasher";
-	pixel_x = 0;
 	pixel_y = 16
 	},
 /turf/simulated/floor{
@@ -62723,8 +60873,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -62736,8 +60885,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/item/weapon/storage/secure/briefcase,
 /turf/simulated/floor{
@@ -62826,13 +60974,9 @@
 "ctT" = (
 /obj/structure/rack,
 /obj/item/weapon/circuitboard/robotics{
-	pixel_x = -2;
-	pixel_y = 2
+	pixel_y = 4
 	},
-/obj/item/weapon/circuitboard/mecha_control{
-	pixel_x = 1;
-	pixel_y = -1
-	},
+/obj/item/weapon/circuitboard/mecha_control,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "vault"
@@ -62917,8 +61061,7 @@
 "cug" = (
 /obj/machinery/light{
 	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -62958,14 +61101,12 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -62981,8 +61122,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/item/weapon/handcuffs,
 /turf/simulated/floor{
@@ -63028,7 +61168,6 @@
 "cut" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/reagent_dispensers/fueltank,
@@ -63057,8 +61196,7 @@
 "cuw" = (
 /obj/machinery/computer/security/mining,
 /obj/machinery/keycard_auth{
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -63086,8 +61224,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -63109,14 +61246,12 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Module South";
 	dir = 4;
-	network = list("SS13","Research");
-	pixel_x = 0
+	network = list("SS13","Research")
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/door_control{
 	id = "xenobio1";
 	name = "Containment Blast Doors";
-	pixel_x = 0;
 	pixel_y = 4;
 	req_access_txt = "55"
 	},
@@ -63134,8 +61269,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -63167,7 +61301,9 @@
 /area/medical/genetics)
 "cuK" = (
 /obj/structure/table/glass,
-/obj/item/weapon/medical/teleporter,
+/obj/item/weapon/medical/teleporter{
+	pixel_y = 8
+	},
 /obj/item/stack/medical/advanced/bruise_pack,
 /obj/item/stack/medical/advanced/bruise_pack,
 /obj/item/stack/medical/advanced/ointment,
@@ -63203,8 +61339,7 @@
 "cuP" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -63259,8 +61394,7 @@
 /obj/item/weapon/storage/belt/utility,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/simulated/floor,
 /area/engine/engineering)
@@ -63290,13 +61424,6 @@
 	},
 /area/toxins/brainstorm_center)
 "cvc" = (
-/obj/machinery/requests_console{
-	announcementConsole = 1;
-	department = "Head of Personnel's Desk";
-	departmentType = 5;
-	name = "Head of Personnel RC";
-	pixel_y = -30
-	},
 /obj/machinery/camera{
 	c_tag = "Head of Personnel's Office";
 	dir = 1
@@ -63429,6 +61556,13 @@
 	pixel_y = 5;
 	req_access_txt = "57"
 	},
+/obj/machinery/requests_console{
+	announcementConsole = 1;
+	department = "Head of Personnel's Desk";
+	departmentType = 5;
+	name = "Head of Personnel RC";
+	pixel_y = -30
+	},
 /turf/simulated/floor{
 	dir = 0;
 	icon_state = "blue"
@@ -63441,8 +61575,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 6;
@@ -63535,12 +61668,10 @@
 /obj/structure/stool,
 /obj/machinery/camera{
 	c_tag = "Aft Starboard Solar Control";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor/plating,
@@ -63560,8 +61691,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -63580,8 +61710,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -63663,8 +61792,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -63709,8 +61837,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -63718,8 +61845,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -63727,7 +61853,6 @@
 	id_tag = "solar_xeno_inner";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "13"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
@@ -63742,16 +61867,14 @@
 /area/maintenance/port)
 "cwy" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
@@ -63808,8 +61931,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
@@ -63844,7 +61966,6 @@
 "cwL" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -63870,8 +61991,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/medical/hallway/outbranch)
@@ -63928,8 +62048,7 @@
 "cwR" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor,
@@ -63945,14 +62064,12 @@
 	id_tag = "solar_xeno_outer";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "10;13"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/starboardsolar)
@@ -64010,8 +62127,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -64031,8 +62147,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -64046,8 +62161,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -64122,8 +62236,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
@@ -64183,7 +62296,6 @@
 "cxy" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -64245,8 +62357,7 @@
 "cxH" = (
 /obj/machinery/camera{
 	c_tag = "Engineering West";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots,
@@ -64269,7 +62380,6 @@
 /area/engine/engineering)
 "cxK" = (
 /obj/machinery/ai_status_display{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/camera{
@@ -64287,7 +62397,6 @@
 "cxL" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor{
@@ -64394,9 +62503,7 @@
 	},
 /area/hallway/primary/central)
 "cxX" = (
-/obj/machinery/hydroponics/constructable{
-	pixel_y = 0
-	},
+/obj/machinery/hydroponics/constructable,
 /obj/machinery/light{
 	dir = 8;
 	icon_state = "tube1"
@@ -64430,7 +62537,6 @@
 "cya" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/space_heater,
@@ -64445,8 +62551,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/camera{
 	c_tag = "Fore Port Solar Access";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -64533,8 +62638,7 @@
 /obj/machinery/alarm{
 	dir = 4;
 	frequency = 1439;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/simulated/floor,
 /area/atmos)
@@ -64544,9 +62648,7 @@
 /turf/space,
 /area/space)
 "cyn" = (
-/obj/machinery/hydroponics/constructable{
-	pixel_y = 0
-	},
+/obj/machinery/hydroponics/constructable,
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
@@ -64595,8 +62697,7 @@
 /area/maintenance/asmaint)
 "cyr" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -64619,8 +62720,7 @@
 /area/maintenance/port)
 "cyt" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -64681,8 +62781,7 @@
 "cyC" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Secure Storage";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/shield_capacitor,
 /turf/simulated/floor/plating,
@@ -64740,8 +62839,7 @@
 "cyI" = (
 /obj/machinery/camera{
 	c_tag = "Engine West";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -64788,7 +62886,6 @@
 	name = "interior access button";
 	pixel_x = 20;
 	pixel_y = -20;
-	req_access_txt = "0";
 	req_one_access_txt = "13;45;1"
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible{
@@ -64834,8 +62931,7 @@
 /area/medical/checkpoint)
 "cyX" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -64924,8 +63020,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -64967,8 +63062,7 @@
 "czn" = (
 /obj/structure/closet/radiation,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/simulated/floor,
 /area/engine/engineering)
@@ -64991,8 +63085,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/quartermaster/storage)
@@ -65007,18 +63100,6 @@
 	icon_state = "warning"
 	},
 /area/security/warden)
-"czs" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor{
-	dir = 2;
-	icon_state = "redcorner"
-	},
-/area/security/main)
 "czt" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -65068,8 +63149,7 @@
 /area/engine/break_room)
 "czy" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/space,
 /area/space)
@@ -65139,8 +63219,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -65187,8 +63266,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -65332,8 +63410,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/machinery/cryopod,
 /turf/simulated/floor/carpet/green,
@@ -65351,7 +63428,6 @@
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Library Maintenance";
-	req_access_txt = "0";
 	req_one_access_txt = "12;37"
 	},
 /turf/simulated/floor/plating,
@@ -65454,7 +63530,6 @@
 	id = "Singularity";
 	name = "Shutters Control";
 	pixel_x = 25;
-	pixel_y = 0;
 	req_access_txt = "10"
 	},
 /obj/structure/cable/yellow{
@@ -65472,7 +63547,6 @@
 	id = "Singularity";
 	name = "Shutters Control";
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access_txt = "10"
 	},
 /obj/structure/cable/yellow{
@@ -65499,7 +63573,6 @@
 	id = "Singularity";
 	name = "Shutters Control";
 	pixel_x = 25;
-	pixel_y = 0;
 	req_access_txt = "10"
 	},
 /turf/simulated/floor/plating{
@@ -65523,8 +63596,7 @@
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
 	name = "HIGH VOLTAGE";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -65570,8 +63642,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway 2";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -65600,8 +63671,7 @@
 /obj/machinery/disposal,
 /obj/machinery/camera{
 	c_tag = "Drone Fabrication";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -65622,8 +63692,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -65775,8 +63844,7 @@
 	department = "Engineering";
 	departmentType = 4;
 	name = "Engineering RC";
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/machinery/light{
 	dir = 4
@@ -65794,8 +63862,7 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -65938,8 +64005,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -66002,8 +64068,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/solar/starboard)
@@ -66035,8 +64100,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/solar/starboard)
@@ -66056,7 +64120,6 @@
 "cBH" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/light{
@@ -66105,7 +64168,6 @@
 	id_tag = "engineering_west_outer";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "10;13"
 	},
 /turf/simulated/floor/plating,
@@ -66153,7 +64215,6 @@
 	cell_type = 20000;
 	dir = 1;
 	name = "Engineering APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable/yellow{
@@ -66244,7 +64305,6 @@
 	id_tag = "engineering_east_outer";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "10;13"
 	},
 /turf/simulated/floor/plating,
@@ -66252,7 +64312,6 @@
 "cBX" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -22
 	},
 /turf/simulated/floor{
@@ -66309,8 +64368,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -66323,8 +64381,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/engine/singularity)
@@ -66332,8 +64389,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/power/grounding_rod,
 /turf/simulated/floor/plating/airless,
@@ -66387,8 +64443,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/engine/engineering)
@@ -66436,8 +64491,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/engine/engineering)
@@ -66564,35 +64618,17 @@
 	},
 /turf/space,
 /area/space)
-"cCD" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	icon_state = "white"
-	},
-/area/medical/hallway/outbranch)
 "cCE" = (
 /obj/machinery/requests_console{
 	department = "AI";
 	departmentType = 5;
 	name = "AI Requests Console";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/whitegreed,
 /area/turret_protected/ai)
@@ -66871,8 +64907,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -66881,7 +64916,6 @@
 "cDr" = (
 /obj/machinery/flasher{
 	id = "AI";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -66942,8 +64976,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/machinery/camera/motion{
 	c_tag = "AI Chamber North";
@@ -66989,7 +65022,6 @@
 "cDC" = (
 /obj/machinery/flasher{
 	id = "AI";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/simulated/floor/whitegreed,
@@ -67053,8 +65085,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/solar/starboard)
@@ -67086,8 +65117,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/grille,
 /turf/simulated/floor/plating/airless,
@@ -67164,8 +65194,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -67176,8 +65205,7 @@
 /area/aisat)
 "cEd" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -67194,8 +65222,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -67282,8 +65309,7 @@
 /area/space)
 "cEt" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -67302,7 +65328,6 @@
 	id_tag = "engineering_aux_outer";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "13";
 	req_one_access_txt = "11;24"
 	},
@@ -67321,7 +65346,6 @@
 /obj/machinery/airlock_sensor{
 	frequency = 1379;
 	id_tag = "satellite_aux_sensor";
-	pixel_x = 0;
 	pixel_y = 25;
 	req_one_access_txt = "13;45;1"
 	},
@@ -67330,7 +65354,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/plating,
@@ -67382,8 +65405,7 @@
 /area/shuttle/escape_pod5/station)
 "cEE" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -67539,15 +65561,11 @@
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
 	icon_state = "closed";
-	id_tag = "satellite_aux_inner";
+	id_tag = "satellite_aux_outer";
 	locked = 1;
 	name = "Satellite External Access";
-	req_access = null;
 	req_access_txt = "13";
 	req_one_access_txt = "11;24"
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/aisat)
@@ -67582,7 +65600,6 @@
 /obj/structure/table,
 /obj/item/device/flashlight/lamp,
 /obj/machinery/ai_status_display{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor{
@@ -67606,7 +65623,6 @@
 /obj/structure/table,
 /obj/item/weapon/folder/white,
 /obj/machinery/ai_status_display{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/item/weapon/paper_bin,
@@ -67637,12 +65653,9 @@
 /turf/simulated/floor,
 /area/hydroponics)
 "cFo" = (
-/obj/machinery/hydroponics/constructable{
-	pixel_y = 0
-	},
+/obj/machinery/hydroponics/constructable,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -67677,7 +65690,6 @@
 	name = "exterior access button";
 	pixel_x = 25;
 	pixel_y = -25;
-	req_access_txt = "0";
 	req_one_access_txt = "13;45;1"
 	},
 /turf/simulated/floor/plating,
@@ -67686,9 +65698,7 @@
 /obj/machinery/embedded_controller/radio/airlock_controller{
 	frequency = 1379;
 	id_tag = "engin_airlock";
-	pixel_x = 0;
 	pixel_y = 28;
-	req_access_txt = "0";
 	req_one_access_txt = "13;45;1";
 	tag_airpump = "engin_pump";
 	tag_chamber_sensor = "engin_sensor";
@@ -67714,8 +65724,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/r_wall,
 /area/turret_protected/ai)
@@ -67726,8 +65735,6 @@
 	id_tag = "engin_outer";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
-	req_access_txt = "0";
 	req_one_access_txt = "13;45;1"
 	},
 /turf/simulated/floor/plating,
@@ -67759,8 +65766,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -67795,8 +65801,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -67816,8 +65821,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -67840,8 +65844,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -67897,7 +65900,6 @@
 	name = "interior access button";
 	pixel_x = -25;
 	pixel_y = 25;
-	req_access_txt = "0";
 	req_one_access_txt = "13;45;1"
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible{
@@ -67912,8 +65914,6 @@
 	id_tag = "engin_inner";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
-	req_access_txt = "0";
 	req_one_access_txt = "13;45;1"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -67943,8 +65943,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/wall/r_wall,
 /area/ai_monitored/storage/secure)
@@ -67958,7 +65957,6 @@
 	control_area = "AI Satellite";
 	dir = 2;
 	name = "Aisat Turret Control";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor{
@@ -68003,8 +66001,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall/r_wall,
@@ -68020,8 +66017,7 @@
 	frequency = 1485;
 	listening = 1;
 	name = "Station Intercom (Medbay)";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /turf/simulated/floor{
 	dir = 10;
@@ -68089,7 +66085,6 @@
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
-	pixel_x = 0;
 	pixel_y = 20
 	},
 /obj/item/device/radio/intercom{
@@ -68098,7 +66093,6 @@
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/item/device/radio/intercom{
@@ -68121,8 +66115,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -68153,7 +66146,6 @@
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
-	pixel_x = 0;
 	pixel_y = 19
 	},
 /obj/item/device/radio/intercom{
@@ -68162,7 +66154,6 @@
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/item/device/radio/intercom{
@@ -68190,8 +66181,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/quartermaster/storage)
@@ -68225,8 +66215,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/quartermaster/storage)
@@ -68239,7 +66228,6 @@
 /area/quartermaster/storage)
 "cGx" = (
 /obj/machinery/ai_status_display{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/light,
@@ -68295,7 +66283,6 @@
 	},
 /obj/structure/table,
 /obj/machinery/alarm{
-	frequency = 1600;
 	pixel_y = 26
 	},
 /obj/item/clothing/accessory/stethoscope,
@@ -68339,8 +66326,6 @@
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway 1";
 	dir = 8;
-	network = list("SS13");
-	pixel_x = 0;
 	pixel_y = -22
 	},
 /obj/machinery/light{
@@ -68376,10 +66361,7 @@
 /area/library)
 "cGP" = (
 /obj/structure/table/woodentable,
-/obj/item/weapon/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /turf/simulated/floor/wood,
 /area/library)
@@ -68413,8 +66395,7 @@
 /obj/item/device/camera_film,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -68430,7 +66411,6 @@
 	id_tag = "engineering_west_inner";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "10;13"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
@@ -68448,7 +66428,6 @@
 /obj/machinery/camera{
 	c_tag = "Garden West";
 	dir = 8;
-	pixel_x = 0;
 	pixel_y = -22
 	},
 /turf/simulated/floor{
@@ -68464,8 +66443,7 @@
 /area/ai_monitored/storage/secure)
 "cHa" = (
 /obj/machinery/atm{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -68484,7 +66462,6 @@
 	frequency = 1379;
 	id_tag = "virology_airlock";
 	pixel_x = 25;
-	req_access_txt = "0";
 	req_one_access_txt = "13;45;1";
 	tag_airpump = "virology_pump";
 	tag_chamber_sensor = "virology_sensor";
@@ -68538,8 +66515,7 @@
 	anyai = 1;
 	freerange = 1;
 	name = "General Listening Channel";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /turf/simulated/floor/carpet,
 /area/tcommsat/computer)
@@ -68568,8 +66544,6 @@
 	id_tag = "virology_outer";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
-	req_access_txt = "0";
 	req_one_access_txt = "13;45;1"
 	},
 /turf/simulated/floor/plating,
@@ -68582,8 +66556,7 @@
 	anyai = 1;
 	freerange = 1;
 	name = "General Listening Channel";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/simulated/floor/carpet,
 /area/tcommsat/computer)
@@ -68598,13 +66571,10 @@
 /turf/simulated/floor/carpet,
 /area/tcommsat/computer)
 "cHv" = (
-/obj/machinery/hydroponics/constructable{
-	pixel_y = 0
-	},
+/obj/machinery/hydroponics/constructable,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -68617,7 +66587,6 @@
 	id_tag = "engineering_east_inner";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
 	req_access_txt = "10;13"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
@@ -68625,13 +66594,10 @@
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "cHx" = (
-/obj/machinery/hydroponics/constructable{
-	pixel_y = 0
-	},
+/obj/machinery/hydroponics/constructable,
 /obj/machinery/camera{
 	c_tag = "Hydroponics South";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -68653,8 +66619,7 @@
 	},
 /obj/machinery/light{
 	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor/carpet,
 /area/tcommsat/computer)
@@ -68737,8 +66702,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -68774,8 +66738,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen/blue,
@@ -68823,8 +66786,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
@@ -68846,13 +66808,11 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Detective APC";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -68869,7 +66829,6 @@
 	name = "Detective"
 	},
 /obj/item/weapon/storage/secure/safe{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/structure/stool/bed/chair/office/dark{
@@ -68932,8 +66891,7 @@
 /area/tcommsat/chamber)
 "cIq" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -68946,8 +66904,7 @@
 /area/space)
 "cIr" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/lattice,
 /turf/space,
@@ -68995,17 +66952,13 @@
 /area/library)
 "cIE" = (
 /obj/structure/table/woodentable,
-/obj/machinery/computer/libraryconsole/bookmanagement{
-	pixel_y = 0
-	},
+/obj/machinery/computer/libraryconsole/bookmanagement,
 /obj/machinery/light_switch{
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/machinery/camera{
 	c_tag = "Library East";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -69040,8 +66993,7 @@
 /area/garden)
 "cIM" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -69080,8 +67032,7 @@
 /obj/structure/sink{
 	dir = 8;
 	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 0
+	pixel_x = -12
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -69144,8 +67095,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -69403,8 +67353,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -69470,8 +67419,7 @@
 /obj/structure/sink{
 	dir = 8;
 	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 0
+	pixel_x = -12
 	},
 /obj/item/device/radio/intercom{
 	broadcasting = 0;
@@ -69480,8 +67428,7 @@
 	frequency = 1485;
 	listening = 1;
 	name = "Station Intercom (Medbay)";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -69502,8 +67449,7 @@
 	frequency = 1485;
 	listening = 1;
 	name = "Station Intercom (Medbay)";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -69660,8 +67606,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -69756,9 +67701,7 @@
 	},
 /area/medical/hallway/outbranch)
 "cKH" = (
-/obj/machinery/hydroponics/constructable{
-	pixel_y = 0
-	},
+/obj/machinery/hydroponics/constructable,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -29
@@ -69834,8 +67777,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -69850,7 +67792,6 @@
 /area/quartermaster/miningoffice)
 "cKT" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "9;12;47"
 	},
 /obj/structure/disposalpipe/segment{
@@ -69892,8 +67833,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -69920,7 +67860,6 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "9;12;47"
 	},
 /obj/machinery/door/firedoor,
@@ -69947,8 +67886,7 @@
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_y = 0
+	name = "HIGH VOLTAGE"
 	},
 /turf/simulated/wall,
 /area/security/main)
@@ -69980,8 +67918,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -69990,8 +67927,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -70006,8 +67942,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
@@ -70068,9 +68003,7 @@
 "cLn" = (
 /obj/structure/rack,
 /obj/item/stack/cable_coil/red{
-	amount = 12;
-	pixel_x = 3;
-	pixel_y = -7
+	amount = 12
 	},
 /obj/item/stack/rods{
 	amount = 23
@@ -70111,8 +68044,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -70150,18 +68082,16 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/wood,
 /area/library)
 "cLA" = (
+/obj/machinery/light/small,
 /obj/machinery/alarm{
 	dir = 1;
-	locked = 0;
-	pixel_y = -24
+	pixel_y = -22
 	},
-/obj/machinery/light/small,
 /turf/simulated/floor/wood,
 /area/library)
 "cLC" = (
@@ -70203,7 +68133,6 @@
 	name = "exterior access button";
 	pixel_x = 20;
 	pixel_y = 20;
-	req_access_txt = "0";
 	req_one_access_txt = "13;45;1"
 	},
 /turf/simulated/floor/plating/airless,
@@ -70381,8 +68310,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -70405,8 +68333,7 @@
 	c_tag = "Singularity Observation";
 	dir = 1;
 	network = list("Singularity");
-	pixel_x = 20;
-	pixel_y = 0
+	pixel_x = 20
 	},
 /turf/simulated/floor/plating/airless,
 /area/engine/singularity)
@@ -70470,8 +68397,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
@@ -70511,8 +68437,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -70524,8 +68449,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 12;
-	pixel_y = 0
+	pixel_x = 12
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -70534,9 +68458,7 @@
 /area/rnd/xenobiology)
 "cMC" = (
 /obj/machinery/alarm{
-	dir = 2;
-	locked = 0;
-	pixel_y = 25
+	pixel_y = 23
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -70626,7 +68548,6 @@
 /area/hydroponics)
 "cMW" = (
 /obj/machinery/keycard_auth{
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/table/reinforced,
@@ -70640,8 +68561,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment,
 /mob/living/simple_animal/parrot/Poly,
@@ -70665,8 +68585,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -70682,8 +68601,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -70740,7 +68658,6 @@
 	department = "Forensic's Desk";
 	departmentType = 5;
 	name = "Forensic RC";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/simulated/floor{
@@ -70783,15 +68700,13 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
 	name = "HIGH VOLTAGE";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -70911,8 +68826,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating{
 	icon_state = "platingdmg3"
@@ -70929,8 +68843,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor{
@@ -70950,8 +68863,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4;
@@ -70972,8 +68884,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -70986,11 +68897,8 @@
 /area/medical/genetics)
 "dnb" = (
 /obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 0
-	},
+/obj/machinery/recharger,
 /obj/machinery/alarm{
-	frequency = 1600;
 	pixel_y = 26
 	},
 /turf/simulated/floor{
@@ -71000,8 +68908,7 @@
 /area/security/main)
 "dob" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor{
 	dir = 9;
@@ -71037,8 +68944,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/medical/genetics)
@@ -71109,8 +69015,7 @@
 /obj/structure/sink{
 	dir = 8;
 	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 0
+	pixel_x = -12
 	},
 /obj/item/device/radio/intercom{
 	dir = 2;
@@ -71124,9 +69029,7 @@
 /area/garden)
 "dzb" = (
 /obj/machinery/light{
-	dir = 4;
-	light_power = 0.9;
-	light_range = 8
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -71145,8 +69048,7 @@
 "dBb" = (
 /obj/machinery/camera{
 	c_tag = "Arrival Auxillar Dock's South";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -71248,14 +69150,12 @@
 	c_tag = "Singularity North-West";
 	dir = 3;
 	network = list("Singularity");
-	pixel_x = 20;
-	pixel_y = 0
+	pixel_x = 20
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/engine/singularity)
@@ -71284,8 +69184,7 @@
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
 	departmentType = 2;
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -71330,8 +69229,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/airless,
 /area/engine/singularity)
@@ -71355,8 +69253,7 @@
 "dTb" = (
 /obj/structure/flora/plant/random,
 /obj/machinery/light_switch{
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /turf/simulated/floor{
 	icon_state = "bar"
@@ -71383,8 +69280,7 @@
 /obj/structure/sink{
 	dir = 8;
 	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 0
+	pixel_x = -12
 	},
 /obj/item/device/radio/intercom{
 	freerange = 0;
@@ -71432,10 +69328,7 @@
 /area/maintenance/asmaint)
 "dZb" = (
 /obj/structure/table/woodentable,
-/obj/item/weapon/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/pen/invisible,
 /turf/simulated/floor/wood,
 /area/library)
@@ -71449,8 +69342,7 @@
 "ebb" = (
 /obj/machinery/camera{
 	c_tag = "Library North";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -71526,7 +69418,6 @@
 	cell_type = 5000;
 	dir = 2;
 	name = "Armory APC";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/structure/cable{
@@ -71560,7 +69451,6 @@
 "erb" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/rack,
@@ -71598,8 +69488,7 @@
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_y = 0
+	name = "HIGH VOLTAGE"
 	},
 /turf/simulated/floor/plating,
 /area/security/main)
@@ -71609,7 +69498,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/portable_atmospherics/canister/air,
@@ -71641,8 +69529,7 @@
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_y = 0
+	name = "HIGH VOLTAGE"
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/auxsolarport)
@@ -71667,8 +69554,7 @@
 	broadcasting = 0;
 	listening = 1;
 	name = "Station Intercom (General)";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /turf/simulated/floor,
 /area/quartermaster/office)
@@ -71680,16 +69566,13 @@
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "EXTERNAL AIRLOCK"
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/fsmaint)
 "eCb" = (
 /obj/machinery/flasher{
-	id = "solitary1";
-	pixel_x = 0
+	id = "solitary1"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -71731,13 +69614,11 @@
 /obj/item/clothing/glasses/sunglasses,
 /obj/machinery/light{
 	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/structure/table/glass,
 /obj/machinery/newscaster{
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor{
@@ -71872,7 +69753,6 @@
 	name = "Medbay Doors Control";
 	normaldoorcontrol = 1;
 	pixel_x = 4;
-	pixel_y = 0;
 	range = 8;
 	req_access_txt = "5"
 	},
@@ -71882,10 +69762,7 @@
 	},
 /area/medical/reception)
 "eRb" = (
-/obj/structure/sign/warning/pods{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/structure/sign/warning/pods,
 /turf/simulated/wall/r_wall,
 /area/maintenance/fsmaint)
 "eSb" = (
@@ -71908,7 +69785,6 @@
 	name = "Medbay Doors Control";
 	normaldoorcontrol = 1;
 	pixel_x = -4;
-	pixel_y = 0;
 	range = 8;
 	req_access_txt = "5"
 	},
@@ -71941,14 +69817,12 @@
 "eVb" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel";
-	req_access = null;
 	req_access_txt = "57"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -71964,9 +69838,7 @@
 	},
 /area/medical/reception)
 "eXb" = (
-/obj/machinery/hydroponics/constructable{
-	pixel_y = 0
-	},
+/obj/machinery/hydroponics/constructable,
 /obj/machinery/newscaster{
 	pixel_y = -30
 	},
@@ -71980,8 +69852,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/door/firedoor,
@@ -72024,9 +69895,7 @@
 "fdb" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
-	pixel_x = -22;
-	pixel_y = 0
+	pixel_x = -22
 	},
 /turf/simulated/floor,
 /area/quartermaster/office)
@@ -72085,8 +69954,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -72100,8 +69968,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
@@ -72111,8 +69978,7 @@
 /area/quartermaster/recycleroffice)
 "flb" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -72138,8 +70004,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/binary/pump/on,
 /turf/simulated/floor/plating,
@@ -72192,8 +70057,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/recycleroffice)
@@ -72210,7 +70074,6 @@
 	id_tag = "recycler_inner";
 	locked = 1;
 	name = "Recycler External Access";
-	req_access = null;
 	req_access_txt = "67";
 	req_one_access_txt = ""
 	},
@@ -72290,7 +70153,6 @@
 	id_tag = "recycler_airlock";
 	layer = 3.3;
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access_txt = "67";
 	tag_airpump = "recycler_pump";
 	tag_chamber_sensor = "recycler_sensor";
@@ -72301,8 +70163,7 @@
 /area/quartermaster/recycleroffice)
 "fyb" = (
 /obj/machinery/flasher{
-	id = "solitary2";
-	pixel_x = 0
+	id = "solitary2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -72320,8 +70181,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -72370,7 +70230,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Recycler APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plating/airless,
@@ -72388,8 +70247,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "red"
@@ -72430,9 +70288,7 @@
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "HIGH VOLTAGE"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -72481,10 +70337,7 @@
 	},
 /area/medical/cmo)
 "fOb" = (
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/item/weapon/folder/red,
 /obj/structure/table/glass,
@@ -72572,12 +70425,10 @@
 /obj/machinery/disposal,
 /obj/machinery/camera{
 	c_tag = "Atmospherics Monitoring";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/structure/disposalpipe/trunk{
@@ -72649,8 +70500,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -72668,8 +70518,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -72711,8 +70560,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/wood,
 /area/maintenance/aft)
@@ -72728,7 +70576,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/vending/engivend,
@@ -72740,28 +70587,24 @@
 	department = "Chief Engineer's Desk";
 	departmentType = 3;
 	name = "Chief Engineer RC";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/flora/plant,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/engine/chiefs_office)
 "gnb" = (
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -72788,8 +70631,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/engine/chiefs_office)
@@ -72797,9 +70639,9 @@
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots,
 /obj/item/clothing/mask/breath,
-/obj/item/clothing/head/helmet/space/rig/engineering/chief,
 /obj/item/clothing/suit/space/rig/engineering/chief,
 /obj/structure/disposalpipe/segment,
+/obj/item/clothing/head/helmet/space/rig/engineering/chief,
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
@@ -72823,9 +70665,7 @@
 /turf/simulated/floor,
 /area/engine/chiefs_office)
 "gvb" = (
-/obj/structure/closet/secure_closet/engineering_chief{
-	req_access_txt = "0"
-	},
+/obj/structure/closet/secure_closet/engineering_chief,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -72865,10 +70705,7 @@
 /obj/item/weapon/folder/yellow,
 /obj/item/weapon/stamp/ce,
 /obj/item/weapon/pen,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/device/megaphone,
 /obj/item/weapon/paper/wires,
 /turf/simulated/floor,
@@ -72886,8 +70723,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -72926,8 +70762,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "CE Office APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable/yellow{
 	d2 = 8;
@@ -73034,13 +70869,11 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/airlock_sensor{
 	frequency = 1379;
 	id_tag = "security_sensor";
-	pixel_x = 0;
 	pixel_y = 25;
 	req_one_access_txt = "13;45;1"
 	},
@@ -73084,7 +70917,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/cable{
@@ -73121,8 +70953,7 @@
 	},
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA";
-	pixel_y = 0
+	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/exit)
@@ -73165,8 +70996,7 @@
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_y = 0
+	name = "HIGH VOLTAGE"
 	},
 /turf/simulated/wall,
 /area/lawoffice)
@@ -73261,8 +71091,7 @@
 "hjb" = (
 /obj/machinery/light{
 	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /obj/machinery/computer/mine_sci_shuttle/flight_comp{
 	dir = 8
@@ -73312,8 +71141,7 @@
 /area/shuttle/mining/station)
 "hpb" = (
 /obj/machinery/door/airlock{
-	name = "Sauna";
-	req_access_txt = "0"
+	name = "Sauna"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -73373,8 +71201,7 @@
 	},
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA";
-	pixel_y = 0
+	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/floor/plating,
 /area/hallway/secondary/entry)
@@ -73387,8 +71214,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -73407,9 +71233,7 @@
 /area/library)
 "hyb" = (
 /obj/structure/table/woodentable,
-/obj/item/device/taperecorder{
-	pixel_y = 0
-	},
+/obj/item/device/taperecorder,
 /obj/item/device/camera,
 /obj/item/device/eftpos{
 	eftpos_name = "Library EFTPOS scanner"
@@ -73444,11 +71268,7 @@
 /obj/item/stack/rods{
 	amount = 23
 	},
-/obj/item/stack/cable_coil/red{
-	amount = 12;
-	pixel_x = 3;
-	pixel_y = -7
-	},
+/obj/item/stack/cable_coil/red,
 /obj/random/tools/tech_supply,
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
@@ -73466,8 +71286,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/port)
@@ -73519,8 +71338,7 @@
 /area/hallway/secondary/exit)
 "hJb" = (
 /obj/structure/sign/warning/securearea{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/item/weapon/cigbutt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -73575,13 +71393,11 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/airlock_sensor{
 	frequency = 1379;
 	id_tag = "chapel_sensor";
-	pixel_x = 0;
 	pixel_y = 16;
 	req_access_txt = "13";
 	req_one_access_txt = "13;45;1"
@@ -73612,7 +71428,6 @@
 "hSb" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor{
@@ -73629,8 +71444,7 @@
 /obj/machinery/hologram/holopad,
 /obj/machinery/camera{
 	c_tag = "Escape Arm Airlocks";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/simulated/floor{
 	icon_state = "delivery"
@@ -73642,7 +71456,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/door/firedoor,
@@ -73654,8 +71467,7 @@
 "hVb" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA";
-	pixel_y = 0
+	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/wall/r_wall,
 /area/hallway/secondary/entry)
@@ -73747,8 +71559,7 @@
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0
+	name = "EXTERNAL AIRLOCK"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced{
@@ -73844,8 +71655,7 @@
 /obj/machinery/disposal,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -73895,7 +71705,6 @@
 "irb" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/simulated/floor{
@@ -73956,8 +71765,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 2;
@@ -74047,7 +71855,6 @@
 	name = "interior access button";
 	pixel_x = 20;
 	pixel_y = 20;
-	req_access_txt = "0";
 	req_one_access_txt = "13;45;1"
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible{
@@ -74070,13 +71877,11 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/airlock_sensor{
 	frequency = 1379;
 	id_tag = "toxin_test_sensor";
-	pixel_x = 0;
 	pixel_y = 25;
 	req_one_access_txt = "13;45;1"
 	},
@@ -74103,9 +71908,7 @@
 /obj/machinery/embedded_controller/radio/airlock_controller{
 	frequency = 1379;
 	id_tag = "toxin_test_airlock";
-	pixel_x = 0;
 	pixel_y = 25;
-	req_access_txt = "0";
 	req_one_access_txt = "13;45;1";
 	tag_airpump = "toxin_test_pump";
 	tag_chamber_sensor = "toxin_test_sensor";
@@ -74119,8 +71922,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -74159,8 +71961,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Module SW";
 	dir = 4;
-	network = list("SS13","Research");
-	pixel_x = 0
+	network = list("SS13","Research")
 	},
 /obj/item/weapon/book/manual/wiki/guide_to_xenobiology,
 /obj/item/weapon/storage/box/syringes,
@@ -74172,7 +71973,6 @@
 "iOb" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /turf/simulated/floor{
@@ -74202,8 +72002,7 @@
 	opacity = 0
 	},
 /obj/structure/sign/warning/securearea{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -74220,8 +72019,7 @@
 	opacity = 0
 	},
 /obj/structure/sign/warning/securearea{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -74289,8 +72087,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	locked = 0;
-	pixel_y = -24
+	pixel_y = -22
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -74336,10 +72133,7 @@
 "jbb" = (
 /obj/structure/table/woodentable,
 /obj/machinery/light,
-/obj/item/weapon/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
+/obj/item/weapon/paper_bin,
 /turf/simulated/floor/wood,
 /area/library)
 "jcb" = (
@@ -74472,7 +72266,6 @@
 	},
 /obj/structure/closet/secure_closet{
 	name = "Psychiatrist's Locker";
-	req_access = null;
 	req_access_txt = "64"
 	},
 /obj/item/weapon/storage/box/cups,
@@ -74480,7 +72273,6 @@
 	c_tag = "Psychiatric Office";
 	dir = 8;
 	network = list("SS13","Medical");
-	pixel_x = 0;
 	pixel_y = -22
 	},
 /obj/item/toy/plushie/tuxedo_cat,
@@ -74550,8 +72342,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Disposal APC";
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plating,
@@ -74577,8 +72368,7 @@
 	buildable_sign = 0;
 	dir = 4;
 	icon_state = "direction_sci";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/structure/sign/directions/evac{
 	buildable_sign = 0;
@@ -74704,8 +72494,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 1;
@@ -74733,8 +72522,7 @@
 /area/quartermaster/office)
 "jVb" = (
 /obj/machinery/door/airlock{
-	name = "Private Restroom";
-	req_access_txt = "0"
+	name = "Private Restroom"
 	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor2"
@@ -74744,8 +72532,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 12;
-	pixel_y = 0
+	pixel_x = 12
 	},
 /obj/structure/mirror{
 	pixel_x = 28
@@ -74851,22 +72638,6 @@
 	icon_state = "whitegreenfull"
 	},
 /area/medical/reception)
-"kfb" = (
-/obj/structure/grille,
-/obj/structure/sign/warning/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
-	pixel_y = 0
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 5
-	},
-/turf/simulated/floor/plating,
-/area/hallway/secondary/entry)
 "khb" = (
 /turf/simulated/floor{
 	dir = 2;
@@ -74885,8 +72656,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -74909,8 +72679,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -74989,8 +72758,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -75000,14 +72768,12 @@
 	req_access_txt = "17"
 	},
 /obj/structure/sign/warning/securearea{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -75086,8 +72852,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -75112,8 +72877,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/sign/poster{
 	official = 1;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor{
 	dir = 2;
@@ -75126,8 +72890,7 @@
 /area/maintenance/asmaint)
 "kFb" = (
 /obj/structure/sign/warning/securearea{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -75139,8 +72902,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -75163,10 +72925,7 @@
 /area/medical/sleeper)
 "kIb" = (
 /obj/structure/table,
-/obj/item/weapon/paper_bin{
-	pixel_x = -5;
-	pixel_y = 10
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/folder,
 /obj/item/weapon/pen,
 /obj/effect/decal/cleanable/dirt,
@@ -75180,8 +72939,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -75251,8 +73009,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -75427,15 +73184,13 @@
 	id_tag = "recycler_outer";
 	locked = 1;
 	name = "Recycler External Access";
-	req_access = null;
 	req_access_txt = "67";
 	req_one_access_txt = ""
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/recycleroffice)
@@ -75452,8 +73207,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/hologram/holopad,
@@ -75481,8 +73235,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -75532,8 +73285,7 @@
 /area/medical/genetics_cloning)
 "lJb" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -75549,8 +73301,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -75575,10 +73326,6 @@
 	},
 /area/medical/cmo)
 "lMb" = (
-/obj/structure/stool/bed/chair/metal/blue{
-	dir = 4;
-	icon_state = "chair_blu"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -75586,6 +73333,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/stool/bed/chair/metal/blue{
+	dir = 4;
+	icon_state = "chair_blue"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -75600,8 +73351,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -75612,8 +73362,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -75626,8 +73375,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -75717,10 +73465,7 @@
 	},
 /area/medical/cryo)
 "lXb" = (
-/obj/item/weapon/paper_bin{
-	pixel_x = -2;
-	pixel_y = 5
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/structure/table/glass,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -75799,8 +73544,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/medical{
-	name = "Patient Room 1";
-	req_access_txt = 0
+	name = "Patient Room 1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -75812,8 +73556,7 @@
 /area/medical/patient_b)
 "mfb" = (
 /obj/machinery/door/airlock/medical{
-	name = "Patient Room 1";
-	req_access_txt = 0
+	name = "Patient Room 1"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -75852,8 +73595,7 @@
 	icon_state = "space";
 	layer = 4;
 	name = "VACUUM";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
@@ -75863,13 +73605,13 @@
 	},
 /area/maintenance/aft)
 "mib" = (
-/obj/structure/stool/bed/chair/metal/green{
-	dir = 4;
-	icon_state = "chair_gr"
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
+	},
+/obj/structure/stool/bed/chair/metal/green{
+	dir = 4;
+	icon_state = "chair_green"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -75930,7 +73672,7 @@
 	},
 /obj/structure/stool/bed/chair/metal/green{
 	dir = 4;
-	icon_state = "chair_gr"
+	icon_state = "chair_green"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -76025,8 +73767,7 @@
 "mAb" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics North West";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -76124,8 +73865,7 @@
 	icon_state = "space";
 	layer = 4;
 	name = "VACUUM";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
@@ -76255,8 +73995,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -76273,8 +74012,7 @@
 /area/maintenance/asmaint)
 "nfb" = (
 /obj/structure/sign/warning/securearea{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/shower{
 	dir = 4;
@@ -76305,7 +74043,6 @@
 	dir = 1;
 	name = "Medical Monitor";
 	network = list("Medical");
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor{
@@ -76374,8 +74111,7 @@
 "npb" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -76433,8 +74169,6 @@
 	id_tag = "virology_inner";
 	locked = 1;
 	name = "Engineering External Access";
-	req_access = null;
-	req_access_txt = "0";
 	req_one_access_txt = "13;45;1"
 	},
 /turf/simulated/floor/plating,
@@ -76443,8 +74177,7 @@
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_y = 0
+	name = "HIGH VOLTAGE"
 	},
 /turf/simulated/wall,
 /area/rnd/xenobiology)
@@ -76452,8 +74185,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -76482,8 +74214,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -76528,8 +74259,7 @@
 /area/engine/break_room)
 "nCb" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor{
@@ -76575,8 +74305,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -76585,8 +74314,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/access_button{
@@ -76595,7 +74323,6 @@
 	master_tag = "virology_airlock_control";
 	name = "Virology Access Button";
 	pixel_x = -24;
-	pixel_y = 0;
 	req_access_txt = "39"
 	},
 /obj/machinery/door/airlock/medical{
@@ -76726,8 +74453,7 @@
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_y = 0
+	name = "HIGH VOLTAGE"
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/starboardsolar)
@@ -76768,8 +74494,7 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/components/unary/portables_connector,
@@ -76779,8 +74504,7 @@
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_y = 0
+	name = "HIGH VOLTAGE"
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/portsolar)
@@ -76812,7 +74536,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/portable_atmospherics/canister/air,
@@ -76866,9 +74589,7 @@
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
-	name = "RADIOACTIVE AREA";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "RADIOACTIVE AREA"
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/engineering)
@@ -76881,8 +74602,7 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor,
 /area/engine/engineering)
@@ -76904,7 +74624,6 @@
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
 	name = "RADIOACTIVE AREA";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/light,
@@ -76943,8 +74662,7 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -76983,7 +74701,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor/engine/vacuum,
@@ -77011,17 +74728,12 @@
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "EXTERNAL AIRLOCK"
 	},
 /turf/simulated/wall/r_wall,
 /area/maintenance/aft)
 "ovb" = (
-/obj/structure/sign/warning/pods{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/structure/sign/warning/pods,
 /turf/simulated/wall/r_wall,
 /area/maintenance/aft)
 "owb" = (
@@ -77036,8 +74748,7 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
@@ -77048,9 +74759,7 @@
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
 	icon_state = "radiation";
-	name = "RADIOACTIVE AREA";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "RADIOACTIVE AREA"
 	},
 /turf/simulated/wall/r_wall,
 /area/engine/singularity)
@@ -77130,8 +74839,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/crew_quarters/locker)
@@ -77145,8 +74853,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/crew_quarters/locker)
@@ -77160,8 +74867,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/crew_quarters/locker)
@@ -77197,8 +74903,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -77233,8 +74938,7 @@
 "oNb" = (
 /obj/machinery/camera{
 	c_tag = "Vacant Office";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/filingcabinet/chestdrawer/black,
 /turf/simulated/floor/wood,
@@ -77246,8 +74950,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -77261,8 +74964,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/sign/poster{
 	official = 1;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -77386,8 +75088,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -77404,8 +75105,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/central)
@@ -77417,8 +75117,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -77434,8 +75133,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment{
@@ -77511,15 +75209,13 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "pgb" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/machinery/disposal,
@@ -77535,8 +75231,7 @@
 	name = "Evidence Closet"
 	},
 /obj/machinery/light_switch{
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/item/device/radio/intercom{
 	broadcasting = 1;
@@ -77544,7 +75239,6 @@
 	frequency = 1475;
 	listening = 0;
 	name = "Station Intercom (Security)";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor{
@@ -77567,8 +75261,7 @@
 "pkb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/stool/bed/chair/metal/black{
-	dir = 8;
-	icon_state = "chair_bla"
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -77592,8 +75285,7 @@
 /obj/structure/sink{
 	dir = 8;
 	icon_state = "sink";
-	pixel_x = -12;
-	pixel_y = 0
+	pixel_x = -12
 	},
 /obj/structure/mirror{
 	pixel_x = -28
@@ -77610,7 +75302,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Barbershop APC";
-	pixel_x = 0;
 	pixel_y = 27
 	},
 /obj/structure/cable{
@@ -77627,7 +75318,6 @@
 	department = "Detective's Desk";
 	departmentType = 5;
 	name = "Detective RC";
-	pixel_x = 0;
 	pixel_y = -31
 	},
 /obj/structure/cable{
@@ -77648,9 +75338,7 @@
 /obj/machinery/camera{
 	c_tag = "Chief Medical Office";
 	dir = 2;
-	network = list("SS13","Medical");
-	pixel_x = 0;
-	pixel_y = 0
+	network = list("SS13","Medical")
 	},
 /obj/structure/closet/secure_closet/CMO,
 /turf/simulated/floor{
@@ -77664,13 +75352,11 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fpmaint)
@@ -77684,8 +75370,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/alarm{
 	pixel_y = 23
@@ -77705,8 +75390,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -77741,8 +75425,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/grille{
 	density = 0;
@@ -77760,8 +75443,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -77828,8 +75510,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "CM Office APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -77851,13 +75532,10 @@
 	department = "Chief Medical Officer's Desk";
 	departmentType = 5;
 	name = "Chief Medical Officer RC";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/alarm{
-	dir = 2;
-	locked = 0;
-	pixel_y = 25
+	pixel_y = 23
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -77889,8 +75567,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 2;
@@ -77913,8 +75590,7 @@
 	},
 /obj/structure/sign/poster{
 	official = 1;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor{
 	dir = 2;
@@ -77944,8 +75620,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -77956,15 +75631,13 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
 	name = "HIGH VOLTAGE";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor{
 	dir = 9;
@@ -78113,8 +75786,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -78124,9 +75796,7 @@
 /area/security/lobby)
 "pWb" = (
 /obj/machinery/newscaster{
-	layer = 3.3;
-	pixel_x = 0;
-	pixel_y = -27
+	pixel_y = -30
 	},
 /turf/simulated/floor{
 	dir = 2;
@@ -78144,8 +75814,7 @@
 /obj/item/device/radio/intercom{
 	dir = 4;
 	name = "Station Intercom (General)";
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/structure/disposalpipe/segment,
 /obj/item/weapon/razor,
@@ -78165,8 +75834,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -78183,9 +75851,7 @@
 "qab" = (
 /obj/structure/rack,
 /obj/item/stack/cable_coil/red{
-	amount = 12;
-	pixel_x = 3;
-	pixel_y = -7
+	amount = 12
 	},
 /obj/item/stack/rods{
 	amount = 23
@@ -78202,8 +75868,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -78214,8 +75879,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -78234,8 +75898,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -78261,8 +75924,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
@@ -78301,15 +75963,13 @@
 	desc = "A remote control-switch for secure storage.";
 	id = "Secure Storage";
 	name = "Engineering Secure Storage";
-	pixel_x = 0;
 	pixel_y = 24;
 	req_access_txt = "56"
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/item/weapon/storage/secure/safe{
 	pixel_x = 8;
@@ -78338,7 +75998,6 @@
 /obj/item/weapon/reagent_containers/dropper/precision,
 /obj/item/weapon/reagent_containers/glass/beaker/large,
 /obj/item/weapon/reagent_containers/dropper{
-	pixel_x = 0;
 	pixel_y = -4
 	},
 /obj/structure/table/glass,
@@ -78413,8 +76072,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -78428,11 +76086,9 @@
 	},
 /obj/item/weapon/storage/box/syringes,
 /obj/item/clothing/glasses/science{
-	pixel_x = 0;
 	pixel_y = 1
 	},
 /obj/item/clothing/glasses/science{
-	pixel_x = 0;
 	pixel_y = 1
 	},
 /obj/item/weapon/reagent_containers/spray/cleaner{
@@ -78466,8 +76122,7 @@
 	frequency = 1485;
 	listening = 1;
 	name = "Station Intercom (Medbay)";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -78497,7 +76152,6 @@
 /obj/item/weapon/reagent_containers/dropper/precision,
 /obj/item/weapon/reagent_containers/glass/beaker/large,
 /obj/item/weapon/reagent_containers/dropper{
-	pixel_x = 0;
 	pixel_y = -4
 	},
 /obj/structure/disposalpipe/segment,
@@ -78547,7 +76201,6 @@
 /obj/structure/closet/theatrecloset,
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor/carpet/purple,
@@ -78578,10 +76231,13 @@
 	},
 /area/maintenance/asmaint)
 "qCb" = (
+/obj/machinery/power/terminal{
+	dir = 1;
+	icon_state = "term"
+	},
 /obj/structure/cable{
-	d1 = 1;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/plating,
 /area/security/brig)
@@ -78607,7 +76263,6 @@
 /obj/machinery/camera{
 	c_tag = "Security Lobby";
 	dir = 8;
-	pixel_x = 0;
 	pixel_y = -22
 	},
 /obj/item/device/radio/intercom{
@@ -78624,10 +76279,7 @@
 	dir = 4
 	},
 /obj/item/weapon/newspaper,
-/obj/item/weapon/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /turf/simulated/floor{
 	dir = 5;
@@ -78644,8 +76296,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -78857,10 +76508,7 @@
 	},
 /area/engine/break_room)
 "rfb" = (
-/obj/item/weapon/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
+/obj/item/weapon/paper_bin,
 /obj/structure/table/glass,
 /turf/simulated/floor{
 	dir = 2;
@@ -78881,7 +76529,6 @@
 	id_tag = "virology_airlock_control";
 	name = "Virology Access Console";
 	pixel_x = 22;
-	pixel_y = 0;
 	tag_exterior_door = "virology_airlock_exterior";
 	tag_interior_door = "virology_airlock_interior"
 	},
@@ -78962,8 +76609,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -78980,8 +76626,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Virology APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/sign/warning/biohazard{
 	pixel_y = 32
@@ -79010,9 +76655,6 @@
 /area/medical/virology)
 "rpb" = (
 /obj/structure/stool,
-/obj/machinery/light_switch{
-	pixel_y = 24
-	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "whitegreen"
@@ -79025,13 +76667,10 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/alarm{
-	dir = 2;
-	locked = 0;
-	pixel_y = 25
+	pixel_y = 23
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -79042,8 +76681,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/asmaint)
@@ -79176,8 +76814,7 @@
 /obj/machinery/smartfridge/secure/virology,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -79294,8 +76931,7 @@
 	},
 /obj/item/trash/popcorn,
 /obj/machinery/vending/wallmed1{
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -79306,8 +76942,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -79398,8 +77033,7 @@
 	frequency = 1485;
 	listening = 1;
 	name = "Station Intercom (Medbay)";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/item/weapon/reagent_containers/glass/bottle/synaptizine,
 /obj/item/weapon/reagent_containers/glass/bottle/phoron,
@@ -79409,10 +77043,7 @@
 	},
 /area/medical/virology)
 "rZb" = (
-/obj/item/weapon/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
+/obj/item/weapon/paper_bin,
 /obj/item/weapon/pen{
 	layer = 3.1;
 	pixel_x = 3;
@@ -79423,7 +77054,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor{
@@ -79475,7 +77105,6 @@
 /obj/structure/table/glass,
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /obj/item/device/radio/headset/headset_med,
@@ -79486,7 +77115,6 @@
 /area/medical/virology)
 "sgb" = (
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /turf/simulated/floor{
@@ -79561,9 +77189,6 @@
 /obj/item/weapon/crowbar,
 /obj/item/weapon/wrench,
 /obj/item/weapon/handcuffs,
-/obj/machinery/light_switch{
-	pixel_x = -28
-	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "whitegreen"
@@ -79581,8 +77206,7 @@
 /obj/structure/sink{
 	dir = 4;
 	icon_state = "sink";
-	pixel_x = 12;
-	pixel_y = 0
+	pixel_x = 12
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -79650,9 +77274,7 @@
 "sxb" = (
 /obj/item/seeds/ambrosiavulgarisseed,
 /obj/item/seeds/carrotseed,
-/obj/machinery/hydroponics/constructable{
-	pixel_y = 0
-	},
+/obj/machinery/hydroponics/constructable,
 /turf/simulated/floor/plating{
 	dir = 1;
 	icon_state = "warnplate"
@@ -79902,8 +77524,7 @@
 /obj/machinery/computer/med_data/laptop,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/item/device/radio/intercom{
 	pixel_y = -28
@@ -79915,10 +77536,7 @@
 /area/medical/virology)
 "sUb" = (
 /obj/structure/table/glass,
-/obj/item/weapon/paper_bin{
-	pixel_x = 1;
-	pixel_y = 9
-	},
+/obj/item/weapon/paper_bin,
 /obj/machinery/camera{
 	c_tag = "Virology South";
 	dir = 1;
@@ -79928,7 +77546,6 @@
 /obj/item/weapon/pen,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/simulated/floor{
@@ -79954,8 +77571,7 @@
 /area/space)
 "sXb" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -79969,19 +77585,18 @@
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
 	icon_state = "closed";
-	id_tag = "satellite_aux_outer";
+	id_tag = "engineering_aux_inner";
 	locked = 1;
-	name = "Satellite External Access";
-	req_access = null;
+	name = "Engineering External Access";
 	req_access_txt = "13";
 	req_one_access_txt = "11;24"
 	},
+/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
-/area/aisat)
+/area/engine/engineering)
 "sZb" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "MiniSat North";
@@ -79998,8 +77613,7 @@
 /area/aisat)
 "tab" = (
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -80141,8 +77755,7 @@
 	base_state = "left";
 	dir = 1;
 	icon_state = "left";
-	name = "Shower";
-	req_access_txt = "0"
+	name = "Shower"
 	},
 /obj/item/weapon/soap/deluxe,
 /obj/item/weapon/bikehorn/rubberducky,
@@ -80177,17 +77790,6 @@
 	icon_state = "whitegreen"
 	},
 /area/medical/checkpoint)
-"trb" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/maintenance/aft)
 "tsb" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -80195,8 +77797,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
@@ -80365,7 +77966,6 @@
 "tJb" = (
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/machinery/vending/cola,
@@ -80455,8 +78055,7 @@
 "tUb" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/newscaster{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -80485,18 +78084,6 @@
 	icon_state = "escape"
 	},
 /area/hallway/secondary/exit)
-"tYb" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/asmaint)
 "tZb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -80518,8 +78105,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -80538,8 +78124,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -80603,8 +78188,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo Office";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/photocopier,
 /turf/simulated/floor,
@@ -80739,9 +78323,7 @@
 "uMb" = (
 /obj/structure/closet/crate/freezer,
 /obj/machinery/alarm{
-	dir = 2;
-	locked = 0;
-	pixel_y = 25
+	pixel_y = 23
 	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
@@ -80791,21 +78373,18 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/aft)
 "uSb" = (
 /obj/machinery/door/airlock{
-	name = "Port Emergency Storage";
-	req_access_txt = "0"
+	name = "Port Emergency Storage"
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
@@ -80851,8 +78430,7 @@
 "uYb" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Bay Storage";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -80883,7 +78461,6 @@
 	id = "qm_warehouse";
 	name = "Warehouse Door Control";
 	pixel_x = 28;
-	pixel_y = 0;
 	req_access_txt = "31"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -80913,16 +78490,14 @@
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
 	departmentType = 2;
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /obj/machinery/cell_charger,
 /obj/item/clothing/head/soft,
 /obj/item/clothing/head/soft,
 /obj/machinery/light{
 	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	icon_state = "tube1"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -80965,8 +78540,7 @@
 /obj/item/weapon/hand_labeler,
 /obj/structure/sign/poster{
 	official = 1;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -80977,8 +78551,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -80992,8 +78565,7 @@
 "vjb" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -81027,8 +78599,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
@@ -81044,8 +78615,7 @@
 "vpb" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -81096,9 +78666,7 @@
 /area/quartermaster/storage)
 "vBb" = (
 /obj/structure/disposalpipe/segment{
-	desc = "Pipe for transfer more fuel.";
-	dir = 4;
-	name = "filling pipe"
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
@@ -81106,9 +78674,7 @@
 /area/quartermaster/storage)
 "vCb" = (
 /obj/structure/disposalpipe/segment{
-	desc = "Pipe for transfer more fuel.";
-	dir = 4;
-	name = "filling pipe"
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "delivery"
@@ -81117,9 +78683,7 @@
 "vGb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
-	desc = "Pipe for transfer more fuel.";
-	dir = 4;
-	name = "filling pipe"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -81137,16 +78701,13 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/quartermaster/storage)
 "vHb" = (
 /obj/structure/disposalpipe/segment{
-	desc = "Pipe for transfer more fuel.";
-	dir = 4;
-	name = "filling pipe"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -81159,8 +78720,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -81176,8 +78736,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -81186,9 +78745,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	desc = "Pipe for transfer more fuel.";
-	dir = 4;
-	name = "filling pipe"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/quartermaster/storage)
@@ -81196,8 +78753,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -81206,9 +78762,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
-	desc = "Pipe for transfer more fuel.";
-	dir = 4;
-	name = "filling pipe"
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -81267,8 +78821,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -81279,12 +78832,10 @@
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/food/drinks/bottle/beer,
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/newscaster{
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor{
@@ -81331,8 +78882,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/quartermaster/storage)
@@ -81379,8 +78929,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -81392,19 +78941,11 @@
 "wfb" = (
 /obj/structure/rack,
 /obj/item/weapon/pickaxe/drill{
-	pixel_x = 2;
-	pixel_y = -2
+	pixel_y = 4
 	},
-/obj/item/weapon/pickaxe/drill{
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/weapon/pickaxe/drill{
-	pixel_x = 2;
-	pixel_y = -2
-	},
+/obj/item/weapon/pickaxe/drill,
+/obj/item/weapon/pickaxe/drill,
 /obj/machinery/alarm{
-	frequency = 1600;
 	pixel_y = 26
 	},
 /turf/simulated/floor{
@@ -81429,8 +78970,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
@@ -81482,8 +79022,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "bar"
@@ -81502,8 +79041,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "bar"
@@ -81513,8 +79051,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -81539,8 +79076,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/quartermaster/miningoffice)
@@ -81566,8 +79102,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "bar"
@@ -81595,8 +79130,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -81709,8 +79243,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -81728,7 +79261,6 @@
 /obj/machinery/power/apc{
 	dir = 2;
 	name = "Mining office APC";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/cable,
@@ -81828,8 +79360,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -81845,8 +79376,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -81864,8 +79394,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -81892,8 +79421,7 @@
 "xsb" = (
 /obj/structure/sign/poster{
 	official = 1;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/light{
 	dir = 4
@@ -82070,8 +79598,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo Recieving Dock";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "warning"
@@ -82088,7 +79615,6 @@
 /obj/machinery/status_display{
 	density = 0;
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = -32;
 	supply_display = 1
 	},
@@ -82174,9 +79700,7 @@
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "EXTERNAL AIRLOCK"
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/storage)
@@ -82184,8 +79708,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
@@ -82195,8 +79718,7 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/recycleroffice)
@@ -82204,8 +79726,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
@@ -82235,8 +79756,7 @@
 /obj/structure/grille,
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA";
-	pixel_y = 0
+	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /obj/structure/lattice,
 /turf/space,
@@ -91380,7 +88900,7 @@ bgj
 apT
 uDb
 urb
-kfb
+icb
 btD
 btD
 btD
@@ -105218,7 +102738,7 @@ aKY
 agO
 aKY
 aIV
-aKn
+clo
 aLR
 aLR
 aOC
@@ -105767,7 +103287,7 @@ bjN
 aYE
 bmi
 qcb
-trb
+cfq
 xrb
 aYD
 ciH
@@ -105817,7 +103337,7 @@ bIz
 bQl
 bQl
 ctb
-ceW
+xqb
 bQl
 cog
 bQl
@@ -106836,7 +104356,7 @@ bQl
 chX
 cdA
 bIZ
-ceW
+xqb
 cpg
 aPc
 cqd
@@ -107530,7 +105050,7 @@ aNd
 alZ
 auI
 agO
-bhM
+avI
 aCq
 aPr
 aQg
@@ -107612,7 +105132,7 @@ cfr
 bxn
 cfr
 cha
-chE
+cii
 cii
 cjb
 cjz
@@ -109143,7 +106663,7 @@ bIZ
 bpR
 bQl
 mnb
-cfX
+cal
 crH
 crH
 crH
@@ -109400,7 +106920,7 @@ chV
 chV
 chV
 chV
-cfX
+cal
 crH
 csM
 cud
@@ -109657,7 +107177,7 @@ cJl
 cJl
 cmA
 chV
-cfX
+cal
 crH
 bZJ
 cuj
@@ -110156,12 +107676,12 @@ bIZ
 bYd
 ckg
 bZy
-bZA
+uRb
 bQl
 cci
 cdH
 bIz
-bZA
+uRb
 bvY
 aaa
 bTW
@@ -110171,7 +107691,7 @@ cmB
 brB
 cke
 chV
-cfX
+cal
 crH
 cbN
 cuf
@@ -110418,7 +107938,7 @@ bVo
 bVo
 cdI
 bVo
-bZA
+uRb
 bvY
 aaa
 bTW
@@ -110428,7 +107948,7 @@ cke
 cmA
 aLJ
 chV
-cfX
+cal
 crH
 csQ
 cuf
@@ -110675,7 +108195,7 @@ bVp
 bWB
 cdJ
 bVo
-bZA
+uRb
 bvY
 aaa
 bTW
@@ -110685,7 +108205,7 @@ cke
 cke
 cjZ
 chV
-cfX
+cal
 crH
 cbO
 cuf
@@ -110942,7 +108462,7 @@ cke
 cke
 ckv
 chV
-cfX
+cal
 crH
 cBN
 cuh
@@ -111199,7 +108719,7 @@ cke
 cke
 cmA
 chV
-cfX
+cal
 crH
 cbP
 cuf
@@ -111446,7 +108966,7 @@ bOU
 bPG
 cdL
 bVo
-bZA
+uRb
 cdA
 chX
 chV
@@ -111703,7 +109223,7 @@ bOT
 bVp
 cdM
 bVo
-bZA
+uRb
 bQl
 bQl
 chV
@@ -112139,7 +109659,7 @@ akB
 alh
 pLb
 aoB
-aoF
+aqW
 aqI
 aqW
 aqW
@@ -113509,7 +111029,7 @@ bVJ
 bXb
 clx
 clx
-chY
+ckT
 reb
 nEb
 cqu
@@ -116358,7 +113878,7 @@ bVI
 crH
 cLT
 cLV
-ckT
+sYb
 owb
 clC
 cEv
@@ -116745,13 +114265,13 @@ aah
 aah
 aaV
 aby
-adk
+acd
 ctE
 acX
 adc
 adc
 ael
-czs
+csO
 agW
 agw
 agy
@@ -117350,7 +114870,7 @@ aPT
 bME
 bMD
 bHY
-bMz
+geb
 bSV
 ccs
 cdZ
@@ -119131,8 +116651,8 @@ btc
 kab
 kmb
 bob
-bpQ
-bsx
+bAQ
+bza
 bob
 bvt
 bwQ
@@ -120478,7 +117998,7 @@ aaa
 aah
 aaa
 cmE
-sYb
+cFe
 cCW
 aaa
 aYs
@@ -120671,7 +118191,7 @@ jQb
 jNb
 cbb
 kcb
-bna
+bnn
 bth
 kzb
 bAp
@@ -121249,7 +118769,7 @@ agn
 aah
 cBm
 cCW
-cFe
+adk
 cHK
 aZH
 aYc
@@ -121979,7 +119499,7 @@ bKk
 bDl
 bCl
 bDl
-cCD
+bFI
 bDl
 cKz
 aNc
@@ -124523,7 +122043,7 @@ bVh
 bNS
 bNS
 bNS
-bKG
+chC
 bJi
 csh
 bxi
@@ -127374,7 +124894,7 @@ pib
 cak
 aKa
 bFo
-tYb
+lOb
 cbz
 cbz
 cEy
@@ -127631,12 +125151,12 @@ cak
 qvb
 aNe
 bFo
-tYb
+lOb
 cbz
 cKi
 cer
 cfC
-chC
+chY
 cbz
 aah
 aah
@@ -128145,7 +125665,7 @@ cak
 cak
 mUb
 cak
-tYb
+lOb
 cbz
 ccR
 cew
@@ -128402,7 +125922,7 @@ bFo
 bFo
 bFo
 cak
-tYb
+lOb
 cbz
 cbz
 cbz
@@ -128914,7 +126434,7 @@ lvb
 nab
 bFo
 nKb
-tYb
+lOb
 aBR
 aBR
 bMQ
@@ -129171,7 +126691,7 @@ mHb
 ngb
 bFo
 hKb
-tYb
+lOb
 cak
 aBR
 bFo
@@ -129601,22 +127121,22 @@ aaa
 aaa
 aaa
 aaa
-agm
-agN
-agm
-agm
-agm
-agn
-agn
-agn
-agn
-agn
-agn
-agn
-agn
-agn
-agn
-aah
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -129858,29 +127378,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 agm
+agN
+agm
+agm
+agm
+agn
+agn
+agn
+agn
+agn
+agn
+agn
+agn
+agn
+agn
+aah
+aaa
+aaa
+aaa
 aaa
 aah
 aah
-aah
 aaa
-aah
-aah
-aaa
-aaa
-aah
-aah
-aah
-aaa
-aaa
-aaa
-aah
-aah
-aah
-aah
-aah
 aah
 aup
 jpb
@@ -130119,23 +127639,23 @@ aaa
 aaa
 agm
 aaa
-ajm
-ajF
-akA
-aaa
-ajm
-ajF
-akA
-aaa
-ajm
-ajF
-akA
 aah
-agm
+aah
+aah
+aaa
 aah
 aah
 aaa
 aaa
+aah
+aah
+aah
+aaa
+aaa
+aaa
+aaa
+aaa
+aah
 aah
 aah
 aup
@@ -130375,25 +127895,25 @@ aaa
 aaa
 aaa
 agm
-aah
+aaa
 ajm
-ajG
+ajF
 akA
 aaa
 ajm
-ajG
+ajF
 akA
 aaa
 ajm
-ajG
+ajF
 akA
-aaa
+aah
+agm
 aah
 aah
 aaa
 aaa
-aaa
-aaa
+aah
 aah
 aLy
 axy
@@ -130636,22 +128156,22 @@ aah
 ajm
 ajG
 akA
-aah
+aaa
 ajm
 ajG
 akA
-aah
+aaa
 ajm
 ajG
 akA
-aah
-aah
+aaa
 aah
 aah
 aaa
 aaa
 aaa
 aaa
+aah
 aup
 aup
 aup
@@ -130888,24 +128408,24 @@ aaa
 aaa
 aaa
 aaa
-aaa
+agm
 aah
 ajm
 ajG
 akA
-aaa
-ajm
-ajG
-akA
-aaa
+aah
 ajm
 ajG
 akA
 aah
+ajm
+ajG
+akA
+aah
+aah
+aah
 aah
 aaa
-aah
-aah
 aaa
 aaa
 aaa
@@ -131142,11 +128662,11 @@ aaa
 aaa
 aaa
 aaa
-agm
-agm
-agm
 aaa
 aaa
+aaa
+aaa
+aah
 ajm
 ajG
 akA
@@ -131158,15 +128678,15 @@ aaa
 ajm
 ajG
 akA
+aah
+aah
 aaa
+aah
 aah
 aaa
 aaa
-aqj
-aul
-aul
-aul
-aul
+aaa
+aAg
 awx
 awx
 awx
@@ -131400,29 +128920,29 @@ aaa
 aaa
 aaa
 agm
+agm
+agm
+aaa
+aaa
+ajm
+ajG
+akA
+aaa
+ajm
+ajG
+akA
+aaa
+ajm
+ajG
+akA
 aaa
 aah
 aaa
 aaa
-aah
-ajH
-aah
-aah
-aah
-ajH
-aah
-aaa
-aah
-ajH
-aah
-aaa
-aah
 aqj
-aqj
-aqj
-gQb
-avu
-awj
+aul
+aul
+aul
 aul
 awL
 axz
@@ -131657,29 +129177,29 @@ aaa
 aaa
 aaa
 agm
+aaa
 aah
-ahv
-akC
-akC
-ajn
-ajI
-ajI
-ajI
-ajI
-ajI
-ajI
-ajI
-ajI
-ajI
-ajI
-ajI
-asN
-aqY
-arX
-atA
-atU
-avd
-avm
+aaa
+aaa
+aah
+ajH
+aah
+aah
+aah
+ajH
+aah
+aaa
+aah
+ajH
+aah
+aaa
+aah
+aqj
+aqj
+aqj
+gQb
+avu
+awj
 aAh
 axz
 axG
@@ -131704,9 +129224,9 @@ aaa
 aaa
 aaa
 aVD
-ayQ
-ayc
-ayQ
+aVD
+biF
+aVD
 aVD
 aVD
 biF
@@ -131913,30 +129433,30 @@ aaa
 aaa
 aaa
 aaa
-agn
-aaa
+agm
 aah
-aaa
-aah
-aah
-ajJ
-aah
-aaa
-aah
-ajJ
-aah
-aaa
-aah
-ajJ
-aah
-aaa
-aah
-aqj
-aqj
-aqj
-atV
-avw
-awl
+ahv
+akC
+akC
+ajn
+ajI
+ajI
+ajI
+ajI
+ajI
+ajI
+ajI
+ajI
+ajI
+ajI
+ajI
+asN
+aqY
+arX
+atA
+atU
+avd
+avm
 aAj
 axH
 aBK
@@ -132171,29 +129691,29 @@ aaa
 aaa
 aaa
 agn
-agN
-agm
 aaa
 aah
-ajm
-ajK
-akA
 aaa
-ajm
-ajK
-akA
+aah
+aah
+ajJ
+aah
 aaa
-ajm
-ajK
-akA
+aah
+ajJ
+aah
 aaa
+aah
+ajJ
 aah
 aaa
 aah
 aqj
-aul
-aul
-aul
+aqj
+aqj
+atV
+avw
+awl
 aul
 ayL
 aAU
@@ -132427,11 +129947,11 @@ aac
 aac
 aaa
 aaa
+agn
+agN
+agm
 aaa
-aaa
-aaa
-aaa
-aaa
+aah
 ajm
 ajK
 akA
@@ -132443,15 +129963,15 @@ aaa
 ajm
 ajK
 akA
-aah
+aaa
 aah
 aaa
 aah
-aah
-aaa
-aaa
-aaa
-aAg
+aqj
+aul
+aul
+aul
+aul
 awx
 awx
 awx
@@ -132687,24 +130207,24 @@ aaa
 aaa
 aaa
 aaa
-agm
-aah
-ajm
-ajK
-akA
-aah
-ajm
-ajK
-akA
-aah
+aaa
+aaa
 ajm
 ajK
 akA
 aaa
-aah
+ajm
+ajK
+akA
+aaa
+ajm
+ajK
+akA
 aah
 aah
 aaa
+aah
+aah
 aaa
 aaa
 aaa
@@ -132949,18 +130469,18 @@ aah
 ajm
 ajK
 akA
-aaa
+aah
 ajm
 ajK
 akA
-aaa
+aah
 ajm
 ajK
 akA
 aaa
 aah
 aah
-aaa
+aah
 aaa
 aaa
 aaa
@@ -133201,22 +130721,22 @@ aaa
 aaa
 aaa
 aaa
-agn
-aaa
-ajm
-ajL
-akA
-aaa
-ajm
-ajL
-akA
-aaa
-ajm
-ajL
-akA
-aah
 agm
+aah
+ajm
+ajK
+akA
 aaa
+ajm
+ajK
+akA
+aaa
+ajm
+ajK
+akA
+aaa
+aah
+aah
 aaa
 aaa
 aaa
@@ -133460,18 +130980,18 @@ aaa
 aaa
 agn
 aaa
-aah
-aah
-aah
+ajm
+ajL
+akA
 aaa
-aah
-aah
-aah
+ajm
+ajL
+akA
 aaa
+ajm
+ajL
+akA
 aah
-aah
-aaa
-aaa
 agm
 aaa
 aaa
@@ -133716,19 +131236,19 @@ aaa
 aaa
 aaa
 agn
-agn
-agm
-agm
-agm
-agn
-agm
-agm
-agm
-agn
-agm
-agm
-agN
-agm
+aaa
+aah
+aah
+aah
+aaa
+aah
+aah
+aah
+aaa
+aah
+aah
+aaa
+aaa
 agm
 aaa
 aaa
@@ -133972,21 +131492,21 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+agn
+agn
+agm
+agm
+agm
+agn
+agm
+agm
+agm
+agn
+agm
+agm
+agN
+agm
+agm
 aaa
 aaa
 aaa


### PR DESCRIPTION
fixes #3232
Почистил файл карты от всяких ненужных переменных (объявлены у родителя и продублированы на карте), убрал с карты неправильные объекты - мусорные трубы, подписанные как топливные, алярмы с неправильными частотами. лампы с измененной силой освещения и другое (так получилось, что пришлось затронуть файл с гидропоник треями). Разложил предметы на новых полках корректно
Список удаленного:
`pixel_x = 0`
`pixel_y = 0`
`network = list("SS13")`
`req_acess_txt = 0`
`req_acess_txt = "0"`
`req_one_acess_txt = 0`
`req_one_acess_txt = "0"`
`req_acess = null`