### PR TITLE
Ребаланс цен карго

### DIFF
--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -62,12 +62,12 @@
 	export_types = list(/obj/machinery/field_generator)
 
 /datum/export/large/collector
-	cost = 600
+	cost = 250
 	unit_name = "collector"
 	export_types = list(/obj/machinery/power/rad_collector)
 
 /datum/export/large/collector/pa
-	cost = 300
+	cost = 450
 	unit_name = "particle accelerator part"
 	export_types = list(/obj/structure/particle_accelerator)
 

--- a/code/modules/cargo/exports/sheets.dm
+++ b/code/modules/cargo/exports/sheets.dm
@@ -92,7 +92,7 @@
 
 // Wood. Quite expensive in the grim and dark 26 century.
 /datum/export/stack/wood
-	cost = 25
+	cost = 15
 	unit_name = "wood plank"
 	export_types = list(/obj/item/stack/sheet/wood)
 

--- a/code/modules/cargo/exports/sheets.dm
+++ b/code/modules/cargo/exports/sheets.dm
@@ -137,7 +137,7 @@
 
 // Phoron. The oil of 26 century. The reason why you are here.
 /datum/export/stack/phoron
-	cost = 300
+	cost = 350
 	export_types = list(/obj/item/stack/sheet/mineral/phoron)
 	message = "of phoron"
 
@@ -148,7 +148,7 @@
 
 // Refined scrap. The coal of 26 century. The reason why you are here.
 /datum/export/stack/scrap
-	cost = 300
+	cost = 250
 	export_types = list(/obj/item/stack/sheet/refined_scrap)
 	message = "of scrap"
 

--- a/code/modules/cargo/exports/tools.dm
+++ b/code/modules/cargo/exports/tools.dm
@@ -105,3 +105,10 @@
 	cost = 15 // 1.5 metal, 1 glass -> 12.5 credits, +2.5 credits
 	unit_name = "compressed matter cardridge"
 	export_types = list(/obj/item/weapon/rcd_ammo)
+
+// Kitchen utensils
+
+/datum/export/knife
+	cost = 20
+	unit_name = "kitchen knife"
+	export_types = list(/obj/item/weapon/kitchenknife)

--- a/code/modules/cargo/exports/weapons.dm
+++ b/code/modules/cargo/exports/weapons.dm
@@ -8,12 +8,6 @@
 	unit_name = "stun baton"
 	export_types = list(/obj/item/weapon/melee/baton)
 
-/datum/export/weapon/knife
-	cost = 750
-	unit_name = "combat knife"
-	export_types = list(/obj/item/weapon/kitchenknife)
-
-
 /datum/export/weapon/taser
 	cost = 250
 	unit_name = "taser"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -511,7 +511,7 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	name = "50 wooden planks"
 	contains = list(/obj/item/stack/sheet/wood)
 	amount = 50
-	cost = 1000
+	cost = 1500
 	crate_type = /obj/structure/closet/crate/engi
 	crate_name = "Wooden planks crate"
 	group = "Engineering"
@@ -620,7 +620,7 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	name = "Emitter crate"
 	contains = list(/obj/machinery/power/emitter,
 					/obj/machinery/power/emitter)
-	cost = 1000
+	cost = 1500
 	crate_type = /obj/structure/closet/crate/secure/engisec
 	crate_name = "Emitter crate"
 	access = access_ce
@@ -636,6 +636,7 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 /datum/supply_pack/engine/sing_gen
 	name = "Singularity Generator crate"
 	contains = list(/obj/machinery/the_singularitygen)
+	cost = 2000
 	crate_type = /obj/structure/closet/crate/engi
 	crate_name = "Singularity Generator crate"
 


### PR DESCRIPTION
<!--
Подробно про оформление ПРов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
Там же написано про то, как сделать чейнджлог. 

!!!
Если авторство не полностью ваше, вы делаете порт с другого билда - укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
!!!

Если есть форумное обсуждение на тему изменений PR-а - укажите ссылку.

Для копипаста:
Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment.

Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
Убрал различные абузы в экспорте карго:
-Стоимость кухонного ножа снижена с баснословной цены в 750 до рядовых 20 очков.
-Абуз с перепродажей дерева устранён
-Абуз с перепродажей ядра сингулярности, частей ПА и остальных частей сингулярного двигателя устранён

Также немного снизил цену на экспорт переработанного мусора, подняв при этом цену на экспорт форона. (с 300 до 250 и с 300 до 350 соответственно)

Если я какие-то ещё недочёты в ценах поставки я оставил без внимания, прошу написать тут.
P.s. Ещё надо не забыть поменять [тут](https://wiki.taucetistation.org/Supply_crates) цены, если это замёржат.

:cl: TEXHAPb
- balance[link]: изменены цены на импорт и экспорт некоторых предметов