### PR TITLE
Исправления рантаймов касательно мусора.

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -32,6 +32,7 @@
 	sort_surgeries()
 
 	init_subtypes(/datum/crafting_recipe, crafting_recipes)
+	init_subtypes(/datum/dirt_cover, global.all_dirt_covers)
 
 	//Medical side effects. List all effects by their names
 	for(var/T in subtypesof(/datum/medical_effect))

--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -13,6 +13,7 @@ var/global/list/crafting_recipes = list()   //list of all personal craft recipes
 var/global/list/side_effects = list()       //list of all medical sideeffects types by thier names |BS12
 var/global/list/mechas_list = list()        //list of all mechs. Used by hostile mobs target tracking.
 var/global/list/joblist = list()            //list of all jobstypes, minus borg and AI
+var/global/list/all_dirt_covers = list()    //list of all /datum/dirt_covers with initial values.
 var/global/list/tree_xmas_list = list()
 var/global/list/rcd_list = list()
 var/global/list/mecha_rcd_list = list()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -844,7 +844,7 @@
 
 /obj/item/add_dirt_cover()
 	if(!blood_overlay)
-		generate_dirt_cover()
+		generate_blood_overlay()
 	..()
 	if(dirt_overlay)
 		if(blood_overlay.color != dirt_overlay.color)
@@ -865,7 +865,7 @@
 	return 1 //we applied blood to the item
 
 var/global/list/items_blood_overlay_by_type = list()
-/obj/item/proc/generate_dirt_cover()
+/obj/item/proc/generate_blood_overlay()
 	if(blood_overlay)
 		return
 

--- a/code/modules/clothing/spacesuits/rig.dm
+++ b/code/modules/clothing/spacesuits/rig.dm
@@ -337,14 +337,15 @@
 		set_light(0)
 
 /obj/item/clothing/head/helmet/space/rig/syndi/update_icon(mob/user)
-	user.overlays -= lamp
-	if(equipped_on_head && camera && (on || combat_mode))
-		lamp = image(icon = 'icons/mob/nuclear_helm_overlays.dmi', icon_state = "terror[combat_mode ? "_combat" : ""]_glow", layer = ABOVE_LIGHTING_LAYER)
-		lamp.plane = LIGHTING_PLANE + 1
-		lamp.alpha = on ? 255 : 127
-		user.overlays += lamp
 	icon_state = "rig[on]-syndie[combat_mode ? "-combat" : ""]"
-	user.update_inv_head()
+	if(user)
+		user.overlays -= lamp
+		if(equipped_on_head && camera && (on || combat_mode))
+			lamp = image(icon = 'icons/mob/nuclear_helm_overlays.dmi', icon_state = "terror[combat_mode ? "_combat" : ""]_glow", layer = ABOVE_LIGHTING_LAYER)
+			lamp.plane = LIGHTING_PLANE + 1
+			lamp.alpha = on ? 255 : 127
+			user.overlays += lamp
+		user.update_inv_head()
 
 /obj/item/clothing/head/helmet/space/rig/syndi/attack_self(mob/user)
 	if(camera)

--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -31,7 +31,8 @@
 /obj/item/clothing/head/helmet/space/syndicate/update_icon(mob/user)
 	. = ..()
 	icon_state = "[initial(icon_state)][lit ? "-lit" : ""]"
-	user.update_inv_head()
+	if(user)
+		user.update_inv_head()
 
 /obj/item/clothing/head/helmet/space/syndicate/attack_self(mob/user)
 	. = ..()

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -227,7 +227,7 @@
 
 /obj/item/weapon/reagent_containers/pill/dexalin_plus/atom_init()
 	. = ..()
-	reagents.add_reagent("dexalin_plus", 10)
+	reagents.add_reagent("dexalinp", 10)
 
 /obj/item/weapon/reagent_containers/pill/bicaridine
 	name = "Bicaridine pill (20u)"

--- a/code/modules/scrap/oldificator.dm
+++ b/code/modules/scrap/oldificator.dm
@@ -126,8 +126,8 @@
 	if(prob(35))
 		contaminate()
 	if(prob(75))
-		generate_dirt_cover()
-		add_dirt_cover(pick(subtypesof(/datum/dirt_cover)))
+		generate_blood_overlay()
+		add_dirt_cover(pick(global.all_dirt_covers))
 	..()
 
 

--- a/code/modules/scrap/oldificator.dm
+++ b/code/modules/scrap/oldificator.dm
@@ -220,28 +220,14 @@
 	if(prob(75))
 		var/del_count = rand(0,product_records.len)
 		for(var/i = 1 to del_count)
-			var/removed_item = pick(contents)
-			contents -= removed_item
+			var/removed_item = pick(product_records)
+			product_records -= removed_item
+			qdel(removed_item)
 
 /obj/structure/closet/critter/make_old()
 	..()
 	if(prob(50))
 		content_mob = /mob/living/simple_animal/hostile/giant_spider
-
-/obj/machinery/vending/make_old()
-	..()
-	if(prob(60))
-		seconds_electrified = -1
-	if(prob(60))
-		shut_up = 0
-	if(prob(60))
-		shoot_inventory = 1
-	if(prob(75))
-		var/del_count = rand(0,product_records.len)
-		for(var/i = 1 to del_count)
-			var/removed_item = pick(product_records)
-			product_records -= removed_item
-
 
 /obj/item/clothing/glasses/sunglasses/sechud/make_old()
 	..()


### PR DESCRIPTION
Ошибки в коммит сообщениях.
Переименовал `generate_dirt_cover()` в `generate_blood_overlay()`. На мой взгляд generate_dirt_cover больше запутывает, т.к думаешь что оно про датумы грязи, а на деле совсем иное.