### PR TITLE
Переосмысление задержки на прыжок у хантера.

### DIFF
--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -85,8 +85,7 @@
 
 
 /mob/living/carbon/alien/humanoid/hunter/ClickOn(atom/A, params)
-	face_atom(A)
-	if(leap_on_click)
+	if(next_move <= world.time && leap_on_click)
 		leap_at(A)
 	else
 		..()
@@ -115,12 +114,14 @@
 		return
 
 	else //Maybe uses plasma in the future, although that wouldn't make any sense...
+		face_atom(A)
 		stop_pulling()
 		leaping = TRUE
 		update_icons()
-		throw_at(A, MAX_ALIEN_LEAP_DIST, 2, spin = FALSE, diagonals_first = TRUE, callback = CALLBACK(src, .leap_end))
+		throw_at(A, MAX_ALIEN_LEAP_DIST, 1, spin = FALSE, diagonals_first = TRUE, callback = CALLBACK(src, .leap_end))
 
 /mob/living/carbon/alien/humanoid/hunter/proc/leap_end()
+	SetNextMove(CLICK_CD_MELEE) // so we can't click again right after leaping.
 	leaping = FALSE
 	update_icons()
 

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -15,7 +15,7 @@
 	var/leap_on_click = 0
 
 	var/pounce_cooldown = 0
-	var/pounce_cooldown_time = 50
+	var/pounce_cooldown_time = 15 SECONDS
 
 	var/neurotoxin_on_click = 0
 	var/neurotoxin_delay = 15

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -130,7 +130,7 @@
 
 	if(isobserver(mob))	return mob.Move(n,direct)
 
-	if(moving)	return 0
+	if(moving || mob.throwing)	return 0
 
 	if(world.time < move_delay)	return
 


### PR DESCRIPTION
Это прежде всего переосмысление ПРа #3252 , но сделано иначе и на мой взгляд. Про траву не забыл, просто нет желания смотреть в ее слои и думать, поэтому в этом ПРе изменений касательно травы точно не будет.

* Исправлена возможность вертеться во время прыжка.
* Также исправлен недочет, что будучи в состоянии брошенности, клиент мог преждевременно завершить бросок использовав движение (это нужно будет отдельно залить, если этот ПР вдруг не будет замержен).

:cl:
 - balance: Задержка умения броска (leap) охотника ксеноморфов поднята с 5 до 15 секунд при успешном столкновении с мобом, и после применения вне зависимости от результата тоже добавлена небольшая задержка.
 - balance: Уменьшена скорость "полета" броска у охотника (бросок все еще быстрый и может использоваться как основное средство для передвижения).
