### PR TITLE
Исправление рецептов цветных красок для волос

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -2318,42 +2318,42 @@ TODO: Convert everything to custom hair dye,
 	name = "Red Hair Dye"
 	id = "redhairdye"
 	result = "redhairdye"
-	required_reagents = list("hairdye" = 1, "iron" = 1)
+	required_reagents = list("whitehairdye" = 1, "iron" = 1)
 	result_amount = 1 // They don't mix, instead they react.
 
 /datum/chemical_reaction/hair_dye/blue
 	name = "Blue Hair Dye"
 	id = "bluehairdye"
 	result = "bluehairdye"
-	required_reagents = list("hairdye" = 1, "copper" = 1)
+	required_reagents = list("whitehairdye" = 1, "copper" = 1)
 	result_amount = 1
 
 /datum/chemical_reaction/hair_dye/green
 	name = "Green Hair Dye"
 	id = "greenhairdye"
 	result = "greenhairdye"
-	required_reagents = list("hairdye" = 1, "chlorine" = 1)
+	required_reagents = list("whitehairdye" = 1, "chlorine" = 1)
 	result_amount = 1
 
 /datum/chemical_reaction/hair_dye/black
 	name = "Black Hair Dye"
 	id = "blackhairdye"
 	result = "blackhairdye"
-	required_reagents = list("hairdye" = 1, "carbon" = 1)
+	required_reagents = list("whitehairdye" = 1, "carbon" = 1)
 	result_amount = 1
 
 /datum/chemical_reaction/hair_dye/brown
 	name = "Brown Hair Dye"
 	id = "brownhairdye"
 	result = "brownhairdye"
-	required_reagents = list("hairdye" = 1, "sulfur" = 1)
+	required_reagents = list("whitehairdye" = 1, "sulfur" = 1)
 	result_amount = 1
 
 /datum/chemical_reaction/hair_dye/blond
 	name = "Blond Hair Dye"
 	id = "blondhairdye"
 	result = "blondhairdye"
-	required_reagents = list("hairdye" = 1, "sugar" = 1)
+	required_reagents = list("whitehairdye" = 1, "sugar" = 1)
 	result_amount = 1
 
 // Converting dyes to paint. START madness
@@ -2362,7 +2362,7 @@ TODO: Convert everything to custom hair dye,
 	name = "White Dye Empowering"
 	id = "whitedyeempower"
 	result = "paint_white"
-	required_reagents = list("hairdye" = 1, "glycerol" = 10)
+	required_reagents = list("whitehairdye" = 1, "glycerol" = 10)
 	result_amount = 1
 
 /datum/chemical_reaction/hair_dye_empowering/red


### PR DESCRIPTION
<!--
Подробно про оформление ПРов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
Там же написано про то, как сделать чейнджлог. 

!!!
Если авторство не полностью ваше, вы делаете порт с другого билда - укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
!!!

Если есть форумное обсуждение на тему изменений PR-а - укажите ссылку.

Для копипаста:
Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment.

Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
Исправлен рецепт создания цветных красок для волос - теперь вместо несуществующего реагента "hairdye" используется "whitehairdye".

P.S. Работаю с гитхабом впервые, так что, если я сделал что-то не так - напишите, пожалуйста.

:cl:
 - bugfix: Было невозможно из белой краски для волос создавать цветную.