### PR TITLE
Замедление щитов и одежды СБ

### DIFF
--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -51,7 +51,7 @@
 	icon_state = "marinad"
 	item_state = "marinad_armor"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
-	slowdown = 1
+	slowdown = 0
 	armor = list(melee = 60, bullet = 65, laser = 55, energy = 60, bomb = 40, bio = 0, rad = 0)
 /obj/item/clothing/suit/armor/vest/warden
 	name = "Warden's jacket"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -92,7 +92,7 @@
 	icon_state = "riot"
 	item_state = "swat_suit"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
-	slowdown = 1
+	slowdown = 0
 	armor = list(melee = 70, bullet = 10, laser = 5, energy = 10, bomb = 0, bio = 0, rad = 0)
 	flags_inv = HIDEJUMPSUIT
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -88,7 +88,7 @@
 
 /obj/item/clothing/suit/armor/riot
 	name = "riot suit"
-	desc = "A suit of armor with heavy padding to protect against melee attacks. Looks like it might impair movement."
+	desc = "A suit of armor with heavy padding to protect against melee attacks."
 	icon_state = "riot"
 	item_state = "swat_suit"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -63,7 +63,8 @@
 			for(var/x in list(l_hand, r_hand))
 				var/obj/item/O = x
 				if(O && !(O.flags & ABSTRACT) && O.w_class >= ITEM_SIZE_NORMAL)
-					tally += 0.5 * (O.w_class - 2) // (3 = 0.5) || (4 = 1) || (5 = 1.5)
+					if (!istype(O, /obj/item/weapon/shield/riot))
+						tally += 0.5 * (O.w_class - 2) // (3 = 0.5) || (4 = 1) || (5 = 1.5)
 
 		if(buckled) // so, if we buckled we have large debuff
 			tally += 5.5


### PR DESCRIPTION
Не знаю кто и зачем балансировал щиты СБ и одежду, но проблема в том, что теперь их охрана вообще не использует. Нюкеры имеют щит который можно класть в карман, а у СБ щиты замедляют сильнее рига, теперь замедление одинаковое, размер остался прежним

Тоже самое с одеждой морпеха и риотом - довольно неплохие костюмы, которые по факту имеют свое предназначение. Отражающая броня с уклоном на лазер, от пуль очевидно bulletproof, а вот риот исключительно ближнего боя, внезапно, ЗАМЕДЛЯЕТ! Броня морпеха, как баланс между всем, замедляет как риг. Это обновление по сути вернет смысл их использовать

:cl:
- tweak: Щит охраны замедляет также как и нюкеров
- tweak: Marine armor  не замедляет
- tweak: Riot не замедляет