### PR TITLE
Скорость унатхов

### DIFF
--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -207,7 +207,7 @@
 	deform = 'icons/mob/human_races/r_def_lizard.dmi'
 	language = "Sinta'unathi"
 	tail = "sogtail"
-	unarmed_type = /datum/unarmed_attack/claws
+	unarmed_type = /datum/unarmed_attack/claws/unathi
 	dietflags = DIET_MEAT | DIET_DAIRY
 	primitive = /mob/living/carbon/monkey/unathi
 	darksight = 3
@@ -720,6 +720,9 @@
 	damage = 5
 	sharp = 1
 	edge = 1
+
+/datum/unarmed_attack/claws/unathi
+	damage = 3
 
 /datum/unarmed_attack/claws/armalis
 	attack_verb = list("slash", "claw")

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -222,7 +222,6 @@
 
 	brute_mod = 0.80
 	burn_mod = 0.90
-	speed_mod = 0.7
 
 	flags = list(
 	 IS_WHITELISTED = TRUE


### PR DESCRIPTION
По каким-то причинам в билде унатхи замедлены на 30% (1/3!). Если надеть риг, взять в руки оружие, то передвижение становится крайне медленным, при том что по логике они сильнее людей. Это обновление делает скорость унатхов как у человека

:cl:
- tweak: Унатхи теперь перемещаются со скоростью человека