### PR TITLE
Предметы больше не остаются на спрайте мешочков криминалиста при сканировании

### DIFF
--- a/code/modules/detectivework/detective_work.dm
+++ b/code/modules/detectivework/detective_work.dm
@@ -144,7 +144,7 @@ var/const/FINGERPRINT_COMPLETE = 6	//This is the output of the stringpercent(pri
 				if(istype(I, /obj/item/weapon/evidencebag))
 					scanning = I.contents[1]
 					scanning.loc = src
-					I.overlays.Cut()
+					I.underlays.Cut()
 					I.w_class = initial(I.w_class)
 					I.icon_state = "evidenceobj"
 				else


### PR DESCRIPTION
Fixes #3192 
P.S. Извините за спам пул реквестами, предыдущий удалил случайно.
:cl:
 - bugfix: При сканировании мешочков криминалиста предмет доставался, но оставался на спрайте.