### PR TITLE
Убирает спишиз зомби из списка all species

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -59,7 +59,8 @@
 		rkey++
 		var/datum/species/S = new T
 		S.race_key = rkey //Used in mob icon caching.
-		all_species[S.name] = S
+		if(S != /datum/species/zombie) // To prevent some grief shit
+			all_species[S.name] = S
 
 		if(S.flags[IS_WHITELISTED])
 			whitelisted_species += S.name


### PR DESCRIPTION
fixes #3283
Убрал зомби из списка all species, чтобы они вообще никогда ни в чём подобном случайно не использовались. Слишком грифозно может получиться.

:cl: Richard Jones
 - bugfix: Маг больше не сможет сделать из человека зомби.
