### PR TITLE
Частота звуков окружения

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -394,7 +394,7 @@ var/list/ghostteleportlocs = list()
 		if(!L.client.played)
 			L << sound(sound, repeat = 0, wait = 0, volume = 25, channel = 1)
 			L.client.played = TRUE
-			addtimer(CALLBACK(src, .proc/set_played_false, L), 600)
+			addtimer(CALLBACK(src, .proc/set_played_false, L), 300)
 
 /area/proc/set_played_false(mob/living/L)
 	if(L && L.client)


### PR DESCRIPTION
В билде есть звуки которые включаются в зависимости от плитки на которой находишься. По каким-то причинам, они играют не чаще 1 раза в 10 минут (9 раз на 90 минут раунда), то есть ОЧЕНЬ РЕДКО. Все же звуки это важно, по этому сделал их в два раза чаще, а дальше думаю стоит собрать отзывы игроков после тест мержа

:cl:
 - tweak: Звуки окружения каждые 5 минут вместо 10