### PR TITLE
Самодельные гранаты, режем максимальный радиус

### DIFF
--- a/code/game/objects/items/weapons/grenades/ghettobomb.dm
+++ b/code/game/objects/items/weapons/grenades/ghettobomb.dm
@@ -24,7 +24,7 @@
 		range = 1
 		det_time = rand(30, 80)
 	else
-		range = pick(2,2,2, 3,3,3, 4, 6)
+		range = pick(2,2,2, 3,3,3, 4)
 
 /obj/item/weapon/grenade/iedcasing/CheckParts(list/parts_list)
 	..()


### PR DESCRIPTION
fix #3332
Сделать это нужно было очень давно, так как и правда, одна такая гранат с 6 радиусом ломала под собой весь пол, из-за чего образовывались дырки в полу, а с нашим любимым атмосом из-за этого постоянно начинается цирк

🆑 
- balance: Снижен максимальный радиус взрыва у самодельных алюминиевых гранат