### PR TITLE
Вернул возможность выбирать часть тела, в которую воткнётся жало гено…

### DIFF
--- a/code/game/gamemodes/changeling/powers/stings.dm
+++ b/code/game/gamemodes/changeling/powers/stings.dm
@@ -77,8 +77,8 @@
 				return 1
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
-		var/obj/item/organ/external/BP = H.bodyparts_by_name[BP_CHEST]
-		var/result = H.check_thickmaterial(BP) || H.isSynthetic(BP_CHEST)
+		var/obj/item/organ/external/BP = H.get_bodypart(user.zone_sel.selecting)
+		var/result = H.check_thickmaterial(BP) || H.isSynthetic(user.zone_sel.selecting)
 		if(result)
 			if(result == NOLIMB)
 				to_chat(user, "<span class='warning'>We missed! [target.name] has no [BP.name]!</span>")
@@ -242,22 +242,6 @@
 	target.eye_blind = 20
 	target.eye_blurry = 40
 	feedback_add_details("changeling_powers","BS")
-	return 1
-
-/obj/effect/proc_holder/changeling/sting/paralysis
-	name = "Paralysis Sting"
-	helptext = "Temporarily paralyse the target."
-	desc = "We silently sting a human, paralyzing them for a short time."
-	sting_icon = "sting_paralyse"
-	chemical_cost = 40
-	genomecost = 8
-
-/obj/effect/proc_holder/changeling/sting/paralysis/sting_action(mob/user, mob/living/carbon/target)
-	if(sting_fail(user,target))
-		return 0
-	to_chat(target, "<span class='danger'>Your muscles begin to painfully tighten.</span>")
-	target.Weaken(20)
-	feedback_add_details("changeling_powers","PS")
 	return 1
 
 /obj/effect/proc_holder/changeling/sting/unfat


### PR DESCRIPTION
<!--
Подробно про оформление ПРов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
Там же написано про то, как сделать чейнджлог. 

!!!
Если авторство не полностью ваше, вы делаете порт с другого билда - укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
!!!

Если есть форумное обсуждение на тему изменений PR-а - укажите ссылку.

Для копипаста:
Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment.

Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
…крада. Выпилен парастинг. Частичный ревёрт https://github.com/TauCetiStation/TauCetiClassic/pull/2300
Обсуждение на форуме:
https://forum.taucetistation.org/t/discussion-done-make-stings-great-again/8999
:cl:
- tweak: Возможность выбирать конечность, куда колоть жало у генокрада
- rscdel: Выпил парализующего жала у генокрада