### PR TITLE
Перк немоты

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -10,6 +10,7 @@
 #define TRAIT_STRESS_EATER        "stresseater"
 #define TRAIT_MULTITASKING        "multitasking"
 #define TRAIT_NATURECHILD         "child_of_nature"
+#define TRAIT_MUTE                "mute"
 
 // common trait sources
 #define ROUNDSTART_TRAIT   "roundstart" //cannot be removed without admin intervention

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -99,3 +99,13 @@
 	mob_trait = TRAIT_STRESS_EATER
 	gain_text = "<span class='danger'>You feel quenchless hunger when hurt.</span>"
 	lose_text = "<span class='notice'>You no longer feel the quenchless hunger when hurt.</span>"
+
+
+
+/datum/quirk/mute
+	name = "Mute"
+	desc = "You are completely and incurably mute."
+	value = -2
+	mob_trait = TRAIT_MUTE
+	gain_text = "<span class='danger'>Your voicebox feels wrong somehow.</span>"
+	lose_text = "<span class='notice'>Your voicebox appears to work now.</span>"

--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -21,7 +21,8 @@
 	if(!ishuman(user))
 		to_chat(user, "\red You don't know how to use this!")
 		return
-	if(user.silent || isabductor(user))
+	if(user.silent || isabductor(user) || user.has_trait(TRAIT_MUTE))
+		to_chat(user, "<span class='userdange'>You can't speak.</span>")
 		return
 	if(spamcheck)
 		to_chat(user, "\red \The [src] needs to recharge!")

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -61,7 +61,7 @@
 			if (input2 == "Visible")
 				m_type = 1
 			else if (input2 == "Hearable")
-				if (src.miming)
+				if (src.miming || has_trait(TRAIT_MUTE))
 					return
 				m_type = 2
 			else
@@ -104,8 +104,8 @@
 			m_type = 1
 
 		if ("choke")
-			if(miming)
-				message = "<B>[src]</B> clutches his throat desperately!"
+			if(miming || has_trait(TRAIT_MUTE))
+				message = "<B>[src]</B> clutches their throat desperately!"
 				m_type = 1
 			else
 				if (!muzzled)
@@ -144,7 +144,7 @@
 			m_type = 1
 
 		if ("chuckle")
-			if(miming)
+			if(miming || has_trait(TRAIT_MUTE))
 				message = "<B>[src]</B> appears to chuckle."
 				m_type = 1
 			else
@@ -171,7 +171,7 @@
 			m_type = 1
 
 		if ("cough")
-			if(miming)
+			if(miming || has_trait(TRAIT_MUTE))
 				message = "<B>[src]</B> appears to cough!"
 				m_type = 1
 			else
@@ -203,7 +203,10 @@
 			m_type = 1
 
 		if ("gasp")
-			if(miming)
+			if(has_trait(TRAIT_MUTE))
+				message = "<B>[src]</B> sucks in air violently!"
+				m_type = 1
+			else if(miming)
 				message = "<B>[src]</B> appears to be gasping!"
 				m_type = 1
 			else
@@ -229,7 +232,7 @@
 			m_type = 1
 
 		if ("giggle")
-			if(miming)
+			if(miming || has_trait(TRAIT_MUTE))
 				message = "<B>[src]</B> giggles silently!"
 				m_type = 1
 			else
@@ -292,7 +295,7 @@
 			m_type = 1
 
 		if ("cry")
-			if(miming)
+			if(miming || has_trait(TRAIT_MUTE))
 				message = "<B>[src]</B> cries."
 				m_type = 1
 			else
@@ -304,7 +307,7 @@
 					m_type = 2
 
 		if ("sigh")
-			if(miming)
+			if(miming || has_trait(TRAIT_MUTE))
 				message = "<B>[src]</B> sighs."
 				m_type = 1
 			else
@@ -316,7 +319,10 @@
 					m_type = 2
 
 		if ("laugh")
-			if(miming)
+			if(has_trait(TRAIT_MUTE))
+				message = "<B>[src]</B> laughs silently."
+				m_type = 1
+			else if(miming)
 				message = "<B>[src]</B> acts out a laugh."
 				m_type = 1
 			else
@@ -328,16 +334,23 @@
 					m_type = 2
 
 		if ("mumble")
-			message = "<B>[src]</B> mumbles!"
-			m_type = 2
-			if(miming)
+			if(has_trait(TRAIT_MUTE))
+				message = "<B>[src]</B> makes an annoyed face!"
 				m_type = 1
+			else
+				message = "<B>[src]</B> mumbles!"
+				m_type = 2
+				if(miming)
+					m_type = 1
 
 		if ("grumble")
 			if(miming)
 				message = "<B>[src]</B> grumbles!"
 				m_type = 1
-			if (!muzzled)
+			else if(has_trait(TRAIT_MUTE))
+				message = "<B>[src]</B> makes an annoyed face!"
+				m_type = 1
+			else if (!muzzled)
 				message = "<B>[src]</B> grumbles!"
 				m_type = 2
 			else
@@ -347,6 +360,9 @@
 		if ("groan")
 			if(miming)
 				message = "<B>[src]</B> appears to groan!"
+				m_type = 1
+			else if(has_trait(TRAIT_MUTE))
+				message = "<B>[src]</B> makes a very annoyed face!"
 				m_type = 1
 			else
 				if (!muzzled)
@@ -360,6 +376,9 @@
 			if(miming)
 				message = "<B>[src]</B> appears to moan!"
 				m_type = 1
+			else if(has_trait(TRAIT_MUTE))
+				message = "<B>[src]</B> moans silently!"
+				m_type = 1
 			else
 				message = "<B>[src]</B> moans!"
 				m_type = 2
@@ -371,7 +390,7 @@
 			if (!M)
 				param = null
 			else
-				if(miming)
+				if(miming || has_trait(TRAIT_MUTE))
 					message = "<B>[src]</B> takes a drag from a cigarette and blows \"[M]\" out in smoke."
 					m_type = 1
 				else
@@ -434,7 +453,7 @@
 			m_type = 1
 
 		if ("sneeze")
-			if (miming)
+			if (miming || has_trait(TRAIT_MUTE))
 				message = "<B>[src]</B> sneezes."
 				m_type = 1
 			else
@@ -448,11 +467,11 @@
 		if ("sniff")
 			message = "<B>[src]</B> sniffs."
 			m_type = 2
-			if(miming)
+			if(miming || has_trait(TRAIT_MUTE))
 				m_type = 1
 
 		if ("snore")
-			if (miming)
+			if (miming || has_trait(TRAIT_MUTE))
 				message = "<B>[src]</B> sleeps soundly."
 				m_type = 1
 			else
@@ -464,7 +483,7 @@
 					m_type = 2
 
 		if ("whimper")
-			if (miming)
+			if (miming || has_trait(TRAIT_MUTE))
 				message = "<B>[src]</B> appears hurt."
 				m_type = 1
 			else
@@ -483,7 +502,7 @@
 			if (!muzzled)
 				message = "<B>[src]</B> yawns."
 				m_type = 2
-				if(miming)
+				if(miming || has_trait(TRAIT_MUTE))
 					m_type = 1
 
 		if ("collapse")
@@ -561,7 +580,10 @@
 				if(virus_scream || !(species && species.flags[NO_PAIN]))
 					if (!muzzled)
 						if (auto)
-							if(world.time-lastSoundEmote >= 30)//prevent scream spam with things like poly spray
+							if(has_trait(TRAIT_MUTE))
+								message = "<B>[src]</B> twists their face into an agonised expression!"
+								m_type = 1
+							else if(world.time-lastSoundEmote >= 30)//prevent scream spam with things like poly spray
 								message = "<B>[src]</B> screams in agony!"
 								var/list/screamSound = list('sound/misc/malescream1.ogg', 'sound/misc/malescream2.ogg', 'sound/misc/malescream3.ogg', 'sound/misc/malescream4.ogg', 'sound/misc/malescream5.ogg', 'sound/misc/wilhelm.ogg', 'sound/misc/goofy.ogg')
 								if (gender == FEMALE) //Females have their own screams. Trannys be damned.
@@ -574,9 +596,16 @@
 							if(!message)
 								message = "<B>[src]</B> screams!"
 							m_type = 2
+							if(has_trait(TRAIT_MUTE))
+								message = "<B>[src]</B> opens their mouth like a fish gasping for air!"
+								m_type = 1
 					else
-						message = "<B>[src]</B> makes a very loud noise."
-						m_type = 2
+						if(has_trait(TRAIT_MUTE))
+							message = "<B>[src]</B> makes a very hurt expression!"
+							m_type = 1
+						else
+							message = "<B>[src]</B> makes a very loud noise."
+							m_type = 2
 
 			cloud_emote = "cloud-scream"
 

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -580,9 +580,10 @@
 				if(virus_scream || !(species && species.flags[NO_PAIN]))
 					if (!muzzled)
 						if (auto)
-							if(has_trait(TRAIT_MUTE))
+							if(has_trait(TRAIT_MUTE) && world.time-lastSoundEmote >= 30)
 								message = "<B>[src]</B> twists their face into an agonised expression!"
 								m_type = 1
+								lastSoundEmote = world.time
 							else if(world.time-lastSoundEmote >= 30)//prevent scream spam with things like poly spray
 								message = "<B>[src]</B> screams in agony!"
 								var/list/screamSound = list('sound/misc/malescream1.ogg', 'sound/misc/malescream2.ogg', 'sound/misc/malescream3.ogg', 'sound/misc/malescream4.ogg', 'sound/misc/malescream5.ogg', 'sound/misc/wilhelm.ogg', 'sound/misc/goofy.ogg')

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -9,7 +9,7 @@
 			return
 
 	//Meme stuff
-	if((!speech_allowed && usr == src) || miming)
+	if((!speech_allowed && usr == src) || ((miming || has_trait(TRAIT_MUTE)) && !(copytext(message, 1, 2) == "*")))
 		to_chat(usr, "<span class='userdange'>You can't speak.</span>")
 		return
 

--- a/code/modules/mob/living/carbon/human/whisper.dm
+++ b/code/modules/mob/living/carbon/human/whisper.dm
@@ -56,7 +56,7 @@
 	message = capitalize(trim(message))
 
 	//TODO: handle_speech_problems for silent
-	if(!message || silent || miming)
+	if(!message || silent || miming || has_trait(TRAIT_MUTE))
 		return
 
 	// Mute disability


### PR DESCRIPTION
Добавляет перк немоты.

Перки глухоты и слепоты есть, а немоты нет? Неправильно как то. Плюс добавил мимам возможность использовать эмоуты.

:cl: Holy_Tape
 - rscadd: Добавлен перк немоты.
 - bugfix: Мимы могут использовать эмоуты(*scream).
