### PR TITLE
механические органы не лечатся от химии

### DIFF
--- a/code/modules/reagents/reagent_types/Chemistry-Medicine.dm
+++ b/code/modules/reagents/reagent_types/Chemistry-Medicine.dm
@@ -380,7 +380,7 @@
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/internal/eyes/IO = H.organs_by_name[O_EYES]
 		if(istype(IO))
-			if(IO.damage > 0)
+			if(IO.damage > 0 && IO.robotic < 2)
 				IO.damage = max(IO.damage - 1, 0)
 
 /datum/reagent/peridaxon
@@ -400,7 +400,7 @@
 
 		//Peridaxon is hard enough to get, it's probably fair to make this all organs
 		for(var/obj/item/organ/internal/IO in H.organs)
-			if(IO.damage > 0)
+			if(IO.damage > 0 && IO.robotic < 2)
 				IO.damage = max(IO.damage - 0.20, 0)
 
 /datum/reagent/kyphotorin


### PR DESCRIPTION
добавил проверку на то чтобы механические глаза и другие мех органы не лечились от имидазолина и парадоксона 
фикс https://github.com/TauCetiStation/TauCetiClassic/issues/1816
:cl: Winter Schock
 - bugfix: механические органы лечились от парадаксона и имидазолина
