### PR TITLE
Паникбункер по дате регистрации

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -64,6 +64,8 @@
 	var/load_jobs_from_txt = 0
 	var/automute_on = 0					//enables automuting/spam prevention
 
+	var/registration_panic_bunker_age = null
+
 	var/cult_ghostwriter = 1               //Allows ghosts to write in blood in cult rounds...
 	var/cult_ghostwriter_req_cultists = 10 //...so long as this many cultists are active.
 
@@ -609,6 +611,9 @@
 
 				if("repository_link")
 					config.repository_link = value
+
+				if("registration_panic_bunker_age")
+					config.registration_panic_bunker_age = value
 
 				else
 					log_misc("Unknown setting in configuration: '[name]'")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -188,7 +188,8 @@ var/list/admin_verbs_permissions = list(
 	/client/proc/edit_admin_permissions,
 	/client/proc/gsw_add,
 	/client/proc/library_debug_remove,
-	/client/proc/library_debug_read
+	/client/proc/library_debug_read,
+	/client/proc/regisration_panic_bunker
 	)
 var/list/admin_verbs_rejuv = list(
 	/client/proc/respawn_character

--- a/code/modules/admin/verbs/panicbunker.dm
+++ b/code/modules/admin/verbs/panicbunker.dm
@@ -1,0 +1,29 @@
+/client/proc/regisration_panic_bunker()
+	set category = "Server"
+	set name = "Toggle Registration Panic Bunker"
+
+	if (config.registration_panic_bunker_age)
+		config.registration_panic_bunker_age = null
+		fdel("data/regisration_panic_bunker.sav")
+		log_admin("[key_name(src)] disable regisration panic bunker")
+		message_admins("[key_name_admin(src)] disable regisration panic bunker")
+		return
+	
+	var/year = sanitize_integer(input("Registration year", "Year (min: 2000, max: [game_year])", game_year) as num, 2000, game_year, game_year)
+	var/month = sanitize_integer(input("Registration month", "Month (min: 1, max: 12)", 1) as num, 1, 12, 1)
+	var/day = sanitize_integer(input("Registration day", "Day (min: 1, max: 31)", 1) as num, 1, 31, 1)
+	var/active_hours = sanitize_integer(input("Hours from current moment to keep panic bunker active (-1 to enable for current round only)", "Active hours (min: -1 or 1, max: 24)", -1) as num, -1, 24, -1)
+
+	var/panic_age = "[year]-[month]-[day]"
+
+	config.registration_panic_bunker_age = panic_age
+
+	if (active_hours != -1)
+		var/savefile/S = new /savefile("data/regisration_panic_bunker.sav")
+		S["enabled_by"] = ckey
+		S["active_until"] = world.realtime + active_hours * 36000
+		S["panic_age"] = panic_age
+
+	var/msg = "enables registration panic bunker for [active_hours != -1 ? "[active_hours] hours" : "current round"] with value: [panic_age]"
+	log_admin("[key_name(src)] [msg]")
+	message_admins("[key_name_admin(src)] [msg]")

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -152,12 +152,10 @@ var/list/blacklisted_builds = list(
 
 	//Admin Authorisation
 	holder = admin_datums[ckey]
-	var/deadminned = FALSE
 	if(holder)
 		holder.owner = src
 		admins += src
 		if(holder.deadminned)
-			deadminned = TRUE
 			holder.disassociate()
 			verbs += /client/proc/readmin_self
 
@@ -211,12 +209,14 @@ var/list/blacklisted_builds = list(
 				return
 
 		if(config.registration_panic_bunker_age)
-			if(!holder && !deadminned && !(src in mentors) && is_blocked_by_regisration_panic_bunker())
+			if(!(src in admin_datums) && !(src in mentors) && is_blocked_by_regisration_panic_bunker())
 				to_chat(src, "<span class='danger'>Sorry, but server is currently accepting only users with registration date before [config.registration_panic_bunker_age]. Try to connect later.</span>")
 				message_admins("<span class='adminnotice'>[key_name(src)] has been blocked by panic bunker. Connection rejected.</span>")
 				log_access("Failed Login: [key] [computer_id] [address] - blocked by panic bunker")
 				qdel(src)
 				return
+			if(holder)
+				to_chat("<span class='adminnotice'>Round with registration panic bunker! Panic age: [config.registration_panic_bunker_age]</span>")
 
 	if(custom_event_msg && custom_event_msg != "")
 		to_chat(src, "<h1 class='alert'>Custom Event</h1>")

--- a/code/world.dm
+++ b/code/world.dm
@@ -21,6 +21,7 @@
 	make_datum_references_lists() //initialises global lists for referencing frequently used datums (so that we only ever do it once)
 
 	load_configuration()
+	load_regisration_panic_bunker()
 	load_stealth_keys()
 	load_mode()
 	load_last_mode()
@@ -315,6 +316,25 @@ var/world_topic_spam_protect_time = world.timeofday
 		var/list/prs = splittext(trim(file2text("test_merge.txt")), " ")
 		for(var/pr in prs)
 			join_test_merge += "<a href='[config.repository_link]/pull/[pr]'>#[pr]</a> "
+
+/world/proc/load_regisration_panic_bunker()
+	if(config.registration_panic_bunker_age)
+		log_game("Round with active panic bunker! Enabled by configuration")
+		message_admins("Registration panic bunker is active! It was enabled by configuration.")
+		return
+
+	if(fexists("data/regisration_panic_bunker.sav"))
+		var/savefile/S = new /savefile("data/regisration_panic_bunker.sav")
+		var/active_until = text2num(S["active_until"])
+
+		if(active_until <= world.realtime)
+			fdel("data/regisration_panic_bunker.sav")
+		else
+			config.registration_panic_bunker_age = S["panic_age"]
+			var/enabled_by = S["enabled_by"]
+			var/active_hours_left = num2text((active_until - world.realtime) / 36000, 1)
+			log_game("Round with active panic bunker! Enabled by: [enabled_by]. Active hours left: [active_hours_left]")
+			message_admins("Registration panic bunker is active! It was enabled by [enabled_by] and will be active for [active_hours_left] hours.")
 
 /world/proc/load_donators()
 	if(!fexists("config/donators.txt"))

--- a/code/world.dm
+++ b/code/world.dm
@@ -319,8 +319,7 @@ var/world_topic_spam_protect_time = world.timeofday
 
 /world/proc/load_regisration_panic_bunker()
 	if(config.registration_panic_bunker_age)
-		log_game("Round with active panic bunker! Enabled by configuration")
-		message_admins("Registration panic bunker is active! It was enabled by configuration.")
+		log_game("Round with registration panic bunker! Panic age: [config.registration_panic_bunker_age]. Enabled by configuration. No active hours limit")
 		return
 
 	if(fexists("data/regisration_panic_bunker.sav"))
@@ -333,8 +332,7 @@ var/world_topic_spam_protect_time = world.timeofday
 			config.registration_panic_bunker_age = S["panic_age"]
 			var/enabled_by = S["enabled_by"]
 			var/active_hours_left = num2text((active_until - world.realtime) / 36000, 1)
-			log_game("Round with active panic bunker! Enabled by: [enabled_by]. Active hours left: [active_hours_left]")
-			message_admins("Registration panic bunker is active! It was enabled by [enabled_by] and will be active for [active_hours_left] hours.")
+			log_game("Round with registration panic bunker! Panic age: [config.registration_panic_bunker_age]. Enabled by [enabled_by]. Active hours left: [active_hours_left]")
 
 /world/proc/load_donators()
 	if(!fexists("config/donators.txt"))

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -282,3 +282,6 @@ CHANGELOG_HASH_LINK https://changelog.taucetistation.org/hash.txt
 
 ## Repository link
 REPOSITORY_LINK https://github.com/TauCetiStation/TauCetiClassic
+
+## Registration panic bunker won't allow user with registration date less than that. (format: year-month-day)
+# REGISTRATION_PANIC_BUNKER_AGE 2000-1-1

--- a/taucetistation.dme
+++ b/taucetistation.dme
@@ -960,6 +960,7 @@
 #include "code\modules\admin\verbs\modifyvariables.dm"
 #include "code\modules\admin\verbs\one_click_antag.dm"
 #include "code\modules\admin\verbs\onlyone.dm"
+#include "code\modules\admin\verbs\panicbunker.dm"
 #include "code\modules\admin\verbs\playsound.dm"
 #include "code\modules\admin\verbs\possess.dm"
 #include "code\modules\admin\verbs\pray.dm"


### PR DESCRIPTION
<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений
Админы с пермишенами получили возможность включать паникбункер, который ограничит вход пользователей с датой регистрации позже указанной. Включать можно либо на один (текущий) раунд, либо на какое-то количество часов с момент активации. Также можно задать конфигом. Конфигом, естественно, оно будет висеть ровно столько, сколько строчка в файле не будет трогаться.

Так как паникбункер явление **временное**, то и включать можно **максимум на 24 часа**. После этого тот автоматически спадёт.

Включается кнопкой `"Toggle Registration Panic Bunker"`, ею же выключается.

Админы и менторы паникбункер игнорируют.

<!--
Опишите изменения данного ПР-а.
Если есть связные ишью (issues), или другие ПРы - укажите их тут, для автоматического закрытия ишью следует использовать ключевые слова https://help.github.com/en/articles/closing-issues-using-keywords
Если есть связное форумное обсуждение на тему изменений - укажите ссылку на эту тему.
-->

## Почему и что этот ПР улучшит
На текущий момент существует нехватка админов. Ситуации когда на сервере 90+ игроков на пару админов суть неадекватны. Кроме того нельзя забывать про набегаторов, который с нынешними нанотехнологиями могут создать аккаунт и обойти перму на раз два.

Ограничение по дате регистрации поможет срезать огромный пласт набегаторов, а также снизит критическую нагрузку связанную с наплывом новичков в определённые моменты времени (вечер воскресенья, каникулы и т.д.)

Подразумевается, что это **крайняя мера**, поэтому ограничение на пермишнс флаги.


