### PR TITLE
Запрещает боргам и остальным синтетикам садиться

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -71,7 +71,7 @@
 		to_chat(user, "<span class='warning'>The [M] is too squishy to buckle in.</span>")
 		return
 
-	if(istype(M, /mob/living/silicon))
+	if(issilicon(M))
 		to_chat(user, "<span class='warning'>The [M] is too heavy to buckle in.</span>")
 		return
 

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -71,6 +71,10 @@
 		to_chat(user, "<span class='warning'>The [M] is too squishy to buckle in.</span>")
 		return
 
+	if(istype(M, /mob/living/silicon))
+		to_chat(user, "<span class='warning'>The [M] is too heavy to buckle in.</span>")
+		return
+
 	add_fingerprint(user)
 	unbuckle_mob()
 


### PR DESCRIPTION
## Описание изменений

ПР фиксит извечную проблему с тем, что боргов можно посадить на стулья, при этом они присаживаются пока их кто-нибудь из экипажа не снимет.

Resolves #2827 
Resolves #1665 

## Почему и что этот ПР улучшит

ПР закрывает два бага. Подобная механика запрещает садиться слизням, поэтому резонно сделать её и для боргов.

:cl: f8upd8
 - bugfix: Синтетиков больше невозможно пристегнуть к стульям.

