### PR TITLE
Remove outdated hack for я letter in datum/browser

### DIFF
--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -45,10 +45,10 @@
 	scripts[name] = file
 
 /datum/browser/proc/set_content(ncontent)
-	content = entity_ja(ncontent)
+	content = ncontent
 
 /datum/browser/proc/add_content(ncontent)
-	content += entity_ja(ncontent)
+	content += ncontent
 
 /datum/browser/proc/get_header()
 	var/key


### PR DESCRIPTION
Недавно со Зве обсуждалось, я накосячил и у нас этот костыль для "я" дважды срабатывает - на сервере, и в клиетне 

https://github.com/TauCetiStation/TauCetiClassic/blob/c31823a8dd13e5127ede777e55d4b94f0f315bed/code/datums/browser.dm#L88