### PR TITLE
NT Breacher update

### DIFF
--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -50,6 +50,25 @@
 	item_state = "unathi_helm_cheap"
 	item_color = "unathi_helm_cheap"
 
+	action_button_name = "Toggle Helmet Light"
+	var/brightness_on = 4 //luminosity when on
+	var/on = 0
+
+/obj/item/clothing/head/helmet/space/unathi/helmet_cheap/attack_self(mob/user)
+	if(!isturf(user.loc))
+		to_chat(user, "You cannot turn the light on while in this [user.loc]")//To prevent some lighting anomalities.
+		return
+	on = !on
+	icon_state = "unathi_helm_cheap[on ? "-light" : ""]"
+	usr.update_inv_head()
+
+	if(on)	set_light(brightness_on)
+	else	set_light(0)
+
+	if(istype(user,/mob/living/carbon/human))
+		var/mob/living/carbon/human/H = user
+		H.update_inv_head()
+
 /obj/item/clothing/suit/space/unathi
 	armor = list(melee = 40, bullet = 30, laser = 30,energy = 15, bomb = 35, bio = 100, rad = 50)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/weapon/storage/bag/ore,/obj/item/device/t_scanner,/obj/item/weapon/pickaxe, /obj/item/weapon/rcd)

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -81,7 +81,7 @@
 	desc = "A cheap NT knock-off of a Unathi battle-rig. Looks like a fish, moves like a fish, steers like a cow."
 	icon_state = "rig-unathi-cheap"
 	item_state = "rig-unathi-cheap"
-	slowdown = 3
+	slowdown = 0.5
 
 /obj/item/clothing/head/helmet/space/unathi/breacher
 	name = "breacher helm"

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -54,6 +54,8 @@
 	var/brightness_on = 4 //luminosity when on
 	var/on = 0
 
+	light_color = "#00ffff"
+
 /obj/item/clothing/head/helmet/space/unathi/helmet_cheap/attack_self(mob/user)
 	if(!isturf(user.loc))
 		to_chat(user, "You cannot turn the light on while in this [user.loc]")//To prevent some lighting anomalities.

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -67,7 +67,7 @@
 	if(on)	set_light(brightness_on)
 	else	set_light(0)
 
-	if(istype(user,/mob/living/carbon/human))
+	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		H.update_inv_head()
 

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -40,7 +40,7 @@
 	armor = list(melee = 40, bullet = 30, laser = 30,energy = 15, bomb = 35, bio = 100, rad = 50)
 	heat_protection = HEAD
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
-	var/up = 0 //So Unathi helmets play nicely with the weldervision check.
+	var/up = 1 //So Unathi helmets play nicely with the weldervision check.
 	species_restricted = list(UNATHI)
 
 /obj/item/clothing/head/helmet/space/unathi/helmet_cheap

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -83,7 +83,7 @@
 	desc = "A cheap NT knock-off of a Unathi battle-rig. Looks like a fish, moves like a fish, steers like a cow."
 	icon_state = "rig-unathi-cheap"
 	item_state = "rig-unathi-cheap"
-	slowdown = 0.5
+	slowdown = 2.3
 
 /obj/item/clothing/head/helmet/space/unathi/breacher
 	name = "breacher helm"

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -812,6 +812,17 @@
 	slowdown = 1.4
 	max_mounted_devices = 4
 	initial_modules = list(/obj/item/rig_module/simple_ai, /obj/item/rig_module/selfrepair, /obj/item/rig_module/device/flash)
+<<<<<<< HEAD
+=======
+	item_color = "sec"
+	action_button_name = "Toggle Chase Lights"
+	var/chase_lights_enabled = 0
+
+/obj/item/clothing/suit/space/rig/security/attack_self(mob/user)
+	chase_lights_enabled = !chase_lights_enabled
+	icon_state = "rig-[item_color][chase_lights_enabled ? "-led" : ""]"
+	user.update_inv_wear_suit()
+>>>>>>> 1fc66905de... Fixes
 
 //HoS Rig
 /obj/item/clothing/head/helmet/space/rig/security/hos

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -812,17 +812,6 @@
 	slowdown = 1.4
 	max_mounted_devices = 4
 	initial_modules = list(/obj/item/rig_module/simple_ai, /obj/item/rig_module/selfrepair, /obj/item/rig_module/device/flash)
-<<<<<<< HEAD
-=======
-	item_color = "sec"
-	action_button_name = "Toggle Chase Lights"
-	var/chase_lights_enabled = 0
-
-/obj/item/clothing/suit/space/rig/security/attack_self(mob/user)
-	chase_lights_enabled = !chase_lights_enabled
-	icon_state = "rig-[item_color][chase_lights_enabled ? "-led" : ""]"
-	user.update_inv_wear_suit()
->>>>>>> 1fc66905de... Fixes
 
 //HoS Rig
 /obj/item/clothing/head/helmet/space/rig/security/hos


### PR DESCRIPTION
## Почему и что этот ПР улучшит

> Унатхи замедленны сами по себе, тут подробнее: #3318
NT breacher может быть надет исключительно унатхом, у обычных ригов замедление 1, по сравнению с ними разница не столь ощутима, да и на риге нет толком брони
Было обсуждение тут: #3394

## Чеинжлог
:cl:
 - balance: Уменьшено замедление у NT breacher chassis c 3 до 2.3
 - tweak: Добавлен свет в шлем
 - tweak: Шлем больше не режет обзор как сварочная маска