### PR TITLE
Глобальный нерф воксов 

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -110,7 +110,7 @@
 	if(prob(armor))
 		damage_flags &= ~(DAM_SHARP | DAM_EDGE)
 
-	var/created_wound = apply_damage(throw_damage, dtype, null, armor, damage_flags, O)
+	var/created_wound = apply_damage(throw_damage, dtype, zone, armor, damage_flags, O)
 
 	//thrown weapon embedded object code.
 	if(dtype == BRUTE && istype(O, /obj/item))


### PR DESCRIPTION
## Описание изменений

Исправлен баг, из-за которого нельзя было снять урон после вынимания некоторых снарядов из тела.
Также урон арбалета и тому подобного теперь будет проходить в ту зону, в которою целился игрок, как и должно было бы быть.

fixes #3065
fixes #1652 


## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
:cl:
 - bugfix: Неснимаемый урон от арбалетов воксов is no more
