### PR TITLE
Пара мелкофиксов для анонсов: Наложение звуков шаттла и спам звуками уровня угрозы

### DIFF
--- a/code/defines/procs/captain_announce.dm
+++ b/code/defines/procs/captain_announce.dm
@@ -1,3 +1,6 @@
+#define IS_ON_EMER_SHUTTLE is_type_in_list(get_area(M), list(/area/shuttle/escape/transit, \
+                                                             /area/shuttle/escape_pod1/transit, /area/shuttle/escape_pod2/transit, \
+                                                             /area/shuttle/escape_pod3/transit, /area/shuttle/escape_pod5/transit))
 /proc/captain_announce(message, title = "Priority Announcement", announcer = "", sound = "")
 	for(var/mob/M in player_list)
 		if(!isnewplayer(M))
@@ -15,8 +18,7 @@
 				if("emer_shut_docked")
 					announce_sound = 'sound/AI/emergency_s_docked.ogg'
 				if("emer_shut_left")
-					M.get_location(is_on_shuttle = FALSE)
-					if(M.get_location(is_on_shuttle = TRUE))
+					if(IS_ON_EMER_SHUTTLE)
 						continue
 					announce_sound = 'sound/AI/emergency_s_left.ogg'
 				if("crew_shut_scalled")
@@ -26,8 +28,7 @@
 				if("crew_shut_docked")
 					announce_sound = 'sound/AI/crew_s_docked.ogg'
 				if("crew_shut_left")
-					M.get_location(is_on_shuttle = FALSE)
-					if(M.get_location(is_on_shuttle = TRUE))
+					if(IS_ON_EMER_SHUTTLE)
 						continue
 					announce_sound = 'sound/AI/crew_s_left.ogg'
 				if("malf1")
@@ -43,3 +44,4 @@
 				if("nuke")
 					announce_sound = 'sound/AI/nuke.ogg'
 			M.playsound_local(null, announce_sound, 70, channel = CHANNEL_ANNOUNCE, wait = 1, is_global = 1)
+#undef IS_ON_EMER_SHUTTLE

--- a/code/defines/procs/captain_announce.dm
+++ b/code/defines/procs/captain_announce.dm
@@ -21,7 +21,7 @@
 					if(IS_ON_ESCAPE_SHUTTLE)
 						continue
 					announce_sound = 'sound/AI/emergency_s_left.ogg'
-				if("crew_shut_scalled")
+				if("crew_shut_called")
 					announce_sound = 'sound/AI/crew_s_called.ogg'
 				if("crew_shut_recalled")
 					announce_sound = 'sound/AI/crew_s_recalled.ogg'

--- a/code/defines/procs/captain_announce.dm
+++ b/code/defines/procs/captain_announce.dm
@@ -1,7 +1,11 @@
-#define IS_ON_EMER_SHUTTLE is_type_in_list(get_area(M), list(/area/shuttle/escape/transit, \
-                                                             /area/shuttle/escape_pod1/transit, /area/shuttle/escape_pod2/transit, \
-                                                             /area/shuttle/escape_pod3/transit, /area/shuttle/escape_pod5/transit))
+#define IS_ON_ESCAPE_SHUTTLE is_type_in_typecache(get_area(M), escape_shuttle_area)
 /proc/captain_announce(message, title = "Priority Announcement", announcer = "", sound = "")
+	var/escape_shuttle_area = list()
+	escape_shuttle_area = typecacheof(/area/shuttle/escape/transit)
+	escape_shuttle_area += typecacheof(/area/shuttle/escape_pod1/transit)
+	escape_shuttle_area += typecacheof(/area/shuttle/escape_pod2/transit)
+	escape_shuttle_area += typecacheof(/area/shuttle/escape_pod3/transit)
+	escape_shuttle_area += typecacheof(/area/shuttle/escape_pod5/transit)
 	for(var/mob/M in player_list)
 		if(!isnewplayer(M))
 			to_chat(M, "<h1 class='alert'>[title]</h1>")
@@ -18,7 +22,7 @@
 				if("emer_shut_docked")
 					announce_sound = 'sound/AI/emergency_s_docked.ogg'
 				if("emer_shut_left")
-					if(IS_ON_EMER_SHUTTLE)
+					if(IS_ON_ESCAPE_SHUTTLE)
 						continue
 					announce_sound = 'sound/AI/emergency_s_left.ogg'
 				if("crew_shut_scalled")
@@ -28,7 +32,7 @@
 				if("crew_shut_docked")
 					announce_sound = 'sound/AI/crew_s_docked.ogg'
 				if("crew_shut_left")
-					if(IS_ON_EMER_SHUTTLE)
+					if(IS_ON_ESCAPE_SHUTTLE)
 						continue
 					announce_sound = 'sound/AI/crew_s_left.ogg'
 				if("malf1")
@@ -44,4 +48,4 @@
 				if("nuke")
 					announce_sound = 'sound/AI/nuke.ogg'
 			M.playsound_local(null, announce_sound, 70, channel = CHANNEL_ANNOUNCE, wait = 1, is_global = 1)
-#undef IS_ON_EMER_SHUTTLE
+#undef IS_ON_ESCPAE_SHUTTLE

--- a/code/defines/procs/captain_announce.dm
+++ b/code/defines/procs/captain_announce.dm
@@ -1,6 +1,9 @@
-#define IS_ON_ESCAPE_SHUTTLE is_type_in_typecache(get_area(M), typecacheof(list(/area/shuttle/escape/transit, \
-                                                                                /area/shuttle/escape_pod1/transit, /area/shuttle/escape_pod2/transit, \
-                                                                                /area/shuttle/escape_pod3/transit, /area/shuttle/escape_pod5/transit)))
+var/list/escape_area_transit = typecacheof(list(/area/shuttle/escape/transit,
+                                                /area/shuttle/escape_pod1/transit,
+                                                /area/shuttle/escape_pod2/transit,
+                                                /area/shuttle/escape_pod3/transit,
+                                                /area/shuttle/escape_pod5/transit))
+#define IS_ON_ESCAPE_SHUTTLE is_type_in_typecache(get_area(M), escape_area_transit)
 /proc/captain_announce(message, title = "Priority Announcement", announcer = "", sound = "")
 	for(var/mob/M in player_list)
 		if(!isnewplayer(M))

--- a/code/defines/procs/captain_announce.dm
+++ b/code/defines/procs/captain_announce.dm
@@ -1,11 +1,7 @@
-#define IS_ON_ESCAPE_SHUTTLE is_type_in_typecache(get_area(M), escape_shuttle_area)
+#define IS_ON_ESCAPE_SHUTTLE is_type_in_typecache(get_area(M), typecacheof(list(/area/shuttle/escape/transit, \
+                                                                                /area/shuttle/escape_pod1/transit, /area/shuttle/escape_pod2/transit, \
+                                                                                /area/shuttle/escape_pod3/transit, /area/shuttle/escape_pod5/transit)))
 /proc/captain_announce(message, title = "Priority Announcement", announcer = "", sound = "")
-	var/escape_shuttle_area = list()
-	escape_shuttle_area = typecacheof(/area/shuttle/escape/transit)
-	escape_shuttle_area += typecacheof(/area/shuttle/escape_pod1/transit)
-	escape_shuttle_area += typecacheof(/area/shuttle/escape_pod2/transit)
-	escape_shuttle_area += typecacheof(/area/shuttle/escape_pod3/transit)
-	escape_shuttle_area += typecacheof(/area/shuttle/escape_pod5/transit)
 	for(var/mob/M in player_list)
 		if(!isnewplayer(M))
 			to_chat(M, "<h1 class='alert'>[title]</h1>")

--- a/code/defines/procs/captain_announce.dm
+++ b/code/defines/procs/captain_announce.dm
@@ -15,6 +15,9 @@
 				if("emer_shut_docked")
 					announce_sound = 'sound/AI/emergency_s_docked.ogg'
 				if("emer_shut_left")
+					M.get_location(is_on_shuttle = FALSE)
+					if(M.get_location(is_on_shuttle = TRUE))
+						continue
 					announce_sound = 'sound/AI/emergency_s_left.ogg'
 				if("crew_shut_scalled")
 					announce_sound = 'sound/AI/crew_s_called.ogg'
@@ -23,6 +26,9 @@
 				if("crew_shut_docked")
 					announce_sound = 'sound/AI/crew_s_docked.ogg'
 				if("crew_shut_left")
+					M.get_location(is_on_shuttle = FALSE)
+					if(M.get_location(is_on_shuttle = TRUE))
+						continue
 					announce_sound = 'sound/AI/crew_s_left.ogg'
 				if("malf1")
 					announce_sound = 'sound/AI/ai_malf_1.ogg'

--- a/code/game/gamemodes/events.dm
+++ b/code/game/gamemodes/events.dm
@@ -39,7 +39,7 @@
 				spawn_meteors()
 
 		if(2)
-			command_alert("Gravitational anomalies detected on the station. There is no additional data.", "Anomaly Alert", "gravanom")
+			command_alert("Gravitational anomalies detected on the station. There is no additional data.", "Anomaly Alert", sound = "gravanom")
 			var/turf/T = pick(blobstart)
 			var/obj/effect/bhole/bh = new /obj/effect/bhole( T.loc, 30 )
 			spawn(rand(50, 300))

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -104,8 +104,14 @@
 			authenticated = 0
 
 		if("swipeidseclevel")
+			var/static/last_seclevel_change = 0 // prevents announcement sounds spam
 			var/mob/M = usr
 			var/obj/item/weapon/card/id/I = M.get_active_hand()
+			if(last_seclevel_change > world.time)
+				to_chat(usr, "<span class='warning'>A red light flashes on the console. It looks like you can't change the security level that fast.</span>")
+				return
+			else
+				last_seclevel_change = world.time + 600 // One minute seconds cooldown
 			if (istype(I, /obj/item/device/pda))
 				var/obj/item/device/pda/pda = I
 				I = pda.id
@@ -134,17 +140,18 @@
 				to_chat(usr, "You need to swipe your ID.")
 
 		if("announce")
-			if(src.authenticated==2)
-				if(message_cooldown)	return
-				var/input = sanitize(input(usr, "Please choose a message to announce to the station crew.", "What?"), extra = FALSE)
-				if(!input || !(usr in view(1,src)))
-					return
-				captain_announce(input)//This should really tell who is, IE HoP, CE, HoS, RD, Captain
-				log_say("[key_name(usr)] has made a captain announcement: [input]")
-				message_admins("[key_name_admin(usr)] has made a captain announcement. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[usr.x];Y=[usr.y];Z=[usr.z]'>JMP</a>)")
-				message_cooldown = 1
-				spawn(600)//One minute cooldown
-					message_cooldown = 0
+			var/static/last_announcement = 0
+			if(last_announcement > world.time)
+				to_chat(usr, "<span class='warning'>A red light flashes on the console. It looks like you can't make announcements that fast.</span>")
+				return
+			else
+				last_announcement = world.time + 600 // One minute cooldown
+			var/input = sanitize(input(usr, "Please choose a message to announce to the station crew.", "What?"), extra = FALSE)
+			if(!input || !(usr in view(1,src)))
+				return
+			captain_announce(input)//This should really tell who is, IE HoP, CE, HoS, RD, Captain
+			log_say("[key_name(usr)] has made a captain announcement: [input]")
+			message_admins("[key_name_admin(usr)] has made a captain announcement. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[usr.x];Y=[usr.y];Z=[usr.z]'>JMP</a>)")
 
 		if("callshuttle")
 			src.state = STATE_DEFAULT

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -20,6 +20,8 @@
 	var/message_cooldown = 0
 	var/centcomm_message_cooldown = 0
 	var/tmp_alertlevel = 0
+	var/last_seclevel_change = 0 // prevents announcement sounds spam
+	var/last_announcement = 0    // ^ ^ ^
 	var/const/STATE_DEFAULT = 1
 	var/const/STATE_CALLSHUTTLE = 2
 	var/const/STATE_CANCELSHUTTLE = 3
@@ -104,7 +106,6 @@
 			authenticated = 0
 
 		if("swipeidseclevel")
-			var/static/last_seclevel_change = 0 // prevents announcement sounds spam
 			var/mob/M = usr
 			var/obj/item/weapon/card/id/I = M.get_active_hand()
 			if(last_seclevel_change > world.time)
@@ -141,7 +142,6 @@
 
 		if("announce")
 			if(src.authenticated == 2)
-				var/static/last_announcement = 0
 				if(last_announcement > world.time)
 					to_chat(usr, "<span class='warning'>A red light flashes on the console. It looks like you can't make announcements that fast.</span>")
 					return

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -140,18 +140,19 @@
 				to_chat(usr, "You need to swipe your ID.")
 
 		if("announce")
-			var/static/last_announcement = 0
-			if(last_announcement > world.time)
-				to_chat(usr, "<span class='warning'>A red light flashes on the console. It looks like you can't make announcements that fast.</span>")
-				return
-			else
-				last_announcement = world.time + 600 // One minute cooldown
-			var/input = sanitize(input(usr, "Please choose a message to announce to the station crew.", "What?"), extra = FALSE)
-			if(!input || !(usr in view(1,src)))
-				return
-			captain_announce(input)//This should really tell who is, IE HoP, CE, HoS, RD, Captain
-			log_say("[key_name(usr)] has made a captain announcement: [input]")
-			message_admins("[key_name_admin(usr)] has made a captain announcement. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[usr.x];Y=[usr.y];Z=[usr.z]'>JMP</a>)")
+			if(src.authenticated == 2)
+				var/static/last_announcement = 0
+				if(last_announcement > world.time)
+					to_chat(usr, "<span class='warning'>A red light flashes on the console. It looks like you can't make announcements that fast.</span>")
+					return
+				else
+					last_announcement = world.time + 600 // One minute cooldown
+				var/input = sanitize(input(usr, "Please choose a message to announce to the station crew.", "What?"), extra = FALSE)
+				if(!input || !(usr in view(1,src)))
+					return
+				captain_announce(input)//This should really tell who is, IE HoP, CE, HoS, RD, Captain
+				log_say("[key_name(usr)] has made a captain announcement: [input]")
+				message_admins("[key_name_admin(usr)] has made a captain announcement. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[usr.x];Y=[usr.y];Z=[usr.z]'>JMP</a>)")
 
 		if("callshuttle")
 			src.state = STATE_DEFAULT

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -111,7 +111,7 @@
 				to_chat(usr, "<span class='warning'>A red light flashes on the console. It looks like you can't change the security level that fast.</span>")
 				return
 			else
-				last_seclevel_change = world.time + 600 // One minute cooldown
+				last_seclevel_change = world.time + 1 MINUTE
 			if (istype(I, /obj/item/device/pda))
 				var/obj/item/device/pda/pda = I
 				I = pda.id
@@ -146,7 +146,7 @@
 					to_chat(usr, "<span class='warning'>A red light flashes on the console. It looks like you can't make announcements that fast.</span>")
 					return
 				else
-					last_announcement = world.time + 600 // One minute cooldown
+					last_announcement = world.time + 1 MINUTE
 				var/input = sanitize(input(usr, "Please choose a message to announce to the station crew.", "What?"), extra = FALSE)
 				if(!input || !(usr in view(1,src)))
 					return

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -111,7 +111,7 @@
 				to_chat(usr, "<span class='warning'>A red light flashes on the console. It looks like you can't change the security level that fast.</span>")
 				return
 			else
-				last_seclevel_change = world.time + 600 // One minute seconds cooldown
+				last_seclevel_change = world.time + 600 // One minute cooldown
 			if (istype(I, /obj/item/device/pda))
 				var/obj/item/device/pda/pda = I
 				I = pda.id

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2236,7 +2236,7 @@
 			if("gravanomalies")
 				feedback_inc("admin_secrets_fun_used",1)
 				feedback_add_details("admin_secrets_fun_used","GA")
-				command_alert("Gravitational anomalies detected on the station. There is no additional data.", "Anomaly Alert", "gravanom")
+				command_alert("Gravitational anomalies detected on the station. There is no additional data.", "Anomaly Alert", sound = "gravanom")
 				var/turf/T = pick(blobstart)
 				var/obj/effect/bhole/bh = new /obj/effect/bhole( T.loc, 30 )
 				spawn(rand(100, 600))

--- a/code/modules/anomaly/anomaly.dm
+++ b/code/modules/anomaly/anomaly.dm
@@ -18,7 +18,7 @@
 		setup(safety_loop)
 
 /datum/event/anomaly/announce()
-	command_alert("Localized hyper-energetic flux wave detected on long range scanners. Expected location of impact: [impact_area.name].", "Anomaly Alert", "flux")
+	command_alert("Localized hyper-energetic flux wave detected on long range scanners. Expected location of impact: [impact_area.name].", "Anomaly Alert", sound = "fluxanom")
 
 /datum/event/anomaly/start()
 	var/turf/T = pick(get_area_turfs(impact_area))

--- a/code/modules/anomaly/anomaly_bluespace.dm
+++ b/code/modules/anomaly/anomaly_bluespace.dm
@@ -4,7 +4,7 @@
 	endWhen = 95
 
 /datum/event/anomaly/anomaly_bluespace/announce()
-	command_alert("Unstable bluespace anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert", "bluspaceanom")
+	command_alert("Unstable bluespace anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert", sound = "bluspaceanom")
 
 /datum/event/anomaly/anomaly_bluespace/start()
 	var/turf/T = pick(get_area_turfs(impact_area))

--- a/code/modules/anomaly/anomaly_flux.dm
+++ b/code/modules/anomaly/anomaly_flux.dm
@@ -4,7 +4,7 @@
 	endWhen = 80
 
 /datum/event/anomaly/anomaly_flux/announce()
-	command_alert("Localized hyper-energetic flux wave detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert", "flux")
+	command_alert("Localized hyper-energetic flux wave detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert", sound = "fluxanom")
 
 /datum/event/anomaly/anomaly_flux/start()
 	var/turf/T = pick(get_area_turfs(impact_area))

--- a/code/modules/anomaly/anomaly_grav.dm
+++ b/code/modules/anomaly/anomaly_grav.dm
@@ -7,7 +7,7 @@
 	impact_area = findEventArea()
 
 /datum/event/anomaly/anomaly_grav/announce()
-	command_alert("Gravitational anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert", "gravanom")
+	command_alert("Gravitational anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert", sound = "gravanom")
 
 /datum/event/anomaly/anomaly_grav/start()
 	var/turf/T = pick(get_area_turfs(impact_area))

--- a/code/modules/anomaly/anomaly_pyro.dm
+++ b/code/modules/anomaly/anomaly_pyro.dm
@@ -4,7 +4,7 @@
 	endWhen = 110
 
 /datum/event/anomaly/anomaly_pyro/announce()
-	command_alert("Pyroclastic anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert", "pyroanom")
+	command_alert("Pyroclastic anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert", sound = "pyroanom")
 
 /datum/event/anomaly/anomaly_pyro/start()
 	var/turf/T = pick(get_area_turfs(impact_area))

--- a/code/modules/anomaly/anomaly_vortex.dm
+++ b/code/modules/anomaly/anomaly_vortex.dm
@@ -7,7 +7,7 @@
 	impact_area = findEventArea()
 
 /datum/event/anomaly/anomaly_vortex/announce()
-	command_alert("Localized high-intensity vortex anomaly detected on long range scanners. Expected location: [impact_area.name]", "Anomaly Alert", "vortexanom")
+	command_alert("Localized high-intensity vortex anomaly detected on long range scanners. Expected location: [impact_area.name]", "Anomaly Alert", sound = "vortexanom")
 
 /datum/event/anomaly/anomaly_vortex/start()
 	var/turf/T = pick(get_area_turfs(impact_area))

--- a/code/modules/events/meteors.dm
+++ b/code/modules/events/meteors.dm
@@ -9,7 +9,7 @@
 	endWhen = rand(10,25) * 3
 
 /datum/event/meteor_wave/announce()
-	command_alert("Meteors have been detected on collision course with the station. The energy field generator is disabled or missng.", "Meteor Alert", "meteors")
+	command_alert("Meteors have been detected on collision course with the station. The energy field generator is disabled or missing.", "Meteor Alert", "meteors")
 
 /datum/event/meteor_wave/tick()
 	if(IsMultiple(activeFor, 3))
@@ -29,7 +29,7 @@
 	waves = rand(1,4)
 
 /datum/event/meteor_shower/announce()
-	command_alert("The station is now in a meteor shower. The energy field generator is disabled or missng.", "Meteor Alert", "meteors")
+	command_alert("The station is now in a meteor shower. The energy field generator is disabled or missing.", "Meteor Alert", "meteors")
 
 //meteor showers are lighter and more common,
 /datum/event/meteor_shower/tick()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1116,9 +1116,3 @@ note dizziness decrements automatically in the mob's Life() proc.
 			updatehealth()
 		if("resize")
 			update_transform()*/
-
-/mob/proc/get_location(is_on_shuttle = FALSE)
-	var/area/A = get_area(src)
-	if(A in list(/area/shuttle/escape/transit, /area/shuttle/escape_pod1/transit, /area/shuttle/escape_pod2/transit, /area/shuttle/escape_pod3/transit, /area/shuttle/escape_pod5/transit))
-		is_on_shuttle = TRUE
-	return is_on_shuttle

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1116,3 +1116,9 @@ note dizziness decrements automatically in the mob's Life() proc.
 			updatehealth()
 		if("resize")
 			update_transform()*/
+
+/mob/proc/get_location(is_on_shuttle = FALSE)
+	var/area/A = get_area(src)
+	if(A in list(/area/shuttle/escape/transit, /area/shuttle/escape_pod1/transit, /area/shuttle/escape_pod2/transit, /area/shuttle/escape_pod3/transit, /area/shuttle/escape_pod5/transit))
+		is_on_shuttle = TRUE
+	return is_on_shuttle


### PR DESCRIPTION
Думаю, оформлять все по шаблону и добавлять чейнжлог здесь не надо - слишком незначительные изменения.

Звуки автоматического анонса ИИ об отбытии шаттла и звук ускорения шаттла больше не накладываются. Вставил в if() в switch()'e чтобы не засорять прок анонсов лишними проверками. Сделал отдельный прок для определения местоположения чтобы не засорять красивые списки звуков анонсов.
Случайно обнаружил, что какая то злая глава прямо во время игры на сервере начала спамить звуками смены уровня угрозы. Теперь спамить нельзя - смена уровня угрозы имеет КД в минуту. Бонусом заменил spawn(600) в "announce" в этом же проке на более современное решение, ведь, кажется, мейнтейнеры так не любят спавны...