### PR TITLE
Фикс наличия синди тулбокса на слоях.

### DIFF
--- a/maps/z3.dmm
+++ b/maps/z3.dmm
@@ -539,7 +539,7 @@
 /obj/item/clothing/suit/space/syndicate,
 /obj/item/clothing/head/helmet/space/syndicate,
 /obj/item/clothing/mask/breath,
-/obj/item/weapon/storage/toolbox/syndicate,
+/obj/item/weapon/storage/toolbox/emergency,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},

--- a/maps/z4.dmm
+++ b/maps/z4.dmm
@@ -1428,12 +1428,6 @@
 	},
 /turf/simulated/floor,
 /area/derelict/bridge)
-"dS" = (
-/obj/item/weapon/storage/toolbox/syndicate,
-/turf/simulated/floor/airless{
-	icon_state = "damaged2"
-	},
-/area/derelict/singularity_engine)
 "dT" = (
 /obj/item/stack/cable_coil/cut/red,
 /turf/simulated/floor/airless{
@@ -4115,10 +4109,6 @@
 /area/derelict/bridge/ai_upload)
 "ls" = (
 /turf/simulated/floor/plating/airless,
-/area/derelict/bridge/ai_upload)
-"lt" = (
-/obj/item/weapon/storage/toolbox/syndicate,
-/turf/simulated/floor/airless,
 /area/derelict/bridge/ai_upload)
 "lu" = (
 /obj/structure/cable{
@@ -42816,7 +42806,7 @@ pb
 do
 dz
 dK
-dS
+dM
 eb
 ej
 ew
@@ -49296,7 +49286,7 @@ kA
 lg
 ll
 lq
-lt
+lq
 lw
 lD
 ls


### PR DESCRIPTION

<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений

Два тулбокса исчезли с лица карты, а третий заменен на красный.
<!--
Опишите изменения данного ПР-а.
Если есть связные ишью (issues), или другие ПРы - укажите их тут, для автоматического закрытия ишью следует использовать ключевые слова https://help.github.com/en/articles/closing-issues-using-keywords
Если есть связное форумное обсуждение на тему изменений - укажите ссылку на эту тему.
-->

## Почему и что этот ПР улучшит
В связи с тем что игроки, пользуясь калькуляторами телесаенса уже на "пятой" минуте бегут с "подозрительными тулбоксами" в РнД, даже не пытаясь обыгрывать, то как они натолкнулись на "данж с лутом", а администраторы по данному не принимают никаких действий, мы посовещались в #RnD и пришли к выводу, что лучшее на данный момент решение  - убрать их со слоев до введения рандомного спавна или иной фичи.
<!--
Опишите причину для изменений.
Этот пункт особенно важен для описания изменений баланса, новых механик.
-->



<!-- Опциональный пункт!
Если авторство не полностью ваше, вы делаете порт с другого билда - обязательно укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
-->

## Чеинжлог

<!-- Опциональный пункт!
Если это что-то, о чём следует сообщить игрокам - опишите по форме (https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies#Changelog) свои изменения для игрового чеинжлога, они будут отображены на специальной страничке http://changelog.taucetistation.org

Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment
  
Пример списка:
:cl:
 - balance: Все подозрительные тулбоксы дающие нелегальную технологию убраны со всех слоев (слой 3 - 1шт., слой 4 - 2шт.). На слое 3, заменен на красный тулбокс.
-->

:cl:
 - balance: Все подозрительные тулбоксы дающие нелегальную технологию убраны со всех слоев (слой 3 - 1шт., слой 4 - 2шт.). На слое 3, заменен на красный тулбокс.
