### PR TITLE
Добавляем проверку на форс языков в шёпот

### DIFF
--- a/code/modules/mob/living/carbon/human/whisper.dm
+++ b/code/modules/mob/living/carbon/human/whisper.dm
@@ -39,6 +39,8 @@
 	var/datum/language/speaking = parse_language(message)
 	if(speaking)
 		message = copytext(message,2+length(speaking.key))
+	else if(species.force_racial_language)
+		speaking = all_languages[species.language]
 
 	whisper_say(message, speaking, alt_name)
 


### PR DESCRIPTION
Воксы теперь могут автоматически шептать на родном языке.
Fixes#3212

:cl:

- bugfix: теперь Воксы шепчут (whisper) на родном языке