### PR TITLE
Небольшая доработка контроля воздушных насосов в аир алярмах

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -541,7 +541,8 @@
 						"power"     = info["power"],
 						"checks"    = info["checks"],
 						"direction" = info["direction"],
-						"external"  = info["external"]
+						"external"  = info["external"],
+						"internal"  = info["internal"]
 					)
 			data["vents"] = vents
 		if(AALARM_SCREEN_SCRUB)
@@ -668,7 +669,17 @@
 					return FALSE
 
 				if("reset_external_pressure")
-					send_signal(device_id, list(href_list["command"] = ONE_ATMOSPHERE))
+					send_signal(device_id, list(href_list["command"] = TRUE))
+					return FALSE
+
+				if("set_internal_pressure")
+					var/input_pressure = input("What pressure you like the system to mantain?", "Pressure Controls") as num|null
+					if(isnum(input_pressure))
+						send_signal(device_id, list(href_list["command"] = input_pressure))
+					return FALSE
+
+				if("reset_internal_pressure")
+					send_signal(device_id, list(href_list["command"] = TRUE))
 					return FALSE
 
 				if( "power",

--- a/code/modules/atmospheric/machinery/components/unary_devices/vent_pump.dm
+++ b/code/modules/atmospheric/machinery/components/unary_devices/vent_pump.dm
@@ -329,6 +329,12 @@
 				ONE_ATMOSPHERE * 50
 			)
 
+	if(signal.data["reset_internal_pressure"] != null)
+		internal_pressure_bound = internal_pressure_bound_default
+
+	if(signal.data["reset_external_pressure"] != null)
+		external_pressure_bound = external_pressure_bound_default
+
 	if(signal.data["adjust_internal_pressure"] != null)
 		internal_pressure_bound = between(
 			0,

--- a/nano/templates/air_alarm.tmpl
+++ b/nano/templates/air_alarm.tmpl
@@ -150,6 +150,15 @@ Used In File(s): \code\game\machinery\alarm.dm
 					{{:helper.link('Reset', null, { 'id_tag' : value.id_tag, 'command' : 'reset_external_pressure'})}}
 				</div>
 			</div>
+			<div class="item">
+				<div class="itemLabel">
+					Internal Pressure Bound:
+				</div>
+				<div class="itemContent">
+					{{:helper.link(helper.fixed(value.internal,2), null, { 'id_tag' : value.id_tag, 'command' : 'set_internal_pressure'})}}
+					{{:helper.link('Reset', null, { 'id_tag' : value.id_tag, 'command' : 'reset_internal_pressure'})}}
+				</div>
+			</div>
 			<HR>
 		{{empty}}
 			No vents connected.


### PR DESCRIPTION

## Описание изменений

1. Кнопка reset теперь сбрасывает настройки давления к стандартным, как и должно быть.
2. Добавлена возможность настройки ограничения внутреннего давления

## Почему и что этот ПР улучшит

Фикс бага, возможность более гибких настроек воздушных насосов.

## Авторство

## Чеинжлог

:cl:
 - bugfix: Не работала кнопка reset в меню управления воздушными насосами аир алярмов.
 - tweak: Добавлена возможность настройки ограничения внутреннего давления воздушных насосов в аир алярмах.
