### PR TITLE
Исправлено направление выбрасывания предметов из мусорного выбрасывателя

### DIFF
--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -260,9 +260,8 @@
 
 					else if(ptype==7) // Disposal outlet
 
-						var/obj/structure/disposaloutlet/P = new /obj/structure/disposaloutlet(src.loc)
+						var/obj/structure/disposaloutlet/P = new /obj/structure/disposaloutlet(src.loc, dir)
 						src.transfer_fingerprints_to(P)
-						P.dir = dir
 						var/obj/structure/disposalpipe/trunk/Trunk = CP
 						Trunk.linked = P
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -1323,8 +1323,10 @@
 	var/turf/target	// this will be where the output objects are 'thrown' to.
 	var/mode = 0
 
-/obj/structure/disposaloutlet/atom_init()
+/obj/structure/disposaloutlet/atom_init(mapload, dir)
 	..()
+	if(dir)
+		src.dir = dir
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/structure/disposaloutlet/atom_init_late()
@@ -1381,6 +1383,7 @@
 				C.update()
 				C.anchored = 1
 				C.density = 1
+				C.dir = dir
 				qdel(src)
 			return
 		else


### PR DESCRIPTION

## Описание изменений

Теперь мусорный выбрасыватель выбрасывает содержимое в правильном направлении. 
Также теперь `dir` не теряется при отваривании, но изменение слишком незначительное, чтобы добавлять в чеинжлог.

## Почему и что этот ПР улучшит

Фикс багов

## Авторство

## Чеинжлог

:cl:
 - bugfix: Мусорный выбрасыватель выбрасывал предметы всегда на юг.

