### PR TITLE
Пачка багфиксов, связанных со шлюзами

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -39,6 +39,7 @@ var/list/airlock_overlays = list()
 	var/shockedby = list()
 	var/close_timer_id = null
 	var/datum/wires/airlock/wires = null
+	var/denying = FALSE
 
 	var/inner_material = null //material of inner filling; if its an airlock with glass, this should be set to "glass"
 	var/overlays_file = 'icons/obj/doors/airlocks/station/overlays.dmi'
@@ -353,11 +354,14 @@ var/list/airlock_overlays = list()
 		if("closing")
 			update_icon(AIRLOCK_CLOSING)
 		if("deny")
-			update_icon(AIRLOCK_DENY)
-			playsound(src, door_deni_sound, 40, 0, 3)
-			sleep(6)
-			update_icon(AIRLOCK_CLOSED)
-			icon_state = "closed"
+			if(deny_animation_check())
+				denying = TRUE
+				update_icon(AIRLOCK_DENY)
+				playsound(src, door_deni_sound, 40, 0, 3)
+				sleep(6)
+				update_icon(AIRLOCK_CLOSED)
+				icon_state = "closed"
+				denying = FALSE
 
 /obj/machinery/door/airlock/attack_ghost(mob/user)
 	//Separate interface for ghosts.
@@ -1010,6 +1014,11 @@ var/list/airlock_overlays = list()
 
 /obj/machinery/door/airlock/normal_close_checks()
 	if(hasPower() && !isWireCut(AIRLOCK_WIRE_DOOR_BOLTS))
+		return TRUE
+	return FALSE
+
+/obj/machinery/door/airlock/proc/deny_animation_check()
+	if(!denying && !welded && !locked && hasPower() && !isWireCut(AIRLOCK_WIRE_OPEN_DOOR))
 		return TRUE
 	return FALSE
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -147,7 +147,7 @@
 	if(!src.requiresID())
 		user = null
 	user.SetNextMove(CLICK_CD_INTERACT)
-	if(src.allowed(user))
+	if(src.allowed(user) || emergency)
 		if(src.density)
 			open()
 		else

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -175,6 +175,7 @@
 			if(created_name)
 				door.name = created_name
 			electronics.loc = door
+			electronics = null
 			qdel(src)
 	else
 		..()


### PR DESCRIPTION

## Описание изменений

1. fixes #3038
2. fixes #3017
3. При отсутствии доступа шлюзы, которые нельзя открыть (болтированные, без энергии, заваренные и т.д.), теперь не проигрывают анимацию отказа в доступе.
fixes #3035
4. Плата шлюзов при некоторых обстоятельствах могла пропасть.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог

:cl:
 - bugfix: Анимация отказа в доступе накладывалась, если одновременно идти в сторону шлюза и кликать на него
 - bugfix: При отсутствии доступа шлюзы, которые нельзя открыть, теперь не проигрывают анимацию отказа в доступе.
 - bugfix: Шлюзы с аварийным доступом нельзя было открыть кликом.
 - bugfix: Плата шлюзов при некоторых обстоятельствах могла пропасть из шлюза.

