### PR TITLE
Выкидной нож почему то не острый

### DIFF
--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -172,6 +172,7 @@
 	desc = "A sharp, concealable, spring-loaded knife."
 	flags = CONDUCT
 	force = 20
+	edge = 1
 	w_class = ITEM_SIZE_SMALL
 	throwforce = 15
 	throw_speed = 3

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -180,7 +180,7 @@
 	m_amt = 12000
 	origin_tech = "materials=1"
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	attack_verb = list("stubbed", "poked")
+	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	var/extended = TRUE
 
 /obj/item/weapon/switchblade/attack_self(mob/user)

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -181,7 +181,7 @@
 	origin_tech = "materials=1"
 	hitsound = 'sound/weapons/Genhit.ogg'
 	attack_verb = list("stubbed", "poked")
-	var/extended
+	var/extended = TRUE
 
 /obj/item/weapon/switchblade/attack_self(mob/user)
 	extended = !extended

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -168,12 +168,13 @@
 
 /obj/item/weapon/switchblade
 	name = "switchblade"
-	icon_state = "switchblade"
+	icon_state = "switchblade_ext"
 	desc = "A sharp, concealable, spring-loaded knife."
 	flags = CONDUCT
 	force = 20
 	w_class = ITEM_SIZE_SMALL
 	throwforce = 15
+	edge = 1
 	throw_speed = 3
 	throw_range = 6
 	m_amt = 12000

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -168,20 +168,20 @@
 
 /obj/item/weapon/switchblade
 	name = "switchblade"
-	icon_state = "switchblade_ext"
+	icon_state = "switchblade"
 	desc = "A sharp, concealable, spring-loaded knife."
 	flags = CONDUCT
-	force = 20
-	w_class = ITEM_SIZE_NORMAL
-	throwforce = 15
-	edge = 1
+	force = 1
+	w_class = ITEM_SIZE_SMALL
+	throwforce = 5
+	edge = FALSE
 	throw_speed = 3
 	throw_range = 6
 	m_amt = 12000
 	origin_tech = "materials=1"
-	hitsound = 'sound/weapons/bladeslice.ogg'
-	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
-	var/extended = TRUE
+	hitsound = 'sound/weapons/Genhit.ogg'
+	attack_verb = list("stubbed", "poked")
+	var/extended = FALSE
 
 /obj/item/weapon/switchblade/attack_self(mob/user)
 	extended = !extended
@@ -190,7 +190,7 @@
 		force = 20
 		w_class = ITEM_SIZE_NORMAL
 		throwforce = 15
-		edge = 1
+		edge = TRUE
 		icon_state = "switchblade_ext"
 		attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 		hitsound = 'sound/weapons/bladeslice.ogg'
@@ -198,7 +198,7 @@
 		force = 1
 		w_class = ITEM_SIZE_SMALL
 		throwforce = 5
-		edge = 0
+		edge = FALSE
 		icon_state = "switchblade"
 		attack_verb = list("stubbed", "poked")
 		hitsound = 'sound/weapons/Genhit.ogg'

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -172,7 +172,7 @@
 	desc = "A sharp, concealable, spring-loaded knife."
 	flags = CONDUCT
 	force = 20
-	w_class = ITEM_SIZE_SMALL
+	w_class = ITEM_SIZE_NORMAL
 	throwforce = 15
 	edge = 1
 	throw_speed = 3

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -172,7 +172,6 @@
 	desc = "A sharp, concealable, spring-loaded knife."
 	flags = CONDUCT
 	force = 20
-	edge = 1
 	w_class = ITEM_SIZE_SMALL
 	throwforce = 15
 	throw_speed = 3
@@ -190,6 +189,7 @@
 		force = 20
 		w_class = ITEM_SIZE_NORMAL
 		throwforce = 15
+		edge = 1
 		icon_state = "switchblade_ext"
 		attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 		hitsound = 'sound/weapons/bladeslice.ogg'
@@ -197,6 +197,7 @@
 		force = 1
 		w_class = ITEM_SIZE_SMALL
 		throwforce = 5
+		edge = 0
 		icon_state = "switchblade"
 		attack_verb = list("stubbed", "poked")
 		hitsound = 'sound/weapons/Genhit.ogg'

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -179,7 +179,7 @@
 	throw_range = 6
 	m_amt = 12000
 	origin_tech = "materials=1"
-	hitsound = 'sound/weapons/Genhit.ogg'
+	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("stubbed", "poked")
 	var/extended = TRUE
 


### PR DESCRIPTION
Немного странно что выкидной нож не острый как например кухонный нож

<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений
Добавил остроту выкидному мечу
<!--
Опишите изменения данного ПР-а.
Если есть связные ишью (issues), или другие ПРы - укажите их тут, для автоматического закрытия ишью следует использовать ключевые слова https://help.github.com/en/articles/closing-issues-using-keywords
Если есть связное форумное обсуждение на тему изменений - укажите ссылку на эту тему.
-->

## Почему и что этот ПР улучшит
Добавит логики, все мечи и ножи острые кроме этого
<!--
Опишите причину для изменений.
Этот пункт особенно важен для описания изменений баланса, новых механик.
-->

## Авторство
1DarkWater1
<!-- Опциональный пункт!
Если авторство не полностью ваше, вы делаете порт с другого билда - обязательно укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
-->

## Чеинжлог
:cl: 1DarkWater1
 - balance: Выкидной нож стал острым
 - bugfix: Свернутый нож при спавне наносил урон как развернутый
<!-- Опциональный пункт!
Если это что-то, о чём следует сообщить игрокам - опишите по форме (https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies#Changelog) свои изменения для игрового чеинжлога, они будут отображены на специальной страничке http://changelog.taucetistation.org

Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment
  
Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
