### PR TITLE
Round stats

### DIFF
--- a/code/__HELPERS/logging.dm
+++ b/code/__HELPERS/logging.dm
@@ -196,3 +196,35 @@
 	log_game(text)
 
 #undef LOG_CLEANING
+
+/proc/drop_round_stats()
+	var/date = time2text(world.realtime, "YYYY/MM/DD")
+	var/round_stats_loc = "data/stat_logs/[date]/round-"
+
+	if(round_id)
+		round_stats_loc += round_id
+	else
+		var/timestamp = replacetext(time_stamp(), ":", ".")
+		round_stats_loc += "[timestamp]"
+
+	var/list/stats = list()
+
+	stats["round_id"] = round_id
+	stats["start_time"] = time2text(round_start_realtime, "hh:mm:ss")
+	stats["end_time"] = time2text(world.realtime, "hh:mm:ss")
+	stats["duration"] = roundduration2text()
+	stats["mode"] = ticker.mode
+	stats["mode_result"] = ticker.mode.mode_result
+
+	stats["antagonists"] = antagonists_completion//todo: icon2base64 icons?
+
+	stats["score"] = score
+	stats["achievements"] = achievements
+	stats["centcomm_communications"] = centcomm_communications
+
+	var/stat_file = file("[round_stats_loc]/stat.json")
+
+	stat_file << list2json(stats)
+
+/proc/add_communication_log(type = 0, title = 0, author = 0, content = 0, time = roundduration2text())
+	centcomm_communications += list(list("type" = type, "title" = title, "time" = time, "content" = content))

--- a/code/__HELPERS/logging.dm
+++ b/code/__HELPERS/logging.dm
@@ -216,7 +216,8 @@
 	stats["mode"] = ticker.mode
 	stats["mode_result"] = ticker.mode.mode_result
 
-	stats["antagonists"] = antagonists_completion//todo: icon2base64 icons?
+	stats["completion_html"] = ticker.mode.completion_text
+	stats["completion_antagonists"] = antagonists_completion//todo: icon2base64 icons?
 
 	stats["score"] = score
 	stats["achievements"] = achievements

--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -70,26 +70,7 @@ var/global/list/achievements = list()
 //line format: type, title, time, content
 var/global/list/centcomm_communications = list()
 
-//antagonists_completion format: 
-// [mode, mode]
-//
-// mode: {
-// 	"mode": "traitor",
-// 	"antagonists": []
-//    "team": []
-// 	"objectives": []
-// }
-//
-// antagonists: [antagonist, antagonist]
-//
-// antagonist: {"name": "", "objectives": objectives}
-//
-// team: {"name", "antagonists": antagonists}
-//
-// objectives: [objective, objective]
-//
-// objective: {"desc", "success"}
-//todo: base64 icons?
+//line format: mode, html
 var/global/list/antagonists_completion = list()
 
 // Icons that appear on the Round End pop-up browser

--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -29,19 +29,24 @@ var/list/score=list(
 	"researchdone"   = 0,
 	"eventsendured"  = 0, // how many random events did the station survive?
 	"powerloss"      = 0, // how many APCs have poor charge?
-	"escapees"       = 0, // how many people got out alive?
-	"deadcrew"       = 0, // dead bodies on the station, oh no
 	"mess"           = 0, // how much poo, puke, gibs, etc went uncleaned
 	"meals"          = 0,
 	"disease"        = 0, // how many rampant, uncured diseases are on board the station
 	"deadcommand"    = 0, // used during rev, how many command staff perished
 	"arrested"       = 0, // how many traitors/revs/whatever are alive in the brig
 	"traitorswon"    = 0, // how many traitors were successful?
-	"roleswon"        = 0, // how many roles were successful?
+	"roleswon"       = 0, // how many roles were successful?
 	"allarrested"    = 0, // did the crew catch all the enemies alive?
 	"opkilled"       = 0, // used during nuke mode, how many operatives died?
 	"disc"           = 0, // is the disc safe and secure?
 	"nuked"          = 0, // was the station blown into little bits?
+
+	//crew
+	"crew_escaped"   = 0,      // how many people got out alive?
+	"crew_dead"      = 0,      // dead bodies on the station, oh no
+	"crew_total"     = 0,      // how many people was registred as crew
+	"crew_survived"  = 0,      // how many people was registred as crew
+	"captain"        = list(), // who was captain of the shift (or captains?...)
 
 	// these ones are mainly for the stat panel
 	"powerbonus"    = 0, // if all APCs on the station are running optimally, big bonus
@@ -49,18 +54,43 @@ var/list/score=list(
 	"deadaipenalty" = 0, // is the AI dead? if so, big penalty
 	"foodeaten"     = 0, // nom nom nom
 	"clownabuse"    = 0, // how many times a clown was punched, struck or otherwise maligned
-	"richestname"   = null, // this is all stuff to show who was the richest alive on the shuttle
-	"richestjob"    = null,  // kinda pointless if you dont have a money system i guess
+	"richestname"   = 0, // this is all stuff to show who was the richest alive on the shuttle
+	"richestjob"    = 0, // kinda pointless if you dont have a money system i guess
 	"richestcash"   = 0,
-	"richestkey"    = null,
-	"dmgestname"    = null, // who had the most damage on the shuttle (but was still alive)
-	"dmgestjob"     = null,
+	"richestkey"    = 0,
+	"dmgestname"    = 0, // who had the most damage on the shuttle (but was still alive)
+	"dmgestjob"     = 0,
 	"dmgestdamage"  = 0,
-	"dmgestkey"     = null
+	"dmgestkey"     = 0
 )
 
+//line format: key, name, title, desc
 var/global/list/achievements = list()
 
+//line format: type, title, time, content
+var/global/list/centcomm_communications = list()
+
+//antagonists_completion format: 
+// [mode, mode]
+//
+// mode: {
+// 	"mode": "traitor",
+// 	"antagonists": []
+//    "team": []
+// 	"objectives": []
+// }
+//
+// antagonists: [antagonist, antagonist]
+//
+// antagonist: {"name": "", "objectives": objectives}
+//
+// team: {"name", "antagonists": antagonists}
+//
+// objectives: [objective, objective]
+//
+// objective: {"desc", "success"}
+//todo: base64 icons?
+var/global/list/antagonists_completion = list()
 
 // Icons that appear on the Round End pop-up browser
 var/global/list/end_icons = list()

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -1,4 +1,5 @@
 var/round_start_time = 0
+var/round_start_realtime = 0
 
 var/datum/subsystem/ticker/ticker
 
@@ -133,6 +134,8 @@ var/datum/subsystem/ticker/ticker
 						attachment_color = BRIDGE_COLOR_ANNOUNCE,
 					)
 
+					drop_round_stats()
+
 					if (mode.station_was_nuked)
 						feedback_set_details("end_proper","nuke")
 						if(!delay_end)
@@ -233,6 +236,7 @@ var/datum/subsystem/ticker/ticker
 
 	current_state = GAME_STATE_PLAYING
 	round_start_time = world.time
+	round_start_realtime = world.realtime
 
 	if(dbcon.IsConnected())
 		var/DBQuery/query_round_game_mode = dbcon.NewQuery("UPDATE erro_round SET start_datetime = Now() WHERE id = [round_id]")
@@ -421,7 +425,7 @@ var/datum/subsystem/ticker/ticker
 	to_chat(world, "<BR><BR><BR><FONT size=3><B>The round has ended.</B></FONT>")
 
 	//Player status report
-	for(var/mob/Player in mob_list)
+	for(var/mob/Player in mob_list)//todo: remove in favour of /game_mode/proc/declare_completion
 		if(Player.mind && !isnewplayer(Player))
 			if(Player.stat != DEAD && !isbrain(Player))
 				num_survivors++
@@ -525,7 +529,8 @@ var/datum/subsystem/ticker/ticker
 	end_icons += cup
 	var/tempstate = end_icons.len
 	for(var/winner in achievements)
-		text += {"<br><img src="logo_[tempstate].png"> [winner]"}
+		var/winner_text = "<b>[winner["key"]]</b> as <b>[winner["name"]]</b> won \"<b>[winner["title"]]</b>\"! \"[winner["desc"]]\""
+		text += {"<br><img src="logo_[tempstate].png"> [winner_text]"}
 
 	return text
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -414,7 +414,7 @@ var/datum/subsystem/ticker/ticker
 			if(!isnewplayer(M))
 				to_chat(M, "Captainship not forced on anyone.")
 
-
+//cursed code
 /datum/subsystem/ticker/proc/declare_completion()
 	var/station_evacuated
 	if(SSshuttle.location > 0)
@@ -459,7 +459,8 @@ var/datum/subsystem/ticker/ticker
 	var/ai_completions = "<h1>Round End Information</h1><HR>"
 
 	if(silicon_list.len)
-		ai_completions += "<H3>Silicons Laws</H3>"
+		ai_completions += "<h2>Silicons Laws</h2>"
+		ai_completions += "<div class='block'>"
 		for (var/mob/living/silicon/ai/aiPlayer in ai_list)
 			if(!aiPlayer)
 				continue
@@ -501,12 +502,14 @@ var/datum/subsystem/ticker/ticker
 		if(dronecount)
 			ai_completions += "<B>There [dronecount>1 ? "were" : "was"] [dronecount] industrious maintenance [dronecount>1 ? "drones" : "drone"] this round.</B>"
 
-		ai_completions += "<HR>"
+		ai_completions += "</div>"
 
 	mode.declare_completion()//To declare normal completion.
 
-	ai_completions += "<BR><h2>Mode Result</h2>"
-	ai_completions += "[mode.completion_text]<HR>"
+	ai_completions += "<br><h2>Mode Result</h2>"
+	
+	if(mode.completion_text)//extendet has empty completion text
+		ai_completions += "<div class='block'>[mode.completion_text]</div>"
 
 	//calls auto_declare_completion_* for all modes
 	for(var/handler in typesof(/datum/game_mode/proc))

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -154,6 +154,8 @@
 		//L.fields["image"]		= getFlatIcon(H)	//This is god-awful
 		L.fields["image"]		= get_id_photo(H)
 		locked += L
+
+		score["crew_total"]++
 	return
 
 

--- a/code/defines/procs/announces.dm
+++ b/code/defines/procs/announces.dm
@@ -22,6 +22,7 @@ var/list/escape_area_transit = typecacheof(list(/area/shuttle/escape/transit,
 	if(sound)
 		announce_sound = get_announce_sound(sound)
 
+
 	for(var/mob/M in player_list)
 		if(!isnewplayer(M))
 			if(announce_text)
@@ -36,9 +37,15 @@ var/list/escape_area_transit = typecacheof(list(/area/shuttle/escape/transit,
 #undef IS_ON_ESCPAE_SHUTTLE
 
 //station announces: communication console, shuttle(?), departaments
-/proc/captain_announce(message, title = "Priority Announcement", announcer, sound = "announce")
-	station_announce(message, title, null, announcer, sound)
+/proc/captain_announce(message, title = "Priority Announcement", announcer, sound = "announce", subtitle)
+	
+	station_announce(message, title, subtitle, announcer, sound)
+
+	add_communication_log(type = "station", title = title ? title : subtitle, author = announcer, content = message)
 
 //messages from centcomm
 /proc/command_alert(message, title, sound = "commandreport")
+
 	station_announce(message, "[command_name()] Update", title, null, sound)
+
+	add_communication_log(type = "centcomm", title = title, content = message)

--- a/code/game/gamemodes/abduction/abduction.dm
+++ b/code/game/gamemodes/abduction/abduction.dm
@@ -263,7 +263,7 @@
 	return ..()
 
 /datum/game_mode/abduction/declare_completion()
-	completion_text += "<B>Abduction mode resume:</B><br>"
+	completion_text += "<h3>Abduction mode resume:</h3>"
 	for(var/team_number in 1 to abductor_teams)
 		var/obj/machinery/abductor/console/console = get_team_console(team_number)
 		var/datum/objective/objective = team_objectives[team_number]
@@ -271,13 +271,13 @@
 		if(console.experiment.points >= objective.target_amount)
 			mode_result = "win - abductor complete mission"
 			feedback_set_details("round_end_result",mode_result)
-			completion_text += "<B>[team_name]</B> team managed to <font color='green'><B>complete</B></font> their mission! "
+			completion_text += "<b>[team_name]</b> team managed to <span style='color: green; font-weight: bold;'>complete</span> their mission! "
 			completion_text += "[live_check(team_number)]"
 			completion_text += "[pick("Science of Galaxy","Greytide Science")] continues moving forward!<BR>"
 		else
 			mode_result = "loss - staff stopped abductors"
 			feedback_set_details("round_end_result",mode_result)
-			completion_text += "<B>[team_name]</B> team <font color='red'>failed</font> their mission."
+			completion_text += "<b>[team_name]</b> team <span style='color: red; font-weight: bold;'>failed</span> their mission."
 			completion_text += "[live_check(team_number)]"
 			completion_text += "Station crew managed to stop [pick("Science of Galaxy","Greytide Science")].<BR>"
 	..()
@@ -293,9 +293,9 @@
 		if((A.team == team_number) && (A.stat != DEAD))
 			alive++
 	if(alive >= 2)
-		text += "All of them <B>alive</B>. "
+		text += "All of them <b>alive</b>. "
 	else
-		text += "Someone from them is <B>dead</B>. "
+		text += "Someone from them is <b>dead</b>. "
 	return text
 
 /datum/game_mode/proc/auto_declare_completion_abduction()
@@ -303,7 +303,7 @@
 	if(abductors.len)
 		text += printlogo("abductor", "abductors")
 		for(var/team_name in abduction_teams)
-			text += "<BR><FONT size = 4, color = #800080><b>[team_name] members:</B></FONT>"
+			text += "<br><span style='color: #800080; font-weight: bold;'>[team_name] members:</span>"
 
 			for(var/datum/mind/abductor in abductors)
 				if(findtext(abductor.name,team_name))
@@ -314,29 +314,33 @@
 					if(!config.objectives_disabled)
 						for(var/datum/objective/objective in abductor.objectives)
 							if(objective.check_completion())
-								text += "<BR><B>Objective #[count]</B>: [objective.explanation_text] <font color='green'><B>Success!</B></font>"
+								text += "<br><b>Objective #[count]</b>: [objective.explanation_text] <span style='color: green; font-weight: bold;'>Success!</span>"
 								feedback_add_details("abductor_objective","[objective.type]|SUCCESS")
 							else
-								text += "<BR><B>Objective #[count]</B>: [objective.explanation_text] <font color='red'>Fail.</font>"
+								text += "<br><b>Objective #[count]</b>: [objective.explanation_text] <span style='color: red; font-weight: bold;'>Fail.</span>"
 								feedback_add_details("abductor_objective","[objective.type]|FAIL")
 								abductorwin = 0
 							count++
 
 						if(abductor.current && abductor.current.stat!=2 && abductorwin)
-							text += "<BR><font color='green'><B>The abductor was successful!</B></font>"
+							text += "<br><span style='color: green; font-weight: bold;'>The abductor was successful!</span>"
 							feedback_add_details("abductor_success","SUCCESS")
 							score["roleswon"]++
 						else
-							text += "<BR><font color='red'><B>The abductor has failed!</B></font>"
+							text += "<br><span style='color: red; font-weight: bold;'>The abductor has failed!</span>"
 							feedback_add_details("abductor_success","FAIL")
 
-		text += "<BR>"
+		text += "<br>"
 		if(abductees.len)
-			text += "<BR><B>The abductees were:</B>"
+			text += "<br><b>The abductees were:</b>"
 			for(var/datum/mind/abductee_mind in abductees)
 				text += printplayer(abductee_mind)
 				text += printobjectives(abductee_mind)
-		text += "<BR><HR>"
+
+	if(text)
+		antagonists_completion += list(list("mode" = "abduction", "html" = text))
+		text = "<div class='block'>[text]</div>"
+	
 	return text
 
 // Machinery

--- a/code/game/gamemodes/blob/blob_finish.dm
+++ b/code/game/gamemodes/blob/blob_finish.dm
@@ -11,30 +11,30 @@
 
 
 /datum/game_mode/blob/declare_completion()
-	completion_text += "<B>Blob mode resume:</B><BR>"
+	completion_text += "<h3>Blob mode resume:</h3>"
 	if(blobwincount <= blobs.len)
 		mode_result = "loss - blob took over"
 		feedback_set_details("round_end_result",mode_result)
-		completion_text += "<BR><FONT size = 3><B>The blob has taken over the station!</B></FONT>"
-		completion_text += "<B>The entire station was eaten by the Blob.</B>"
+		completion_text += "<br><span style='font-weight: bold;'>The blob has taken over the station!</span>"
+		completion_text += "<b>The entire station was eaten by the Blob.</b>"
 		score["roleswon"]++
 		log_game("Blob mode completed with a blob victory.")
 
 	else if(station_was_nuked)
 		mode_result = "halfwin - nuke"
 		feedback_set_details("round_end_result",mode_result)
-		completion_text += "<BR><FONT size = 3><B>Partial Win: The station has been destroyed!</B></FONT>"
-		completion_text += "<B>Directive 7-12 has been successfully carried out preventing the Blob from spreading.</B>"
+		completion_text += "<br><span style='font-weight: bold;'>Partial Win: The station has been destroyed!</span>"
+		completion_text += "<b>Directive 7-12 has been successfully carried out preventing the Blob from spreading.</b>"
 		log_game("Blob mode completed with a tie (station destroyed).")
 
 	else if(!blob_cores.len)
 		mode_result = "win - blob eliminated"
 		feedback_set_details("round_end_result",mode_result)
-		completion_text += "<BR><FONT size = 3><B>The staff has won!</B></FONT>"
-		completion_text += "<B>The alien organism has been eradicated from the station.</B>"
+		completion_text += "<br><span style='font-weight: bold;'>The staff has won!</span>"
+		completion_text += "<b>The alien organism has been eradicated from the station.</b>"
 
 		log_game("Blob mode completed with a crew victory.")
-	to_chat(world, "<BR><span class='info'>Rebooting in 30s.</span>")
+	to_chat(world, "<br><span class='info'>Rebooting in 30s.</span>")
 	..()
 	return 1
 
@@ -43,12 +43,16 @@
 	if(istype(ticker.mode,/datum/game_mode/blob) )
 		var/datum/game_mode/blob/blob_mode = src
 		if(blob_mode.infected_crew.len)
-			text += "<B>The blob[(blob_mode.infected_crew.len > 1 ? "s were" : " was")]:</B>"
+			text += "<b>The blob[(blob_mode.infected_crew.len > 1 ? "s were" : " was")]:</b>"
 
 			var/icon/logo = icon('icons/mob/blob.dmi', "blob_core")
 			end_icons += logo
 			var/tempstate = end_icons.len
 			for(var/datum/mind/blob in blob_mode.infected_crew)
-				text += {"<BR><img src="logo_[tempstate].png"> <B>[blob.key]</B> was <B>[blob.name]</B>"}
-		text += "<BR><HR>"
+				text += {"<br><img src="logo_[tempstate].png"> <b>[blob.key]</b> was <b>[blob.name]</b>"}
+	
+	if(text)
+		antagonists_completion += list(list("mode" = "blob", "html" = text))
+		text = "<div class='block'>[text]</div>"
+	
 	return text

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -166,13 +166,13 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 /datum/game_mode/changeling/declare_completion()
 	var/prefinal_text = ""
 	var/final_text = ""
-	completion_text += "<B>Changeling mode resume:</B><BR>"
+	completion_text += "<h3>Changeling mode resume:</h3>"
 
 	for(var/datum/mind/changeling in changelings)
 		if(changeling.current.stat == DEAD)
 			mode_result = "loss - changeling killed"
 			feedback_set_details("round_end_result", mode_result)
-			prefinal_text = "<FONT size = 3>Changeling <b>[changeling.changeling.changelingID]</b><i> ([changeling.key])</i> has been <font color='red'><b>killed</b></font> by the crew! The Thing failed again...</FONT><BR>"
+			prefinal_text = "<span>Changeling <b>[changeling.changeling.changelingID]</b> <i>([changeling.key])</i> has been <span style='color: red; font-weight: bold;'>killed</span> by the crew! The Thing failed again...</span><br>"
 		else
 			var/failed = 0
 			for(var/datum/objective/objective in changeling.objectives)
@@ -181,11 +181,11 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 			if(!failed)
 				mode_result = "win - changeling alive"
 				feedback_set_details("round_end_result", mode_result)
-				prefinal_text = "<FONT size = 3>Changeling <b>[changeling.changeling.changelingID]</b><i> ([changeling.key])</i> managed to <font color='green'><B>complete</B></font> his mission! All humanity soon will be infested!</FONT><BR>"
+				prefinal_text = "<span>Changeling <b>[changeling.changeling.changelingID]</b> <i>([changeling.key])</i> managed to <span style='color: green; font-weight: bold;'>complete</span> his mission! All humanity soon will be infested!</span><br>"
 			else
 				mode_result = "loss - changeling alive"
 				feedback_set_details("round_end_result", mode_result)
-				prefinal_text = "<FONT size = 3>Changeling <b>[changeling.changeling.changelingID]</b><i> ([changeling.key])</i> managed to stay alive, but <font color='red'><B>failed</B></font> his mission! Next time he will come more prepared!</FONT><BR>"
+				prefinal_text = "<span>Changeling <b>[changeling.changeling.changelingID]</b> <i>([changeling.key])</i> managed to stay alive, but <span style='color: red; font-weight: bold;'>failed</span> his mission! Next time he will come more prepared!</span><br>"
 		final_text += "[prefinal_text]"
 
 	completion_text += "[final_text]"
@@ -201,7 +201,7 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 		var/tempstatea = end_icons.len
 		end_icons += logob
 		var/tempstateb = end_icons.len
-		text += {"<img src="logo_[tempstatea].png"> <B>The changelings were:</B> <img src="logo_[tempstateb].png">"}
+		text += {"<img src="logo_[tempstatea].png"> <b>The changelings were:</b> <img src="logo_[tempstateb].png">"}
 
 		for(var/datum/mind/changeling in changelings)
 			text += printplayerwithicon(changeling)
@@ -210,50 +210,54 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 			if(!changeling.current)
 				changelingwin = 0
 			//Removed sanity if(changeling) because we -want- a runtime to inform us that the changelings list is incorrect and needs to be fixed.
-			text += "<BR><B>Changeling ID:</B> [changeling.changeling.changelingID]"
-			text += "<BR><B>Genomes Absorbed:</B> [changeling.changeling.absorbedcount]"
-			text +="<BR><B>Stored Essences:</B>"
+			text += "<br><b>Changeling ID:</b> [changeling.changeling.changelingID]"
+			text += "<br><b>Genomes Absorbed:</b> [changeling.changeling.absorbedcount]"
+			text +="<br><b>Stored Essences:</b>"
 			for(var/mob/living/parasite/essence/E in changeling.changeling.essences)
 				text += printplayerwithicon(E.mind)
-				text += "<BR>"
+				text += "<br>"
 			if(!config.objectives_disabled)
 				if(changeling.objectives.len)
 					var/count = 1
 					for(var/datum/objective/objective in changeling.objectives)
 						if(objective.check_completion())
-							text += "<BR><B>Objective #[count]</B>: [objective.explanation_text] <font color='green'><B>Success!</B></font>"
+							text += "<br><b>Objective #[count]</b>: [objective.explanation_text] <span style='color: green; font-weight: bold;'>Success!</span>"
 							feedback_add_details("changeling_objective","[objective.type]|SUCCESS")
 						else
-							text += "<BR><B>Objective #[count]</B>: [objective.explanation_text] <font color='red'>Fail.</font>"
+							text += "<br><b>Objective #[count]</b>: [objective.explanation_text] <span style='color: red; font-weight: bold;'>Fail.</span>"
 							feedback_add_details("changeling_objective","[objective.type]|FAIL")
 							changelingwin = 0
 						count++
 					if(changelingwin)
-						text += "<BR><FONT color='green'><B>The changeling was successful!</B></FONT>"
+						text += "<br><span style='color: green; font-weight: bold;'>The changeling was successful!</span>"
 						feedback_add_details("changeling_success","SUCCESS")
 						score["roleswon"]++
 					else
-						text += "<BR><FONT color='red'><B>The changeling has failed.</B></FONT>"
+						text += "<br><span style='color: red; font-weight: bold;'>The changeling has failed.</span>"
 						feedback_add_details("changeling_success","FAIL")
 					if(changeling.current && changeling.changeling.purchasedpowers)
-						text += "<BR><B>[changeling.changeling.changelingID] used the following abilities: </B>"
+						text += "<br><b>[changeling.changeling.changelingID] used the following abilities: </b>"
 						var/i = 0
 						for(var/obj/effect/proc_holder/changeling/C in changeling.changeling.purchasedpowers)
 							if(C.genomecost >= 1)
-								text += "<BR><B>#[++i]</B>: [C.name]"
+								text += "<br><b>#[++i]</b>: [C.name]"
 						if(!i)
-							text += "<BR>Changeling was too autistic and did't buy anything."
+							text += "<br>Changeling was too autistic and did't buy anything."
 
 
 			if(changeling.total_TC)
 				if(changeling.spent_TC)
-					text += "<BR><B>TC Remaining:</B> [changeling.total_TC - changeling.spent_TC]/[changeling.total_TC]"
-					text += "<BR><B>The tools used by the Changeling were:</B>"
+					text += "<br><b>TC Remaining:</b> [changeling.total_TC - changeling.spent_TC]/[changeling.total_TC]"
+					text += "<br><b>The tools used by the Changeling were:</b>"
 					for(var/entry in changeling.uplink_items_bought)
-						text += "<BR>[entry]"
+						text += "<br>[entry]"
 				else
-					text += "<BR>The Changeling was a smooth operator this round (did not purchase any uplink items)"
-		text += "<BR><HR>"
+					text += "<br>The Changeling was a smooth operator this round (did not purchase any uplink items)"
+
+	if(text)
+		antagonists_completion += list(list("mode" = "changeling", "html" = text))
+		text = "<div class='block'>[text]</div>"
+		
 	return text
 
 /datum/changeling //stores changeling powers, changeling recharge thingie, changeling absorbed DNA and changeling ID (for changeling hivemind)

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -281,18 +281,18 @@
 /datum/game_mode/cult/declare_completion()
 	if(config.objectives_disabled)
 		return 1
-	completion_text += "<B>Cult mode resume:</B><BR>"
+	completion_text += "<h3>Cult mode resume:</h3>"
 	if(!check_cult_victory())
 		mode_result = "win - cult win"
 		feedback_set_details("round_end_result",mode_result)
 		feedback_set("round_end_result",acolytes_survived)
-		completion_text += "<FONT size = 3 color='red'><B>The cult <font color='green'>wins</font>! It has succeeded in serving its dark masters!</B></FONT>"
+		completion_text += "<span class='color: red; font-weight: bold;'>The cult <span style='color: green'>wins</span>! It has succeeded in serving its dark masters!</span><br>"
 		score["roleswon"]++
 	else
 		mode_result = "loss - staff stopped the cult"
 		feedback_set_details("round_end_result",mode_result)
 		feedback_set("round_end_result",acolytes_survived)
-		completion_text += "<FONT size = 3 color='red'><B>The staff managed to stop the cult!</B></FONT><BR>"
+		completion_text += "<span class='color: red; font-weight: bold;'>The staff managed to stop the cult!</span><br>"
 
 	var/text = "<b>Cultists escaped:</b> [acolytes_survived]"
 	if(!config.objectives_disabled)
@@ -303,33 +303,33 @@
 				switch(objectives[obj_count])
 					if("survive")
 						if(!check_survive())
-							explanation = "Make sure at least [acolytes_needed] acolytes escape on the shuttle. <font color='green'><B>Success!</B></font>"
+							explanation = "Make sure at least [acolytes_needed] acolytes escape on the shuttle. <span style='color: green; font-weight: bold;'>Success!</span>"
 							feedback_add_details("cult_objective","cult_survive|SUCCESS|[acolytes_needed]")
 						else
-							explanation = "Make sure at least [acolytes_needed] acolytes escape on the shuttle. <font color='red'>Fail.</font>"
+							explanation = "Make sure at least [acolytes_needed] acolytes escape on the shuttle. <span style='color: red; font-weight: bold;'>Fail.</span>"
 							feedback_add_details("cult_objective","cult_survive|FAIL|[acolytes_needed]")
 					if("sacrifice")
 						if(sacrifice_target)
 							if(sacrifice_target in sacrificed)
-								explanation = "Sacrifice [sacrifice_target.name], the [sacrifice_target.assigned_role]. <font color='green'><B>Success!</B></font>"
+								explanation = "Sacrifice [sacrifice_target.name], the [sacrifice_target.assigned_role]. <span style='color: green; font-weight: bold;'>Success!</span>"
 								feedback_add_details("cult_objective","cult_sacrifice|SUCCESS")
 							else if(sacrifice_target && sacrifice_target.current)
-								explanation = "Sacrifice [sacrifice_target.name], the [sacrifice_target.assigned_role]. <font color='red'>Fail.</font>"
+								explanation = "Sacrifice [sacrifice_target.name], the [sacrifice_target.assigned_role]. <span style='color: red; font-weight: bold;'>Fail.</span>"
 								feedback_add_details("cult_objective","cult_sacrifice|FAIL")
 							else
-								explanation = "Sacrifice [sacrifice_target.name], the [sacrifice_target.assigned_role]. <font color='red'>Fail (Gibbed).</font>"
+								explanation = "Sacrifice [sacrifice_target.name], the [sacrifice_target.assigned_role]. <span style='color: red; font-weight: bold;'>Fail (Gibbed).</span>"
 								feedback_add_details("cult_objective","cult_sacrifice|FAIL|GIBBED")
 						else
-							explanation = "Free objective. <font color='green'><B>Success!</B></font>"
+							explanation = "Free objective. <span style='color: green; font-weight: bold;'>Success!</span>"
 							feedback_add_details("cult_objective","cult_free_objective|SUCCESS")
 					if("eldergod")
 						if(!eldergod)
-							explanation = "Summon Nar-Sie. <font color='green'><B>Success!</B></font>"
+							explanation = "Summon Nar-Sie. <span style='color: green; font-weight: bold;'>Success!</span>"
 							feedback_add_details("cult_objective","cult_narsie|SUCCESS")
 						else
-							explanation = "Summon Nar-Sie. <font color='red'>Fail.</font>"
+							explanation = "Summon Nar-Sie. <span style='color: red; font-weight: bold;'>Fail.</span>"
 						feedback_add_details("cult_objective","cult_narsie|FAIL")
-				text += "<BR><B>Objective #[obj_count]</B>: [explanation]"
+				text += "<br><b>Objective #[obj_count]</b>: [explanation]"
 
 	completion_text += text
 	..()
@@ -341,5 +341,9 @@
 		text += printlogo("cult", "cultists")
 		for(var/datum/mind/cultist in cult)
 			text += printplayerwithicon(cultist)
-		text += "<BR><HR>"
+
+	if(text)
+		antagonists_completion += list(list("mode" = "cult", "html" = text))
+		text = "<div class='block'>[text]</div>"
+		
 	return text

--- a/code/game/gamemodes/epidemic/epidemic.dm
+++ b/code/game/gamemodes/epidemic/epidemic.dm
@@ -213,10 +213,10 @@
 	if(finished == 1)
 		mode_result = "win - epidemic cured"
 		feedback_set_details("round_end_result",mode_result)
-		to_chat(world, "\red <FONT size = 3><B> The virus outbreak was contained! The crew wins!</B></FONT>")
+		completion_text += "<span style='font-weight: bold; color: red;'>The virus outbreak was contained! The crew wins!</span>"
 	else if(finished == 2)
 		mode_result = "loss - crew succumbed to the epidemic"
 		feedback_set_details("round_end_result",mode_result)
-		to_chat(world, "\red <FONT size = 3><B> The crew succumbed to the epidemic!</B></FONT>")
+		completion_text += "<span style='font-weight: bold; color: red;'>The crew succumbed to the epidemic!</span>"
 	..()
 	return 1

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -468,9 +468,9 @@ Implants;
 	var/count = 1
 	for(var/datum/objective/objective in ply.objectives)
 		if(objective.check_completion())
-			text += "<br><b>Objective #[count]</b>: [objective.explanation_text] <font color='green'><b>Success!</b></font>"
+			text += "<br><b>Objective #[count]</b>: [objective.explanation_text] <span style='color: green; font-weight: bold;'>Success!</span>"
 		else
-			text += "<br><b>Objective #[count]</b>: [objective.explanation_text] <font color='red'><b>Fail.</b></font>"
+			text += "<br><b>Objective #[count]</b>: [objective.explanation_text] <span style='color: red; font-weight: bold;'>Fail.</span>"
 		count++
 	return text
 
@@ -482,7 +482,7 @@ Implants;
 		var/icon/flat = getFlatIcon(ply.current,exact=1)
 		end_icons += flat
 		tempstate = end_icons.len
-		text += {"<BR><img src="logo_[tempstate].png"> <B>[ply.key]</B> was <B>[ply.name]</B> ("}
+		text += {"<br><img src="logo_[tempstate].png"> <b>[ply.key]</b> was <b>[ply.name]</b> ("}
 		if(ply.current.stat == DEAD)
 			text += "died"
 			flat.Turn(90)
@@ -495,7 +495,7 @@ Implants;
 		var/icon/sprotch = icon('icons/effects/blood.dmi', "gibbearcore")
 		end_icons += sprotch
 		tempstate = end_icons.len
-		text += {"<BR><img src="logo_[tempstate].png"> <B>[ply.key]</B> was <B>[ply.name]</B> ("}
+		text += {"<br><img src="logo_[tempstate].png"> <b>[ply.key]</b> was <b>[ply.name]</b> ("}
 		text += "body destroyed"
 	text += ")"
 	return text
@@ -506,5 +506,5 @@ Implants;
 	end_icons += logo
 	var/tempstate = end_icons.len
 	var/text = ""
-	text += {"<img src="logo_[tempstate].png"> <B>The [antagname] were:</B> <img src="logo_[tempstate].png">"}
+	text += {"<img src="logo_[tempstate].png"> <b>The [antagname] were:</b> <img src="logo_[tempstate].png">"}
 	return text

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -167,26 +167,27 @@ Implants;
 	for(var/mob/M in player_list)
 		if(M.client)
 			clients++
+			var/area/mob_area = get_area(M)
 			if(ishuman(M))
 				if(!M.stat)
 					surviving_humans++
-					if(M.loc && M.loc.loc && M.loc.loc.type in escape_locations)
+					if(mob_area.type in escape_locations)
 						escaped_humans++
 			if(!M.stat)
 				surviving_total++
-				if(M.loc && M.loc.loc && M.loc.loc.type in escape_locations)
+				if(mob_area.type in escape_locations)
 					escaped_total++
 
-				if(M.loc && M.loc.loc && M.loc.loc.type == /area/shuttle/escape/centcom)
+				if(mob_area.type == /area/shuttle/escape/centcom)
 					escaped_on_shuttle++
 
-				if(M.loc && M.loc.loc && M.loc.loc.type == /area/shuttle/escape_pod1/centcom)
+				if(mob_area.type == /area/shuttle/escape_pod1/centcom)
 					escaped_on_pod_1++
-				if(M.loc && M.loc.loc && M.loc.loc.type == /area/shuttle/escape_pod2/centcom)
+				if(mob_area.type == /area/shuttle/escape_pod2/centcom)
 					escaped_on_pod_2++
-				if(M.loc && M.loc.loc && M.loc.loc.type == /area/shuttle/escape_pod3/centcom)
+				if(mob_area.type == /area/shuttle/escape_pod3/centcom)
 					escaped_on_pod_3++
-				if(M.loc && M.loc.loc && M.loc.loc.type == /area/shuttle/escape_pod5/centcom)
+				if(mob_area.type == /area/shuttle/escape_pod5/centcom)
 					escaped_on_pod_5++
 
 			if(isobserver(M))
@@ -200,8 +201,10 @@ Implants;
 		feedback_set("survived_human",surviving_humans)
 	if(surviving_total > 0)
 		feedback_set("survived_total",surviving_total)
+		score["crew_survived"] = surviving_total
 	if(escaped_humans > 0)
 		feedback_set("escaped_human",escaped_humans)
+		score["crew_escaped"] = escaped_humans
 	if(escaped_total > 0)
 		feedback_set("escaped_total",escaped_total)
 	if(escaped_on_shuttle > 0)

--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -469,15 +469,15 @@
 //Announces the end of the game with all relavent information stated//
 //////////////////////////////////////////////////////////////////////
 /datum/game_mode/gang/declare_completion()
-	completion_text += "<B>Gang mode resume:</B><BR>"
+	completion_text += "<h3>Gang mode resume:</h3>"
 	if(!finished)
 		mode_result = "loss - gangs were not successful"
 		feedback_set_details("round_end_result",mode_result)
-		completion_text += "<FONT size=3 color=red><B>The station was [station_was_nuked ? "destroyed!" : "evacuated before either gang could claim it!"]</B></FONT>"
+		completion_text += "<span style='color: red; font-weight: bold;'>The station was [station_was_nuked ? "destroyed!" : "evacuated before either gang could claim it!"]</span>"
 	else
 		mode_result = "win - gang captured the station"
 		feedback_set_details("round_end_result",mode_result)
-		completion_text += "<FONT size=3 color=red><B>The [finished=="A" ? gang_name("A") : gang_name("B")] Gang successfully performed a hostile takeover of the station!!</B></FONT>"
+		completion_text += "<span style='color: red; font-weight: bold;'>The [finished=="A" ? gang_name("A") : gang_name("B")] Gang successfully performed a hostile takeover of the station!!</span>"
 		score["roleswon"]++
 	..()
 	return 1
@@ -496,22 +496,24 @@
 
 		if(A_bosses.len || A_gang.len)
 			if(winner)
-				text += "<BR><B>The [gang_name("A")] Gang was [winner=="A" ? "<font color=green>victorious</font>" : "<font color=red>defeated</font>"] with [round((A_territory.len/start_state.num_territories)*100, 1)]% control of the station!</B>"
-			text += "<BR><B>The [gang_name("A")] Gang Bosses were:</B>"
+				text += "<br><b>The [gang_name("A")] Gang was [winner=="A" ? "<span style='color: green;'>victorious</span>" : "<span style='color: red;'>defeated</span>"] with [round((A_territory.len/start_state.num_territories)*100, 1)]% control of the station!</b>"
+			text += "<br><b>The [gang_name("A")] Gang Bosses were:</b>"
 			text += gang_membership_report(A_bosses)
-			text += "<BR><B>The [gang_name("A")] Gangsters were:</B>"
+			text += "<br><b>The [gang_name("A")] Gangsters were:</b>"
 			text += gang_membership_report(A_gang)
-			text += "<BR>"
 
 		if(B_bosses.len || B_gang.len)
 			if(winner)
-				text += "<BR><B>The [gang_name("B")] Gang was [winner=="B" ? "<font color=green>victorious</font>" : "<font color=red>defeated</font>"] with [round((B_territory.len/start_state.num_territories)*100, 1)]% control of the station!</B>"
-			text += "<BR>The [gang_name("B")] Gang Bosses were:"
+				text += "<br><b>The [gang_name("B")] Gang was [winner=="B" ? "<font color=green>victorious</font>" : "<font color=red>defeated</font>"] with [round((B_territory.len/start_state.num_territories)*100, 1)]% control of the station!</b>"
+			text += "<br>The [gang_name("B")] Gang Bosses were:"
 			text += gang_membership_report(B_bosses)
-			text += "<BR>The [gang_name("B")] Gangsters were:"
+			text += "<br>The [gang_name("B")] Gangsters were:"
 			text += gang_membership_report(B_gang)
-			text += "<BR>"
-		text += "<HR>"
+	
+	if(text)
+		antagonists_completion += list(list("mode" = "gang", "html" = text))
+		text = "<div class='block'>[text]</div>"
+		
 	return text
 
 /datum/game_mode/proc/gang_membership_report(list/membership)
@@ -522,7 +524,7 @@
 			var/icon/flat = getFlatIcon(gangster.current,exact=1)
 			end_icons += flat
 			tempstate = end_icons.len
-			text += {"<BR><img src="logo_[tempstate].png"> <B>[gangster.key]</B> was <B>[gangster.name]</B> ("}
+			text += {"<br><img src="logo_[tempstate].png"> <b>[gangster.key]</b> was <b>[gangster.name]</b> ("}
 			if(gangster.current.stat == DEAD || isbrain(gangster.current))
 				text += "died"
 				flat.Turn(90)
@@ -532,12 +534,12 @@
 			else
 				text += "survived"
 			if(gangster.current.real_name != gangster.name)
-				text += " as <B>[gangster.current.real_name]</B>"
+				text += " as <b>[gangster.current.real_name]</b>"
 		else
 			var/icon/sprotch = icon('icons/effects/blood.dmi', "gibbearcore")
 			end_icons += sprotch
 			tempstate = end_icons.len
-			text += {"<BR><img src="logo_[tempstate].png"> [gangster.key] was [gangster.name] ("}
+			text += {"<br><img src="logo_[tempstate].png"> [gangster.key] was [gangster.name] ("}
 			text += "body destroyed"
 		text += ")"
 	return text

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -1,3 +1,5 @@
+//not used, look heist_old (wtf)
+
 /obj/effect/landmark/heist/aurora //used to locate shuttle.
 	name = "Aurora"
 	icon_state = "x3"
@@ -231,17 +233,17 @@
 	for(var/datum/objective/objective in raid_objectives)
 		if(objective.check_completion())
 			if(objective.target == "valuables")
-				completion_text += "<BR><B>Objective #[count]</B>: [objective.explanation_text] ([num2text(heist_rob_total,9)]/[num2text(objective.target_amount,9)]) <font color='green'><B>Success!</B></font>"
+				completion_text += "<BR><B>Objective #[count]</B>: [objective.explanation_text] ([num2text(heist_rob_total,9)]/[num2text(objective.target_amount,9)]) <span style='color: green; font-weight: bold;'>Success!</span>"
 				feedback_add_details("traitor_objective","[objective.type]|SUCCESS")
 			else
-				completion_text += "<BR><B>Objective #[count]</B>: [objective.explanation_text] <font color='green'><B>Success!</B></font>"
+				completion_text += "<BR><B>Objective #[count]</B>: [objective.explanation_text] <span style='color: green; font-weight: bold;'>Success!</span>"
 				feedback_add_details("traitor_objective","[objective.type]|SUCCESS")
 		else
 			if(objective.target == "valuables")
-				completion_text += "<BR><B>Objective #[count]</B>: [objective.explanation_text] ([num2text(heist_rob_total,9)]/[num2text(objective.target_amount,9)]) <font color='red'>Fail.</font>"
+				completion_text += "<BR><B>Objective #[count]</B>: [objective.explanation_text] ([num2text(heist_rob_total,9)]/[num2text(objective.target_amount,9)]) <span style='color: red; font-weight: bold;'>Fail.</span>"
 				feedback_add_details("traitor_objective","[objective.type]|FAIL")
 			else
-				completion_text += "<BR><B>Objective #[count]</B>: [objective.explanation_text] <font color='red'>Fail.</font>"
+				completion_text += "<BR><B>Objective #[count]</B>: [objective.explanation_text] <span style='color: red; font-weight: bold;'>Fail.</span>"
 				feedback_add_details("traitor_objective","[objective.type]|FAIL")
 		count++
 
@@ -300,7 +302,10 @@
 				text += "body destroyed"
 			text += ")"
 
-		text += "<BR><HR>"
+	if(text)
+		antagonists_completion += list(list("mode" = "heist", "html" = text))
+		text = "<div class='block'>[text]</div>"
+		
 	return text
 
 /datum/game_mode/heist/check_finished()

--- a/code/game/gamemodes/heist/heist_old.dm
+++ b/code/game/gamemodes/heist/heist_old.dm
@@ -211,7 +211,7 @@ VOX HEIST ROUNDTYPE
 	//No objectives, go straight to the feedback.
 	if(!(raid_objectives.len)) return ..()
 
-	completion_text += "<B>Heist mode resume:</B><BR>"
+	completion_text += "<h3>Heist mode resume:</h3>"
 
 	var/win_type = "Major"
 	var/win_group = "Crew"
@@ -239,7 +239,7 @@ VOX HEIST ROUNDTYPE
 
 		win_type = "Major"
 		win_group = "Crew"
-		completion_text += "<B>The Vox Raiders have been wiped out!</B>"
+		completion_text += "<b>The Vox Raiders have been wiped out!</b>"
 
 	else if(!is_raider_crew_safe())
 
@@ -247,7 +247,7 @@ VOX HEIST ROUNDTYPE
 			win_type = "Major"
 
 		win_group = "Crew"
-		win_msg += "<B>The Vox Raiders have left someone behind!</B>"
+		win_msg += "<b>The Vox Raiders have left someone behind!</b>"
 
 	else
 
@@ -255,21 +255,21 @@ VOX HEIST ROUNDTYPE
 			if(win_type == "Minor")
 
 				win_type = "Major"
-			win_msg += "<B>The Vox Raiders escaped the station!</B>"
+			win_msg += "<b>The Vox Raiders escaped the station!</b>"
 		else
-			win_msg += "<B>The Vox Raiders were repelled!</B>"
+			win_msg += "<b>The Vox Raiders were repelled!</b>"
 
-	completion_text += " <B>[win_type] [win_group] victory!</B>"
+	completion_text += " <b>[win_type] [win_group] victory!</b>"
 	completion_text += win_msg
 	feedback_set_details("round_end_result","heist - [win_type] [win_group]")
 
 	var/count = 1
 	for(var/datum/objective/objective in raid_objectives)
 		if(objective.check_completion())
-			completion_text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <font color='green'><B>Success!</B></font>"
+			completion_text += "<br><b>Objective #[count]</b>: [objective.explanation_text] <span style='color: green; font-weight: bold;'>Success!</span>"
 			feedback_add_details("traitor_objective","[objective.type]|SUCCESS")
 		else
-			completion_text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <font color='red'>Fail.</font>"
+			completion_text += "<br><b>Objective #[count]</b>: [objective.explanation_text] <span style='color: red; font-weight: bold;'>Fail.</span>"
 			feedback_add_details("traitor_objective","[objective.type]|FAIL")
 		count++
 

--- a/code/game/gamemodes/infestation/infestation.dm
+++ b/code/game/gamemodes/infestation/infestation.dm
@@ -135,15 +135,20 @@ Infestation:
 	if(xenomorphs.len)
 		if(check_xeno_queen())
 			if(check_xeno_queen() == 1)
-				text += "<font size=3 color=green><b>The Queen is alive!</FONT></b>"
+				text += "<span style='color: green; font-weight: bold;'>The Queen is alive!</span>"
 			if(check_xeno_queen() == 2)
-				text += "<span class='danger'><font size=3><b>The Queen has been killed!</b></FONT></span>"
+				text += "<span style='color: red; font-weight: bold;'>The Queen has been killed!</span>"
 		else
-			text += "<font size=3 color=blue><b>The Queen was never born.</FONT></b>"
+			text += "<span style='color: orange; font-weight: bold;'>The Queen was never born.</span>"
 		if(count_hive_power())
-			text += "<font size=3 color=green><b>There is [count_hive_power()] xenomorphs alive!</FONT></b>"
+			text += "<span style='color: green; font-weight: bold;'>There is [count_hive_power()] xenomorphs alive!</span>"
 		else
-			text += "<span class='danger'><font size=3><b>All xenomorphs were eradicated.</b></FONT></span>"
+			text += "<span style='color: red; font-weight: bold;'>All xenomorphs were eradicated.</span>"
 		if(count_hive_looses())
-			text += "<span class='danger'><font size=3><b>[count_hive_looses()] xenomorphs are dead.</b></FONT></span>"
+			text += "<span style='color: red; font-weight: bold;'>[count_hive_looses()] xenomorphs are dead.</span>"
+		
+	if(text)
+		antagonists_completion += list(list("mode" = "infestation", "html" = text))
+		text = "<div class='block'>[text]</div>"
+		
 	return text

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -206,51 +206,51 @@
 /datum/game_mode/malfunction/declare_completion()
 	var/malf_dead = is_malf_ai_dead()
 	var/crew_evacuated = (SSshuttle.location==2)
-	completion_text += "<B>Malfunction mode resume:</B><BR>"
+	completion_text += "<h3>Malfunction mode resume:</h3>"
 
 	if(station_captured &&						station_was_nuked)
 		mode_result = "win - AI win - nuke"
 		feedback_set_details("round_end_result",mode_result)
-		completion_text += "<FONT size = 3, color='red'><B>AI Victory!</B></FONT>"
-		completion_text += "<BR><B>Everyone was killed by the self-destruct!</B>"
+		completion_text += "<span style='color: red; font-weight: bold;'>AI Victory!</span>"
+		completion_text += "<br><b>Everyone was killed by the self-destruct!</b>"
 		score["roleswon"]++
 
 	else if(station_captured && malf_dead &&	!station_was_nuked)
 		mode_result = "halfwin - AI killed, staff lost control"
 		feedback_set_details("round_end_result",mode_result)
-		completion_text += "<FONT size = 3, color='red'><B>Neutral Victory.</B></FONT>"
-		completion_text += "<BR><B>The AI has been killed!</B> The staff has lose control over the station."
+		completion_text += "<span style='color: red; font-weight: bold;'>Neutral Victory.</span>"
+		completion_text += "<br><b>The AI has been killed!</b> The staff has lose control over the station."
 
 	else if(station_captured && !malf_dead &&	!station_was_nuked)
 		mode_result = "win - AI win - no explosion"
 		feedback_set_details("round_end_result",mode_result)
-		completion_text += "<FONT size = 3, color='red'><B>AI Victory!</B></FONT>"
-		completion_text += "<BR><B>The AI has chosen not to explode you all!</B>"
+		completion_text += "<span style='color: red; font-weight: bold;'>AI Victory!</span>"
+		completion_text += "<br><b>The AI has chosen not to explode you all!</b>"
 		score["roleswon"]++
 
 	else if(!station_captured && station_was_nuked)
 		mode_result = "halfwin - everyone killed by nuke"
 		feedback_set_details("round_end_result",mode_result)
-		completion_text += "<FONT size = 3, color='red'><B>Neutral Victory.</B></FONT>"
-		completion_text += "<BR><B>Everyone was killed by the nuclear blast!</B>"
+		completion_text += "<span style='color: red; font-weight: bold;'>Neutral Victory.</span>"
+		completion_text += "<br><b>Everyone was killed by the nuclear blast!</b>"
 
 	else if(!station_captured && malf_dead &&	!station_was_nuked)
 		mode_result = "loss - staff win"
 		feedback_set_details("round_end_result",mode_result)
-		completion_text += "<FONT size = 3, color='red'><B>Human Victory.</B></FONT>"
-		completion_text += "<BR><B>The AI has been killed!</B> The staff is victorious."
+		completion_text += "<span style='color: red; font-weight: bold;'>Human Victory.</span>"
+		completion_text += "<br><b>The AI has been killed!</b> The staff is victorious."
 
 	else if(!station_captured && !malf_dead &&	!station_was_nuked && crew_evacuated)
 		mode_result = "halfwin - evacuated"
 		feedback_set_details("round_end_result",mode_result)
-		completion_text += "<FONT size = 3, color='red'><B>Neutral Victory.</B></FONT>"
-		completion_text += "<BR><B>The Corporation has lose [station_name()]! All survived personnel will be fired!</B>"
+		completion_text += "<span style='color: red; font-weight: bold;'>Neutral Victory.</span>"
+		completion_text += "<br><b>The Corporation has lose [station_name()]! All survived personnel will be fired!</b>"
 
 	else if(!station_captured && !malf_dead &&	!station_was_nuked && !crew_evacuated)
 		mode_result = "nalfwin - interrupted"
 		feedback_set_details("round_end_result",mode_result)
-		completion_text += "<FONT size = 3, color='red'><B>Neutral Victory.</B></FONT>"
-		completion_text += "<BR><B>Round was mysteriously interrupted!</B>"
+		completion_text += "<span style='color: red; font-weight: bold;'>Neutral Victory.</span>"
+		completion_text += "<br><b>Round was mysteriously interrupted!</b>"
 	..()
 	return 1
 
@@ -258,7 +258,7 @@
 /datum/game_mode/proc/auto_declare_completion_malfunction()
 	var/text = ""
 	if( malf_ai.len || istype(ticker.mode,/datum/game_mode/malfunction) )
-		text += "<B>The malfunctioning AI were:</B>"
+		text += "<b>The malfunctioning AI were:</b>"
 
 		for(var/datum/mind/malf in malf_ai)
 
@@ -266,7 +266,7 @@
 				var/icon/flat = getFlatIcon(malf.current)
 				end_icons += flat
 				var/tempstate = end_icons.len
-				text += {"<BR><img src="logo_[tempstate].png"> <B>[malf.key]</B> was <b>[malf.name]</B> ("}
+				text += {"<br><img src="logo_[tempstate].png"> <b>[malf.key]</b> was <b>[malf.name]</b> ("}
 				if(malf.current.stat == DEAD)
 					text += "deactivated"
 				else
@@ -277,11 +277,14 @@
 				var/icon/sprotch = icon('icons/mob/robots.dmi', "gib7")
 				end_icons += sprotch
 				var/tempstate = end_icons.len
-				text += {"<BR><img src="logo_[tempstate].png"> <B>[malf.key]</B> was <b>[malf.name]</B> ("}
+				text += {"<br><img src="logo_[tempstate].png"> <b>[malf.key]</b> was <b>[malf.name]</b> ("}
 				text += "hardware destroyed"
 			text += ")"
 
-		text += "<BR><HR>"
+	if(text)
+		antagonists_completion += list(list("mode" = "malfunction", "html" = text))
+		text = "<div class='block'>[text]</div>"
+		
 	return text
 
 #undef INTERCEPT_APCS

--- a/code/game/gamemodes/meme/meme.dm
+++ b/code/game/gamemodes/meme/meme.dm
@@ -221,17 +221,17 @@
 		var/memewin = 1
 		var/attuned = 0
 		if((meme.current) && istype(meme.current,/mob/living/parasite/meme))
-			text += "The meme was <B>[meme.current.key]</B>.<BR>"
-			text += "The last host was <B>[meme.current:host.key]</B>.<BR>"
-			text += "<B>Hosts attuned:</B> [attuned]<BR>"
+			text += "The meme was <b>[meme.current.key]</b>.<br>"
+			text += "The last host was <b>[meme.current:host.key]</b>.<br>"
+			text += "<b>Hosts attuned:</b> [attuned]<br>"
 
 			var/count = 1
 			for(var/datum/objective/objective in meme.objectives)
 				if(objective.check_completion())
-					text += "<B>Objective #[count]</B>: [objective.explanation_text] <font color='green'><B>Success!</B></font><BR>"
+					text += "<b>Objective #[count]</b>: [objective.explanation_text] <span style='color: green; font-weight: bold;'>Success!</span><br>"
 					feedback_add_details("meme_objective","[objective.type]|SUCCESS")
 				else
-					text += "<B>Objective #[count]</B>: [objective.explanation_text] <font color='red'>Failed.</font><BR>"
+					text += "<b>Objective #[count]</b>: [objective.explanation_text] <span style='color: red; font-weight: bold;'>Failed.</span><br>"
 					feedback_add_details("meme_objective","[objective.type]|FAIL")
 					memewin = 0
 				count++
@@ -240,11 +240,15 @@
 			memewin = 0
 
 		if(memewin)
-			text += "<B>The meme was successful!</B>"
+			text += "<b>The meme was successful!</b>"
 			feedback_add_details("meme_success","SUCCESS")
 			score["roleswon"]++
 		else
-			text += "<B>The meme has failed!</B>"
+			text += "<b>The meme has failed!</b>"
 			feedback_add_details("meme_success","FAIL")
-		text += "<BR><HR>"
+
+	if(text)
+		antagonists_completion += list(list("mode" = "meme", "html" = text))
+		text = "<div class='block'>[text]</div>"
+		
 	return text

--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -36,25 +36,25 @@
 /datum/game_mode/meteor/declare_completion()
 	var/text = ""
 	var/survivors = 0
-	completion_text += "<B>Meteor mode resume:</B><BR>"
+	completion_text += "<h3>Meteor mode resume:</h3>"
 	for(var/mob/living/player in player_list)
 		if(player.stat != DEAD)
 			var/turf/location = get_turf(player.loc)
 			if(!location)	continue
 			switch(location.loc.type)
 				if( /area/shuttle/escape/centcom )
-					text += "<BR><b><font size=2>[player.real_name] escaped on the emergency shuttle</font></b>"
+					text += "<br><b>[player.real_name] escaped on the emergency shuttle</b>"
 				if( /area/shuttle/escape_pod1/centcom, /area/shuttle/escape_pod2/centcom, /area/shuttle/escape_pod3/centcom, /area/shuttle/escape_pod5/centcom )
-					text += "<BR><font size=2>[player.real_name] escaped in a life pod.</font>"
+					text += "<br>[player.real_name] escaped in a life pod."
 				else
-					text += "<BR><font size=1>[player.real_name] survived but is stranded without any hope of rescue.</font>"
+					text += "<br>[player.real_name] survived but is stranded without any hope of rescue."
 			survivors++
 
 	if(survivors)
-		completion_text += "<B>The following survived the meteor storm</B>:"
+		completion_text += "<b>The following survived the meteor storm</b>:"
 		completion_text += "[text]"
 	else
-		completion_text += "<font color='red'><B>Nobody survived the meteor storm!</B></font>"
+		completion_text += "<span style='color: red; font-weight: bold;'>Nobody survived the meteor storm!</span>"
 
 	mode_result = "end - evacuation"
 	feedback_set_details("round_end_result",mode_result)

--- a/code/game/gamemodes/mutiny/mutiny.dm
+++ b/code/game/gamemodes/mutiny/mutiny.dm
@@ -1,3 +1,5 @@
+//no declare_completion?
+
 #define MUTINY_RECRUITMENT_COOLDOWN 5
 
 /datum/game_mode/mutiny

--- a/code/game/gamemodes/ninja/ninja.dm
+++ b/code/game/gamemodes/ninja/ninja.dm
@@ -240,10 +240,10 @@
 				var/count = 1
 				for(var/datum/objective/objective in ninja.objectives)
 					if(objective.check_completion())
-						text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <font color='green'><B>Success!</B></font>"
+						text += "<br><b>Objective #[count]</b>: [objective.explanation_text] <span style='color: green; font-weight: bold;'>Success!</span>"
 						feedback_add_details("ninja_objective","[objective.type]|SUCCESS")
 					else
-						text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <font color='red'>Fail.</font>"
+						text += "<br><b>Objective #[count]</b>: [objective.explanation_text] <span style='color: red; font-weight: bold;'>Fail.</span>"
 						feedback_add_details("ninja_objective","[objective.type]|FAIL")
 						ninjawin = 0
 					count++
@@ -256,13 +256,15 @@
 
 			if(!config.objectives_disabled)
 				if(ninjawin)
-					text += "<br><font color='green'><B>The [special_role_text] was successful!</B></font>"
+					text += "<br><span style='color: green; font-weight: bold;'>The [special_role_text] was successful!</span>"
 					feedback_add_details("traitor_success","SUCCESS")
 					score["roleswon"]++
 				else
-					text += "<br><font color='red'><B>The [special_role_text] has failed!</B></font>"
+					text += "<br><span style='color: green; font-weight: bold;'>The [special_role_text] has failed!</span>"
 					feedback_add_details("traitor_success","FAIL")
 
-				text += "<BR>"
-		text += "<HR>"
+	if(text)
+		antagonists_completion += list(list("mode" = "ninja", "html" = text))
+		text = "<div class='block'>[text]</div>"
+		
 	return text

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -325,57 +325,57 @@
 	if      (!disk_rescued &&  station_was_nuked &&          !syndies_didnt_escape)
 		mode_result = "win - syndicate nuke"
 		feedback_set_details("round_end_result",mode_result)
-		completion_text += "<FONT size = 3, color='red'><B>Syndicate Major Victory!</B></FONT>"
-		completion_text += "<BR><B>Gorlex Maradeurs operatives have destroyed NSS Exodus!</B>"
+		completion_text += "<span style='font-color: red; font-weight: bold;'>Syndicate Major Victory!</span>"
+		completion_text += "<br><b>Gorlex Maradeurs operatives have destroyed NSS Exodus!</b>"
 		score["roleswon"]++
 
 	else if (!disk_rescued &&  station_was_nuked &&           syndies_didnt_escape)
 		mode_result = "halfwin - syndicate nuke - did not evacuate in time"
 		feedback_set_details("round_end_result",mode_result)
-		completion_text += "<FONT size = 3, color='red'><B>Total Annihilation</B></FONT>"
-		completion_text += "<BR><B>Gorlex Maradeurs operatives destroyed NSS Exodus but did not leave the area in time and got caught in the explosion.</B> Next time, don't lose the disk!"
+		completion_text += "<span style='font-color: red; font-weight: bold;'>Total Annihilation</span>"
+		completion_text += "<br><b>Gorlex Maradeurs operatives destroyed NSS Exodus but did not leave the area in time and got caught in the explosion.</b> Next time, don't lose the disk!"
 
 	else if (!disk_rescued && !station_was_nuked &&  nuke_off_station && !syndies_didnt_escape)
 		mode_result = "halfwin - blew wrong station"
 		feedback_set_details("round_end_result",mode_result)
-		completion_text += "<FONT size = 3, color='red'><B>Crew Minor Victory</B></FONT>"
-		completion_text += "<BR><B>Gorlex Maradeurs operatives secured the authentication disk but blew up something that wasn't NSS Exodus.</B> Next time, don't lose the disk!"
+		completion_text += "<span style='font-color: red; font-weight: bold;'>Crew Minor Victory</span>"
+		completion_text += "<br><b>Gorlex Maradeurs operatives secured the authentication disk but blew up something that wasn't NSS Exodus.</b> Next time, don't lose the disk!"
 
 	else if (!disk_rescued && !station_was_nuked &&  nuke_off_station &&  syndies_didnt_escape)
 		mode_result = "halfwin - blew wrong station - did not evacuate in time"
 		feedback_set_details("round_end_result",mode_result)
-		completion_text += "<FONT size = 3, color='red'><B>Gorlex Maradeurs operatives have earned Darwin Award!</B></FONT>"
-		completion_text += "<BR><B>Gorlex Maradeurs operatives blew up something that wasn't NSS Exodus and got caught in the explosion.</B> Next time, don't lose the disk!"
+		completion_text += "<span style='font-color: red; font-weight: bold;'>Gorlex Maradeurs span earned Darwin Award!</span>"
+		completion_text += "<br><b>Gorlex Maradeurs operatives blew up something that wasn't NSS Exodus and got caught in the explosion.</b> Next time, don't lose the disk!"
 
 	else if ( disk_rescued                                         && is_operatives_are_dead())
 		mode_result = "loss - evacuation - disk secured - syndi team dead"
 		feedback_set_details("round_end_result",mode_result)
-		completion_text += "<FONT size = 3, color='red'><B>Crew Major Victory!</B></FONT>"
-		completion_text += "<BR><B>The Research Staff has saved the disc and killed the Gorlex Maradeurs Operatives</B>"
+		completion_text += "<span style='font-color: red; font-weight: bold;'>Crew Major Victory!</span>"
+		completion_text += "<br><b>The Research Staff has saved the disc and killed the Gorlex Maradeurs Operatives</b>"
 
 	else if ( disk_rescued                                        )
 		mode_result = "loss - evacuation - disk secured"
 		feedback_set_details("round_end_result",mode_result)
-		completion_text += "<FONT size = 3, color='red'><B>Crew Major Victory</B></FONT>"
-		completion_text += "<BR><B>The Research Staff has saved the disc and stopped the Gorlex Maradeurs Operatives!</B>"
+		completion_text += "<span style='font-color: red; font-weight: bold;'>Crew Major Victory</span>"
+		completion_text += "<br><b>The Research Staff has saved the disc and stopped the Gorlex Maradeurs Operatives!</b>"
 
 	else if (!disk_rescued                                         && is_operatives_are_dead())
 		mode_result = "loss - evacuation - disk not secured"
 		feedback_set_details("round_end_result",mode_result)
-		completion_text += "<FONT size = 3, color='red'><B>Syndicate Minor Victory!</B></FONT>"
-		completion_text += "<BR><B>The Research Staff failed to secure the authentication disk but did manage to kill most of the Gorlex Maradeurs Operatives!</B>"
+		completion_text += "<span style='font-color: red; font-weight: bold;'>Syndicate Minor Victory!</span>"
+		completion_text += "<br><b>The Research Staff failed to secure the authentication disk but did manage to kill most of the Gorlex Maradeurs Operatives!</b>"
 
 	else if (!disk_rescued                                         &&  crew_evacuated)
 		mode_result = "halfwin - detonation averted"
 		feedback_set_details("round_end_result",mode_result)
-		completion_text += "<FONT size = 3, color='red'><B>Syndicate Minor Victory!</B></FONT>"
-		completion_text += "<BR><B>Gorlex Maradeurs operatives recovered the abandoned authentication disk but detonation of NSS Exodus was averted.</B> Next time, don't lose the disk!"
+		completion_text += "<span style='font-color: red; font-weight: bold;'>Syndicate Minor Victory!</span>"
+		completion_text += "<br><b>Gorlex Maradeurs operatives recovered the abandoned authentication disk but detonation of NSS Exodus was averted.</b> Next time, don't lose the disk!"
 
 	else if (!disk_rescued                                         && !crew_evacuated)
 		mode_result = "halfwin - interrupted"
 		feedback_set_details("round_end_result",mode_result)
-		completion_text += "<FONT size = 3, color='red'><B>Neutral Victory</B></FONT>"
-		completion_text += "<BR><B>Round was mysteriously interrupted!</B>"
+		completion_text += "<span style='font-color: red; font-weight: bold;'>Neutral Victory</span>"
+		completion_text += "<br><b>Round was mysteriously interrupted!</b>"
 
 	..()
 	return 1
@@ -391,12 +391,16 @@
 		var/obj/item/nuclear_uplink = src:nuclear_uplink
 		if(nuclear_uplink && nuclear_uplink.hidden_uplink)
 			if(nuclear_uplink.hidden_uplink.purchase_log.len)
-				text += "<BR><B>The tools used by the syndicate operatives were:</B> "
+				text += "<br><b>The tools used by the syndicate operatives were:</b> "
 				for(var/entry in nuclear_uplink.hidden_uplink.purchase_log)
-					text += "<BR>[entry]TC(s)"
+					text += "<br>[entry]TC(s)"
 			else
-				text += "<BR>The nukeops were smooth operators this round (did not purchase any uplink items)."
-		text += "<BR><HR>"
+				text += "<br>The nukeops were smooth operators this round (did not purchase any uplink items)."
+
+	if(text)
+		antagonists_completion += list(list("mode" = "nuclear", "html" = text))
+		text = "<div class='block'>[text]</div>"
+		
 	return text
 
 

--- a/code/game/gamemodes/revolution/anti_revolution.dm
+++ b/code/game/gamemodes/revolution/anti_revolution.dm
@@ -1,3 +1,5 @@
+//not used anymore
+
 // A sort of anti-revolution where the heads are given objectives to mess with the crew
 
 /datum/game_mode/anti_revolution
@@ -184,10 +186,10 @@
 			var/count = 1
 			for(var/datum/objective/objective in head_mind.objectives)
 				if(objective.check_completion())
-					text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <font color='green'><B>Success!</B></font>"
+					text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <span style='color: green; font-weight: bold;'>Success!</span>"
 					feedback_add_details("head_objective","[objective.type]|SUCCESS")
 				else
-					text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <font color='red'>Fail.</font>"
+					text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <span style='color: red; font-weight: bold;'>Fail.</span>"
 					feedback_add_details("head_objective","[objective.type]|FAIL")
 				count++
 		break // just print once

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -372,22 +372,22 @@
 //Announces the end of the game with all relavent information stated//
 //////////////////////////////////////////////////////////////////////
 /datum/game_mode/revolution/declare_completion()
-	completion_text += "<B>Revolution mode resume:</B><BR>"
+	completion_text += "<h3>Revolution mode resume:</h3>"
 	if(!config.objectives_disabled)
 		if(finished == 1)
 			mode_result = "win - heads killed"
 			feedback_set_details("round_end_result",mode_result)
-			completion_text += "<br><FONT size = 3, color='red'><B>The heads of staff were killed or exiled! The revolutionaries win!</B></FONT>"
+			completion_text += "<br><span style='color: red; font-weight: bold;'>The heads of staff were killed or exiled! The revolutionaries win!</span>"
 		else if(finished == 2)
 			mode_result = "loss - rev heads killed"
 			feedback_set_details("round_end_result",mode_result)
-			completion_text += "<br><FONT size = 3, color='red'><B>The heads of staff managed to stop the revolution!</B></FONT>"
+			completion_text += "<br><span style='color: red; font-weight: bold;'>The heads of staff managed to stop the revolution!</span>"
 	var/num_revs = 0
 	for(var/mob/living/carbon/mob in alive_mob_list)
 		if(mob.mind)
 			if(mob.mind in head_revolutionaries || mob.mind in revolutionaries)
 				num_revs++
-	completion_text += "<BR>[TAB]Command's Approval Rating: <B>[100 - round((num_revs/alive_mob_list.len)*100, 0.1)]%</B>" // % of loyal crew
+	completion_text += "<br>[TAB]Command's Approval Rating: <b>[100 - round((num_revs/alive_mob_list.len)*100, 0.1)]%</b>" // % of loyal crew
 	..()
 	return 1
 
@@ -403,7 +403,7 @@
 				var/icon/flat = getFlatIcon(headrev.current,exact=1)
 				end_icons += flat
 				var/tempstate = end_icons.len
-				text += {"<BR><img src="logo_[tempstate].png"> <B>[headrev.key]</B> was <B>[headrev.name]</B> ("}
+				text += {"<br><img src="logo_[tempstate].png"> <b>[headrev.key]</b> was <b>[headrev.name]</b> ("}
 				if(headrev.current.stat == DEAD)
 					text += "died"
 					flat.Turn(90)
@@ -418,36 +418,36 @@
 				var/icon/sprotch = icon('icons/effects/blood.dmi', "gibbearcore")
 				end_icons += sprotch
 				var/tempstate = end_icons.len
-				text += {"<BR><img src="logo_[tempstate].png"> <B>[headrev.key]</B> was <B>[headrev.name]</B> ("}
+				text += {"<br><img src="logo_[tempstate].png"> <b>[headrev.key]</b> was <b>[headrev.name]</b> ("}
 				text += "body destroyed"
 			text += ")"
 			if(headrev.total_TC)
 				if(headrev.spent_TC)
-					text += "<BR><B>TC Remaining:</B> [headrev.total_TC - headrev.spent_TC]/[headrev.total_TC]"
-					text += "<BR><B>The tools used by the Head Revolutionary were:</B>"
+					text += "<br><b>TC Remaining:</b> [headrev.total_TC - headrev.spent_TC]/[headrev.total_TC]"
+					text += "<br><b>The tools used by the Head Revolutionary were:</b>"
 					for(var/entry in headrev.uplink_items_bought)
-						text += "<BR>[entry]"
+						text += "<br>[entry]"
 				else
-					text += "<BR>The Head Revolutionary was a smooth operator this round (did not purchase any uplink items)."
+					text += "<br>The Head Revolutionary was a smooth operator this round (did not purchase any uplink items)."
 
 			for(var/datum/objective/mutiny/objective in headrev.objectives)
 				targets |= objective.target
 
 
 	if(revolutionaries.len || istype(ticker.mode,/datum/game_mode/revolution))
-		text += "<BR>"
+		text += "<br>"
 		text += printlogo("rev-logo", "head revolutionaries")
 		var/icon/logo2 = icon('icons/mob/mob.dmi', "rev-logo")
 		end_icons += logo2
 		var/tempstate = end_icons.len
-		text += {"<BR><img src="logo_[tempstate].png"> <B>The revolutionaries were:</B> <img src="logo_[tempstate].png">"}
+		text += {"<br><img src="logo_[tempstate].png"> <b>The revolutionaries were:</b> <img src="logo_[tempstate].png">"}
 
 		for(var/datum/mind/rev in revolutionaries)
 			if(rev.current)
 				var/icon/flat = getFlatIcon(rev.current,exact=1)
 				end_icons += flat
 				tempstate = end_icons.len
-				text += {"<BR><img src="logo_[tempstate].png"> <B>[rev.key]</B> was <B>[rev.name]</B> ("}
+				text += {"<br><img src="logo_[tempstate].png"> <b>[rev.key]</b> was <b>[rev.name]</b> ("}
 				if(rev.current.stat == DEAD || isbrain(rev.current))
 					text += "died"
 					flat.Turn(90)
@@ -462,25 +462,25 @@
 				var/icon/sprotch = icon('icons/effects/blood.dmi', "gibbearcore")
 				end_icons += sprotch
 				tempstate = end_icons.len
-				text += {"<BR><img src="logo_[tempstate].png"> <B>[rev.key]</B> was <B>[rev.name]</B> ("}
+				text += {"<br><img src="logo_[tempstate].png"> <b>[rev.key]</b> was <b>[rev.name]</b> ("}
 				text += "body destroyed"
 			text += ")"
 
 
-	text += "<BR>"
 	if( head_revolutionaries.len || revolutionaries.len || istype(ticker.mode,/datum/game_mode/revolution) )
+		text += "<br>"
 		text += printlogo("nano-logo", "heads of staff")
 
 		var/list/heads = get_all_heads()
 		for(var/datum/mind/head in heads)
 			var/target = (head in targets)
 			if(target)
-				text += "<FONT color='red'>"
+				text += "<span style='color: red'>"
 			if(head.current)
 				var/icon/flat = getFlatIcon(head.current,exact=1)
 				end_icons += flat
 				var/tempstate = end_icons.len
-				text += {"<BR><img src="logo_[tempstate].png"> <B>[head.key]</B> was <B>[head.name]</B> ("}
+				text += {"<br><img src="logo_[tempstate].png"> <b>[head.key]</b> was <b>[head.name]</b> ("}
 				if(head.current.stat == DEAD || isbrain(head.current))
 					text += "died"
 					flat.Turn(90)
@@ -495,11 +495,14 @@
 				var/icon/sprotch = icon('icons/effects/blood.dmi', "gibbearcore")
 				end_icons += sprotch
 				var/tempstate = end_icons.len
-				text += {"<BR><img src="logo_[tempstate].png"> <B>[head.key]</B> was <B>[head.name]</B> ("}
+				text += {"<br><img src="logo_[tempstate].png"> <b>[head.key]</b> was <b>[head.name]</b> ("}
 				text += "body destroyed"
 			text += ")"
 			if(target)
-				text += "</FONT>"
+				text += "</span>"
 
-		text += "<BR><HR>"
+	if(text)
+		antagonists_completion += list(list("mode" = "revolution", "html" = text))
+		text = "<div class='block'>[text]</div>"
+		
 	return text

--- a/code/game/gamemodes/revolution/rp_revolution.dm
+++ b/code/game/gamemodes/revolution/rp_revolution.dm
@@ -145,17 +145,17 @@
 //Announces the end of the game with all relavent information stated//
 //////////////////////////////////////////////////////////////////////
 /datum/game_mode/revolution/rp_revolution/declare_completion()
-	completion_text += "<B>RP-revolution mode resume:</B><BR>"
+	completion_text += "<h3>RP-revolution mode resume:</h3>"
 	if(!config.objectives_disabled)
 		if(finished == 1)
 			mode_result = "win - heads overthrown"
 			feedback_set_details("round_end_result",mode_result)
-			completion_text += "<FONT size=3, color='red'><B>The heads of staff were overthrown! The revolutionaries win!</B></FONT>"
+			completion_text += "<span style='color: red; font-weight: bold;'>The heads of staff were overthrown! The revolutionaries win!</span>"
 			score["traitorswon"]++
 		else if(finished == 2)
 			mode_result = "loss - revolution stopped"
 			feedback_set_details("round_end_result",mode_result)
-			completion_text += "<FONT size=3, color='red'><B>The heads of staff managed to stop the revolution!</B></FONT>"
+			completion_text += "<span style='color: red; font-weight: bold;'>The heads of staff managed to stop the revolution!</span>"
 	..()
 	return 1
 

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -1,6 +1,6 @@
 /datum/subsystem/ticker/proc/scoreboard(completions)
 	if(achievements.len)
-		completions += "<br>[achievement_declare_completion()]"
+		completions += "<div class='block'>[achievement_declare_completion()]</div>"
 
 	// Score Calculation and Display
 
@@ -246,9 +246,9 @@
 
 
 
-/mob/proc/scorestats(completions)
+/mob/proc/scorestats(completions)//omg why we count this for every player
 	var/dat = completions
-	dat += {"<BR><h2>Round Statistics and Score</h2>"}
+	dat += {"<h2>Round Statistics and Score</h2><div class='block'>"}
 	if (ticker.mode.name == "nuclear emergency")
 		var/foecount = 0
 		var/crewcount = 0
@@ -400,6 +400,7 @@
 		if(10000 to 49999) score["rating"] = "The Pride of Science Itself"
 		if(50000 to INFINITY) score["rating"] = "NanoTrasen's Finest"
 	dat += "<B><U>RATING:</U></B> [score["rating"]]"
+	dat += "</div>"
 	for(var/i in 1 to end_icons.len)
 		src << browse_rsc(end_icons[i],"logo_[i].png")
 
@@ -407,5 +408,8 @@
 		endgame_info_logged = 1
 		log_game(dat)
 
-	src << browse(entity_ja(dat), "window=roundstats;size=1000x600")
+	var/datum/browser/popup = new(src, "roundstats", "Round #[round_id] Stats", 1000, 600)
+	popup.set_content(dat)
+	popup.open()
+
 	return

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -8,13 +8,13 @@
 	for (var/mob/living/silicon/ai/I in ai_list)
 		if (I.stat == DEAD && I.z == ZLEVEL_STATION)
 			score["deadaipenalty"] = 1
-			score["deadcrew"] += 1
+			score["crew_dead"] += 1
 
 	for (var/mob/living/carbon/human/I in human_list)
 //		for (var/datum/ailment/disease/V in I.ailments)
 //			if (!V.vaccine && !V.spread != "Remissive") score["disease"]++
 		if (I.stat == DEAD && I.z == ZLEVEL_STATION)
-			score["deadcrew"] += 1
+			score["crew_dead"] += 1
 		if (I.job == "Clown")
 			for(var/thing in I.attack_log)
 				if(findtext(thing, "<font color='orange'>")) //</font>
@@ -22,11 +22,13 @@
 
 	var/area/escape_zone = locate(/area/shuttle/escape/centcom)
 
+/*
+	moved to /game_mode/proc/declare_completion, where we already count players
 	for(var/mob/living/player in alive_mob_list)
 		if (player.client)
 			var/turf/location = get_turf(player.loc)
 			if (location in escape_zone)
-				score["escapees"] += 1
+				score["crew_escaped"] += 1*/
 //					player.unlock_medal("100M Dash", 1)
 //				player.unlock_medal("Survivor", 1)
 //				for (var/obj/item/weapon/gnomechompski/G in player.get_contents())
@@ -167,10 +169,10 @@
 	// Bonus Modifiers
 	//var/traitorwins = score["traitorswon"]
 	var/rolesuccess = score["roleswon"] * 250
-	var/deathpoints = score["deadcrew"] * 250 //done
+	var/deathpoints = score["crew_dead"] * 250 //done
 	var/researchpoints = score["researchdone"] * 30
 	var/eventpoints = score["eventsendured"] * 50
-	var/escapoints = score["escapees"] * 25 //done
+	var/escapoints = score["crew_escaped"] * 25 //done
 	var/harvests = score["stuffharvested"] //done
 	var/shipping = score["stuffshipped"] * 75
 	var/mining = score["oremined"] //done
@@ -349,14 +351,14 @@
 	<B>Ore Mined:</B> [score["oremined"]] ([score["oremined"]] Points)<BR>
 	<B>Refreshments Prepared:</B> [score["meals"]] ([score["meals"] * 5] Points)<BR>
 	<B>Research Completed:</B> [score["researchdone"]] ([score["researchdone"] * 30] Points)<BR>"}
-	dat += "<B>Shuttle Escapees:</B> [score["escapees"]] ([score["escapees"] * 25] Points)<BR>"
+	dat += "<B>Shuttle Escapees:</B> [score["crew_escaped"]] ([score["crew_escaped"] * 25] Points)<BR>"
 	dat += {"<B>Random Events Endured:</B> [score["eventsendured"]] ([score["eventsendured"] * 50] Points)<BR>
 	<B>Whole Station Powered:</B> [score["powerbonus"] ? "Yes" : "No"] ([score["powerbonus"] * 2500] Points)<BR>
 	<B>Ultra-Clean Station:</B> [score["mess"] ? "No" : "Yes"] ([score["messbonus"] * 3000] Points)<BR><BR>
 	<U>THE BAD:</U><BR>
 	<B>Roles successful:</B> [score["roleswon"]] (-[score["roleswon"] * 250] Points)<BR>
 	<B>Antags reconverted:</B> [score["rec_antags"]] ([score["rec_antags"] * 500] Points)<BR>
-	<B>Dead Bodies on Station:</B> [score["deadcrew"]] (-[score["deadcrew"] * 250] Points)<BR>
+	<B>Dead Bodies on Station:</B> [score["crew_dead"]] (-[score["crew_dead"] * 250] Points)<BR>
 	<B>Uncleaned Messes:</B> [score["mess"]] (-[score["mess"]] Points)<BR>
 	<B>Station Power Issues:</B> [score["powerloss"]] (-[score["powerloss"] * 30] Points)<BR>
 	<B>Rampant Diseases:</B> [score["disease"]] (-[score["disease"] * 30] Points)<BR>
@@ -370,7 +372,7 @@
 		dat += "<B>Station Deficit:</B> [num2text(profit,50)]<BR>"
 	dat += {"<B>Food Eaten:</b> [score["foodeaten"]]<BR>
 	<B>Times a Clown was Abused:</B> [score["clownabuse"]]<BR><BR>"}
-	if (score["escapees"])
+	if (score["crew_escaped"])
 		dat += "<B>Most Richest Escapee:</B> [score["richestname"]], [score["richestjob"]]: [score["richestcash"]] credits ([score["richestkey"]])<BR>"
 		dat += "<B>Most Battered Escapee:</B> [score["dmgestname"]], [score["dmgestjob"]]: [score["dmgestdamage"]] damage ([score["dmgestkey"]])<BR>"
 	else

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -205,22 +205,22 @@ Made by Xhuis
 
 /datum/game_mode/shadowling/declare_completion()
 	//if(check_shadow_victory() && SSshuttle.emergency.mode >= SHUTTLE_ESCAPE) //Doesn't end instantly - this is hacky and I don't know of a better way ~X
-	completion_text += "<B>Shadowling mode resume:</B><BR>"
+	completion_text += "<h3>Shadowling mode resume:</h3>"
 	if(check_shadow_victory() && SSshuttle.location==2)
 		mode_result = "win - shadowlings ascended"
 		feedback_set_details("round_end_result",mode_result)
-		completion_text += "<font size=3, color=green><B>The shadowlings have ascended and taken over the station!</FONT></B>"
+		completion_text += "<span style='color: green; font-weight: bold;'>The shadowlings have ascended and taken over the station!</span>"
 		score["roleswon"]++
 	//else if(shadowling_dead && !check_shadow_victory()) //If the shadowlings have ascended, they can not lose the round
 	else if(check_shadow_killed() && !check_shadow_victory())
 		mode_result = "loss - shadowlings dead"
 		feedback_set_details("round_end_result",mode_result)
-		completion_text += "<font size=3, color=red><B>The shadowlings have been killed by the crew!</B></FONT>"
+		completion_text += "<span style='color: red; font-weight: bold;'>The shadowlings have been killed by the crew!</span>"
 	//else if(!check_shadow_victory() && SSshuttle.emergency.mode >= SHUTTLE_ESCAPE)
 	else if(!check_shadow_victory() && SSshuttle.location==2)
 		mode_result = "halfwin - evacuation"
 		feedback_set_details("round_end_result",mode_result)
-		completion_text += "<font size=3, color=red><B>The crew has escaped the station before the shadowlings could ascend!</B></FONT>"
+		completion_text += "<span style='color: red; font-weight: bold;'>The crew has escaped the station before the shadowlings could ascend!</span>"
 	..()
 	return 1
 
@@ -231,13 +231,17 @@ Made by Xhuis
 		text += printlogo("shadowling", "shadowlings")
 		for(var/datum/mind/shadow in shadows)
 			text += printplayerwithicon(shadow)
-		text += "<BR>"
+		text += "<br>"
 		if(thralls.len)
 			text += printlogo("thrall", "thralls")
 			for(var/datum/mind/thrall in thralls)
 				text += printplayerwithicon(thrall)
-			text += "<BR>"
-		text += "<HR>"
+			text += "<br>"
+
+	if(text)
+		antagonists_completion += list(list("mode" = "shadowling", "html" = text))
+		text = "<div class='block'>[text]</div>"
+		
 	return text
 
 /*

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -218,10 +218,10 @@
 				var/count = 1
 				for(var/datum/objective/objective in traitor.objectives)
 					if(objective.check_completion())
-						text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <font color='green'><B>Success!</B></font>"
+						text += "<br><b>Objective #[count]</b>: [objective.explanation_text] <span style='color: green; font-weight: bold;'>Success!</span>"
 						feedback_add_details("traitor_objective","[objective.type]|SUCCESS")
 					else
-						text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <font color='red'>Fail.</font>"
+						text += "<br><b>Objective #[count]</b>: [objective.explanation_text] <span style='color: red; font-weight: bold;'>Fail.</span>"
 						feedback_add_details("traitor_objective","[objective.type]|FAIL")
 						traitorwin = 0
 					count++
@@ -233,27 +233,31 @@
 				special_role_text = "antagonist"
 			if(!config.objectives_disabled)
 				if(traitorwin)
-					text += "<br><font color='green'><B>The [special_role_text] was successful!</B></font>"
+					text += "<br><span style='color: green; font-weight: bold;'>The [special_role_text] was successful!</span>"
 					feedback_add_details("traitor_success","SUCCESS")
 					score["roleswon"]++
 				else
-					text += "<br><font color='red'><B>The [special_role_text] has failed!</B></font>"
+					text += "<br><span style='color: red; font-weight: bold;'>The [special_role_text] has failed!</span>"
 					feedback_add_details("traitor_success","FAIL")
 
 			if(traitor.total_TC)
 				if(traitor.spent_TC)
-					text += "<BR><B>TC Remaining:</B> [traitor.total_TC - traitor.spent_TC]/[traitor.total_TC]"
-					text += "<BR><B>The tools used by the traitor were:</B>"
+					text += "<br><b>TC Remaining:</b> [traitor.total_TC - traitor.spent_TC]/[traitor.total_TC]"
+					text += "<br><b>The tools used by the traitor were:</b>"
 					for(var/entry in traitor.uplink_items_bought)
 						text += "<br>[entry]"
 				else
 					text += "<br>The traitor was a smooth operator this round (did not purchase any uplink items)."
-		text += "<BR><HR>"
+
 	if(ticker.reconverted_antags.len)
+		text += "<br><hr>"
 		for(var/reconverted in ticker.reconverted_antags)
 			text += printplayerwithicon(ticker.reconverted_antags[reconverted])
 			text += "<br> Has been deconverted, and is now a [pick("loyal", "effective", "nominal")] [pick("dog", "pig", "underdog", "servant")] of [pick("corporation", "NanoTrasen")]"
-		text += "<BR><HR>"
+	if(text)
+		antagonists_completion += list(list("mode" = "traitor", "html" = text))
+		text = "<div class='block'>[text]</div>"
+		
 	return text
 
 

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -209,13 +209,13 @@
 /datum/game_mode/wizard/declare_completion()
 	var/prefinal_text = ""
 	var/final_text = ""
-	completion_text += "<B>Wizard mode resume:</B><BR>"
+	completion_text += "<h3>Wizard mode resume:</h3>"
 
 	for(var/datum/mind/wizard in wizards)
 		if(wizard.current.stat == DEAD || finished)
 			mode_result = "loss - wizard killed"
 			feedback_set_details("round_end_result",mode_result)
-			prefinal_text = "<FONT size = 3>Wizard <b>[wizard.name]</b><i> ([wizard.key])</i> has been <font color='red'><b>killed</b></font> by the crew! The Space Wizards Federation has been taught a lesson they will not soon forget!</FONT><BR>"
+			prefinal_text = "<span>Wizard <b>[wizard.name]</b> <i>([wizard.key])</i> has been <span style='color: red; font-weight: bold;'>killed</span> by the crew! The Space Wizards Federation has been taught a lesson they will not soon forget!</span><br>"
 		else
 			var/failed = 0
 			for(var/datum/objective/objective in wizard.objectives)
@@ -224,11 +224,11 @@
 			if(!failed)
 				mode_result = "win - wizard alive"
 				feedback_set_details("round_end_result",mode_result)
-				prefinal_text = "<FONT size = 3>Wizard <b>[wizard.name]</b><i> ([wizard.key])</i> managed to <font color='green'><B>complete</B></font> his mission! The Space Wizards Federation understood that station crew - easy target and will use them next time.</FONT><BR>"
+				prefinal_text = "<span>Wizard <b>[wizard.name]</b> <i>([wizard.key])</i> managed to <span style='color: green; font-weight: bold;'>complete</span> his mission! The Space Wizards Federation understood that station crew - easy target and will use them next time.</span><br>"
 			else
 				mode_result = "loss - wizard alive"
 				feedback_set_details("round_end_result",mode_result)
-				prefinal_text = "<FONT size = 3>Wizard <b>[wizard.name]</b><i> ([wizard.key])</i> managed to stay alive, but <font color='red'><B>failed</B></font> his mission! The Space Wizards Federation wouldn't forget this shame!</FONT><BR>"
+				prefinal_text = "<span>Wizard <b>[wizard.name]</b><i> ([wizard.key])</i> managed to stay alive, but <span style='color: red; font-weight: bold;'>failed</span> his mission! The Space Wizards Federation wouldn't forget this shame!</span><br>"
 		final_text += "[prefinal_text]"
 
 	completion_text += "[final_text]"
@@ -249,34 +249,38 @@
 			if(!config.objectives_disabled)
 				for(var/datum/objective/objective in wizard.objectives)
 					if(objective.check_completion())
-						text += "<BR><B>Objective #[count]</B>: [objective.explanation_text] <font color='green'><B>Success!</B></font>"
+						text += "<br><b>Objective #[count]</b>: [objective.explanation_text] <span style='color: green; font-weight: bold;'>Success!</span>"
 						feedback_add_details("wizard_objective","[objective.type]|SUCCESS")
 					else
-						text += "<BR><B>Objective #[count]</B>: [objective.explanation_text] <font color='red'>Fail.</font>"
+						text += "<br><b>Objective #[count]</b>: [objective.explanation_text] <span style='color: red; font-weight: bold;'>Fail.</span>"
 						feedback_add_details("wizard_objective","[objective.type]|FAIL")
 						wizardwin = 0
 					count++
 
 				if(wizard.current && wizard.current.stat!=2 && wizardwin)
-					text += "<BR><FONT color='green'><B>The wizard was successful!</B></FONT>"
+					text += "<br><FONT color='green'><b>The wizard was successful!</b></FONT>"
 					feedback_add_details("wizard_success","SUCCESS")
 					score["roleswon"]++
 				else
-					text += "<BR><FONT color='red'><B>The wizard has failed!</B></FONT>"
+					text += "<br><FONT color='red'><b>The wizard has failed!</b></FONT>"
 					feedback_add_details("wizard_success","FAIL")
 				if(wizard.current && wizard.current.spell_list)
-					text += "<BR><B>[wizard.name] used the following spells: </B>"
+					text += "<br><b>[wizard.name] used the following spells: </b>"
 					var/i = 1
 					for(var/obj/effect/proc_holder/spell/S in wizard.current.spell_list)
 						var/icon/spellicon = icon('icons/mob/actions.dmi', S.action_icon_state)
 						end_icons += spellicon
 						var/tempstate = end_icons.len
-						text += {"<BR><img src="logo_[tempstate].png"> [S.name]"}
+						text += {"<br><img src="logo_[tempstate].png"> [S.name]"}
 						if(wizard.current.spell_list.len > i)
 							text += ", "
 						i++
-				text += "<BR>"
-		text += "<HR>"
+				text += "<br>"
+
+	if(text)
+		antagonists_completion += list(list("mode" = "wizard", "html" = text))
+		text = "<div class='block'>[text]</div>"
+		
 	return text
 
 //OTHER PROCS

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -45,7 +45,10 @@
 	var/obj/item/weapon/implant/mindshield/loyalty/L = new(H)
 	L.inject(H)
 	START_PROCESSING(SSobj, L)
-	to_chat(world, "<b>[H.real_name] is the captain!</b>")
+	to_chat(world, "<b>[H.real_name] is the captain!</b>")//maybe should be announcment, not OOC notification?
+	
+	score["captain"].Add(H.real_name)
+
 	return TRUE
 
 /datum/job/captain/get_access()

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -410,7 +410,7 @@ What a mess.*/
 				screen = 3
 
 		if("New Record (General)")
-			active1 = CreateGeneralRecord()
+			active1 = CreateGeneralRecord() // todo: datacore.manifest_inject or scaner (Identity Analyser)
 			active2 = null
 
 //FIELD FUNCTIONS

--- a/code/game/machinery/computer/skills.dm
+++ b/code/game/machinery/computer/skills.dm
@@ -308,7 +308,7 @@ What a mess.*/
 		if ("New Record (General)")
 			if(PDA_Manifest.len)
 				PDA_Manifest.Cut()
-			active1 = CreateGeneralRecord()
+			active1 = CreateGeneralRecord() // todo: datacore.manifest_inject or scaner (Identity Analyser)
 
 //FIELD FUNCTIONS
 		if ("Edit Field")

--- a/code/game/machinery/fax.dm
+++ b/code/game/machinery/fax.dm
@@ -194,12 +194,15 @@ var/list/alldepartments = list("Central Command")
 		to_chat(C, msg)
 
 	send_fax(sender, P, "Central Command")
+
+	add_communication_log(type = "fax-station", author = sender.name, content = P.info + "\n" + P.stamp_text)
+
 	world.send2bridge(
 		type = list(BRIDGE_ADMINCOM),
 		attachment_title = ":fax: **[key_name(sender)]** sent fax to ***Centcomm***",
 		attachment_msg = P.info + P.stamp_text,
 		attachment_color = BRIDGE_COLOR_ADMINCOM,
-	)	
+	)
 
 /proc/send_fax(mob/sender, obj/item/weapon/paper/P, department)
 	for(var/obj/machinery/faxmachine/F in allfaxes)

--- a/code/game/machinery/records_scanner.dm
+++ b/code/game/machinery/records_scanner.dm
@@ -37,6 +37,7 @@
 		icon_state = "scanner_idle"
 		stat &= ~NOPOWER
 
+//todo: rewrite to datacore.manifest_inject ?
 /obj/machinery/scanner/attack_hand(mob/living/carbon/human/user)
 	. = ..()
 	if(.)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -694,7 +694,7 @@ proc/message_admins(msg, reg_flag = R_ADMIN)
 	set desc="Restarts the world"
 	if (!usr.client.holder)
 		return
-	var/confirm = alert("Restart the game world?", "Restart", "Yes", "Cancel")
+	var/confirm = alert("Restart the game world? Warning: game stats will be lost if round not ended.", "Restart", "Yes", "Cancel")
 	if(confirm == "Cancel")
 		return
 	if(confirm == "Yes")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -965,7 +965,7 @@ var/list/admin_verbs_hideable = list(
 
 	to_chat(winner, "<span class='danger'>Congratulations!</span>")
 
-	achievements += "<b>[winner.key]</b> as <b>[winner.name]</b> won \"<b>[name]</b>\"! \"[desc]\""
+	achievements += list(list("key" = winner.key, "name" = winner.name, "title" = name, "desc" = desc))
 
 /client/proc/aooc()
 	set category = "Admin"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1732,6 +1732,8 @@
 
 		send_fax(usr, P, "All")
 
+		add_communication_log(type = "fax-centcomm", title = customname ? customname : 0, author = "Centcomm Officer", content = input)
+
 		to_chat(src.owner, "Message reply to transmitted successfully.")
 		log_admin("[key_name(src.owner)] replied to a fax message from [key_name(H)]: [input]")
 		message_admins("[key_name_admin(src.owner)] replied to a fax message from [key_name_admin(H)]")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1106,6 +1106,8 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 	send_fax(usr, P, department)
 
+	add_communication_log(type = "fax-centcomm", title = sent_name, author = "Centcomm Officer", content = P.info + "\n" + P.stamp_text)
+
 	feedback_add_details("admin_verb","FAXMESS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	message_admins("Fax message was created by [key_name_admin(usr)] and sent to [department]")
 	world.send2bridge(

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -121,7 +121,7 @@
 	to_chat(O, "<B>To look at other parts of the station, click on yourself to get a camera menu.</B>")
 	to_chat(O, "<B>While observing through a camera, you can use most (networked) devices which you can see, such as computers, APCs, intercoms, doors, etc.</B>")
 	to_chat(O, "To use something, simply click on it.")
-	to_chat(O, {"Use say ":b to speak to your cyborgs through binary."})
+	to_chat(O, "Use say \":b to speak to your cyborgs through binary.")
 	if (!(ticker && ticker.mode && (O.mind in ticker.mode.malf_ai)))
 		O.show_laws()
 		to_chat(O, "<b>These laws may be changed by other players, or by you being the traitor.</b>")

--- a/code/modules/security levels/security levels.dm
+++ b/code/modules/security levels/security levels.dm
@@ -17,7 +17,7 @@
 		switch(level)
 			if(SEC_LEVEL_GREEN)
 				security_level = SEC_LEVEL_GREEN
-				station_announce(config.alert_desc_green, subtitle = "Attention! Security level lowered to green", sound = "downtogreen")
+				captain_announce(config.alert_desc_green, title = null, subtitle = "Attention! Security level lowered to green", sound = "downtogreen")
 
 				for(var/obj/machinery/firealarm/FA in firealarm_list)
 					if(FA.z == ZLEVEL_STATION || FA.z == ZLEVEL_ASTEROID)
@@ -25,9 +25,9 @@
 						FA.overlays += image('icons/obj/monitors.dmi', "overlay_green")
 			if(SEC_LEVEL_BLUE)
 				if(security_level < SEC_LEVEL_BLUE)
-					station_announce(config.alert_desc_blue_upto, subtitle = "Attention! Security level elevated to blue", sound = "blue")
+					captain_announce(config.alert_desc_blue_upto, title = null, subtitle = "Attention! Security level elevated to blue", sound = "blue")
 				else
-					station_announce(config.alert_desc_blue_downto, subtitle = "Attention! Security level lowered to blue", sound = "downtoblue")
+					captain_announce(config.alert_desc_blue_downto, title = null, subtitle = "Attention! Security level lowered to blue", sound = "downtoblue")
 				security_level = SEC_LEVEL_BLUE
 				for(var/obj/machinery/firealarm/FA in firealarm_list)
 					if(FA.z == ZLEVEL_STATION || FA.z == ZLEVEL_ASTEROID)
@@ -35,9 +35,9 @@
 						FA.overlays += image('icons/obj/monitors.dmi', "overlay_blue")
 			if(SEC_LEVEL_RED)
 				if(security_level < SEC_LEVEL_RED)
-					station_announce(config.alert_desc_red_upto, subtitle = "Attention! Code red!", sound = "red")
+					captain_announce(config.alert_desc_red_upto, title = null, subtitle = "Attention! Code red!", sound = "red")
 				else
-					station_announce(config.alert_desc_red_downto, "Attention! Code red!", sound = "downtored")
+					captain_announce(config.alert_desc_red_downto, "Attention! Code red!", sound = "downtored")
 				security_level = SEC_LEVEL_RED
 
 				var/obj/machinery/computer/communications/CC = locate() in communications_list
@@ -51,7 +51,7 @@
 
 			if(SEC_LEVEL_DELTA)
 				security_level = SEC_LEVEL_DELTA
-				station_announce(config.alert_desc_delta, subtitle = "Attention! Delta security level reached!", sound = "delta")
+				captain_announce(config.alert_desc_delta, title = null, subtitle = "Attention! Delta security level reached!", sound = "delta")
 				for(var/obj/machinery/firealarm/FA in firealarm_list)
 					if(FA.z == ZLEVEL_STATION || FA.z == ZLEVEL_ASTEROID)
 						FA.overlays = list()


### PR DESCRIPTION
## Описание изменений

* Подготовка к хабу, сбор статистики по раунду:
  * Отчеты
  * Антагонисты
  * Счет и прочие метрики
* Попап по окончанию раунда переведён на датум, местами причесана верстка (так как тот же код будет выводится на сайте, пришлось уделить внимание)

Зависим от #3512

## Чеинжлог

:cl:
 - rscadd: По каждому раунду теперь сохраняется основная статистика: антагонисты, анонсы, отчеты и факсы, финальный счет смены. В будущем по каждому раунду информацию можно будет просмотреть у нас сайте, и наконец то ваши факсы хоть кто-то будет читать.
 - rscadd: Переверстано окно со статистикой по окончанию раунда.

На правах рекламы: мне бы не помешала помощь опытных пхп-погромистов.