### PR TITLE
Нерф соча и фикс бага связанного с перезарядкой посохов

### DIFF
--- a/code/modules/projectiles/guns/magic.dm
+++ b/code/modules/projectiles/guns/magic.dm
@@ -35,11 +35,15 @@
 		return FALSE
 	return TRUE
 
+/obj/item/weapon/gun/magic/examine(mob/user)
+	..()
+	to_chat(user, "The [name] has [charges] charges.")
+
 /obj/item/weapon/gun/magic/proc/newshot()
 	if (charges && chambered)
 		chambered.newshot()
 		charges--
-	return
+		charge_tick = 0
 
 /obj/item/weapon/gun/magic/atom_init()
 	. = ..()

--- a/code/modules/projectiles/guns/magic/staff.dm
+++ b/code/modules/projectiles/guns/magic/staff.dm
@@ -10,6 +10,7 @@
 	icon_state = "staffofchange"
 	item_state = "staffofchange"
 	fire_delay = 30
+	max_charges = 1
 
 /obj/item/weapon/gun/magic/staff/animate
 	name = "staff of animation"


### PR DESCRIPTION
## Описание изменений
* Добавил в экзамайн посохов количество текущих зарядов
* Уменьшил количество зарядов в соче до 1
* Пофиксил баг в результате которого переменная `charge_tick` как бы стакалась. Это приводило к том, что после выстрела в посох накидывался ещё один заряд практически моментально. Таким образом, если маг долго не стрелял из посоха, то он мог выстрелить очередь из `max_charges + 1` зарядов.

## Почему и что этот ПР улучшит
Нерф должен помочь слегка уменьшить грифозность и накал страстей в раунде с магом, выбравшем соч

## Чеинжлог
:cl:
 - tweak: При экзамайне магические посохи покажут количество зарядов внутри них.
 - bugfix: Если маг некоторое время не использовал посох (это касается всех видов), то можно было выстрелить двумя зарядами практически без кд. Таким образом появлялся халявный заряд, который не зависел от максимального количества зарядов в посохе.
- balance: Нерф посоха изменений: максимальное количество зарядов уменьшено с 3 до 1.
