### PR TITLE
Decoy AI removed from silicon_list, they should not affect round end statistics

### DIFF
--- a/code/modules/mob/living/silicon/decoy/decoy.dm
+++ b/code/modules/mob/living/silicon/decoy/decoy.dm
@@ -4,3 +4,7 @@
 	icon_state = "ai"
 	anchored = 1 // -- TLE
 	canmove = 0
+
+/mob/living/silicon/decoy/atom_init()
+	. = ..()
+	silicon_list -= src //because fake ai break round end statistics


### PR DESCRIPTION
## Описание изменений

В конце раунда при выводе законов синтетиков мы сверяемся с ``silicon_list``, есть ли они у нас: 

https://github.com/TauCetiStation/TauCetiClassic/blob/14d59b8ea8cfba088dccf3970c861854f3affbb2/code/controllers/subsystem/ticker.dm#L429-L434

Но так получилось, что на слое цк есть два не вполне настоящих ИИ, и список поэтому никогда не пуст.

Я всё еще не уверен, что это хороший способ пофиксить проблему, но сейчас ничего не должно сломаться.

## Почему и что этот ПР улучшит

Больше никаких пустых "Silicons Laws" в попапе в конце раунда.