### PR TITLE
Fix the problem with early 'dp_vent_pump/update_icon' call from mapload initialization

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -12,7 +12,10 @@
 	var/dirt = 0
 
 /turf/simulated/atom_init()
-	. = ..()
+	..()
+	return INITIALIZE_HINT_LATELOAD
+
+/turf/simulated/atom_init_late()
 	levelupdate()
 
 /turf/simulated/proc/AddTracks(mob/M,bloodDNA,comingdir,goingdir, blooddatum = null)


### PR DESCRIPTION
## Описание изменений

Если грузить карту маплоадом, то там какие-то гонки с инициализацией труб и может много рантаймить. Сами рантаймы уже потерял.