### PR TITLE
Status display fixes

### DIFF
--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -54,6 +54,8 @@ var/datum/subsystem/shuttle/SSshuttle
 		//pod stuff
 	var/list/pod_station_area
 
+	var/status_display_last_mode
+
 	//var/datum/round_event/shuttle_loan/shuttle_loan
 
 /datum/subsystem/shuttle/New()
@@ -626,6 +628,11 @@ var/datum/subsystem/shuttle/SSshuttle
 /datum/subsystem/shuttle/proc/incall(coeff = 1)
 	if(deny_shuttle && alert == 1) //crew transfer shuttle does not gets recalled by gamemode
 		return
+	var/obj/machinery/status_display/S = status_display_list[1]
+	status_display_last_mode = S.mode
+	for(var/obj/machinery/status_display/Screen in status_display_list)
+		Screen.mode = 1
+		Screen.update()
 	if(endtime)
 		if(direction == -1)
 			setdirection(1)
@@ -634,6 +641,7 @@ var/datum/subsystem/shuttle/SSshuttle
 		online = 1
 		if(always_fake_recall)
 			fake_recall = rand(300,500)		//turning on the red lights in hallways
+
 
 /datum/subsystem/shuttle/proc/get_shuttle_arrive_time()
 	// During mutiny rounds, the shuttle takes twice as long.
@@ -648,12 +656,18 @@ var/datum/subsystem/shuttle/SSshuttle
 /datum/subsystem/shuttle/proc/recall()
 	if(direction == 1)
 		var/timeleft = timeleft()
+		for(var/obj/machinery/status_display/Screen in status_display_list)
+			if(Screen.mode == 1) 	// we don't need to change the mode if the mode is already non-shuttle-ETA
+				Screen.mode = status_display_last_mode
+				Screen.update()
+
 		if(alert == 0)
 			if(timeleft >= get_shuttle_arrive_time())
 				return
 			captain_announce("The emergency shuttle has been recalled.", sound = "emer_shut_recalled")
 			setdirection(-1)
 			online = 1
+
 			return
 		else //makes it possible to send shuttle back.
 			captain_announce("The shuttle has been recalled.", sound = "crew_shut_recalled")

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -207,6 +207,8 @@
 					post_status("message", stat_msg1, stat_msg2)
 				if("alert")
 					post_status("alert", href_list["alert"])
+				if("default")
+					post_status("default")
 				else
 					post_status(href_list["statdisp"])
 
@@ -371,12 +373,12 @@
 		if(STATE_STATUSDISPLAY)
 			dat += "Set Status Displays<BR>"
 			dat += "\[ <A HREF='?src=\ref[src];operation=setstat;statdisp=blank'>Clear</A> \]<BR>"
+			dat += "\[ <A HREF='?src=\ref[src];operation=setstat;statdisp=default'>Default</A> \]<BR>"
 			dat += "\[ <A HREF='?src=\ref[src];operation=setstat;statdisp=shuttle'>Shuttle ETA</A> \]<BR>"
 			dat += "\[ <A HREF='?src=\ref[src];operation=setstat;statdisp=message'>Message</A> \]"
 			dat += "<ul><li> Line 1: <A HREF='?src=\ref[src];operation=setmsg1'>[ stat_msg1 ? stat_msg1 : "(none)"]</A>"
 			dat += "<li> Line 2: <A HREF='?src=\ref[src];operation=setmsg2'>[ stat_msg2 ? stat_msg2 : "(none)"]</A></ul><br>"
-			dat += "\[ Alert: <A HREF='?src=\ref[src];operation=setstat;statdisp=alert;alert=default'>None</A> |"
-			dat += " <A HREF='?src=\ref[src];operation=setstat;statdisp=alert;alert=redalert'>Red Alert</A> |"
+			dat += " \[ Alert: <A HREF='?src=\ref[src];operation=setstat;statdisp=alert;alert=redalert'>Red Alert</A> |"
 			dat += " <A HREF='?src=\ref[src];operation=setstat;statdisp=alert;alert=lockdown'>Lockdown</A> |"
 			dat += " <A HREF='?src=\ref[src];operation=setstat;statdisp=alert;alert=biohazard'>Biohazard</A> \]<BR><HR>"
 		if(STATE_ALERT_LEVEL)

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -19,11 +19,12 @@
 	density = 0
 	use_power = 1
 	idle_power_usage = 10
-	var/mode = 1	// 0 = Blank
+	var/mode = 5	// 0 = Blank
 					// 1 = Shuttle timer
 					// 2 = Arbitrary message(s)
 					// 3 = alert picture
 					// 4 = Supply shuttle timer
+					// 5 = default N picture
 
 	var/picture_state	// icon_state of alert picture
 	var/message1 = ""	// message line 1
@@ -46,6 +47,8 @@
 	. = ..()
 	status_display_list += src
 	radio_controller.add_object(src, frequency)
+	update()
+
 
 /obj/machinery/status_display/Destroy()
 	status_display_list -= src
@@ -130,6 +133,8 @@
 				else
 					line1 = ""
 			update_display(line1, line2)
+		if(5)				// default picture
+			set_picture("default")
 
 /obj/machinery/status_display/examine(mob/user)
 	..()
@@ -204,6 +209,10 @@
 		if("supply")
 			if(supply_display)
 				mode = 4
+
+		if("default")
+			mode = 5
+
 
 	update()
 

--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -511,7 +511,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                 <b> ALERT!</b>:
             </div>
             <div class="itemContent">
-                {{:helper.link('None', 'alert', {'cartmenu' : "1", 'choice' : "Status",'statdisp' : "alert", 'alert' : "default"}, null, null)}}
+                {{:helper.link('Default', 'gear', {'cartmenu' : "1", 'choice' : "Status",'statdisp' : "default"}, null, null)}}
                 {{:helper.link('Red Alert', 'alert', {'cartmenu' : "1", 'choice' : "Status",'statdisp' : "alert", 'alert' : "redalert"}, null, null)}}
                 {{:helper.link('Lockdown', 'caution', {'cartmenu' : "1", 'choice' : "Status",'statdisp' : "alert", 'alert' : "lockdown"}, null, null)}}
                 {{:helper.link('Biohazard', 'radiation', {'cartmenu' : "1", 'choice' : "Status",'statdisp' : "alert", 'alert' : "biohazard"}, null, null)}}


### PR DESCRIPTION
<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений

Теперь со старта раунда статус дисплеи показывают не несуществующий ETA шаттла, а дефолтную заставку НТ.
Когда шаттл вызывается, дисплеи показывают его ETA.
Когда отзывается, возвращается то, что было до вызова шаттла на дисплеях.

:cl:
 - tweak: Несколько поправок в работе статус дисплеев (поведение при вызове шаттла etc.)

