### PR TITLE
[DNM] quick lazy hack for play server sound

### DIFF
--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -5,8 +5,15 @@ var/global/list/sounds_cache = list()
 	set name = "Play Global Sound"
 	if(!check_rights(R_SOUNDS))	return
 
-	var/sound/uploaded_sound = new()//sound(S, repeat = 0, wait = 1, channel = CHANNEL_ADMIN)
-	uploaded_sound.file = S
+	var/sound/uploaded_sound
+
+	if(istext(S))
+		//we need 'path' type for .file field, but seems like text2path not working with sounds, and this is the only way...
+		uploaded_sound = new(S) 
+	else
+		uploaded_sound = new()
+		uploaded_sound.file = S
+
 	uploaded_sound.priority = 250
 	uploaded_sound.channel = CHANNEL_ADMIN
 	uploaded_sound.wait = 1


### PR DESCRIPTION
## Описание изменений

Пример, для работы play server sound.

Тут есть какая-то проблема со стороны бьенда, и
* Либо text2path должен работать с любыми файлами (сейчас он не конвертит "текстовый" путь к звуку в настоящий 'путь')
* Либо S.file должен принимать в качестве значения не только файл, но и текстовый путь, для консистентности работы с конструктором new()

UPD: возможно, что решением является использование ``file()``