### PR TITLE
Изменения баланса дробовиков. 

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -198,8 +198,8 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 					/obj/item/clothing/suit/storage/flak/bulletproof,
 					/obj/item/clothing/head/helmet/bulletproof,
 					/obj/item/clothing/head/helmet/bulletproof,
-					/obj/item/weapon/gun/projectile/shotgun/combat,
-					/obj/item/weapon/gun/projectile/shotgun/combat)
+					/obj/item/weapon/gun/projectile/shotgun,
+					/obj/item/weapon/gun/projectile/shotgun)
 	cost = 5000
 	crate_type = /obj/structure/closet/crate/secure
 	crate_name = "Ballistic gear crate"

--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -41,7 +41,7 @@
 	desc = "Oh god, this shouldn't be here!"
 	ammo_type = /obj/item/ammo_casing/shotgun/beanbag
 	caliber = "shotgun"
-	max_ammo = 4
+	max_ammo = 3
 	multiload = 0
 
 /obj/item/ammo_box/magazine/internal/heavyrifle
@@ -65,7 +65,7 @@
 	desc = "Oh god, this shouldn't be here!"
 	ammo_type = /obj/item/ammo_casing/shotgun/buckshot
 	caliber = "shotgun"
-	max_ammo = 8
+	max_ammo = 5
 	multiload = 0
 
 /obj/item/ammo_box/magazine/internal/cylinder/dualshot

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -1,7 +1,7 @@
 /obj/item/projectile/bullet
 	name = "bullet"
 	icon_state = "bullet"
-	damage = 60
+	damage = 40
 	damage_type = BRUTE
 	nodamage = 0
 	flag = "bullet"
@@ -26,11 +26,11 @@
 
 /obj/item/projectile/bullet/pellet
 	name = "pellet"
-	damage = 20
+	damage = 9
 
 /obj/item/projectile/bullet/weakbullet/beanbag		//because beanbags are not bullets
 	name = "beanbag"
-	agony = 95
+	agony = 50
 
 /obj/item/projectile/bullet/weakbullet/rubber
 	name = "rubber bullet"

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -1,7 +1,7 @@
 /obj/item/projectile/bullet
 	name = "bullet"
 	icon_state = "bullet"
-	damage = 40
+	damage = 45
 	damage_type = BRUTE
 	nodamage = 0
 	flag = "bullet"
@@ -26,11 +26,11 @@
 
 /obj/item/projectile/bullet/pellet
 	name = "pellet"
-	damage = 9
+	damage = 12
 
 /obj/item/projectile/bullet/weakbullet/beanbag		//because beanbags are not bullets
 	name = "beanbag"
-	agony = 50
+	agony = 45
 
 /obj/item/projectile/bullet/weakbullet/rubber
 	name = "rubber bullet"

--- a/maps/z1.dmm
+++ b/maps/z1.dmm
@@ -3556,9 +3556,9 @@
 	name = "Weapons locker";
 	req_access_txt = "3"
 	},
-/obj/item/ammo_box/shotgun/beanbag,
-/obj/item/ammo_box/shotgun/beanbag,
 /obj/item/weapon/storage/box/r4046,
+/obj/item/weapon/storage/box/shotgun/beanbag,
+/obj/item/weapon/storage/box/shotgun/beanbag,
 /turf/simulated/floor{
 	icon_state = "delivery"
 	},


### PR DESCRIPTION
<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений
Было уменьшено количество зарядов в магазине для дробовика. Классический теперь имеет три, плюс один в патроннике. На выходе 4. 
Боевой 5 + 1 в патроннике. На выходе 6. 
Дробь - в сумме имела 100 единиц урона. Это крит и артериальное без брони, и даже с усредненной броней в 50 защиты - 100% переломы и порванный риг. 
Слаги (патроны ружейного типа) - урон был выравнен до 40 с 60. 
Бенбанги (соль) - имели урон агонией 95 единиц - это два-три попадания для сваливания на пол для человека в риге. 

Боевые дробовики были заменены на классические при заказе ящика с баллистическим оружием. 


С карты, а точнее с арсенала, была убрана старая коробка с солью и заменена на новую. Проблема в том, что из этой коробки можно было посредством простого закликивания, в мгновение ока, перезарядить дробовик. По хорошему бы пересмотреть механ старых коробок, или окончательно их удалить из билда. Но это не в этмо ПРе
<!--
Опишите изменения данного ПР-а.
Если есть связные ишью (issues), или другие ПРы - укажите их тут, для автоматического закрытия ишью следует использовать ключевые слова https://help.github.com/en/articles/closing-issues-using-keywords
Если есть связное форумное обсуждение на тему изменений - укажите ссылку на эту тему.
-->

## Почему и что этот ПР улучшит
Выравняет баланс помпового оружия по отношению к остальному. Дробовики имели неоправданно завышенный урон/размер магазина и достаточно легко могли быть заказаны. 




<!--
Опишите причину для изменений.
Этот пункт особенно важен для описания изменений баланса, новых механик.
-->

## Авторство

<!-- Опциональный пункт!
Если авторство не полностью ваше, вы делаете порт с другого билда - обязательно укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
-->

## Чеинжлог

<!-- Опциональный пункт!
Если это что-то, о чём следует сообщить игрокам - опишите по форме (https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies#Changelog) свои изменения для игрового чеинжлога, они будут отображены на специальной страничке http://changelog.taucetistation.org

Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment
  
Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
:cl:
 - balance: Пересмотрен баланс дробовиков. В частности урезан урон, а так же размер магазина дробовика. 