### PR TITLE
Минимальное время до взрыва нюки увеличено на 5 минут (с 7 до 12)

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -1,5 +1,5 @@
-#define TIMER_MIN 420
-#define TIMER_MAX 600
+#define TIMER_MIN 600
+#define TIMER_MAX 780
 
 var/bomb_set
 
@@ -15,7 +15,7 @@ var/bomb_set
 	var/extended = 0.0
 	var/lighthack = 0
 	var/opened = 0.0
-	var/timeleft = 600.0
+	var/timeleft = TIMER_MAX
 	var/timing = 0.0
 	var/r_code = "ADMIN"
 	var/code = ""


### PR DESCRIPTION
<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений
Еще немного увеличил минимальное время, на которую нюку можно установить. 
>В планах немного допилить чтоб нюкеры стали играть в позиционную войну

Ольт хотел еще что-то балансить, но умер, сделаю хотя бы это
<!--
Опишите изменения данного ПР-а.
Если есть связные ишью (issues), или другие ПРы - укажите их тут, для автоматического закрытия ишью следует использовать ключевые слова https://help.github.com/en/articles/closing-issues-using-keywords
Если есть связное форумное обсуждение на тему изменений - укажите ссылку на эту тему.
-->

## Почему и что этот ПР улучшит
Данное изменение увеличит довольно небольшой шанс экипажа против стелсо / фаст нюки. Дав возможность ЕРТ успеть прилететь(если их вызовут) и хоть повоевать чуть-чуть, а не сдохнуть от взрыва сразу по прилету на своем шаттле. Или экипажу попробовать отбить бомбу самостоятельно, очухавшись от нападения.
В общем нюке придется все же некоторые вещи планировать, а не играть чисто в победку, рассчитывая на медленную реакцию экипажа и аутизм.
<!--
Опишите причину для изменений.
Этот пункт особенно важен для описания изменений баланса, новых механик.
-->


:cl:
 - balance: Минимальное время до взрыва нюки увеличено на 3 минуты (с 7 до 10)


