### PR TITLE
Фикс исчезновения отростков скреллов от радиации и при ожогах

### DIFF
--- a/code/modules/holidays/new_year/presents.dm
+++ b/code/modules/holidays/new_year/presents.dm
@@ -116,10 +116,11 @@
 		new /obj/item/weapon/ore/coal/special(src.loc)
 		if(prob(5) && ishuman(user))
 			var/mob/living/carbon/human/H = user
-			H.visible_message("[user] begins balding.", \
-									 "<span class='notice'>You become bald from shame.</span>")
-			H.h_style = "Bald"
-			H.update_hair()
+			if(H.species.flags[HAS_HAIR])
+				H.visible_message("[user] begins balding.", \
+										 "<span class='notice'>You become bald from shame.</span>")
+				H.h_style = "Bald"
+				H.update_hair()
 		qdel(src)
 		return
 

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -128,10 +128,15 @@
 /mob/living/carbon/human/proc/ChangeToHusk()
 	if(HUSK in mutations)
 		return
-	if(f_style)
-		f_style = "Shaved"		//we only change the icon_state of the hair datum, so it doesn't mess up their UI/UE
-	if(h_style)
-		h_style = "Bald"
+	if(species.flags[HAS_HAIR])
+		if(f_style)
+			f_style = "Shaved" // we only change the icon_state of the hair datum, so it doesn't mess up their UI/UE
+		if(h_style)
+			h_style = "Bald"
+	else if(species.name == SKRELL)
+		r_hair = 85
+		g_hair = 85 // grey
+		b_hair = 85
 
 	update_hair()
 	mutations.Add(HUSK)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -323,7 +323,7 @@
 			if(radiation > 50)
 				radiation--
 				damage = 1
-				if(prob(5) && prob(radiation) && (h_style != "Bald" || f_style != "Shaved"))
+				if(prob(5) && species.flags[HAS_HAIR] && prob(radiation) && (h_style != "Bald" || f_style != "Shaved"))
 					h_style = "Bald"
 					f_style = "Shaved"
 					update_hair()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -344,7 +344,7 @@ Please contact me on #coderbus IRC. ~Carn x
 	if(standing.len)
 		overlays_standing[MUTANTRACE_LAYER]	= standing
 
-	if( !((HUSK in mutations) && !(species.flags[HAS_HAIR])) )
+	if(species.flags[HAS_HAIR] || !(HUSK in mutations))
 		update_hair()
 
 	apply_overlay(MUTANTRACE_LAYER)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -344,7 +344,8 @@ Please contact me on #coderbus IRC. ~Carn x
 	if(standing.len)
 		overlays_standing[MUTANTRACE_LAYER]	= standing
 
-	update_hair()
+	if( !((HUSK in mutations) && !(species.flags[HAS_HAIR])) )
+		update_hair()
 
 	apply_overlay(MUTANTRACE_LAYER)
 


### PR DESCRIPTION
Надеюсь меня не заставят оформлять все как надо... Просто фикс одного бага с исчезновением отростков скреллов от радиации, ожогов и от подарка. При ожогах отростки сереют. 
В идеале создать какой нибудь новый спрайт на подобии того как это работает сейчас с телом и остальным, но я не умею в спрайтинг... Думаю на время обойтись сменой цвета - нормальное решение

:cl: Lizzzard
 - bugfix: Скреллы больше не теряют свои отростки на голове от радиации или сильных ожогов.