### PR TITLE
Чистка основных слоёв

### DIFF
--- a/maps/z1.dmm
+++ b/maps/z1.dmm
@@ -422,7 +422,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/hologram/holopad,
@@ -472,7 +471,6 @@
 "aaP" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /obj/structure/mirror{
@@ -650,10 +648,7 @@
 /area/maintenance/eva)
 "abh" = (
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	freerange = 0;
 	frequency = 1475;
-	listening = 1;
 	name = "Station Intercom (Security)";
 	pixel_y = 27
 	},
@@ -831,8 +826,7 @@
 "abx" = (
 /obj/machinery/computer/station_alert,
 /obj/machinery/camera{
-	c_tag = "Security Office North-West";
-	dir = 2
+	c_tag = "Security Office North-West"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -925,8 +919,6 @@
 "abH" = (
 /obj/machinery/deployable/barrier,
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
@@ -967,7 +959,6 @@
 	dir = 4
 	},
 /obj/machinery/door/window/brigdoor{
-	dir = 2;
 	name = "Weapons locker";
 	req_access_txt = "3"
 	},
@@ -1010,7 +1001,6 @@
 	dir = 4
 	},
 /obj/machinery/door/window/brigdoor{
-	dir = 2;
 	name = "Weapons locker";
 	req_access_txt = "3"
 	},
@@ -1028,7 +1018,6 @@
 	},
 /obj/structure/closet/wardrobe/tactical,
 /obj/machinery/door/window/brigdoor{
-	dir = 2;
 	name = "Weapons locker";
 	req_access = null;
 	req_access_txt = "3"
@@ -1081,7 +1070,6 @@
 	dir = 8
 	},
 /obj/machinery/door/window/brigdoor{
-	dir = 2;
 	name = "Weapons locker";
 	req_access = null;
 	req_access_txt = "3"
@@ -1101,7 +1089,6 @@
 	dir = 1
 	},
 /obj/machinery/door/window/brigdoor{
-	dir = 2;
 	name = "Weapons locker";
 	req_access_txt = "3"
 	},
@@ -1128,7 +1115,6 @@
 	},
 /obj/structure/closet/wardrobe/tactical,
 /obj/machinery/door/window/brigdoor{
-	dir = 2;
 	name = "Weapons locker";
 	req_access = null;
 	req_access_txt = "3"
@@ -1173,7 +1159,6 @@
 	dir = 4
 	},
 /obj/machinery/door/window/brigdoor{
-	dir = 2;
 	name = "Weapons locker";
 	req_access_txt = "3"
 	},
@@ -1221,7 +1206,6 @@
 	},
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/simulated/floor{
@@ -1245,7 +1229,6 @@
 /obj/item/weapon/wrench,
 /obj/item/weapon/screwdriver,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/main)
@@ -1388,15 +1371,13 @@
 "acr" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/main)
 "acs" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -1574,7 +1555,6 @@
 "acJ" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/main)
@@ -1614,7 +1594,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/main)
@@ -1656,7 +1635,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/main)
@@ -1796,8 +1774,7 @@
 /area/security/execution)
 "acZ" = (
 /obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j1"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
@@ -1926,7 +1903,6 @@
 "adk" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "satellite_aux_inner";
 	locked = 1;
 	name = "Satellite External Access";
@@ -2013,7 +1989,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/main)
@@ -2104,7 +2079,6 @@
 "ady" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "solar_tool_inner";
 	locked = 1;
 	name = "Engineering External Access";
@@ -2134,7 +2108,6 @@
 /area/holodeck/alphadeck)
 "adB" = (
 /obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1379;
 	id_tag = "solar_tool_airlock";
 	pixel_y = 28;
 	req_access_txt = "13";
@@ -2150,7 +2123,6 @@
 	},
 /obj/machinery/light/small,
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "solar_tool_sensor";
 	layer = 3.3;
 	pixel_x = 12;
@@ -2193,16 +2165,12 @@
 /area/maintenance/auxsolarport)
 "adF" = (
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	freerange = 0;
 	frequency = 1475;
-	listening = 1;
 	name = "Station Intercom (Security)";
 	pixel_x = 30
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/main)
@@ -2219,7 +2187,6 @@
 	dir = 8
 	},
 /obj/machinery/door/window/brigdoor{
-	dir = 2;
 	name = "Weapons locker";
 	req_access_txt = "3"
 	},
@@ -2279,7 +2246,6 @@
 	dir = 1
 	},
 /obj/machinery/door/window/brigdoor{
-	dir = 2;
 	name = "Weapons locker";
 	req_access_txt = "3"
 	},
@@ -2343,8 +2309,7 @@
 /obj/structure/table,
 /obj/item/device/megaphone,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 10;
@@ -2379,7 +2344,6 @@
 /area/security/brig)
 "adT" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor{
@@ -2388,9 +2352,7 @@
 	},
 /area/security/brig)
 "adU" = (
-/obj/machinery/power/smes{
-	charge = 0
-	},
+/obj/machinery/power/smes,
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -2421,7 +2383,6 @@
 	dir = 4
 	},
 /obj/machinery/door/window/brigdoor{
-	dir = 2;
 	name = "Weapons locker";
 	req_access_txt = "3"
 	},
@@ -2441,7 +2402,6 @@
 	dir = 1
 	},
 /obj/machinery/door/window/brigdoor{
-	dir = 2;
 	name = "Weapons locker";
 	req_access_txt = "3"
 	},
@@ -2475,7 +2435,6 @@
 /area/security/warden)
 "aea" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/structure/table,
@@ -2562,7 +2521,6 @@
 "aeh" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
-	icon_state = "pipe-j1s";
 	name = "HoS Office";
 	sortType = "HoS Office"
 	},
@@ -2583,7 +2541,6 @@
 "aei" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/main)
@@ -2637,7 +2594,6 @@
 /area/security/main)
 "aem" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
 	dir = 8;
 	name = "Warden APC";
 	pixel_x = -24
@@ -2722,7 +2678,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/main)
@@ -2749,7 +2704,6 @@
 "aev" = (
 /obj/machinery/camera{
 	c_tag = "Evidence Storage";
-	dir = 2;
 	network = list("SS13","Prison")
 	},
 /turf/simulated/floor{
@@ -2758,8 +2712,6 @@
 /area/security/brig)
 "aew" = (
 /obj/machinery/door/airlock/engineering{
-	icon_state = "closed";
-	locked = 0;
 	name = "Fore Port Solar Access";
 	req_access_txt = "10"
 	},
@@ -2793,7 +2745,6 @@
 "aez" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "solar_tool_outer";
 	locked = 1;
 	name = "Engineering External Access";
@@ -2831,7 +2782,6 @@
 "aeC" = (
 /obj/machinery/camera{
 	c_tag = "Prison Solitary Confinement 2";
-	dir = 2;
 	network = list("SS13","Prison")
 	},
 /obj/structure/table,
@@ -2985,7 +2935,6 @@
 "aeR" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3112,7 +3061,6 @@
 /obj/structure/table,
 /obj/item/weapon/storage/fancy/donut_box,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/main)
@@ -3224,8 +3172,7 @@
 /obj/machinery/power/solar_control{
 	dir = 4;
 	id = "auxsolareast";
-	name = "Fore Port Solar Control";
-	track = 0
+	name = "Fore Port Solar Control"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
@@ -3342,7 +3289,6 @@
 /area/security/main)
 "afy" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Fore Port Solar APC";
 	pixel_y = -28
 	},
@@ -3449,7 +3395,6 @@
 /obj/item/weapon/handcuffs,
 /obj/item/weapon/razor,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/main)
@@ -3712,7 +3657,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/main)
@@ -3856,7 +3800,6 @@
 	dir = 8
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor{
@@ -3989,16 +3932,12 @@
 	pixel_x = 30
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/main)
 "agG" = (
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	freerange = 0;
 	frequency = 1475;
-	listening = 1;
 	name = "Station Intercom (Security)";
 	pixel_x = -30
 	},
@@ -4026,7 +3965,6 @@
 "agJ" = (
 /obj/machinery/camera{
 	c_tag = "Prison Solitary Confinement 1";
-	dir = 2;
 	network = list("SS13","Prison")
 	},
 /obj/structure/table,
@@ -4058,15 +3996,13 @@
 	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 2;
 	icon_state = "shutter0";
 	id = "kitchen";
 	name = "Kitchen Shutters";
 	opacity = 0
 	},
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/crew_quarters/kitchen)
 "agN" = (
@@ -4135,8 +4071,7 @@
 /area/security/brig)
 "agT" = (
 /obj/machinery/camera{
-	c_tag = "Security Processing";
-	dir = 2
+	c_tag = "Security Processing"
 	},
 /obj/machinery/alarm{
 	pixel_y = 26
@@ -4152,10 +4087,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	freerange = 0;
 	frequency = 1475;
-	listening = 1;
 	name = "Station Intercom (Security)";
 	pixel_y = 27
 	},
@@ -4183,7 +4115,6 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/main)
@@ -4299,7 +4230,6 @@
 	icon_state = "plant-6"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/main)
@@ -4742,7 +4672,6 @@
 "ahR" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/main)
@@ -4932,8 +4861,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -4996,7 +4924,6 @@
 "aip" = (
 /obj/machinery/bodyscanner,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
@@ -5139,8 +5066,7 @@
 /area/assembly/robotics)
 "aiD" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -5189,11 +5115,7 @@
 /obj/item/weapon/folder/white,
 /obj/item/clothing/accessory/stethoscope,
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_x = 28
 	},
@@ -5203,7 +5125,6 @@
 	pixel_y = -25
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/patient_b)
@@ -5242,7 +5163,6 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/light,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/hallway/secondary/exit)
@@ -5269,7 +5189,6 @@
 	pixel_y = 3
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/security/brig)
@@ -5277,7 +5196,6 @@
 /obj/structure/table,
 /obj/item/weapon/storage/box/evidence,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "darkred"
 	},
 /area/security/brig)
@@ -5341,10 +5259,7 @@
 /area/security/hos)
 "aiU" = (
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	freerange = 0;
 	frequency = 1475;
-	listening = 1;
 	name = "Station Intercom (Security)";
 	pixel_x = 30
 	},
@@ -5388,7 +5303,6 @@
 "aiW" = (
 /obj/machinery/vending/security,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/main)
@@ -5438,12 +5352,10 @@
 "ajb" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/soda{
-	dir = 4;
-	icon_state = "soda_dispenser"
+	dir = 4
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/door_control{
 	id = "Bar";
@@ -5990,7 +5902,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 2;
 	icon_state = "shutter0";
 	id = "kitchen";
 	name = "Kitchen Shutters";
@@ -6015,7 +5926,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
-	icon_state = "pipe-j1s";
 	name = "Detective Office";
 	sortType = "Detective Office"
 	},
@@ -6075,7 +5985,6 @@
 /area/security/brig)
 "ajZ" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -6301,7 +6210,6 @@
 /area/security/brig)
 "akj" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -6380,15 +6288,13 @@
 "akn" = (
 /obj/item/device/radio/intercom{
 	broadcasting = 1;
-	freerange = 0;
 	frequency = 1475;
 	listening = 0;
 	name = "Station Intercom (Security)";
 	pixel_y = 28
 	},
 /obj/machinery/camera{
-	c_tag = "Brig East";
-	dir = 2
+	c_tag = "Brig East"
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -6509,7 +6415,6 @@
 "akw" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/brig)
@@ -6534,7 +6439,6 @@
 "aky" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/brig)
@@ -6543,7 +6447,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/brig)
@@ -6564,7 +6467,6 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/brig)
@@ -6700,13 +6602,11 @@
 /area/maintenance/eva)
 "akO" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Brig APC";
 	pixel_y = -24
 	},
 /obj/structure/cable,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/brig)
@@ -6724,12 +6624,8 @@
 	},
 /area/security/brig)
 "akQ" = (
-/obj/machinery/door_timer/cell_1{
-	dir = 2;
-	pixel_y = -32
-	},
+/obj/machinery/door_timer/cell_1,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/brig)
@@ -6755,11 +6651,8 @@
 	},
 /area/storage/primary)
 "akS" = (
-/obj/machinery/door_timer/cell_2{
-	dir = 2
-	},
+/obj/machinery/door_timer/cell_2,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/brig)
@@ -6777,19 +6670,15 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/brig)
 "akU" = (
-/obj/machinery/door_timer/cell_3{
-	dir = 2
-	},
+/obj/machinery/door_timer/cell_3,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/brig)
@@ -6804,7 +6693,6 @@
 	req_access_txt = "2"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/brig)
@@ -6819,7 +6707,6 @@
 	req_access_txt = "2"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/brig)
@@ -6866,7 +6753,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 2;
 	icon_state = "shutter0";
 	id = "kitchen";
 	name = "Kitchen Shutters";
@@ -6875,9 +6761,7 @@
 /obj/machinery/door/firedoor,
 /obj/item/weapon/bell,
 /obj/machinery/door/window{
-	base_state = "left";
 	dir = 8;
-	icon_state = "left";
 	name = "Kitchen";
 	req_access_txt = "28"
 	},
@@ -6888,8 +6772,7 @@
 /area/crew_quarters/kitchen)
 "alb" = (
 /obj/machinery/camera{
-	c_tag = "Security Warden Office";
-	dir = 2
+	c_tag = "Security Warden Office"
 	},
 /obj/structure/filingcabinet/chestdrawer/black,
 /turf/simulated/floor{
@@ -6965,7 +6848,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 2;
 	icon_state = "shutter0";
 	id = "kitchen";
 	name = "Kitchen Shutters";
@@ -7174,7 +7056,6 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/rnd/misc_lab)
@@ -7273,7 +7154,6 @@
 	desc = "A remote control switch for the brig foyer.";
 	id = "BrigFoyer";
 	name = "Brig Foyer Doors";
-	normaldoorcontrol = 1;
 	pixel_x = -25;
 	pixel_y = -18;
 	range = 10
@@ -7309,7 +7189,6 @@
 	desc = "A remote control switch for the brig foyer.";
 	id = "prisonentry";
 	name = "Entry Doors";
-	normaldoorcontrol = 1;
 	pixel_x = -6;
 	pixel_y = 24;
 	range = 10
@@ -7318,7 +7197,6 @@
 	desc = "A remote control switch for the brig foyer.";
 	id = "prisonexit";
 	name = "Exit Doors";
-	normaldoorcontrol = 1;
 	pixel_x = 6;
 	pixel_y = 24;
 	range = 10
@@ -7445,7 +7323,6 @@
 /area/security/prison)
 "alN" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/door/window/southright{
@@ -7496,8 +7373,7 @@
 "alS" = (
 /obj/structure/flora/plant/random,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/alarm{
 	pixel_y = 23
@@ -7546,8 +7422,6 @@
 /area/security/lobby)
 "alX" = (
 /obj/item/device/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = -30;
 	pixel_y = 5
@@ -7746,12 +7620,10 @@
 "amr" = (
 /obj/structure/window/reinforced/polarized{
 	dir = 1;
-	icon_state = "fwindow";
 	id = "Detective"
 	},
 /obj/structure/window/reinforced/polarized{
 	dir = 4;
-	icon_state = "fwindow";
 	id = "Detective"
 	},
 /obj/structure/window/reinforced/polarized{
@@ -7759,7 +7631,6 @@
 	},
 /obj/structure/window/reinforced/polarized{
 	dir = 8;
-	icon_state = "fwindow";
 	id = "Detective"
 	},
 /obj/structure/grille,
@@ -7799,12 +7670,10 @@
 "amu" = (
 /obj/structure/window/reinforced/polarized{
 	dir = 1;
-	icon_state = "fwindow";
 	id = "Detective"
 	},
 /obj/structure/window/reinforced/polarized{
 	dir = 4;
-	icon_state = "fwindow";
 	id = "Detective"
 	},
 /obj/structure/window/reinforced/polarized{
@@ -7812,7 +7681,6 @@
 	},
 /obj/structure/window/reinforced/polarized{
 	dir = 8;
-	icon_state = "fwindow";
 	id = "Detective"
 	},
 /obj/structure/grille,
@@ -7902,8 +7770,7 @@
 	chargemode = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Security Substation";
-	dir = 2
+	c_tag = "Security Substation"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -8007,8 +7874,7 @@
 	},
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/security/brig)
@@ -8216,7 +8082,6 @@
 "amZ" = (
 /obj/machinery/flasher{
 	id = "Cell 2";
-	pass_flags = 0;
 	pixel_x = 28
 	},
 /obj/structure/stool/bed,
@@ -8241,7 +8106,6 @@
 /obj/structure/stool/bed,
 /obj/machinery/flasher{
 	id = "Cell 3";
-	pass_flags = 0;
 	pixel_x = 28
 	},
 /turf/simulated/floor{
@@ -8397,8 +8261,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced/tinted{
-	dir = 8;
-	icon_state = "twindow"
+	dir = 8
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
@@ -8410,8 +8273,7 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
@@ -8695,7 +8557,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/medical/hallway)
@@ -8711,8 +8572,7 @@
 /area/security/brig)
 "anI" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -8741,7 +8601,6 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/brig)
@@ -8790,7 +8649,6 @@
 "anS" = (
 /obj/structure/stool,
 /obj/machinery/vending/wallmed1{
-	name = "NanoMed";
 	pixel_y = 30;
 	req_access_txt = "0"
 	},
@@ -8855,17 +8713,14 @@
 "anZ" = (
 /obj/structure/window/reinforced/polarized{
 	dir = 4;
-	icon_state = "fwindow";
 	id = "Detective"
 	},
 /obj/structure/window/reinforced/polarized{
 	dir = 8;
-	icon_state = "fwindow";
 	id = "Detective"
 	},
 /obj/structure/window/reinforced/polarized{
 	dir = 1;
-	icon_state = "fwindow";
 	id = "Detective"
 	},
 /obj/structure/grille,
@@ -8901,7 +8756,6 @@
 "aob" = (
 /obj/structure/window/reinforced/polarized{
 	dir = 4;
-	icon_state = "fwindow";
 	id = "Detective"
 	},
 /obj/structure/window/reinforced/polarized{
@@ -8909,7 +8763,6 @@
 	},
 /obj/structure/window/reinforced/polarized{
 	dir = 8;
-	icon_state = "fwindow";
 	id = "Detective"
 	},
 /obj/structure/grille,
@@ -9180,8 +9033,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -9253,7 +9105,6 @@
 /area/maintenance/eva)
 "aoI" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "damaged4"
 	},
 /area/maintenance/science)
@@ -9598,7 +9449,6 @@
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 12
 	},
 /turf/simulated/floor{
@@ -9687,9 +9537,7 @@
 /area/security/detectives_office)
 "apE" = (
 /obj/structure/table/woodentable,
-/obj/machinery/computer/forensic_scanning/detective{
-	req_access = null
-	},
+/obj/machinery/computer/forensic_scanning/detective,
 /turf/simulated/floor/wood,
 /area/security/vacantoffice)
 "apF" = (
@@ -9719,7 +9567,6 @@
 "apI" = (
 /obj/item/device/radio/intercom{
 	broadcasting = 1;
-	freerange = 0;
 	frequency = 1475;
 	listening = 0;
 	name = "Station Intercom (Security)";
@@ -9814,7 +9661,6 @@
 	opacity = 0
 	},
 /obj/machinery/door/window/brigdoor{
-	dir = 2;
 	id = "Cell 1";
 	name = "Cell 1";
 	req_access_txt = "2"
@@ -9928,7 +9774,6 @@
 	opacity = 0
 	},
 /obj/machinery/door/window/brigdoor{
-	dir = 2;
 	id = "Cell 2";
 	name = "Cell 2";
 	req_access_txt = "2"
@@ -9963,8 +9808,7 @@
 /area/security/prison)
 "aqa" = (
 /obj/structure/stool/bed/chair{
-	dir = 8;
-	icon_state = "chair"
+	dir = 8
 	},
 /obj/item/target,
 /turf/simulated/floor/plating/airless{
@@ -10018,7 +9862,6 @@
 /area/crew_quarters/kitchen)
 "aqh" = (
 /turf/simulated/floor/plating/airless{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/rnd/mixing)
@@ -10077,7 +9920,6 @@
 	opacity = 0
 	},
 /obj/machinery/door/window/brigdoor{
-	dir = 2;
 	id = "Cell 3";
 	name = "Cell 3";
 	req_access_txt = "2"
@@ -10107,7 +9949,6 @@
 "aqp" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "security_inner";
 	locked = 1;
 	name = "Engineering External Access";
@@ -10396,8 +10237,7 @@
 "aqL" = (
 /obj/structure/flora/plant/random,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -10413,7 +10253,6 @@
 /area/shuttle/mining/station)
 "aqN" = (
 /turf/simulated/shuttle/wall/newes_shuttle/mining{
-	dir = 2;
 	icon_state = "ming2_wall"
 	},
 /area/shuttle/mining/station)
@@ -10499,7 +10338,6 @@
 "aqY" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "solar_chapel_outer";
 	locked = 1;
 	name = "Engineering External Access";
@@ -10730,8 +10568,6 @@
 /area/hallway/primary/fore)
 "arz" = (
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
@@ -10743,7 +10579,6 @@
 /area/hallway/primary/fore)
 "arA" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -10766,7 +10601,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/office)
@@ -10779,15 +10613,13 @@
 "arD" = (
 /obj/item/device/radio/intercom{
 	broadcasting = 1;
-	freerange = 0;
 	frequency = 1475;
 	listening = 0;
 	name = "Station Intercom (Security)";
 	pixel_x = -30
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -10988,7 +10820,6 @@
 /area/rnd/xenobiology)
 "arV" = (
 /obj/item/device/radio/intercom{
-	dir = 2;
 	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
@@ -11014,7 +10845,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1379;
 	id_tag = "solar_chapel_airlock";
 	pixel_x = 25;
 	req_access_txt = "13";
@@ -11024,7 +10854,6 @@
 	tag_interior_door = "solar_chapel_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "solar_chapel_sensor";
 	pixel_x = 25;
 	pixel_y = 12
@@ -11064,7 +10893,6 @@
 	id = "packageSort2"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/office)
@@ -11420,7 +11248,6 @@
 /area/maintenance/dormitory)
 "asI" = (
 /obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1379;
 	id_tag = "security_airlock";
 	pixel_y = 25;
 	req_one_access_txt = "13;45;1";
@@ -11501,8 +11328,7 @@
 /area/rnd/xenobiology)
 "asR" = (
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/item/weapon/soap/nanotrasen,
 /turf/simulated/floor{
@@ -11683,7 +11509,6 @@
 /area/maintenance/eva)
 "ati" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/hallway/primary/fore)
@@ -11859,7 +11684,6 @@
 	},
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "solar_chapel_inner";
 	locked = 1;
 	name = "Engineering External Access";
@@ -12140,8 +11964,7 @@
 	pixel_y = 1
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -12273,7 +12096,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /obj/machinery/alarm{
@@ -12398,7 +12220,6 @@
 /area/hallway/primary/starboard)
 "auB" = (
 /obj/structure/object_wall/mining{
-	dir = 2;
 	icon_state = "ming_l4"
 	},
 /turf/space,
@@ -12561,8 +12382,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j1"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/eva)
@@ -12724,7 +12544,6 @@
 "avn" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "asteroid3"
 	},
 /area/garden)
@@ -12756,7 +12575,6 @@
 "avs" = (
 /obj/structure/table/woodentable,
 /obj/item/device/radio/intercom{
-	dir = 2;
 	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
@@ -13020,7 +12838,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Xenobiology Module SE";
-	dir = 2;
 	network = list("SS13","Research")
 	},
 /obj/structure/table/glass,
@@ -13216,7 +13033,6 @@
 /area/garden)
 "awf" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warnwhite"
 	},
 /area/rnd/xenobiology)
@@ -13225,7 +13041,6 @@
 	pixel_x = 27
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "purplechecker"
 	},
 /area/crew_quarters/barbershop)
@@ -13270,9 +13085,7 @@
 	c_tag = "Fore Starboard Solars";
 	dir = 1
 	},
-/obj/machinery/power/smes{
-	charge = 0
-	},
+/obj/machinery/power/smes,
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -13306,7 +13119,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warnwhite"
 	},
 /area/rnd/xenobiology)
@@ -13339,7 +13151,6 @@
 /area/lawoffice)
 "aws" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/fore)
@@ -13359,12 +13170,10 @@
 "awu" = (
 /obj/machinery/camera{
 	c_tag = "Research Division Access";
-	dir = 2;
 	network = list("SS13","Research")
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 12
 	},
 /obj/machinery/firealarm{
@@ -13535,7 +13344,6 @@
 	},
 /obj/structure/table/glass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/rnd/xenobiology)
@@ -13551,8 +13359,7 @@
 /area/rnd/xenobiology)
 "awS" = (
 /obj/machinery/shower{
-	dir = 8;
-	icon_state = "shower"
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
@@ -13627,7 +13434,6 @@
 	},
 /obj/structure/table/glass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/rnd/xenobiology)
@@ -13806,7 +13612,6 @@
 "axv" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor{
@@ -13827,7 +13632,6 @@
 /obj/item/clothing/gloves/latex,
 /obj/structure/table/glass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/rnd/xenobiology)
@@ -13856,7 +13660,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurplefull"
 	},
 /area/rnd/telesci)
@@ -13873,7 +13676,6 @@
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 12
 	},
 /turf/simulated/floor{
@@ -14178,7 +13980,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/rnd/xenobiology)
@@ -14220,7 +14021,6 @@
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 12
 	},
 /obj/machinery/alarm{
@@ -14329,7 +14129,6 @@
 	icon_state = "asteroid"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "siding8"
 	},
 /area/crew_quarters/kitchen)
@@ -14390,8 +14189,7 @@
 "ayB" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -14400,8 +14198,7 @@
 /area/rnd/xenobiology)
 "ayC" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/table,
 /obj/item/weapon/module/power_control,
@@ -14690,7 +14487,6 @@
 "azb" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "security_outer";
 	locked = 1;
 	name = "Engineering External Access";
@@ -14902,7 +14698,6 @@
 /area/rnd/xenobiology)
 "azu" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_x = 32
 	},
@@ -15006,7 +14801,6 @@
 /obj/machinery/door/airlock/research{
 	autoclose = 0;
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "xeno_airlock_interior";
 	locked = 1;
 	name = "Xenobiology Internal Airlock";
@@ -15104,17 +14898,14 @@
 /area/hallway/primary/starboard)
 "azR" = (
 /obj/structure/stool/bed/chair/comfy/beige{
-	dir = 1;
-	icon_state = "comfychair"
+	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Toxins Launch Room";
-	dir = 2;
 	network = list("SS13","Research")
 	},
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the test chamber.";
-	dir = 2;
 	layer = 4;
 	name = "Test Chamber Telescreen";
 	network = list("Toxins Test Area");
@@ -15143,19 +14934,16 @@
 /area/ai_monitored/storage/eva)
 "azU" = (
 /obj/structure/stool/bed/chair/comfy/beige{
-	dir = 1;
-	icon_state = "comfychair"
+	dir = 1
 	},
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the test chamber.";
-	dir = 2;
 	layer = 4;
 	name = "Test Chamber Telescreen";
 	network = list("Toxins Test Area");
 	pixel_y = 30
 	},
 /obj/machinery/driver_button{
-	dir = 2;
 	id = "toxinsdriver";
 	layer = 4;
 	pixel_x = 24
@@ -15199,7 +14987,6 @@
 "azY" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -15320,7 +15107,6 @@
 	icon_state = "asteroid"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "siding8"
 	},
 /area/crew_quarters/kitchen)
@@ -15363,8 +15149,6 @@
 /area/ai_monitored/storage/eva)
 "aAj" = (
 /obj/machinery/door/airlock/engineering{
-	icon_state = "closed";
-	locked = 0;
 	name = "Fore Starboard Solar Access";
 	req_access_txt = "10"
 	},
@@ -15495,7 +15279,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/crew_quarters)
@@ -15646,7 +15429,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "siding8"
 	},
 /area/crew_quarters/kitchen)
@@ -15714,7 +15496,6 @@
 	icon_state = "asteroid"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "siding8"
 	},
 /area/crew_quarters/kitchen)
@@ -15830,7 +15611,6 @@
 	},
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "siding8"
 	},
 /area/crew_quarters/kitchen)
@@ -15920,7 +15700,6 @@
 /obj/structure/flora/tree/jungle,
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "wood_siding2"
 	},
 /area/garden)
@@ -16149,7 +15928,6 @@
 	dir = 4;
 	external_pressure_bound = 140;
 	external_pressure_bound_default = 140;
-	icon_state = "map_vent_out";
 	name = "(OUT) Space Large Air Vent"
 	},
 /turf/simulated/floor/plating/airless,
@@ -16157,7 +15935,6 @@
 "aBB" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /obj/machinery/firealarm{
@@ -16321,7 +16098,6 @@
 	},
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "wood_siding2"
 	},
 /area/garden)
@@ -16362,8 +16138,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -16411,7 +16186,6 @@
 	pixel_y = 6
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Law Office APC";
 	pixel_y = -24
 	},
@@ -16501,7 +16275,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "wood_siding2"
 	},
 /area/garden)
@@ -16538,7 +16311,6 @@
 "aCd" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "arrival_dock_inner";
 	locked = 1;
 	name = "Arrival Dock External Access";
@@ -16633,7 +16405,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "wood_siding2"
 	},
 /area/garden)
@@ -16706,7 +16477,6 @@
 /area/ai_monitored/storage/eva)
 "aCy" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor{
@@ -16718,7 +16488,6 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "wood_siding6"
 	},
 /area/garden)
@@ -16819,13 +16588,11 @@
 /area/crew_quarters/toilet)
 "aCJ" = (
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "arrival_dock_sensor";
 	pixel_x = 25;
 	pixel_y = 12
 	},
 /obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1379;
 	id_tag = "arrival_dock_airlock";
 	pixel_x = 25;
 	req_one_access_txt = "13;45;1";
@@ -16842,7 +16609,6 @@
 "aCK" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "toxin_test_inner";
 	locked = 1;
 	name = "Garden External Access";
@@ -16950,7 +16716,6 @@
 "aCV" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "toxin_test_outer";
 	locked = 1;
 	name = "Garden External Access";
@@ -17058,7 +16823,6 @@
 "aDh" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "arrival_dock_outer";
 	locked = 1;
 	name = "Arrival Dock External Access";
@@ -17269,7 +17033,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "wood_siding10"
 	},
 /area/garden)
@@ -17278,7 +17041,6 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "wood_siding8"
 	},
 /area/garden)
@@ -17379,7 +17141,6 @@
 /obj/structure/flora/junglebush/b,
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "wood_siding1"
 	},
 /area/garden)
@@ -17502,7 +17263,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "wood_siding5"
 	},
 /area/garden)
@@ -17547,7 +17307,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warnwhite"
 	},
 /area/rnd/xenobiology)
@@ -17588,7 +17347,6 @@
 /obj/structure/flora/junglebush/b,
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "wood_siding8"
 	},
 /area/garden)
@@ -17615,7 +17373,6 @@
 /obj/structure/flora/rock/jungle,
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "wood_siding4"
 	},
 /area/garden)
@@ -17641,7 +17398,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/hallway/secondary/exit)
@@ -17707,7 +17463,6 @@
 	},
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "wood_siding8"
 	},
 /area/garden)
@@ -17740,7 +17495,6 @@
 "aEv" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /turf/simulated/floor{
@@ -17802,7 +17556,6 @@
 /area/crew_quarters/gym)
 "aEC" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/structure/closet/wardrobe/pjs,
@@ -17882,8 +17635,7 @@
 /area/crew_quarters/gym)
 "aEK" = (
 /obj/structure/stool/bed/chair/comfy/teal{
-	dir = 4;
-	icon_state = "comfychair"
+	dir = 4
 	},
 /obj/structure/sign/poster{
 	pixel_y = 32
@@ -17894,7 +17646,6 @@
 /area/crew_quarters/gym)
 "aEL" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry)
@@ -17933,8 +17684,7 @@
 /area/maintenance/science)
 "aEO" = (
 /obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j1"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -17958,7 +17708,6 @@
 /obj/machinery/door/airlock/research{
 	autoclose = 0;
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "xeno_airlock_exterior";
 	locked = 1;
 	name = "Xenobiology External Airlock";
@@ -17986,7 +17735,6 @@
 "aEQ" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
-	icon_state = "pipe-j1s";
 	name = "Science";
 	sortType = "Science"
 	},
@@ -18043,7 +17791,6 @@
 /obj/structure/flora/junglebush/b,
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "wood_siding2"
 	},
 /area/garden)
@@ -18055,7 +17802,6 @@
 "aEV" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
-	icon_state = "pipe-j1s";
 	name = "RD Office";
 	sortType = "RD Office"
 	},
@@ -18126,8 +17872,7 @@
 	pixel_y = 1
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -18182,7 +17927,6 @@
 /obj/structure/flora/ausbushes/reedbush,
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "wood_siding2"
 	},
 /area/garden)
@@ -18195,7 +17939,6 @@
 	},
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "wood_siding8"
 	},
 /area/garden)
@@ -18203,14 +17946,12 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "wood_siding8"
 	},
 /area/garden)
 "aFh" = (
 /obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j1"
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -18227,8 +17968,7 @@
 /area/maintenance/science)
 "aFi" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -18237,8 +17977,7 @@
 /area/hallway/primary/fore)
 "aFj" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -18262,7 +18001,6 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "wood_siding9"
 	},
 /area/garden)
@@ -18275,7 +18013,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "wood_siding1"
 	},
 /area/garden)
@@ -18285,7 +18022,6 @@
 "aFp" = (
 /obj/item/device/radio/intercom{
 	freerange = 1;
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = -30
 	},
@@ -18300,8 +18036,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -18326,12 +18061,10 @@
 /area/ai_monitored/storage/eva)
 "aFr" = (
 /obj/item/device/radio/intercom{
-	dir = 2;
 	name = "Station Intercom (General)";
 	pixel_x = 31
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/fore)
@@ -18376,7 +18109,6 @@
 "aFv" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /obj/structure/mirror{
@@ -18521,7 +18253,6 @@
 	},
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "wood_siding9"
 	},
 /area/garden)
@@ -18529,7 +18260,6 @@
 /obj/structure/flora/rock/jungle,
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "wood_siding1"
 	},
 /area/garden)
@@ -18537,14 +18267,12 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "wood_siding1"
 	},
 /area/garden)
 "aFK" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /obj/structure/mirror{
@@ -18577,7 +18305,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/genetics_cloning)
@@ -18585,7 +18312,6 @@
 /obj/structure/flora/junglebush/large,
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "wood_siding1"
 	},
 /area/garden)
@@ -18620,7 +18346,6 @@
 /area/crew_quarters/fitness)
 "aFS" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -18774,7 +18499,6 @@
 "aGg" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /obj/structure/mirror{
@@ -18860,8 +18584,7 @@
 /area/crew_quarters/bar)
 "aGo" = (
 /obj/structure/stool/bed/chair/comfy/teal{
-	dir = 4;
-	icon_state = "comfychair"
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "wooden-2"
@@ -18946,7 +18669,6 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cult"
 	},
 /area/library)
@@ -18998,8 +18720,7 @@
 /area/maintenance/eva)
 "aGB" = (
 /obj/structure/stool/bed/chair/comfy/beige{
-	dir = 4;
-	icon_state = "comfychair"
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
@@ -19013,11 +18734,9 @@
 /area/maintenance/science)
 "aGD" = (
 /obj/structure/stool/bed/chair/comfy/beige{
-	dir = 8;
-	icon_state = "comfychair"
+	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warningcorner"
 	},
 /area/maintenance/science)
@@ -19030,7 +18749,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/maintenance/science)
@@ -19074,7 +18792,6 @@
 "aGI" = (
 /obj/machinery/camera{
 	c_tag = "Medbay West";
-	dir = 2;
 	network = list("SS13","Medical")
 	},
 /turf/simulated/floor{
@@ -19622,8 +19339,7 @@
 /area/crew_quarters/gym)
 "aHO" = (
 /obj/decal/boxingropeenter{
-	dir = 8;
-	icon_state = "ringrope"
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "boxing"
@@ -19720,7 +19436,6 @@
 /obj/structure/table,
 /obj/random/tools/tech_supply,
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
@@ -19967,7 +19682,6 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor{
@@ -20179,7 +19893,6 @@
 /area/maintenance/chapel)
 "aIM" = (
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Medical Hardsuits";
 	req_access_txt = "5"
 	},
@@ -20435,7 +20148,6 @@
 	pixel_y = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/rnd/mixing)
@@ -20548,8 +20260,6 @@
 /area/maintenance/science)
 "aJv" = (
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
@@ -20693,13 +20403,11 @@
 "aJK" = (
 /obj/structure/flora/plant/random,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/hallway/secondary/exit)
 "aJL" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/hallway/secondary/exit)
@@ -20769,8 +20477,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/hallway/secondary/entry)
@@ -20852,8 +20559,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	desc = "\"This is a plaque in honour of our comrades on the G4407 Stations. Hopefully TG4407 model can live up to your fame and fortune.\" Scratched in beneath that is a crude image of a meteor and a spaceman. The spaceman is laughing. The meteor is exploding.";
@@ -20867,8 +20573,7 @@
 /area/hallway/secondary/entry)
 "aKc" = (
 /obj/structure/toilet{
-	dir = 1;
-	icon_state = "toilet00"
+	dir = 1
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -20911,7 +20616,6 @@
 	pixel_y = -22
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/crew_quarters/fitness)
@@ -20928,7 +20632,6 @@
 "aKh" = (
 /obj/structure/dresser,
 /obj/item/device/radio/intercom{
-	dir = 2;
 	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
@@ -20999,7 +20702,6 @@
 /area/maintenance/engineering)
 "aKo" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "EVA Maintenance APC";
 	pixel_y = -24
 	},
@@ -21010,7 +20712,6 @@
 "aKp" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /obj/structure/mirror{
@@ -21587,7 +21288,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Toxins Lab North";
-	dir = 2;
 	network = list("SS13","Research")
 	},
 /turf/simulated/floor{
@@ -21898,8 +21598,7 @@
 	pixel_x = -22
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -22020,7 +21719,6 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warnwhite"
 	},
 /area/rnd/mixing)
@@ -22052,8 +21750,6 @@
 /area/maintenance/eva)
 "aMq" = (
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
@@ -22088,14 +21784,12 @@
 "aMt" = (
 /obj/structure/stool,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/rnd/storage)
 "aMu" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/rnd/storage)
@@ -22104,7 +21798,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/rnd/storage)
@@ -22116,7 +21809,6 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/ai_monitored/storage/eva)
@@ -22251,7 +21943,6 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/ai_monitored/storage/eva)
@@ -22402,8 +22093,7 @@
 "aNb" = (
 /obj/structure/closet/toolcloset,
 /obj/machinery/camera{
-	c_tag = "Auxiliary Tool Storage";
-	dir = 2
+	c_tag = "Auxiliary Tool Storage"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -22576,8 +22266,7 @@
 "aNt" = (
 /obj/machinery/requests_console{
 	department = "Crew Quarters";
-	pixel_x = 32;
-	pixel_z = 0
+	pixel_x = 32
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -22676,7 +22365,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/rnd/hallway)
@@ -22686,7 +22374,6 @@
 	},
 /obj/structure/flora/plant/random,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitecorner"
 	},
 /area/rnd/hallway)
@@ -22731,7 +22418,6 @@
 /obj/item/weapon/table_parts,
 /obj/item/weapon/kitchen/utensil/spoon,
 /obj/item/device/radio/intercom{
-	dir = 2;
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
@@ -22779,8 +22465,7 @@
 /area/rnd/storage)
 "aNO" = (
 /obj/machinery/atmospherics/components/trinary/filter{
-	dir = 1;
-	icon_state = "map"
+	dir = 1
 	},
 /obj/machinery/light{
 	dir = 8
@@ -22904,7 +22589,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/meter,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warnwhitecorner"
 	},
 /area/rnd/mixing)
@@ -22937,7 +22621,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warnwhite"
 	},
 /area/rnd/mixing)
@@ -23072,7 +22755,6 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/secondary/entry)
@@ -23282,7 +22964,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Mid-East";
-	dir = 2;
 	network = list("SS13","Medical")
 	},
 /turf/simulated/floor{
@@ -23375,7 +23056,6 @@
 "aOQ" = (
 /obj/machinery/camera{
 	c_tag = "Dormitory South";
-	c_tag_order = 999;
 	dir = 8
 	},
 /obj/structure/cable{
@@ -23446,8 +23126,7 @@
 /area/crew_quarters/gym)
 "aOW" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -23564,7 +23243,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/hallway)
@@ -23712,7 +23390,6 @@
 "aPw" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "chapel_inner";
 	locked = 1;
 	name = "Chapel External Access";
@@ -23806,7 +23483,6 @@
 /obj/machinery/mech_bay_recharge_port,
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor{
@@ -23862,7 +23538,6 @@
 "aPM" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "yellow"
 	},
 /area/storage/tools)
@@ -23874,7 +23549,6 @@
 /area/hallway/secondary/entry)
 "aPO" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "yellow"
 	},
 /area/storage/tools)
@@ -23897,7 +23571,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "yellow"
 	},
 /area/storage/tools)
@@ -23958,8 +23631,7 @@
 /area/quartermaster/office)
 "aPY" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -24145,7 +23817,6 @@
 "aQq" = (
 /obj/item/device/radio/intercom{
 	freerange = 1;
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = -30
 	},
@@ -24316,7 +23987,6 @@
 	dir = 8
 	},
 /obj/item/device/radio/intercom{
-	dir = 2;
 	name = "Station Intercom (General)";
 	pixel_x = 31
 	},
@@ -24327,11 +23997,9 @@
 /area/rnd/hallway)
 "aQJ" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/hallway/secondary/entry)
@@ -24448,7 +24116,6 @@
 /area/storage/primary)
 "aQU" = (
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
@@ -24470,7 +24137,6 @@
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 12
 	},
 /obj/structure/mirror{
@@ -24599,7 +24265,6 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/toxins/brainstorm_center)
@@ -24614,7 +24279,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/toxins/brainstorm_center)
@@ -24630,7 +24294,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/toxins/brainstorm_center)
@@ -24650,7 +24313,6 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitebot"
 	},
 /area/crew_quarters/hor)
@@ -24759,15 +24421,11 @@
 "aRy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_y = 25
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/medical/hallway)
@@ -24869,8 +24527,7 @@
 /area/maintenance/chapel)
 "aRH" = (
 /obj/structure/morgue{
-	dir = 8;
-	icon_state = "morgue1"
+	dir = 8
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -24902,7 +24559,6 @@
 /area/maintenance/science)
 "aRK" = (
 /obj/machinery/status_display{
-	density = 0;
 	pixel_y = 2;
 	supply_display = 1
 	},
@@ -24910,8 +24566,7 @@
 /area/quartermaster/qm)
 "aRL" = (
 /obj/machinery/atmospherics/components/trinary/mixer/m_mixer{
-	dir = 1;
-	icon_state = "mmap"
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/rnd/mixing)
@@ -25030,7 +24685,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/hallway)
@@ -25110,7 +24764,6 @@
 /obj/machinery/vending/assist,
 /obj/machinery/requests_console{
 	department = "Tool Storage";
-	departmentType = 0;
 	pixel_y = 30
 	},
 /turf/simulated/floor{
@@ -25171,7 +24824,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitebluecorner"
 	},
 /area/medical/hallway)
@@ -25218,7 +24870,6 @@
 	name = "Forbidden Knowledge"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cult"
 	},
 /area/library)
@@ -25244,7 +24895,6 @@
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen/invisible,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cult"
 	},
 /area/library)
@@ -25295,12 +24945,10 @@
 	},
 /obj/structure/window/reinforced/tinted,
 /obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
+	dir = 4
 	},
 /obj/structure/window/reinforced/tinted{
-	dir = 8;
-	icon_state = "twindow"
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -25335,8 +24983,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/bridge)
 "aSE" = (
@@ -25456,7 +25103,6 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warnwhite"
 	},
 /area/crew_quarters/hor)
@@ -25483,7 +25129,6 @@
 /area/hallway/secondary/entry)
 "aSW" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitebluecorner"
 	},
 /area/medical/hallway)
@@ -25534,8 +25179,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/bridge)
 "aTb" = (
@@ -25575,8 +25219,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
@@ -25597,7 +25240,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "darkbluefull"
 	},
 /area/bridge)
@@ -25628,8 +25270,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/bridge)
 "aTh" = (
@@ -25728,12 +25369,10 @@
 "aTq" = (
 /obj/structure/window/reinforced/polarized{
 	dir = 1;
-	icon_state = "fwindow";
 	id = "Patients"
 	},
 /obj/structure/window/reinforced/polarized{
 	dir = 4;
-	icon_state = "fwindow";
 	id = "Patients"
 	},
 /obj/structure/window/reinforced/polarized{
@@ -25741,7 +25380,6 @@
 	},
 /obj/structure/window/reinforced/polarized{
 	dir = 8;
-	icon_state = "fwindow";
 	id = "Patients"
 	},
 /obj/structure/grille,
@@ -25757,8 +25395,7 @@
 	pixel_x = 5
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -25939,8 +25576,7 @@
 /obj/random/tools/tech_supply,
 /obj/random/tools/tech_supply,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -26015,8 +25651,7 @@
 "aTR" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -26051,7 +25686,6 @@
 /area/crew_quarters/playroom)
 "aTV" = (
 /obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1379;
 	id_tag = "chapel_airlock";
 	pixel_y = 25;
 	req_one_access_txt = "13;45;1";
@@ -26117,7 +25751,6 @@
 /area/gateway)
 "aUe" = (
 /obj/machinery/sparker{
-	dir = 2;
 	id = "mixingsparker";
 	pixel_x = 25
 	},
@@ -26160,7 +25793,6 @@
 "aUi" = (
 /obj/machinery/disposal,
 /obj/item/device/radio/intercom{
-	dir = 2;
 	name = "Station Intercom (General)";
 	pixel_x = 31
 	},
@@ -26251,8 +25883,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -26279,8 +25910,7 @@
 	name = "Intern"
 	},
 /obj/machinery/camera{
-	c_tag = "Locker Room";
-	dir = 2
+	c_tag = "Locker Room"
 	},
 /turf/simulated/floor,
 /area/crew_quarters/locker)
@@ -26332,7 +25962,6 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/rnd/mixing)
@@ -26341,7 +25970,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/rnd/mixing)
@@ -26435,8 +26063,7 @@
 "aUK" = (
 /obj/structure/closet/wardrobe/chaplain_black,
 /obj/machinery/camera{
-	c_tag = "Chapel Office";
-	dir = 2
+	c_tag = "Chapel Office"
 	},
 /obj/machinery/requests_console{
 	department = "Chapel";
@@ -26460,8 +26087,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Chapel North";
-	dir = 2
+	c_tag = "Chapel North"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -26525,7 +26151,6 @@
 	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 2;
 	icon_state = "shutter0";
 	id = "Medical_Room1";
 	name = "Privacy Shutters";
@@ -26574,8 +26199,7 @@
 /area/quartermaster/office)
 "aUX" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/quartermaster/office)
@@ -26632,11 +26256,7 @@
 	dir = 4
 	},
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_y = -28
 	},
@@ -26870,7 +26490,6 @@
 "aVC" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 12
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -27270,8 +26889,6 @@
 /area/rnd/hallway)
 "aWj" = (
 /obj/machinery/door/airlock/highsecurity{
-	icon_state = "closed";
-	locked = 0;
 	name = "AI Upload Access";
 	req_access_txt = "16"
 	},
@@ -27394,8 +27011,7 @@
 /obj/item/clothing/suit/bio_suit/particle_protection,
 /obj/item/clothing/head/bio_hood/particle_protection,
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/hallway/secondary/entry)
 "aWr" = (
@@ -27445,7 +27061,6 @@
 "aWv" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "escape"
 	},
 /area/hallway/secondary/entry)
@@ -27810,8 +27425,7 @@
 "aXj" = (
 /obj/structure/flora/plant/random,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -28048,8 +27662,7 @@
 /area/rnd/hallway)
 "aXF" = (
 /obj/structure/window/phoronreinforced{
-	dir = 6;
-	icon_state = "phoronrwindow"
+	dir = 6
 	},
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -28128,8 +27741,7 @@
 /obj/item/clothing/suit/bio_suit/particle_protection,
 /obj/item/clothing/head/bio_hood/particle_protection,
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/hallway/secondary/entry)
 "aXP" = (
@@ -28197,7 +27809,6 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "greencorner"
 	},
 /area/hallway/secondary/entry)
@@ -28210,7 +27821,6 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "greencorner"
 	},
 /area/hallway/secondary/entry)
@@ -28629,8 +28239,7 @@
 /area/quartermaster/storage)
 "aYN" = (
 /obj/machinery/camera{
-	c_tag = "Bridge East Entrance";
-	dir = 2
+	c_tag = "Bridge East Entrance"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -28944,7 +28553,6 @@
 /area/crew_quarters/locker)
 "aZs" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/hydroponics)
@@ -29000,8 +28608,7 @@
 /obj/machinery/power/solar_control{
 	dir = 4;
 	id = "portsolar";
-	name = "Aft Port Solar Control";
-	track = 0
+	name = "Aft Port Solar Control"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
@@ -29303,8 +28910,7 @@
 /obj/structure/table,
 /obj/item/weapon/aiModule/reset,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/whitegreed,
 /area/turret_protected/ai_upload)
@@ -29358,7 +28964,6 @@
 /area/hallway/primary/port)
 "bad" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Central Hall APC";
 	pixel_y = -24
 	},
@@ -29375,7 +28980,6 @@
 /area/shuttle/escape_pod1/station)
 "baf" = (
 /obj/machinery/door/poddoor/shutters{
-	dir = 2;
 	id = "Gateway_shutters";
 	name = "Gateway Shutters"
 	},
@@ -29386,7 +28990,6 @@
 /area/gateway)
 "bag" = (
 /obj/machinery/door/poddoor/shutters{
-	dir = 2;
 	id = "Gateway_shutters";
 	name = "Gateway Shutters"
 	},
@@ -29408,8 +29011,6 @@
 /area/hallway/primary/central)
 "baj" = (
 /obj/item/device/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = -30;
 	pixel_y = 5
@@ -29505,7 +29106,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "darkbluefull"
 	},
 /area/bridge)
@@ -29705,15 +29305,11 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "greencorner"
 	},
 /area/hallway/secondary/entry)
 "baL" = (
 /obj/machinery/door/airlock/command{
-	icon_state = "closed";
-	lockdownbyai = 0;
-	locked = 0;
 	name = "Gateway Access";
 	req_access_txt = "62"
 	},
@@ -29782,8 +29378,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/hallway/secondary/entry)
 "baS" = (
@@ -30047,7 +29642,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/office)
@@ -30063,7 +29657,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/office)
@@ -30120,7 +29713,6 @@
 /obj/structure/sign/directions/evac{
 	buildable_sign = 0;
 	dir = 1;
-	icon_state = "direction_evac";
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -30247,7 +29839,6 @@
 /area/hallway/primary/port)
 "bbJ" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -30362,13 +29953,11 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "greencorner"
 	},
 /area/hallway/secondary/entry)
 "bbU" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Science Break Room APC";
 	pixel_y = -24
 	},
@@ -30496,7 +30085,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "greencorner"
 	},
 /area/hallway/secondary/entry)
@@ -30579,14 +30167,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "stairs_middle"
 	},
 /area/hallway/secondary/entry)
 "bcq" = (
 /obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway 5";
-	dir = 2
+	c_tag = "Starboard Primary Hallway 5"
 	},
 /obj/structure/sign/warning/pods{
 	pixel_y = 32
@@ -30627,8 +30213,7 @@
 /area/rnd/hallway)
 "bcu" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/item/weapon/storage/box/rxglasses{
 	pixel_x = -6
@@ -30720,7 +30305,6 @@
 	req_access_txt = "12"
 	},
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/maintenance/disposal)
@@ -30757,7 +30341,6 @@
 	req_access_txt = "0"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/rnd/xenobiology)
@@ -30896,9 +30479,7 @@
 /obj/item/weapon/aiModule/oxygen,
 /obj/item/weapon/aiModule/oneHuman,
 /obj/machinery/door/window{
-	base_state = "left";
 	dir = 8;
-	icon_state = "left";
 	name = "High-Risk Modules";
 	req_access_txt = "20"
 	},
@@ -31040,9 +30621,7 @@
 /area/medical/psych)
 "bdl" = (
 /obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1379;
 	id_tag = "satellite_aux_airlock";
-	layer = 3.3;
 	pixel_y = 25;
 	req_access_txt = "66";
 	tag_airpump = "satellite_aux_pump";
@@ -31055,7 +30634,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior";
-	dir = 2;
 	network = list("MiniSat")
 	},
 /turf/simulated/floor/plating,
@@ -31168,7 +30746,6 @@
 "bdy" = (
 /obj/structure/table/glass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "chapel"
 	},
 /area/chapel/main)
@@ -31250,8 +30827,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/hallway/secondary/entry)
@@ -31281,14 +30857,12 @@
 /area/bridge/meeting_room)
 "bdJ" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "bdK" = (
 /obj/machinery/camera{
-	c_tag = "Port Hallway 2";
-	dir = 2
+	c_tag = "Port Hallway 2"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31316,8 +30890,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
@@ -31485,7 +31058,6 @@
 	name = "Central Access"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/port)
@@ -31551,13 +31123,11 @@
 /area/hallway/primary/central)
 "bel" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
 /obj/machinery/camera{
-	c_tag = "Conference Room";
-	dir = 2
+	c_tag = "Conference Room"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -31721,7 +31291,6 @@
 /area/maintenance/medbay)
 "bex" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/light{
@@ -31794,7 +31363,6 @@
 /area/crew_quarters/captain)
 "beD" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
 	dir = 1;
 	name = "Captain's Office APC";
 	pixel_y = 24
@@ -31871,8 +31439,7 @@
 /area/crew_quarters/locker)
 "beK" = (
 /obj/machinery/camera{
-	c_tag = "Central Hallway North-West";
-	dir = 2
+	c_tag = "Central Hallway North-West"
 	},
 /obj/machinery/alarm{
 	pixel_y = 23
@@ -31897,12 +31464,10 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/item/device/radio/intercom{
-	dir = 2;
 	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/hallway/primary/central)
@@ -31921,7 +31486,6 @@
 /area/bridge/meeting_room)
 "beO" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -31971,14 +31535,11 @@
 /area/maintenance/science)
 "beT" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/rnd/hallway)
 "beU" = (
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
@@ -32002,7 +31563,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/rnd/hallway)
@@ -32040,13 +31600,11 @@
 /area/quartermaster/office)
 "beZ" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
 /obj/machinery/camera{
-	c_tag = "Central Hallway North-East";
-	dir = 2
+	c_tag = "Central Hallway North-East"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -32071,7 +31629,6 @@
 "bfc" = (
 /obj/structure/noticeboard{
 	dir = 1;
-	icon_state = "nboard00";
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -32088,7 +31645,6 @@
 /area/rnd/hallway)
 "bfd" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/light{
@@ -32104,7 +31660,6 @@
 	name = "Central Access"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -32121,7 +31676,6 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warnwhite"
 	},
 /area/medical/virology)
@@ -32361,7 +31915,6 @@
 /area/quartermaster/recycleroffice)
 "bfA" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -32459,7 +32012,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitebluecorner"
 	},
 /area/rnd/hallway)
@@ -32471,8 +32023,6 @@
 /area/space)
 "bfL" = (
 /obj/machinery/power/apc{
-	dir = 2;
-	level = 2;
 	name = "Operating 2 APC";
 	pixel_y = -25
 	},
@@ -32507,16 +32057,12 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/rnd/hallway)
 "bfO" = (
 /obj/item/device/radio/intercom{
-	anyai = 1;
-	broadcasting = 0;
 	freerange = 1;
-	listening = 1;
 	name = "Captain's Intercom";
 	pixel_x = -27;
 	pixel_y = -3
@@ -32603,15 +32149,10 @@
 /area/medical/surgery)
 "bfX" = (
 /obj/structure/morgue{
-	dir = 8;
-	icon_state = "morgue1"
+	dir = 8
 	},
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_x = 28
 	},
@@ -32633,8 +32174,7 @@
 	},
 /obj/machinery/windowtint{
 	id = "op1";
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/simulated/floor,
 /area/medical/surgery)
@@ -32648,12 +32188,10 @@
 "bga" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 12
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 12
 	},
 /turf/simulated/floor{
@@ -32664,7 +32202,6 @@
 "bgb" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/port)
@@ -32677,8 +32214,7 @@
 	},
 /obj/structure/dryer{
 	dir = 4;
-	pixel_x = -6;
-	pixel_y = 0
+	pixel_x = -6
 	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
@@ -32850,14 +32386,12 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/port)
 "bgs" = (
 /obj/machinery/shower{
-	dir = 1;
-	icon_state = "shower"
+	dir = 1
 	},
 /obj/structure/curtain/open/shower,
 /turf/simulated/floor{
@@ -32883,8 +32417,7 @@
 /area/medical/morgue)
 "bgu" = (
 /obj/machinery/camera{
-	c_tag = "Mining office";
-	dir = 2
+	c_tag = "Mining office"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -32989,7 +32522,6 @@
 /area/quartermaster/recycleroffice)
 "bgE" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/port)
@@ -33080,7 +32612,6 @@
 "bgP" = (
 /obj/machinery/light,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/port)
@@ -33094,7 +32625,6 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/port)
@@ -33216,7 +32746,6 @@
 	pixel_y = -23
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry)
@@ -33235,7 +32764,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "arrivalcorner"
 	},
 /area/hallway/secondary/entry)
@@ -33247,7 +32775,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/secondary/entry)
@@ -33257,13 +32784,11 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/secondary/entry)
 "bhj" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/secondary/entry)
@@ -33284,7 +32809,6 @@
 "bhm" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	icon_state = "pipe-j1s";
 	name = "CMO Office";
 	sortType = "CMO Office"
 	},
@@ -33312,7 +32836,6 @@
 "bhp" = (
 /obj/machinery/light,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/secondary/entry)
@@ -33321,7 +32844,6 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/secondary/entry)
@@ -33367,7 +32889,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "browncorner"
 	},
 /area/hallway/primary/port)
@@ -33435,8 +32956,6 @@
 /area/turret_protected/ai_upload)
 "bhF" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
-	dir = 2;
 	name = "Upload APC";
 	pixel_y = -24
 	},
@@ -33458,7 +32977,6 @@
 	c_tag = "Cargo Bay North"
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -33541,10 +33059,7 @@
 	},
 /obj/structure/table/glass,
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_y = 25
 	},
@@ -33583,7 +33098,6 @@
 /area/hallway/primary/central)
 "bhQ" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "greencorner"
 	},
 /area/hallway/primary/starboard)
@@ -33602,7 +33116,6 @@
 "bhS" = (
 /obj/machinery/camera{
 	c_tag = "Research Division West";
-	dir = 2;
 	network = list("SS13","Research")
 	},
 /obj/machinery/computer/guestpass{
@@ -33643,7 +33156,6 @@
 	id = "packageExternal"
 	},
 /obj/machinery/door/window{
-	dir = 2;
 	layer = 3;
 	name = "Delivery Office";
 	req_access_txt = "50"
@@ -33680,7 +33192,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
-	req_access = null;
 	req_access_txt = "71";
 	req_one_access_txt = null
 	},
@@ -33704,7 +33215,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
-	req_access = null;
 	req_access_txt = "71";
 	req_one_access_txt = null
 	},
@@ -33735,8 +33245,7 @@
 /area/hallway/primary/starboard)
 "bid" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/computer/telecomms/server{
 	dir = 4;
@@ -33804,8 +33313,7 @@
 /area/quartermaster/recycleroffice)
 "bij" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/computer/telecomms/server{
 	dir = 8;
@@ -34121,10 +33629,7 @@
 "biS" = (
 /obj/structure/flora/plant/random,
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_y = 25
 	},
@@ -34172,7 +33677,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/rnd/hallway)
@@ -34249,8 +33753,7 @@
 /area/medical/chemistry)
 "bjo" = (
 /obj/structure/stool/bed/chair/comfy/teal{
-	dir = 4;
-	icon_state = "comfychair"
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -34283,7 +33786,6 @@
 /area/assembly/robotics)
 "bju" = (
 /obj/item/device/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	name = "General Listening Channel";
 	pixel_x = 28
@@ -34416,7 +33918,6 @@
 "bjI" = (
 /obj/machinery/dna_scannernew,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/genetics_cloning)
@@ -34477,7 +33978,6 @@
 /obj/structure/table/glass,
 /obj/machinery/light/small,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "chapel"
 	},
 /area/chapel/main)
@@ -34485,13 +33985,11 @@
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/regular,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Cargo Office APC";
 	pixel_y = -24
 	},
 /obj/structure/cable,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/office)
@@ -34572,7 +34070,6 @@
 /obj/machinery/door_control{
 	id = "Medical_Surgery2";
 	name = "Privacy Shutters";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /turf/simulated/floor,
@@ -34641,7 +34138,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 2;
 	icon_state = "shutter0";
 	id = "kitchen";
 	name = "Kitchen Shutters";
@@ -34671,7 +34167,6 @@
 	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 2;
 	icon_state = "shutter0";
 	id = "kitchen";
 	name = "Kitchen Shutters";
@@ -34746,7 +34241,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 2;
 	icon_state = "shutter0";
 	id = "Bar_Privacy1";
 	name = "Privacy Shutters";
@@ -34901,13 +34395,11 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
 "bkT" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4
 	},
 /turf/simulated/wall/r_wall,
@@ -35065,7 +34557,6 @@
 "blg" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/rnd/hallway)
@@ -35096,7 +34587,6 @@
 	dir = 6
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/rnd/hallway)
@@ -35222,8 +34712,6 @@
 /area/rnd/hallway)
 "bls" = (
 /obj/structure/closet/gmcloset{
-	icon_closed = "black";
-	icon_state = "black";
 	name = "formal wardrobe"
 	},
 /obj/item/weapon/book/manual/wiki/barman_recipes{
@@ -35272,7 +34760,6 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteyellow"
 	},
 /area/medical/chemistry)
@@ -35322,7 +34809,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/qm)
@@ -35396,7 +34882,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Robotics";
-	dir = 2;
 	network = list("SS13","Research");
 	pixel_x = 22
 	},
@@ -35428,7 +34913,6 @@
 "blH" = (
 /obj/machinery/camera{
 	c_tag = "Research Division Server Room";
-	dir = 2;
 	network = list("SS13","Research")
 	},
 /obj/machinery/power/apc{
@@ -35437,7 +34921,6 @@
 	pixel_y = 25
 	},
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 2;
 	icon_state = "freezer_1";
 	power_setting = 20;
 	set_temperature = 73;
@@ -35472,7 +34955,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "chapel"
 	},
 /area/chapel/main)
@@ -35504,7 +34986,6 @@
 /area/chapel/main)
 "blQ" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "chapel"
 	},
 /area/chapel/main)
@@ -35546,11 +35027,9 @@
 /obj/machinery/chem_dispenser/soda,
 /obj/structure/table,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
@@ -35559,8 +35038,7 @@
 /area/security/nuke_storage)
 "blX" = (
 /obj/machinery/camera{
-	c_tag = "Kitchen";
-	dir = 2
+	c_tag = "Kitchen"
 	},
 /obj/structure/table,
 /obj/machinery/kitchen_machine/microwave{
@@ -35692,7 +35170,6 @@
 "bmp" = (
 /obj/machinery/vending/dinnerware,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/light{
@@ -35712,7 +35189,6 @@
 /area/crew_quarters/kitchen)
 "bmr" = (
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Chemistry Lab";
 	req_access_txt = "5; 33"
 	},
@@ -35753,8 +35229,7 @@
 /area/medical/reception)
 "bmC" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -35870,13 +35345,11 @@
 /area/rnd/lab)
 "bmZ" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Arrival Shuttle Hallway APC";
 	pixel_y = -24
 	},
 /obj/structure/cable,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/secondary/entry)
@@ -35947,7 +35420,6 @@
 	},
 /obj/item/device/multitool,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/office)
@@ -35957,7 +35429,6 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/office)
@@ -36105,7 +35576,6 @@
 "bnE" = (
 /obj/structure/closet/secure_closet/quartermaster,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/qm)
@@ -36127,7 +35597,6 @@
 	pixel_x = 30
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -36185,8 +35654,7 @@
 /area/maintenance/bridge)
 "bnR" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/computer/secure_data{
 	dir = 8
@@ -36200,8 +35668,7 @@
 /obj/structure/table/glass,
 /obj/machinery/computer/med_data/laptop,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -36368,7 +35835,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteyellow"
 	},
 /area/medical/chemistry)
@@ -36391,7 +35857,6 @@
 /obj/machinery/computer/scan_consolenew,
 /obj/machinery/requests_console{
 	department = "Genetics";
-	departmentType = 0;
 	name = "Genetics Requests Console";
 	pixel_y = 30
 	},
@@ -36433,7 +35898,6 @@
 "bow" = (
 /obj/machinery/door/window/northleft{
 	dir = 8;
-	icon_state = "left";
 	name = "Reception Window"
 	},
 /obj/structure/table/reinforced,
@@ -36462,7 +35926,6 @@
 /area/crew_quarters/heads)
 "box" = (
 /obj/machinery/door/airlock/vault{
-	icon_state = "closed";
 	locked = 1;
 	req_access_txt = "53"
 	},
@@ -36504,7 +35967,6 @@
 	req_access_txt = "7"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurplefull"
 	},
 /area/rnd/lab)
@@ -36711,12 +36173,9 @@
 	id = "garbage"
 	},
 /obj/machinery/door/poddoor{
-	density = 1;
-	icon_state = "pdoor1";
 	id = "Disposal Exit";
 	layer = 3.1;
-	name = "Disposal Exit Vent";
-	opacity = 1
+	name = "Disposal Exit Vent"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/disposal)
@@ -36755,7 +36214,6 @@
 	location = "QM #1"
 	},
 /obj/machinery/bot/mulebot{
-	beacon_freq = 1400;
 	home_destination = "QM #1";
 	suffix = "#1"
 	},
@@ -36994,7 +36452,6 @@
 /area/teleporter)
 "bpI" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/light{
@@ -37164,8 +36621,7 @@
 /area/crew_quarters/bar)
 "bqi" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/item/weapon/storage/box/ids,
 /obj/item/weapon/storage/box/PDAs{
@@ -37313,7 +36769,6 @@
 	},
 /obj/structure/table,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/rnd/lab)
@@ -37329,7 +36784,6 @@
 	},
 /obj/structure/table,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/rnd/lab)
@@ -37340,7 +36794,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Research and Development Lab";
-	dir = 2;
 	network = list("SS13","Research")
 	},
 /obj/item/taperoll/science,
@@ -37559,8 +37012,6 @@
 	pixel_y = -2
 	},
 /obj/item/device/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = -30
 	},
@@ -37639,12 +37090,10 @@
 /area/security/vacantoffice)
 "brm" = (
 /obj/item/device/radio/intercom{
-	dir = 2;
 	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -37825,7 +37274,6 @@
 /area/rnd/telesci)
 "brQ" = (
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
@@ -37875,7 +37323,6 @@
 /area/maintenance/chapel)
 "brY" = (
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
@@ -37980,7 +37427,6 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "chapel"
 	},
 /area/chapel/main)
@@ -38002,7 +37448,6 @@
 "bsj" = (
 /obj/structure/stool,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "chapel"
 	},
 /area/chapel/main)
@@ -38103,8 +37548,6 @@
 /area/medical/sleeper)
 "bsv" = (
 /obj/item/device/radio/intercom{
-	anyai = 1;
-	broadcasting = 0;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -38112,7 +37555,6 @@
 	pixel_y = 5
 	},
 /obj/item/device/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
@@ -38125,7 +37567,6 @@
 /obj/item/device/radio/intercom{
 	broadcasting = 1;
 	freerange = 1;
-	listening = 1;
 	name = "Common Channel";
 	pixel_y = 25
 	},
@@ -38288,7 +37729,6 @@
 	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 2;
 	icon_state = "shutter0";
 	id = "Bar_Privacy1";
 	name = "Privacy Shutters";
@@ -38357,7 +37797,6 @@
 "btb" = (
 /obj/machinery/vending/cola,
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -38369,7 +37808,6 @@
 "btc" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /obj/structure/disposalpipe/segment,
@@ -38395,8 +37833,7 @@
 /area/medical/hallway)
 "btf" = (
 /obj/machinery/camera{
-	c_tag = "Bridge West";
-	dir = 2
+	c_tag = "Bridge West"
 	},
 /obj/item/weapon/folder/white,
 /obj/item/device/radio/off{
@@ -38440,7 +37877,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/hallway)
@@ -38624,7 +38060,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/office)
@@ -38832,8 +38267,7 @@
 /area/hallway/primary/central)
 "btY" = (
 /obj/machinery/camera{
-	c_tag = "Bridge West";
-	dir = 2
+	c_tag = "Bridge West"
 	},
 /obj/item/weapon/storage/fancy/donut_box,
 /obj/structure/noticeboard{
@@ -38860,7 +38294,6 @@
 "bua" = (
 /obj/machinery/computer/security/mining,
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -38950,7 +38383,6 @@
 /obj/item/weapon/storage/box/gloves,
 /obj/structure/table/glass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitecorner"
 	},
 /area/medical/hallway)
@@ -38999,8 +38431,7 @@
 	},
 /obj/machinery/windowtint{
 	id = "op2";
-	pixel_x = 27;
-	pixel_y = 0
+	pixel_x = 27
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -39086,14 +38517,12 @@
 /area/medical/sleeper)
 "buE" = (
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/structure/drain{
 	drainage = 2
 	},
 /obj/machinery/door/window/eastright{
-	dir = 4;
 	icon_state = "left";
 	name = "Cloning Cell";
 	req_access_txt = "5"
@@ -39491,7 +38920,6 @@
 	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 2;
 	icon_state = "shutter0";
 	id = "kitchen";
 	name = "Kitchen Shutters";
@@ -39565,7 +38993,6 @@
 "bvS" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/item/device/radio/intercom{
-	dir = 2;
 	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
@@ -39645,7 +39072,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor{
@@ -40110,8 +39536,6 @@
 /area/quartermaster/qm)
 "bxc" = (
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
@@ -40124,7 +39548,6 @@
 	c_tag = "Teleporter"
 	},
 /obj/machinery/alarm{
-	frequency = 1439;
 	pixel_y = 23
 	},
 /turf/simulated/floor,
@@ -40254,13 +39677,11 @@
 "bxu" = (
 /obj/structure/flora/plant/random,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Treatment Center APC";
 	pixel_y = -25
 	},
 /obj/structure/cable,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
@@ -40315,7 +39736,6 @@
 "bxC" = (
 /obj/item/device/radio/intercom{
 	freerange = 1;
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = -30
 	},
@@ -40333,7 +39753,6 @@
 /obj/item/device/mmi,
 /obj/item/device/mmi,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitecorner"
 	},
 /area/assembly/robotics)
@@ -40354,7 +39773,6 @@
 /obj/item/device/mmi/posibrain,
 /obj/item/device/robotanalyzer,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/assembly/robotics)
@@ -40398,7 +39816,6 @@
 /area/assembly/chargebay)
 "bxM" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/light{
@@ -40603,10 +40020,7 @@
 "byr" = (
 /obj/machinery/vending/blood,
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_y = 25
 	},
@@ -40637,8 +40051,7 @@
 /area/server)
 "byx" = (
 /obj/machinery/camera{
-	c_tag = "Pre Vault";
-	dir = 2
+	c_tag = "Pre Vault"
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -40661,7 +40074,6 @@
 "byz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/westleft{
-	dir = 8;
 	name = "Server Room";
 	opacity = 1;
 	req_access_txt = "30"
@@ -40752,7 +40164,6 @@
 /area/teleporter)
 "byI" = (
 /obj/machinery/door/morgue{
-	dir = 2;
 	name = "Confession Booth (Chaplain)";
 	req_access_txt = "22"
 	},
@@ -40833,7 +40244,6 @@
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/crew_quarters/kitchen)
@@ -40984,7 +40394,6 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitebluecorner"
 	},
 /area/medical/hallway)
@@ -41134,7 +40543,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "darkbluecorners"
 	},
 /area/bridge)
@@ -41151,7 +40559,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/bridge)
@@ -41329,7 +40736,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/bridge)
@@ -41356,7 +40762,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/bridge)
@@ -41411,7 +40816,6 @@
 	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 2;
 	icon_state = "shutter0";
 	id = "Medical_Room2";
 	name = "Privacy Shutters";
@@ -41479,12 +40883,10 @@
 "bAx" = (
 /obj/structure/window/reinforced/polarized{
 	dir = 8;
-	icon_state = "fwindow";
 	id = "Patients"
 	},
 /obj/structure/window/reinforced/polarized{
 	dir = 1;
-	icon_state = "fwindow";
 	id = "Patients"
 	},
 /obj/structure/window/reinforced/polarized{
@@ -41522,7 +40924,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/bridge)
@@ -41549,8 +40950,6 @@
 /obj/machinery/door_control{
 	id = "Genetics";
 	name = "Genetics";
-	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/simulated/floor{
@@ -41582,7 +40981,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/bridge)
@@ -41685,7 +41083,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitebluecorner"
 	},
 /area/medical/sleeper)
@@ -41696,7 +41093,6 @@
 /area/medical/sleeper)
 "bAT" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
@@ -41807,7 +41203,6 @@
 	pixel_y = -25
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/bridge)
@@ -41819,7 +41214,6 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/bridge)
@@ -41828,7 +41222,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "arrival"
 	},
 /area/hallway/secondary/entry)
@@ -41861,14 +41254,11 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/bridge)
 "bBo" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
-	dir = 2;
 	name = "Bridge APC";
 	pixel_y = -24
 	},
@@ -41877,7 +41267,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/bridge)
@@ -41917,8 +41306,7 @@
 /area/quartermaster/miningbreaktime)
 "bBu" = (
 /obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j1"
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -42365,11 +41753,9 @@
 "bCr" = (
 /obj/structure/closet/firecloset,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/item/device/radio/intercom{
-	dir = 2;
 	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
@@ -42430,7 +41816,6 @@
 /area/assembly/chargebay)
 "bCB" = (
 /obj/item/device/radio/intercom{
-	dir = 2;
 	name = "Station Intercom (General)";
 	pixel_x = 31
 	},
@@ -42462,7 +41847,6 @@
 "bCF" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	icon_state = "pipe-j1s";
 	name = "HoP Office";
 	sortType = "HoP Office"
 	},
@@ -42719,10 +42103,7 @@
 	},
 /obj/item/weapon/reagent_containers/glass/beaker/cryoxadone,
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_y = 25
 	},
@@ -42735,7 +42116,6 @@
 "bDh" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "chapel_outer";
 	locked = 1;
 	name = "Chapel External Access";
@@ -42886,7 +42266,6 @@
 "bDz" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /turf/simulated/floor{
@@ -43112,7 +42491,6 @@
 "bEd" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -43256,7 +42634,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/bridge)
@@ -43273,7 +42650,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/bridge)
@@ -43308,7 +42684,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/bridge)
@@ -43331,13 +42706,11 @@
 /area/storage/tech)
 "bEG" = (
 /obj/item/device/radio/intercom{
-	dir = 2;
 	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /turf/simulated/floor{
@@ -43520,7 +42893,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	icon_state = "pipe-j1s";
 	name = "Janitor Closet";
 	sortType = "Janitor Closet"
 	},
@@ -43675,7 +43047,6 @@
 /area/lawoffice)
 "bFl" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/rnd/lab)
@@ -43768,7 +43139,6 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/rnd/lab)
@@ -43822,7 +43192,6 @@
 "bFD" = (
 /obj/structure/stool/bed/chair/office/light,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/rnd/lab)
@@ -43930,7 +43299,6 @@
 	name = "Research Assistant"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warnwhite"
 	},
 /area/rnd/hallway)
@@ -44024,12 +43392,10 @@
 "bGf" = (
 /obj/structure/window/reinforced/polarized{
 	dir = 4;
-	icon_state = "fwindow";
 	id = "Patients"
 	},
 /obj/structure/window/reinforced/polarized{
 	dir = 1;
-	icon_state = "fwindow";
 	id = "Patients"
 	},
 /obj/structure/window/reinforced/polarized{
@@ -44170,7 +43536,6 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/assembly/robotics)
@@ -44181,7 +43546,6 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/assembly/robotics)
@@ -44191,7 +43555,6 @@
 	pixel_y = -29
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/assembly/robotics)
@@ -44215,8 +43578,6 @@
 "bGK" = (
 /obj/structure/closet/secure_closet/atmos_personal,
 /obj/item/device/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = -30
 	},
@@ -44225,7 +43586,6 @@
 "bGL" = (
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the singularity chamber.";
-	dir = 2;
 	layer = 4;
 	name = "Singularity Engine Telescreen";
 	network = list("Singularity");
@@ -44348,8 +43708,7 @@
 /area/assembly/chargebay)
 "bGW" = (
 /obj/machinery/mech_bay_recharge_port{
-	dir = 1;
-	icon_state = "recharge_port"
+	dir = 1
 	},
 /turf/simulated/floor/plating{
 	icon_state = "platebot";
@@ -44414,7 +43773,6 @@
 /area/chapel/main)
 "bHd" = (
 /obj/machinery/door/morgue{
-	dir = 2;
 	name = "Confession Booth"
 	},
 /obj/machinery/door/firedoor,
@@ -44455,17 +43813,14 @@
 "bHi" = (
 /obj/structure/window/reinforced/polarized{
 	dir = 8;
-	icon_state = "fwindow";
 	id = "op2"
 	},
 /obj/structure/window/reinforced/polarized{
 	dir = 4;
-	icon_state = "fwindow";
 	id = "op2"
 	},
 /obj/structure/window/reinforced/polarized{
 	dir = 1;
-	icon_state = "fwindow";
 	id = "op2"
 	},
 /obj/structure/grille,
@@ -44651,8 +44006,7 @@
 /area/crew_quarters/kitchen)
 "bHD" = (
 /obj/machinery/chem_dispenser/beer{
-	dir = 4;
-	icon_state = "booze_dispenser"
+	dir = 4
 	},
 /obj/structure/table,
 /obj/machinery/alarm{
@@ -44679,7 +44033,6 @@
 /area/crew_quarters/bar)
 "bHG" = (
 /obj/item/device/radio/intercom{
-	dir = 2;
 	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
@@ -44802,8 +44155,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Break Room APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor{
@@ -44884,7 +44236,6 @@
 	desc = "A remote control switch for the medbay foyer.";
 	id = "MedbayFoyer1";
 	name = "Medbay Doors Control";
-	normaldoorcontrol = 1;
 	pixel_y = 28;
 	range = 8
 	},
@@ -44947,7 +44298,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/patient_b)
@@ -45023,11 +44373,7 @@
 /obj/item/weapon/folder/white,
 /obj/item/clothing/accessory/stethoscope,
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_x = -28
 	},
@@ -45037,7 +44383,6 @@
 	pixel_y = -25
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/patient_a)
@@ -45047,7 +44392,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/office)
@@ -45079,7 +44423,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/patient_a)
@@ -45117,10 +44460,7 @@
 "bIw" = (
 /obj/structure/table/glass,
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_x = -27
 	},
@@ -45182,7 +44522,6 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/medical/surgery2)
@@ -45194,15 +44533,11 @@
 	},
 /obj/item/weapon/bonesetter,
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_y = 25
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/medical/surgery2)
@@ -45273,11 +44608,7 @@
 	},
 /obj/structure/table/glass,
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_x = -28
 	},
@@ -45359,7 +44690,6 @@
 "bJd" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /turf/simulated/floor/plating{
@@ -45491,14 +44821,12 @@
 /area/assembly/chargebay)
 "bJt" = (
 /obj/machinery/door_control{
-	dir = 2;
 	id = "Skynet_launch";
 	name = "Mech Bay Door Control";
 	pixel_x = 6;
 	pixel_y = -24
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warningcorner"
 	},
 /area/assembly/chargebay)
@@ -45525,7 +44853,6 @@
 /area/medical/hallway)
 "bJv" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/assembly/chargebay)
@@ -45537,7 +44864,6 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/assembly/chargebay)
@@ -45647,7 +44973,6 @@
 /area/hallway/primary/central)
 "bJN" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_x = -32
 	},
@@ -45706,11 +45031,7 @@
 /obj/structure/stool/bed,
 /obj/item/weapon/bedsheet/medical,
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_x = -28
 	},
@@ -45762,8 +45083,7 @@
 /obj/structure/stool/bed/roller,
 /obj/machinery/iv_drip,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -45820,15 +45140,13 @@
 /area/storage/tech)
 "bKm" = (
 /obj/machinery/alarm{
-	frequency = 1439;
 	pixel_y = 23
 	},
 /turf/simulated/floor/plating,
 /area/storage/tech)
 "bKn" = (
 /obj/machinery/camera{
-	c_tag = "Tech Storage";
-	dir = 2
+	c_tag = "Tech Storage"
 	},
 /obj/machinery/power/apc{
 	dir = 1;
@@ -45908,7 +45226,6 @@
 "bKw" = (
 /obj/structure/closet/l3closet/janitor,
 /obj/machinery/alarm{
-	frequency = 1439;
 	pixel_y = 23
 	},
 /turf/simulated/floor,
@@ -45922,7 +45239,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/rnd/misc_lab)
@@ -45980,7 +45296,6 @@
 	dir = 4
 	},
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_x = -32
 	},
@@ -46016,19 +45331,16 @@
 "bKI" = (
 /obj/machinery/light,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
 "bKJ" = (
 /obj/structure/window/reinforced/polarized{
 	dir = 8;
-	icon_state = "fwindow";
 	id = "op2"
 	},
 /obj/structure/window/reinforced/polarized{
 	dir = 4;
-	icon_state = "fwindow";
 	id = "op2"
 	},
 /obj/structure/window/reinforced/polarized{
@@ -46041,7 +45353,6 @@
 "bKL" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /obj/machinery/alarm{
@@ -46090,8 +45401,7 @@
 "bKQ" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -46124,15 +45434,6 @@
 	icon_state = "grimy"
 	},
 /area/crew_quarters/bar)
-"bKV" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
-	},
-/turf/simulated/floor,
-/area/hallway/primary/port)
 "bKW" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -46156,7 +45457,6 @@
 "bKZ" = (
 /obj/machinery/body_scanconsole,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/sleeper)
@@ -46233,7 +45533,6 @@
 /area/rnd/misc_lab)
 "bLl" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/rnd/misc_lab)
@@ -46419,8 +45718,7 @@
 /area/hallway/primary/starboard)
 "bLH" = (
 /obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway";
-	dir = 2
+	c_tag = "Starboard Primary Hallway"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -46526,7 +45824,6 @@
 "bLU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
-	dir = 2;
 	id = "Skynet_launch";
 	name = "Mech Bay"
 	},
@@ -46536,7 +45833,6 @@
 /area/assembly/chargebay)
 "bLV" = (
 /obj/machinery/door/poddoor/shutters{
-	dir = 2;
 	id = "Skynet_launch";
 	name = "Mech Bay"
 	},
@@ -46581,7 +45877,6 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/rnd/misc_lab)
@@ -46780,13 +46075,11 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
 "bMv" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -46828,14 +46121,12 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/medical/hallway)
 "bMA" = (
 /obj/machinery/light,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "greencorner"
 	},
 /area/hallway/primary/starboard)
@@ -46895,7 +46186,6 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/rnd/misc_lab)
@@ -47051,7 +46341,6 @@
 /area/hallway/primary/starboard)
 "bNe" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor{
@@ -47103,8 +46392,7 @@
 /area/hallway/primary/starboard)
 "bNm" = (
 /obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway 2";
-	dir = 2
+	c_tag = "Starboard Primary Hallway 2"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -47308,7 +46596,6 @@
 /obj/item/clothing/under/patient_gown,
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/simulated/floor{
@@ -47337,11 +46624,9 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the department.";
 	dir = 4;
-	icon_state = "telescreen";
 	name = "Medical Monitor";
 	network = list("Medical");
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -47395,7 +46680,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/genetics)
@@ -47471,7 +46755,6 @@
 	dir = 9
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warnwhite"
 	},
 /area/rnd/mixing)
@@ -47487,7 +46770,6 @@
 "bOi" = (
 /obj/structure/closet/secure_closet/scientist,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warnwhite"
 	},
 /area/rnd/mixing)
@@ -47496,7 +46778,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -47558,7 +46839,6 @@
 "bOs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor{
@@ -47600,7 +46880,6 @@
 	req_access_txt = "8"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurplefull"
 	},
 /area/rnd/mixing)
@@ -47645,13 +46924,11 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "greencorner"
 	},
 /area/hallway/secondary/entry)
 "bOC" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/miningbreaktime)
@@ -47772,7 +47049,6 @@
 	pixel_y = -25
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -47903,7 +47179,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -48040,11 +47315,7 @@
 "bPv" = (
 /obj/machinery/vending/snack,
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_x = 28
 	},
@@ -48149,8 +47420,7 @@
 /area/hallway/primary/starboard)
 "bPD" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
-	dir = 4;
-	icon_state = "heater"
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -48433,8 +47703,7 @@
 /area/storage/tech)
 "bQg" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/closet/wardrobe/medic_white,
 /turf/simulated/floor{
@@ -48445,12 +47714,10 @@
 "bQh" = (
 /obj/structure/window/reinforced/polarized{
 	dir = 1;
-	icon_state = "fwindow";
 	id = "op1"
 	},
 /obj/structure/window/reinforced/polarized{
 	dir = 4;
-	icon_state = "fwindow";
 	id = "op1"
 	},
 /obj/structure/window/reinforced/polarized{
@@ -48458,7 +47725,6 @@
 	},
 /obj/structure/window/reinforced/polarized{
 	dir = 8;
-	icon_state = "fwindow";
 	id = "op1"
 	},
 /obj/structure/grille,
@@ -48582,7 +47848,6 @@
 /obj/structure/table,
 /obj/item/weapon/surgicaldrill,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/medical/surgery)
@@ -48613,7 +47878,6 @@
 /area/hallway/primary/starboard)
 "bQB" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "greencorner"
 	},
 /area/hallway/secondary/entry)
@@ -48626,8 +47890,7 @@
 	req_access_txt = "35"
 	},
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/hydroponics)
 "bQD" = (
@@ -48636,7 +47899,6 @@
 	name = "Botanist"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/hydroponics)
@@ -48647,7 +47909,6 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/hydroponics)
@@ -48743,8 +48004,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/atmos)
 "bQO" = (
@@ -48945,7 +48205,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/hydroponics)
@@ -48983,7 +48242,6 @@
 	pixel_y = 23
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/hydroponics)
@@ -48999,7 +48257,6 @@
 	icon_state = "0-8"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/hydroponics)
@@ -49305,7 +48562,6 @@
 	c_tag = "Atmospherics North East"
 	},
 /obj/item/device/radio/intercom{
-	dir = 2;
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
@@ -49390,11 +48646,7 @@
 "bSh" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_x = -28
 	},
@@ -49431,11 +48683,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/rnd/hallway)
@@ -49481,7 +48731,6 @@
 "bSq" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	icon_state = "pipe-j1s";
 	name = "Chemistry";
 	sortType = "Chemistry"
 	},
@@ -49505,14 +48754,12 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
 "bSs" = (
 /obj/machinery/light,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -49528,7 +48775,6 @@
 /area/maintenance/engineering)
 "bSv" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/storage)
@@ -49544,7 +48790,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -49556,7 +48801,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -49565,7 +48809,6 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -49575,21 +48818,18 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
 "bSD" = (
 /obj/machinery/iv_drip,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/medical/surgery)
 "bSE" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -49853,7 +49093,6 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "greencorner"
 	},
 /area/hallway/secondary/entry)
@@ -49877,17 +49116,12 @@
 /area/maintenance/medbay)
 "bTs" = (
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_x = 28
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 12
 	},
 /turf/simulated/floor{
@@ -49966,11 +49200,7 @@
 	},
 /obj/item/weapon/bonesetter,
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_x = -28
 	},
@@ -50006,8 +49236,7 @@
 /area/maintenance/atmos)
 "bTE" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -50054,8 +49283,6 @@
 /obj/machinery/door/airlock/research/glass{
 	autoclose = 0;
 	frequency = 1379;
-	glass = 1;
-	icon_state = "closed";
 	id_tag = "tox_airlock_interior";
 	locked = 1;
 	name = "Mixing Room Interior Airlock";
@@ -50247,8 +49474,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -50436,7 +49662,6 @@
 	pixel_x = 30
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitebluecorner"
 	},
 /area/medical/hallway)
@@ -50700,7 +49925,6 @@
 /area/construction)
 "bVs" = (
 /obj/machinery/alarm{
-	frequency = 1439;
 	pixel_y = 23
 	},
 /turf/simulated/floor,
@@ -50798,10 +50022,8 @@
 "bVG" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
-	icon_state = "left";
 	name = "Engineering Moniter Station";
-	req_access_txt = "71";
-	req_one_access = null
+	req_access_txt = "71"
 	},
 /turf/simulated/floor{
 	icon_state = "delivery"
@@ -50837,14 +50059,12 @@
 	},
 /obj/machinery/door/window/northleft{
 	dir = 4;
-	icon_state = "left";
 	name = "Engineering Desk";
 	req_access_txt = "71"
 	},
 /obj/item/weapon/bell,
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/engine/break_room)
 "bVK" = (
@@ -50948,7 +50168,6 @@
 "bVT" = (
 /obj/structure/window/reinforced/polarized{
 	dir = 8;
-	icon_state = "fwindow";
 	id = "op1"
 	},
 /obj/structure/window/reinforced/polarized{
@@ -50956,7 +50175,6 @@
 	},
 /obj/structure/window/reinforced/polarized{
 	dir = 1;
-	icon_state = "fwindow";
 	id = "op1"
 	},
 /obj/structure/grille,
@@ -51047,7 +50265,6 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/toxins/brainstorm_center)
@@ -51201,7 +50418,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "escape"
 	},
 /area/hallway/secondary/entry)
@@ -51333,7 +50549,6 @@
 /area/rnd/xenobiology)
 "bWO" = (
 /obj/machinery/sparker{
-	dir = 2;
 	id = "mixingsparker";
 	pixel_x = -23
 	},
@@ -51392,8 +50607,7 @@
 /area/hydroponics)
 "bWU" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/filingcabinet,
 /turf/simulated/floor{
@@ -51506,7 +50720,6 @@
 "bXg" = (
 /obj/structure/window/reinforced/polarized{
 	dir = 1;
-	icon_state = "fwindow";
 	id = "op1"
 	},
 /obj/structure/window/reinforced/polarized{
@@ -51514,7 +50727,6 @@
 	},
 /obj/structure/window/reinforced/polarized{
 	dir = 4;
-	icon_state = "fwindow";
 	id = "op1"
 	},
 /obj/structure/grille,
@@ -51592,8 +50804,6 @@
 "bXn" = (
 /obj/machinery/computer/arcade,
 /obj/structure/sign/poster{
-	dir = 2;
-	official = 0;
 	pixel_y = -32
 	},
 /turf/simulated/floor{
@@ -51627,7 +50837,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/southright{
 	name = "Genetics Desk";
-	req_access_txt = "0";
 	req_one_access_txt = "47; 9"
 	},
 /obj/item/weapon/bell,
@@ -51647,7 +50856,6 @@
 /area/maintenance/disposal)
 "bXt" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/central)
@@ -51766,7 +50974,6 @@
 /area/atmos)
 "bXH" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warnwhite"
 	},
 /area/rnd/mixing)
@@ -51830,11 +51037,7 @@
 "bXS" = (
 /obj/structure/flora/plant/random,
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_x = 28
 	},
@@ -51881,7 +51084,6 @@
 	name = "Central Access"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -51896,7 +51098,6 @@
 "bYe" = (
 /obj/structure/table/woodentable,
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -51940,7 +51141,6 @@
 "bYk" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
-	icon_state = "closed";
 	locked = 1;
 	name = "Assembly Line (KEEP OUT)";
 	req_access_txt = "32"
@@ -52031,7 +51231,6 @@
 "bYu" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	dir = 8;
-	frequency = 1441;
 	input_tag = "waste_in";
 	name = "Gas Mix Tank Control";
 	output_tag = "waste_out";
@@ -52116,7 +51315,6 @@
 /obj/item/weapon/pen,
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cult"
 	},
 /area/library)
@@ -52157,7 +51355,6 @@
 /obj/structure/table/woodentable,
 /obj/item/weapon/folder,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cult"
 	},
 /area/library)
@@ -52169,7 +51366,6 @@
 	},
 /obj/item/weapon/pen,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cult"
 	},
 /area/library)
@@ -52178,7 +51374,6 @@
 /obj/item/weapon/folder,
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cult"
 	},
 /area/library)
@@ -52214,7 +51409,6 @@
 	},
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
-	req_access = null;
 	req_access_txt = "71";
 	req_one_access_txt = "null"
 	},
@@ -52235,7 +51429,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/item/device/radio/intercom{
-	dir = 2;
 	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
@@ -52372,7 +51565,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
@@ -52460,7 +51652,6 @@
 /area/medical/medbreak)
 "bZJ" = (
 /obj/machinery/requests_console{
-	announcementConsole = 0;
 	department = "Engineering";
 	departmentType = 4;
 	name = "Engineering RC";
@@ -52520,7 +51711,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
-	req_access = null;
 	req_access_txt = "71";
 	req_one_access_txt = null
 	},
@@ -53128,9 +52318,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1379;
 	id_tag = "robotics_solar_airlock";
-	layer = 3.3;
 	pixel_y = -25;
 	req_access_txt = "13";
 	tag_airpump = "robotics_solar_pump";
@@ -53139,7 +52327,6 @@
 	tag_interior_door = "robotics_solar_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "robotics_solar_sensor";
 	layer = 3.3;
 	pixel_x = 12;
@@ -53170,8 +52357,7 @@
 "cbx" = (
 /obj/structure/stool/bed/roller,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -53207,7 +52393,6 @@
 "cbA" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 12
 	},
 /obj/structure/dryer{
@@ -53338,7 +52523,6 @@
 	},
 /obj/item/clothing/glasses/welding,
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -53503,7 +52687,6 @@
 /area/atmos)
 "ccq" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cult"
 	},
 /area/library)
@@ -53559,7 +52742,6 @@
 /area/atmos)
 "ccA" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -53595,7 +52777,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cult"
 	},
 /area/library)
@@ -53749,7 +52930,6 @@
 "cdn" = (
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "wood_siding2"
 	},
 /area/garden)
@@ -53765,8 +52945,7 @@
 	},
 /obj/structure/closet/firecloset,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 6
@@ -53879,7 +53058,6 @@
 /area/construction)
 "cdK" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Construction Area APC";
 	pixel_y = -24
 	},
@@ -54203,7 +53381,6 @@
 "ceI" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "greencorner"
 	},
 /area/hallway/secondary/entry)
@@ -54590,14 +53767,12 @@
 "cfx" = (
 /obj/machinery/light,
 /turf/simulated/floor/plating/airless{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/rnd/mixing)
 "cfy" = (
 /obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -54610,7 +53785,6 @@
 	},
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the singularity chamber.";
-	dir = 2;
 	layer = 4;
 	name = "Singularity Engine Telescreen";
 	network = list("Singularity");
@@ -54675,8 +53849,7 @@
 /area/shuttle/escape_pod5/station)
 "cfH" = (
 /obj/structure/stool/bed/chair{
-	dir = 8;
-	icon_state = "chair"
+	dir = 8
 	},
 /turf/simulated/floor/plating/airless{
 	dir = 5;
@@ -54859,8 +54032,7 @@
 	pixel_x = -24
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/atmos)
@@ -54882,8 +54054,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j1"
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
@@ -54894,7 +54065,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1379;
 	id_tag = "solar_xeno_airlock";
 	pixel_x = 25;
 	req_access_txt = "13";
@@ -54904,7 +54074,6 @@
 	tag_interior_door = "solar_xeno_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "solar_xeno_sensor";
 	pixel_x = 25;
 	pixel_y = 12
@@ -55059,8 +54228,6 @@
 /obj/machinery/door/airlock/research/glass{
 	autoclose = 0;
 	frequency = 1379;
-	glass = 1;
-	icon_state = "closed";
 	id_tag = "tox_airlock_exterior";
 	locked = 1;
 	name = "Mixing Room Exterior Airlock";
@@ -55296,7 +54463,6 @@
 "chd" = (
 /obj/machinery/computer/arcade,
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -55457,7 +54623,6 @@
 "chs" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Center";
-	dir = 2;
 	pixel_x = 23
 	},
 /obj/structure/cable/yellow{
@@ -55869,7 +55034,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/engine/engineering)
@@ -55892,7 +55056,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/engine/engineering)
@@ -55909,7 +55072,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/engine/engineering)
@@ -55923,7 +55085,6 @@
 	dir = 5
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/engine/engineering)
@@ -55935,7 +55096,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/engine/engineering)
@@ -55945,7 +55105,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/engine/engineering)
@@ -56268,7 +55427,6 @@
 "cju" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /obj/structure/mirror{
@@ -56340,13 +55498,11 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "engineering_west_sensor";
 	pixel_x = 25;
 	pixel_y = 12
 	},
 /obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1379;
 	id_tag = "engineering_west_airlock";
 	pixel_x = 25;
 	req_access_txt = "10;13";
@@ -56377,13 +55533,11 @@
 /area/garden)
 "cjE" = (
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "engineering_east_sensor";
 	pixel_x = -25;
 	pixel_y = 12
 	},
 /obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1379;
 	id_tag = "engineering_east_airlock";
 	pixel_x = -25;
 	req_access_txt = "10;13";
@@ -56525,7 +55679,6 @@
 "cjX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Medical Checkpoint";
 	req_access_txt = "5"
 	},
@@ -56537,7 +55690,6 @@
 "cjY" = (
 /obj/machinery/door/morgue{
 	dir = 4;
-	icon_state = "door1";
 	name = "Reading Bay"
 	},
 /obj/machinery/door/firedoor,
@@ -56560,7 +55712,6 @@
 /obj/structure/table/glass,
 /obj/item/weapon/lipstick/random,
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
@@ -56732,7 +55883,6 @@
 "ckv" = (
 /obj/structure/table,
 /obj/item/device/radio/intercom{
-	dir = 2;
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
@@ -56785,7 +55935,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "asteroid"
 	},
 /area/garden)
@@ -56840,7 +55989,6 @@
 "ckK" = (
 /obj/machinery/camera{
 	c_tag = "Engineering passage";
-	dir = 2;
 	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -56934,11 +56082,9 @@
 	},
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /obj/item/device/radio/intercom{
-	dir = 2;
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
@@ -56967,7 +56113,6 @@
 "cla" = (
 /obj/structure/stool/bed/chair/schair/wagon/bench,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "asteroid"
 	},
 /area/garden)
@@ -56976,7 +56121,6 @@
 	icon_state = "bench_2"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "asteroid"
 	},
 /area/garden)
@@ -57032,7 +56176,6 @@
 "cll" = (
 /obj/structure/flora/plant/random,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Law Office APC";
 	pixel_y = -24
 	},
@@ -57163,9 +56306,7 @@
 /area/engine/engineering)
 "clC" = (
 /obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1379;
 	id_tag = "engineering_aux_airlock";
-	layer = 3.3;
 	pixel_x = -25;
 	req_access_txt = "13";
 	tag_airpump = "engineering_aux_pump";
@@ -57373,7 +56514,6 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "asteroid"
 	},
 /area/garden)
@@ -57386,7 +56526,6 @@
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/turretid/stun/AI_special{
-	dir = 2;
 	name = "AI Chamber turret control";
 	pixel_x = 26;
 	pixel_y = 24
@@ -57434,7 +56573,6 @@
 "cme" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /turf/simulated/floor{
@@ -57673,8 +56811,7 @@
 /obj/item/clothing/mask/gas/coloured,
 /obj/item/clothing/mask/gas/coloured,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/engine/break_room)
@@ -57687,7 +56824,6 @@
 	opacity = 0
 	},
 /obj/machinery/door/airlock/highsecurity{
-	icon_state = "closed";
 	locked = 1;
 	name = "AI Chamber";
 	req_access_txt = "16"
@@ -57708,7 +56844,6 @@
 "cmH" = (
 /obj/machinery/computer/station_alert,
 /obj/machinery/computer/security/telescreen{
-	dir = 2;
 	name = "MiniSat Monitor";
 	network = list("MiniSat");
 	pixel_y = 30
@@ -57761,8 +56896,7 @@
 	pixel_y = 1
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/carpet/red,
 /area/security/detectives_office)
@@ -57892,7 +57026,6 @@
 "cnn" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /turf/simulated/floor/wood,
@@ -58040,7 +57173,6 @@
 	},
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Antechamber";
-	dir = 2;
 	network = list("MiniSat")
 	},
 /obj/structure/cable{
@@ -58278,15 +57410,13 @@
 /area/crew_quarters/captain)
 "cnY" = (
 /obj/structure/stool/bed/chair/wood/wings{
-	dir = 8;
-	icon_state = "wooden_chair_wings"
+	dir = 8
 	},
 /turf/simulated/floor/carpet/orange,
 /area/maintenance/eva)
 "cnZ" = (
 /obj/structure/stool/bed/chair/wood/wings{
-	dir = 4;
-	icon_state = "wooden_chair_wings"
+	dir = 4
 	},
 /turf/simulated/floor/carpet/orange,
 /area/maintenance/eva)
@@ -58471,7 +57601,6 @@
 /area/turret_protected/aisat)
 "cos" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/aft)
@@ -58604,7 +57733,6 @@
 /obj/machinery/photocopier,
 /obj/machinery/alarm{
 	dir = 4;
-	frequency = 1439;
 	pixel_x = -23
 	},
 /turf/simulated/floor/wood,
@@ -58715,7 +57843,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "asteroid3"
 	},
 /area/garden)
@@ -58727,7 +57854,6 @@
 	dir = 9
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "asteroid6"
 	},
 /area/garden)
@@ -58849,7 +57975,6 @@
 "cpl" = (
 /obj/machinery/power/apc{
 	cell_type = 2500;
-	dir = 2;
 	name = "MiniSat External Power APC";
 	pixel_y = -25
 	},
@@ -58922,7 +58047,6 @@
 	},
 /obj/machinery/power/apc{
 	cell_type = 2500;
-	dir = 2;
 	name = "MiniSat Internal Power APC";
 	pixel_y = -25
 	},
@@ -59076,7 +58200,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "asteroid"
 	},
 /area/garden)
@@ -59088,7 +58211,6 @@
 	},
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "robotics_solar_outer";
 	locked = 1;
 	name = "Engineering External Access";
@@ -59139,7 +58261,6 @@
 	},
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "robotics_solar_inner";
 	locked = 1;
 	name = "Engineering External Access";
@@ -59230,7 +58351,6 @@
 "cpR" = (
 /obj/machinery/smartfridge/secure/extract,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitecorner"
 	},
 /area/rnd/xenobiology)
@@ -59302,7 +58422,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "MiniSat Teleporter";
-	dir = 2;
 	network = list("MiniSat")
 	},
 /obj/structure/cable{
@@ -59310,7 +58429,6 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	aidisabled = 0;
 	dir = 1;
 	name = "AI Satellite APC";
 	pixel_y = 24
@@ -59358,7 +58476,6 @@
 /area/AIsattele)
 "cqg" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Starboard Primary Hallway APC";
 	pixel_y = -24
 	},
@@ -59367,7 +58484,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -59388,7 +58504,6 @@
 "cqi" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -59428,7 +58543,6 @@
 "cqm" = (
 /obj/machinery/light,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "yellowcorner"
 	},
 /area/hallway/primary/starboard)
@@ -59529,7 +58643,6 @@
 /area/security/detectives_office)
 "cqA" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
-	frequency = 1441;
 	input_tag = "n2_in";
 	name = "Nitrogen Supply Control";
 	output_tag = "n2_out";
@@ -59770,8 +58883,7 @@
 "cqU" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -59783,7 +58895,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "asteroid2"
 	},
 /area/garden)
@@ -59793,7 +58904,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "asteroid7"
 	},
 /area/garden)
@@ -59990,9 +59100,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/portsolar)
 "crw" = (
-/obj/machinery/power/smes{
-	charge = 0
-	},
+/obj/machinery/power/smes,
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2";
@@ -60079,7 +59187,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/starboard)
@@ -60127,7 +59234,6 @@
 "crJ" = (
 /obj/machinery/camera{
 	c_tag = "Central Compartment North";
-	dir = 2;
 	network = list("Tcomsat")
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan,
@@ -60283,7 +59389,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "yellow"
 	},
 /area/hallway/primary/starboard)
@@ -60367,7 +59472,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access";
-	req_access_txt = "0";
 	req_one_access_txt = "47; 9"
 	},
 /turf/simulated/floor,
@@ -60419,8 +59523,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -60434,7 +59537,6 @@
 /area/quartermaster/storage)
 "css" = (
 /obj/machinery/status_display{
-	density = 0;
 	pixel_y = 32;
 	supply_display = 1
 	},
@@ -60624,7 +59726,6 @@
 	pixel_x = -24
 	},
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
@@ -60653,7 +59754,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/main)
@@ -60678,7 +59778,6 @@
 /area/engine/engineering)
 "csR" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
 	dir = 4;
 	name = "Telecoms Sat. Central Compartment APC";
 	pixel_x = 28
@@ -60896,7 +59995,6 @@
 /obj/structure/window/reinforced,
 /obj/machinery/camera{
 	c_tag = "MiniSat South";
-	dir = 2;
 	network = list("MiniSat")
 	},
 /obj/machinery/light/small{
@@ -61020,7 +60118,6 @@
 "ctJ" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/medical/reception)
@@ -61071,7 +60168,6 @@
 "ctU" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	dir = 8;
-	frequency = 1441;
 	input_tag = "tox_in";
 	name = "Toxin Supply Control";
 	output_tag = "tox_out";
@@ -61085,7 +60181,6 @@
 "ctV" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	dir = 8;
-	frequency = 1441;
 	input_tag = "n2o_in";
 	name = "Nitrous Oxide Supply Control";
 	output_tag = "n2o_out";
@@ -61162,8 +60257,7 @@
 /area/engine/engineering)
 "cug" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -61214,7 +60308,6 @@
 /area/maintenance/engineering)
 "cul" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_x = 32
 	},
@@ -61317,7 +60410,6 @@
 "cuv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "greencorner"
 	},
 /area/garden)
@@ -61336,7 +60428,6 @@
 "cux" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/garden)
@@ -61368,7 +60459,6 @@
 /area/garden)
 "cuE" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "asteroid"
 	},
 /area/garden)
@@ -61456,13 +60546,11 @@
 /area/rnd/xenobiology)
 "cuM" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "asteroid7"
 	},
 /area/garden)
 "cuN" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "asteroid6"
 	},
 /area/garden)
@@ -61502,9 +60590,7 @@
 /turf/simulated/floor,
 /area/engine/break_room)
 "cuS" = (
-/obj/machinery/power/smes{
-	charge = 0
-	},
+/obj/machinery/power/smes,
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -61809,8 +60895,7 @@
 /area/maintenance/starboardsolar)
 "cvG" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -61845,7 +60930,6 @@
 /area/maintenance/portsolar)
 "cvR" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
-	frequency = 1441;
 	input_tag = "o2_in";
 	name = "Oxygen Supply Control";
 	output_tag = "o2_out";
@@ -61869,8 +60953,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/engine/engineering)
@@ -61888,8 +60971,7 @@
 "cwb" = (
 /obj/structure/closet/secure_closet/engineering_welding,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/engine/break_room)
@@ -61974,7 +61056,6 @@
 	},
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "solar_xeno_inner";
 	locked = 1;
 	name = "Engineering External Access";
@@ -62052,8 +61133,7 @@
 "cwF" = (
 /obj/machinery/power/solar_control{
 	id = "starboardsolar";
-	name = "Aft Starboard Solar Control";
-	track = 0
+	name = "Aft Starboard Solar Control"
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -62159,7 +61239,6 @@
 "cwU" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "solar_xeno_outer";
 	locked = 1;
 	name = "Engineering External Access";
@@ -62214,7 +61293,6 @@
 /area/hallway/primary/central)
 "cwZ" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor{
@@ -62269,8 +61347,7 @@
 /area/hallway/primary/central)
 "cxh" = (
 /obj/machinery/camera{
-	c_tag = "Central Primary Hallway South";
-	dir = 2
+	c_tag = "Central Primary Hallway South"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -62288,7 +61365,6 @@
 /area/hallway/primary/central)
 "cxj" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor{
@@ -62343,13 +61419,11 @@
 "cxp" = (
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "wood_siding1"
 	},
 /area/garden)
 "cxs" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "asteroid3"
 	},
 /area/garden)
@@ -62364,7 +61438,6 @@
 /area/hallway/primary/central)
 "cxu" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "asteroid2"
 	},
 /area/garden)
@@ -62394,7 +61467,6 @@
 /area/toxins/server)
 "cxy" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitebot"
 	},
 /area/medical/reception)
@@ -62490,7 +61562,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior";
-	dir = 2;
 	network = list("MiniSat")
 	},
 /obj/machinery/light/small{
@@ -62506,7 +61577,6 @@
 	pixel_y = -22
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -62515,7 +61585,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -62526,7 +61595,6 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -62535,7 +61603,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -62545,7 +61612,6 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -62611,8 +61677,7 @@
 "cxX" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -62743,7 +61808,6 @@
 "cyl" = (
 /obj/machinery/alarm{
 	dir = 4;
-	frequency = 1439;
 	pixel_x = -23
 	},
 /turf/simulated/floor,
@@ -62756,8 +61820,7 @@
 "cyn" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -62768,7 +61831,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "greencorner"
 	},
 /area/garden)
@@ -63004,8 +62066,7 @@
 /area/maintenance/medbay)
 "cyT" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/engine/engineering)
@@ -63115,7 +62176,6 @@
 "czf" = (
 /obj/structure/bookcase/manuals/research_and_development,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/toxins/brainstorm_center)
@@ -63281,8 +62341,7 @@
 /area/solar/starboard)
 "czE" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -63292,7 +62351,6 @@
 "czF" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	dir = 8;
-	frequency = 1441;
 	input_tag = "co2_in";
 	name = "Carbon Dioxide Supply Control";
 	output_tag = "co2_out";
@@ -63517,7 +62575,6 @@
 /obj/item/weapon/razor,
 /obj/machinery/camera{
 	c_tag = "Surgery Operating 2";
-	dir = 2;
 	network = list("SS13","Medical")
 	},
 /obj/structure/disposalpipe/segment,
@@ -63588,15 +62645,13 @@
 	amount = 25
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "cAk" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -63611,7 +62666,6 @@
 /area/hallway/primary/aft)
 "cAn" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/engine/engineering)
@@ -63623,7 +62677,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/engine/engineering)
@@ -63635,7 +62688,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/engine/engineering)
@@ -63652,7 +62704,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/engine/engineering)
@@ -63701,7 +62752,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/engine/engineering)
@@ -63740,8 +62790,7 @@
 "cAC" = (
 /obj/structure/transit_tube_pod,
 /obj/structure/transit_tube/station{
-	dir = 8;
-	icon_state = "closed"
+	dir = 8
 	},
 /turf/simulated/floor/plating{
 	dir = 8;
@@ -63756,7 +62805,6 @@
 /area/space)
 "cAE" = (
 /obj/item/device/radio/intercom{
-	dir = 2;
 	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
@@ -63870,8 +62918,7 @@
 	},
 /obj/item/weapon/crowbar,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -63909,7 +62956,6 @@
 	autoclose = 0;
 	frequency = 1379;
 	heat_proof = 1;
-	icon_state = "closed";
 	id_tag = "incinerator_airlock_exterior";
 	locked = 1;
 	name = "Mixing Room Exterior Airlock";
@@ -63922,7 +62968,6 @@
 	autoclose = 0;
 	frequency = 1379;
 	heat_proof = 1;
-	icon_state = "closed";
 	id_tag = "incinerator_airlock_interior";
 	locked = 1;
 	name = "Mixing Room Interior Airlock";
@@ -63960,7 +63005,6 @@
 /area/medical/cmo)
 "cAY" = (
 /obj/machinery/requests_console{
-	announcementConsole = 0;
 	department = "Engineering";
 	departmentType = 4;
 	name = "Engineering RC";
@@ -63980,7 +63024,6 @@
 /area/engine/break_room)
 "cAZ" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_x = -32
 	},
@@ -64021,9 +63064,7 @@
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "cBf" = (
-/obj/machinery/the_singularitygen{
-	anchored = 0
-	},
+/obj/machinery/the_singularitygen,
 /turf/simulated/floor/plating,
 /area/engine/engineering)
 "cBg" = (
@@ -64236,8 +63277,7 @@
 	pixel_y = -22
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -64246,7 +63286,6 @@
 /area/engine/drone_fabrication)
 "cBI" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "south bump";
 	pixel_y = -24
 	},
@@ -64277,7 +63316,6 @@
 	},
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "engineering_west_outer";
 	locked = 1;
 	name = "Engineering External Access";
@@ -64359,7 +63397,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/engine/engineering)
@@ -64371,13 +63408,11 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/engine/engineering)
 "cBS" = (
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/engine/engineering)
@@ -64411,7 +63446,6 @@
 "cBW" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "engineering_east_outer";
 	locked = 1;
 	name = "Engineering External Access";
@@ -64459,7 +63493,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/garden)
@@ -64640,7 +63673,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "asteroid"
 	},
 /area/garden)
@@ -64775,7 +63807,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "asteroid7"
 	},
 /area/garden)
@@ -64784,7 +63815,6 @@
 	dir = 10
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "asteroid"
 	},
 /area/garden)
@@ -65284,8 +64314,7 @@
 /area/turret_protected/ai)
 "cDV" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -65350,7 +64379,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 2;
 	icon_state = "shutter0";
 	id = "Medical_Psychiatry";
 	name = "Privacy Shutters";
@@ -65454,7 +64482,6 @@
 "cEv" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "engineering_aux_outer";
 	locked = 1;
 	name = "Engineering External Access";
@@ -65474,7 +64501,6 @@
 	name = "Satellite Aux Large Air Vent"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "satellite_aux_sensor";
 	pixel_y = 25;
 	req_one_access_txt = "13;45;1"
@@ -65658,7 +64684,6 @@
 	dir = 8
 	},
 /obj/machinery/power/apc{
-	aidisabled = 0;
 	dir = 1;
 	name = "AI Chamber APC";
 	pixel_y = 24
@@ -65694,7 +64719,6 @@
 "cFe" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "satellite_aux_outer";
 	locked = 1;
 	name = "Satellite External Access";
@@ -65768,7 +64792,6 @@
 /obj/machinery/cell_charger,
 /obj/item/weapon/stock_parts/cell/high,
 /obj/machinery/computer/security/telescreen{
-	dir = 2;
 	name = "MiniSat Monitor";
 	network = list("MiniSat");
 	pixel_y = 30
@@ -65828,7 +64851,6 @@
 /area/maintenance/engineering)
 "cFu" = (
 /obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1379;
 	id_tag = "engin_airlock";
 	pixel_y = 28;
 	req_one_access_txt = "13;45;1";
@@ -65838,7 +64860,6 @@
 	tag_interior_door = "engin_inner"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "engin_sensor";
 	layer = 3.3;
 	pixel_x = 12;
@@ -65863,7 +64884,6 @@
 "cFw" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "engin_outer";
 	locked = 1;
 	name = "Engineering External Access";
@@ -65996,7 +65016,6 @@
 /area/turret_protected/aisat_interior)
 "cFK" = (
 /obj/item/device/radio/intercom{
-	dir = 2;
 	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
@@ -66038,7 +65057,6 @@
 "cFO" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "engin_inner";
 	locked = 1;
 	name = "Engineering External Access";
@@ -66083,7 +65101,6 @@
 	},
 /obj/machinery/turretid/stun/AI_special{
 	control_area = "AI Satellite";
-	dir = 2;
 	name = "Aisat Turret Control";
 	pixel_y = 24
 	},
@@ -66144,9 +65161,7 @@
 	},
 /obj/item/device/radio/intercom{
 	broadcasting = 1;
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_x = -28
 	},
@@ -66169,8 +65184,7 @@
 	icon_state = "N-S"
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plating{
 	dir = 4;
@@ -66247,25 +65261,20 @@
 	name = "tripai"
 	},
 /obj/item/device/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
 	pixel_y = 20
 	},
 /obj/item/device/radio/intercom{
-	anyai = 1;
-	broadcasting = 0;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
 	pixel_y = -26
 	},
 /obj/item/device/radio/intercom{
-	anyai = 1;
 	broadcasting = 1;
 	freerange = 1;
-	listening = 1;
 	name = "Common Channel";
 	pixel_x = -25;
 	pixel_y = -4
@@ -66317,25 +65326,20 @@
 	name = "tripai"
 	},
 /obj/item/device/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
 	pixel_y = 19
 	},
 /obj/item/device/radio/intercom{
-	anyai = 1;
-	broadcasting = 0;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
 	pixel_y = -26
 	},
 /obj/item/device/radio/intercom{
-	anyai = 1;
 	broadcasting = 1;
 	freerange = 1;
-	listening = 1;
 	name = "Common Channel";
 	pixel_x = 27;
 	pixel_y = -3
@@ -66410,8 +65414,7 @@
 /area/turret_protected/ai)
 "cGy" = (
 /obj/structure/transit_tube/station{
-	dir = 4;
-	icon_state = "closed"
+	dir = 4
 	},
 /turf/simulated/floor/plating{
 	dir = 4;
@@ -66577,7 +65580,6 @@
 	},
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "engineering_west_inner";
 	locked = 1;
 	name = "Engineering External Access";
@@ -66622,14 +65624,12 @@
 /area/hallway/primary/aft)
 "cHb" = (
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "virology_sensor";
 	pixel_x = 25;
 	pixel_y = 12;
 	req_one_access_txt = "13;45;1"
 	},
 /obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1379;
 	id_tag = "virology_airlock";
 	pixel_x = 25;
 	req_one_access_txt = "13;45;1";
@@ -66653,7 +65653,6 @@
 "cHg" = (
 /obj/machinery/camera{
 	c_tag = "Main Computer Room";
-	dir = 2;
 	network = list("Tcomsat")
 	},
 /obj/structure/table/woodentable,
@@ -66669,7 +65668,6 @@
 "cHi" = (
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "wood_siding6"
 	},
 /area/garden)
@@ -66682,7 +65680,6 @@
 /area/space)
 "cHm" = (
 /obj/item/device/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	name = "General Listening Channel";
 	pixel_x = -28
@@ -66713,7 +65710,6 @@
 "cHq" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "virology_outer";
 	locked = 1;
 	name = "Engineering External Access";
@@ -66746,7 +65742,6 @@
 "cHw" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "engineering_east_inner";
 	locked = 1;
 	name = "Engineering External Access";
@@ -66963,7 +65958,6 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Detective APC";
 	pixel_y = -24
 	},
@@ -67022,7 +66016,6 @@
 /area/maintenance/engineering)
 "cIi" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "damaged4"
 	},
 /area/maintenance/engineering)
@@ -67103,9 +66096,7 @@
 /area/maintenance/engineering)
 "cID" = (
 /obj/machinery/door/window/northright{
-	base_state = "right";
 	dir = 8;
-	icon_state = "right";
 	name = "Library Desk Door";
 	req_access_txt = "37"
 	},
@@ -67194,7 +66185,6 @@
 	},
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /turf/simulated/floor{
@@ -67297,7 +66287,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warningcorner"
 	},
 /area/quartermaster/storage)
@@ -67378,7 +66367,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "loadingareadirty2"
 	},
 /area/quartermaster/storage)
@@ -67451,7 +66439,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/engine/engineering)
@@ -67475,7 +66462,6 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/engine/engineering)
@@ -67533,7 +66519,6 @@
 "cJF" = (
 /obj/structure/noticeboard{
 	dir = 8;
-	icon_state = "nboard00";
 	pixel_x = 32
 	},
 /turf/simulated/floor/wood,
@@ -67865,7 +66850,6 @@
 /area/maintenance/engineering)
 "cKK" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Psyciatric Office APC";
 	pixel_y = -28
 	},
@@ -68069,7 +67053,6 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor{
@@ -68087,7 +67070,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/engine/engineering)
@@ -68178,8 +67160,7 @@
 /area/maintenance/medbay)
 "cLv" = (
 /obj/machinery/shower{
-	dir = 8;
-	icon_state = "shower"
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -68354,7 +67335,6 @@
 	icon_state = "bench_2"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "asteroid"
 	},
 /area/garden)
@@ -68409,7 +67389,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/engine/engineering)
@@ -68527,7 +67506,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "asteroid"
 	},
 /area/garden)
@@ -68604,7 +67582,6 @@
 "cMz" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 12
 	},
 /turf/simulated/floor{
@@ -68763,7 +67740,6 @@
 "cNe" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 12
 	},
 /turf/simulated/floor{
@@ -68773,11 +67749,7 @@
 /area/medical/hallway)
 "cNf" = (
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_x = 28
 	},
@@ -68836,7 +67808,6 @@
 "cRb" = (
 /obj/machinery/computer/med_data,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor{
@@ -68845,8 +67816,7 @@
 /area/security/forensic_office)
 "cSb" = (
 /obj/machinery/camera{
-	c_tag = "Detective North";
-	dir = 2
+	c_tag = "Detective North"
 	},
 /obj/machinery/computer/forensic_scanning,
 /turf/simulated/floor{
@@ -68925,7 +67895,6 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteredcorner"
 	},
 /area/medical/reception)
@@ -69163,7 +68132,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
 	dock_tag = "arrival_1";
-	icon_state = "closed";
 	locked = 1;
 	name = "Arrival Airlock"
 	},
@@ -69191,11 +68159,9 @@
 "dyb" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /obj/item/device/radio/intercom{
-	dir = 2;
 	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
@@ -69360,8 +68326,7 @@
 	pixel_x = -30
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -69394,7 +68359,6 @@
 "dRb" = (
 /obj/machinery/camera/emp_proof{
 	c_tag = "Singularity North East";
-	dir = 2;
 	network = list("Singularity")
 	},
 /obj/structure/cable{
@@ -69443,19 +68407,15 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/rnd/xenobiology)
 "dVb" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /obj/item/device/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = -30;
 	pixel_y = 5
@@ -69514,8 +68474,7 @@
 /area/library)
 "ebb" = (
 /obj/machinery/camera{
-	c_tag = "Library North";
-	dir = 2
+	c_tag = "Library North"
 	},
 /turf/simulated/floor/wood,
 /area/library)
@@ -69528,14 +68487,12 @@
 /obj/structure/cult/tome,
 /obj/item/clothing/under/suit_jacket/red,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cult"
 	},
 /area/library)
 "eeb" = (
 /obj/structure/stool/bed/chair/comfy/brown,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cult"
 	},
 /area/library)
@@ -69592,8 +68549,6 @@
 /area/security/armoury)
 "enb" = (
 /obj/machinery/power/apc{
-	cell_type = 5000;
-	dir = 2;
 	name = "Armory APC";
 	pixel_y = -28
 	},
@@ -69728,8 +68683,6 @@
 /obj/item/weapon/storage/box,
 /obj/item/weapon/storage/box,
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
 	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
@@ -69807,8 +68760,7 @@
 /obj/item/device/flash,
 /obj/item/clothing/glasses/sunglasses,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/table/glass,
 /obj/machinery/newscaster{
@@ -69832,7 +68784,6 @@
 /obj/structure/table,
 /obj/machinery/camera{
 	c_tag = "Medbay Foyer North";
-	dir = 2;
 	network = list("SS13","Medical")
 	},
 /turf/simulated/floor{
@@ -69842,7 +68793,6 @@
 /area/medical/reception)
 "eHb" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "arrivalcorner"
 	},
 /area/security/main)
@@ -70063,9 +69013,7 @@
 	dir = 1;
 	id = "packageSort1"
 	},
-/obj/structure/plasticflaps{
-	opacity = 0
-	},
+/obj/structure/plasticflaps,
 /turf/simulated/floor/plating{
 	dir = 4;
 	icon_state = "warnplate"
@@ -70117,8 +69065,7 @@
 	id = "packageSort1"
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plating{
 	dir = 4;
@@ -70175,7 +69122,6 @@
 /area/medical/cmo)
 "fmb" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/brig)
@@ -70249,7 +69195,6 @@
 	},
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "recycler_inner";
 	locked = 1;
 	name = "Recycler External Access";
@@ -70273,7 +69218,6 @@
 	name = "Recycler Large Air Vent"
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "recycler_sensor";
 	pixel_x = -25;
 	pixel_y = -20
@@ -70317,9 +69261,7 @@
 	name = "Recycler Large Air Vent"
 	},
 /obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1379;
 	id_tag = "recycler_airlock";
-	layer = 3.3;
 	pixel_x = -25;
 	req_access_txt = "67";
 	tag_airpump = "recycler_pump";
@@ -70368,7 +69310,6 @@
 "fAb" = (
 /obj/machinery/camera{
 	c_tag = "Recycler External South";
-	dir = 2;
 	pixel_x = 4
 	},
 /turf/simulated/floor/plating/airless,
@@ -70477,8 +69418,7 @@
 "fKb" = (
 /obj/structure/curtain/open/shower/security,
 /obj/machinery/shower{
-	dir = 1;
-	icon_state = "shower"
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor2"
@@ -70551,7 +69491,6 @@
 "fTb" = (
 /obj/structure/stool/bed/chair/office/light,
 /obj/item/device/radio/intercom{
-	dir = 2;
 	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
@@ -70579,8 +69518,7 @@
 /area/medical/reception)
 "fVb" = (
 /obj/structure/morgue{
-	dir = 8;
-	icon_state = "morgue1"
+	dir = 8
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -70627,7 +69565,6 @@
 /obj/item/weapon/storage/box/lights/mixed,
 /obj/item/weapon/extinguisher,
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Port Emergency Storage APC";
 	pixel_y = -24
 	},
@@ -70766,7 +69703,6 @@
 /area/maintenance/cargo)
 "glb" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = 32
 	},
@@ -70991,7 +69927,6 @@
 	dir = 4;
 	external_pressure_bound = 140;
 	external_pressure_bound_default = 140;
-	icon_state = "map_vent_out";
 	name = "(OUT) Space Large Air Vent"
 	},
 /turf/simulated/floor/plating/airless,
@@ -71065,7 +70000,6 @@
 	pixel_y = -32
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "security_sensor";
 	pixel_y = 25;
 	req_one_access_txt = "13;45;1"
@@ -71102,8 +70036,7 @@
 "gQb" = (
 /obj/machinery/power/solar_control{
 	id = "auxsolareast";
-	name = "Fore Starboard Solar Control";
-	track = 0
+	name = "Fore Starboard Solar Control"
 	},
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -71146,7 +70079,6 @@
 /area/medical/cmo)
 "gUb" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "yellow"
 	},
 /area/hallway/primary/fore)
@@ -71206,7 +70138,6 @@
 /area/shuttle/mining/station)
 "hbb" = (
 /obj/structure/object_wall/mining{
-	dir = 2;
 	icon_state = "ming_l3"
 	},
 /turf/simulated/shuttle/floor/mining{
@@ -71215,7 +70146,6 @@
 /area/shuttle/mining/station)
 "hcb" = (
 /obj/structure/shuttle/window/new_shuttle{
-	dir = 2;
 	icon_state = "ming2_window_w"
 	},
 /obj/structure/grille,
@@ -71223,8 +70153,7 @@
 /area/shuttle/mining/station)
 "hdb" = (
 /obj/structure/stool/bed/chair{
-	dir = 8;
-	icon_state = "chair"
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/eva)
@@ -71247,8 +70176,7 @@
 /area/hallway/secondary/exit)
 "hgb" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/closet/crate,
 /turf/simulated/shuttle/floor/mining{
@@ -71270,8 +70198,7 @@
 /area/shuttle/mining/station)
 "hjb" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/computer/mine_sci_shuttle/flight_comp{
 	dir = 8
@@ -71369,7 +70296,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/brig)
@@ -71415,7 +70341,6 @@
 	eftpos_name = "Library EFTPOS scanner"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cult"
 	},
 /area/library)
@@ -71537,7 +70462,6 @@
 "hLb" = (
 /obj/machinery/gateway/center/station,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "darkblue"
 	},
 /area/gateway)
@@ -71577,7 +70501,6 @@
 	pixel_y = -32
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "chapel_sensor";
 	pixel_y = 16;
 	req_access_txt = "13";
@@ -71624,8 +70547,7 @@
 	},
 /obj/machinery/hologram/holopad,
 /obj/machinery/camera{
-	c_tag = "Escape Arm Airlocks";
-	dir = 2
+	c_tag = "Escape Arm Airlocks"
 	},
 /turf/simulated/floor{
 	icon_state = "delivery"
@@ -71679,7 +70601,6 @@
 /obj/structure/sign/directions/security{
 	buildable_sign = 0;
 	dir = 1;
-	icon_state = "direction_sec";
 	pixel_y = 40
 	},
 /turf/simulated/floor{
@@ -71689,8 +70610,7 @@
 /area/hallway/primary/central)
 "hZb" = (
 /obj/machinery/camera{
-	c_tag = "Central Hallway North";
-	dir = 2
+	c_tag = "Central Hallway North"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -71698,19 +70618,16 @@
 /obj/structure/sign/directions/evac{
 	buildable_sign = 0;
 	dir = 8;
-	icon_state = "direction_evac";
 	pixel_y = 24
 	},
 /obj/structure/sign/directions/science{
 	buildable_sign = 0;
 	dir = 4;
-	icon_state = "direction_sci";
 	pixel_y = 32
 	},
 /obj/structure/sign/directions/medical{
 	buildable_sign = 0;
 	dir = 4;
-	icon_state = "direction_med";
 	pixel_y = 40
 	},
 /turf/simulated/floor{
@@ -71784,19 +70701,16 @@
 /obj/structure/sign/directions/medical{
 	buildable_sign = 0;
 	dir = 4;
-	icon_state = "direction_med";
 	pixel_y = 40
 	},
 /obj/structure/sign/directions/science{
 	buildable_sign = 0;
 	dir = 4;
-	icon_state = "direction_sci";
 	pixel_y = 32
 	},
 /obj/structure/sign/directions/evac{
 	buildable_sign = 0;
 	dir = 8;
-	icon_state = "direction_evac";
 	pixel_y = 24
 	},
 /turf/simulated/floor{
@@ -71845,7 +70759,6 @@
 /area/library)
 "imb" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "arrivalcorner"
 	},
 /area/hallway/secondary/entry)
@@ -71861,25 +70774,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "yellow"
 	},
 /area/hallway/secondary/entry)
 "ipb" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "browncorner"
 	},
 /area/hallway/primary/port)
 "iqb" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Port Hall APC";
 	pixel_y = -26
 	},
 /obj/structure/cable,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "browncorner"
 	},
 /area/hallway/primary/port)
@@ -71889,7 +70798,6 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "browncorner"
 	},
 /area/hallway/primary/port)
@@ -71898,7 +70806,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "browncorner"
 	},
 /area/hallway/primary/port)
@@ -71912,7 +70819,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
 	name = "Medbay Reception";
 	req_access_txt = "5"
 	},
@@ -71924,7 +70830,6 @@
 /obj/machinery/light,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "browncorner"
 	},
 /area/hallway/primary/port)
@@ -71932,7 +70837,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "browncorner"
 	},
 /area/hallway/primary/port)
@@ -71949,7 +70853,6 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "yellow"
 	},
 /area/hallway/primary/port)
@@ -71965,7 +70868,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/port)
@@ -72012,7 +70914,6 @@
 /obj/structure/sign/directions/security{
 	buildable_sign = 0;
 	dir = 4;
-	icon_state = "direction_sec";
 	pixel_y = -24
 	},
 /obj/structure/sign/directions/engineering{
@@ -72024,7 +70925,6 @@
 	pixel_y = -40
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -72061,7 +70961,6 @@
 	pixel_y = -32
 	},
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "toxin_test_sensor";
 	pixel_y = 25;
 	req_one_access_txt = "13;45;1"
@@ -72087,7 +70986,6 @@
 /area/quartermaster/qm)
 "iJb" = (
 /obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1379;
 	id_tag = "toxin_test_airlock";
 	pixel_y = 25;
 	req_one_access_txt = "13;45;1";
@@ -72187,8 +71085,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/bridge)
 "iRb" = (
@@ -72204,8 +71101,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/bridge)
 "iSb" = (
@@ -72230,8 +71126,7 @@
 /area/maintenance/medbay)
 "iUb" = (
 /obj/structure/morgue{
-	dir = 8;
-	icon_state = "morgue1"
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -72337,7 +71232,6 @@
 /obj/structure/sign/directions/security{
 	buildable_sign = 0;
 	dir = 1;
-	icon_state = "direction_sec";
 	pixel_x = 32;
 	pixel_y = 8
 	},
@@ -72348,12 +71242,10 @@
 /obj/structure/sign/directions/command{
 	buildable_sign = 0;
 	dir = 8;
-	icon_state = "direction_bridge";
 	pixel_x = 32;
 	pixel_y = -8
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -72410,7 +71302,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/maintenance/disposal)
@@ -72442,9 +71333,7 @@
 /obj/item/weapon/reagent_containers/pill/citalopram,
 /obj/item/weapon/reagent_containers/pill/methylphenidate,
 /obj/item/weapon/reagent_containers/glass/bottle/stoxin,
-/obj/item/clothing/suit/straight_jacket{
-	layer = 3
-	},
+/obj/item/clothing/suit/straight_jacket,
 /obj/structure/closet/secure_closet{
 	name = "Psychiatrist's Locker";
 	req_access_txt = "64"
@@ -72546,20 +71435,17 @@
 /obj/structure/sign/directions/medical{
 	buildable_sign = 0;
 	dir = 4;
-	icon_state = "direction_med";
 	pixel_x = 32;
 	pixel_y = 8
 	},
 /obj/structure/sign/directions/science{
 	buildable_sign = 0;
 	dir = 4;
-	icon_state = "direction_sci";
 	pixel_x = 32
 	},
 /obj/structure/sign/directions/evac{
 	buildable_sign = 0;
 	dir = 1;
-	icon_state = "direction_evac";
 	pixel_x = 32;
 	pixel_y = -8
 	},
@@ -72631,8 +71517,7 @@
 /area/medical/reception)
 "jIb" = (
 /obj/structure/stool/bed/chair/comfy/teal{
-	dir = 8;
-	icon_state = "comfychair"
+	dir = 8
 	},
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -72687,7 +71572,6 @@
 	desc = "A remote control switch for the medbay foyer.";
 	id = "MedbayFoyer1";
 	name = "Medbay Doors Control";
-	normaldoorcontrol = 1;
 	pixel_x = -6;
 	pixel_y = -2;
 	range = 8;
@@ -72695,7 +71579,6 @@
 	},
 /obj/machinery/door/window/eastleft{
 	dir = 1;
-	icon_state = "left";
 	name = "Medbay Reception"
 	},
 /turf/simulated/floor{
@@ -72760,7 +71643,6 @@
 "jWb" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 12
 	},
 /obj/structure/mirror{
@@ -72859,7 +71741,6 @@
 /area/medical/chemistry)
 "khb" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/office)
@@ -72879,7 +71760,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteyellow"
 	},
 /area/medical/chemistry)
@@ -72947,8 +71827,7 @@
 /obj/item/weapon/pen,
 /obj/structure/table/glass,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -72995,8 +71874,7 @@
 /area/medical/reception)
 "kub" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/grass,
 /area/medical/genetics)
@@ -73011,7 +71889,6 @@
 /obj/item/weapon/packageWrap,
 /obj/item/weapon/packageWrap,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/office)
@@ -73098,7 +71975,6 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/office)
@@ -73153,7 +72029,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/brig)
@@ -73162,7 +72037,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains/human{
 	desc = "This guy seemed to have died in terrible way! Half his remains are dust.";
-	icon_state = "remains";
 	name = "Syndicate agent remains"
 	},
 /obj/item/clothing/glasses/regular/hipster,
@@ -73228,7 +72102,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "yellow"
 	},
 /area/hallway/primary/central)
@@ -73249,7 +72122,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "yellow"
 	},
 /area/hallway/primary/central)
@@ -73266,7 +72138,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitebluecorner"
 	},
 /area/medical/hallway)
@@ -73306,7 +72177,6 @@
 /obj/structure/sign/directions/security{
 	buildable_sign = 0;
 	dir = 1;
-	icon_state = "direction_sec";
 	pixel_y = -24
 	},
 /obj/structure/sign/directions/engineering{
@@ -73316,11 +72186,9 @@
 /obj/structure/sign/directions/command{
 	buildable_sign = 0;
 	dir = 1;
-	icon_state = "direction_bridge";
 	pixel_y = -40
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "neutralcorner"
 	},
 /area/hallway/primary/central)
@@ -73328,19 +72196,16 @@
 /obj/structure/sign/directions/medical{
 	buildable_sign = 0;
 	dir = 4;
-	icon_state = "direction_med";
 	pixel_y = -24
 	},
 /obj/structure/sign/directions/science{
 	buildable_sign = 0;
 	dir = 4;
-	icon_state = "direction_sci";
 	pixel_y = -32
 	},
 /obj/structure/sign/directions/evac{
 	buildable_sign = 0;
 	dir = 8;
-	icon_state = "direction_evac";
 	pixel_y = -40
 	},
 /turf/simulated/floor{
@@ -73394,7 +72259,6 @@
 "lxb" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "recycler_outer";
 	locked = 1;
 	name = "Recycler External Access";
@@ -73533,8 +72397,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/stool/bed/chair/metal/blue{
-	dir = 4;
-	icon_state = "chair_blue"
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -73619,7 +72482,6 @@
 "lTb" = (
 /obj/effect/spider/stickyweb,
 /obj/machinery/chem_dispenser{
-	anchored = 1;
 	name = "old chem dispenser"
 	},
 /turf/simulated/floor/plating,
@@ -73636,7 +72498,6 @@
 /obj/structure/sign/directions/engineering{
 	buildable_sign = 0;
 	dir = 4;
-	icon_state = "direction_eng";
 	pixel_y = -8
 	},
 /turf/simulated/wall,
@@ -73755,7 +72616,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/reception)
@@ -73871,8 +72731,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/hallway/secondary/entry)
@@ -73944,8 +72803,7 @@
 /area/atmos)
 "mAb" = (
 /obj/machinery/camera{
-	c_tag = "Atmospherics North West";
-	dir = 2
+	c_tag = "Atmospherics North West"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -73992,7 +72850,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/medical/hallway)
@@ -74178,7 +73035,6 @@
 "ndb" = (
 /obj/machinery/mass_driver{
 	dir = 1;
-	icon_state = "mass_driver";
 	id = "toxinsdriver"
 	},
 /turf/simulated/floor/plating/airless{
@@ -74210,8 +73066,7 @@
 	pixel_x = -32
 	},
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -74298,9 +73153,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/medbay)
 "nob" = (
-/obj/structure/mineral_door/wood{
-	icon_state = "wood"
-	},
+/obj/structure/mineral_door/wood,
 /turf/simulated/floor/plating,
 /area/maintenance/engineering)
 "npb" = (
@@ -74319,9 +73172,7 @@
 /turf/simulated/floor/plating,
 /area/crew_quarters/playroom)
 "nqb" = (
-/obj/structure/mineral_door/wood{
-	icon_state = "wood"
-	},
+/obj/structure/mineral_door/wood,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -74347,8 +73198,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Genetics Cloning APC";
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -74370,7 +73220,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "virology_inner";
 	locked = 1;
 	name = "Engineering External Access";
@@ -74397,19 +73246,16 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "yellow"
 	},
 /area/hallway/primary/aft)
 "nwb" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/medical/hallway)
 "nxb" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "yellow"
 	},
 /area/engine/break_room)
@@ -74422,7 +73268,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "yellow"
 	},
 /area/engine/break_room)
@@ -74434,7 +73279,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "yellow"
 	},
 /area/engine/break_room)
@@ -74452,7 +73296,6 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "yellow"
 	},
 /area/engine/break_room)
@@ -74462,7 +73305,6 @@
 	},
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "yellow"
 	},
 /area/engine/break_room)
@@ -74549,9 +73391,7 @@
 	},
 /area/medical/virology)
 "nIb" = (
-/obj/structure/mineral_door/wood{
-	icon_state = "wood"
-	},
+/obj/structure/mineral_door/wood,
 /turf/simulated/floor/wood,
 /area/maintenance/engineering)
 "nJb" = (
@@ -74637,7 +73477,6 @@
 /obj/structure/table/glass,
 /obj/item/weapon/reagent_containers/dropper,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "purplechecker"
 	},
 /area/crew_quarters/barbershop)
@@ -74653,7 +73492,6 @@
 /obj/structure/closet/l3closet/general,
 /obj/item/clothing/mask/gas/coloured,
 /obj/item/device/radio/intercom{
-	dir = 2;
 	name = "Station Intercom (General)";
 	pixel_x = -28
 	},
@@ -74664,8 +73502,7 @@
 /area/medical/virology)
 "nVb" = (
 /obj/structure/toilet{
-	dir = 1;
-	icon_state = "toilet00"
+	dir = 1
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -74813,7 +73650,6 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/engine/engineering)
@@ -74946,7 +73782,6 @@
 /area/maintenance/engineering)
 "owb" = (
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "engineering_aux_sensor";
 	pixel_x = -25;
 	pixel_y = -20
@@ -74994,10 +73829,8 @@
 /obj/machinery/door_control{
 	id = "CMO_door";
 	name = "CMO door-control";
-	normaldoorcontrol = 1;
 	pixel_x = -24;
-	pixel_y = 6;
-	pixel_z = 0
+	pixel_y = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -75229,7 +74062,6 @@
 	},
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
-	icon_state = "pipe-j1s";
 	name = "Forensic";
 	sortType = "Forensic"
 	},
@@ -75397,7 +74229,6 @@
 /obj/structure/cable,
 /obj/machinery/power/apc{
 	cell_type = 2000;
-	dir = 2;
 	name = "Forensic APC";
 	pixel_y = -24
 	},
@@ -75441,7 +74272,6 @@
 	},
 /obj/item/device/radio/intercom{
 	broadcasting = 1;
-	freerange = 0;
 	frequency = 1475;
 	listening = 0;
 	name = "Station Intercom (Security)";
@@ -75490,7 +74320,6 @@
 "pmb" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12
 	},
 /obj/structure/mirror{
@@ -75500,7 +74329,6 @@
 	pixel_y = 14
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "purplechecker"
 	},
 /area/crew_quarters/barbershop)
@@ -75515,7 +74343,6 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "purplechecker"
 	},
 /area/crew_quarters/barbershop)
@@ -75543,7 +74370,6 @@
 "pqb" = (
 /obj/machinery/camera{
 	c_tag = "Chief Medical Office";
-	dir = 2;
 	network = list("SS13","Medical")
 	},
 /obj/structure/closet/secure_closet/CMO,
@@ -75582,12 +74408,10 @@
 	pixel_y = 23
 	},
 /obj/machinery/camera{
-	c_tag = "Barbershop";
-	dir = 2
+	c_tag = "Barbershop"
 	},
 /obj/machinery/color_mixer,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "purplechecker"
 	},
 /area/crew_quarters/barbershop)
@@ -75788,7 +74612,6 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "purplechecker"
 	},
 /area/crew_quarters/barbershop)
@@ -75803,15 +74626,13 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/sign/poster{
 	official = 1;
 	pixel_x = -32
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "purplechecker"
 	},
 /area/crew_quarters/barbershop)
@@ -75820,7 +74641,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "purplechecker"
 	},
 /area/crew_quarters/barbershop)
@@ -75830,7 +74650,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "purplechecker"
 	},
 /area/crew_quarters/barbershop)
@@ -75870,14 +74689,12 @@
 	name = "Barber"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "purplechecker"
 	},
 /area/crew_quarters/barbershop)
 "pNb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "purplechecker"
 	},
 /area/crew_quarters/barbershop)
@@ -75896,7 +74713,6 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "purplechecker"
 	},
 /area/crew_quarters/barbershop)
@@ -75937,7 +74753,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "purplechecker"
 	},
 /area/crew_quarters/barbershop)
@@ -75946,7 +74761,6 @@
 	dir = 9
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "purplechecker"
 	},
 /area/crew_quarters/barbershop)
@@ -75982,14 +74796,12 @@
 	pixel_y = -30
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "purplechecker"
 	},
 /area/crew_quarters/barbershop)
 "pXb" = (
 /obj/structure/closet/secure_closet/barber,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "purplechecker"
 	},
 /area/crew_quarters/barbershop)
@@ -76004,7 +74816,6 @@
 /obj/structure/table/glass,
 /obj/item/weapon/reagent_containers/dropper/precision,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "purplechecker"
 	},
 /area/crew_quarters/barbershop)
@@ -76025,7 +74836,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "purplechecker"
 	},
 /area/crew_quarters/barbershop)
@@ -76177,7 +74987,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/machinery/camera{
 	c_tag = "Medbay North";
-	dir = 2;
 	network = list("SS13","Medical")
 	},
 /turf/simulated/floor{
@@ -76273,7 +75082,6 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitehall"
 	},
 /area/medical/hallway)
@@ -76345,7 +75153,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/vending/barbervend,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "purplechecker"
 	},
 /area/crew_quarters/barbershop)
@@ -76369,7 +75176,6 @@
 	},
 /obj/structure/flora/plant/random,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "purplechecker"
 	},
 /area/crew_quarters/barbershop)
@@ -76381,8 +75187,7 @@
 /area/hallway/primary/central)
 "qCb" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -76403,8 +75208,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/hallway/primary/port)
@@ -76415,10 +75219,7 @@
 	pixel_y = -22
 	},
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	freerange = 0;
 	frequency = 1475;
-	listening = 1;
 	name = "Station Intercom (Security)";
 	pixel_x = 30;
 	pixel_y = 4
@@ -76475,7 +75276,6 @@
 /area/security/lobby)
 "qLb" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor/plating,
@@ -76519,11 +75319,7 @@
 	},
 /obj/item/weapon/pen,
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_x = 28
 	},
@@ -76549,7 +75345,6 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "yellow"
 	},
 /area/storage/tools)
@@ -76583,13 +75378,11 @@
 "qXb" = (
 /obj/machinery/door/morgue{
 	dir = 4;
-	icon_state = "door1";
 	name = "Librarian";
 	req_access_txt = "37"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cult"
 	},
 /area/library)
@@ -76632,7 +75425,6 @@
 /obj/item/bodybag/cryobag,
 /obj/structure/table/glass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "yellow"
 	},
 /area/engine/break_room)
@@ -76640,7 +75432,6 @@
 /obj/item/weapon/paper_bin,
 /obj/structure/table/glass,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "yellow"
 	},
 /area/engine/break_room)
@@ -77144,11 +75935,7 @@
 /obj/item/weapon/reagent_containers/syringe/antiviral,
 /obj/structure/table/glass,
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
-	freerange = 0;
 	frequency = 1485;
-	listening = 1;
 	name = "Station Intercom (Medbay)";
 	pixel_x = -28
 	},
@@ -77169,7 +75956,6 @@
 /obj/structure/table/glass,
 /obj/machinery/light/small,
 /obj/machinery/status_display{
-	density = 0;
 	layer = 4;
 	pixel_y = -32
 	},
@@ -77321,7 +76107,6 @@
 "spb" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
 	pixel_x = 12
 	},
 /turf/simulated/floor{
@@ -77407,7 +76192,6 @@
 "sAb" = (
 /obj/machinery/alarm{
 	dir = 4;
-	frequency = 1439;
 	pixel_x = -23
 	},
 /turf/simulated/floor{
@@ -77504,8 +76288,7 @@
 /area/medical/virology)
 "sJb" = (
 /obj/structure/stool/bed/chair/comfy/teal{
-	dir = 1;
-	icon_state = "comfychair"
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -77514,10 +76297,8 @@
 "sKb" = (
 /obj/machinery/power/apc{
 	dir = 4;
-	level = 2;
 	name = "Operating 1 APC";
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -77679,7 +76460,6 @@
 "sYb" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
-	icon_state = "closed";
 	id_tag = "engineering_aux_inner";
 	locked = 1;
 	name = "Engineering External Access";
@@ -77745,8 +76525,7 @@
 /area/medical/virology)
 "tdb" = (
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
@@ -77828,8 +76607,7 @@
 /area/crew_quarters/toilet)
 "tlb" = (
 /obj/machinery/shower{
-	dir = 1;
-	icon_state = "shower"
+	dir = 1
 	},
 /obj/structure/curtain/open/shower,
 /turf/simulated/floor{
@@ -77856,8 +76634,7 @@
 /obj/item/weapon/bikehorn/rubberducky,
 /obj/structure/curtain/open/shower,
 /obj/machinery/shower{
-	dir = 1;
-	icon_state = "shower"
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor2"
@@ -78010,7 +76787,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "escape"
 	},
 /area/hallway/secondary/exit)
@@ -78025,7 +76801,6 @@
 	pixel_y = -28
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "escape"
 	},
 /area/hallway/secondary/exit)
@@ -78062,7 +76837,6 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/hallway/secondary/exit)
@@ -78071,7 +76845,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/hallway/secondary/exit)
@@ -78084,7 +76857,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/hallway/secondary/exit)
@@ -78249,8 +77021,7 @@
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Cargo Office";
-	dir = 2
+	c_tag = "Cargo Office"
 	},
 /obj/machinery/photocopier,
 /turf/simulated/floor,
@@ -78376,7 +77147,6 @@
 "uLb" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
-	icon_state = "pipe-j1s";
 	name = "QM Office";
 	sortType = "QM Office"
 	},
@@ -78399,7 +77169,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor{
@@ -78463,7 +77232,6 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/office)
@@ -78548,8 +77316,7 @@
 /obj/item/clothing/head/soft,
 /obj/item/clothing/head/soft,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -78558,7 +77325,6 @@
 /area/quartermaster/storage)
 "veb" = (
 /obj/machinery/door/poddoor/shutters{
-	dir = 2;
 	id = "qm_warehouse";
 	name = "Warehouse Shutters"
 	},
@@ -78566,8 +77332,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/quartermaster/storage)
 "vfb" = (
@@ -78680,8 +77445,7 @@
 /area/quartermaster/storage)
 "vrb" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -78894,8 +77658,7 @@
 /obj/structure/table,
 /obj/random/foods/food_trash,
 /obj/machinery/camera{
-	c_tag = "Cargo cafe";
-	dir = 2
+	c_tag = "Cargo cafe"
 	},
 /turf/simulated/floor{
 	icon_state = "bar"
@@ -78909,7 +77672,6 @@
 	},
 /obj/item/weapon/cigbutt,
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor{
@@ -78969,7 +77731,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "redcorner"
 	},
 /area/security/brig)
@@ -79307,20 +78068,17 @@
 /area/quartermaster/miningoffice)
 "wYb" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Mining office APC";
 	pixel_y = -24
 	},
 /obj/structure/cable,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/miningoffice)
 "wZb" = (
 /obj/machinery/vending/assist,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/miningoffice)
@@ -79330,14 +78088,12 @@
 /obj/item/weapon/packageWrap,
 /obj/machinery/light,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/miningoffice)
 "xbb" = (
 /obj/structure/table,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/miningoffice)
@@ -79507,7 +78263,6 @@
 /area/quartermaster/storage)
 "xxb" = (
 /obj/machinery/conveyor_switch/oneway{
-	convdir = 1;
 	id = "QMLoad"
 	},
 /turf/simulated/floor{
@@ -79517,7 +78272,6 @@
 /area/quartermaster/storage)
 "xyb" = (
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "QMLoad"
 	},
 /turf/simulated/floor/plating,
@@ -79530,7 +78284,6 @@
 /area/quartermaster/storage)
 "xAb" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Cargo Bay APC";
 	pixel_x = 1;
 	pixel_y = -24
@@ -79579,7 +78332,6 @@
 "xEb" = (
 /obj/structure/flora/plant/random,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/miningbreaktime)
@@ -79589,7 +78341,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/miningbreaktime)
@@ -79599,7 +78350,6 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/quartermaster/miningbreaktime)
@@ -79611,7 +78361,6 @@
 /area/quartermaster/storage)
 "xIb" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 3.3;
 	pixel_y = -30;
 	supply_display = 1
@@ -79637,7 +78386,6 @@
 	pixel_y = -32
 	},
 /obj/machinery/door_control{
-	dir = 2;
 	id = "QMLoaddoor1";
 	layer = 4;
 	name = "Loading Doors";
@@ -79661,7 +78409,6 @@
 /area/quartermaster/storage)
 "xMb" = (
 /obj/machinery/status_display{
-	density = 0;
 	layer = 3.3;
 	pixel_y = -32;
 	supply_display = 1
@@ -79677,11 +78424,8 @@
 /area/quartermaster/recycler)
 "xOb" = (
 /obj/machinery/door/poddoor{
-	density = 1;
-	icon_state = "pdoor1";
 	id = "QMLoaddoor2";
-	name = "Supply Dock Loading Door";
-	opacity = 1
+	name = "Supply Dock Loading Door"
 	},
 /obj/structure/plasticflaps/mining,
 /obj/machinery/conveyor{
@@ -79701,15 +78445,11 @@
 /area/quartermaster/storage)
 "xQb" = (
 /obj/machinery/door/poddoor{
-	density = 1;
-	icon_state = "pdoor1";
 	id = "QMLoaddoor1";
-	name = "Supply Dock Loading Door";
-	opacity = 1
+	name = "Supply Dock Loading Door"
 	},
 /obj/structure/plasticflaps/mining,
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "QMLoad"
 	},
 /obj/machinery/door/firedoor,
@@ -97915,7 +96655,7 @@ alZ
 alZ
 aoA
 bbI
-bKV
+bdX
 ipb
 bcK
 aTs

--- a/maps/z2.dmm
+++ b/maps/z2.dmm
@@ -10,7 +10,6 @@
 "aab" = (
 /obj/effect/step_trigger/thrower{
 	affect_ghosts = 1;
-	direction = 2;
 	name = "thrower_throwdownside";
 	nostop = 1;
 	tiles = 0
@@ -432,7 +431,6 @@
 /area/shuttle/escape_pod3/centcom)
 "adH" = (
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "floor"
 	},
 /area/syndicate_mothership/droppod_garage)
@@ -535,8 +533,7 @@
 /area/centcom/holding)
 "aeb" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	dir = 8;
@@ -561,8 +558,7 @@
 /area/shuttle/escape/centcom)
 "aee" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	dir = 4;
@@ -587,7 +583,6 @@
 /area/centcom/control)
 "aem" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall14"
 	},
 /area/shuttle/escape/centcom)
@@ -599,7 +594,6 @@
 /area/space)
 "aeF" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall1"
 	},
 /area/shuttle/escape/centcom)
@@ -623,7 +617,6 @@
 "afa" = (
 /obj/machinery/flasher{
 	id = "shutflash";
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/structure/stool/bed/chair/schair/wagon,
@@ -672,7 +665,6 @@
 "afp" = (
 /obj/machinery/status_display,
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall2"
 	},
 /area/shuttle/escape/centcom)
@@ -689,7 +681,6 @@
 "afy" = (
 /obj/machinery/flasher{
 	id = "shutflash";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/structure/stool/bed/chair/schair/wagon{
@@ -707,9 +698,7 @@
 /area/centcom/evac)
 "afC" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor2"
@@ -717,8 +706,7 @@
 /area/shuttle/escape/centcom)
 "afD" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor2"
@@ -743,9 +731,7 @@
 /area/centcom/evac)
 "afL" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Waiting Room";
-	opacity = 1;
-	req_access_txt = "0"
+	name = "Waiting Room"
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -754,7 +740,6 @@
 "afQ" = (
 /obj/machinery/vending/wallmed1{
 	name = "Emergency NanoMed";
-	pixel_x = 0;
 	pixel_y = -32;
 	req_access_txt = "0"
 	},
@@ -775,7 +760,6 @@
 /obj/machinery/vending/wallmed1{
 	name = "Emergency NanoMed";
 	pixel_x = 30;
-	pixel_y = 0;
 	req_access_txt = "0"
 	},
 /turf/simulated/shuttle/floor{
@@ -785,7 +769,6 @@
 "agb" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Gateway room";
-	opacity = 1;
 	req_access_txt = "150"
 	},
 /turf/unsimulated/floor{
@@ -1065,8 +1048,7 @@
 /area/shuttle/transport1/centcom)
 "ahh" = (
 /obj/structure/object_wall/erokez{
-	icon_state = "1,6";
-	opacity = 1
+	icon_state = "1,6"
 	},
 /turf/space,
 /area/shuttle/transport1/centcom)
@@ -1262,8 +1244,7 @@
 /area/shuttle/syndicate_elite/mothership)
 "ahP" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 1;
-	icon_state = "propulsion"
+	dir = 1
 	},
 /turf/space,
 /area/shuttle/syndicate_elite/mothership)
@@ -1331,9 +1312,7 @@
 	dir = 1;
 	freerange = 1;
 	frequency = 1213;
-	listening = 1;
 	name = "Syndicate Ops Intercom";
-	pixel_y = 0;
 	subspace_transmission = 1;
 	syndie = 1
 	},
@@ -1360,9 +1339,7 @@
 /area/syndicate_mothership)
 "aif" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	dir = 4;
@@ -1374,9 +1351,7 @@
 /area/syndicate_mothership)
 "aih" = (
 /obj/structure/table/reinforced,
-/obj/machinery/recharger{
-	pixel_y = 0
-	},
+/obj/machinery/recharger,
 /obj/machinery/door_control{
 	id = "syndieshutters";
 	name = "remote shutter control";
@@ -1389,7 +1364,6 @@
 /area/syndicate_station/start)
 "aii" = (
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
@@ -1404,7 +1378,6 @@
 	pods_spawned = 3
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "floor"
 	},
 /area/syndicate_mothership/droppod_garage)
@@ -1413,7 +1386,6 @@
 	pods_spawned = 4
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "floor"
 	},
 /area/syndicate_mothership/droppod_garage)
@@ -1428,7 +1400,6 @@
 	pods_spawned = 5
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "floor"
 	},
 /area/syndicate_mothership/droppod_garage)
@@ -1479,7 +1450,6 @@
 	dir = 8
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
@@ -1488,7 +1458,6 @@
 	dir = 1
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
@@ -1497,18 +1466,14 @@
 	dir = 9
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
 "aiA" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	dir = 4
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
@@ -1517,7 +1482,6 @@
 	dir = 5
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
@@ -1538,8 +1502,7 @@
 /area/syndicate_station/start)
 "aiD" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/structure/computerframe{
 	dir = 8
@@ -1651,7 +1614,6 @@
 "aiV" = (
 /obj/effect/landmark/syndie_gateway,
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
@@ -1673,8 +1635,7 @@
 /area/syndicate_mothership/elite_squad)
 "aiZ" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor4"
@@ -1682,8 +1643,7 @@
 /area/syndicate_mothership/elite_squad)
 "aja" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor4"
@@ -1703,8 +1663,7 @@
 /obj/structure/stool/bed,
 /obj/item/weapon/bedsheet/syndie,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "grimy"
@@ -1714,8 +1673,7 @@
 /obj/structure/stool/bed,
 /obj/item/weapon/bedsheet/syndie,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "grimy"
@@ -1726,7 +1684,6 @@
 	dir = 8
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
@@ -1778,14 +1735,12 @@
 	dir = 4
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
 "ajm" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -1821,7 +1776,6 @@
 "ajq" = (
 /obj/machinery/gateway,
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
@@ -1845,7 +1799,6 @@
 	dir = 10
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
@@ -1861,10 +1814,8 @@
 	req_access_txt = "150"
 	},
 /obj/machinery/door/poddoor{
-	icon_state = "pdoor1";
 	id = "syndicate_elite";
-	name = "Front Hull Door";
-	opacity = 1
+	name = "Front Hull Door"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/syndicate_elite/mothership)
@@ -1875,29 +1826,17 @@
 	icon_state = "diagonalWall3"
 	},
 /area/shuttle/syndicate_elite/mothership)
-"ajx" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "dark"
-	},
-/area/syndicate_mothership)
 "ajy" = (
 /obj/machinery/gateway{
 	dir = 6
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "dark"
 	},
 /area/syndicate_mothership)
 "ajz" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Barracks";
-	opacity = 1;
 	req_access_txt = "150"
 	},
 /turf/unsimulated/floor{
@@ -1941,7 +1880,6 @@
 "ajK" = (
 /obj/effect/landmark/droppod_spawn,
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "floor"
 	},
 /area/syndicate_mothership/droppod_garage)
@@ -1950,7 +1888,6 @@
 	pods_spawned = 1
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "floor"
 	},
 /area/syndicate_mothership/droppod_garage)
@@ -1974,7 +1911,6 @@
 	pods_spawned = 2
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "floor"
 	},
 /area/syndicate_mothership/droppod_garage)
@@ -1990,8 +1926,7 @@
 /area/syndicate_mothership)
 "ajV" = (
 /obj/structure/object_wall/erokez{
-	icon_state = "14,5";
-	opacity = 1
+	icon_state = "14,5"
 	},
 /turf/space,
 /area/shuttle/transport1/centcom)
@@ -2045,7 +1980,6 @@
 	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 2;
 	icon_state = "shutter0";
 	id = "syndieshutters";
 	name = "Blast Shutters";
@@ -2061,7 +1995,6 @@
 	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 2;
 	icon_state = "shutter0";
 	id = "syndieshutters";
 	name = "Blast Shutters";
@@ -2080,7 +2013,6 @@
 	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
-	dir = 2;
 	icon_state = "shutter0";
 	id = "syndieshutters";
 	name = "Blast Shutters";
@@ -2100,8 +2032,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor6"
@@ -2133,8 +2064,7 @@
 /area/syndicate_mothership)
 "akk" = (
 /obj/structure/object_wall/erokez{
-	icon_state = "1,4";
-	opacity = 1
+	icon_state = "1,4"
 	},
 /turf/space,
 /area/shuttle/transport1/centcom)
@@ -2218,16 +2148,13 @@
 	},
 /area/syndicate_station/start)
 "akx" = (
-/obj/machinery/computer/syndicate_station{
-	req_access_txt = "0"
-	},
+/obj/machinery/computer/syndicate_station,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor6"
 	},
 /area/syndicate_station/start)
 "aky" = (
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "black"
 	},
 /area/syndicate_mothership/droppod_garage)
@@ -2324,7 +2251,6 @@
 /area/syndicate_station/start)
 "akQ" = (
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "bar"
 	},
 /area/syndicate_mothership)
@@ -2333,7 +2259,6 @@
 	pixel_y = 32
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/syndicate_mothership)
@@ -2345,7 +2270,6 @@
 	dir = 8
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/syndicate_mothership)
@@ -2358,7 +2282,6 @@
 	dir = 4
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/syndicate_mothership)
@@ -2413,27 +2336,22 @@
 "alc" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Restroom";
-	opacity = 1;
 	req_access_txt = "150"
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/syndicate_mothership)
 "ald" = (
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/syndicate_mothership)
 "ale" = (
 /obj/machinery/shower{
-	dir = 1;
-	icon_state = "shower"
+	dir = 1
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/syndicate_mothership)
@@ -2503,12 +2421,10 @@
 	},
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/syndicate_mothership)
@@ -2516,11 +2432,9 @@
 /obj/machinery/light/small,
 /obj/structure/dryer{
 	dir = 8;
-	pixel_x = 6;
-	pixel_y = 0
+	pixel_x = 6
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/syndicate_mothership)
@@ -2652,8 +2566,7 @@
 "alH" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor6"
@@ -2670,7 +2583,6 @@
 "alK" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -2697,7 +2609,6 @@
 "alN" = (
 /obj/structure/table/reinforced,
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "bar"
 	},
 /area/syndicate_mothership)
@@ -2707,9 +2618,7 @@
 	frequency = 1331;
 	master_tag = "synd_airlock";
 	name = "interior access button";
-	pixel_x = 0;
-	pixel_y = -25;
-	req_access_txt = "0"
+	pixel_y = -25
 	},
 /obj/machinery/light,
 /turf/simulated/shuttle/floor{
@@ -2765,8 +2674,7 @@
 /area/syndicate_station/start)
 "alV" = (
 /obj/structure/closet/medical_wall{
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/item/weapon/surgicaldrill,
 /obj/item/clothing/gloves/latex,
@@ -2784,7 +2692,6 @@
 	req_access_txt = "151"
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "bar"
 	},
 /area/syndicate_mothership)
@@ -2803,7 +2710,6 @@
 /area/syndicate_mothership)
 "alZ" = (
 /obj/machinery/door/window{
-	dir = 2;
 	name = "Seating";
 	req_access_txt = "150"
 	},
@@ -2817,7 +2723,6 @@
 	id_tag = "synd_airlock";
 	pixel_x = -5;
 	pixel_y = 32;
-	req_access_txt = "0";
 	tag_airpump = "synd_pump";
 	tag_chamber_sensor = "synd_sensor";
 	tag_exterior_door = "synd_outer";
@@ -2858,7 +2763,6 @@
 /area/syndicate_station/start)
 "amd" = (
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "podhatchfull"
 	},
 /area/syndicate_mothership)
@@ -2923,10 +2827,7 @@
 	frequency = 1331;
 	icon_state = "door_closed";
 	id_tag = "synd_inner";
-	locked = 0;
-	name = "Ship External Access";
-	req_access = null;
-	req_access_txt = "0"
+	name = "Ship External Access"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/shuttle/floor{
@@ -2949,7 +2850,6 @@
 	dir = 8
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "bar"
 	},
 /area/syndicate_mothership)
@@ -2971,7 +2871,6 @@
 "amp" = (
 /obj/structure/closet/syndicate/personal,
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "podhatch"
 	},
 /area/syndicate_mothership)
@@ -2992,7 +2891,6 @@
 	req_access_txt = "150"
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "podhatch"
 	},
 /area/syndicate_mothership)
@@ -3061,7 +2959,6 @@
 "amy" = (
 /obj/machinery/vending/snack,
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "bar"
 	},
 /area/syndicate_mothership)
@@ -3136,10 +3033,7 @@
 	frequency = 1331;
 	icon_state = "door_closed";
 	id_tag = "synd_outer";
-	locked = 0;
-	name = "Ship External Access";
-	req_access = null;
-	req_access_txt = "0"
+	name = "Ship External Access"
 	},
 /obj/machinery/access_button{
 	command = "cycle_exterior";
@@ -3147,8 +3041,7 @@
 	master_tag = "synd_airlock";
 	name = "exterior access button";
 	pixel_x = 8;
-	pixel_y = 28;
-	req_access_txt = "0"
+	pixel_y = 28
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor6"
@@ -3209,12 +3102,8 @@
 /turf/space,
 /area/space)
 "amM" = (
-/obj/machinery/vending/cigarette{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/machinery/vending/cigarette,
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "bar"
 	},
 /area/syndicate_mothership)
@@ -3230,7 +3119,6 @@
 	id = "nukeop_war"
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "bar"
 	},
 /area/syndicate_mothership)
@@ -3246,11 +3134,8 @@
 /area/syndicate_station/start)
 "anc" = (
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
 	name = "Station Intercom (General)";
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor2"
@@ -3408,7 +3293,6 @@
 	dir = 1
 	},
 /obj/structure/shuttle/engine/heater{
-	dir = 2;
 	icon_state = "heater1"
 	},
 /turf/simulated/floor/plating/airless,
@@ -3468,7 +3352,6 @@
 "aob" = (
 /obj/effect/step_trigger/thrower{
 	affect_ghosts = 1;
-	direction = 2;
 	name = "thrower_throwdownside";
 	nostop = 1;
 	stopper = 0;
@@ -3605,8 +3488,7 @@
 /area/centcom/arrival)
 "aoI" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor5"
@@ -3931,8 +3813,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/unsimulated/floor{
 	icon_state = "sandwater"
@@ -4038,7 +3919,6 @@
 	name = "toilet door"
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/centcom/arrival)
@@ -4053,7 +3933,6 @@
 	dir = 8
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/centcom/arrival)
@@ -4068,7 +3947,6 @@
 	dir = 4
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/centcom/arrival)
@@ -4078,12 +3956,9 @@
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/centcom/arrival)
@@ -4148,7 +4023,6 @@
 "aqb" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Drop Pods room";
-	opacity = 1;
 	req_access_txt = "150"
 	},
 /turf/unsimulated/floor{
@@ -4166,9 +4040,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/shuttle/floor/cargo{
-	icon_state = "1"
-	},
+/turf/simulated/shuttle/floor/cargo,
 /area/supply/dock)
 "aqh" = (
 /turf/unsimulated/wall/splashscreen,
@@ -4187,8 +4059,7 @@
 "aqk" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/reagent_containers/food/drinks/sillycup{
-	pixel_x = -2;
-	pixel_y = 0
+	pixel_x = -2
 	},
 /obj/item/weapon/reagent_containers/food/drinks/sillycup{
 	pixel_x = 4;
@@ -4218,27 +4089,22 @@
 /area/centcom/arrival)
 "aqn" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/centcom/arrival)
 "aqo" = (
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/centcom/arrival)
 "aqp" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/centcom/arrival)
@@ -4284,8 +4150,6 @@
 /area/centcom/arrival)
 "aqw" = (
 /obj/machinery/firealarm{
-	dir = 2;
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/machinery/light{
@@ -4374,7 +4238,6 @@
 "aqO" = (
 /obj/machinery/washing_machine,
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/centcom/arrival)
@@ -4384,14 +4247,12 @@
 	},
 /obj/machinery/washing_machine,
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/centcom/arrival)
 "aqQ" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/centcom/arrival)
@@ -4648,24 +4509,19 @@
 "arO" = (
 /obj/structure/table/reinforced,
 /obj/machinery/status_display{
-	density = 0;
 	pixel_x = 32;
-	pixel_y = 0;
 	supply_display = 1
 	},
 /obj/machinery/door_control{
-	dir = 2;
 	id = "QMLoaddoor";
 	layer = 4;
 	name = "Loading Doors";
-	pixel_x = 0;
 	pixel_y = -8
 	},
 /obj/machinery/door_control{
 	id = "QMLoaddoor2";
 	layer = 4;
 	name = "Loading Doors";
-	pixel_x = 0;
 	pixel_y = 8
 	},
 /turf/unsimulated/floor{
@@ -4693,8 +4549,6 @@
 /obj/machinery/door_control{
 	id = "velocity_room02";
 	name = "Blast Door Control";
-	pixel_x = 0;
-	pixel_y = 0;
 	req_access_txt = "101"
 	},
 /obj/structure/disposalpipe/segment{
@@ -4727,7 +4581,6 @@
 "asa" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Supply Shuttle";
-	opacity = 1;
 	req_access_txt = "101"
 	},
 /turf/unsimulated/floor{
@@ -4938,8 +4791,6 @@
 /area/centcom/arrival)
 "asF" = (
 /obj/machinery/firealarm{
-	dir = 2;
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/closet/secure_closet/personal,
@@ -5046,7 +4897,6 @@
 "atb" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Kitchen";
-	opacity = 1;
 	req_access_txt = "150"
 	},
 /turf/unsimulated/floor{
@@ -5056,9 +4906,6 @@
 /area/syndicate_mothership)
 "atc" = (
 /obj/machinery/status_display{
-	density = 0;
-	pixel_x = 0;
-	pixel_y = 0;
 	supply_display = 1
 	},
 /obj/structure/disposalpipe/segment,
@@ -5071,10 +4918,7 @@
 	},
 /area/supply/dock)
 "ate" = (
-/obj/structure/sign/poster{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/structure/sign/poster,
 /turf/unsimulated/wall,
 /area/centcom/arrival)
 "atf" = (
@@ -5171,8 +5015,7 @@
 /area/centcom/arrival)
 "atr" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "white"
@@ -5204,8 +5047,7 @@
 	pixel_x = -24
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -5226,7 +5068,6 @@
 	},
 /obj/machinery/door_control{
 	desc = "A remote control switch for port-side blast doors.";
-	icon_state = "doorctrl0";
 	id = "velocity_cell02";
 	name = "Security Doors Cell 2";
 	pixel_x = 26;
@@ -5235,7 +5076,6 @@
 	},
 /obj/machinery/door_control{
 	desc = "A remote control switch for port-side blast doors.";
-	icon_state = "doorctrl0";
 	id = "velocity_cell01";
 	name = "Security Doors Cell 1";
 	pixel_x = 26;
@@ -5285,8 +5125,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "white"
@@ -5295,9 +5134,7 @@
 "atJ" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
 	pixel_x = 28
@@ -5315,7 +5152,6 @@
 "atL" = (
 /obj/machinery/door_control{
 	desc = "A remote control switch for port-side blast doors.";
-	icon_state = "doorctrl0";
 	id = "monorail_01";
 	name = "Security Doors Monorail 01";
 	pixel_x = 32;
@@ -5324,16 +5160,12 @@
 	},
 /obj/machinery/door_control{
 	desc = "A remote control switch for port-side blast doors.";
-	icon_state = "doorctrl0";
 	id = "monorail_02";
 	name = "Security Doors Monorail 02";
 	pixel_x = 32;
-	pixel_y = 0;
 	req_access_txt = "101"
 	},
 /obj/machinery/firealarm{
-	dir = 2;
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/unsimulated/floor{
@@ -5420,8 +5252,7 @@
 /area/centcom/arrival)
 "aub" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -5430,8 +5261,7 @@
 "auc" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
-	name = "Unisex Restrooms";
-	req_access_txt = "0"
+	name = "Unisex Restrooms"
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -5479,8 +5309,7 @@
 	pixel_x = -7
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	dir = 1;
@@ -5604,7 +5433,6 @@
 "auA" = (
 /obj/machinery/door_control{
 	desc = "A remote control switch for port-side blast doors.";
-	icon_state = "doorctrl0";
 	id = "velocity05";
 	name = "Security Doors Right";
 	pixel_x = 7;
@@ -5613,7 +5441,6 @@
 	},
 /obj/machinery/door_control{
 	desc = "A remote control switch for port-side blast doors.";
-	icon_state = "doorctrl0";
 	id = "velocity06";
 	name = "Security Doors Left";
 	pixel_x = -4;
@@ -5647,7 +5474,6 @@
 "auC" = (
 /obj/machinery/door_control{
 	desc = "A remote control switch for port-side shutters.";
-	icon_state = "doorctrl0";
 	id = "velocity_01";
 	name = "Security Shutters";
 	pixel_y = -32;
@@ -5662,9 +5488,7 @@
 "auI" = (
 /turf/simulated/shuttle/plating,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f10";
-	layer = 2
+	icon_state = "swall_f10"
 	},
 /area/centcom/arrival)
 "auJ" = (
@@ -5676,7 +5500,6 @@
 "auK" = (
 /obj/machinery/door_control{
 	desc = "A remote control switch for port-side blast doors.";
-	icon_state = "doorctrl0";
 	id = "velocity_cell03";
 	name = "Security Doors Cell 3";
 	pixel_x = 26;
@@ -5685,7 +5508,6 @@
 	},
 /obj/machinery/door_control{
 	desc = "A remote control switch for port-side blast doors.";
-	icon_state = "doorctrl0";
 	id = "velocity_cell04";
 	name = "Security Doors Cell 4";
 	pixel_x = 26;
@@ -5757,7 +5579,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
-	dir = 2;
 	id = "velocity_01";
 	name = "Security Shutters"
 	},
@@ -5773,7 +5594,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
-	dir = 2;
 	id = "velocity_01";
 	name = "Security Shutters"
 	},
@@ -5781,7 +5601,6 @@
 	dir = 4
 	},
 /obj/machinery/door/window/southleft{
-	dir = 2;
 	name = "Security";
 	req_access_txt = "101"
 	},
@@ -5792,7 +5611,6 @@
 "auV" = (
 /turf/unsimulated/floor{
 	dir = 4;
-	heat_capacity = 1;
 	icon_state = "warning"
 	},
 /area/centcom/arrival)
@@ -5967,7 +5785,6 @@
 /area/shuttle/transport1/centcom)
 "avv" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall12"
 	},
 /area/space)
@@ -6006,8 +5823,7 @@
 /area/centcom/arrival)
 "avB" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -6050,7 +5866,6 @@
 "avN" = (
 /obj/machinery/status_display,
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall3"
 	},
 /area/shuttle/escape/centcom)
@@ -6077,10 +5892,7 @@
 /area/centcom/arrival)
 "avU" = (
 /obj/structure/rack,
-/obj/item/weapon/storage/briefcase{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/weapon/storage/briefcase,
 /obj/item/weapon/storage/briefcase{
 	pixel_x = -2;
 	pixel_y = -5
@@ -6090,8 +5902,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	dir = 4;
@@ -6119,7 +5930,6 @@
 /obj/machinery/porta_turret/crescent,
 /turf/unsimulated/floor{
 	dir = 4;
-	heat_capacity = 1;
 	icon_state = "warning"
 	},
 /area/prison/solitary{
@@ -6163,18 +5973,14 @@
 /area/centcom/arrival)
 "awm" = (
 /obj/machinery/status_display{
-	density = 0;
-	layer = 4;
-	pixel_x = 0;
-	pixel_y = 0
+	layer = 4
 	},
 /turf/unsimulated/wall,
 /area/centcom/arrival)
 "awn" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "green"
@@ -6189,7 +5995,6 @@
 "awr" = (
 /obj/structure/sign/directions/velocity{
 	dir = 4;
-	icon_state = "tablo01";
 	pixel_x = -32
 	},
 /turf/simulated/shuttle/floor{
@@ -6223,7 +6028,6 @@
 "awx" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Brig";
-	opacity = 1;
 	req_access_txt = "109"
 	},
 /obj/structure/sign/mark{
@@ -6268,17 +6072,13 @@
 	icon_state = "circuit"
 	},
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f10";
-	layer = 2
+	icon_state = "swall_f10"
 	},
 /area/centcom/arrival)
 "awC" = (
 /turf/simulated/shuttle/plating,
 /turf/simulated/shuttle/wall{
-	dir = 2;
-	icon_state = "swall_f10";
-	layer = 2
+	icon_state = "swall_f10"
 	},
 /area/centcom/evac)
 "awD" = (
@@ -6376,7 +6176,6 @@
 "awV" = (
 /turf/unsimulated/floor{
 	dir = 4;
-	heat_capacity = 1;
 	icon_state = "warning"
 	},
 /area/prison/solitary{
@@ -6421,7 +6220,6 @@
 "axa" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Cargo";
-	opacity = 1;
 	req_access_txt = "101"
 	},
 /obj/structure/disposalpipe/segment,
@@ -6542,7 +6340,6 @@
 "axB" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Brig";
-	opacity = 1;
 	req_access_txt = "109"
 	},
 /obj/structure/sign/mark{
@@ -6589,8 +6386,7 @@
 /obj/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	dir = 4;
@@ -6624,14 +6420,12 @@
 /area/supply/dock)
 "axS" = (
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "red"
 	},
 /area/centcom/arrival)
 "axT" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Brig";
-	opacity = 1;
 	req_access_txt = "109"
 	},
 /obj/structure/sign/mark{
@@ -6647,7 +6441,6 @@
 "axU" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Brig";
-	opacity = 1;
 	req_access_txt = "109"
 	},
 /obj/structure/sign/mark{
@@ -6744,7 +6537,6 @@
 "ayf" = (
 /obj/machinery/door_control{
 	desc = "A remote control switch for port-side blast doors.";
-	icon_state = "doorctrl0";
 	id = "velocity03";
 	name = "Security Doors Right";
 	pixel_x = 7;
@@ -6753,7 +6545,6 @@
 	},
 /obj/machinery/door_control{
 	desc = "A remote control switch for port-side blast doors.";
-	icon_state = "doorctrl0";
 	id = "velocity04";
 	name = "Security Doors Left";
 	pixel_x = -4;
@@ -6789,7 +6580,6 @@
 "ayh" = (
 /obj/machinery/door_control{
 	desc = "A remote control switch for port-side shutters.";
-	icon_state = "doorctrl0";
 	id = "velocity_02";
 	name = "Security Shutters";
 	pixel_y = 32;
@@ -6837,7 +6627,6 @@
 "ayo" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Brig";
-	opacity = 1;
 	req_access_txt = "109"
 	},
 /obj/structure/sign/mark{
@@ -6853,7 +6642,6 @@
 "ayp" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Brig";
-	opacity = 1;
 	req_access_txt = "109"
 	},
 /obj/structure/sign/mark{
@@ -6921,7 +6709,6 @@
 "ayx" = (
 /obj/machinery/door_control{
 	desc = "A remote control switch for port-side blast doors.";
-	icon_state = "doorctrl0";
 	id = "monorail_01";
 	name = "Security Doors Monorail 01";
 	pixel_x = 32;
@@ -6930,11 +6717,9 @@
 	},
 /obj/machinery/door_control{
 	desc = "A remote control switch for port-side blast doors.";
-	icon_state = "doorctrl0";
 	id = "monorail_02";
 	name = "Security Doors Monorail 02";
 	pixel_x = 32;
-	pixel_y = 0;
 	req_access_txt = "101"
 	},
 /obj/structure/centcom_barrier,
@@ -6956,8 +6741,7 @@
 	pixel_x = -30
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -6977,8 +6761,7 @@
 /area/centcom/arrival)
 "ayC" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -6987,7 +6770,6 @@
 "ayE" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Brig";
-	opacity = 1;
 	req_access_txt = "109"
 	},
 /obj/structure/sign/mark{
@@ -7049,7 +6831,6 @@
 "ayI" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/unsimulated/floor{
@@ -7110,18 +6891,14 @@
 /area/shuttle/administration/centcom)
 "ayT" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 8;
-	icon_state = "propulsion"
+	dir = 8
 	},
 /turf/space,
 /area/shuttle/specops/centcom)
 "ayU" = (
 /obj/structure/table/reinforced,
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	dir = 2;
 	frequency = 1443;
-	listening = 1;
 	name = "Spec Ops Intercom";
 	pixel_y = 28
 	},
@@ -7138,7 +6915,6 @@
 "ayW" = (
 /obj/machinery/camera{
 	c_tag = "Spec. Ops. Shuttle";
-	dir = 2;
 	network = list("ERT")
 	},
 /obj/structure/stool/bed/chair/metal,
@@ -7225,10 +7001,8 @@
 "azn" = (
 /obj/machinery/door/airlock/external,
 /obj/machinery/door/poddoor{
-	icon_state = "pdoor1";
 	id = "NTrasen";
-	name = "Outer Airlock";
-	p_open = 0
+	name = "Outer Airlock"
 	},
 /turf/simulated/shuttle/plating,
 /area/shuttle/specops/centcom)
@@ -7238,7 +7012,6 @@
 "azq" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Brig";
-	opacity = 1;
 	req_access_txt = "109"
 	},
 /obj/structure/sign/mark{
@@ -7277,7 +7050,6 @@
 	pixel_y = 0
 	},
 /obj/structure/stool/bed/chair/schair/monorail_chair{
-	dir = 2;
 	icon_state = "chair_c03";
 	name = "shuttle chair"
 	},
@@ -7287,7 +7059,6 @@
 /area/shuttle/officer/velocity)
 "azv" = (
 /obj/structure/stool/bed/chair/schair/monorail_chair{
-	dir = 2;
 	icon_state = "chair_c02";
 	name = "shuttle chair"
 	},
@@ -7297,7 +7068,6 @@
 /area/shuttle/officer/velocity)
 "azw" = (
 /obj/structure/stool/bed/chair/schair/monorail_chair{
-	dir = 2;
 	icon_state = "chair_c01";
 	name = "shuttle chair"
 	},
@@ -7435,7 +7205,6 @@
 "azV" = (
 /obj/item/device/radio/intercom{
 	freerange = 1;
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = -30
 	},
@@ -7614,7 +7383,6 @@
 "aAr" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Brig";
-	opacity = 1;
 	req_access_txt = "109"
 	},
 /obj/structure/sign/mark{
@@ -7951,7 +7719,6 @@
 "aBf" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Brig";
-	opacity = 1;
 	req_access_txt = "109"
 	},
 /turf/unsimulated/floor{
@@ -8043,7 +7810,6 @@
 /obj/structure/stool/bed/chair/comfy/black,
 /turf/unsimulated/floor{
 	dir = 4;
-	heat_capacity = 1;
 	icon_state = "warning"
 	},
 /area/centcom/arrival)
@@ -8080,7 +7846,6 @@
 "aBD" = (
 /obj/machinery/camera{
 	c_tag = "Assault Armor North";
-	dir = 2;
 	network = list("ERT")
 	},
 /obj/mecha/combat/gygax/dark,
@@ -8092,7 +7857,6 @@
 "aBE" = (
 /turf/unsimulated/floor{
 	dir = 4;
-	heat_capacity = 1;
 	icon_state = "warning"
 	},
 /area/centcom/living)
@@ -8304,10 +8068,8 @@
 /area/centcom/living)
 "aBY" = (
 /obj/machinery/door/poddoor{
-	icon_state = "pdoor1";
 	id = "ASSAULT3";
-	name = "Launch Bay #3";
-	p_open = 0
+	name = "Launch Bay #3"
 	},
 /turf/unsimulated/floor{
 	name = "plating"
@@ -8349,8 +8111,7 @@
 /area/centcom/living)
 "aCe" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	dir = 1;
@@ -8360,7 +8121,6 @@
 "aCf" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Medical Special Operations";
-	opacity = 1;
 	req_access_txt = "103"
 	},
 /turf/unsimulated/floor{
@@ -8371,7 +8131,6 @@
 "aCh" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Engineering Special Operations";
-	opacity = 1;
 	req_access_txt = "103"
 	},
 /turf/unsimulated/floor{
@@ -8382,7 +8141,6 @@
 "aCi" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Special Operations";
-	opacity = 1;
 	req_access_txt = "103"
 	},
 /turf/unsimulated/floor{
@@ -8415,7 +8173,6 @@
 "aCo" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Special Operations";
-	opacity = 1;
 	req_access_txt = "103"
 	},
 /turf/unsimulated/floor{
@@ -8439,7 +8196,6 @@
 "aCs" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Brig";
-	opacity = 1;
 	req_access_txt = "109"
 	},
 /turf/unsimulated/floor{
@@ -8505,7 +8261,6 @@
 /obj/structure/window/reinforced,
 /turf/unsimulated/floor{
 	dir = 4;
-	heat_capacity = 1;
 	icon_state = "warning"
 	},
 /area/centcom/arrival)
@@ -8526,8 +8281,7 @@
 "aCD" = (
 /obj/machinery/mech_bay_recharge_port,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "bot"
@@ -8550,8 +8304,7 @@
 /area/centcom/living)
 "aCL" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -8640,10 +8393,8 @@
 /area/syndicate_mothership)
 "aDi" = (
 /obj/machinery/door/poddoor{
-	icon_state = "pdoor1";
 	id = "ASSAULT2";
-	name = "Launch Bay #2";
-	p_open = 0
+	name = "Launch Bay #2"
 	},
 /turf/unsimulated/floor{
 	name = "plating"
@@ -8675,7 +8426,6 @@
 "aDr" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Special Operations";
-	opacity = 1;
 	req_access_txt = "103"
 	},
 /obj/effect/landmark/trololo,
@@ -8692,7 +8442,6 @@
 "aDt" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Special Operations";
-	opacity = 1;
 	req_access_txt = "103"
 	},
 /turf/unsimulated/floor{
@@ -8708,7 +8457,6 @@
 /area/centcom/living)
 "aDD" = (
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "red"
 	},
 /area/centcom/living)
@@ -8750,7 +8498,6 @@
 "aDI" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Creed's Office";
-	opacity = 1;
 	req_access_txt = "108"
 	},
 /turf/unsimulated/floor{
@@ -8798,8 +8545,7 @@
 /area/centcom/specops)
 "aDN" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	dir = 8;
@@ -8822,10 +8568,8 @@
 /area/centcom/specops)
 "aDV" = (
 /obj/machinery/door/poddoor{
-	icon_state = "pdoor1";
 	id = "ASSAULT1";
-	name = "Launch Bay #1";
-	p_open = 0
+	name = "Launch Bay #1"
 	},
 /turf/unsimulated/floor{
 	name = "plating"
@@ -8848,12 +8592,10 @@
 	frequency = 1441;
 	listening = 0;
 	name = "Spec Ops Intercom";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -8908,8 +8650,7 @@
 /area/centcom/specops)
 "aEe" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	dir = 6;
@@ -8953,9 +8694,7 @@
 /obj/item/weapon/reagent_containers/glass/bottle/stoxin,
 /obj/item/weapon/reagent_containers/glass/bottle/stoxin,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -9078,7 +8817,6 @@
 /area/centcom/creed)
 "aEw" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall13"
 	},
 /area/shuttle/escape/centcom)
@@ -9087,10 +8825,8 @@
 /area/centcom)
 "aEG" = (
 /obj/machinery/door/poddoor{
-	icon_state = "pdoor1";
 	id = "ASSAULT0";
-	name = "Launch Bay #0";
-	p_open = 0
+	name = "Launch Bay #0"
 	},
 /turf/unsimulated/floor{
 	name = "plating"
@@ -9207,8 +8943,7 @@
 /area/centcom)
 "aEY" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	name = "plating"
@@ -9248,20 +8983,6 @@
 "aFf" = (
 /obj/machinery/door/airlock/external{
 	name = "Arrival Airlock"
-	},
-/turf/unsimulated/floor,
-/area/centcom/evac)
-"aFg" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
 	},
 /turf/unsimulated/floor,
 /area/centcom/evac)
@@ -9407,7 +9128,6 @@
 "aFu" = (
 /obj/machinery/door/airlock/centcom{
 	name = "General Access";
-	opacity = 1;
 	req_access_txt = "101"
 	},
 /turf/unsimulated/floor{
@@ -9426,8 +9146,7 @@
 /area/centcom/specops)
 "aFx" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	dir = 8;
@@ -9510,7 +9229,6 @@
 /area/shuttle/administration/centcom)
 "aFJ" = (
 /obj/structure/table{
-	dir = 2;
 	icon_state = "tabledir"
 	},
 /obj/item/device/multitool,
@@ -9521,7 +9239,6 @@
 /area/shuttle/administration/centcom)
 "aFK" = (
 /obj/structure/table{
-	dir = 2;
 	icon_state = "tabledir"
 	},
 /obj/item/weapon/storage/toolbox/mechanical,
@@ -9531,8 +9248,7 @@
 /area/shuttle/administration/centcom)
 "aFO" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -9594,15 +9310,13 @@
 "aFY" = (
 /obj/machinery/door/airlock/centcom{
 	name = "General Access";
-	opacity = 1;
 	req_access_txt = "101"
 	},
 /turf/unsimulated/floor,
 /area/shuttle/administration/centcom)
 "aFZ" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -9616,7 +9330,6 @@
 /area/shuttle/administration/centcom)
 "aGb" = (
 /obj/structure/table{
-	dir = 2;
 	icon_state = "tabledir"
 	},
 /obj/machinery/cell_charger,
@@ -9662,8 +9375,7 @@
 /area/centcom/living)
 "aGt" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "grimy"
@@ -9696,8 +9408,7 @@
 "aGA" = (
 /obj/machinery/door/window/northright,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -9726,8 +9437,7 @@
 	},
 /obj/item/weapon/storage/fancy/cigarettes,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -9752,17 +9462,14 @@
 	amount = 5000
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
 	},
 /area/shuttle/administration/centcom)
 "aGH" = (
-/obj/machinery/door/poddoor/shutters{
-	dir = 2
-	},
+/obj/machinery/door/poddoor/shutters,
 /turf/unsimulated/wall,
 /area/centcom/arrival)
 "aGI" = (
@@ -9879,8 +9586,7 @@
 "aHi" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/regular{
-	pixel_x = 2;
-	pixel_y = 0
+	pixel_x = 2
 	},
 /obj/item/weapon/storage/firstaid/regular{
 	pixel_x = -2;
@@ -9917,7 +9623,6 @@
 /area/centcom/living)
 "aHo" = (
 /obj/structure/shuttle/engine/heater{
-	dir = 2;
 	icon_state = "heater1"
 	},
 /obj/structure/window/reinforced{
@@ -9942,7 +9647,6 @@
 /obj/machinery/vending/wallmed1{
 	name = "Emergency NanoMed";
 	pixel_x = -30;
-	pixel_y = 0;
 	req_access_txt = "0"
 	},
 /turf/simulated/shuttle/floor,
@@ -9958,7 +9662,6 @@
 /obj/machinery/vending/wallmed1{
 	name = "Emergency NanoMed";
 	pixel_x = 30;
-	pixel_y = 0;
 	req_access_txt = "0"
 	},
 /turf/simulated/shuttle/floor,
@@ -10102,14 +9805,12 @@
 /area/centcom/living)
 "aHO" = (
 /obj/structure/toilet{
-	pixel_x = 0;
 	pixel_y = 7
 	},
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/centcom/living)
@@ -10118,14 +9819,12 @@
 	dir = 1
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/centcom/living)
 "aHS" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor4"
@@ -10208,13 +9907,11 @@
 	name = "Unit 1"
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/centcom/living)
 "aIh" = (
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/centcom/living)
@@ -10283,7 +9980,6 @@
 	},
 /turf/unsimulated/floor{
 	dir = 4;
-	heat_capacity = 1;
 	icon_state = "warning"
 	},
 /area/centcom/evac)
@@ -10292,8 +9988,7 @@
 	pixel_x = 7
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -10304,8 +9999,7 @@
 	pixel_x = -7
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -10317,23 +10011,18 @@
 "aIE" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/centcom/living)
 "aIF" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Special Operations";
-	opacity = 1;
 	req_access_txt = "103"
 	},
 /turf/unsimulated/floor{
@@ -10366,7 +10055,6 @@
 "aIO" = (
 /turf/unsimulated/floor{
 	dir = 4;
-	heat_capacity = 1;
 	icon_state = "warning"
 	},
 /area/centcom/evac)
@@ -10374,13 +10062,6 @@
 /turf/unsimulated/floor{
 	icon_state = "floor5"
 	},
-/area/centcom/evac)
-"aIR" = (
-/obj/machinery/door/airlock/external{
-	locked = 0;
-	name = "Arrival Airlock"
-	},
-/turf/unsimulated/floor,
 /area/centcom/evac)
 "aIS" = (
 /obj/machinery/light/small{
@@ -10390,11 +10071,9 @@
 /area/centcom/evac)
 "aIU" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Showers";
-	req_access_txt = "0"
+	name = "Unisex Showers"
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/centcom/living)
@@ -10423,9 +10102,7 @@
 /area/centcom/evac)
 "aIZ" = (
 /obj/machinery/door/window/northright{
-	base_state = "right";
 	dir = 4;
-	icon_state = "right";
 	name = "Security Desk";
 	req_access_txt = "103"
 	},
@@ -10442,9 +10119,7 @@
 /area/centcom/evac)
 "aJb" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "cult";
@@ -10465,12 +10140,10 @@
 /area/centcom/living)
 "aJh" = (
 /obj/machinery/door/window/northright{
-	dir = 2;
-	icon_state = "right"
+	dir = 2
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor3"
@@ -10485,8 +10158,7 @@
 "aJj" = (
 /obj/structure/table,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor3"
@@ -10528,7 +10200,6 @@
 "aJr" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Living Quarters";
-	opacity = 1;
 	req_access_txt = "105"
 	},
 /turf/unsimulated/floor{
@@ -10576,7 +10247,6 @@
 "aJx" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Special Operations";
-	opacity = 1;
 	req_access_txt = "103"
 	},
 /turf/unsimulated/floor{
@@ -10642,8 +10312,7 @@
 /area/centcom/evac)
 "aJE" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor,
 /area/centcom/evac)
@@ -10652,8 +10321,7 @@
 	pixel_x = -5
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -10664,19 +10332,11 @@
 	pixel_x = 5
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
 	},
-/area/centcom/evac)
-"aJH" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/turf/unsimulated/floor,
 /area/centcom/evac)
 "aJI" = (
 /obj/structure/stool/bed,
@@ -10693,7 +10353,6 @@
 	},
 /obj/machinery/light/small,
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "carpetside"
 	},
 /area/centcom/living)
@@ -10706,8 +10365,7 @@
 /area/centcom/living)
 "aJL" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	dir = 8;
@@ -10716,8 +10374,7 @@
 /area/centcom/living)
 "aJN" = (
 /obj/structure/mirror{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/unsimulated/floor{
 	dir = 8;
@@ -10776,7 +10433,6 @@
 "aKa" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Commander Quarters";
-	opacity = 1;
 	req_access_txt = "109"
 	},
 /turf/unsimulated/floor{
@@ -10793,8 +10449,7 @@
 "aKc" = (
 /obj/structure/stool/bed/chair/metal,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	dir = 4;
@@ -10803,8 +10458,7 @@
 /area/centcom/living)
 "aKd" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -10822,8 +10476,7 @@
 /area/centcom/control)
 "aKh" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -10837,7 +10490,6 @@
 /area/supply/dock)
 "aKj" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall_s6"
 	},
 /area/space)
@@ -10909,7 +10561,6 @@
 /obj/machinery/vending/wallmed1{
 	name = "Emergency NanoMed";
 	pixel_x = -30;
-	pixel_y = 0;
 	req_access_txt = "0"
 	},
 /turf/simulated/shuttle/floor{
@@ -11021,7 +10672,6 @@
 	},
 /turf/unsimulated/floor{
 	dir = 4;
-	heat_capacity = 1;
 	icon_state = "warning"
 	},
 /area/centcom/living)
@@ -11075,7 +10725,6 @@
 /area/centcom/control)
 "aKR" = (
 /obj/machinery/door/window{
-	dir = 2;
 	name = "AI Core Door";
 	req_access_txt = "109"
 	},
@@ -11118,7 +10767,6 @@
 "aKX" = (
 /turf/unsimulated/floor{
 	dir = 4;
-	heat_capacity = 1;
 	icon_state = "warning"
 	},
 /area/centcom/control)
@@ -11144,8 +10792,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	dir = 4;
@@ -11155,7 +10802,6 @@
 "aLd" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Living Quarters";
-	opacity = 1;
 	req_access_txt = "105"
 	},
 /turf/unsimulated/floor{
@@ -11165,7 +10811,6 @@
 "aLe" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Living Quarters";
-	opacity = 1;
 	req_access_txt = "105"
 	},
 /turf/unsimulated/floor{
@@ -11175,7 +10820,6 @@
 "aLg" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Bridge";
-	opacity = 1;
 	req_access_txt = "109"
 	},
 /turf/unsimulated/floor{
@@ -11191,7 +10835,6 @@
 "aLi" = (
 /obj/machinery/door/airlock/centcom{
 	name = "General Access";
-	opacity = 1;
 	req_access_txt = "101"
 	},
 /turf/unsimulated/floor{
@@ -11201,7 +10844,6 @@
 "aLj" = (
 /obj/machinery/door/airlock/centcom{
 	name = "General Access";
-	opacity = 1;
 	req_access_txt = "101"
 	},
 /turf/unsimulated/floor{
@@ -11270,7 +10912,6 @@
 /obj/machinery/light,
 /turf/unsimulated/floor{
 	dir = 4;
-	heat_capacity = 1;
 	icon_state = "warning"
 	},
 /area/centcom/control)
@@ -11295,7 +10936,6 @@
 "aLB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/newscaster/security_unit{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/faxmachine{
@@ -11327,7 +10967,6 @@
 "aLF" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Teleport Room";
-	opacity = 1;
 	req_access_txt = "101"
 	},
 /turf/unsimulated/floor{
@@ -11436,8 +11075,7 @@
 /area/centcom/evac)
 "aMb" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "bot"
@@ -11445,8 +11083,7 @@
 /area/centcom/evac)
 "aMc" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "bot"
@@ -11727,7 +11364,6 @@
 /obj/machinery/door_control{
 	id = "ck_comf_blast";
 	name = "Security Shutters";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/unsimulated/floor{
@@ -11737,7 +11373,6 @@
 /area/centcom/living)
 "aNC" = (
 /obj/machinery/newscaster/security_unit{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/unsimulated/floor{
@@ -11760,16 +11395,12 @@
 	},
 /area/centcom/living)
 "aNG" = (
-/obj/structure/sign/poster{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/structure/sign/poster,
 /turf/unsimulated/wall,
 /area/centcom/holding)
 "aNH" = (
 /obj/machinery/conveyor{
-	dir = 1;
-	id = ""
+	dir = 1
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -11787,7 +11418,6 @@
 "aNK" = (
 /obj/machinery/door/airlock/centcom{
 	name = "General Access";
-	opacity = 1;
 	req_access_txt = "101"
 	},
 /obj/structure/sign/mark{
@@ -11799,7 +11429,6 @@
 "aNL" = (
 /obj/machinery/door/airlock/centcom{
 	name = "General Access";
-	opacity = 1;
 	req_access_txt = "101"
 	},
 /obj/structure/sign/mark{
@@ -11811,9 +11440,7 @@
 	},
 /area/centcom/holding)
 "aNM" = (
-/obj/machinery/door/airlock/glass{
-	locked = 0
-	},
+/obj/machinery/door/airlock/glass,
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -11908,7 +11535,6 @@
 	dir = 8
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/centcom/living)
@@ -11921,14 +11547,12 @@
 	dir = 1
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/centcom/living)
 "aOs" = (
 /obj/machinery/door/window/northleft,
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/centcom/living)
@@ -11937,7 +11561,6 @@
 	pixel_y = 32
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/centcom/holding)
@@ -11946,13 +11569,11 @@
 	dir = 1
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/centcom/holding)
 "aOv" = (
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/centcom/holding)
@@ -11963,14 +11584,12 @@
 	},
 /turf/unsimulated/floor{
 	dir = 4;
-	heat_capacity = 1;
 	icon_state = "warning"
 	},
 /area/centcom/holding)
 "aOA" = (
 /obj/machinery/conveyor{
-	dir = 1;
-	id = ""
+	dir = 1
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -11978,8 +11597,7 @@
 /area/centcom/holding)
 "aOB" = (
 /obj/machinery/conveyor{
-	dir = 4;
-	id = ""
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -11987,8 +11605,7 @@
 /area/centcom/holding)
 "aOC" = (
 /obj/machinery/conveyor{
-	dir = 9;
-	id = ""
+	dir = 9
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -11997,7 +11614,6 @@
 "aOE" = (
 /obj/machinery/door_control{
 	desc = "A remote control switch for port-side blast doors.";
-	icon_state = "doorctrl0";
 	id = "CentComPort04";
 	name = "Security Doors";
 	pixel_y = 32;
@@ -12038,8 +11654,7 @@
 	pixel_x = 7
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -12127,7 +11742,6 @@
 	dir = 10
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/centcom/living)
@@ -12137,7 +11751,6 @@
 	},
 /obj/item/weapon/folder/red,
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/centcom/living)
@@ -12160,8 +11773,7 @@
 "aPc" = (
 /obj/machinery/power/smes,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -12170,8 +11782,7 @@
 "aPg" = (
 /obj/structure/table,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -12217,7 +11828,6 @@
 	dir = 8
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/centcom/living)
@@ -12226,21 +11836,18 @@
 	dir = 8
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/centcom/living)
 "aPn" = (
 /turf/unsimulated/floor{
 	dir = 4;
-	heat_capacity = 1;
 	icon_state = "warning"
 	},
 /area/centcom/holding)
 "aPo" = (
 /obj/machinery/conveyor{
-	dir = 6;
-	id = ""
+	dir = 6
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -12248,8 +11855,7 @@
 /area/centcom/holding)
 "aPp" = (
 /obj/machinery/conveyor{
-	dir = 10;
-	id = ""
+	dir = 10
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -12270,7 +11876,6 @@
 "aPB" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Living Quarters";
-	opacity = 1;
 	req_access_txt = "105"
 	},
 /turf/unsimulated/floor{
@@ -12295,7 +11900,6 @@
 	},
 /obj/item/weapon/pen,
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/centcom/living)
@@ -12308,7 +11912,6 @@
 	dptdest = "Captain's Office"
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/centcom/living)
@@ -12321,8 +11924,7 @@
 /area/centcom/living)
 "aPL" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Courthouse";
-	opacity = 1
+	name = "Courthouse"
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -12336,7 +11938,6 @@
 	dir = 1
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/centcom/living)
@@ -12354,7 +11955,6 @@
 	pixel_x = 10
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/centcom/living)
@@ -12378,19 +11978,15 @@
 /area/centcom/holding)
 "aPT" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Restrooms";
-	req_access_txt = "0"
+	name = "Unisex Restrooms"
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/centcom/holding)
 "aPU" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Waiting Room";
-	opacity = 1;
-	req_access_txt = "0"
+	name = "Waiting Room"
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -12398,9 +11994,7 @@
 /area/centcom/holding)
 "aPW" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Holding Facility";
-	opacity = 1;
-	req_access_txt = "0"
+	name = "Holding Facility"
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -12409,7 +12003,6 @@
 "aPX" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Living Quarters";
-	opacity = 1;
 	req_access_txt = "105"
 	},
 /turf/unsimulated/floor{
@@ -12464,7 +12057,6 @@
 /area/centcom/living)
 "aQn" = (
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "carpetside"
 	},
 /area/centcom/living)
@@ -12490,24 +12082,20 @@
 "aQt" = (
 /obj/structure/table/woodentable,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/centcom/living)
 "aQu" = (
 /obj/structure/table/woodentable,
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/centcom/living)
 "aQv" = (
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/centcom/living)
@@ -12516,11 +12104,9 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/centcom/living)
@@ -12532,7 +12118,6 @@
 	dir = 1
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/centcom/holding)
@@ -12541,22 +12126,18 @@
 	name = "Unit 1"
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/centcom/holding)
 "aQz" = (
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 11;
-	pixel_y = 0
+	pixel_x = 11
 	},
 /obj/structure/mirror{
 	pixel_x = 28
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/centcom/holding)
@@ -12592,7 +12173,6 @@
 "aQM" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Conference Room";
-	opacity = 1;
 	req_access_txt = "108"
 	},
 /turf/unsimulated/floor{
@@ -12668,7 +12248,6 @@
 	dir = 1
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/centcom/living)
@@ -12707,21 +12286,18 @@
 	name = "Unit 2"
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/centcom/holding)
 "aRl" = (
 /obj/machinery/light,
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/centcom/holding)
 "aRm" = (
 /obj/structure/mopbucket,
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/centcom/holding)
@@ -12736,15 +12312,13 @@
 "aRt" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/unsimulated/wall,
 /area/centcom/evac)
 "aRw" = (
 /obj/machinery/door_control{
 	desc = "A remote control switch for port-side blast doors.";
-	icon_state = "doorctrl0";
 	id = "CentComPort03";
 	name = "Security Doors";
 	pixel_y = -32;
@@ -12844,14 +12418,12 @@
 /area/tdome)
 "aRU" = (
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "red"
 	},
 /area/centcom/holding)
 "aRV" = (
 /obj/machinery/light,
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "red"
 	},
 /area/centcom/holding)
@@ -12871,11 +12443,9 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/centcom/living)
@@ -12884,28 +12454,23 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/centcom/living)
 "aSa" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Courthouse";
-	opacity = 1
+	name = "Courthouse"
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/centcom/living)
 "aSb" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Equipment Room";
-	opacity = 1;
 	req_access_txt = "150"
 	},
 /turf/unsimulated/floor{
@@ -12916,7 +12481,6 @@
 "aSc" = (
 /turf/unsimulated/floor{
 	dir = 5;
-	heat_capacity = 1;
 	icon_state = "warning"
 	},
 /area/centcom/evac)
@@ -12925,9 +12489,7 @@
 /area/centcom/control)
 "aSi" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Holding Facility";
-	opacity = 1;
-	req_access_txt = "0"
+	name = "Holding Facility"
 	},
 /obj/structure/sign/mark{
 	icon_state = "8";
@@ -13073,7 +12635,6 @@
 "aSv" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Creed's Office";
-	opacity = 1;
 	req_access_txt = "108"
 	},
 /turf/unsimulated/floor{
@@ -13120,13 +12681,6 @@
 	name = "plating"
 	},
 /area/centcom/living)
-"aSy" = (
-/obj/structure/table,
-/turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "cafeteria"
-	},
-/area/centcom/living)
 "aSz" = (
 /obj/machinery/camera{
 	c_tag = "Jury Room";
@@ -13140,8 +12694,7 @@
 "aSA" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -13160,8 +12713,7 @@
 /area/centcom/evac)
 "aSD" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "bot"
@@ -13169,8 +12721,7 @@
 /area/centcom/control)
 "aSE" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "bot"
@@ -13290,8 +12841,7 @@
 /obj/machinery/door_control{
 	id = "ck_office_blast";
 	name = "Security Shutters";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /turf/unsimulated/floor{
 	dir = 5;
@@ -13338,32 +12888,21 @@
 "aSZ" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
-	dir = 2;
-	icon_state = "cafeteria"
-	},
-/area/centcom/living)
-"aTa" = (
-/turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/centcom/living)
 "aTb" = (
 /obj/structure/table,
 /obj/machinery/processor{
-	pixel_x = 0;
 	pixel_y = 10
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/centcom/living)
@@ -13453,8 +12992,7 @@
 /obj/item/device/radio/headset/ert,
 /obj/item/device/radio,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "grimy"
@@ -13479,8 +13017,7 @@
 /obj/item/device/radio/headset/ert,
 /obj/item/device/radio,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "grimy"
@@ -13489,8 +13026,7 @@
 "aTu" = (
 /obj/machinery/computer/security,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	dir = 8;
@@ -13500,7 +13036,6 @@
 "aTv" = (
 /obj/structure/stool,
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/centcom/living)
@@ -13509,8 +13044,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	dir = 4;
@@ -13522,8 +13056,7 @@
 /obj/item/weapon/card/id/centcom,
 /obj/item/device/radio,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "grimy"
@@ -13534,8 +13067,7 @@
 /obj/item/weapon/card/id/centcom,
 /obj/item/device/radio,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "grimy"
@@ -13560,8 +13092,7 @@
 	slogan_delay = 700
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor5"
@@ -13574,7 +13105,6 @@
 	pixel_y = 6
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/centcom/living)
@@ -13640,8 +13170,7 @@
 /area/tdome)
 "aTM" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -13649,8 +13178,7 @@
 /area/tdome)
 "aTN" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -13707,8 +13235,7 @@
 /area/centcom/living)
 "aTV" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Courthouse";
-	opacity = 1
+	name = "Courthouse"
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -13757,12 +13284,10 @@
 	pixel_y = 4
 	},
 /obj/item/weapon/reagent_containers/spray/plantbgone{
-	pixel_x = 0;
 	pixel_y = 7
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor5"
@@ -13796,7 +13321,6 @@
 /area/tdome)
 "aUo" = (
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "red"
 	},
 /area/tdome)
@@ -13869,14 +13393,12 @@
 /area/centcom/control)
 "aUE" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall12"
 	},
 /area/shuttle/escape/centcom)
 "aUH" = (
 /obj/machinery/door/airlock/centcom{
 	name = "General Access";
-	opacity = 1;
 	req_access_txt = "101"
 	},
 /turf/unsimulated/floor{
@@ -13892,8 +13414,7 @@
 /area/centcom/living)
 "aUJ" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	dir = 8;
@@ -13909,8 +13430,7 @@
 /obj/item/device/radio,
 /obj/item/clothing/under/color/yellow,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "grimy"
@@ -13928,8 +13448,7 @@
 /obj/item/weapon/storage/backpack/satchel/norm,
 /obj/item/device/radio,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "grimy"
@@ -13937,8 +13456,7 @@
 /area/centcom/living)
 "aUM" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor5"
@@ -13998,7 +13516,6 @@
 /area/supply/dock)
 "aUT" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall3"
 	},
 /area/shuttle/escape/centcom)
@@ -14167,8 +13684,7 @@
 "aVr" = (
 /obj/machinery/vending/snack,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -14177,8 +13693,7 @@
 "aVs" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "dark"
@@ -14317,8 +13832,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -14329,8 +13843,7 @@
 	dir = 8
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor"
@@ -14390,8 +13903,7 @@
 /area/beach)
 "aWq" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 4;
-	icon_state = "propulsion"
+	dir = 4
 	},
 /turf/space,
 /area/shuttle/escape/centcom)
@@ -14448,7 +13960,6 @@
 /obj/structure/table,
 /obj/item/device/nuclear_challenge,
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "bar"
 	},
 /area/syndicate_mothership)
@@ -14473,7 +13984,6 @@
 /area/beach)
 "aWF" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall_s10"
 	},
 /area/space)
@@ -14486,7 +13996,6 @@
 /area/shuttle/vox/station)
 "aWH" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall3"
 	},
 /area/space)
@@ -14499,13 +14008,11 @@
 /area/shuttle/vox/station)
 "aWJ" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall14"
 	},
 /area/space)
 "aWK" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall_s9"
 	},
 /area/space)
@@ -14516,7 +14023,6 @@
 	dir = 1
 	},
 /obj/machinery/door/poddoor{
-	dir = 2;
 	id = "skipjack";
 	name = "Skipjack Blast Shielding"
 	},
@@ -14540,7 +14046,6 @@
 	dir = 8
 	},
 /obj/machinery/door/poddoor{
-	dir = 2;
 	id = "skipjack";
 	name = "Skipjack Blast Shielding"
 	},
@@ -14564,7 +14069,6 @@
 	dir = 4
 	},
 /obj/machinery/door/poddoor{
-	dir = 2;
 	id = "skipjack";
 	name = "Skipjack Blast Shielding"
 	},
@@ -14580,7 +14084,6 @@
 /area/shuttle/vox/station)
 "aWP" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall_s5"
 	},
 /area/space)
@@ -14680,9 +14183,7 @@
 	frequency = 1331;
 	id_tag = "vox_northwest_lock";
 	locked = 1;
-	req_access_txt = "150";
-	req_one_access = null;
-	req_one_access_txt = "0"
+	req_access_txt = "150"
 	},
 /turf/simulated/shuttle/plating{
 	name = "dark plating";
@@ -14704,7 +14205,6 @@
 	pixel_x = -2
 	},
 /obj/item/weapon/storage/backpack/kitbag{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /obj/item/weapon/storage/backpack/kitbag{
@@ -14771,9 +14271,7 @@
 	frequency = 1331;
 	id_tag = "vox_northeast_lock";
 	locked = 1;
-	req_access_txt = "150";
-	req_one_access = null;
-	req_one_access_txt = "0"
+	req_access_txt = "150"
 	},
 /turf/simulated/shuttle/plating{
 	name = "dark plating";
@@ -14934,9 +14432,7 @@
 	frequency = 1331;
 	id_tag = "vox_southwest_lock";
 	locked = 1;
-	req_access_txt = "150";
-	req_one_access = null;
-	req_one_access_txt = "0"
+	req_access_txt = "150"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/shuttle/plating{
@@ -15072,9 +14568,7 @@
 	frequency = 1331;
 	id_tag = "vox_southeast_lock";
 	locked = 1;
-	req_access_txt = "150";
-	req_one_access = null;
-	req_one_access_txt = "0"
+	req_access_txt = "150"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/shuttle/plating{
@@ -15456,7 +14950,6 @@
 "aYW" = (
 /obj/machinery/door/airlock/command{
 	name = "Thunderdome Administration";
-	req_access = null;
 	req_access_txt = "102"
 	},
 /turf/unsimulated/floor{
@@ -15485,7 +14978,6 @@
 /area/shuttle/vox/station)
 "aZb" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall2"
 	},
 /area/shuttle/escape/centcom)
@@ -15524,7 +15016,6 @@
 "aZg" = (
 /obj/machinery/door/airlock/command{
 	name = "Thunderdome Administration";
-	req_access = null;
 	req_access_txt = "102"
 	},
 /turf/unsimulated/floor,
@@ -15651,18 +15142,6 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 8
-	},
-/turf/simulated/shuttle/plating{
-	name = "dark plating";
-	nitrogen = 103.984;
-	oxygen = 0
-	},
-/area/shuttle/vox/station)
-"aZG" = (
-/obj/machinery/door/airlock/hatch{
-	req_access_txt = "150";
-	req_one_access = null;
-	req_one_access_txt = "0"
 	},
 /turf/simulated/shuttle/plating{
 	name = "dark plating";
@@ -15961,7 +15440,6 @@
 	name = "wizard"
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "carpetsymbol"
 	},
 /area/wizard_station)
@@ -15985,8 +15463,7 @@
 /area/wizard_station)
 "baM" = (
 /obj/machinery/shower{
-	dir = 8;
-	icon_state = "shower"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "engine"
@@ -16025,7 +15502,6 @@
 /area/wizard_station)
 "baQ" = (
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "carpetside"
 	},
 /area/wizard_station)
@@ -16155,9 +15631,7 @@
 	syndie = 1
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "grimy"
@@ -16165,8 +15639,7 @@
 /area/wizard_station)
 "bbd" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	dir = 8;
@@ -16271,8 +15744,7 @@
 /area/shuttle/vox/station)
 "bbo" = (
 /obj/structure/stool/bed/chair/wood/wings{
-	dir = 4;
-	icon_state = "wooden_chair_wings"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	dir = 8;
@@ -16297,8 +15769,7 @@
 /area/wizard_station)
 "bbr" = (
 /obj/structure/stool/bed/chair/wood/wings{
-	dir = 8;
-	icon_state = "wooden_chair_wings"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	dir = 8;
@@ -16587,8 +16058,7 @@
 /area/centcom/living)
 "bda" = (
 /turf/unsimulated/wall/fakeglass{
-	dir = 8;
-	icon_state = "fakewindows"
+	dir = 8
 	},
 /area/wizard_station)
 "bdb" = (
@@ -16599,14 +16069,12 @@
 /area/wizard_station)
 "bdc" = (
 /turf/unsimulated/wall/fakeglass{
-	dir = 1;
-	icon_state = "fakewindows"
+	dir = 1
 	},
 /area/wizard_station)
 "bdd" = (
 /turf/unsimulated/wall/fakeglass{
-	dir = 4;
-	icon_state = "fakewindows"
+	dir = 4
 	},
 /area/wizard_station)
 "bde" = (
@@ -16639,7 +16107,6 @@
 "bdu" = (
 /obj/effect/decal/cleanable/blood,
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/wizard_station)
@@ -16648,13 +16115,11 @@
 	name = "Murphey"
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/wizard_station)
 "bdw" = (
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/wizard_station)
@@ -16710,21 +16175,18 @@
 "bdP" = (
 /obj/item/weapon/caution,
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/wizard_station)
 "bdQ" = (
 /obj/machinery/light,
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/wizard_station)
 "bdR" = (
 /obj/item/weapon/kitchenknife/ritual,
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/wizard_station)
@@ -16755,7 +16217,6 @@
 /obj/machinery/door/airlock/external{
 	dock_tag = "velocity_1";
 	icon_state = "door_closed";
-	locked = 0;
 	name = "Arrival Airlock"
 	},
 /turf/unsimulated/floor{
@@ -16947,9 +16408,7 @@
 /area/centcom/living)
 "bfj" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -17264,7 +16723,6 @@
 	},
 /turf/unsimulated/floor{
 	dir = 4;
-	heat_capacity = 1;
 	icon_state = "warning"
 	},
 /area/centcom/living)
@@ -17275,7 +16733,6 @@
 	},
 /obj/structure/table/reinforced,
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "floor"
 	},
 /area/centcom/living)
@@ -17427,26 +16884,20 @@
 	},
 /obj/machinery/door_control{
 	desc = "A remote control switch to block view of the singularity.";
-	icon_state = "doorctrl0";
 	id = "CREED";
 	name = "Spec Ops Ready Room";
 	pixel_w = 10;
-	pixel_y = 0;
 	req_access_txt = "11"
 	},
 /obj/machinery/door_control{
 	desc = "A remote control switch to block view of the singularity.";
-	icon_state = "doorctrl0";
 	id = "Mecha";
 	name = "Mech Storage";
-	pixel_x = 0;
-	pixel_y = 0;
 	req_access_txt = "11"
 	},
 /obj/machinery/door_control{
 	id = "MechaModule";
 	name = "Mech Module Storage";
-	pixel_w = 0;
 	pixel_z = 10
 	},
 /obj/machinery/door_control{
@@ -17577,14 +17028,11 @@
 /area/centcom/arrival)
 "bZb" = (
 /obj/machinery/status_display{
-	density = 0;
 	pixel_x = 32;
-	pixel_y = 0;
 	supply_display = 1
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	dir = 4;
@@ -17738,8 +17186,7 @@
 /area/centcom/arrival)
 "crb" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /turf/unsimulated/floor{
 	icon_state = "sandwater"
@@ -17751,8 +17198,7 @@
 	pixel_x = -24
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	dir = 5;
@@ -17764,12 +17210,10 @@
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
 	name = "HIGH VOLTAGE";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	dir = 5;
@@ -17806,7 +17250,6 @@
 	id = "velocity_hall";
 	name = "Blast Door Control";
 	pixel_x = 24;
-	pixel_y = 0;
 	req_access_txt = "101"
 	},
 /turf/unsimulated/floor{
@@ -17819,7 +17262,6 @@
 	id = "velocity_room02";
 	name = "Blast Door Control";
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access_txt = "101"
 	},
 /obj/structure/disposalpipe/segment,
@@ -17889,8 +17331,6 @@
 /area/centcom/arrival)
 "cIb" = (
 /obj/machinery/firealarm{
-	dir = 2;
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/unsimulated/floor{
@@ -17905,8 +17345,7 @@
 /area/centcom/arrival)
 "cKb" = (
 /obj/structure/disposalpipe/junction{
-	dir = 1;
-	icon_state = "pipe-j1"
+	dir = 1
 	},
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -17956,8 +17395,6 @@
 	dir = 4
 	},
 /obj/machinery/firealarm{
-	dir = 2;
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/unsimulated/floor{
@@ -17986,8 +17423,7 @@
 	pixel_x = -24
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "carpet3-0"
@@ -18046,7 +17482,6 @@
 /obj/machinery/door_control{
 	id = "velocity_hall";
 	name = "Blast Door Control";
-	pixel_x = 0;
 	pixel_y = -24;
 	req_access_txt = "101"
 	},
@@ -18066,7 +17501,6 @@
 	id = "velocity_room02";
 	name = "Blast Door Control";
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access_txt = "101"
 	},
 /obj/structure/disposalpipe/segment,
@@ -18108,8 +17542,7 @@
 /obj/structure/sign/directions/velocity{
 	dir = 4;
 	icon_state = "tablo03_0";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/unsimulated/floor{
 	icon_state = "hydrofloor"
@@ -18133,9 +17566,7 @@
 	icon_state = "table"
 	},
 /obj/item/device/flashlight/lamp,
-/obj/item/device/taperecorder{
-	pixel_y = 0
-	},
+/obj/item/device/taperecorder,
 /turf/unsimulated/floor{
 	icon_state = "bcircuitoff"
 	},
@@ -18184,8 +17615,7 @@
 "djb" = (
 /obj/machinery/flasher{
 	id = "velocity_cell1";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/unsimulated/floor{
 	icon_state = "floorgrime"
@@ -18194,8 +17624,7 @@
 "dkb" = (
 /obj/structure/flora/plant/random,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "hydrofloor"
@@ -18204,7 +17633,6 @@
 "dlb" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /turf/unsimulated/floor{
@@ -18222,7 +17650,6 @@
 "dnb" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -18266,8 +17693,7 @@
 	},
 /obj/structure/sign/mark{
 	icon_state = "2";
-	layer = 3.5;
-	pixel_x = 0
+	layer = 3.5
 	},
 /turf/unsimulated/floor{
 	icon_state = "floorgrime"
@@ -18276,8 +17702,7 @@
 "dsb" = (
 /obj/machinery/flasher{
 	id = "velocity_cell2";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/unsimulated/floor{
 	icon_state = "floorgrime"
@@ -18285,12 +17710,10 @@
 /area/centcom/arrival)
 "dtb" = (
 /obj/structure/sign/warning/securearea{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	dir = 4;
@@ -18303,8 +17726,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	dir = 8;
@@ -18326,7 +17748,6 @@
 "dxb" = (
 /obj/structure/sink{
 	dir = 8;
-	icon_state = "sink";
 	pixel_x = -12;
 	pixel_y = 2
 	},
@@ -18390,8 +17811,7 @@
 "dEb" = (
 /obj/machinery/flasher{
 	id = "velocity_cell3";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/unsimulated/floor{
 	icon_state = "floorgrime"
@@ -18410,8 +17830,7 @@
 /area/centcom/arrival)
 "dHb" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "rampbottom"
@@ -18420,7 +17839,6 @@
 "dIb" = (
 /turf/simulated/shuttle/plating,
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall_f6"
 	},
 /area/centcom/arrival)
@@ -18442,7 +17860,6 @@
 /area/centcom/arrival)
 "dKb" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall12"
 	},
 /area/centcom/arrival)
@@ -18468,7 +17885,6 @@
 /area/centcom/arrival)
 "dNb" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall3"
 	},
 /area/centcom/arrival)
@@ -18504,8 +17920,7 @@
 	},
 /obj/structure/sign/mark{
 	icon_state = "4";
-	layer = 3.5;
-	pixel_x = 0
+	layer = 3.5
 	},
 /turf/unsimulated/floor{
 	icon_state = "floorgrime"
@@ -18514,8 +17929,7 @@
 "dRb" = (
 /obj/machinery/flasher{
 	id = "velocity_cell4";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/unsimulated/floor{
 	icon_state = "floorgrime"
@@ -18624,8 +18038,7 @@
 	icon_state = "chair_c02"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/effect/landmark/latejoin,
 /turf/simulated/shuttle/floor{
@@ -18635,7 +18048,6 @@
 "ebb" = (
 /obj/structure/sign/monorail_map,
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall3"
 	},
 /area/centcom/arrival)
@@ -18697,7 +18109,6 @@
 "ekb" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Brig";
-	opacity = 1;
 	req_access_txt = "109"
 	},
 /obj/structure/sign/mark{
@@ -18728,7 +18139,6 @@
 "enb" = (
 /turf/simulated/shuttle/plating,
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall_f5"
 	},
 /area/centcom/arrival)
@@ -18745,14 +18155,12 @@
 	name = "\improper billboard"
 	},
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall12"
 	},
 /area/centcom/arrival)
 "eqb" = (
 /turf/simulated/shuttle/plating,
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall_f9"
 	},
 /area/centcom/arrival)
@@ -18787,7 +18195,6 @@
 	name = "\improper billboard"
 	},
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall12"
 	},
 /area/centcom/arrival)
@@ -18807,8 +18214,7 @@
 "eyb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	dir = 1;
@@ -18828,7 +18234,6 @@
 "eBb" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Brig";
-	opacity = 1;
 	req_access_txt = "109"
 	},
 /obj/structure/sign/mark{
@@ -18920,8 +18325,7 @@
 /area/centcom/arrival)
 "eKb" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	dir = 8;
@@ -18938,8 +18342,7 @@
 /area/centcom/arrival)
 "eMb" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	dir = 1;
@@ -18958,7 +18361,6 @@
 "ePb" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Brig";
-	opacity = 1;
 	req_access_txt = "109"
 	},
 /obj/structure/sign/mark{
@@ -19009,8 +18411,7 @@
 	icon_state = "vel_wall01"
 	},
 /obj/structure/sign/velocity_shuttle{
-	dir = 1;
-	icon_state = "vel_s01"
+	dir = 1
 	},
 /turf/space,
 /area/shuttle/officer/velocity)
@@ -19051,7 +18452,6 @@
 "eZb" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Brig";
-	opacity = 1;
 	req_access_txt = "109"
 	},
 /obj/structure/sign/mark{
@@ -19130,8 +18530,7 @@
 /area/centcom/arrival)
 "fgb" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/computer/officer_shuttle{
 	dir = 4
@@ -19147,7 +18546,6 @@
 	},
 /obj/structure/stool/bed/chair/schair/velocity_s_chair{
 	dir = 8;
-	icon_state = "vel_s";
 	name = "shuttle chair"
 	},
 /turf/simulated/shuttle/floor/shuttle_new{
@@ -19209,7 +18607,6 @@
 	icon_state = "circuit"
 	},
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall_f6"
 	},
 /area/centcom/arrival)
@@ -19234,7 +18631,6 @@
 "fsb" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Brig";
-	opacity = 1;
 	req_access_txt = "109"
 	},
 /obj/structure/sign/mark{
@@ -19317,8 +18713,7 @@
 	icon_state = "chair_b02"
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "floor4"
@@ -19357,8 +18752,7 @@
 /area/centcom/living)
 "fEb" = (
 /obj/structure/sign/directions/security{
-	dir = 1;
-	icon_state = "direction_sec"
+	dir = 1
 	},
 /turf/unsimulated/wall,
 /area/centcom/arrival)
@@ -19398,7 +18792,6 @@
 	icon_state = "circuit"
 	},
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall_f5"
 	},
 /area/centcom/arrival)
@@ -19407,7 +18800,6 @@
 	icon_state = "circuit"
 	},
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall_f9"
 	},
 /area/centcom/arrival)
@@ -19427,8 +18819,7 @@
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'LETHAL TURRETS'. Enter at your own risk!";
 	name = "LETHAL TURRETS";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -19450,11 +18841,9 @@
 	})
 "fOb" = (
 /obj/machinery/turretid{
-	ailock = 0;
 	control_area = "Solitary Confinement";
 	desc = "A firewall prevents AIs from interacting with this device.";
 	icon_state = "motion3";
-	lethal = 0;
 	name = "CentCom brig turret control";
 	pixel_y = 29;
 	req_access = 109
@@ -19462,8 +18851,7 @@
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'LETHAL TURRETS'. Enter at your own risk!";
 	name = "LETHAL TURRETS";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -19509,9 +18897,7 @@
 	},
 /area/centcom/specops)
 "fUb" = (
-/obj/structure/sign/departments/medbay/old{
-	pixel_y = 0
-	},
+/obj/structure/sign/departments/medbay/old,
 /turf/unsimulated/wall,
 /area/centcom/living)
 "fVb" = (
@@ -19519,8 +18905,7 @@
 	icon_state = "x4"
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "bot"
@@ -19664,7 +19049,6 @@
 "gkb" = (
 /obj/structure/sign/velocity_overlay{
 	desc = "Parking mark";
-	dir = 2;
 	icon_state = "line04";
 	name = "\improper parking mark"
 	},
@@ -19740,10 +19124,8 @@
 /area/centcom/living)
 "grb" = (
 /obj/machinery/door/poddoor{
-	icon_state = "pdoor1";
 	id = "CREED";
-	name = "Ready Room";
-	p_open = 0
+	name = "Ready Room"
 	},
 /turf/unsimulated/floor{
 	dir = 8;
@@ -19767,8 +19149,7 @@
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0
+	name = "EXTERNAL AIRLOCK"
 	},
 /turf/unsimulated/wall,
 /area/centcom/specops)
@@ -19781,8 +19162,6 @@
 	},
 /obj/structure/sign/velocity_overlay/car_impala{
 	dir = 8;
-	icon_state = "1981 Chevrolet Impala Velocity";
-	layer = 4;
 	pixel_x = 16
 	},
 /obj/effect/forcefield{
@@ -19791,8 +19170,7 @@
 	name = "Blocker"
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor/velocity{
 	dir = 4;
@@ -19860,7 +19238,6 @@
 "gBb" = (
 /obj/machinery/door/airlock/centcom{
 	name = "General Access";
-	opacity = 1;
 	req_access_txt = "101"
 	},
 /turf/unsimulated/floor{
@@ -19901,7 +19278,6 @@
 "gEb" = (
 /obj/structure/sign/velocity_overlay{
 	desc = "Parking mark";
-	dir = 2;
 	icon_state = "line06";
 	name = "\improper parking mark"
 	},
@@ -19930,7 +19306,6 @@
 "gGb" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Armory Special Operations";
-	opacity = 1;
 	req_access_txt = "103"
 	},
 /turf/unsimulated/floor{
@@ -19951,8 +19326,7 @@
 	name = "Blocker"
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor/velocity{
 	dir = 4;
@@ -19987,7 +19361,6 @@
 	},
 /obj/structure/sign/velocity_overlay/car_ferrari{
 	dir = 1;
-	icon_state = "Ferrari Daytona";
 	pixel_x = 16;
 	pixel_y = -16
 	},
@@ -20013,7 +19386,6 @@
 "gMb" = (
 /obj/structure/sign/velocity_overlay{
 	desc = "Parking mark";
-	dir = 2;
 	icon_state = "line02";
 	name = "\improper parking mark"
 	},
@@ -20025,8 +19397,6 @@
 	},
 /obj/structure/sign/velocity_overlay/car_carmageddon{
 	dir = 8;
-	icon_state = "carmageddon";
-	layer = 4;
 	pixel_x = 16
 	},
 /turf/unsimulated/floor/velocity{
@@ -20037,7 +19407,6 @@
 "gNb" = (
 /obj/structure/sign/velocity_overlay{
 	desc = "Parking mark";
-	dir = 2;
 	icon_state = "line02";
 	name = "\improper parking mark"
 	},
@@ -20049,7 +19418,6 @@
 "gOb" = (
 /obj/structure/sign/velocity_overlay{
 	desc = "Parking mark";
-	dir = 2;
 	icon_state = "line03";
 	name = "\improper parking mark"
 	},
@@ -20103,7 +19471,6 @@
 "gSb" = (
 /obj/machinery/door/airlock/centcom{
 	name = "General Access";
-	opacity = 1;
 	req_access_txt = "101"
 	},
 /turf/unsimulated/floor{
@@ -20222,8 +19589,7 @@
 /area/centcom/specops)
 "heb" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor/velocity{
 	dir = 4;
@@ -20257,7 +19623,6 @@
 /obj/machinery/vending/wallmed1{
 	name = "Emergency NanoMed";
 	pixel_x = 30;
-	pixel_y = 0;
 	req_access_txt = "0"
 	},
 /turf/unsimulated/floor{
@@ -20281,8 +19646,7 @@
 /area/centcom/living)
 "hkb" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	dir = 5;
@@ -20326,7 +19690,6 @@
 "hpb" = (
 /obj/structure/sign/velocity_overlay{
 	desc = "Parking mark";
-	dir = 2;
 	icon_state = "line02";
 	name = "\improper parking mark"
 	},
@@ -20345,7 +19708,6 @@
 	},
 /obj/structure/sign/velocity_overlay{
 	desc = "Parking mark";
-	dir = 2;
 	icon_state = "line02";
 	name = "\improper parking mark"
 	},
@@ -20356,7 +19718,6 @@
 /area/centcom/arrival)
 "hrb" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall_s6"
 	},
 /area/centcom/evac)
@@ -20369,8 +19730,7 @@
 /area/centcom/evac)
 "htb" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 1;
-	icon_state = "propulsion"
+	dir = 1
 	},
 /turf/space,
 /area/centcom/evac)
@@ -20383,7 +19743,6 @@
 /area/centcom/evac)
 "hvb" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall_s10"
 	},
 /area/centcom/evac)
@@ -20430,25 +19789,21 @@
 /area/centcom/specops)
 "hCb" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall3"
 	},
 /area/centcom/evac)
 "hDb" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall7"
 	},
 /area/centcom/evac)
 "hEb" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall12"
 	},
 /area/centcom/evac)
 "hFb" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall11"
 	},
 /area/centcom/evac)
@@ -20476,14 +19831,12 @@
 "hJb" = (
 /turf/simulated/shuttle/plating,
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall_f6"
 	},
 /area/centcom/evac)
 "hKb" = (
 /turf/simulated/shuttle/floor,
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall_f9"
 	},
 /area/centcom/evac)
@@ -20495,7 +19848,6 @@
 "hMb" = (
 /turf/simulated/shuttle/floor,
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall_f5"
 	},
 /area/centcom/evac)
@@ -20519,7 +19871,6 @@
 /area/centcom/evac)
 "hQb" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall1"
 	},
 /area/centcom/evac)
@@ -20544,13 +19895,11 @@
 /area/centcom)
 "hUb" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall_s5"
 	},
 /area/centcom/evac)
 "hVb" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall_s9"
 	},
 /area/centcom/evac)
@@ -20561,21 +19910,17 @@
 /area/centcom/evac)
 "hXb" = (
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/centcom/living)
 "hYb" = (
 /obj/machinery/shower{
-	dir = 8;
-	icon_state = "shower"
+	dir = 8
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/centcom/living)
@@ -20591,22 +19936,18 @@
 "iab" = (
 /obj/structure/window/reinforced,
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/centcom/living)
 "ibb" = (
 /obj/structure/window/reinforced,
 /obj/machinery/shower{
-	dir = 8;
-	icon_state = "shower"
+	dir = 8
 	},
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "freezerfloor"
 	},
 /area/centcom/living)
@@ -20656,8 +19997,7 @@
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0
+	name = "EXTERNAL AIRLOCK"
 	},
 /turf/unsimulated/wall,
 /area/centcom/evac)
@@ -20712,8 +20052,7 @@
 /area/centcom/control)
 "irb" = (
 /obj/machinery/door/airlock/hatch{
-	name = "Infirmary";
-	req_access_txt = "0"
+	name = "Infirmary"
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor2"
@@ -20765,7 +20104,6 @@
 /area/centcom/control)
 "izb" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall14"
 	},
 /area/centcom/evac)
@@ -20783,8 +20121,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	dir = 8;
@@ -20803,8 +20140,7 @@
 /area/centcom/living)
 "iEb" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	dir = 8;
@@ -20813,8 +20149,7 @@
 /area/centcom/control)
 "iFb" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	dir = 4;
@@ -20823,13 +20158,11 @@
 /area/centcom/control)
 "iGb" = (
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "orange"
 	},
 /area/centcom/control)
 "iHb" = (
 /turf/unsimulated/floor{
-	dir = 2;
 	icon_state = "purple"
 	},
 /area/centcom/control)
@@ -20848,7 +20181,6 @@
 "iKb" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Server Room";
-	opacity = 1;
 	req_access_txt = "101"
 	},
 /turf/unsimulated/floor{
@@ -20904,8 +20236,7 @@
 "iSb" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "cafeteria"
@@ -20930,8 +20261,7 @@
 "iVb" = (
 /obj/structure/table,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /obj/machinery/kitchen_machine/microwave{
 	pixel_x = -3;
@@ -20976,8 +20306,7 @@
 	pixel_y = -7
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/unsimulated/floor{
 	dir = 1;
@@ -21081,17 +20410,13 @@
 	},
 /area/centcom/evac)
 "job" = (
-/obj/machinery/smartfridge{
-	pixel_y = 0
-	},
+/obj/machinery/smartfridge,
 /turf/unsimulated/floor{
 	icon_state = "cafeteria"
 	},
 /area/centcom/living)
 "jpb" = (
-/obj/machinery/vending/dinnerware{
-	pixel_y = 0
-	},
+/obj/machinery/vending/dinnerware,
 /turf/unsimulated/floor{
 	icon_state = "cafeteria"
 	},
@@ -21166,7 +20491,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door_control{
 	desc = "A remote control switch for port-side blast doors.";
-	icon_state = "doorctrl0";
 	id = "CentComPort06";
 	name = "Security Doors";
 	pixel_y = 4;
@@ -21184,7 +20508,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door_control{
 	desc = "A remote control switch for port-side blast doors.";
-	icon_state = "doorctrl0";
 	id = "CentComPort05";
 	name = "Security Doors";
 	pixel_y = 4;
@@ -21220,7 +20543,6 @@
 	dir = 4
 	},
 /obj/machinery/door/window/southright{
-	dir = 2;
 	name = "Security";
 	req_access_txt = "101"
 	},
@@ -21233,7 +20555,6 @@
 	dir = 8
 	},
 /obj/machinery/door/window/southleft{
-	dir = 2;
 	name = "Security";
 	req_access_txt = "101"
 	},
@@ -21294,9 +20615,7 @@
 /turf/unsimulated/wall,
 /area/centcom/living)
 "jOb" = (
-/obj/machinery/door/airlock/glass{
-	locked = 0
-	},
+/obj/machinery/door/airlock/glass,
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -22023,7 +21342,6 @@
 /area/centcom/holding)
 "lEb" = (
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/unsimulated/floor{
@@ -22059,7 +21377,6 @@
 /area/centcom/control)
 "lJb" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall_s6"
 	},
 /area/shuttle/escape/centcom)
@@ -22184,7 +21501,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door_control{
 	desc = "A remote control switch for port-side blast doors.";
-	icon_state = "doorctrl0";
 	id = "CentComPort02";
 	name = "Security Doors";
 	pixel_y = -4;
@@ -22202,7 +21518,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door_control{
 	desc = "A remote control switch for port-side blast doors.";
-	icon_state = "doorctrl0";
 	id = "CentComPort";
 	name = "Security Doors";
 	pixel_y = -4;
@@ -22265,7 +21580,6 @@
 /area/centcom/control)
 "mcb" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall_s5"
 	},
 /area/shuttle/escape/centcom)
@@ -22339,13 +21653,11 @@
 /area/centcom/living)
 "mjb" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall4"
 	},
 /area/shuttle/escape/centcom)
 "mkb" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall11"
 	},
 /area/shuttle/escape/centcom)
@@ -22378,20 +21690,17 @@
 /area/tdome)
 "mob" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall7"
 	},
 /area/shuttle/escape/centcom)
 "mpb" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall8"
 	},
 /area/shuttle/escape/centcom)
 "mqb" = (
 /obj/machinery/door/airlock/centcom{
 	name = "General Access";
-	opacity = 1;
 	req_access_txt = "101"
 	},
 /turf/unsimulated/floor{
@@ -22453,7 +21762,6 @@
 /area/tdome/tdomeobserve)
 "mxb" = (
 /obj/structure/table{
-	dir = 2;
 	icon_state = "tabledir"
 	},
 /obj/item/weapon/reagent_containers/food/drinks/cans/cola,
@@ -22593,8 +21901,7 @@
 	pixel_x = -7
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	dir = 1;
@@ -22918,18 +22225,14 @@
 	},
 /area/tdome/tdomeadmin)
 "nFb" = (
-/obj/structure/mineral_door/wood{
-	icon_state = "wood"
-	},
+/obj/structure/mineral_door/wood,
 /turf/unsimulated/floor{
 	dir = 8;
 	icon_state = "wood"
 	},
 /area/wizard_station)
 "nGb" = (
-/obj/structure/mineral_door/wood{
-	icon_state = "wood"
-	},
+/obj/structure/mineral_door/wood,
 /turf/unsimulated/floor{
 	icon_state = "grimy"
 	},
@@ -22982,8 +22285,7 @@
 /area/wizard_station)
 "nNb" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/unsimulated/floor{
 	icon_state = "cult";
@@ -23097,7 +22399,6 @@
 "oab" = (
 /obj/machinery/door/airlock/centcom{
 	name = "General Access";
-	opacity = 1;
 	req_access_txt = "108"
 	},
 /obj/structure/sign/mark{
@@ -23130,7 +22431,6 @@
 /obj/effect/step_trigger/thrower{
 	direction = 1;
 	name = "thrower_throwup";
-	nostop = 0;
 	tiles = 0
 	},
 /turf/space,
@@ -23138,7 +22438,6 @@
 "oeb" = (
 /obj/effect/step_trigger/thrower{
 	affect_ghosts = 1;
-	direction = 2;
 	name = "thrower_throwdown";
 	stopper = 0;
 	tiles = 0
@@ -23189,7 +22488,6 @@
 /obj/structure/table,
 /obj/machinery/vending/wallmed1{
 	name = "Emergency NanoMed";
-	pixel_x = 0;
 	pixel_y = 32;
 	req_access_txt = "0"
 	},
@@ -23210,9 +22508,7 @@
 	},
 /obj/item/device/radio/intercom{
 	freerange = 1;
-	frequency = 1459;
 	name = "Station Intercom (General)";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/simulated/shuttle/floor,
@@ -23225,7 +22521,6 @@
 "osb" = (
 /obj/structure/sign/nanotrasen,
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall1"
 	},
 /area/shuttle/escape/centcom)
@@ -23298,9 +22593,7 @@
 /area/shuttle/escape/centcom)
 "oBb" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	dir = 4
 	},
 /obj/structure/stool/bed/chair/schair/wagon{
 	dir = 8
@@ -23309,9 +22602,7 @@
 /area/shuttle/escape/centcom)
 "oCb" = (
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
-	name = "Escape Shuttle Infirmary";
-	req_access_txt = "0"
+	name = "Escape Shuttle Infirmary"
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor2"
@@ -23397,8 +22688,7 @@
 /area/shuttle/escape/centcom)
 "oNb" = (
 /obj/structure/closet/hydrant{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/simulated/shuttle/floor{
 	icon_state = "floor2"
@@ -23431,14 +22721,12 @@
 "oRb" = (
 /obj/machinery/vending/wallmed1,
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall1"
 	},
 /area/shuttle/escape/centcom)
 "oSb" = (
 /obj/machinery/status_display,
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall12"
 	},
 /area/shuttle/escape/centcom)
@@ -23516,7 +22804,6 @@
 /obj/structure/stool/bed/chair/schair/wagon,
 /obj/machinery/flasher_button{
 	id = "shutflash";
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/simulated/shuttle/floor4,
@@ -23597,7 +22884,6 @@
 "pmb" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Hatch";
-	req_access_txt = "0";
 	req_one_access_txt = "11;24"
 	},
 /turf/simulated/shuttle/plating{
@@ -23759,15 +23045,13 @@
 "pHb" = (
 /obj/structure/sign/nanotrasen,
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall12"
 	},
 /area/shuttle/escape/centcom)
 "pIb" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -23867,7 +23151,6 @@
 /obj/item/weapon/reagent_containers/pill/dexalin,
 /obj/item/weapon/reagent_containers/pill/dexalin,
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall2"
 	},
 /area/shuttle/escape/centcom)
@@ -23912,30 +23195,23 @@
 /area/shuttle/escape/centcom)
 "pYb" = (
 /obj/item/device/radio/intercom{
-	broadcasting = 0;
-	listening = 1;
 	name = "Station Intercom (General)";
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/table,
 /obj/machinery/door_control{
 	desc = "A remote control switch for port-side blast doors.";
-	icon_state = "doorctrl0";
 	id = "EmergencyShuttle";
 	name = "Blast Doors Control";
-	pixel_y = 0;
 	req_access_txt = "19"
 	},
 /turf/simulated/shuttle/floor,
 /area/shuttle/escape/centcom)
 "pZb" = (
 /turf/simulated/shuttle/wall{
-	dir = 2;
 	icon_state = "swall15"
 	},
 /area/shuttle/escape/centcom)
@@ -23957,7 +23233,6 @@
 /obj/structure/flora/plant/random,
 /obj/machinery/vending/wallmed1{
 	name = "Emergency NanoMed";
-	pixel_x = 0;
 	pixel_y = -32;
 	req_access_txt = "0"
 	},
@@ -23980,8 +23255,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 0
+	dir = 1
 	},
 /turf/unsimulated/floor,
 /area/centcom/evac)
@@ -24011,7 +23285,6 @@
 	name = "Supply Shuttle Loading Door"
 	},
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "QMLoad"
 	},
 /turf/simulated/shuttle/floor/wagon,
@@ -40929,7 +40202,7 @@ afh
 afp
 aUT
 aEw
-aFg
+agt
 afx
 aUR
 hgb
@@ -42471,7 +41744,7 @@ avJ
 aVy
 qbb
 aUE
-aFg
+agt
 aQB
 pKb
 hgb
@@ -45516,7 +44789,7 @@ aaM
 aaM
 aaM
 aIc
-aIR
+aFf
 aIc
 aaM
 aaM
@@ -46287,7 +45560,7 @@ aHv
 aHv
 aHv
 aId
-aIR
+aFf
 aId
 aHv
 aHv
@@ -47059,11 +46332,11 @@ aHv
 aHv
 aHv
 iib
-aIR
+aFf
 iib
 aHv
 iib
-aIR
+aFf
 iib
 aHv
 aHv
@@ -48344,11 +47617,11 @@ aHv
 aHv
 aHv
 iib
-aIR
+aFf
 iib
 aHv
 iib
-aIR
+aFf
 iib
 aHv
 aHv
@@ -48860,7 +48133,7 @@ aIy
 aIy
 aIy
 hRb
-aJH
+aXj
 hgb
 aIy
 aIy
@@ -49114,13 +48387,13 @@ aAm
 aHv
 aHv
 aIc
-aIR
+aFf
 aIc
 aHv
 aHv
 aHv
 aIc
-aIR
+aFf
 aIc
 aHv
 aHv
@@ -49628,13 +48901,13 @@ aAm
 aaM
 aaM
 aId
-aIR
+aFf
 aId
 aaM
 aaM
 aaM
 aId
-aIR
+aFf
 aId
 aaM
 aaM
@@ -68418,7 +67691,7 @@ aQS
 aRY
 aAm
 aSZ
-aTa
+iNb
 aAm
 aBK
 aAm
@@ -68673,9 +67946,9 @@ aQS
 aQv
 aQS
 aQS
-aSy
-aTa
-aTa
+jcb
+iNb
+iNb
 aAm
 aBK
 aAm
@@ -68930,9 +68203,9 @@ aQv
 aQv
 aQS
 aQS
-aSy
-aTa
-aTa
+jcb
+iNb
+iNb
 aTV
 aBK
 aAm
@@ -69187,9 +68460,9 @@ aQS
 aQv
 aQS
 aQS
-aSy
-aTa
-aTa
+jcb
+iNb
+iNb
 aAm
 aUg
 aAm
@@ -82879,7 +82152,7 @@ aXg
 aXg
 aXg
 aXg
-aZG
+aXK
 aZQ
 bbm
 bag
@@ -84212,7 +83485,7 @@ aie
 aii
 aiA
 aii
-ajx
+aiA
 aii
 aii
 aie

--- a/maps/z5.dmm
+++ b/maps/z5.dmm
@@ -163,8 +163,7 @@
 	desc = "A warning sign which reads 'WARNING'.";
 	icon_state = "xenoarch_4";
 	name = "\improper ISOLATION ROOM FOUR";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/light{
 	dir = 4
@@ -200,8 +199,7 @@
 "aD" = (
 /obj/structure/transit_tube,
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/research_outpost/hallway)
 "aE" = (
@@ -246,7 +244,6 @@
 /area/research_outpost/maintstore1)
 "aL" = (
 /obj/structure/closet/hydrant{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/light/small{
@@ -378,18 +375,14 @@
 	icon_state = "E-NW"
 	},
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/research_outpost/maintstore1)
 "be" = (
 /obj/machinery/door_control{
 	id = "rdorm1";
 	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
 	pixel_x = 25;
-	pixel_y = 0;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -402,14 +395,12 @@
 	icon_state = "W-NE"
 	},
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/research_outpost/maintstore1)
 "bg" = (
 /obj/machinery/seed_extractor,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "green"
 	},
 /area/research_outpost/maintstore1)
@@ -423,8 +414,7 @@
 	network = list("Research","SS13")
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor,
@@ -433,10 +423,7 @@
 /obj/machinery/door_control{
 	id = "rdorm2";
 	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
 	pixel_x = -25;
-	pixel_y = 0;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -490,9 +477,7 @@
 	},
 /obj/structure/sink{
 	dir = 4;
-	icon_state = "sink";
-	pixel_x = 12;
-	pixel_y = 0
+	pixel_x = 12
 	},
 /mob/living/simple_animal/mouse,
 /turf/simulated/floor/plating,
@@ -591,7 +576,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/research_outpost/hallway)
@@ -633,8 +617,7 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Auxiliary Storage APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -674,7 +657,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/research_outpost/hallway)
@@ -764,7 +746,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "greencorner"
 	},
 /area/research_outpost/maintstore1)
@@ -823,8 +804,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -865,13 +845,11 @@
 	},
 /obj/structure/mirror{
 	dir = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/dryer{
 	dir = 4;
-	pixel_x = -6;
-	pixel_y = 0
+	pixel_x = -6
 	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
@@ -882,7 +860,6 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitecorner"
 	},
 /area/research_outpost/hallway)
@@ -906,7 +883,6 @@
 /obj/item/weapon/folder/blue,
 /obj/item/weapon/folder/blue,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warnwhite"
 	},
 /area/research_outpost/spectro)
@@ -960,7 +936,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/research_outpost/hallway)
@@ -968,13 +943,11 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Mass Spectrometry APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -986,8 +959,7 @@
 	icon_state = "N-S"
 	},
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/research_outpost/atmos)
 "cm" = (
@@ -997,7 +969,6 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitecorner"
 	},
 /area/research_outpost/hallway)
@@ -1067,8 +1038,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -1094,7 +1064,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Outpost Atmospherics APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -1137,8 +1106,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -1147,8 +1115,7 @@
 /area/research_outpost/maintstore1)
 "cD" = (
 /obj/machinery/shower{
-	dir = 4;
-	icon_state = "shower"
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -1177,10 +1144,7 @@
 /obj/machinery/door_control{
 	id = "rbath";
 	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = -25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1195,8 +1159,7 @@
 /area/research_outpost/hallway)
 "cG" = (
 /obj/structure/transit_tube/station{
-	dir = 8;
-	icon_state = "closed"
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 4
@@ -1207,7 +1170,6 @@
 /area/research_outpost/atmos)
 "cH" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/research_outpost/hallway)
@@ -1219,14 +1181,12 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/research_outpost/hallway)
 "cJ" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
@@ -1237,8 +1197,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/red{
 	dir = 8
@@ -1299,8 +1258,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Sample Preparation APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -1358,13 +1316,11 @@
 /area/research_outpost/anomaly)
 "cZ" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/research_outpost/hallway)
@@ -1381,8 +1337,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -1450,8 +1405,7 @@
 	dir = 10
 	},
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/research_outpost/atmos)
 "dk" = (
@@ -1462,7 +1416,6 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/research_outpost/sample)
@@ -1483,8 +1436,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -1526,7 +1478,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/research_outpost/sample)
@@ -1534,8 +1485,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1544,7 +1494,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/research_outpost/sample)
@@ -1556,7 +1505,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whiteblue"
 	},
 /area/research_outpost/sample)
@@ -1564,7 +1512,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Anomalous Materials APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -1579,7 +1526,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/research_outpost/anomaly)
@@ -1614,7 +1560,6 @@
 	dir = 9
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/research_outpost/anomaly)
@@ -1630,7 +1575,6 @@
 /area/research_outpost/anomaly)
 "dx" = (
 /obj/machinery/alarm{
-	dir = 2;
 	locked = 0;
 	pixel_y = 25
 	},
@@ -1641,14 +1585,12 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/research_outpost/anomaly)
 "dy" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/research_outpost/hallway)
@@ -1657,7 +1599,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/research_outpost/hallway)
@@ -1671,8 +1612,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -1706,12 +1646,10 @@
 /area/research_outpost/hallway)
 "dE" = (
 /obj/structure/shuttle/engine/propulsion{
-	dir = 4;
-	icon_state = "propulsion"
+	dir = 4
 	},
 /obj/structure/window/reinforced/tinted{
-	dir = 4;
-	icon_state = "twindow"
+	dir = 4
 	},
 /turf/simulated/floor/plating/airless,
 /area/shuttle/alien/mine)
@@ -1724,9 +1662,7 @@
 	},
 /area/shuttle/alien/mine)
 "dG" = (
-/obj/structure/alien/weeds{
-	icon_state = "weeds"
-	},
+/obj/structure/alien/weeds,
 /turf/simulated/shuttle/floor{
 	icon_state = "floor2"
 	},
@@ -1741,9 +1677,7 @@
 /obj/item/weapon/shard{
 	icon_state = "medium"
 	},
-/obj/structure/alien/weeds{
-	icon_state = "weeds"
-	},
+/obj/structure/alien/weeds,
 /turf/simulated/floor/airless{
 	icon_state = "floorscorched1"
 	},
@@ -1788,8 +1722,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1814,8 +1747,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/wall/r_wall,
 /area/research_outpost/sample)
@@ -1824,8 +1756,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1842,7 +1773,6 @@
 	},
 /obj/item/weapon/pen,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurplefull"
 	},
 /area/research_outpost/anomaly)
@@ -1852,7 +1782,6 @@
 	},
 /obj/structure/table,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurplefull"
 	},
 /area/research_outpost/anomaly)
@@ -1907,7 +1836,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "cafeteria"
 	},
 /area/research_outpost/hallway)
@@ -1919,8 +1847,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -1930,14 +1857,12 @@
 "dZ" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Outpost Atmospherics";
-	req_access_txt = "0";
 	req_one_access_txt = "65;10;24"
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
@@ -1958,8 +1883,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/machinery/meter,
@@ -1968,7 +1892,6 @@
 "ec" = (
 /obj/machinery/camera{
 	c_tag = "Misc Test Chamber";
-	dir = 2;
 	network = list("Research","SS13")
 	},
 /obj/structure/cable{
@@ -2020,21 +1943,18 @@
 /area/mine/explored)
 "ek" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/machinery/requests_console{
 	department = "Science";
 	departmentType = 2;
 	name = "Science Requests Console";
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /turf/simulated/floor,
 /area/research_outpost/hallway)
 "el" = (
 /obj/structure/noticeboard/anomaly{
-	icon_state = "nboard05";
 	pixel_y = 32
 	},
 /turf/simulated/floor,
@@ -2043,13 +1963,11 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Outpost Lobby APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /turf/simulated/floor,
 /area/research_outpost/hallway)
@@ -2065,7 +1983,6 @@
 "eo" = (
 /obj/machinery/camera{
 	c_tag = "Research Outpost Lobby";
-	dir = 2;
 	network = list("Research","SS13")
 	},
 /obj/machinery/light{
@@ -2077,8 +1994,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2093,10 +2009,7 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/weapon/xenoarch_utilizer{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/weapon/xenoarch_utilizer,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -2104,7 +2017,6 @@
 /area/research_outpost/harvesting)
 "er" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /turf/simulated/floor{
@@ -2113,7 +2025,6 @@
 /area/research_outpost/hallway)
 "es" = (
 /obj/machinery/alarm{
-	dir = 2;
 	pixel_y = 25
 	},
 /obj/machinery/hologram/holopad,
@@ -2158,7 +2069,6 @@
 /obj/item/weapon/folder/purple,
 /obj/item/weapon/folder/purple,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurplefull"
 	},
 /area/research_outpost/anomaly)
@@ -2180,7 +2090,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurplefull"
 	},
 /area/research_outpost/anomaly)
@@ -2201,7 +2110,6 @@
 "eC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurplefull"
 	},
 /area/research_outpost/anomaly)
@@ -2228,8 +2136,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -2242,7 +2149,6 @@
 "eG" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Outpost Atmospherics";
-	req_access_txt = "0";
 	req_one_access_txt = "65;10;24"
 	},
 /obj/machinery/door/firedoor,
@@ -2409,8 +2315,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -2599,8 +2504,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -2700,8 +2604,7 @@
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -2720,9 +2623,7 @@
 	},
 /area/research_outpost/anomaly)
 "fq" = (
-/obj/machinery/shieldwallgen{
-	req_access = list(47)
-	},
+/obj/machinery/shieldwallgen,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -2798,8 +2699,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -2876,8 +2776,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -2919,8 +2818,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -2932,16 +2830,14 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Outpost Power APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/research_outpost/power)
@@ -2954,8 +2850,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -2969,8 +2864,7 @@
 	network = list("Research","SS13")
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2990,7 +2884,6 @@
 "fQ" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Outpost Power";
-	req_access_txt = "0";
 	req_one_access_txt = "65;10;24"
 	},
 /obj/machinery/door/firedoor,
@@ -3016,8 +2909,7 @@
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/structure/cable,
 /obj/structure/cable{
@@ -3046,9 +2938,7 @@
 	},
 /area/research_outpost/power)
 "fW" = (
-/obj/structure/disposaloutlet{
-	dir = 2
-	},
+/obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
@@ -3118,7 +3008,6 @@
 "gf" = (
 /obj/machinery/newscaster{
 	layer = 3.3;
-	pixel_x = 0;
 	pixel_y = -27
 	},
 /obj/machinery/light,
@@ -3126,17 +3015,6 @@
 	dir = 5
 	},
 /turf/simulated/floor/wood,
-/area/research_outpost/hallway)
-"gg" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
-	},
-/turf/simulated/floor{
-	icon_state = "white"
-	},
 /area/research_outpost/hallway)
 "gh" = (
 /obj/structure/table,
@@ -3179,8 +3057,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -3322,12 +3199,6 @@
 	icon_state = "floorscorched1"
 	},
 /area/mine/abandoned)
-"gF" = (
-/obj/structure/alien/weeds{
-	icon_state = "weeds"
-	},
-/turf/simulated/floor,
-/area/mine/abandoned)
 "gG" = (
 /obj/structure/alien/weeds,
 /turf/simulated/floor/plating,
@@ -3398,8 +3269,7 @@
 /obj/machinery/portable_atmospherics/canister/phoron,
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -23;
-	pixel_y = 0
+	pixel_x = -23
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -3509,7 +3379,6 @@
 /obj/item/weapon/storage/firstaid/fire,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/item/weapon/storage/firstaid/small_firstaid_kit/space,
@@ -3547,9 +3416,7 @@
 	},
 /area/research_outpost/tempstorage)
 "hf" = (
-/obj/machinery/shieldwallgen{
-	req_access = list(47)
-	},
+/obj/machinery/shieldwallgen,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -3646,9 +3513,7 @@
 "hs" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'INTERNALS REQUIRED'.";
-	name = "INTERNALS REQUIRED";
-	pixel_x = 0;
-	pixel_y = 0
+	name = "INTERNALS REQUIRED"
 	},
 /turf/simulated/wall,
 /area/mine/explored)
@@ -3671,8 +3536,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -3729,8 +3593,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -3746,9 +3609,7 @@
 /area/research_outpost/hallway)
 "hE" = (
 /obj/machinery/door/window/westleft{
-	dir = 8;
 	name = "Locker room";
-	opacity = 0;
 	req_access_txt = "65"
 	},
 /turf/simulated/floor{
@@ -3784,7 +3645,6 @@
 "hI" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Power substation";
-	req_access_txt = "0";
 	req_one_access_txt = "65;10;24"
 	},
 /obj/structure/cable{
@@ -3818,8 +3678,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3833,8 +3692,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/research/glass{
 	name = "Research Shuttle Dock";
@@ -3861,21 +3719,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/research_outpost/power)
-"hN" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/research_outpost/entry)
 "hO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -4000,7 +3843,6 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/research_outpost/hallway)
@@ -4008,8 +3850,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -4025,15 +3866,13 @@
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "";
 	name = "Medbay";
-	req_access_txt = "0";
 	req_one_access_txt = "65;5"
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4090,10 +3929,7 @@
 /area/research_outpost/tempstorage)
 "ij" = (
 /obj/machinery/conveyor_switch{
-	id = "anotempload";
-	name = "conveyor switch";
-	pixel_x = 0;
-	pixel_y = 0
+	id = "anotempload"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -4233,7 +4069,6 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/research_outpost/hallway)
@@ -4249,8 +4084,7 @@
 /obj/item/clothing/suit/bio_suit/particle_protection,
 /obj/item/clothing/gloves/latex,
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/research_outpost/hallway)
 "iv" = (
@@ -4263,8 +4097,7 @@
 /obj/item/clothing/suit/bio_suit/particle_protection,
 /obj/item/clothing/gloves/latex,
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/research_outpost/hallway)
 "iw" = (
@@ -4274,8 +4107,7 @@
 	layer = 4;
 	name = "Isolation Room Telescreen";
 	network = list("Anomaly Isolation");
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/stool/bed/chair/metal{
 	dir = 1
@@ -4286,7 +4118,6 @@
 /obj/machinery/door/window/westleft{
 	dir = 2;
 	name = "Locker room";
-	opacity = 0;
 	req_access_txt = "65"
 	},
 /turf/simulated/floor{
@@ -4303,8 +4134,7 @@
 /obj/item/clothing/suit/bio_suit/particle_protection,
 /obj/item/clothing/gloves/latex,
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/research_outpost/hallway)
 "iz" = (
@@ -4392,8 +4222,7 @@
 	icon_state = "plant-22"
 	},
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/research_outpost/hallway)
 "iF" = (
@@ -4401,8 +4230,7 @@
 	icon_state = "E-NW"
 	},
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/research_outpost/hallway)
 "iH" = (
@@ -4592,8 +4420,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -4616,7 +4443,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/camera{
 	c_tag = "Research Outpost Hallway Starboard";
-	dir = 2;
 	network = list("Research","SS13");
 	pixel_x = 24
 	},
@@ -4678,7 +4504,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Misc Research APC";
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/structure/cable{
@@ -4693,8 +4518,7 @@
 /area/research_outpost/outpost_misc_lab)
 "jf" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -4759,7 +4583,6 @@
 /area/research_outpost/entry)
 "jj" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warnwhite"
 	},
 /area/research_outpost/med)
@@ -4797,8 +4620,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -4821,7 +4643,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/research_outpost/hallway)
@@ -4830,7 +4651,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/research_outpost/hallway)
@@ -4841,13 +4661,11 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/research_outpost/hallway)
@@ -4873,8 +4691,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5006,8 +4823,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -5024,8 +4840,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -5039,8 +4854,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -5050,13 +4864,11 @@
 "jY" = (
 /obj/machinery/door/window/southleft{
 	dir = 8;
-	icon_state = "left";
 	name = "Test Chamber";
 	req_access_txt = "47"
 	},
 /obj/machinery/door/window/southleft{
 	dir = 4;
-	icon_state = "left";
 	name = "Test Chamber";
 	req_access_txt = "47"
 	},
@@ -5082,8 +4894,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5129,12 +4940,10 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Outpost Medbay APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warnwhite"
 	},
 /area/research_outpost/med)
@@ -5194,8 +5003,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -5210,8 +5018,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -5226,8 +5033,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -5241,14 +5047,12 @@
 "ko" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Maintenance Storage";
-	req_access_txt = "0";
 	req_one_access_txt = "12;65"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5263,8 +5067,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5277,7 +5080,6 @@
 "kq" = (
 /obj/machinery/firealarm{
 	dir = 1;
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/structure/stool/bed/chair/metal{
@@ -5301,8 +5103,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5337,10 +5138,7 @@
 /obj/machinery/door_control{
 	id = "riso1";
 	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
 	pixel_x = -25;
-	pixel_y = 0;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /turf/simulated/floor,
@@ -5366,8 +5164,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -5405,8 +5202,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -5427,7 +5223,6 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/research_outpost/hallway)
@@ -5461,7 +5256,6 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurplecorner"
 	},
 /area/research_outpost/hallway)
@@ -5469,8 +5263,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5538,14 +5331,6 @@
 /obj/structure/table,
 /turf/simulated/floor/airless,
 /area/mine/abandoned)
-"kN" = (
-/obj/structure/alien/weeds{
-	icon_state = "weeds"
-	},
-/turf/simulated/floor/airless{
-	icon_state = "damaged5"
-	},
-/area/mine/abandoned)
 "kO" = (
 /turf/simulated/mineral,
 /area/mine/explored)
@@ -5590,8 +5375,7 @@
 	icon_state = "S-NW"
 	},
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/research_outpost/entry)
 "kU" = (
@@ -5620,8 +5404,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -5638,8 +5421,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -5658,8 +5440,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5682,8 +5463,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -5696,8 +5476,7 @@
 "lb" = (
 /obj/structure/stool/bed/roller,
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/research_outpost/med)
 "lc" = (
@@ -5705,8 +5484,7 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/research_outpost/med)
 "ld" = (
@@ -5724,14 +5502,12 @@
 /area/research_outpost/maint)
 "lf" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;65"
 	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -5743,7 +5519,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Temporary Storage APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -5762,8 +5537,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5796,8 +5570,7 @@
 	layer = 4;
 	name = "Isolation Room Telescreen";
 	network = list("Anomaly Isolation");
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/item/weapon/folder/purple,
 /turf/simulated/floor,
@@ -5825,10 +5598,7 @@
 /obj/machinery/door_control{
 	id = "riso3";
 	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
 	pixel_x = -25;
-	pixel_y = 0;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/item/weapon/folder/purple,
@@ -5839,8 +5609,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -5868,8 +5637,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
@@ -5885,7 +5653,6 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Long Term Storage APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -5900,13 +5667,11 @@
 "lv" = (
 /obj/machinery/door/window/southleft{
 	dir = 8;
-	icon_state = "left";
 	name = "Test Chamber";
 	req_access_txt = "47"
 	},
 /obj/machinery/door/window/southleft{
 	dir = 4;
-	icon_state = "left";
 	name = "Test Chamber";
 	req_access_txt = "47"
 	},
@@ -5923,8 +5688,7 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/research_outpost/gearstore)
 "lx" = (
@@ -5972,8 +5736,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -6000,8 +5763,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Expedition Area APC";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/machinery/camera{
 	c_tag = "Research Outpost Expedition Prep";
@@ -6014,7 +5776,6 @@
 "lJ" = (
 /obj/structure/plasticflaps/mining,
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "anotempload"
 	},
 /turf/simulated/floor/plating,
@@ -6039,8 +5800,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Maintenance APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -6098,8 +5858,7 @@
 	layer = 4;
 	name = "Isolation Room Telescreen";
 	network = list("Anomaly Isolation");
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/simulated/floor,
 /area/research_outpost/iso2)
@@ -6107,8 +5866,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6120,8 +5878,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -6162,8 +5919,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6179,9 +5935,7 @@
 	dir = 10
 	},
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -6194,8 +5948,7 @@
 /obj/item/clothing/head/helmet/space/globose/science,
 /obj/item/weapon/storage/firstaid/small_firstaid_kit/space,
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/research_outpost/gearstore)
 "md" = (
@@ -6270,14 +6023,6 @@
 	icon_state = "weeds2"
 	},
 /turf/simulated/floor,
-/area/mine/abandoned)
-"mm" = (
-/obj/structure/alien/weeds{
-	icon_state = "weeds"
-	},
-/turf/simulated/floor/airless{
-	icon_state = "damaged2"
-	},
 /area/mine/abandoned)
 "mn" = (
 /obj/machinery/power/grounding_rod,
@@ -6366,8 +6111,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -6383,7 +6127,6 @@
 /area/research_outpost/outpost_misc_lab)
 "mC" = (
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "anotempload"
 	},
 /turf/simulated/floor/plating{
@@ -6421,7 +6164,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/research_outpost/iso1)
@@ -6437,8 +6179,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Isolation Room One APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -6468,7 +6209,6 @@
 	pixel_y = 16
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "loadingarea"
 	},
 /area/research_outpost/tempstorage)
@@ -6476,8 +6216,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Isolation Room Two APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -6486,10 +6225,7 @@
 /obj/machinery/door_control{
 	id = "riso2";
 	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 0;
 	pixel_y = -25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /turf/simulated/floor,
@@ -6498,12 +6234,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/research/glass{
-	autoclose = 1;
 	frequency = 1379;
-	glass = 1;
-	icon_state = "closed";
 	id_tag = "riso1";
-	locked = 0;
 	name = "Isolation Section Airlock";
 	req_access_txt = "65"
 	},
@@ -6522,9 +6254,7 @@
 "mP" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1";
-	pixel_x = 0
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/research_outpost/iso2)
@@ -6536,8 +6266,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Isolation Room Three APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -6554,8 +6283,7 @@
 	dir = 5
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -6592,9 +6320,7 @@
 	},
 /area/research_outpost/longtermstorage)
 "mW" = (
-/obj/structure/disposaloutlet{
-	dir = 2
-	},
+/obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
@@ -6605,8 +6331,7 @@
 "mX" = (
 /obj/machinery/suspension_gen,
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/research_outpost/gearstore)
 "mY" = (
@@ -6632,14 +6357,6 @@
 "nb" = (
 /obj/effect/decal/remains/xeno,
 /turf/simulated/floor,
-/area/mine/abandoned)
-"nc" = (
-/obj/structure/alien/weeds{
-	icon_state = "weeds"
-	},
-/turf/simulated/floor/airless{
-	icon_state = "damaged3"
-	},
 /area/mine/abandoned)
 "nd" = (
 /obj/structure/ore_box,
@@ -6678,7 +6395,6 @@
 	pixel_x = 22
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/research_outpost/iso1)
@@ -6706,7 +6422,6 @@
 	dir = 10
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/research_outpost/harvesting)
@@ -6723,7 +6438,6 @@
 	pixel_x = 22
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/research_outpost/harvesting)
@@ -6748,8 +6462,7 @@
 	layer = 4;
 	name = "Isolation Room Telescreen";
 	network = list("Anomaly Isolation");
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
@@ -6771,7 +6484,6 @@
 /area/research_outpost/longtermstorage)
 "nr" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "0";
 	req_one_access_txt = "12;65"
 	},
 /obj/machinery/door/firedoor,
@@ -6844,21 +6556,17 @@
 	id_tag = "research_inner";
 	locked = 1;
 	name = "Research Outpost External Access";
-	req_access = null;
 	req_access_txt = null
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/research_outpost/gearstore)
 "nz" = (
 /obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1379;
 	id_tag = "research_airlock";
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access_txt = null;
 	tag_airpump = "research_pump";
 	tag_chamber_sensor = "research_sensor";
@@ -6908,14 +6616,6 @@
 	},
 /turf/simulated/floor,
 /area/mine/abandoned)
-"nF" = (
-/obj/structure/alien/weeds{
-	icon_state = "weeds"
-	},
-/turf/simulated/floor/airless{
-	icon_state = "floorscorched1"
-	},
-/area/mine/abandoned)
 "nG" = (
 /obj/machinery/light_construct/small{
 	dir = 4
@@ -6927,8 +6627,7 @@
 	icon_state = "N-S"
 	},
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/mine/explored)
 "nJ" = (
@@ -6946,10 +6645,8 @@
 /area/research_outpost/gearstore)
 "nL" = (
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "research_sensor";
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
 	dir = 4;
@@ -6982,8 +6679,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/binary/valve/open{
 	dir = 4
@@ -7005,9 +6701,6 @@
 "nR" = (
 /obj/machinery/conveyor_switch{
 	id = "anotempload";
-	name = "conveyor switch";
-	pixel_x = 0;
-	pixel_y = 0;
 	req_access_txt = "65"
 	},
 /turf/simulated/floor/airless{
@@ -7017,7 +6710,6 @@
 /area/mine/explored)
 "nS" = (
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "anotempload"
 	},
 /turf/simulated/floor/airless{
@@ -7057,8 +6749,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 6
@@ -7082,8 +6773,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
@@ -7145,7 +6835,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/research_outpost/iso2)
@@ -7157,7 +6846,6 @@
 	pixel_y = 2
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/research_outpost/iso2)
@@ -7166,8 +6854,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/research_outpost/maintstore2)
@@ -7188,17 +6875,14 @@
 "ol" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/item/weapon/pickaxe/drill,
 /obj/item/weapon/gun/energy/kinetic_accelerator{
 	pixel_x = 3
 	},
 /obj/machinery/door/window/westleft{
-	dir = 8;
 	name = "Locker room";
-	opacity = 0;
 	req_access_txt = "65"
 	},
 /obj/structure/rack,
@@ -7303,8 +6987,7 @@
 /area/mine/explored)
 "ow" = (
 /obj/structure/transit_tube/station{
-	dir = 8;
-	icon_state = "closed"
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -7318,7 +7001,6 @@
 	id_tag = "dwarf_inner";
 	locked = 1;
 	name = "External Access";
-	req_access = null;
 	req_access_txt = null
 	},
 /obj/machinery/door/firedoor,
@@ -7346,13 +7028,11 @@
 	pixel_x = -24
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/research_outpost/iso1)
 "oB" = (
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "anominerals"
 	},
 /obj/machinery/mineral/output,
@@ -7368,7 +7048,6 @@
 /area/mine/explored)
 "oD" = (
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "anotempload"
 	},
 /turf/simulated/floor/plating/airless{
@@ -7442,7 +7121,6 @@
 "oL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/research_outpost/harvesting)
@@ -7475,12 +7153,10 @@
 	layer = 4;
 	name = "Isolation Room Telescreen";
 	network = list("Anomaly Isolation");
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/window/reinforced,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/research_outpost/iso2)
@@ -7499,9 +7175,7 @@
 	pixel_x = 3
 	},
 /obj/machinery/door/window/westleft{
-	dir = 8;
 	name = "Locker room";
-	opacity = 0;
 	req_access_txt = "65"
 	},
 /obj/structure/rack,
@@ -7541,8 +7215,7 @@
 /obj/machinery/power/apc{
 	dir = 4;
 	name = "Maintenance Storage APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -7595,8 +7268,7 @@
 /area/mine/abandoned)
 "oZ" = (
 /obj/machinery/door/airlock/glass{
-	name = "Glass Airlock";
-	req_access_txt = "0"
+	name = "Glass Airlock"
 	},
 /turf/simulated/floor/airless{
 	dir = 5;
@@ -7629,18 +7301,14 @@
 "pc" = (
 /obj/machinery/floodlight,
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/research_outpost/gearstore)
 "pd" = (
 /obj/machinery/door_control{
 	id = "miningdorm1";
 	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
 	pixel_x = 25;
-	pixel_y = 0;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -7667,7 +7335,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/mine/living_quarters)
@@ -7707,10 +7374,7 @@
 /obj/machinery/door_control{
 	id = "miningdorm3";
 	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
 	pixel_x = 25;
-	pixel_y = 0;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -7757,8 +7421,7 @@
 	dir = 1
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -7768,7 +7431,6 @@
 "pq" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/structure/flora/pottedplant{
@@ -7782,10 +7444,7 @@
 /obj/machinery/door_control{
 	id = "miningdorm2";
 	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
 	pixel_x = 25;
-	pixel_y = 0;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -7799,8 +7458,7 @@
 	dir = 4
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -7816,8 +7474,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/alarm{
 	dir = 8;
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -7932,8 +7589,7 @@
 /area/mine/explored)
 "pI" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/structure/closet/secure_closet/xenoarchaeologist_tools,
 /turf/simulated/floor{
@@ -8048,8 +7704,7 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/mine/explored)
 "pX" = (
@@ -8075,8 +7730,7 @@
 /obj/machinery/suspension_gen,
 /obj/machinery/light,
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/research_outpost/gearstore)
 "qb" = (
@@ -8094,7 +7748,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/mine/living_quarters)
@@ -8130,8 +7783,7 @@
 /area/mine/explored)
 "qg" = (
 /obj/structure/transit_tube/station{
-	dir = 8;
-	icon_state = "closed"
+	dir = 8
 	},
 /obj/structure/transit_tube_pod,
 /turf/simulated/floor{
@@ -8204,7 +7856,6 @@
 /area/mine/explored)
 "qp" = (
 /obj/structure/sign/xeno_warning_mining{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/light/small,
@@ -8277,8 +7928,7 @@
 	icon_state = "N-SE"
 	},
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/mine/explored)
 "qz" = (
@@ -8304,7 +7954,6 @@
 "qD" = (
 /obj/machinery/door/airlock/external{
 	name = "Mining Bridge";
-	req_access_txt = "0";
 	req_one_access_txt = "54;65"
 	},
 /turf/simulated/floor/airless{
@@ -8327,7 +7976,6 @@
 	id_tag = "research_outer";
 	locked = 1;
 	name = "Research Outpost External Access";
-	req_access = null;
 	req_access_txt = "10;13"
 	},
 /turf/simulated/floor/plating,
@@ -8346,8 +7994,7 @@
 	icon_state = "D-NE"
 	},
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/mine/explored)
 "qJ" = (
@@ -8377,8 +8024,7 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/mine/unexplored)
 "qN" = (
@@ -8399,8 +8045,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/mine/unexplored)
 "qP" = (
@@ -8417,8 +8062,7 @@
 /area/mine/abandoned)
 "qS" = (
 /obj/machinery/door/airlock/external{
-	name = "External Airlock";
-	req_access_txt = "0"
+	name = "External Airlock"
 	},
 /turf/simulated/floor/airless{
 	dir = 5;
@@ -8443,7 +8087,6 @@
 "qU" = (
 /obj/machinery/alarm{
 	dir = 4;
-	icon_state = "alarm0";
 	pixel_x = -24
 	},
 /turf/simulated/floor{
@@ -8466,7 +8109,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "carpet"
 	},
 /area/mine/living_quarters)
@@ -8571,7 +8213,6 @@
 "rj" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/airless{
-	dir = 2;
 	icon_state = "asteroidwarning"
 	},
 /area/mine/explored)
@@ -8579,8 +8220,7 @@
 /obj/structure/rack,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/mine/west_outpost)
 "rl" = (
@@ -8595,7 +8235,6 @@
 /area/mine/abandoned)
 "rn" = (
 /turf/simulated/floor/airless{
-	dir = 2;
 	icon_state = "asteroidwarning"
 	},
 /area/mine/abandoned)
@@ -8604,7 +8243,6 @@
 	icon_state = "medium"
 	},
 /turf/simulated/floor/airless{
-	dir = 2;
 	icon_state = "asteroidwarning"
 	},
 /area/mine/abandoned)
@@ -8672,7 +8310,6 @@
 /area/mine/unexplored)
 "ry" = (
 /turf/simulated/floor/airless{
-	dir = 2;
 	icon_state = "asteroidwarning"
 	},
 /area/mine/unexplored)
@@ -9017,8 +8654,7 @@
 "sC" = (
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/mine/west_outpost)
 "sD" = (
@@ -9044,7 +8680,6 @@
 /area/mine/dwarf)
 "sH" = (
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "dw_c"
 	},
 /obj/machinery/mineral/output,
@@ -9072,8 +8707,7 @@
 "sL" = (
 /obj/structure/rack,
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/mine/west_outpost)
 "sM" = (
@@ -9086,7 +8720,6 @@
 "sN" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
@@ -9112,7 +8745,6 @@
 /area/mine/dwarf)
 "sQ" = (
 /obj/structure/sign/xeno_warning_mining{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/light/small{
@@ -9147,7 +8779,6 @@
 /area/mine/dwarf)
 "sU" = (
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "dw_c"
 	},
 /obj/machinery/light_construct/small{
@@ -9172,8 +8803,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/mine/dwarf)
@@ -9231,7 +8861,6 @@
 /area/mine/dwarf)
 "te" = (
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "dw_c"
 	},
 /turf/simulated/floor/plating,
@@ -9250,8 +8879,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/mine/dwarf)
@@ -9330,8 +8958,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -9357,8 +8984,7 @@
 /area/mine/dwarf)
 "ts" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -9456,7 +9082,6 @@
 /area/mine/dwarf)
 "tF" = (
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "dwarf_sensor";
 	pixel_x = 25;
 	pixel_y = -5
@@ -9479,7 +9104,6 @@
 /area/mine/dwarf)
 "tJ" = (
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "dw_c"
 	},
 /obj/machinery/mineral/input,
@@ -9492,7 +9116,6 @@
 	id_tag = "dwarf_outer";
 	locked = 1;
 	name = "External Access";
-	req_access = null;
 	req_access_txt = null
 	},
 /obj/machinery/door/firedoor,
@@ -9500,7 +9123,6 @@
 /area/mine/dwarf)
 "tL" = (
 /turf/simulated/floor/airless{
-	dir = 2;
 	icon_state = "asteroidwarning"
 	},
 /area/mine/explored)
@@ -9515,7 +9137,6 @@
 	req_access_txt = null
 	},
 /turf/simulated/floor/airless{
-	dir = 2;
 	icon_state = "asteroidwarning"
 	},
 /area/mine/explored)
@@ -9718,7 +9339,6 @@
 	id_tag = "mining_west_outpost_inner";
 	locked = 1;
 	name = "Mining External Access";
-	req_access = null;
 	req_access_txt = null
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -9864,8 +9484,7 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/mine/living_quarters)
 "uD" = (
@@ -9873,13 +9492,11 @@
 /obj/structure/plasticflaps/mining,
 /obj/machinery/door/poddoor/shutters{
 	dir = 4;
-	icon_state = "shutter1";
 	id = "Mecha Shutters";
 	name = "Mecha Shutters"
 	},
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/mine/eva)
 "uE" = (
@@ -9922,8 +9539,7 @@
 /area/mine/eva)
 "uJ" = (
 /obj/machinery/mech_bay_recharge_port{
-	dir = 2;
-	icon_state = "recharge_port"
+	dir = 2
 	},
 /turf/simulated/floor/plating,
 /area/mine/eva)
@@ -10068,8 +9684,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Station EVA";
@@ -10146,7 +9761,6 @@
 /obj/machinery/recharge_station,
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor{
@@ -10190,7 +9804,6 @@
 /area/mine/living_quarters)
 "vq" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/mine/living_quarters)
@@ -10198,8 +9811,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/item/weapon/storage/box/lights/mixed,
 /turf/simulated/floor/plating,
@@ -10212,8 +9824,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
@@ -10246,8 +9857,7 @@
 /obj/item/weapon/mining_charge,
 /obj/item/weapon/mining_charge,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/camera{
 	c_tag = "EVA";
@@ -10298,15 +9908,13 @@
 "vA" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/mine/living_quarters)
 "vB" = (
 /obj/structure/closet/secure_closet/miner,
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/mine/living_quarters)
 "vC" = (
@@ -10403,24 +10011,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor,
 /area/mine/west_outpost)
-"vM" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/mine/living_quarters)
 "vN" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor,
@@ -10429,8 +10024,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -10455,7 +10049,6 @@
 	id_tag = "mining_west_outpost_outer";
 	locked = 1;
 	name = "Mining External Access";
-	req_access = null;
 	req_access_txt = "10;13"
 	},
 /turf/simulated/floor/plating,
@@ -10480,8 +10073,7 @@
 /obj/item/weapon/reagent_containers/food/drinks/bottle/beer,
 /obj/item/weapon/reagent_containers/food/drinks/bottle/beer,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "bar"
@@ -10539,8 +10131,7 @@
 /obj/random/tools/tech_supply,
 /obj/random/tools/tech_supply,
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/mine/living_quarters)
 "wa" = (
@@ -10591,7 +10182,6 @@
 /area/mine/west_outpost)
 "wf" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Mining West Outpost APC";
 	pixel_x = 1;
 	pixel_y = -23
@@ -10609,8 +10199,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -10620,9 +10209,7 @@
 "wh" = (
 /obj/structure/ore_box,
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "mining_west_outpost_sensor";
-	pixel_x = 0;
 	pixel_y = -25
 	},
 /turf/simulated/floor/plating{
@@ -10645,13 +10232,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/mine/west_outpost)
 "wk" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/mine/west_outpost)
@@ -10691,8 +10276,7 @@
 "wq" = (
 /obj/machinery/mecha_part_fabricator/mining_fabricator,
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/mine/living_quarters)
 "wr" = (
@@ -10702,7 +10286,6 @@
 	network = list("MINE")
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warning"
 	},
 /area/mine/living_quarters)
@@ -10784,8 +10367,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/mine/production)
@@ -10800,8 +10382,7 @@
 /obj/item/weapon/storage/backpack/satchel,
 /obj/item/clothing/glasses/hud/mining,
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "bar"
@@ -10819,8 +10400,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Mining Station Maintenance";
@@ -10857,8 +10437,7 @@
 /obj/random/tools/tech_supply,
 /obj/random/tools/tech_supply,
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/mine/living_quarters)
 "wK" = (
@@ -10869,9 +10448,7 @@
 /area/mine/west_outpost)
 "wL" = (
 /obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1379;
 	id_tag = "mining_west_outpost_airlock";
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access_txt = null;
 	tag_airpump = "mining_west_outpost_pump";
@@ -10883,8 +10460,7 @@
 /area/mine/west_outpost)
 "wM" = (
 /obj/machinery/power/terminal{
-	dir = 1;
-	icon_state = "term"
+	dir = 1
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -10914,8 +10490,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -10963,8 +10538,7 @@
 /obj/random/tools/tech_supply,
 /obj/random/tools/tech_supply,
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/mine/living_quarters)
 "wV" = (
@@ -10979,8 +10553,7 @@
 	network = list("MINE")
 	},
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/mine/living_quarters)
 "wW" = (
@@ -11003,8 +10576,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
@@ -11027,8 +10599,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
@@ -11040,8 +10611,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/camera{
 	c_tag = "West Outpost";
@@ -11049,7 +10619,6 @@
 	network = list("MINE")
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/mine/west_outpost)
@@ -11062,7 +10631,6 @@
 "xd" = (
 /obj/machinery/alarm{
 	dir = 1;
-	icon_state = "alarm0";
 	pixel_y = -22
 	},
 /turf/simulated/floor{
@@ -11091,7 +10659,6 @@
 	},
 /obj/machinery/mineral/output,
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/mine/west_outpost)
@@ -11103,7 +10670,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/mine/west_outpost)
@@ -11161,8 +10727,7 @@
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -11178,7 +10743,6 @@
 "xq" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor{
@@ -11206,8 +10770,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11271,7 +10834,6 @@
 "xD" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/light/small{
@@ -11314,7 +10876,6 @@
 "xO" = (
 /obj/machinery/conveyor{
 	backwards = 2;
-	dir = 2;
 	forwards = 1;
 	id = "mining_west"
 	},
@@ -11323,7 +10884,6 @@
 /area/mine/west_outpost)
 "xZ" = (
 /obj/structure/sign/xeno_warning_mining{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/light/small{
@@ -11369,7 +10929,6 @@
 	id_tag = "mining_west_inner";
 	locked = 1;
 	name = "Mining External Access";
-	req_access = null;
 	req_access_txt = null
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -11402,7 +10961,6 @@
 	id_tag = "mining_east_outer";
 	locked = 1;
 	name = "Mining External Access";
-	req_access = null;
 	req_access_txt = "10;13"
 	},
 /turf/simulated/floor/plating,
@@ -11421,8 +10979,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -11446,20 +11003,17 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor/airless{
-	dir = 2;
 	icon_state = "asteroidwarning"
 	},
 /area/mine/explored)
 "ys" = (
 /obj/structure/sign/xeno_warning_mining{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/plating/airless/asteroid,
@@ -11468,8 +11022,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11545,9 +11098,7 @@
 /area/mine/west_outpost)
 "yX" = (
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = null;
-	name = "Infirmary";
-	req_access_txt = "0"
+	name = "Infirmary"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
@@ -11597,7 +11148,6 @@
 	dir = 5
 	},
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/mine/living_quarters)
@@ -11609,8 +11159,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/mine/production)
@@ -11636,8 +11185,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11655,8 +11203,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -11673,8 +11220,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Station Bridge";
@@ -11692,8 +11238,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11707,8 +11252,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11726,7 +11270,6 @@
 /area/mine/production)
 "zo" = (
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Mining EVA APC";
 	pixel_x = 1;
 	pixel_y = -23
@@ -11744,8 +11287,7 @@
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/head/helmet/space/globose/mining,
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/mine/eva)
 "zq" = (
@@ -11759,8 +11301,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/mine/eva)
 "zs" = (
@@ -11775,9 +11316,7 @@
 /area/mine/living_quarters)
 "zt" = (
 /obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1379;
 	id_tag = "mining_east_airlock";
-	pixel_x = 0;
 	pixel_y = -25;
 	req_access_txt = null;
 	tag_airpump = "mining_east_pump";
@@ -11806,9 +11345,7 @@
 "zz" = (
 /obj/structure/ore_box,
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "mining_east_sensor";
-	pixel_x = 0;
 	pixel_y = -25
 	},
 /turf/simulated/floor/plating{
@@ -11827,7 +11364,6 @@
 	id_tag = "mining_east_inner";
 	locked = 1;
 	name = "Mining External Access";
-	req_access = null;
 	req_access_txt = null
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -11840,8 +11376,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/mine/production)
@@ -11901,8 +11436,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11925,8 +11459,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/mining/glass{
 	name = "Mining Station Bridge";
@@ -11948,8 +11481,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11967,8 +11499,7 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_y = 0
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -12019,7 +11550,6 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/research_outpost/hallway)
@@ -12066,7 +11596,6 @@
 	id_tag = "mining_west_outer";
 	locked = 1;
 	name = "Mining External Access";
-	req_access = null;
 	req_access_txt = null
 	},
 /turf/simulated/floor/plating,
@@ -12198,7 +11727,6 @@
 	icon_state = "0-4"
 	},
 /turf/simulated/floor/airless{
-	dir = 2;
 	icon_state = "asteroidwarning"
 	},
 /area/mine/explored)
@@ -12206,11 +11734,9 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/airless{
-	dir = 2;
 	icon_state = "asteroidwarning"
 	},
 /area/mine/explored)
@@ -12218,15 +11744,12 @@
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
-	icon_state = "4-8";
-	pixel_x = 0
+	icon_state = "4-8"
 	},
 /obj/structure/sign/xeno_warning_mining{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor/airless{
-	dir = 2;
 	icon_state = "asteroidwarning"
 	},
 /area/mine/explored)
@@ -12237,7 +11760,6 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/airless{
-	dir = 2;
 	icon_state = "asteroidwarning"
 	},
 /area/mine/explored)
@@ -12261,8 +11783,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor,
 /area/research_outpost/hallway)
@@ -12441,8 +11962,7 @@
 	},
 /obj/structure/transit_tube/station,
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/research_outpost/maintstore1)
 "Bp" = (
@@ -12519,8 +12039,7 @@
 "BB" = (
 /obj/machinery/alarm{
 	dir = 4;
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /mob/living/carbon/monkey,
 /turf/simulated/floor{
@@ -12541,7 +12060,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "VACUUM";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/light/small{
@@ -12559,7 +12077,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/mine/production)
@@ -12569,8 +12086,7 @@
 	icon_state = "space";
 	layer = 4;
 	name = "EXTERNAL AIRLOCK";
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
 	dir = 8;
@@ -12579,7 +12095,6 @@
 	name = "Mining West Large Air Vent"
 	},
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/mine/living_quarters)
@@ -12624,16 +12139,12 @@
 	},
 /area/research_outpost/hallway)
 "Dc" = (
-/obj/structure/transit_tube/station{
-	dir = 2;
-	icon_state = "closed"
-	},
+/obj/structure/transit_tube/station,
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'VACUUM'";
 	icon_state = "space";
 	layer = 4;
 	name = "VACUUM";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/light/small{
@@ -12650,7 +12161,6 @@
 	id = "mining_internal"
 	},
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/mine/production)
@@ -12691,7 +12201,6 @@
 /area/research_outpost/longtermstorage)
 "Eb" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "greencorner"
 	},
 /area/research_outpost/maintstore1)
@@ -12701,7 +12210,6 @@
 	icon_state = "space";
 	layer = 4;
 	name = "VACUUM";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/machinery/door/window/westleft,
@@ -12780,7 +12288,6 @@
 	},
 /obj/machinery/mineral/output,
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/mine/production)
@@ -12827,7 +12334,6 @@
 	},
 /obj/machinery/mineral/input,
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/mine/production)
@@ -12838,7 +12344,6 @@
 	},
 /obj/structure/plasticflaps/mining,
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/mine/production)
@@ -12856,7 +12361,6 @@
 "Hb" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Auxiliary Storage";
-	req_access_txt = "0";
 	req_one_access_txt = "65;12"
 	},
 /obj/machinery/door/firedoor,
@@ -12877,7 +12381,6 @@
 	},
 /obj/structure/plasticflaps/mining,
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/mine/production)
@@ -12963,14 +12466,12 @@
 /area/research_outpost/iso2)
 "Jb" = (
 /obj/structure/sign/warning/nosmoking{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "whitepurple"
 	},
 /area/research_outpost/anomaly)
@@ -12984,17 +12485,14 @@
 /area/mine/living_quarters)
 "Jd" = (
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warnwhite"
 	},
 /area/mine/living_quarters)
 "Je" = (
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "mining_internal"
 	},
 /turf/simulated/floor/plating{
@@ -13042,7 +12540,6 @@
 /area/research_outpost/entry)
 "Kd" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "warnwhite"
 	},
 /area/mine/living_quarters)
@@ -13087,8 +12584,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA";
-	pixel_y = 0
+	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/floor/plating,
 /area/mine/production)
@@ -13129,8 +12625,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -13150,8 +12645,7 @@
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
 	icon_state = "space";
 	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 0
+	name = "EXTERNAL AIRLOCK"
 	},
 /turf/simulated/floor/plating,
 /area/mine/production)
@@ -13164,7 +12658,6 @@
 /obj/item/weapon/storage/firstaid/fire,
 /obj/machinery/alarm{
 	dir = 8;
-	icon_state = "alarm0";
 	pixel_x = 24
 	},
 /obj/item/weapon/storage/firstaid/small_firstaid_kit/space,
@@ -13187,7 +12680,6 @@
 /area/mine/production)
 "Mf" = (
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "mining_internal"
 	},
 /obj/machinery/mineral/output,
@@ -13198,7 +12690,6 @@
 /area/mine/production)
 "Mg" = (
 /obj/machinery/sparker{
-	dir = 2;
 	id = "isolationsparker";
 	pixel_x = -23
 	},
@@ -13263,8 +12754,7 @@
 	},
 /obj/structure/cable{
 	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 0
+	icon_state = "0-2"
 	},
 /obj/structure/sign/warning/electricshock{
 	pixel_x = 32
@@ -13281,7 +12771,6 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/mine/living_quarters)
@@ -13306,7 +12795,6 @@
 "Of" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/mine/production)
@@ -13326,19 +12814,16 @@
 /area/research_outpost/sample)
 "Pc" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/mine/living_quarters)
 "Pd" = (
 /obj/machinery/airlock_sensor{
-	frequency = 1379;
 	id_tag = "mining_west_sensor";
 	pixel_x = 25;
 	pixel_y = -5
 	},
 /obj/machinery/embedded_controller/radio/airlock_controller{
-	frequency = 1379;
 	id_tag = "mining_west_airlock";
 	pixel_x = 25;
 	pixel_y = 5;
@@ -13359,7 +12844,6 @@
 "Pe" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/simulated/floor{
@@ -13369,7 +12853,6 @@
 /area/mine/production)
 "Pf" = (
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/mine/production)
@@ -13385,19 +12868,16 @@
 "Qc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/mine/living_quarters)
 "Qd" = (
 /obj/machinery/status_display{
 	layer = 4;
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/light{
-	dir = 8;
-	icon_state = "tube1"
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
@@ -13428,12 +12908,10 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/mine/living_quarters)
@@ -13478,13 +12956,11 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/mine/living_quarters)
 "Sd" = (
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "mining_internal"
 	},
 /obj/structure/plasticflaps/mining,
@@ -13530,13 +13006,11 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/mine/living_quarters)
 "Td" = (
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "mining_internal"
 	},
 /obj/machinery/mineral/output,
@@ -13586,7 +13060,6 @@
 	},
 /obj/machinery/atmospherics/components/binary/valve/open,
 /turf/simulated/floor{
-	dir = 2;
 	icon_state = "brown"
 	},
 /area/mine/living_quarters)
@@ -13595,7 +13068,6 @@
 	dir = 8
 	},
 /turf/simulated/floor/airless{
-	dir = 2;
 	icon_state = "asteroidwarning"
 	},
 /area/mine/explored)
@@ -13636,14 +13108,12 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/mine/living_quarters)
 "Ve" = (
 /obj/machinery/mineral/input,
 /obj/machinery/conveyor{
-	dir = 2;
 	id = "mining_internal"
 	},
 /turf/simulated/floor/plating{
@@ -13654,7 +13124,6 @@
 "Vf" = (
 /obj/machinery/conveyor{
 	dir = 10;
-	icon_state = "conveyor0";
 	id = "mining_internal"
 	},
 /obj/machinery/mineral/input,
@@ -13673,8 +13142,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/hologram/holopad,
 /obj/machinery/light{
@@ -13698,8 +13166,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor{
-	icon_state = "delivery";
-	name = "floor"
+	icon_state = "delivery"
 	},
 /area/mine/living_quarters)
 "We" = (
@@ -13769,8 +13236,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -13824,8 +13290,7 @@
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2";
-	pixel_y = 0
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -13847,7 +13312,6 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/mine/living_quarters)
@@ -33209,7 +32673,7 @@ mZ
 gb
 or
 oX
-gF
+jN
 jN
 ei
 co
@@ -33465,7 +32929,7 @@ ei
 kH
 eO
 os
-gF
+jN
 jN
 dJ
 ei
@@ -33981,7 +33445,7 @@ na
 hk
 jN
 iQ
-gF
+jN
 ei
 qB
 qQ
@@ -34491,7 +33955,7 @@ hk
 kM
 mj
 nb
-kN
+fu
 or
 hj
 hi
@@ -34747,11 +34211,11 @@ jM
 kM
 kM
 mk
-gF
+jN
 nE
 os
 kK
-gF
+jN
 iT
 ei
 qC
@@ -35254,15 +34718,15 @@ eN
 ft
 gb
 dJ
-gF
+jN
 fu
 iS
 jN
 dJ
-gF
+jN
 dJ
 eO
-nF
+kK
 hj
 iT
 hj
@@ -35510,12 +34974,12 @@ di
 eO
 fu
 gc
-gF
+jN
 hn
 hW
 iT
 jO
-kN
+fu
 jN
 ml
 eO
@@ -36031,7 +35495,7 @@ ei
 jP
 jP
 jP
-mm
+kH
 co
 kH
 nb
@@ -36285,11 +35749,11 @@ gH
 gG
 hX
 ei
-gF
+jN
 fu
 eO
 eO
-nc
+lz
 co
 ot
 oY
@@ -36543,7 +36007,7 @@ ei
 ei
 ei
 jQ
-gF
+jN
 lz
 ft
 eO
@@ -49254,7 +48718,7 @@ tD
 vp
 zb
 wn
-vM
+tp
 Pc
 uo
 wS
@@ -49511,7 +48975,7 @@ Au
 vq
 uo
 xq
-vM
+tp
 Sc
 uo
 zw
@@ -50539,7 +50003,7 @@ xr
 wU
 uo
 zv
-vM
+tp
 Pc
 ia
 Pd
@@ -52989,7 +52453,7 @@ aS
 aS
 hz
 Ap
-hN
+hK
 ic
 jG
 hp
@@ -55556,9 +55020,9 @@ Mb
 eV
 Zb
 fH
-gg
-gg
-gg
+gp
+gp
+gp
 ip
 jm
 le
@@ -58127,7 +57591,7 @@ ff
 fy
 fL
 gp
-gg
+gp
 hC
 iK
 js

--- a/maps/z7.dmm
+++ b/maps/z7.dmm
@@ -56,8 +56,7 @@
 /area/awaymission/junkyard)
 "n" = (
 /obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/awaymission/junkyard)
@@ -163,7 +162,6 @@
 /area/awaymission/junkyard)
 "E" = (
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/awaymission/junkyard)
@@ -192,7 +190,6 @@
 "I" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating{
-	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/awaymission/junkyard)


### PR DESCRIPTION
## Описание изменений
Прогнал основные z-слои через StrongDMM и, таким образом, почистил карты от "грязных" переменных. Грязные это значит, что у инстансов объектов переменные имеют те же значения, что и объекты в коде. Что не имеет никакого смысла.

Остальные карты посмотрю позже.

## Почему и что этот ПР улучшит
Карта чище, инстансов меньше, общее улучшение, так сказать.