### PR TITLE
Возможность пулла движущихся атомов через Z-уровни

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -127,9 +127,9 @@
 		A.Bumped(src)
 
 
-/atom/movable/proc/forceMove(atom/destination)
+/atom/movable/proc/forceMove(atom/destination, keep_pulling = FALSE)
 	if(destination)
-		if(pulledby)
+		if(pulledby && !keep_pulling)
 			pulledby.stop_pulling()
 		var/atom/oldloc = loc
 		var/same_loc = (oldloc == destination)
@@ -158,8 +158,9 @@
 		return TRUE
 	return FALSE
 
-/mob/living/forceMove()
-	stop_pulling()
+/mob/living/forceMove(atom/destination, keep_pulling = FALSE)
+	if(!keep_pulling)
+		stop_pulling()
 	if(buckled)
 		buckled.unbuckle_mob()
 	. = ..()

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -157,6 +157,11 @@
 				A.y = TRANSITIONEDGE + 1
 				A.x = rand(TRANSITIONEDGE + 2, world.maxx - TRANSITIONEDGE - 2)
 
+			if(ismob(A))
+				var/mob/M = A
+				if(M.pulling)
+					M.pulling.forceMove(get_turf(M), keep_pulling = TRUE)
+
 
 			stoplag()//Let a diagonal move finish, if necessary
 			A.newtonian_move(A.inertia_dir)


### PR DESCRIPTION
## Описание изменений

Теперь мобы могут пуллить с собой движущиеся атомы и, переходя на другой z-уровень, они заберут с собой то, что несли за собой. Причем им не придется заного брать то, что они уже тащат.

## Почему и что этот ПР улучшит

Путешествие с другом или редким сокровищем с дереликта теперь стало возможным. 

## Чеинжлог

:cl: Lizzzard
 - tweak: Теперь при переходе на другой Z-уровень то, что вы пулите, перейдет вместе с вами, а пулл не прекратится. Путешествие вдвоем стало возможным!