### PR TITLE
Fix sound save

### DIFF
--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -557,7 +557,9 @@ voluminosity = if FALSE, removes the difference between left and right ear.
 			function updateVolume(slider_id) {
 				if (!volumeUpdating) {
 					volumeUpdating = true;
-					setTimeout(setVolume, 300, slider_id);
+					setTimeout(function() {
+						setVolume(slider_id);
+					}, 300);
 				}
 
 			}


### PR DESCRIPTION
## Описание изменений
Fixes #3582 
Как обычно проблема в старом IE. Это синтаксис с параметром для колбэка поддерживается с 10+ версии.

## Чеинжлог
:cl:
 - bugfix: Исправлено сохранение звука в новом меню настроек. (Пожалуйста, обновите свой IE минимум до 10-ой версии, не мучайте себя).
