### PR TITLE
Изменение конфига stale-бота

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -17,9 +17,10 @@ pulls:
 
 issues:
   daysUntilStale: 200
-  daysUntilClose: false
-  staleLabel: Old issue
-  exemptLabels:
-    - Proposal
-  markComment: >
-    Этот ишью пробыл открытым более полугода. Пожалуйста, сообщите, является ли он актуальным для текущей версии билда?
+  daysUntilClose: 0
+  staleLabel: Stalled Proposal
+  onlyLabels: [Proposal]
+  closeComment: >
+    Данное предложение пробыло без активности открытым более полугода. Если вы найдёте того, кто его реализует,
+    и вам нужно открыть данный ишью, пожалуйста, обратитесь к кому-либо из мейнтейнеров.
+    Вы можете призвать их в комментарии слапнув ``@TauCetiStation/maintainers``.


### PR DESCRIPTION
## Описание изменений
Поменял конфигурацию так, чтобы бот закрывал ишью помеченные как `Proposal` и пробывшие без активности более полугода. Кроме закрытия они будут помечены специальным лэйблом.

## Почему и что этот ПР улучшит
Переспрашивать "а актуален ли ещё баг" - на самом деле не самое полезное занятие. В смысле, вероятность того, что баг исправился сам собой небольшая. А подтверждение что баг ещё актуален, особенно если вопрос касается багов из конца списка... В общем, мало полезного и задать вопрос может сам кодер.

В то же время, уже ни раз оговаривалась мысль о сомнительности `Proposal` лэйбла. Были предложения его выпилить. Но ничего страшного в нём не вижу. Какие-то идеи проскачить могут и вдруг, мало ли, кто-нибудь действительно решит идею воплотить. Но, объективно, если пропозал висит более полугода, то значит за него, с высокой долей вероятности, никто браться и не планирует. А предложение продолжает висеть...

В общем, лёгким движением конфига почистим гитхаб от старых "естьидея" ишуёв. 
