### PR TITLE
Уменьшение шрифта кнопок гунчата

### DIFF
--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -144,6 +144,7 @@ a.popt {text-decoration: none;}
 	line-height: 30px;
 	float: left;
 	margin-left: 5px;
+	font-size: 0.85em;
 }
 
 #userBar .sub i {


### PR DESCRIPTION
## Описание изменений
Уменьшение шрифта кнопок гунчата

## Почему и что этот ПР улучшит
Кнопка "объединения строк" слишком длинная, из-за этого всё поплыло. А шрифт меньше делает всё аккуратней.

<details>
<summary>Было</summary>

![было](https://user-images.githubusercontent.com/12721311/61169515-581cae80-a567-11e9-87f0-3c9d1d4bdf1a.PNG)

</details>
<details>
<summary>Стало</summary>

![стало2](https://user-images.githubusercontent.com/12721311/61169517-64087080-a567-11e9-998e-211f8bbfb0d9.PNG)

</details>

