### PR TITLE
Возвращение магам возможности стрелять

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -45,8 +45,6 @@
 	return 0
 
 /obj/item/weapon/gun/proc/special_check(mob/M, atom/target) //Placeholder for any special checks, like detective's revolver. or wizards
-	if(M.mind.special_role == "Wizard")
-		return FALSE
 	return TRUE
 
 /obj/item/weapon/gun/proc/shoot_with_empty_chamber(mob/living/user)


### PR DESCRIPTION
<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений

fixes #3633 

Маги снова могут стрелять.
<!--
Опишите изменения данного ПР-а.
Если есть связные ишью (issues), или другие ПРы - укажите их тут, для автоматического закрытия ишью следует использовать ключевые слова https://help.github.com/en/articles/closing-issues-using-keywords
Если есть связное форумное обсуждение на тему изменений - укажите ссылку на эту тему.
-->

## Почему и что этот ПР улучшит

Маги не "не могут" стрелять, а "презирают" использование технологий. Никакое презирство технологий не должно мешать зажать курок коли очень надо.
<!--
Опишите причину для изменений.
Этот пункт особенно важен для описания изменений баланса, новых механик.
-->

<!-- Опциональный пункт!
Если авторство не полностью ваше, вы делаете порт с другого билда - обязательно укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
-->

## Чеинжлог

:cl: Luduk
- balance: Маги могут использовать пушки.

<!-- Опциональный пункт!
Если это что-то, о чём следует сообщить игрокам - опишите по форме (https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies#Changelog) свои изменения для игрового чеинжлога, они будут отображены на специальной страничке http://changelog.taucetistation.org

Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment
  
Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
