### PR TITLE
Меню camera bug не обновлялось при режиме Cancel camera view

### DIFF
--- a/code/game/objects/items/devices/camera_bug.dm
+++ b/code/game/objects/items/devices/camera_bug.dm
@@ -237,7 +237,6 @@
 					usr << browse(null, "window=camerabug")
 			return
 		else
-			usr.unset_machine()
 			usr.reset_view(null)
 
 	interact()
@@ -246,7 +245,7 @@
 	if(track_mode == BUGMODE_LIST || (world.time < (last_tracked + refresh_interval)))
 		return
 	last_tracked = world.time
-	if(track_mode == BUGMODE_TRACK ) // search for user
+	if(track_mode == BUGMODE_TRACK) // search for user
 		// Note that it will be tricked if your name appears to change.
 		// This is not optimal but it is better than tracking you relentlessly despite everything.
 		if(!tracking)


### PR DESCRIPTION


<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений

Если выбрать цель для отслеживания и нажать [cancel camera view], меню перестает обновляться самостоятельно при перемещении цели в другую зону. 
Это связано из-за unset'a машины у игрока. unset отключил "автоматическое обновление" у camera bug'a так как она была неиспользуемой.

fixed #855 

## Почему и что этот ПР улучшит
Фикс двухлетнего бага. 

## Авторство
## Чеинжлог

:cl:
 - bugfix: Использование [Сancel camera view] в camera bug обновляет местоположение цели.
