### PR TITLE
Фикс обрывающегося звука при переходе между зонами с одинаковым эмбие…

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -721,6 +721,19 @@
 		used_key_list[input_key] = 1
 	return input_key
 
+/proc/compare_list(list/l, list/d)
+	if (!islist(l) || !islist(d))
+		return FALSE
+
+	if (l.len != d.len)
+		return FALSE
+
+	for (var/i in 1 to l.len)
+		if (l[i] != d[i])
+			return FALSE
+
+	return TRUE
+
 #define LAZYINITLIST(L) if (!L) L = list()
 #define UNSETEMPTY(L) if (L && !L.len) L = null
 #define LAZYADD(L, I) if(!L) { L = list(); } L += I;

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -392,7 +392,7 @@ var/list/ghostteleportlocs = list()
 		L.client.sound_old_looped_ambience = looped_ambience
 		L.playsound_music(looped_ambience, VOL_AMBIENT, TRUE, null, CHANNEL_AMBIENT_LOOP)
 
-	if (old_area.ambience != new_area.ambience)
+	if (!compare_list(old_area.ambience, new_area.ambience))
 		L.playsound_stop(CHANNEL_AMBIENT)
 
 	if (ambience != null && (is_force_ambience || (prob(50) && L.client.sound_next_ambience_play <= world.time)))


### PR DESCRIPTION
## Описание изменений
Фикс обрывающегося звука при переходе между зонами с одинаковым эмбиентом. Добавление метода для сравнения двух списков на равенство.

:cl:
- bugfix: При переход из зоны в зону звук проигрываемого эмбиента перестанет резко обрываться (если эмбиенс для зон одинаковый).