### PR TITLE
Fixing the req_access list being null.

### DIFF
--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -183,7 +183,7 @@ for reference:
 		user.SetNextMove(CLICK_CD_MELEE)
 		if (src.emagged == 0)
 			src.emagged = 1
-			src.req_access = null
+			src.req_access = list()
 			to_chat(user, "You break the ID authentication lock on \the [src].")
 			var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
 			s.set_up(2, 1, src)

--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -8,7 +8,7 @@
 
 	req_access = list(access_engine)
 
-	var/list/conf_access = null
+	var/list/conf_access = list()
 	var/one_access = 0 //if set to 1, door would receive req_one_access instead of req_access
 	var/last_configurator = null
 	var/locked = 1
@@ -93,17 +93,11 @@
 
 /obj/item/weapon/airlock_electronics/proc/toggle_access(acc)
 	if (acc == "all")
-		conf_access = null
+		conf_access = list()
 	else
 		var/req = text2num(acc)
-
-		if (conf_access == null)
-			conf_access = list()
 
 		if (!(req in conf_access))
 			conf_access += req
 		else
 			conf_access -= req
-			if (!conf_access.len)
-				conf_access = null
-

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -106,7 +106,7 @@
 			visible_message("[bicon(src)] <b>\The [src]</b> beeps: \"User DB corrupted \[Code 0x00FA\]. Truncating data structure...\"")
 			sleep(30)
 			visible_message("[bicon(src)] <b>\The [src]</b> beeps: \"User DB truncated. Please contact your Nanotrasen system operator for future assistance.\"")
-			req_access = null
+			req_access = list()
 			emagged = 1
 		if(0.5)
 			visible_message("[bicon(src)] <b>\The [src]</b> beeps: \"DB not responding \[Code 0x0003\]...\"")

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -168,7 +168,7 @@
 			door.assembly_type = type
 			door.electronics = electronics
 			if(electronics.one_access)
-				door.req_access = null
+				door.req_access = list()
 				door.req_one_access = electronics.conf_access
 			else
 				door.req_access = electronics.conf_access

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -221,7 +221,7 @@
 						windoor.density = 0
 
 						if(src.electronics.one_access)
-							windoor.req_access = null
+							windoor.req_access = list()
 							windoor.req_one_access = src.electronics.conf_access
 						else
 							windoor.req_access = src.electronics.conf_access
@@ -243,7 +243,7 @@
 						windoor.density = 0
 
 						if(src.electronics.one_access)
-							windoor.req_access = null
+							windoor.req_access = list()
 							windoor.req_one_access = src.electronics.conf_access
 						else
 							windoor.req_access = src.electronics.conf_access


### PR DESCRIPTION
<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений

fixes #3649

Если шлюз настраивали платой, можно было выставить вместо списка требуемых доступов null что приводило к рантаймам, и невозможности открыть этот шлюз.

Теперь нельзя(а так же нельзя нулл выставить емагом на некоторых вещах, и стеклянные дверки тоже работают как надо).

<!--
Опишите изменения данного ПР-а.
Если есть связные ишью (issues), или другие ПРы - укажите их тут, для автоматического закрытия ишью следует использовать ключевые слова https://help.github.com/en/articles/closing-issues-using-keywords
Если есть связное форумное обсуждение на тему изменений - укажите ссылку на эту тему.
-->

## Почему и что этот ПР улучшит

Закрывает иссуй 3649.
