### PR TITLE
Менторы могут отвечать на Mhelp

### DIFF
--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -55,7 +55,7 @@
 	if(reply_type != MHELP_REPLY)
 		cmd_admin_pm(whom, msg)
 	else
-		if(!holder && mob.mind && mob.mind.special_role) //Mentors are just a players, so they shan't know gamemode from these ones who toggles all role prefs to yes
+		if(!holder && mob.mind && mob.mind.special_role && !(C in mentors)) //Mentors are just a players, so they shan't know gamemode from these ones who toggles all role prefs to yes
 			to_chat(src, "<font color='red'>You cannot ask mentors for help while being antag. File a ticket instead if you wish question this to admins.</font>")
 			return
 		cmd_mentor_pm(whom, msg)


### PR DESCRIPTION
## Описание изменений
fix #3618 

Менторы могут отвечать на вопросы в их Mhelp, но не задавать их.
## Почему и что этот ПР улучшит
Исправление бага. Теперь менторы смогут работать, работая за тритора.
## Авторство
## Чеинжлог
:cl:
 - bugfix: Менторы не могли отвечать на вопросы, играя за антагониста.
