### PR TITLE
Make client hard deleted

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -101,6 +101,10 @@ var/list/blacklisted_builds = list(
 
 	..()	//redirect to hsrc.Topic()
 
+/client/Destroy()
+	..() // Even though we're going to be hard deleted there are still some things that want to know the destroy is happening
+	return QDEL_HINT_HARDDEL_NOW
+
 /client/proc/handle_spam_prevention(message, mute_type)
 	if(global_message_cooldown && (world.time < last_message_time + 5))
 		return 1


### PR DESCRIPTION
## Описание изменений
Добавление в детрой клиента хинта на хард делит. Без этого клиент мог некоторое время висеть в очереди на удаление, что, по сути, означало задержку его дисконекта.

## Почему и что этот ПР улучшит
Пофиксит проблему, когда моб, например, попадл на паник бункер, его не пускало, но пару минут он оставался в игре. Плюс другие кейсы, где клиент удаляется через `qdel`
