### PR TITLE
personal closet нельзя забронировать картой внутри ПДА

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -870,11 +870,6 @@
 		if(id_overlay)
 			overlays += image('icons/obj/pda.dmi', id_overlay)
 
-/obj/item/device/pda/proc/get_registered_name()
-	if(!id || !id.registered_name)
-		return
-	return id.registered_name
-
 /obj/item/device/pda/proc/get_id_overlay(obj/item/weapon/card/id/I)
 	if(!I)
 		return

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -870,6 +870,11 @@
 		if(id_overlay)
 			overlays += image('icons/obj/pda.dmi', id_overlay)
 
+/obj/item/device/pda/proc/get_registered_name()
+	if(!id || !id.registered_name)
+		return
+	return id.registered_name
+
 /obj/item/device/pda/proc/get_id_overlay(obj/item/weapon/card/id/I)
 	if(!I)
 		return

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -43,14 +43,9 @@
 	new /obj/item/device/radio/headset(src)
 
 /obj/structure/closet/secure_closet/personal/proc/get_registered_name(obj/item/W)
-	if(istype(W, /obj/item/device/pda))
-		var/obj/item/device/pda/pda = W
-		return pda.get_registered_name()
-	else if(istype(W, /obj/item/weapon/card/id))
-		var/obj/item/weapon/card/id/id = W
-		return id.registered_name
 
 /obj/structure/closet/secure_closet/personal/attackby(obj/item/W, mob/user)
+	var/user_registered_name = null
 	if (src.opened)
 		if (istype(W, /obj/item/weapon/grab))
 			var/obj/item/weapon/grab/G = W
@@ -61,15 +56,21 @@
 		if(src.broken)
 			to_chat(user, "<span class='warning'>It appears to be broken.</span>")
 			return
-		if(src.allowed(user) || !src.registered_name || (src.registered_name == get_registered_name(W)))
+		if(istype(W, /obj/item/device/pda))
+			var/obj/item/device/pda/pda = W
+			user_registered_name = pda.id.registered_name
+		else if(istype(W, /obj/item/weapon/card/id))
+			var/obj/item/weapon/card/id/id = W
+			user_registered_name = id.registered_name
+		if(src.allowed(user) || !src.registered_name || (src.registered_name == user_registered_name))
 			//they can open all lockers, or nobody owns this, or they own this locker
 			src.locked = !( src.locked )
 			if(src.locked)	src.icon_state = src.icon_locked
 			else	src.icon_state = src.icon_closed
 
 			if(!src.registered_name)
-				src.registered_name = get_registered_name(W)
-				src.desc = "Owned by [get_registered_name(W)]."
+				src.registered_name = user_registered_name
+				src.desc = "Owned by [user_registered_name]."
 		else
 			to_chat(user, "\red Access Denied")
 	else if((istype(W, /obj/item/weapon/melee/energy/blade)||istype(W, /obj/item/weapon/twohanded/dualsaber)) && !src.broken)

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -42,10 +42,7 @@
 	new /obj/item/weapon/storage/backpack/satchel/withwallet(src)
 	new /obj/item/device/radio/headset(src)
 
-/obj/structure/closet/secure_closet/personal/proc/get_registered_name(obj/item/W)
-
 /obj/structure/closet/secure_closet/personal/attackby(obj/item/W, mob/user)
-	var/user_registered_name = null
 	if (src.opened)
 		if (istype(W, /obj/item/weapon/grab))
 			var/obj/item/weapon/grab/G = W
@@ -53,12 +50,16 @@
 		user.drop_item()
 		if (W) W.forceMove(src.loc)
 	else if(istype(W, /obj/item/weapon/card/id) || istype(W, /obj/item/device/pda))
+		var/user_registered_name = null
 		if(src.broken)
 			to_chat(user, "<span class='warning'>It appears to be broken.</span>")
 			return
 		if(istype(W, /obj/item/device/pda))
 			var/obj/item/device/pda/pda = W
-			user_registered_name = pda.id.registered_name
+			user_registered_name = pda?.id?.registered_name
+			if(isnull(user_registered_name))
+				to_chat(user, "<span class='red'> You need ID card in PDA for this.</span>")
+				return
 		else if(istype(W, /obj/item/weapon/card/id))
 			var/obj/item/weapon/card/id/id = W
 			user_registered_name = id.registered_name
@@ -68,7 +69,7 @@
 			if(src.locked)	src.icon_state = src.icon_locked
 			else	src.icon_state = src.icon_closed
 
-			if(!src.registered_name)
+			if(!src.registered_name && user_registered_name)
 				src.registered_name = user_registered_name
 				src.desc = "Owned by [user_registered_name]."
 		else

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -42,28 +42,34 @@
 	new /obj/item/weapon/storage/backpack/satchel/withwallet(src)
 	new /obj/item/device/radio/headset(src)
 
-/obj/structure/closet/secure_closet/personal/attackby(obj/item/weapon/W, mob/user)
+/obj/structure/closet/secure_closet/personal/proc/get_registered_name(obj/item/W)
+	if(istype(W, /obj/item/device/pda))
+		var/obj/item/device/pda/pda = W
+		return pda.get_registered_name()
+	else if(istype(W, /obj/item/weapon/card/id))
+		var/obj/item/weapon/card/id/id = W
+		return id.registered_name
+
+/obj/structure/closet/secure_closet/personal/attackby(obj/item/W, mob/user)
 	if (src.opened)
 		if (istype(W, /obj/item/weapon/grab))
 			var/obj/item/weapon/grab/G = W
 			MouseDrop_T(G.affecting, user)      //act like they were dragged onto the closet
 		user.drop_item()
 		if (W) W.forceMove(src.loc)
-	else if(istype(W, /obj/item/weapon/card/id))
+	else if(istype(W, /obj/item/weapon/card/id) || istype(W, /obj/item/device/pda))
 		if(src.broken)
 			to_chat(user, "<span class='warning'>It appears to be broken.</span>")
 			return
-		var/obj/item/weapon/card/id/I = W
-		if(!I || !I.registered_name)	return
-		if(src.allowed(user) || !src.registered_name || (istype(I) && (src.registered_name == I.registered_name)))
+		if(src.allowed(user) || !src.registered_name || (src.registered_name == get_registered_name(W)))
 			//they can open all lockers, or nobody owns this, or they own this locker
 			src.locked = !( src.locked )
 			if(src.locked)	src.icon_state = src.icon_locked
 			else	src.icon_state = src.icon_closed
 
 			if(!src.registered_name)
-				src.registered_name = I.registered_name
-				src.desc = "Owned by [I.registered_name]."
+				src.registered_name = get_registered_name(W)
+				src.desc = "Owned by [get_registered_name(W)]."
 		else
 			to_chat(user, "\red Access Denied")
 	else if((istype(W, /obj/item/weapon/melee/energy/blade)||istype(W, /obj/item/weapon/twohanded/dualsaber)) && !src.broken)


### PR DESCRIPTION
Новая функция выдает имя владельца карты, а код шкафа адаптирован под эту функцию.

<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений

fix #3697 
Теперь забронировать personal closet можно как ПДА, так и картой

## Почему и что этот ПР улучшит
Несправедливо, если ПДА может разлочить все, где требуется доступ

## Авторство
@KuzyXD 

## Чеинжлог
:cl:
 - bugfix: personal closet нельзя было забронировать с помощью ПДА и карты внутри
