### PR TITLE
2 небольших фикса pAI

### DIFF
--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -148,7 +148,7 @@
 				</td>
 			</table>
 		"}
-		if(pai && (!pai.master_dna || !pai.master))
+		if(!pai.master_dna || !pai.master)
 			dat += {"
 				<table>
 					<td class="button">
@@ -157,25 +157,25 @@
 				</table>
 			"}
 		dat += "<br>"
-		if(radio)
+		if(radio && radio.wires)
 			dat += "<b>Radio Uplink</b>"
 			dat += {"
 				<table class="request">
 					<tr>
 						<td class="radio">Transmit:</td>
-						<td><a href='byond://?src=\ref[src];wires=4'>[(radio.wires & 4) ? "<font color=#55FF55>Enabled</font>" : "<font color=#FF5555>Disabled</font>" ]</a>
+						<td><a href='byond://?src=\ref[src];wires=4'>[!radio.wires.is_index_cut(RADIO_WIRE_TRANSMIT) ? "<font color=#55FF55>Enabled</font>" : "<font color=#FF5555>Disabled</font>" ]</a>
 
 						</td>
 					</tr>
 					<tr>
 						<td class="radio">Receive:</td>
-						<td><a href='byond://?src=\ref[src];wires=2'>[(radio.wires & 2) ? "<font color=#55FF55>Enabled</font>" : "<font color=#FF5555>Disabled</font>" ]</a>
+						<td><a href='byond://?src=\ref[src];wires=2'>[!radio.wires.is_index_cut(RADIO_WIRE_RECEIVE) ? "<font color=#55FF55>Enabled</font>" : "<font color=#FF5555>Disabled</font>" ]</a>
 
 						</td>
 					</tr>
 					<tr>
 						<td class="radio">Signal Pulser:</td>
-						<td><a href='byond://?src=\ref[src];wires=1'>[(radio.wires & 1) ? "<font color=#55FF55>Enabled</font>" : "<font color=#FF5555>Disabled</font>" ]</a>
+						<td><a href='byond://?src=\ref[src];wires=1'>[!radio.wires.is_index_cut(RADIO_WIRE_SIGNAL) ? "<font color=#55FF55>Enabled</font>" : "<font color=#FF5555>Disabled</font>" ]</a>
 
 						</td>
 					</tr>
@@ -255,10 +255,7 @@
 			removePersonality()
 	if(href_list["wires"])
 		var/t1 = text2num(href_list["wires"])
-		if (radio.wires & t1)
-			radio.wires &= ~t1
-		else
-			radio.wires |= t1
+		radio.wires.cut_wire_index(t1)
 	if(href_list["setlaws"])
 		var/newlaws = sanitize(input("Enter any additional directives you would like your pAI personality to follow. Note that these directives will not override the personality's allegiance to its imprinted master. Conflicting directives will be ignored.", "pAI Directive Configuration", input_default(pai.pai_laws)) as message)
 		if(newlaws)

--- a/code/modules/mob/living/silicon/pai/life.dm
+++ b/code/modules/mob/living/silicon/pai/life.dm
@@ -6,8 +6,7 @@
 			var/turf/T = get_turf_or_move(src.loc)
 			for (var/mob/M in viewers(T))
 				M.show_message("<span class='warning'>The data cable rapidly retracts back into its spool.</span>", 3, "<span class='warning'>You hear a click and the sound of wire spooling rapidly.</span>", 2)
-			qdel(src.cable)
-			cable = null
+			QDEL_NULL(src.cable)
 
 	add_ingame_age()
 	regular_hud_updates()

--- a/code/modules/mob/living/silicon/pai/life.dm
+++ b/code/modules/mob/living/silicon/pai/life.dm
@@ -7,6 +7,7 @@
 			for (var/mob/M in viewers(T))
 				M.show_message("<span class='warning'>The data cable rapidly retracts back into its spool.</span>", 3, "<span class='warning'>You hear a click and the sound of wire spooling rapidly.</span>", 2)
 			qdel(src.cable)
+			cable = null
 
 	add_ingame_age()
 	regular_hud_updates()

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -643,6 +643,9 @@
 			src.temp = "Door Jack: Connection to airlock has been lost. Hack aborted."
 			hackprogress = 0
 			src.hackdoor = null
+			if(src.cable)
+				qdel(src.cable)
+				cable = null
 			return
 		if(hackprogress >= 100)		// This is clunky, but works. We need to make sure we don't ever display a progress greater than 100,
 			hackprogress = 100		// but we also need to reset the progress AFTER it's been displayed
@@ -651,6 +654,8 @@
 		if(hackprogress >= 100)
 			src.hackprogress = 0
 			src.cable.machine:open()
+			qdel(src.cable)
+			cable = null
 		sleep(50)			// Update every 5 seconds
 
 // Digital Messenger

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -644,8 +644,7 @@
 			hackprogress = 0
 			src.hackdoor = null
 			if(src.cable)
-				qdel(src.cable)
-				cable = null
+				QDEL_NULL(src.cable)
 			return
 		if(hackprogress >= 100)		// This is clunky, but works. We need to make sure we don't ever display a progress greater than 100,
 			hackprogress = 100		// but we also need to reset the progress AFTER it's been displayed
@@ -654,8 +653,7 @@
 		if(hackprogress >= 100)
 			src.hackprogress = 0
 			src.cable.machine:open()
-			qdel(src.cable)
-			cable = null
+			QDEL_NULL(src.cable)
 		sleep(50)			// Update every 5 seconds
 
 // Digital Messenger

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -643,8 +643,7 @@
 			src.temp = "Door Jack: Connection to airlock has been lost. Hack aborted."
 			hackprogress = 0
 			src.hackdoor = null
-			if(src.cable)
-				QDEL_NULL(src.cable)
+			QDEL_NULL(src.cable)
 			return
 		if(hackprogress >= 100)		// This is clunky, but works. We need to make sure we don't ever display a progress greater than 100,
 			hackprogress = 100		// but we also need to reset the progress AFTER it's been displayed


### PR DESCRIPTION
## Описание изменений

Теперь (наконец-то) у пИИ снова будет открываться менюшка с привязкой по ДНК. А еще не будет спамить после взлома двери. Ура.

## Почему и что этот ПР улучшит

Ну, может быть, за пИИ будет играть больше игроков, будет нормальный взлом дверей, не будет непонятного спама про кабели rapidly волочащиеся по полу, можно будет выключать особенно надоедливым пИИ радио.

## Авторство

OriaOriginal

:cl: OriaOriginal
 - bugfix: pAI снова может взламывать двери без спама
 - bugfix: у pAI снова может быть программный хозяин