### PR TITLE
Handling "abstract" reagents holders, fixing mop runtimes.

### DIFF
--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -199,7 +199,7 @@
 				to_chat(user, "<span class='warning'>Your [src] has hit [A]! There's not enough space for broad sweeps here!</span>")
 				var/resolved = A.attackby(src, user, list())
 				if(!resolved && src)
-					afterattack(A, src, TRUE, list()) // 1 indicates adjacency
+					afterattack(A, user, TRUE, list()) // 1 indicates adjacency
 				turf_clear = FALSE
 				break
 			if(istype(A, /obj/item))

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -204,6 +204,13 @@ var/const/INGEST = 2
 	update_total()
 
 /datum/reagents/proc/handle_reactions()
+	if(!my_atom)
+		/*
+		We are created abstractly, there is no need for us to handle any reactions, unless somebody wants to
+		code in such support.
+		*/
+		return
+
 	if(my_atom.flags & NOREACT) return //Yup, no reactions here. No siree.
 
 
@@ -399,7 +406,8 @@ var/const/INGEST = 2
 		if (R.id == reagent)
 			R.volume += amount
 			update_total()
-			my_atom.on_reagent_change()
+			if(my_atom)
+				my_atom.on_reagent_change()
 
 			// mix dem viruses
 			if(R.id == "blood" && reagent == "blood")
@@ -453,7 +461,8 @@ var/const/INGEST = 2
 			R.color = numlist2hex(list(R.data["r_color"], R.data["g_color"], R.data["b_color"]))
 
 		update_total()
-		my_atom.on_reagent_change()
+		if(my_atom)
+			my_atom.on_reagent_change()
 		if(!safety)
 			handle_reactions()
 		return 0
@@ -476,7 +485,8 @@ var/const/INGEST = 2
 			update_total()
 			if(!safety)//So it does not handle reactions when it need not to
 				handle_reactions()
-			my_atom.on_reagent_change()
+			if(my_atom)
+				my_atom.on_reagent_change()
 			return TRUE
 
 	return FALSE


### PR DESCRIPTION
## Описание изменений

Это определенно выглядит как заглушка, но у нас в билде есть немало случаев где вот такие "абстрактные" контейнеры для реагентов существуют, и юзаются, но у них нет своего атома.

Заодно пофиксил что швабра себя передаёт как пользователя когда кто-то ею утыкается об вещи.

## Почему и что этот ПР улучшит

Меньше рантаймов.

<!--
Опишите причину для изменений.
Этот пункт особенно важен для описания изменений баланса, новых механик.
-->

<!-- Опциональный пункт!
Если авторство не полностью ваше, вы делаете порт с другого билда - обязательно укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
-->

<!-- Опциональный пункт!
Если это что-то, о чём следует сообщить игрокам - опишите по форме (https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies#Changelog) свои изменения для игрового чеинжлога, они будут отображены на специальной страничке http://changelog.taucetistation.org

Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment
  
Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
