### PR TITLE
Ускорение генерации иконок личных дел

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -852,7 +852,7 @@ The _flatIcons list is a cache for generated icon files.
 
 var/global/list/humanoid_icon_cache = list()
 //For creating consistent icons for human looking simple animals
-/proc/get_flat_human_icon(icon_id,datum/job/J,datum/preferences/prefs)
+/proc/get_flat_human_icon(icon_id,datum/job/J,datum/preferences/prefs, showDirs = cardinal)
 	if(!icon_id || !humanoid_icon_cache[icon_id])
 		var/mob/living/carbon/human/dummy/body = new(null, prefs.species)
 
@@ -863,21 +863,10 @@ var/global/list/humanoid_icon_cache = list()
 
 		var/icon/out_icon = icon('icons/effects/effects.dmi', "nothing")
 
-		body.dir = NORTH
-		var/icon/partial = getFlatIcon(body)
-		out_icon.Insert(partial,dir=NORTH)
-
-		body.dir = SOUTH
-		partial = getFlatIcon(body)
-		out_icon.Insert(partial,dir=SOUTH)
-
-		body.dir = WEST
-		partial = getFlatIcon(body)
-		out_icon.Insert(partial,dir=WEST)
-
-		body.dir = EAST
-		partial = getFlatIcon(body)
-		out_icon.Insert(partial,dir=EAST)
+		for(var/D in showDirs)
+			body.dir = D
+			var/icon/partial = getFlatIcon(body)
+			out_icon.Insert(partial,dir=D)
 
 		qdel(body)
 

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -22,11 +22,11 @@
 	var/data = null
 
 /obj/effect/datacore/proc/manifest()
-	spawn()
-		for(var/mob/living/carbon/human/H in player_list)
-			manifest_inject(H)
+	set waitfor = FALSE
+	for(var/mob/living/carbon/human/H in player_list)
+		manifest_inject(H)
 
-			CHECK_TICK
+		CHECK_TICK
 
 /obj/effect/datacore/proc/manifest_modify(name, assignment)
 	if(PDA_Manifest.len)
@@ -54,8 +54,6 @@
 		foundrecord.fields["real_rank"] = real_title
 
 /obj/effect/datacore/proc/manifest_inject(mob/living/carbon/human/H)
-	set waitfor = FALSE
-	var/static/list/show_directions = list(SOUTH, WEST)
 	if(PDA_Manifest.len)
 		PDA_Manifest.Cut()
 
@@ -75,7 +73,7 @@
 
 		//General Record
 		//Creating photo
-		var/icon/ticon = get_id_photo(H, show_directions)
+		var/icon/ticon = get_id_photo(H, cardinal)
 		var/icon/photo_front = new(ticon, dir = SOUTH)
 		var/icon/photo_side = new(ticon, dir = WEST)
 		var/datum/data/record/G = new()
@@ -151,8 +149,7 @@
 		L.fields["citizenship"]	= H.citizenship
 		L.fields["faction"]		= H.personal_faction
 		L.fields["religion"]	= H.religion
-		L.fields["identity"]	= H.dna.UI // "
-		//L.fields["image"]		= getFlatIcon(H)	//This is god-awful
+		L.fields["identity"]	= H.dna.UI
 		L.fields["image"]		= ticon
 		locked += L
 

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -21,13 +21,12 @@
 	name = "text"
 	var/data = null
 
-/obj/effect/datacore/proc/manifest(nosleep = 0)
+/obj/effect/datacore/proc/manifest()
 	spawn()
-		if(!nosleep)
-			sleep(40)
 		for(var/mob/living/carbon/human/H in player_list)
 			manifest_inject(H)
-		return
+
+			CHECK_TICK
 
 /obj/effect/datacore/proc/manifest_modify(name, assignment)
 	if(PDA_Manifest.len)
@@ -55,6 +54,8 @@
 		foundrecord.fields["real_rank"] = real_title
 
 /obj/effect/datacore/proc/manifest_inject(mob/living/carbon/human/H)
+	set waitfor = FALSE
+	var/static/list/show_directions = list(SOUTH, WEST)
 	if(PDA_Manifest.len)
 		PDA_Manifest.Cut()
 
@@ -69,14 +70,14 @@
 		else
 			assignment = "Unassigned"
 
-		var/id = add_zero(num2hex(rand(1, 1.6777215E7)), 6)	//this was the best they could come up with? A large random number? *sigh*
+		var/static/record_id_num = 1001
+		var/id = num2hex(record_id_num++, 6)
 
 		//General Record
 		//Creating photo
-		var/icon/ticon = get_id_photo(H)
+		var/icon/ticon = get_id_photo(H, show_directions)
 		var/icon/photo_front = new(ticon, dir = SOUTH)
 		var/icon/photo_side = new(ticon, dir = WEST)
-		qdel(ticon)
 		var/datum/data/record/G = new()
 		G.fields["id"]			= id
 		G.fields["name"]		= H.real_name
@@ -152,17 +153,17 @@
 		L.fields["religion"]	= H.religion
 		L.fields["identity"]	= H.dna.UI // "
 		//L.fields["image"]		= getFlatIcon(H)	//This is god-awful
-		L.fields["image"]		= get_id_photo(H)
+		L.fields["image"]		= ticon
 		locked += L
 
 		score["crew_total"]++
 	return
 
 
-/proc/get_id_photo(mob/living/carbon/human/H)
+/proc/get_id_photo(mob/living/carbon/human/H, show_directions = list(SOUTH))
 	var/datum/job/J = SSjob.GetJob(H.mind.assigned_role)
 	var/datum/preferences/P = H.client.prefs
-	return get_flat_human_icon(null,J,P)
+	return get_flat_human_icon(null, J, P, show_directions)
 
 
 

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -187,6 +187,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 
 /obj/machinery/hologram/holopad/proc/move_hologram()
 	if(hologram)
+		step_to(hologram, master.eyeobj) // So it turns.
 		hologram.loc = get_turf(master.eyeobj)
 
 	return 1

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -187,7 +187,6 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 
 /obj/machinery/hologram/holopad/proc/move_hologram()
 	if(hologram)
-		step_to(hologram, master.eyeobj) // So it turns.
 		hologram.loc = get_turf(master.eyeobj)
 
 	return 1


### PR DESCRIPTION
## Описание изменений
Порт вот этого https://github.com/tgstation/tgstation/pull/36781
У нас сейчас при старте раунда для каждой куклы генерируется по 8 иконок для личных дел, этот пр снижает это количество до 4 плюс добавляет модный CHECK_TICK что наверно должно убрать начальный лаг совсем.

## Чеинжлог

:cl:
 - performance: Начальный лаг должен стать меньше из-за уменьшения количества операций с иконками для личных дел