### PR TITLE
Небольшое облегчение цели воксов на кражу ресурсов

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -873,31 +873,16 @@ var/global/list/all_objectives = list()
 	return FALSE
 
 /datum/objective/heist/salvage/choose_target()
-	switch(rand(1,4))
+	switch(rand(1, 3))
 		if(1)
 			target = "metal"
-			target_amount = 300
+			target_amount = pick(150, 200)
 		if(2)
 			target = "glass"
-			target_amount = 200
+			target_amount = pick(150, 200)
 		if(3)
 			target = "plasteel"
-			target_amount = 100
-		if(4)
-			target = "solid phoron"
-			target_amount = 100
-		if(5)
-			target = "silver"
-			target_amount = 50
-		if(6)
-			target = "gold"
-			target_amount = 20
-		if(7)
-			target = "uranium"
-			target_amount = 20
-		if(8)
-			target = "diamond"
-			target_amount = 1
+			target_amount = pick(20, 30, 40, 50)
 
 	explanation_text = "Ransack the station and escape with [target_amount] [target]."
 
@@ -975,7 +960,7 @@ var/heist_rob_total = 0
 		return TRUE
 	return FALSE
 
-#define MAX_VOX_KILLS 10 //Number of kills during the round before the Inviolate is broken.
+#define MAX_VOX_KILLS 13 //Number of kills during the round before the Inviolate is broken.
 						 //Would be nice to use vox-specific kills but is currently not feasible.
 var/global/vox_kills = 0 //Used to check the Inviolate.
 


### PR DESCRIPTION
## Описание изменений

* Количество смертей на станции во время этого режима увеличино до 13. Из за плохой системы учета убийств воксами экипажа и постоянного присутствия триторов во время любого режима, эта цифра могла превышаться без вины воксов. Конечно, такой буст на 3 убийства не даст воксам возможность убивать весь экипаж, но даст чуть чуть свободы действий.

* Цели воксов на ресурсы упрощены. Вместо 300 металла теперь требуется украсть 150 или 200. Со стеклом также. Пластали требуется либо 20, либо 30, либо 40, либо 50. Форон больше не требуется. Сделал так потому что ресурсы теперь будет немного сложнее искать после этого ПРа: https://github.com/TauCetiStation/TauCetiClassic/pull/3738. А такое количество форона и без этого ПРа невозможно было найти, если на станции нет живых шахтеров. Копать самому - ахуенный план , всегда мечтал режиме о копателях, прилетевших грабить руду астероида.

* Почистил лишние цели, которые сейчас не используются по причинам, описанным выше.

## Почему и что этот ПР улучшит

Немного облегчит получение гринтекста воксам. Особенно полезно после мержа моего ПРа с нерфом маскирующего скафандра воксов.

## Чеинжлог

:cl: Lizzzard
 - balance: Цели воксов на кражу ресурсов облегчены. Требуется меньше ресурсов, задача на кражу форона больше не может выпасть.