### PR TITLE
Доступ у VV закрыт + оповещение в АХ

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -425,7 +425,7 @@ body
 	if(usr.client != src || !holder)
 		return
 	if(href_list["Vars"])
-		if(!check_rights(R_DEBUG|R_VAREDIT))
+		if(!check_rights(R_DEBUG|R_VAREDIT|R_LOG))
 			return
 		debug_variables(locate(href_list["Vars"]))
 

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -123,6 +123,7 @@
 			if(!current_ticket)
 				to_chat(src, "<font color='red'>You can no longer reply to this ticket, please open another one by using the Adminhelp verb if need be.</font>")
 				to_chat(src, "<font color='blue'>Message: [msg]</font>")
+				return
 			else
 				var/replymsg = "<font color='red'>Reply PM from-<b>[key_name(src, recipient, 1)]</b>: <span class='emojify linkify'>[msg]</span></font>"
 				admin_ticket_log(src, replymsg)


### PR DESCRIPTION
<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений
- Были жалобы, что VV не открывался через PP. Пофикшено.
- Замечал, что после моего фикса с закрытым тикетом #3636, бот в дискоред все равно отписывал сообщение, которого должно не быть и звук тоже был.

## Почему и что этот ПР улучшит
Мелкие фиксы.

## Авторство
@KuzyXD 
<!-- Опциональный пункт!
Если авторство не полностью ваше, вы делаете порт с другого билда - обязательно укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
-->

## Чеинжлог

<!-- Опциональный пункт!
Если это что-то, о чём следует сообщить игрокам - опишите по форме (https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies#Changelog) свои изменения для игрового чеинжлога, они будут отображены на специальной страничке http://changelog.taucetistation.org

Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment
  
Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
