### PR TITLE
Fixes kit items for species for jobs that didn't get them.

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -407,10 +407,6 @@ var/datum/subsystem/job/SSjob
 		job.equip(H)
 		job.apply_fingerprints(H)
 
-		if(H.species)
-			H.species.after_job_equip(H, job)
-
-
 		for(var/thing in custom_equip_leftovers)
 			var/datum/gear/G = gear_datums[thing]
 			if(G.slot in custom_equip_slots)
@@ -484,20 +480,21 @@ var/datum/subsystem/job/SSjob
 			if("Clown")	//don't need bag preference stuff!
 			else
 				switch(H.backbag) //BS12 EDIT
-					if(1)
-						H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H), SLOT_R_HAND)
 					if(2)
 						var/obj/item/weapon/storage/backpack/BPK = new(H)
-						new /obj/item/weapon/storage/box/survival(BPK)
 						H.equip_to_slot_or_del(BPK, SLOT_BACK,1)
 					if(3)
 						var/obj/item/weapon/storage/backpack/satchel/norm/BPK = new(H)
-						new /obj/item/weapon/storage/box/survival(BPK)
 						H.equip_to_slot_or_del(BPK, SLOT_BACK,1)
 					if(4)
 						var/obj/item/weapon/storage/backpack/satchel/BPK = new(H)
-						new /obj/item/weapon/storage/box/survival(BPK)
 						H.equip_to_slot_or_del(BPK, SLOT_BACK,1)
+
+	/*
+	Placed here so the backpack that spawns if there is no job backpack has already spawned by now.
+	*/
+	if(H.species)
+		H.species.after_job_equip(H, job)
 
 	// Happy Valentines day!
 	if(Holiday == "Valentine's Day")

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -137,6 +137,12 @@
 	minimal_player_ingame_minutes = 480
 	restricted_species = list(TAJARAN)
 
+	survival_kit_items = list(/obj/item/ammo_casing/shotgun/beanbag,
+	                          /obj/item/ammo_casing/shotgun/beanbag,
+	                          /obj/item/ammo_casing/shotgun/beanbag,
+	                          /obj/item/ammo_casing/shotgun/beanbag
+	                          )
+
 /datum/job/bartender/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(!H)	return 0
 	switch(H.backbag)
@@ -153,18 +159,6 @@
 		return
 
 	H.equip_to_slot_or_del(new /obj/item/device/pda/bar(H), SLOT_BELT)
-	if(H.backbag == 1)
-		var/obj/item/weapon/storage/box/Barpack = new /obj/item/weapon/storage/box(H)
-		H.equip_to_slot_or_del(Barpack, SLOT_R_HAND)
-		new /obj/item/ammo_casing/shotgun/beanbag(Barpack)
-		new /obj/item/ammo_casing/shotgun/beanbag(Barpack)
-		new /obj/item/ammo_casing/shotgun/beanbag(Barpack)
-		new /obj/item/ammo_casing/shotgun/beanbag(Barpack)
-	else
-		H.equip_to_slot_or_del(new /obj/item/ammo_casing/shotgun/beanbag(H), SLOT_IN_BACKPACK)
-		H.equip_to_slot_or_del(new /obj/item/ammo_casing/shotgun/beanbag(H), SLOT_IN_BACKPACK)
-		H.equip_to_slot_or_del(new /obj/item/ammo_casing/shotgun/beanbag(H), SLOT_IN_BACKPACK)
-		H.equip_to_slot_or_del(new /obj/item/ammo_casing/shotgun/beanbag(H), SLOT_IN_BACKPACK)
 
 	return TRUE
 
@@ -256,10 +250,6 @@
 		return
 
 	H.equip_to_slot_or_del(new /obj/item/device/pda/janitor(H), SLOT_BELT)
-	if(H.backbag == 1)
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H), SLOT_R_HAND)
-	else
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H.back), SLOT_IN_BACKPACK)
 
 	return TRUE
 

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -210,7 +210,6 @@
 	if(!H)	return 0
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(H), SLOT_SHOES)
 	switch(H.backbag)
-		if(1) H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H), SLOT_R_HAND)
 		if(2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/backpack_hyd(H), SLOT_BACK)
 		if(3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel/hyd(H), SLOT_BACK)
 		if(4) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), SLOT_BACK)

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -19,6 +19,10 @@
 	minimal_player_ingame_minutes = 2400
 	restricted_species = list(UNATHI, TAJARAN, DIONA, IPC)
 
+	survival_kit_items = list(/obj/item/weapon/tank/emergency_oxygen/engi)
+
+	prevent_survival_kit_items = list(/obj/item/weapon/tank/emergency_oxygen)
+
 /datum/job/chief_engineer/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(!H)	return 0
 	switch(H.backbag)
@@ -56,6 +60,10 @@
 	minimal_player_ingame_minutes = 540
 	restricted_species = list(IPC)
 
+	survival_kit_items = list(/obj/item/weapon/tank/emergency_oxygen/engi)
+
+	prevent_survival_kit_items = list(/obj/item/weapon/tank/emergency_oxygen)
+
 /datum/job/engineer/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(!H)	return 0
 	switch(H.backbag)
@@ -92,6 +100,10 @@
 	access = list(access_atmospherics, access_maint_tunnels, access_emergency_storage, access_construction, access_external_airlocks, access_engineering_lobby)
 	minimal_player_age = 3
 	minimal_player_ingame_minutes = 600
+
+	survival_kit_items = list(/obj/item/weapon/tank/emergency_oxygen/engi)
+
+	prevent_survival_kit_items = list(/obj/item/weapon/tank/emergency_oxygen)
 
 /datum/job/atmos/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(!H)	return 0

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -47,6 +47,10 @@
 
 	var/list/restricted_species = list()
 
+	var/list/survival_kit_items = list()
+
+	var/list/prevent_survival_kit_items = list()
+
 /datum/job/proc/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	return TRUE
 

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -121,16 +121,19 @@
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/fr_jacket(H), SLOT_WEAR_SUIT)
 	H.equip_to_slot_or_del(new /obj/item/weapon/storage/firstaid/adv(H), SLOT_L_HAND)
 
+	switch(H.backbag)
+		if(2)
+			H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/medic(H), SLOT_BACK)
+		if(3)
+			H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel/med(H), SLOT_BACK)
+		if(4)
+			H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), SLOT_BACK)
+
 	if(visualsOnly)
 		return
 
 	H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_med(H), SLOT_L_EAR)
 	H.equip_to_slot_or_del(new /obj/item/device/pda/medical(H), SLOT_BELT)
-	switch(H.backbag)
-		if(1) H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H), SLOT_R_HAND)
-		if(2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/medic(H), SLOT_BACK)
-		if(3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel/med(H), SLOT_BACK)
-		if(4) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), SLOT_BACK)
 
 	return TRUE
 
@@ -152,20 +155,24 @@
 
 /datum/job/chemist/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(!H)	return 0
+
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/chemist(H), SLOT_W_UNIFORM)
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/white(H), SLOT_SHOES)
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/labcoat/chemist(H), SLOT_WEAR_SUIT)
+
+	switch(H.backbag)
+		if(2)
+			H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/backpack_chem(H), SLOT_BACK)
+		if(3)
+			H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel/chem(H), SLOT_BACK)
+		if(4)
+			H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), SLOT_BACK)
 
 	if(visualsOnly)
 		return
 
 	H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_med(H), SLOT_L_EAR)
 	H.equip_to_slot_or_del(new /obj/item/device/pda/chemist(H), SLOT_BELT)
-	switch(H.backbag)
-		if(1) H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H), SLOT_R_HAND)
-		if(2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/backpack_chem(H), SLOT_BACK)
-		if(3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel/chem(H), SLOT_BACK)
-		if(4) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), SLOT_BACK)
 
 	return TRUE
 
@@ -191,16 +198,19 @@
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/labcoat/genetics(H), SLOT_WEAR_SUIT)
 	H.equip_to_slot_or_del(new /obj/item/device/flashlight/pen(H), SLOT_S_STORE)
 
+	switch(H.backbag)
+		if(2)
+			H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/backpack_gen(H), SLOT_BACK)
+		if(3)
+			H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel/gen(H), SLOT_BACK)
+		if(4)
+			H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), SLOT_BACK)
+
 	if(visualsOnly)
 		return
 
 	H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_medsci(H), SLOT_L_EAR)
 	H.equip_to_slot_or_del(new /obj/item/device/pda/geneticist(H), SLOT_BELT)
-	switch(H.backbag)
-		if(1) H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H), SLOT_R_HAND)
-		if(2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/backpack_gen(H), SLOT_BACK)
-		if(3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel/gen(H), SLOT_BACK)
-		if(4) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), SLOT_BACK)
 
 	return TRUE
 
@@ -222,21 +232,26 @@
 
 /datum/job/virologist/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(!H)	return 0
+
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/virologist(H), SLOT_W_UNIFORM)
 	H.equip_to_slot_or_del(new /obj/item/clothing/mask/surgical(H), SLOT_WEAR_MASK)
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/white(H), SLOT_SHOES)
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/labcoat/virologist(H), SLOT_WEAR_SUIT)
 	H.equip_to_slot_or_del(new /obj/item/device/flashlight/pen(H), SLOT_S_STORE)
 
+	switch(H.backbag)
+		if(2)
+			H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/backpack_vir(H), SLOT_BACK)
+		if(3)
+			H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel/vir(H), SLOT_BACK)
+		if(4)
+			H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), SLOT_BACK)
+
 	if(visualsOnly)
 		return
 
 	H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_med(H), SLOT_L_EAR)
 	H.equip_to_slot_or_del(new /obj/item/device/pda/viro(H), SLOT_BELT)
-	switch(H.backbag)
-		if(2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/backpack_vir(H), SLOT_BACK)
-		if(3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel/vir(H), SLOT_BACK)
-		if(4) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), SLOT_BACK)
 
 	return TRUE
 

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -21,20 +21,24 @@
 
 /datum/job/rd/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(!H)	return 0
+
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/brown(H), SLOT_SHOES)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/research_director(H), SLOT_W_UNIFORM)
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/labcoat(H), SLOT_WEAR_SUIT)
+
+	switch(H.backbag)
+		if(2)
+			H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/backpack_tox(H), SLOT_BACK)
+		if(3)
+			H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel/tox(H), SLOT_BACK)
+		if(4)
+			H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), SLOT_BACK)
 
 	if(visualsOnly)
 		return
 
 	H.equip_to_slot_or_del(new /obj/item/device/radio/headset/heads/rd(H), SLOT_L_EAR)
 	H.equip_to_slot_or_del(new /obj/item/device/pda/heads/rd(H), SLOT_BELT)
-	switch(H.backbag)
-		if(1) H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H), SLOT_R_HAND)
-		if(2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/backpack_tox(H), SLOT_BACK)
-		if(3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel/tox(H), SLOT_BACK)
-		if(4) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), SLOT_BACK)
 
 	return TRUE
 
@@ -60,6 +64,14 @@
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/white(H), SLOT_SHOES)
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/labcoat/science(H), SLOT_WEAR_SUIT)
 
+	switch(H.backbag)
+		if(2)
+			H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/backpack_tox(H), SLOT_BACK)
+		if(3)
+			H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel/tox(H), SLOT_BACK)
+		if(4)
+			H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), SLOT_BACK)
+
 	if(visualsOnly)
 		return
 
@@ -70,12 +82,6 @@
 			access = list(access_tox, access_research)
 		if("Phoron Researcher")
 			access = list(access_research, access_tox_storage)
-
-	switch(H.backbag)
-		if(1) H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H), SLOT_R_HAND)
-		if(2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/backpack_tox(H), SLOT_BACK)
-		if(3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel/tox(H), SLOT_BACK)
-		if(4) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), SLOT_BACK)
 
 	return TRUE
 
@@ -98,17 +104,19 @@
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/white(H), SLOT_SHOES)
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/labcoat/science(H), SLOT_WEAR_SUIT)
 
+	switch(H.backbag)
+		if(2)
+			H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/backpack_tox(H), SLOT_BACK)
+		if(3)
+			H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel/tox(H), SLOT_BACK)
+		if(4)
+			H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), SLOT_BACK)
+
 	if(visualsOnly)
 		return
 
 	H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_sci(H), SLOT_L_EAR)
 	H.equip_to_slot_or_del(new /obj/item/device/pda/science(H), SLOT_BELT)
-
-	switch(H.backbag)
-		if(1) H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H), SLOT_R_HAND)
-		if(2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/backpack_tox(H), SLOT_BACK)
-		if(3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel/tox(H), SLOT_BACK)
-		if(4) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), SLOT_BACK)
 
 	return TRUE
 
@@ -131,16 +139,19 @@
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/white(H), SLOT_SHOES)
 	H.equip_to_slot_or_del(new /obj/item/clothing/suit/storage/labcoat/science(H), SLOT_WEAR_SUIT)
 
+	switch(H.backbag)
+		if(2)
+			H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/backpack_tox(H), SLOT_BACK)
+		if(3)
+			H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel/tox(H), SLOT_BACK)
+		if(4)
+			H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), SLOT_BACK)
+
 	if(visualsOnly)
 		return
 
 	H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_sci(H), SLOT_L_EAR)
 	H.equip_to_slot_or_del(new /obj/item/device/pda/science(H), SLOT_BELT)
-	switch(H.backbag)
-		if(1) H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H), SLOT_R_HAND)
-		if(2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/backpack_tox(H), SLOT_BACK)
-		if(3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel/tox(H), SLOT_BACK)
-		if(4) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), SLOT_BACK)
 
 	return TRUE
 
@@ -196,10 +207,12 @@
 	if(!H)
 		return 0
 	switch(H.backbag)
-		if(1) H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H), SLOT_R_HAND)
-		if(2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/backpack_tox(H), SLOT_BACK)
-		if(3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel/tox(H), SLOT_BACK)
-		if(4) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), SLOT_BACK)
+		if(2)
+			H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/backpack_tox(H), SLOT_BACK)
+		if(3)
+			H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel/tox(H), SLOT_BACK)
+		if(4)
+			H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), SLOT_BACK)
 	H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/scientist_new(H), SLOT_W_UNIFORM)
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/white(H), SLOT_SHOES)
 

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -42,31 +42,7 @@
 //Survival boxes, given by NanoTrasen
 /obj/item/weapon/storage/box/survival
 	name = "emergency box"
-	desc = "It's a box, issued to every employee of NanoTrasen, contains a mask and a spare air tank. It has a ton of ads all over its back."
-
-/obj/item/weapon/storage/box/survival/atom_init()
-	. = ..()
-	new /obj/item/clothing/mask/breath(src)
-	new /obj/item/weapon/tank/emergency_oxygen(src)
-	new /obj/item/weapon/reagent_containers/hypospray/autoinjector(src)
-
-/obj/item/weapon/storage/box/diona_survival
-	name = "emergency box"
-	desc = "It's a box, issued to every diona working for NanoTrasen, contains a flare and a plant analyzer. It has a ton of ads all over its back."
-
-/obj/item/weapon/storage/box/diona_survival/atom_init()
-	. = ..()
-	new /obj/item/device/flashlight/flare(src)
-	new /obj/item/device/plant_analyzer(src)
-
-/obj/item/weapon/storage/box/ipc_survival
-	name = "emergency box"
-	desc = "It's a box, issued to every IPC working for NanoTrasen, contains a flare and a plant analyzer. It has a ton of ads all over its back."
-
-/obj/item/weapon/storage/box/ipc_survival/atom_init()
-	. = ..()
-	new /obj/item/weapon/stock_parts/cell/crap(src)
-	new /obj/item/device/robotanalyzer(src)
+	desc = "It's a box, issued to every employee of NanoTrasen, contains essential items for employee's survival incase of an emergency. It has a ton of ads all over its back."
 
 //Engineer
 /obj/item/weapon/storage/box/engineer

--- a/code/game/objects/random/random_misc.dm
+++ b/code/game/objects/random/random_misc.dm
@@ -27,7 +27,6 @@
 						prob(10);/obj/item/weapon/storage/box/lights,\
 						prob(10);/obj/item/weapon/storage/box/lights/tubes,\
 						prob(10);/obj/item/weapon/storage/box/lights/mixed,\
-						prob(40);/obj/item/weapon/storage/box/survival,\
 						prob(10);/obj/item/weapon/storage/box/engineer,\
 						prob(10);/obj/item/weapon/storage/box/gloves,\
 						prob(60);/obj/item/weapon/storage/box/mousetraps,\

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -1774,7 +1774,6 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 			M.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/mime(M), SLOT_WEAR_MASK)
 			M.equip_to_slot_or_del(new /obj/item/clothing/head/beret/red(M), SLOT_HEAD)
 			M.equip_to_slot_or_del(new /obj/item/clothing/suit/suspenders(M), SLOT_WEAR_SUIT)
-			M.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(M.back), SLOT_IN_BACKPACK)
 			M.equip_to_slot_or_del(new /obj/item/toy/crayon/mime(M), SLOT_IN_BACKPACK)
 			M.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/food/drinks/bottle/bottleofnothing(M), SLOT_IN_BACKPACK)
 
@@ -1794,7 +1793,6 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		if("clown")
 			M.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/clown(M), SLOT_BACK)
 			M.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(M.back), SLOT_IN_BACKPACK)
-			M.equip_to_slot_or_del(new /obj/item/clothing/under/rank/clown(M), SLOT_W_UNIFORM)
 			M.equip_to_slot_or_del(new /obj/item/clothing/shoes/clown_shoes(M), SLOT_SHOES)
 			M.equip_to_slot_or_del(new /obj/item/device/pda/clown(M), SLOT_BELT)
 			M.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/clown_hat(M), SLOT_WEAR_MASK)

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -116,6 +116,13 @@
 
 	var/has_gendered_icons = TRUE // if TRUE = use icon_state with _f or _m for respective gender (see get_icon() external organ proc).
 
+	var/list/survival_kit_items = list(/obj/item/clothing/mask/breath,
+	                                   /obj/item/weapon/tank/emergency_oxygen,
+	                                   /obj/item/weapon/reagent_containers/hypospray/autoinjector
+	                                   )
+
+	var/list/prevent_survival_kit_items = list()
+
 /datum/species/New()
 	blood_datum = new blood_datum_path
 	unarmed = new unarmed_type()
@@ -170,11 +177,24 @@
 	return
 
 /datum/species/proc/after_job_equip(mob/living/carbon/human/H, datum/job/J)
-	var/obj/item/weapon/storage/box/SK
-	if(J.title in list("Shaft Miner", "Chief Engineer", "Station Engineer", "Atmospheric Technician"))
-		SK = new /obj/item/weapon/storage/box/engineer(H)
-	else
-		SK = new /obj/item/weapon/storage/box/survival(H)
+	var/obj/item/weapon/storage/box/survival/SK = new(H)
+
+	species_survival_kit_items:
+		for(var/type in survival_kit_items)
+			/*
+			is_type_in_list only work on instantinated objects.
+			*/
+			for(var/type_to_check in J.prevent_survival_kit_items) // So engineers don't spawn with two oxy tanks.
+				if(ispath(type, type_to_check))
+					continue species_survival_kit_items
+			new type(SK)
+
+	job_survival_kit_items:
+		for(var/type in J.survival_kit_items)
+			for(var/type_to_check in prevent_survival_kit_items) // So IPCs don't spawn with oxy tanks from engi kits
+				if(ispath(type, type_to_check))
+					continue job_survival_kit_items
+			new type(SK)
 
 	if(H.backbag == 1)
 		H.equip_to_slot_or_del(SK, SLOT_R_HAND)
@@ -516,6 +536,12 @@
 
 	has_gendered_icons = FALSE
 
+	survival_kit_items = list(/obj/item/device/flashlight/flare,
+	                          /obj/item/device/plant_analyzer
+	                          )
+
+	prevent_survival_kit_items = list(/obj/item/weapon/tank/emergency_oxygen) // So they don't get the big engi oxy tank, since they need no tank.
+
 /datum/species/diona/handle_post_spawn(mob/living/carbon/human/H)
 	H.gender = NEUTER
 
@@ -540,12 +566,6 @@
 		H.adjustBruteLoss(-(light_amount))
 		H.adjustToxLoss(-(light_amount))
 		H.adjustOxyLoss(-(light_amount))
-
-/datum/species/diona/after_job_equip(mob/living/carbon/human/H, datum/job/J)
-	if(H.backbag == 1)
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/diona_survival(H), SLOT_R_HAND)
-	else
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/diona_survival(H), SLOT_IN_BACKPACK)
 
 /datum/species/diona/call_digest_proc(mob/living/M, datum/reagent/R)
 	return R.on_diona_digest(M)
@@ -631,11 +651,11 @@
 	blood_datum_path = /datum/dirt_cover/oil
 	flesh_color = "#575757"
 
-/datum/species/machine/after_job_equip(mob/living/carbon/human/H, datum/job/J)
-	if(H.backbag == 1)
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/ipc_survival(H), SLOT_R_HAND)
-	else
-		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/ipc_survival(H), SLOT_IN_BACKPACK)
+	survival_kit_items = list(/obj/item/weapon/stock_parts/cell/crap,
+	                          /obj/item/device/robotanalyzer
+	                          )
+
+	prevent_survival_kit_items = list(/obj/item/weapon/tank/emergency_oxygen) // So they don't get the big engi oxy tank, since they need no tank.
 
 /datum/species/abductor
 	name = ABDUCTOR


### PR DESCRIPTION
<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений


СПУ и Дионы на всех профах будут получать свой обязательный набор по спасению.

<!--
Опишите изменения данного ПР-а.
Если есть связные ишью (issues), или другие ПРы - укажите их тут, для автоматического закрытия ишью следует использовать ключевые слова https://help.github.com/en/articles/closing-issues-using-keywords
Если есть связное форумное обсуждение на тему изменений - укажите ссылку на эту тему.
-->

## Почему и что этот ПР улучшит

Диона/СПУ бармен, КМ, каргониец, все сорта врачей не получал нужного набора, а теперь будут.

<!--
Опишите причину для изменений.
Этот пункт особенно важен для описания изменений баланса, новых механик.
-->

## Чеинжлог

<!-- Опциональный пункт!
Если это что-то, о чём следует сообщить игрокам - опишите по форме (https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies#Changelog) свои изменения для игрового чеинжлога, они будут отображены на специальной страничке http://changelog.taucetistation.org

Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment
  
Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->

:cl: Luduk
- bugfix: СПУ и Диона получают корректные предметы в "спасательном наборе" на всех профессиях.