### PR TITLE
If client connection interupts, they can still type.

### DIFF
--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -9,7 +9,7 @@
 		typing_indicator.layer = MOB_LAYER + 1
 
 	if(typing_indicator.icon_state != indi_icon)
-		if(typing)
+		if(typing && state)
 			overlays.Remove(typing_indicator)
 		typing_indicator.icon_state = indi_icon
 
@@ -26,9 +26,6 @@
 /mob/verb/say_wrapper()
 	set name = ".Say"
 	set hidden = TRUE
-
-	if(typing)
-		return
 
 	set_typing_indicator(TRUE)
 	var/message = input("","say (text)") as text|null


### PR DESCRIPTION
<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений

Если клиент отключался во время того как писал по каким-либо причинам, он больше не мог писать. Теперь сможет.

<!--
Опишите изменения данного ПР-а.
Если есть связные ишью (issues), или другие ПРы - укажите их тут, для автоматического закрытия ишью следует использовать ключевые слова https://help.github.com/en/articles/closing-issues-using-keywords
Если есть связное форумное обсуждение на тему изменений - укажите ссылку на эту тему.
-->

## Почему и что этот ПР улучшит

Внезапные скачки пинга не делают людей немыми.

## Чеинжлог

<!-- Опциональный пункт!
Если это что-то, о чём следует сообщить игрокам - опишите по форме (https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies#Changelog) свои изменения для игрового чеинжлога, они будут отображены на специальной страничке http://changelog.taucetistation.org

Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment
  
Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->

:cl: Luduk
- bugfix: Внезапные скачки пинга с отключением не делают куклу немой.
