### PR TITLE
Возможность разобрать взорванный АПЦ, спаси и сохрани

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -603,6 +603,15 @@
 				opened = 1
 			update_icon()
 
+	else if(!opened && wiresexposed && is_wire_tool(W))
+		return wires.interact(user)
+		if (istype(user, /mob/living/silicon))
+			return attack_hand(user)
+		user.SetNextMove(CLICK_CD_MELEE)
+		user.visible_message("<span class='warning'>The [src.name] has been hit with the [W.name] by [user.name]!</span>", \
+			"<span class='warning'>You hit the [src.name] with your [W.name]!</span>", \
+			"You hear bang")
+
 // attack with hand - remove cell (if cover open) or interact with the APC
 
 /obj/machinery/power/apc/interact(mob/user)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -407,13 +407,35 @@
 		else if (opened!=2) //cover isn't removed
 			opened = 0
 			update_icon()
-	else if (iscrowbar(W) && !((stat & BROKEN) || malfhack) )
+
+	else if (iscrowbar(W) && !((stat & BROKEN) || malfhack))
 		if(coverlocked && !(stat & MAINT))
 			to_chat(user, "<span class='warning'>The cover is locked and cannot be opened.</span>")
 			return
 		else
 			opened = 1
 			update_icon()
+
+	else if (iscrowbar(W) && !opened && (stat & BROKEN))
+		user.visible_message("<span class='warning'>[user.name] try open [src.name] cover.</span>", "<span class='notice'>You try open [src.name] cover.</span>")
+		if(W.use_tool(src, user, 25, volume = 25))
+			opened = 1
+			locked = 0
+			update_icon()
+			if(cell)
+				to_chat(user, "<span class='notice'>Power cell from [src.name] is dropped</span>")
+				cell.loc = user.loc
+				cell = null
+
+	else if (iswrench(W) && opened && (stat & BROKEN))
+		if(coverlocked)
+			to_chat(user, "<span class='notice'> Remove security APC bolts.</span>")
+			if(W.use_tool(src, user, 5, volume = 5))
+				coverlocked = 0
+				update_icon()
+		else
+			to_chat(user, "<span class='warning'> APC bolts alredy removed.</span>")
+
 	else if	(istype(W, /obj/item/weapon/stock_parts/cell) && opened)	// trying to put a cell inside
 		if(cell)
 			to_chat(user, "There is a power cell already installed.")
@@ -430,6 +452,7 @@
 				"You insert the power cell.")
 			chargecount = 0
 			update_icon()
+
 	else if	(isscrewdriver(W))	// haxing
 		if(opened)
 			if (cell)
@@ -450,6 +473,7 @@
 					to_chat(user, "<span class='warning'>There is nothing to secure.</span>")
 					return
 				update_icon()
+
 		else if(emagged)
 			to_chat(user, "The interface is broken.")
 		else
@@ -473,6 +497,7 @@
 				update_icon()
 			else
 				to_chat(user, "<span class='warning'>Access denied.</span>")
+
 	else if (istype(W, /obj/item/weapon/card/emag) && !(emagged || malfhack))		// trying to unlock with an emag card
 		if(opened)
 			to_chat(user, "You must close the cover to swipe an ID card.")
@@ -492,6 +517,7 @@
 					update_icon()
 				else
 					to_chat(user, "You fail to [ locked ? "unlock" : "lock"] the APC interface.")
+
 	else if (iscoil(W) && !terminal && opened && has_electronics != 2)
 		if (src.loc:intact)
 			to_chat(user, "<span class='warning'>You must remove the floor plating in front of the APC first.</span>")

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -412,8 +412,8 @@
 		if (stat & BROKEN)
 			user.visible_message("<span class='warning'>[user.name] try open [src.name] cover.</span>", "<span class='notice'>You try open [src.name] cover.</span>")
 			if(W.use_tool(src, user, 25, volume = 25))
-				opened = 1
-				locked = 0
+				opened = TRUE
+				locked = FALSE
 				update_icon()
 				if(cell)
 					to_chat(user, "<span class='notice'>Power cell from [src.name] is dropped</span>")
@@ -425,17 +425,17 @@
 				to_chat(user, "<span class='warning'>The cover is locked and cannot be opened.</span>")
 				return
 			else
-				opened = 1
+				opened = TRUE
 				update_icon()
 
 	else if (iswrench(W) && opened && (stat & BROKEN))
 		if(coverlocked)
 			to_chat(user, "<span class='notice'>Remove security APC bolts.</span>")
 			if(W.use_tool(src, user, 5, volume = 5))
-				coverlocked = 0
+				coverlocked = FALSE
 				update_icon()
 		else
-			to_chat(user, "<span class='warning'> APC bolts alredy removed.</span>")
+			to_chat(user, "<span class='warning'>APC bolts alredy removed.</span>")
 
 	else if	(istype(W, /obj/item/weapon/stock_parts/cell) && opened)	// trying to put a cell inside
 		if(cell)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -258,6 +258,11 @@
 	if(update & 1) // Updating the icon state
 		if(update_state & UPSTATE_ALLGOOD)
 			icon_state = "apc0"
+		else if(update_state & UPSTATE_BROKE)
+			if(update_state & UPSTATE_OPENED1)
+				icon_state = "apc1-b-nocover"
+			else
+				icon_state = "apc-b"
 		else if(update_state & (UPSTATE_OPENED1|UPSTATE_OPENED2))
 			var/basestate = "apc[ cell ? "2" : "1" ]"
 			if(update_state & UPSTATE_OPENED1)
@@ -265,10 +270,6 @@
 					icon_state = "apcmaint" //disabled APC cannot hold cell
 				else
 					icon_state = basestate
-			else if(update_state & UPSTATE_OPENED2)
-				icon_state = "[basestate]-nocover"
-		else if(update_state & UPSTATE_BROKE)
-			icon_state = "apc-b"
 		else if(update_state & UPSTATE_BLUESCREEN)
 			icon_state = "apcemag"
 		else if(update_state & UPSTATE_WIREEXP)
@@ -313,8 +314,6 @@
 	if(opened)
 		if(opened==1)
 			update_state |= UPSTATE_OPENED1
-		if(opened==2)
-			update_state |= UPSTATE_OPENED2
 	else if(emagged || malfai)
 		update_state |= UPSTATE_BLUESCREEN
 	else if(wiresexposed)
@@ -414,11 +413,11 @@
 			if(W.use_tool(src, user, 25, volume = 25))
 				opened = TRUE
 				locked = FALSE
-				update_icon()
 				if(cell)
 					to_chat(user, "<span class='notice'>Power cell from [src.name] is dropped</span>")
 					cell.forceMove(user.loc)
 					cell = null
+				update_icon()
 
 		else if (!(stat & BROKEN) || !malfhack)
 			if(coverlocked && !(stat & MAINT))
@@ -477,7 +476,7 @@
 
 		else if(emagged)
 			to_chat(user, "The interface is broken.")
-		else
+		else if(!(stat & BROKEN))
 			wiresexposed = !wiresexposed
 			to_chat(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"]")
 			update_icon()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -430,7 +430,7 @@
 
 	else if (iswrench(W) && opened && (stat & BROKEN))
 		if(coverlocked)
-			to_chat(user, "<span class='notice'> Remove security APC bolts.</span>")
+			to_chat(user, "<span class='notice'>Remove security APC bolts.</span>")
 			if(W.use_tool(src, user, 5, volume = 5))
 				coverlocked = 0
 				update_icon()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -408,24 +408,25 @@
 			opened = 0
 			update_icon()
 
-	else if (iscrowbar(W) && !((stat & BROKEN) || malfhack))
-		if(coverlocked && !(stat & MAINT))
-			to_chat(user, "<span class='warning'>The cover is locked and cannot be opened.</span>")
-			return
-		else
-			opened = 1
-			update_icon()
+	else if(iscrowbar(W) && !opened)
+		if (stat & BROKEN)
+			user.visible_message("<span class='warning'>[user.name] try open [src.name] cover.</span>", "<span class='notice'>You try open [src.name] cover.</span>")
+			if(W.use_tool(src, user, 25, volume = 25))
+				opened = 1
+				locked = 0
+				update_icon()
+				if(cell)
+					to_chat(user, "<span class='notice'>Power cell from [src.name] is dropped</span>")
+					cell.forceMove(user.loc)
+					cell = null
 
-	else if (iscrowbar(W) && !opened && (stat & BROKEN))
-		user.visible_message("<span class='warning'>[user.name] try open [src.name] cover.</span>", "<span class='notice'>You try open [src.name] cover.</span>")
-		if(W.use_tool(src, user, 25, volume = 25))
-			opened = 1
-			locked = 0
-			update_icon()
-			if(cell)
-				to_chat(user, "<span class='notice'>Power cell from [src.name] is dropped</span>")
-				cell.loc = user.loc
-				cell = null
+		else if (!(stat & BROKEN) || !malfhack)
+			if(coverlocked && !(stat & MAINT))
+				to_chat(user, "<span class='warning'>The cover is locked and cannot be opened.</span>")
+				return
+			else
+				opened = 1
+				update_icon()
 
 	else if (iswrench(W) && opened && (stat & BROKEN))
 		if(coverlocked)
@@ -602,26 +603,6 @@
 			if (opened==2)
 				opened = 1
 			update_icon()
-	else
-		if (((stat & BROKEN) || malfhack) \
-				&& !opened \
-				&& W.force >= 5 \
-				&& W.w_class >= ITEM_SIZE_NORMAL \
-				&& prob(20) )
-			opened = 2
-			user.visible_message("<span class='warning'>The APC cover was knocked down with the [W.name] by [user.name]!</span>", \
-				"<span class='warning'>You knock down the APC cover with your [W.name]!</span>", \
-				"You hear bang")
-			update_icon()
-		else
-			if (!opened && wiresexposed && is_wire_tool(W))
-				return wires.interact(user)
-			if (istype(user, /mob/living/silicon))
-				return attack_hand(user)
-			user.SetNextMove(CLICK_CD_MELEE)
-			user.visible_message("<span class='warning'>The [src.name] has been hit with the [W.name] by [user.name]!</span>", \
-				"<span class='warning'>You hit the [src.name] with your [W.name]!</span>", \
-				"You hear bang")
 
 // attack with hand - remove cell (if cover open) or interact with the APC
 


### PR DESCRIPTION
## Описание изменений

Спустя кучу времени и разных жалоб на то, что взорванный АПЦ нельзя было разобрать, решил выкатить небольшой фикс, победив свою лень

## Почему и что этот ПР улучшит

Избавить админ.состав от ручного удаления АПЦ и сделает это возможным для инженеров

Небольшая инструкция как это делать:

- Ломом выдираем крышку взорванного АПЦ
- Гаечным ключом снимаем болты, что крепят схему
- Отверткой откручиваем дополнительные болты
- Вынимаем ломом поврежденную схему
- Разбираем терминал кусачками от АПЦ, если таковой уцелел
- Развариваем рамку АПЦ
- О боже, оно разобралось

fix #3714 
fix #1831
fix #275 

## Авторство

Miracler

## Чеинжлог

:cl: Miracler

- bugfix[link]: Взорванный АПЦ нельзя было разобрать
