### PR TITLE
Baldness allowed to diona, unathi and female humans

### DIFF
--- a/code/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories.dm
@@ -46,7 +46,7 @@
 /datum/sprite_accessory/hair/bald
 	name = "Bald"
 	icon_state = "bald"
-	gender = MALE
+	species_allowed = list(HUMAN , UNATHI , DIONA)
 
 /datum/sprite_accessory/hair/short
 	name = "Short Hair"	  // try to capatilize the names please~


### PR DESCRIPTION
С дионами и унатхами все в целом понятно, это можно считать багфиксом. Разрешение лысости женщинам - вполне логичный шаг, учитывая, что женщины у нас могут работать в охране, могут работать мусорщиками, ну и бриться налысо - право каждого, запрещать обычные прически - фашизм.
:cl:
 - tweak: Унатхи и дионы теперь могут выбрать отсутствие волос при создании персонажа
