### PR TITLE
Прицеливание на альт-клик

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -82,6 +82,19 @@
 	else
 		Fire(A,user,params) //Otherwise, fire normally.
 
+/mob/living/carbon/AltClickOn(atom/A)
+	if(isliving(A))
+		var/mob/living/M = A
+		var/obj/item/I = get_active_hand()
+		if(istype(I, /obj/item/weapon/gun))
+			var/obj/item/weapon/gun/G = I
+			if(M in G.target)
+				M.NotTargeted(G)
+			else
+				G.PreFire(M, src)
+			return
+	..()
+
 /obj/item/weapon/gun/proc/Fire(atom/target, mob/living/user, params, reflex = 0, point_blank = FALSE)//TODO: go over this
 	//Exclude lasertag guns from the CLUMSY check.
 	if(!user.IsAdvancedToolUser())

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -83,16 +83,19 @@
 		Fire(A,user,params) //Otherwise, fire normally.
 
 /mob/living/carbon/AltClickOn(atom/A)
-	if(isliving(A))
-		var/mob/living/M = A
-		var/obj/item/I = get_active_hand()
-		if(istype(I, /obj/item/weapon/gun))
-			var/obj/item/weapon/gun/G = I
-			if(M in G.target)
-				M.NotTargeted(G)
-			else
-				G.PreFire(M, src)
-			return
+	var/obj/item/I = get_active_hand()
+	if(istype(I, /obj/item/weapon/gun))
+		var/obj/item/weapon/gun/G = I
+		if(src.client.gun_mode)
+			G.Fire(A, src)
+		else
+			if(isliving(A))
+				var/mob/living/M = A
+				if(M in G.target)
+					M.NotTargeted(G)
+				else
+					G.PreFire(M, src)
+				return
 	..()
 
 /obj/item/weapon/gun/proc/Fire(atom/target, mob/living/user, params, reflex = 0, point_blank = FALSE)//TODO: go over this


### PR DESCRIPTION
Порт моего ПРа с гаммы с маленьким дополнением
Теперь при обычном режиме стрельбы альт-клик берет человека на прицел. Если изменить режим стрельбы - функции меняются местами, и теперь на ЛКМ берешь на прицел, а альт-клик стреляет (второй вариант для боевых ситуаций подходит слабо, ибо альт-клик при ходьбе начинает трогать кнопки интерфейса самого окна эсески, короче юзайте первый во время беготни)

:cl:
 - tweak: Добавлена возможность взять на прицел с помощью альт-клика. Изменение режима стрельбы теперь меняет функции местами.
