### PR TITLE
Апдейт юнит тестов

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,26 +3,45 @@ sudo: false
 
 env:
   global:
-    - BYOND_MAJOR="512"
-    - BYOND_MINOR="1463"
+    - BYOND_MAJOR=512
+    - BYOND_MINOR=1463
 
 cache:
   directories:
     - $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}
 
-addons:
-  apt:
-    packages:
-      - libc6-i386
-      - libgcc1:i386
-      - libstdc++6:i386
-      - python3.5
-
-before_script:
+before_install:
   - chmod +x -R scripts/
   - chmod +x test/run-test.sh
-  - ./scripts/install-byond.sh
-  - source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
 
 script:
   - test/run-test.sh
+
+matrix:
+  include:
+    - name: "Unit Tests"
+      env: TEST=UNIT
+      install:
+        - ./scripts/install-byond.sh
+        - source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
+      addons:
+        apt:
+          packages:
+            - libstdc++6:i386
+
+    - name: "Compile Everything"
+      env: TEST=COMPILE
+      install:
+        - ./scripts/install-byond.sh
+        - source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
+      addons:
+        apt:
+          packages:
+            - libstdc++6:i386
+
+    - name: "Code and Map Linter"
+      env: TEST=LINTING
+      addons:
+        apt:
+          packages:
+            - python3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
       - libc6-i386
       - libgcc1:i386
       - libstdc++6:i386
-      - python
+      - python3.5
 
 before_script:
   - chmod +x -R scripts/

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,31 @@ script:
 
 matrix:
   include:
-    - name: "Unit Tests"
-      env: TEST=UNIT
+    - name: "Code and Map Linting"
+      env: TEST=LINTING
+      addons:
+        apt:
+          packages:
+            - python3.5
+
+    - name: "Unit Tests - Box Station"
+      env: 
+        - TEST=UNIT
+        - MAP_NAME=Box Station
+        - MAP_META=boxstation
+      install:
+        - ./scripts/install-byond.sh
+        - source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
+      addons:
+        apt:
+          packages:
+            - libstdc++6:i386
+
+    - name: "Unit Tests - Gamma Station"
+      env: 
+        - TEST=UNIT
+        - MAP_NAME=Gamma Station
+        - MAP_META=gamma
       install:
         - ./scripts/install-byond.sh
         - source $HOME/BYOND-${BYOND_MAJOR}.${BYOND_MINOR}/byond/bin/byondsetup
@@ -38,10 +61,3 @@ matrix:
         apt:
           packages:
             - libstdc++6:i386
-
-    - name: "Code and Map Linter"
-      env: TEST=LINTING
-      addons:
-        apt:
-          packages:
-            - python3.5

--- a/maps/RandomZLevels/stationCollision.dmm
+++ b/maps/RandomZLevels/stationCollision.dmm
@@ -1639,9 +1639,7 @@
 	},
 /area/awaymission/research)
 "eo" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	current_temperature = 80
-	},
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -1941,7 +1939,6 @@
 	icon_state = "in";
 	initialize_directions = 1;
 	internal_pressure_bound = 4000;
-	on = 1;
 	pressure_checks = 2;
 	pump_direction = 0
 	},
@@ -3238,9 +3235,7 @@
 /turf/simulated/floor,
 /area/awaymission/midblock)
 "il" = (
-/obj/machinery/portable_atmospherics/canister/phoron{
-	destroyed = 1
-	},
+/obj/machinery/portable_atmospherics/canister/phoron,
 /turf/simulated/shuttle/plating,
 /area/awaymission/syndishuttle)
 "im" = (

--- a/maps/RandomZLevels/zresearchlabs.dmm
+++ b/maps/RandomZLevels/zresearchlabs.dmm
@@ -555,8 +555,7 @@
 	pixel_x = 11
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 8;
-	on = 1
+	dir = 8
 	},
 /obj/structure/alien/weeds/node,
 /turf/simulated/floor{
@@ -602,8 +601,7 @@
 "bZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	frequency = 1379;
-	id_tag = "medsci_pump";
-	on = 1
+	id_tag = "medsci_pump"
 	},
 /obj/structure/alien/weeds/node,
 /turf/simulated/floor{
@@ -770,8 +768,7 @@
 "ct" = (
 /obj/structure/stool/bed/chair,
 /obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -1161,8 +1158,7 @@
 /obj/structure/stool/bed,
 /obj/item/weapon/bedsheet,
 /obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 8;
-	on = 1
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -1181,9 +1177,7 @@
 	},
 /area/awaymission/labs/researchdivision)
 "dm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	on = 1
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump,
 /obj/structure/alien/weeds/node,
 /turf/simulated/floor{
 	icon_state = "white"
@@ -1259,8 +1253,7 @@
 "dt" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 8;
-	on = 1
+	dir = 8
 	},
 /obj/structure/alien/weeds/node,
 /turf/simulated/floor{
@@ -1975,8 +1968,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
-	layer = 2.4;
-	on = 1
+	layer = 2.4
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -2266,8 +2258,7 @@
 "fO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
-	layer = 2.4;
-	on = 1
+	layer = 2.4
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -2312,8 +2303,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
 	frequency = 1379;
-	id_tag = "mining_maineast_pump";
-	on = 1
+	id_tag = "mining_maineast_pump"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -2493,8 +2483,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
 	frequency = 1379;
-	id_tag = "mining_maineast_pump";
-	on = 1
+	id_tag = "mining_maineast_pump"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -2780,8 +2769,7 @@
 	pixel_y = 2
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 4;
-	on = 1
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -3083,7 +3071,6 @@
 	id_tag = "n2_out";
 	initialize_directions = 1;
 	internal_pressure_bound = 4000;
-	on = 1;
 	pressure_checks = 2;
 	pump_direction = 0
 	},
@@ -3100,8 +3087,7 @@
 	pixel_y = 2
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 8;
-	on = 1
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -3451,8 +3437,7 @@
 "it" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 4;
-	layer = 2.4;
-	on = 1
+	layer = 2.4
 	},
 /turf/simulated/floor,
 /area/awaymission/labs/militarydivision)
@@ -3504,7 +3489,6 @@
 	id_tag = "waste_out";
 	initialize_directions = 1;
 	internal_pressure_bound = 4000;
-	on = 1;
 	pressure_checks = 2;
 	pump_direction = 0
 	},
@@ -3796,7 +3780,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
 	external_pressure_bound = 140;
-	on = 1;
 	pressure_checks = 0
 	},
 /turf/simulated/floor{
@@ -4150,8 +4133,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 8;
-	on = 1
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "carpet"
@@ -4213,7 +4195,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
 	external_pressure_bound = 140;
-	on = 1;
 	pressure_checks = 0
 	},
 /turf/simulated/floor,
@@ -4414,8 +4395,7 @@
 /area/awaymission/labs/solars)
 "kz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/awaymission/labs/command)
@@ -4629,8 +4609,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
 	frequency = 1379;
-	id_tag = "engineering_aux_pump";
-	on = 1
+	id_tag = "engineering_aux_pump"
 	},
 /turf/simulated/floor,
 /area/awaymission/labs/command)
@@ -4701,21 +4680,6 @@
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating{
-	temperature = 393.15
-	},
-/area/awaymission/desert{
-	dynamic_lighting = 1;
-	name = "Desert"
-	})
-"kZ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -4864,19 +4828,6 @@
 /turf/simulated/floor/plating{
 	temperature = 393.15
 	},
-/area/awaymission/desert{
-	dynamic_lighting = 1;
-	name = "Desert"
-	})
-"lo" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
 /area/awaymission/desert{
 	dynamic_lighting = 1;
 	name = "Desert"
@@ -5097,8 +5048,7 @@
 "lG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	frequency = 1379;
-	id_tag = "medsci_pump";
-	on = 1
+	id_tag = "medsci_pump"
 	},
 /turf/simulated/floor,
 /area/awaymission/labs/command)
@@ -5364,7 +5314,6 @@
 	id_tag = "waste_out";
 	initialize_directions = 1;
 	internal_pressure_bound = 4000;
-	on = 1;
 	pressure_checks = 2;
 	pump_direction = 0
 	},
@@ -5571,8 +5520,7 @@
 "mH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	frequency = 1379;
-	id_tag = "medsci_pump";
-	on = 1
+	id_tag = "medsci_pump"
 	},
 /turf/simulated/floor,
 /area/awaymission/labs/cargo)
@@ -5717,8 +5665,7 @@
 /area/awaymission/labs/civilian)
 "mX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 4;
-	on = 1
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/awaymission/labs/command)
@@ -5741,8 +5688,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
 	frequency = 1379;
-	id_tag = "mining_outpost_pump";
-	on = 1
+	id_tag = "mining_outpost_pump"
 	},
 /turf/simulated/floor,
 /area/awaymission/labs/command)
@@ -5821,8 +5767,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
 	frequency = 1379;
-	id_tag = "engineering_aux_pump";
-	on = 1
+	id_tag = "engineering_aux_pump"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -5856,7 +5801,6 @@
 	id_tag = "waste_out";
 	initialize_directions = 1;
 	internal_pressure_bound = 4000;
-	on = 1;
 	pressure_checks = 2;
 	pump_direction = 0
 	},
@@ -6223,9 +6167,7 @@
 /turf/simulated/floor,
 /area/awaymission/labs/civilian)
 "oh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	on = 1
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/simulated/floor,
 /area/awaymission/labs/civilian)
 "oi" = (
@@ -6358,7 +6300,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
 	external_pressure_bound = 140;
-	on = 1;
 	pressure_checks = 0
 	},
 /obj/structure/alien/weeds/node,
@@ -6951,8 +6892,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
 	frequency = 1379;
-	id_tag = "engineering_aux_pump";
-	on = 1
+	id_tag = "engineering_aux_pump"
 	},
 /turf/simulated/floor{
 	icon_state = "wood"
@@ -7187,8 +7127,7 @@
 "qr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	frequency = 1379;
-	id_tag = "medsci_pump";
-	on = 1
+	id_tag = "medsci_pump"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -7458,8 +7397,7 @@
 /area/awaymission/labs/command)
 "qV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /obj/structure/alien/weeds/node,
 /turf/simulated/floor{
@@ -7530,15 +7468,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 1;
 	external_pressure_bound = 140;
-	on = 1;
 	pressure_checks = 0
 	},
 /turf/simulated/floor,
 /area/awaymission/labs/civilian)
 "re" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/awaymission/labs/civilian)
@@ -7989,8 +7925,7 @@
 /area/awaymission/labs/civilian)
 "so" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 4;
-	on = 1
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/awaymission/labs/civilian)
@@ -8355,9 +8290,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump{
-	on = 1
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump,
 /turf/simulated/floor,
 /area/awaymission/labs/security)
 "tk" = (
@@ -8421,8 +8354,7 @@
 /obj/item/weapon/folder/white,
 /obj/item/clothing/accessory/stethoscope,
 /obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -8455,8 +8387,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
 	frequency = 1379;
-	id_tag = "engineering_aux_pump";
-	on = 1
+	id_tag = "engineering_aux_pump"
 	},
 /turf/simulated/floor,
 /area/awaymission/labs/security)
@@ -8536,8 +8467,7 @@
 /area/awaymission/labs/medical)
 "tG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 1;
-	on = 1
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -8587,8 +8517,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 8;
 	frequency = 1379;
-	id_tag = "engineering_aux_pump";
-	on = 1
+	id_tag = "engineering_aux_pump"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -8956,8 +8885,7 @@
 /obj/machinery/recharger,
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/components/unary/vent_pump{
-	dir = 4;
-	on = 1
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -18656,7 +18584,7 @@ bR
 bR
 bR
 bR
-kZ
+kM
 bR
 bR
 bR
@@ -18913,7 +18841,7 @@ bR
 bR
 bR
 bR
-kZ
+kM
 bR
 bR
 bR
@@ -27137,7 +27065,7 @@ bR
 bR
 bR
 bR
-lo
+kF
 bR
 bR
 bR
@@ -27394,7 +27322,7 @@ bR
 bR
 bR
 bR
-lo
+kF
 bR
 bR
 bR
@@ -27651,7 +27579,7 @@ bR
 bR
 bR
 bR
-lo
+kF
 bR
 bR
 bR
@@ -28162,7 +28090,7 @@ bR
 bR
 bR
 bR
-lo
+kF
 bR
 bR
 bR
@@ -28419,7 +28347,7 @@ bR
 bR
 bR
 bR
-lo
+kF
 bR
 bR
 bR
@@ -28676,7 +28604,7 @@ ii
 ii
 bR
 bR
-lo
+kF
 bR
 bR
 bR
@@ -28933,7 +28861,7 @@ kz
 ii
 bR
 bR
-lo
+kF
 bR
 bR
 bR
@@ -29190,7 +29118,7 @@ iy
 ii
 bR
 bR
-lo
+kF
 bR
 bR
 bR
@@ -36129,7 +36057,7 @@ bR
 bR
 bR
 bR
-kZ
+kM
 bR
 bR
 bR
@@ -36386,7 +36314,7 @@ bR
 bR
 bR
 bR
-kZ
+kM
 bR
 bR
 bR
@@ -36643,7 +36571,7 @@ bR
 bR
 bR
 bR
-kZ
+kM
 bR
 bR
 bR
@@ -36900,7 +36828,7 @@ bR
 bR
 bR
 bR
-kZ
+kM
 bR
 bR
 bR
@@ -37157,7 +37085,7 @@ bR
 bR
 bR
 bR
-kZ
+kM
 bR
 bR
 bR
@@ -37414,7 +37342,7 @@ bR
 bR
 bR
 bR
-kZ
+kM
 bR
 bR
 bR
@@ -37671,7 +37599,7 @@ bR
 bR
 bR
 bR
-kZ
+kM
 bR
 bR
 bR
@@ -37928,7 +37856,7 @@ bR
 bR
 bR
 bR
-kZ
+kM
 bR
 bR
 bR
@@ -38442,7 +38370,7 @@ bR
 bR
 bR
 bR
-kZ
+kM
 bR
 bR
 bR
@@ -38699,7 +38627,7 @@ bR
 bR
 bR
 bR
-kZ
+kM
 bR
 bR
 bR
@@ -38956,7 +38884,7 @@ bR
 bR
 bR
 bR
-kZ
+kM
 bR
 bR
 bR
@@ -39213,7 +39141,7 @@ hy
 hy
 bR
 bR
-kZ
+kM
 bR
 bR
 bR

--- a/maps/gamma/gamma.dmm
+++ b/maps/gamma/gamma.dmm
@@ -4556,9 +4556,7 @@
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
-/area/storage/tech{
-	name = "North Technical Storage"
-	})
+/area/storage/tech/north)
 "aBk" = (
 /obj/structure/flora/plant/random,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -10841,9 +10839,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/storage/tech{
-	name = "North Technical Storage"
-	})
+/area/storage/tech/north)
 "cCr" = (
 /obj/structure/flora/junglebush/b,
 /obj/machinery/alarm{
@@ -14631,9 +14627,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/storage/tech{
-	name = "North Technical Storage"
-	})
+/area/storage/tech/north)
 "dOM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -24001,9 +23995,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/storage/tech{
-	name = "North Technical Storage"
-	})
+/area/storage/tech/north)
 "gQJ" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -24156,9 +24148,7 @@
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
-/area/storage/tech{
-	name = "North Technical Storage"
-	})
+/area/storage/tech/north)
 "gTs" = (
 /obj/machinery/pdapainter,
 /obj/machinery/keycard_auth{
@@ -24396,9 +24386,7 @@
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
-/area/storage/tech{
-	name = "North Technical Storage"
-	})
+/area/storage/tech/north)
 "gVY" = (
 /obj/structure/table,
 /obj/item/weapon/circular_saw{
@@ -28736,9 +28724,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/plating,
-/area/storage/tech{
-	name = "North Technical Storage"
-	})
+/area/storage/tech/north)
 "iuU" = (
 /obj/structure/object_wall/mining{
 	dir = 8;
@@ -31198,9 +31184,7 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor/plating,
-/area/storage/tech{
-	name = "North Technical Storage"
-	})
+/area/storage/tech/north)
 "jni" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -31343,9 +31327,7 @@
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
-/area/storage/tech{
-	name = "North Technical Storage"
-	})
+/area/storage/tech/north)
 "jqb" = (
 /obj/machinery/door/poddoor{
 	id = "mixvent";
@@ -31642,9 +31624,7 @@
 /area/medical/sleeper)
 "jwz" = (
 /turf/simulated/wall,
-/area/storage/tech{
-	name = "North Technical Storage"
-	})
+/area/storage/tech/north)
 "jxa" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -32330,9 +32310,7 @@
 "jHE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor/plating,
-/area/storage/tech{
-	name = "North Technical Storage"
-	})
+/area/storage/tech/north)
 "jHF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/stool,
@@ -34216,9 +34194,7 @@
 "klN" = (
 /obj/machinery/mech_bay_recharge_port,
 /turf/simulated/floor/plating,
-/area/storage/tech{
-	name = "North Technical Storage"
-	})
+/area/storage/tech/north)
 "klT" = (
 /obj/structure/table,
 /obj/item/weapon/hand_labeler,
@@ -38724,9 +38700,7 @@
 "lJc" = (
 /obj/structure/computerframe,
 /turf/simulated/floor/plating,
-/area/storage/tech{
-	name = "North Technical Storage"
-	})
+/area/storage/tech/north)
 "lJe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -42259,9 +42233,7 @@
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
-/area/storage/tech{
-	name = "North Technical Storage"
-	})
+/area/storage/tech/north)
 "mNG" = (
 /obj/structure/sink{
 	dir = 4;
@@ -46995,9 +46967,7 @@
 /turf/simulated/floor{
 	icon_state = "damaged1"
 	},
-/area/storage/tech{
-	name = "North Technical Storage"
-	})
+/area/storage/tech/north)
 "oqc" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -48803,9 +48773,7 @@
 	req_access = list(23)
 	},
 /turf/simulated/floor/plating,
-/area/storage/tech{
-	name = "North Technical Storage"
-	})
+/area/storage/tech/north)
 "oXO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -49493,9 +49461,7 @@
 "pmk" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/storage/tech{
-	name = "North Technical Storage"
-	})
+/area/storage/tech/north)
 "pml" = (
 /obj/item/toy/cards,
 /obj/structure/table,
@@ -56390,9 +56356,7 @@
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
-/area/storage/tech{
-	name = "North Technical Storage"
-	})
+/area/storage/tech/north)
 "rxF" = (
 /obj/structure/window/reinforced,
 /obj/machinery/camera{
@@ -63086,9 +63050,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/storage/tech{
-	name = "North Technical Storage"
-	})
+/area/storage/tech/north)
 "tFx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
@@ -72703,9 +72665,7 @@
 /turf/simulated/floor{
 	icon_state = "floorscorched1"
 	},
-/area/storage/tech{
-	name = "North Technical Storage"
-	})
+/area/storage/tech/north)
 "wJc" = (
 /turf/space,
 /area/vox_station/northwest_solars)
@@ -73542,9 +73502,7 @@
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
-/area/storage/tech{
-	name = "North Technical Storage"
-	})
+/area/storage/tech/north)
 "wXH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -74576,9 +74534,7 @@
 /area/maintenance/science)
 "xoB" = (
 /turf/simulated/floor/mech_bay_recharge_floor,
-/area/storage/tech{
-	name = "North Technical Storage"
-	})
+/area/storage/tech/north)
 "xoC" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 8
@@ -76822,9 +76778,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/storage/tech{
-	name = "North Technical Storage"
-	})
+/area/storage/tech/north)
 "ybI" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/folder,

--- a/maps/gamma/gamma.dmm
+++ b/maps/gamma/gamma.dmm
@@ -77031,7 +77031,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
 "yhA" = (
-/obj/structure/table,
 /obj/item/weapon/reagent_containers/glass/beaker/cryoxadone{
 	pixel_x = 7;
 	pixel_y = 1

--- a/scripts/include-additional-files.py
+++ b/scripts/include-additional-files.py
@@ -1,0 +1,26 @@
+import argparse, sys, re
+from os import sep, path, walk
+
+def main():
+	opt = argparse.ArgumentParser()
+	opt.add_argument('dir', help='Dir to parse to include specific files')
+	opt.add_argument('pattern', help='Pattern used to include files')
+	args = opt.parse_args()
+
+	if not path.isdir(args.dir):
+		print('Not a directory')
+		sys.exit(1)
+
+	file = open('additional_files.dm', 'a')
+	pattern = re.compile(args.pattern)
+
+	for root, subdirs, files in walk(args.dir):
+		for filename in files:
+			if pattern.match(filename):
+				file_path = path.join(root, filename).replace('/', '\\')
+				file.write('#include "' + file_path + '"\n')
+
+	file.close()
+
+if __name__ == '__main__':
+	main()

--- a/scripts/maps-tgm-checker.py
+++ b/scripts/maps-tgm-checker.py
@@ -1,0 +1,30 @@
+import argparse, sys
+from os import sep, path, walk
+
+def main():
+	opt = argparse.ArgumentParser()
+	opt.add_argument('dir', help='The directory to recursively scan for *.dmm files with invalid format')
+	args = opt.parse_args()
+
+	if not path.isdir(args.dir):
+		print('Not a directory')
+		sys.exit(1)
+
+	bad_map_files = []
+
+	for root, subdirs, files in walk(args.dir):
+		for filename in files:
+			if filename.endswith('.dmm'):
+				file_path = path.join(root, filename)
+				with open(file_path, 'r') as file:
+					first_line = file.readline()
+					if not first_line.startswith('//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE'):
+						bad_map_files.append(file_path)
+	
+	if len(bad_map_files) > 0:
+		print('Bad map files (not TGM):')
+		print(*bad_map_files, sep='\n')
+		sys.exit(1)
+
+if __name__ == '__main__':
+	main()

--- a/scripts/tag-matcher.py
+++ b/scripts/tag-matcher.py
@@ -112,9 +112,7 @@ for file, mismatches_by_tag in mismatches_by_file.iteritems():
 					print('\t\tLine {0}'.format(abs(mismatch_line)))
 
 # Simply prints the total number of mismatches found and if so returns 1 to, for example, fail Travis builds.				
-if(total_mismatches == 0):
-	print('No mismatches found.')
-else:	
+if(total_mismatches != 0):
 	print('')
 	print('Total number of mismatches: {0}'.format(total_mismatches))
 	sys.exit(1)

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -192,9 +192,9 @@ function run_build_tests {
 
 function run_unit_tests {
     find_byond_deps
-    msg "*** running unit tests ***"
     cp config/example/* config/
     mkdir -p data/ && cp maps/$MAP_META.json data/next_map.json
+    msg "*** running unit tests ***"
     run_test "build unit tests" "scripts/dm.sh -DUNIT_TEST taucetistation.dme"
     run_test "unit tests" "DreamDaemon taucetistation.dmb -invisible -trusted -core 2>&1 | tee log.txt"
     run_test "check correct map loaded" "grep 'Loading $MAP_NAME' log.txt"

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -194,7 +194,7 @@ function run_unit_tests {
     find_byond_deps
     msg "*** running unit tests ***"
     cp config/example/* config/
-    cp maps/$MAP_META.json data/next_map.json
+    mkdir -p data/ && cp maps/$MAP_META.json data/next_map.json
     run_test "build unit tests" "scripts/dm.sh -DUNIT_TEST taucetistation.dme"
     run_test "unit tests" "DreamDaemon taucetistation.dmb -invisible -trusted -core 2>&1 | tee log.txt"
     run_test "check correct map loaded" "grep 'Loading $MAP_NAME' log.txt"


### PR DESCRIPTION
## Описание изменений
Так как теперь почти все карты грузятся в рантайме проблема их валидации стала ещё более актуальной. Собственно, что тут происходит. 
- Вынес тесты для карт, билда и юниттестов в отдельные функции. Для группировки, простоты чтения и т.д.
- Поправил некоторые грепы (мы обсуждали в конфе)
- Добавил использование питона3
- Добавил скрипт который чекает карты на ТГМ хэдер
- Добавил скрипт который создаёт файл с доп. инклудами (используется в run_build_tests). Собственно, благодаря этому во время билда будут компилироваться все имеющиеся карты.

Пр зависит от #3817 т.к. там я пофиксил карты. На сколько я могу судить, пофикисил я не абсолютно всё, но большую часть. Так что дофикшу уже после того, как тот будет смержен.