### PR TITLE
показываем записи по сикею

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -252,9 +252,10 @@ proc/message_admins(msg, reg_flag = R_ADMIN)
 	else return 1
 
 
-/datum/admins/proc/show_player_info(key as text)
+/datum/admins/proc/show_player_info(key)
 	set category = "Admin"
 	set name = "Show Player Info"
+	key = ckey(key)
 	if (!istype(src,/datum/admins))
 		src = usr.client.holder
 	if (!istype(src,/datum/admins))

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -252,7 +252,7 @@ proc/message_admins(msg, reg_flag = R_ADMIN)
 	else return 1
 
 
-/datum/admins/proc/show_player_info(key)
+/datum/admins/proc/show_player_info(key as text)
 	set category = "Admin"
 	set name = "Show Player Info"
 	key = ckey(key)


### PR DESCRIPTION
## Описание изменений
Show Player Info в вкладке Admin выдает записи только по сикеям (kuzyxd), а не по кеям (KuzyXD). Сделал так, чтобы независимо от ввода он выводил сикей.

## Почему и что этот ПР улучшит
Защищает администрацию от ошибок. Я так уже по кею выписал нотес, который не отобразился.

## Авторство
@KuzyXD 

## Чеинжлог


