### PR TITLE
чем мастер обновляет интерфейс при вставлении в него вещей

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -399,6 +399,7 @@
 		B.loc = src
 		to_chat(user, "You add the beaker to the machine!")
 		src.updateUsrDialog()
+		nanomanager.update_uis(src) // update all UIs attached to src
 		icon_state = "mixer1"
 
 	else if(!condi && istype(B, /obj/item/weapon/storage/pill_bottle))
@@ -411,6 +412,7 @@
 		B.loc = src
 		to_chat(user, "You add the pill bottle into the dispenser slot!")
 		src.updateUsrDialog()
+		nanomanager.update_uis(src) // update all UIs attached to src
 
 	return
 


### PR DESCRIPTION
## Описание изменений
При вставлении в чем мастер баночек с таблетками или просто баночек (стаканов и тд) его интерфейс обновляется (раньше это вызывало лютую ненависть когда надо было 2 раза кликать по чем мастеру чтобы нормально с ним работать (не закрывая его)
## Почему и что этот ПР улучшит
Химикам станет чуть легче жить
## Авторство
Felix Ruin - Winter Schock
## Чеинжлог
:cl: Winter Schock
 - bugfix: Чем мастер не обновлял интерфейс при помещении в него вещей
