### PR TITLE
Ребаланс рюкзаков и сумок

### DIFF
--- a/code/__DEFINES/inventory_sizes.dm
+++ b/code/__DEFINES/inventory_sizes.dm
@@ -16,5 +16,6 @@
 #define base_storage_capacity(w_class) (7*(w_class-1))
 
 #define DEFAULT_BACKPACK_STORAGE base_storage_capacity(5)
+#define DEFAULT_SATCHEL_STORAGE (DEFAULT_BACKPACK_STORAGE - 10)
 #define DEFAULT_LARGEBOX_STORAGE base_storage_capacity(4)
 #define DEFAULT_BOX_STORAGE base_storage_capacity(3)

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -13,6 +13,7 @@
 	action_button_name = "Storage"
 	max_w_class = ITEM_SIZE_NORMAL
 	max_storage_space = DEFAULT_BACKPACK_STORAGE
+	reachable_while_equipped = FALSE
 	var/opened = 0
 
 /obj/item/weapon/storage/backpack/ui_action_click()
@@ -30,6 +31,8 @@
 /obj/item/weapon/storage/backpack/equipped(mob/user, slot)
 	if (slot == SLOT_BACK && length(use_sound))
 		playsound(src, pick(use_sound), VOL_EFFECTS_MASTER, null, null, -5)
+		if(reachable_while_equipped == FALSE)
+			close(loc)
 	..(user, slot)
 
 /*
@@ -124,6 +127,8 @@
 	desc = "It's a very fancy satchel made with fine leather."
 	icon_state = "satchel"
 	item_state = "satchel"
+	max_storage_space = DEFAULT_BACKPACK_STORAGE - 10
+	reachable_while_equipped = TRUE
 
 /obj/item/weapon/storage/backpack/satchel/withwallet
 
@@ -270,7 +275,6 @@
 	icon_state = "satchel-flat"
 	item_state = "satchel-flat"
 	w_class = ITEM_SIZE_NORMAL //Can fit in backpacks itself.
-	max_storage_space = DEFAULT_BACKPACK_STORAGE - 10
 	level = 1
 	cant_hold = list(/obj/item/weapon/storage/backpack/satchel/flat) //muh recursive backpacks
 

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -18,11 +18,7 @@
 
 /obj/item/weapon/storage/backpack/ui_action_click()
 	if(!opened)
-		if(!reachable_while_equipped && slot_equipped == SLOT_BACK)
-			to_chat(loc, "<span class='warning'>You can't reach into your [name] while it's equipped!</span>")
-			return
-		else
-			open(loc)
+		open(loc)
 	else
 		close(loc)
 	opened = !opened

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -18,7 +18,11 @@
 
 /obj/item/weapon/storage/backpack/ui_action_click()
 	if(!opened)
-		open(loc)
+		if(!reachable_while_equipped && slot_equipped == SLOT_BACK)
+			to_chat(loc, "<span class='warning'>You can't reach into your [name] while it's equipped!</span>")
+			return
+		else
+			open(loc)
 	else
 		close(loc)
 	opened = !opened

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -31,7 +31,7 @@
 /obj/item/weapon/storage/backpack/equipped(mob/user, slot)
 	if (slot == SLOT_BACK && length(use_sound))
 		playsound(src, pick(use_sound), VOL_EFFECTS_MASTER, null, null, -5)
-		if(reachable_while_equipped == FALSE)
+		if(!reachable_while_equipped)
 			close(loc)
 	..(user, slot)
 
@@ -127,7 +127,7 @@
 	desc = "It's a very fancy satchel made with fine leather."
 	icon_state = "satchel"
 	item_state = "satchel"
-	max_storage_space = DEFAULT_BACKPACK_STORAGE - 10
+	max_storage_space = DEFAULT_SATCHEL_STORAGE
 	reachable_while_equipped = TRUE
 
 /obj/item/weapon/storage/backpack/satchel/withwallet

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -49,7 +49,7 @@
 				to_chat(usr, "<span class='warning'>You can't reach into your [name] while it's equipped!</span>")
 				return
 			else
-				src.open(usr)
+				open(usr)
 				return
 
 		if (!( istype(over_object, /obj/screen) ))
@@ -317,7 +317,7 @@
 			to_chat(user, "<span class='warning'>You can't reach into your [name] while it's equipped!</span>")
 			return
 		else
-			src.open(user)
+			open(user)
 	else
 		..()
 		storage_ui.on_hand_attack(user)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -45,7 +45,7 @@
 			return
 
 		if(over_object == usr && Adjacent(usr)) // this must come before the screen objects only block
-			if(usr.back == src && reachable_while_equipped == FALSE)
+			if(usr.back == src && !reachable_while_equipped)
 				to_chat(usr, "<span class='warning'>You can't reach into your [name] while it's equipped!</span>")
 				return
 			else

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -45,7 +45,7 @@
 			return
 
 		if(over_object == usr && Adjacent(usr)) // this must come before the screen objects only block
-			if(usr.back == src && !reachable_while_equipped)
+			if(slot_equipped == SLOT_BACK && !reachable_while_equipped)
 				to_chat(usr, "<span class='warning'>You can't reach into your [name] while it's equipped!</span>")
 				return
 			else
@@ -313,7 +313,7 @@
 
 /obj/item/weapon/storage/attack_hand(mob/user)
 	if (loc == user)
-		if(!reachable_while_equipped && user.back == src)
+		if(!reachable_while_equipped && slot_equipped == SLOT_BACK)
 			to_chat(user, "<span class='warning'>You can't reach into your [name] while it's equipped!</span>")
 			return
 		else

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -45,12 +45,8 @@
 			return
 
 		if(over_object == usr && Adjacent(usr)) // this must come before the screen objects only block
-			if(slot_equipped == SLOT_BACK && !reachable_while_equipped)
-				to_chat(usr, "<span class='warning'>You can't reach into your [name] while it's equipped!</span>")
-				return
-			else
-				open(usr)
-				return
+			open(usr)
+			return
 
 		if (!( istype(over_object, /obj/screen) ))
 			return ..()
@@ -104,9 +100,13 @@
 	if (length(use_sound))
 		playsound(src, pick(use_sound), VOL_EFFECTS_MASTER, null, null, -5)
 
-	prepare_ui()
-	storage_ui.on_open(user)
-	storage_ui.show_to(user)
+	if(!reachable_while_equipped && slot_equipped == SLOT_BACK)
+		to_chat(loc, "<span class='warning'>You can't reach into your [name] while it's equipped!</span>")
+		return
+	else
+		prepare_ui()
+		storage_ui.on_open(user)
+		storage_ui.show_to(user)
 
 /obj/item/weapon/storage/proc/prepare_ui()
 	storage_ui.prepare_ui()
@@ -313,11 +313,7 @@
 
 /obj/item/weapon/storage/attack_hand(mob/user)
 	if (loc == user)
-		if(!reachable_while_equipped && slot_equipped == SLOT_BACK)
-			to_chat(user, "<span class='warning'>You can't reach into your [name] while it's equipped!</span>")
-			return
-		else
-			open(user)
+		open(user)
 	else
 		..()
 		storage_ui.on_hand_attack(user)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -97,16 +97,16 @@
 		storage_ui.hide_from(user)
 
 /obj/item/weapon/storage/proc/open(mob/user)
+	if(!reachable_while_equipped && slot_equipped == SLOT_BACK)
+		to_chat(user, "<span class='warning'>You can't reach into your [name] while it's equipped!</span>")
+		return
+
 	if (length(use_sound))
 		playsound(src, pick(use_sound), VOL_EFFECTS_MASTER, null, null, -5)
 
-	if(!reachable_while_equipped && slot_equipped == SLOT_BACK)
-		to_chat(loc, "<span class='warning'>You can't reach into your [name] while it's equipped!</span>")
-		return
-	else
-		prepare_ui()
-		storage_ui.on_open(user)
-		storage_ui.show_to(user)
+	prepare_ui()
+	storage_ui.on_open(user)
+	storage_ui.show_to(user)
 
 /obj/item/weapon/storage/proc/prepare_ui()
 	storage_ui.prepare_ui()

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -15,6 +15,7 @@
 	var/max_w_class = ITEM_SIZE_SMALL //Max size of objects that this object can store (in effect only if can_hold isn't set)
 	var/max_storage_space = null //Total storage cost of items this can hold. Will be autoset based on storage_slots if left null.
 	var/storage_slots = null //The number of storage slots in this container.
+	var/reachable_while_equipped = TRUE
 
 	var/use_to_pickup	//Set this to make it possible to use this item in an inverse way, so you can have the item in your hand and click items on the floor to pick them up.
 	var/display_contents_with_number	//Set this to make the storage item group contents of the same type and display them as a number.
@@ -44,8 +45,12 @@
 			return
 
 		if(over_object == usr && Adjacent(usr)) // this must come before the screen objects only block
-			src.open(usr)
-			return
+			if(usr.back == src && reachable_while_equipped == FALSE)
+				to_chat(usr, "<span class='warning'>You can't reach into your [name] while it's equipped!</span>")
+				return
+			else
+				src.open(usr)
+				return
 
 		if (!( istype(over_object, /obj/screen) ))
 			return ..()
@@ -307,8 +312,12 @@
 	return
 
 /obj/item/weapon/storage/attack_hand(mob/user)
-	if (src.loc == user)
-		src.open(user)
+	if (loc == user)
+		if(!reachable_while_equipped && user.back == src)
+			to_chat(user, "<span class='warning'>You can't reach into your [name] while it's equipped!</span>")
+			return
+		else
+			src.open(user)
 	else
 		..()
 		storage_ui.on_hand_attack(user)


### PR DESCRIPTION

<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений
(по сути, порт моего пулреквеста с гаммы)
Сумки теперь вмещают меньше рюкзаков, а рюкзаки нельзя открывать, пока они на спине.

<details> 
  <summary>Примерный расклад (фото в цвете)</summary>

РЮКЗАК
![dreamseeker_ZjPSDL8niP](https://user-images.githubusercontent.com/6051766/63284107-8b1b3600-c2bb-11e9-84f4-308c2f4cfecf.png)

СУМКА
![dreamseeker_8rGvFYo2Cq](https://user-images.githubusercontent.com/6051766/63284116-8d7d9000-c2bb-11e9-8f53-9d9c7738f74d.png)

</details>

## Почему и что этот ПР улучшит

Небольшая предыстория заключается в том, что на гамме год назад эти изменения захейтили и не приняли, ибо тогда была старая система рюкзаков, и всех смутило, что в сумку помещалось три с половиной сигареты.

Так как добрые люди портанули систему инвентаря, теперь это довольно актуально.
Суть в том, чтобы разделить рюкзаки и сумки на два класса, сделать так, чтоб отличались они не только спрайтом. У игрока возникает выбор между доступной, но не очень вместительной сумкой, и большим, но неудобным рюкзаком.

<!--
Опишите причину для изменений.
Этот пункт особенно важен для описания изменений баланса, новых механик.
-->

## Чеинжлог

:cl:
 - balance: Сумки теперь вмещают меньше предметов, а рюкзаки нельзя открывать, пока они на спине.