### PR TITLE
Added B/Ctrl+B hotkeys binded to Apply Item To Self verb

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -79,11 +79,10 @@
 		return
 
 	face_atom(A) // change direction to face what you clicked on
-
 	if(next_move > world.time) // in the year 2000...
 		return
 
-	if(istype(loc,/obj/mecha))
+	if(istype(loc, /obj/mecha))
 		if(!locate(/turf) in list(A, A.loc)) // Prevents inventory from being drilled
 			return
 		var/obj/mecha/M = loc
@@ -97,17 +96,13 @@
 		throw_item(A)
 		return
 
-	if(!istype(A,/obj/item/weapon/gun) && !isturf(A) && !istype(A,/obj/screen))
+	if(!istype(A, /obj/item/weapon/gun) && !isturf(A) && !istype(A, /obj/screen))
 		last_target_click = world.time
 
 	var/obj/item/W = get_active_hand()
-
 	if(W == A)
 		W.attack_self(src)
-		if(hand)
-			update_inv_l_hand()
-		else
-			update_inv_r_hand()
+		W.update_inv_mob()
 		return
 
 	// operate two STORAGE levels deep here (item in backpack in src; NOT item in box in backpack in src)
@@ -116,8 +111,7 @@
 
 		// No adjacency needed
 		if(W)
-
-			var/resolved = A.attackby(W,src,params)
+			var/resolved = A.attackby(W, src, params)
 			if(!resolved && A && W)
 				W.afterattack(A, src, 1, params) // 1 indicates adjacency
 		else

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -1,5 +1,5 @@
 
-// Called when the item is in the active hand, and clicked; alternately, there is an 'activate held object' verb or you can hit pagedown.
+// Called when the item is in the active hand, and clicked; alternately, there is an 'Click On Held Object' verb or you can hit pagedown.
 /obj/item/proc/attack_self(mob/user)
 	return
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1226,17 +1226,6 @@
 		to_chat(R, "Buffers flushed and reset. Camera system shutdown.  All systems operational.")
 		src.verbs -= /mob/living/silicon/robot/proc/ResetSecurityCodes
 
-/mob/living/silicon/robot/mode()
-	set name = "Activate Held Object"
-	set category = "IC"
-	set src = usr
-
-	var/obj/item/W = get_active_hand()
-	if (W)
-		W.attack_self(src)
-
-	return
-
 /mob/living/silicon/robot/verb/pose()
 	set name = "Set Pose"
 	set desc = "Sets a description which will be shown when someone examines you."

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -182,37 +182,20 @@
 	return
 
 /mob/verb/mode()
-	set name = "Activate Held Object"
-	set category = "Object"
-	set src = usr
+	set name = "Click On Held Object"
+	set category = "IC"
 
-	if(istype(loc,/obj/mecha))
+	var/obj/item/W = get_active_hand()
+	if(!W)
 		return
 
-	if(hand)
-		var/obj/item/W = l_hand
-		if(W)
-			W.attack_self(src)
-			update_inv_l_hand()
-	else
-		var/obj/item/W = r_hand
-		if(W)
-			W.attack_self(src)
-			update_inv_r_hand()
-	if(next_move < world.time)
-		next_move = world.time + 2
-	return
+	ClickOn(W)
 
-/*
-/mob/verb/dump_source()
+/mob/verb/click_on_self()
+	set name = "Click On Self"
+	set category = "IC"
 
-	var/master = "<PRE>"
-	for(var/t in typesof(/area))
-		master += text("[]\n", t)
-		//Foreach goto(26)
-	src << browse(master)
-	return
-*/
+	ClickOn(usr)
 
 /mob/verb/memory()
 	set name = "Notes"
@@ -1088,29 +1071,3 @@ note dizziness decrements automatically in the mob's Life() proc.
 
 /mob/proc/can_unbuckle(mob/user)
 	return 1
-
-/*
-/mob/living/on_varedit(modified_var)
-	switch(modified_var)
-		if("weakened")
-			SetWeakened(weakened)
-		if("stunned")
-			SetStunned(stunned)
-		if("paralysis")
-			SetParalysis(paralysis)
-		if("sleeping")
-			SetSleeping(sleeping)
-		if("eye_blind")
-			set_blindness(eye_blind)
-		if("eye_damage")
-			set_eye_damage(eye_damage)
-		if("eye_blurry")
-			set_blurriness(eye_blurry)
-		if("ear_deaf")
-			setEarDamage(-1, ear_deaf)
-		if("ear_damage")
-			setEarDamage(ear_damage, -1)
-		if("maxHealth")
-			updatehealth()
-		if("resize")
-			update_transform()*/

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -23,57 +23,61 @@
 
 	var/hotkey_mode = {"<font color='purple'>
 Hotkey-Mode: (hotkey-mode must be on)
-\tTAB = toggle hotkey-mode
-\ta = left
-\ts = down
-\td = right
-\tw = up
-\tq = drop
-\te = equip
-\tr = throw
-\tt = say
-\tx = swap-hand
-\tz = activate held object (or y)
-\tf = cycle-intents-left
-\tg = cycle-intents-right
-\t1 = help-intent
-\t2 = disarm-intent
-\t3 = grab-intent
-\t4 = harm-intent
+\t TAB = toggle hotkey-mode
+\t a = left
+\t s = down
+\t d = right
+\t w = up
+\t q = drop
+\t e = equip
+\t r = throw
+\t t = say
+\t h = holder/unholder
+\t x = swap-hand
+\t z = click on held object (or y)
+\t b = click on self
+\t f = cycle-intents-left
+\t g = cycle-intents-right
+\t 1 = help-intent
+\t 2 = disarm-intent
+\t 3 = grab-intent
+\t 4 = harm-intent
 </font>"}
 
 	var/other = {"<font color='purple'>
 Any-Mode: (hotkey doesn't need to be on)
-\tCtrl+a = left
-\tCtrl+s = down
-\tCtrl+d = right
-\tCtrl+w = up
-\tCtrl+q = drop
-\tCtrl+e = equip
-\tCtrl+r = throw
-\tCtrl+x = swap-hand
-\tCtrl+z = activate held object (or Ctrl+y)
-\tCtrl+f = cycle-intents-left
-\tCtrl+g = cycle-intents-right
-\tCtrl+1 = help-intent
-\tCtrl+2 = disarm-intent
-\tCtrl+3 = grab-intent
-\tCtrl+4 = harm-intent
-\tDEL = pull
-\tINS = cycle-intents-right
-\tHOME = drop
-\tPGUP = swap-hand
-\tPGDN = activate held object
-\tEND = throw
+\t Ctrl+a = left
+\t Ctrl+s = down
+\t Ctrl+d = right
+\t Ctrl+w = up
+\t Ctrl+q = drop
+\t Ctrl+e = equip
+\t Ctrl+r = throw
+\t Ctrl+h = holder/unholder
+\t Ctrl+x = swap-hand
+\t Ctrl+z = click on held object (or Ctrl+y)
+\t Ctrl+b = click on self
+\t Ctrl+f = cycle-intents-left
+\t Ctrl+g = cycle-intents-right
+\t Ctrl+1 = help-intent
+\t Ctrl+2 = disarm-intent
+\t Ctrl+3 = grab-intent
+\t Ctrl+4 = harm-intent
+\t DEL = pull
+\t INS = cycle-intents-right
+\t HOME = drop
+\t PGUP = swap-hand
+\t PGDN = click on held object
+\t END = throw
 </font>"}
 
 	var/admin = {"<font color='purple'>
 Admin:
-\tF5 = Asay
-\tF6 = player-panel-new
-\tF7 = admin-pm
-\tF8 = Invisimin
-\tF9 = Mentorhelp
+\t F5 = Asay
+\t F6 = player-panel-new
+\t F7 = admin-pm
+\t F8 = Invisimin
+\t F9 = Mentorhelp
 </font>"}
 
 	to_chat(src, hotkey_mode)

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -83,6 +83,10 @@ macro "macro"
 		name = "CTRL+A+REP"
 		command = ".west"
 		is-disabled = false
+	elem "MACRO-CTRL+B"
+		name = "CTRL+B"
+		command = "Click-On-Self"
+		is-disabled = false
 	elem "MACRO-CTRL+D+REP"
 		name = "CTRL+D+REP"
 		command = ".east"
@@ -98,6 +102,10 @@ macro "macro"
 	elem "MACRO-CTRL+G"
 		name = "CTRL+G"
 		command = "a-intent right"
+		is-disabled = false
+	elem "MACRO-CTRL+H"
+		name = "CTRL+H"
+		command = "holster"
 		is-disabled = false
 	elem "MACRO-CTRL+Q"
 		name = "CTRL+Q"
@@ -121,11 +129,11 @@ macro "macro"
 		is-disabled = false
 	elem "MACRO-CTRL+Y"
 		name = "CTRL+Y"
-		command = "Activate-Held-Object"
+		command = "Click-On-Held-Object"
 		is-disabled = false
 	elem "MACRO-CTRL+Z"
 		name = "CTRL+Z"
-		command = "Activate-Held-Object"
+		command = "Click-On-Held-Object"
 		is-disabled = false
 	elem "MACRO-F1"
 		name = "F1"
@@ -285,6 +293,14 @@ macro "hotkeymode"
 		name = "CTRL+A+REP"
 		command = ".west"
 		is-disabled = false
+	elem "HKMODE-B"
+		name = "B"
+		command = "Click-On-Self"
+		is-disabled = false
+	elem "HKMODE-CTRL+B"
+		name = "CTRL+B"
+		command = "Click-On-Self"
+		is-disabled = false
 	elem "HKMODE-D+REP"
 		name = "D+REP"
 		command = ".east"
@@ -371,19 +387,19 @@ macro "hotkeymode"
 		is-disabled = false
 	elem "HKMODE-Y"
 		name = "Y"
-		command = "Activate-Held-Object"
+		command = "Click-On-Held-Object"
 		is-disabled = false
 	elem "HKMODE-CTRL+Y"
 		name = "CTRL+Y"
-		command = "Activate-Held-Object"
+		command = "Click-On-Held-Object"
 		is-disabled = false
 	elem "HKMODE-Z"
 		name = "Z"
-		command = "Activate-Held-Object"
+		command = "Click-On-Held-Object"
 		is-disabled = false
 	elem "HKMODE-CTRL+Z"
 		name = "CTRL+Z"
-		command = "Activate-Held-Object"
+		command = "Click-On-Held-Object"
 		is-disabled = false
 	elem "HKMODE-F1"
 		name = "F1"


### PR DESCRIPTION
## Описание изменений
- Новый метод для атаки(использования) на самого себя итемом в активной руке
- К методу привязан хоткей для большего удобства, установлен на B в режиме движения и Ctrl+B в режиме чата, что достаточно близко к другим хоткеям связанных с руками
- Продублирован хоткей быстрой кобуры(holster) для режима чата на Ctrl+H 
- Добавлены новые хоткеи(в том числе быстрая кобура) в описание хоткеев
- Вынужденно добавлены пробелы в описании хоткеев, из-за неприятия компилятором строки `\th = holder/unholder`
- Переименовал и отрефакторил verb для использования предмета в активной руке хоткеем
- Переместил verb связанные с взаимодействием с предметами в активной руке в раздел IC
- Пара мелких правок в методе ClickOn

## Почему и что этот ПР улучшит
Теперь не обязательно ловить самого себя на экране, чтобы перебинтоваться, поесть или забить себя огнетушителем.

## Чеинжлог 
:cl:
 - rscadd: Клавиша B в режиме движения и сочетание Ctrl+B в режиме чата теперь позволят использовать(или ударить) предмет в активной руке на себя. Теперь выпить кофе или забить себя огнетушителем станет еще проще!
Будьте осторожны: с тем же успехом можно и взорвать себя!
- spellcheck: В список хоткеев добавлены сочетания для быстрой кобуры(H/Ctrl+H) и использования предмета на себя(B/Ctrl+B)