### PR TITLE
Fix holo desert tiles

### DIFF
--- a/maps/templates/holodeck/desert.dmm
+++ b/maps/templates/holodeck/desert.dmm
@@ -21,38 +21,15 @@
 	icon_state = "asteroid"
 	},
 /area/holodeck/source_desert)
-"e" = (
-/turf/simulated/floor/holofloor{
-	dir = 4;
-	icon_state = "asteroid8"
-	},
-/area/holodeck/source_desert)
 "f" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/simulated/floor/holofloor{
 	icon_state = "asteroid"
 	},
 /area/holodeck/source_desert)
-"g" = (
-/turf/simulated/floor/holofloor{
-	dir = 4;
-	icon_state = "asteroid11"
-	},
-/area/holodeck/source_desert)
 "h" = (
 /turf/simulated/floor/holofloor{
 	icon_state = "asteroid7"
-	},
-/area/holodeck/source_desert)
-"i" = (
-/turf/simulated/floor/holofloor{
-	icon_state = "asteroid5"
-	},
-/area/holodeck/source_desert)
-"j" = (
-/turf/simulated/floor/holofloor{
-	dir = 4;
-	icon_state = "asteroid1"
 	},
 /area/holodeck/source_desert)
 "k" = (
@@ -143,7 +120,7 @@ a
 h
 d
 a
-j
+a
 a
 "}
 (8,1,1) = {"
@@ -162,7 +139,7 @@ k
 a
 a
 a
-g
+a
 a
 a
 a
@@ -172,11 +149,11 @@ a
 "}
 (10,1,1) = {"
 a
-e
 a
 a
 a
-i
+a
+a
 f
 a
 h


### PR DESCRIPTION
<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений
Тайлы пола заменены на астероидные в голодеке-пустыне
<!--
Опишите изменения данного ПР-а.
Если есть связные ишью (issues), или другие ПРы - укажите их тут, для автоматического закрытия ишью следует использовать ключевые слова https://help.github.com/en/articles/closing-issues-using-keywords
Если есть связное форумное обсуждение на тему изменений - укажите ссылку на эту тему.
-->

## Почему и что этот ПР улучшит
Fix #3454 
<!--
Опишите причину для изменений.
Этот пункт особенно важен для описания изменений баланса, новых механик.
-->

## Авторство

<!-- Опциональный пункт!
Если авторство не полностью ваше, вы делаете порт с другого билда - обязательно укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
-->

## Чеинжлог

<!-- Опциональный пункт!
Если это что-то, о чём следует сообщить игрокам - опишите по форме (https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies#Changelog) свои изменения для игрового чеинжлога, они будут отображены на специальной страничке http://changelog.taucetistation.org

Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment
  
Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
