### PR TITLE
Фикс Bridge East камеры

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -38195,7 +38195,7 @@
 /area/hallway/primary/central)
 "btY" = (
 /obj/machinery/camera{
-	c_tag = "Bridge West"
+	c_tag = "Bridge East"
 	},
 /obj/item/weapon/storage/fancy/donut_box,
 /obj/structure/noticeboard{


### PR DESCRIPTION
## Описание изменений
До этого было 2 камеры Bridge West 
fix https://github.com/TauCetiStation/TauCetiClassic/issues/3870
## Почему и что этот ПР улучшит
меньше багов богу багов
## Авторство
Felix Ruin - Winter Schock
## Чеинжлог
:cl: Winter Schock
 - bugfix: было 2 камеры Bridge West 