### PR TITLE
 Ребаланс по причине токсик, попытка джва

### DIFF
--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -235,7 +235,7 @@
 
 		//world << "<span class='notice'>Exploding Pressure: [pressure] kPa, intensity: [range]</span>"
 
-		explosion(epicenter, round(Clamp(range*0.25,effrange*0.25,effrange-2)), round(Clamp(range*0.5,effrange*0.5,effrange-1)), round(effrange), round(effrange*1.5))
+		explosion(epicenter, round(CLAMP(range*0.25,effrange*0.25,effrange-2)), round(CLAMP(range*0.5,effrange*0.5,effrange-1)), round(effrange), round(effrange*1.5))
 		qdel(src)
 
 	else if(pressure > TANK_RUPTURE_PRESSURE)

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -230,12 +230,12 @@
 		air_contents.react()
 		pressure = air_contents.return_pressure()
 		var/range = (pressure-TANK_FRAGMENT_PRESSURE)/TANK_FRAGMENT_SCALE
-		range = min(range, MAX_EXPLOSION_RANGE)		// was 8 - - - Changed to a configurable define -- TLE
+		var/effrange = min(range, MAX_EXPLOSION_RANGE)		// was 8 - - - Changed to a configurable define -- TLE
 		var/turf/epicenter = get_turf(loc)
 
 		//world << "<span class='notice'>Exploding Pressure: [pressure] kPa, intensity: [range]</span>"
 
-		explosion(epicenter, round(range*0.25), round(range*0.5), round(range), round(range*1.5))
+		explosion(epicenter, round(Clamp(range*0.25,effrange*0.25,effrange-2)), round(Clamp(range*0.5,effrange*0.5,effrange-1)), round(effrange), round(effrange*1.5))
 		qdel(src)
 
 	else if(pressure > TANK_RUPTURE_PRESSURE)

--- a/code/modules/research/experiment.dm
+++ b/code/modules/research/experiment.dm
@@ -200,7 +200,7 @@
 			var/added_power = max(0, power - saved_power_level)
 			var/already_earned_power = min(saved_power_level, power)
 
-			calculated_research_points = added_power * 1000 + already_earned_power * 200
+			calculated_research_points = added_power * 800 + already_earned_power * 160
 
 			if(power > saved_power_level)
 				RD.files.experiments.saved_best_explosion = power


### PR DESCRIPTION
<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений

1. Увеличина мощность взрывов, которые можно получить с помощью бомб из баллона. Максимальный радиус остался прежним, потолок мощности поднят за счет увеличения разрушительного эффекта.

текущая сила взрывов - 27
Взрыв силой 31, который вполне легко получить:
![изображение](https://user-images.githubusercontent.com/53912632/63216175-4a47e380-c13a-11e9-9262-7254f2f11540.png)

Теоретически максимально возможный взрыв силой 51:
![изображение](https://user-images.githubusercontent.com/53912632/63216187-77949180-c13a-11e9-8fff-543f67157375.png)

Я гарантирую, что взрыв силой 34 получить реально.

2. Очки исследований, даваемые за взрывы, понерфленны с 1000 за новый уровень силы и 200 за уже исследованный до 800/160 соответственно.

Предыдущий максимум был 27 000 очков при норме в 25 000 за первое исследование всего, что доступно в данном направлении исследований.
Сейчас за взрыв силой 31 можно получить 24 800 очков, за взрыв силой 34 - 27 200 очков, то есть примерно на тот же уровень можно выйти.

И если у вас получится добиться взрыва силой 51... 👀

Таблица расчетов:
![изображение](https://user-images.githubusercontent.com/53912632/63216367-a1e74e80-c13c-11e9-8b14-a7fa9ae4bd18.png)

(Мощность взрыва складывается так: радиус легкого поражения плюс радиуса тяжелого поражения плюс дважды радиус полного разрушения. С классической формулой это Power = range+range/2+2*range/2, то есть сила взрыва в два раза больше его радиуса. В измененной формуле используется то же самое соотношение, но каждый радиус обрезается отдельно.)


<!--
Опишите изменения данного ПР-а.
Если есть связные ишью (issues), или другие ПРы - укажите их тут, для автоматического закрытия ишью следует использовать ключевые слова https://help.github.com/en/articles/closing-issues-using-keywords
Если есть связное форумное обсуждение на тему изменений - укажите ссылку на эту тему.
-->

## Почему и что этот ПР улучшит

На данный момент получить лимитку довольно легко, даже делая явно неоптимальные смеси. Теоретическая идеальная смесь сейчас потребует мощности бомбы в три с половиной раза больше, чем на лимитку требуется сейчас, с почти в два раза большей результирующей силой, пусть и в том же радиусе. Это значит, что форонщикам есть чем заняться. У меня в голове есть перспективные пути, но я, пожалуй, умолчу о них.

И человек, который сможет воспользоваться потенциалом, сорвет ощутимый научный куш.

<!--
Опишите причину для изменений.
Этот пункт особенно важен для описания изменений баланса, новых механик.
-->

## Чеинжлог
:cl:
 - balance: Изменен баланс бомб из токсинов. Они не ослаблены и даже наоборот, усилены, но для того, чтобы раскрыть их потенциал на полную, придется поработать. Грифозный потенциал не затронут. Изменения скомпенсированы очками науки.

