### PR TITLE
Removed Staff of Change from spellbook

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -249,12 +249,14 @@
 		dat += "[surplus] left.<br>"
 	return dat
 
+/* Commented because admins ban everyone who uses this staff... Somebody should rebalance this thing
 /datum/spellbook_entry/item/staffchange
 	name = "Staff of Change"
 	desc = "An artefact that spits bolts of coruscating energy which cause the target's very form to reshape itself."
 	item_path = /obj/item/weapon/gun/magic/change
 	log_name = "ST"
 	cost = 4
+*/
 
 /datum/spellbook_entry/item/staffanimation
 	name = "Staff of Animation"


### PR DESCRIPTION
## Описание изменений

СОЧ взят в заложники, если требования не будут выполнены он будет выпилен.

## Почему и что этот ПР улучшит

Наверно каждое использование этого посоха магом сейчас заканчивается баном последнего. Требуется ребаланс, сделать легко, я просто прикреплю пост Спейра в общем:
![Снимок экрана от 2019-08-27 21-27-18](https://user-images.githubusercontent.com/4064061/63797816-7b31d080-c911-11e9-8183-faec825e4090.png)

Всё что нужно - кому-нибудь потратить пол часа на тесты и сообщить приемлемые значения. И мы сможем избавиться от бесконечной чреды банов.

Еще стоит обновить список исключений, это тоже изменение на одну строку...
https://github.com/TauCetiStation/TauCetiClassic/blob/fd458cd8db76156305c150c7b6a27d4ceb89998c/code/modules/projectiles/projectile/magic.dm#L75

## Авторство

<!-- Опциональный пункт!
Если авторство не полностью ваше, вы делаете порт с другого билда - обязательно укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
-->

## Чеинжлог

:cl:
 - bugfix: Админы больше не банят за СоЧ (посох изменений). Потому что его нет!