### PR TITLE
Посохи теперь не имеют экшон кнопки

### DIFF
--- a/code/modules/projectiles/guns/magic.dm
+++ b/code/modules/projectiles/guns/magic.dm
@@ -16,6 +16,7 @@
 	var/ammo_type = /obj/item/ammo_casing/magic
 	var/global_access = FALSE
 	origin_tech = null
+	action_button_name = null
 	clumsy_check = 0
 	can_suicide_with = FALSE
 	can_be_holstered = FALSE


### PR DESCRIPTION
## Описание изменений
Собственно она (экшон кнопка) была бесполезна, теперь её нет
fix https://github.com/TauCetiStation/TauCetiClassic/issues/1590
## Почему и что этот ПР улучшит
Теперь игроки не будут тыкать экшон кнопку магического посоха не понимаю зачем это
## Авторство
Felix Ruin - Winter Schock
## Чеинжлог
:cl: Winter Schock
- bugfix: Посохи имели активную кнопку в углу экрана
