### PR TITLE
Туррет и Епилепсия находились под одним датумом (Турет заменял эпилепсию)

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -56,8 +56,8 @@
 
 
 
-/datum/quirk/epileptic
-	name = "Twitching"
+/datum/quirk/tourette
+	name = "Tourette"
 	desc = "You have incurable twitching."
 	value = -1
 	mob_trait = TRAIT_TOURETTE


### PR DESCRIPTION
## Описание изменений
датум туретта был датумом эпилепсии, заменяя эпилепсию (хоть где-то об этом моменте я не видел комментария(@ZVee ))
## Почему и что этот ПР улучшит
Эпилептики и люди с синдромом Туретта это раздельные вещи
## Авторство
Felix Ruin - Winter Schock
## Чеинжлог 
:cl: Winter Schock
- bugfix: Синдром туретта был эпилепсией (теперь оба квирка есть) 