### PR TITLE
перенос админ вёрба реджува в реджув

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -61,7 +61,6 @@ var/list/admin_verbs_admin = list(
 	/datum/admins/proc/show_player_info,
 	/client/proc/free_slot,			//frees slot for chosen job,
 	/client/proc/cmd_admin_change_custom_event,
-	/client/proc/cmd_admin_rejuvenate,
 	/client/proc/toggleattacklogs,
 	/client/proc/toggledebuglogs,
 	/client/proc/toggleghostwriters,
@@ -192,6 +191,7 @@ var/list/admin_verbs_permissions = list(
 	/client/proc/regisration_panic_bunker
 	)
 var/list/admin_verbs_rejuv = list(
+	/client/proc/cmd_admin_rejuvenate,
 	/client/proc/respawn_character
 	)
 var/list/admin_verbs_whitelist = list(


### PR DESCRIPTION
## Описание изменений
fix https://github.com/TauCetiStation/TauCetiClassic/issues/1548
перенос прока реджув из основных кнопок админов в дополнительные, ибо до этого реджув был не там и без флага реджув он был, но его использовать нельзя было
## Почему и что этот ПР улучшит
не будет более издевательской кнопки которая даже не работает без флага реджув
## Авторство
Felix Ruin - Winter Schock
## Чеинжлог