### PR TITLE
Невозможность дизармить спиной и разброс при стрельбе за спину.

### DIFF
--- a/code/__DEFINES/mob.dm
+++ b/code/__DEFINES/mob.dm
@@ -137,3 +137,5 @@
 //movement intent defines for the m_intent var
 #define MOVE_INTENT_WALK "walk"
 #define MOVE_INTENT_RUN  "run"
+
+#define CHECK_ROBUST_DIR(user, target) ( user != target && get_dist(user, target) > 0 && (get_dir(user, target) in list(turn(user.dir, 180), turn(user.dir, 225), turn(user.dir, -225))) )

--- a/code/__DEFINES/mob.dm
+++ b/code/__DEFINES/mob.dm
@@ -139,3 +139,4 @@
 #define MOVE_INTENT_RUN  "run"
 
 #define CHECK_ROBUST_DIR(user, target) ( user != target && get_dist(user, target) > 0 && (get_dir(user, target) in list(turn(user.dir, 180), turn(user.dir, 225), turn(user.dir, -225))) )
+#define MSG_DISARM_DIR_FAIL "<span class='warning'>You can't disarm your target while facing away from it.</span>" // strings.dm?

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -299,12 +299,19 @@
 	if(client && world.time < client.move_delay) // block turning, if we are in moving state.
 		return
 
+	var/direction
 	if(abs(dx) < abs(dy))
-		if(dy > 0)	usr.dir = NORTH
-		else		usr.dir = SOUTH
+		if(dy > 0)
+			direction = NORTH
+		else
+			direction = SOUTH
 	else
-		if(dx > 0)	usr.dir = EAST
-		else		usr.dir = WEST
+		if(dx > 0)
+			direction = EAST
+		else
+			direction = WEST
+	if(direction != dir)
+		facedir(direction)
 
 // Craft or Build helper (main file can be found here: code/datums/cob_highlight.dm)
 /mob/proc/cob_click(client/C, list/modifiers)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -296,6 +296,9 @@
 	var/dy = A.y - y
 	if(!dx && !dy) return
 
+	if(client && world.time < client.move_delay) // block turning, if we are in moving state.
+		return
+
 	if(abs(dx) < abs(dy))
 		if(dy > 0)	usr.dir = NORTH
 		else		usr.dir = SOUTH

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -58,6 +58,7 @@
 		return FALSE
 
 	var/atom/oldloc = loc
+	var/olddir = dir
 
 	if(loc != NewLoc)
 		if (!(Dir & (Dir - 1))) //Cardinal move
@@ -85,6 +86,10 @@
 						. = step(src, WEST)
 					else if (step(src, WEST))
 						. = step(src, SOUTH)
+
+	if(Dir != olddir)
+		dir = olddir
+		set_dir(Dir)
 
 	if(!loc || (loc == oldloc && oldloc != NewLoc))
 		last_move = 0

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -26,6 +26,7 @@
 		for (var/obj/item/weapon/grab/G in M.grabbed_by)
 			qdel(G)
 	M.buckled = src
+	M.facing_dir = null
 	M.set_dir(dir)
 	buckled_mob = M
 	post_buckle_mob(M)

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -123,7 +123,7 @@
 		layer = OBJ_LAYER
 
 	if(buckled_mob)
-		buckled_mob.dir = dir
+		buckled_mob.set_dir(dir)
 		buckled_mob.update_canmove()
 
 /obj/structure/stool/bed/chair/verb/rotate()

--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -17,7 +17,7 @@
 	var/image/O = image(icon = 'icons/obj/objects.dmi', icon_state = "w_overlay", layer = FLY_LAYER, dir = src.dir)
 	overlays += O
 	if(buckled_mob)
-		buckled_mob.dir = dir
+		buckled_mob.set_dir(dir)
 
 /obj/structure/stool/bed/chair/wheelchair/post_buckle_mob(mob/living/M)
 	. = ..()

--- a/code/modules/mob/living/carbon/alien/alien_defense.dm
+++ b/code/modules/mob/living/carbon/alien/alien_defense.dm
@@ -70,6 +70,7 @@ This is what happens, when we attack aliens.
 
 		if ("disarm")
 			if(CHECK_ROBUST_DIR(M, src))
+				to_chat(M, MSG_DISARM_DIR_FAIL)
 				return
 
 			if (!lying)

--- a/code/modules/mob/living/carbon/alien/alien_defense.dm
+++ b/code/modules/mob/living/carbon/alien/alien_defense.dm
@@ -69,6 +69,9 @@ This is what happens, when we attack aliens.
 						O.show_message(text("<span class='warning'><B>[] has attempted to punch []!</B></span>", M, src), 1)
 
 		if ("disarm")
+			if(CHECK_ROBUST_DIR(M, src))
+				return
+
 			if (!lying)
 				if (prob(5))//Very small chance to push an alien down.
 					Weaken(2)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -132,6 +132,9 @@
 
 
 		if("disarm")
+			if(CHECK_ROBUST_DIR(M, src))
+				return
+
 			M.do_attack_animation(src)
 			M.attack_log += text("\[[time_stamp()]\] <font color='red'>Disarmed [src.name] ([src.ckey])</font>")
 			src.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been disarmed by [M.name] ([M.ckey])</font>")

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -133,6 +133,7 @@
 
 		if("disarm")
 			if(CHECK_ROBUST_DIR(M, src))
+				to_chat(M, MSG_DISARM_DIR_FAIL)
 				return
 
 			M.do_attack_animation(src)

--- a/code/modules/mob/living/carbon/ian/ian.dm
+++ b/code/modules/mob/living/carbon/ian/ian.dm
@@ -402,6 +402,7 @@
 
 		if("disarm")
 			if(CHECK_ROBUST_DIR(M, src))
+				to_chat(M, MSG_DISARM_DIR_FAIL)
 				return
 
 			M.do_attack_animation(src)

--- a/code/modules/mob/living/carbon/ian/ian.dm
+++ b/code/modules/mob/living/carbon/ian/ian.dm
@@ -401,6 +401,9 @@
 			M.Grab(src)
 
 		if("disarm")
+			if(CHECK_ROBUST_DIR(M, src))
+				return
+
 			M.do_attack_animation(src)
 			M.attack_log += text("\[[time_stamp()]\] <font color='red'>Disarmed [src.name] ([src.ckey])</font>")
 			src.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been disarmed by [M.name] ([M.ckey])</font>")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -119,7 +119,14 @@
 //					return
 		if(pulling == AM)
 			stop_pulling()
+		var/old_dir
+		if(ismob(AM))
+			var/mob/M = AM
+			if(M.a_intent == I_DISARM)
+				old_dir = M.dir
 		step(AM, t)
+		if(old_dir)
+			AM.set_dir(old_dir)
 		now_pushing = 0
 
 //mob verbs are a lot faster than object verbs

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -667,14 +667,12 @@ note dizziness decrements automatically in the mob's Life() proc.
 
 // facing verbs
 /mob/proc/canface()
-	if(!canmove)						return 0
-	if(client.moving)					return 0
-	if(world.time < client.move_delay)	return 0
-	if(stat==2)							return 0
-	if(anchored)						return 0
-	if(monkeyizing)						return 0
-	if(restrained())					return 0
-	return 1
+	return !incapacitated()
+
+/mob/living/canface()
+	if(stat)
+		return FALSE
+	return ..()
 
 // Updates canmove, lying and icons. Could perhaps do with a rename but I can't think of anything to describe it.
 // We need speed out of this proc, thats why using incapacitated() helper here is a bad idea.
@@ -731,14 +729,14 @@ note dizziness decrements automatically in the mob's Life() proc.
 
 
 /mob/proc/facedir(ndir)
-	if(!canface())
-		return 0
-	dir = ndir
+	if(!canface() || moving || (buckled && !buckled.buckle_movable))
+		return FALSE
+	set_dir(ndir)
 	if(buckled && buckled.buckle_movable)
-		buckled.dir = ndir
+		buckled.set_dir(ndir)
 		buckled.handle_rotation()
 	client.move_delay += movement_delay()
-	return 1
+	return TRUE
 
 
 /mob/verb/eastface()
@@ -775,6 +773,7 @@ note dizziness decrements automatically in the mob's Life() proc.
 		return
 
 	if(status_flags & CANSTUN || ignore_canstun)
+		facing_dir = null
 		stunned = max(max(stunned, amount), 0) //can't go below 0, getting a low amount of stun doesn't lower your current stun
 		if(updating)
 			update_canmove()
@@ -816,6 +815,7 @@ note dizziness decrements automatically in the mob's Life() proc.
 // ========== WEAKEN ==========
 /mob/proc/Weaken(amount)
 	if(status_flags & CANWEAKEN)
+		facing_dir = null
 		weakened = max(max(weakened, amount), 0)
 		update_canmove() // updates lying, canmove and icons
 	else
@@ -838,6 +838,7 @@ note dizziness decrements automatically in the mob's Life() proc.
 // ========== PARALYSE ==========
 /mob/proc/Paralyse(amount)
 	if(status_flags & CANPARALYSE)
+		facing_dir = null
 		paralysis = max(max(paralysis, amount), 0)
 	else
 		paralysis = 0
@@ -857,6 +858,7 @@ note dizziness decrements automatically in the mob's Life() proc.
 // ========== SLEEPING ==========
 /mob/proc/Sleeping(amount)
 	if(status_flags & CANPARALYSE) // because sleeping and paralysis are very similar statuses and i see no point in separate flags at this time (anyway, golems mostly).
+		facing_dir = null
 		sleeping = max(max(sleeping, amount), 0)
 	else
 		sleeping = 0
@@ -875,6 +877,7 @@ note dizziness decrements automatically in the mob's Life() proc.
 
 // ========== RESTING ==========
 /mob/proc/Resting(amount)
+	facing_dir = null
 	resting = max(max(resting, amount), 0)
 	return
 
@@ -1071,3 +1074,42 @@ note dizziness decrements automatically in the mob's Life() proc.
 
 /mob/proc/can_unbuckle(mob/user)
 	return 1
+
+/mob/verb/face_direction()
+	set name = "Face Direction"
+	set category = "IC"
+	set src = usr
+
+	set_face_dir()
+
+	if(!facing_dir)
+		to_chat(usr, "You are now not facing anything.")
+	else
+		to_chat(usr, "You are now facing [dir2text(facing_dir)].")
+
+/mob/proc/set_face_dir(newdir)
+	if(!isnull(facing_dir) && newdir == facing_dir)
+		facing_dir = null
+	else if(newdir)
+		set_dir(newdir)
+		facing_dir = newdir
+	else if(facing_dir)
+		facing_dir = null
+	else
+		set_dir(dir)
+		facing_dir = dir
+
+/mob/set_dir()
+	if(facing_dir)
+		if(!canface() || lying || restrained())
+			facing_dir = null
+		else if(buckled)
+			if(buckled.buckle_movable)
+				buckled.set_dir(facing_dir)
+				return ..(facing_dir)
+			else
+				facing_dir = null
+		else if(dir != facing_dir)
+			return ..(facing_dir)
+	else
+		return ..()

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -93,6 +93,7 @@
 	var/list/abilities = list()         // For species-derived or admin-given powers.
 	var/list/speak_emote = list("says") // Verbs used when speaking. Defaults to 'say' if speak_emote is null.
 	var/emote_type = 1		// Define emote default type, 1 for seen emotes, 2 for heard emotes
+	var/facing_dir = null // Used for the ancient art of moonwalking.
 	var/floating = 0
 
 	var/name_archive //For admin things like possession

--- a/code/modules/projectiles/firing.dm
+++ b/code/modules/projectiles/firing.dm
@@ -1,4 +1,4 @@
-/obj/item/ammo_casing/proc/fire(atom/target, mob/living/user, params, distro, quiet)
+/obj/item/ammo_casing/proc/fire(atom/target, mob/living/user, params, distro, quiet, add_dispersion)
 	distro += variance
 	for(var/i = max(1, pellets), i > 0, i--)
 		var/curloc = user.loc
@@ -6,7 +6,7 @@
 		ready_proj(target, user, quiet)
 		if(distro)
 			targloc = spread(targloc, curloc, distro)
-		if(!throw_proj(target, targloc, user, params))
+		if(!throw_proj(target, targloc, user, params, add_dispersion))
 			return 0
 		if(i > 1)
 			newshot()
@@ -23,7 +23,7 @@
 	BB.silenced = quiet
 	return
 
-/obj/item/ammo_casing/proc/throw_proj(atom/target, turf/targloc, mob/living/user, params)
+/obj/item/ammo_casing/proc/throw_proj(atom/target, turf/targloc, mob/living/user, params, add_dispersion)
 	var/turf/curloc = user.loc
 	if (!istype(targloc) || !istype(curloc) || !BB)
 		return 0
@@ -45,6 +45,9 @@
 			BB.p_x = text2num(mouse_control["icon-x"])
 		if(mouse_control["icon-y"])
 			BB.p_y = text2num(mouse_control["icon-y"])
+
+	if(add_dispersion)
+		BB.dispersion += add_dispersion
 
 	//randomize clickpoint a bit based on dispersion
 	if(BB.dispersion)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -148,7 +148,11 @@
 		if(point_blank)
 			user.visible_message("<span class='red'><b> \The [user] fires \the [src] point blank at [target]!</b></span>")
 			chambered.BB.damage *= 1.3
-		if(!chambered.fire(target, user, params, , silenced))
+		var/additional_dispersion = 0
+		if(CHECK_ROBUST_DIR(user, target))
+			additional_dispersion = 2
+
+		if(!chambered.fire(target, user, params, , silenced, additional_dispersion))
 			shoot_with_empty_chamber(user)
 		else
 			shoot_live_shot(user)


### PR DESCRIPTION
## Описание изменений

В первую очередь это просто возможность пощупать новые условия, т.е вопрос о мерже на постоянку сейчас не ставится, но если зайдет - то пожалуйста. Когда, куда, и на какой - это сами уже.

---

У меня эта идея уже очень давно в голове витала, но все либо забывал, либо это просто не было приоритетом.
Собственно основное это невозможность делать дизарм жопой, как это говорят у нас в простым языком.
Механ до боли прост:

Если персонаж в движении, а цель его приблизительно в красной зоне как на скриншоте, то дизарм не будет выполнен.

![4dsfds](https://user-images.githubusercontent.com/8426718/64862820-204fe700-d63c-11e9-8e66-fa0d8e62c50f.png)

---

Второй момент это стрельба за спину и эта идея в общем-то родилась прям перед тем как я решил накинуть код для дизарма. Принцип тот же, но вместо блокировки стрельбы накидывается разброс к выстрелу. Стрельба из-за угла не страдает, т.к в учет идут градусы от 135 до 225, т.е охват спины.
Вполне вероятно что какая-нибудь там уникальная пушка которая идет в обход стандартных проков не будет иметь этот механ, и это нормально в рамках хаоса в нашем билде. Потом при желании можно отловить и поправить (пока этот текст писал, возможно там какая-нибудь пневмопушка или вроде того).

---

Прочее:

Еще вместо блокировки можно просто резать шанс дизарма. Однако это плохой вариант, т.к для игрока совсем будет непонятно когда шанс уже вернулся в норму, а когда он порезан (то что персонаж уже встал на турф - не гарантия), плюс это будет не очевидно, в отличии от того, когда у тебя просто дизарм не происходит (конечно можно нагрузить худ доп инфой, отображать в реальном времени какими-то сигналами, но все еще не уверен что это хорошая идея и плюс еще неизвестно придется ли из-за этого половину билда вскрыть).

И один небольшой нюанс, в режиме ходьбы (т.е walk) и из-за того что у нас анимация перемещения спрайта с турфа на турф происходит несколько быстрее, чем это в реальности невидимо для игрока - несмотря на то что персонаж может давно уже быть на соседнем турфе, это не значит что он завершил шаг, а значит и развернуться плюс начать дизармить не выйдет.
На самом деле этот пункт может не существовать при порте плавной анимации движения, но с ней были проблемы в последний раз когда пытался пригнать.

Касательно всех остальных вещей куда бы это все развить можно было:
Не стал накидывать это на атаку, граб там или еще куда, т.к основная идея сейчас это дизарм и ничего более.
На вопрос почему не сделал это алиумам? Вообще, по тем же играм их серии можно вспомнить что они вполне без проблем станили людей и хвостом, плюс можно взять во внимание что более агильные, в общем на мой взгляд им не надо трогать дизарм.

И иногда замечал, что персонаж вроде повернулся, но дизармить еще не позволяет (вероятно это если предыдущий клик был сделан прямо перед тем, как персонаж уже почти закончил движение но все таки раньше времени сделанный клик, однако КД кликов и движения это две разные темы, поэтому возможно либо я найду какое-то решение (не обещаю), либо научиться таймить клик под движение, но в целом там не все так ужасно как может показать с прочтения текста.

~И мимо ходом убита лунная походка (фича позволяющая разворачиваться во время движения, чем некоторые любили заниматься). Если это прям кошмарно-критично, то вообще давно на билдах придумали возможность лочить направление взгляда (но если это вводить, надо позаботиться о дебафах скорости движения спиной, боком и т.д.).~ Лунная походка вернулась с апгрейдом.


<!--
Опишите изменения данного ПР-а.
Если есть связные ишью (issues), или другие ПРы - укажите их тут, для автоматического закрытия ишью следует использовать ключевые слова https://help.github.com/en/articles/closing-issues-using-keywords
Если есть связное форумное обсуждение на тему изменений - укажите ссылку на эту тему.
-->

## Почему и что этот ПР улучшит

Думаю что тут нельзя сказать улучшит или ухудшит, эти изменения дают возможность взглянуть на геймплей таких элементов под другим углом, возможно даже научиться новым приемам в новых условиях.
С другой стороны, очень много "жалоб" на "дизармозад", поэтому возможно с этого угла и улучшит геймлей.
Реализм или что-то такое тут не надо искать, потому что найдутся какие-нибудь там гимнасты которые скачут на одной ноге, а второй ставят подножку бегущему сзади, по факту это такая же игровая условность как и видимость персонажа на 360 градусов. И в целом если и искать смысл, то только в том, как это влияет на игру, не более.

## Чеинжлог

:cl:
 - experiment: Набегу более невозможно произвести дизарм спиной, а при ходьбе продолжительное время персонаж будет стоять на месте при попытках дизармить (анимация и реальное положение дел не соответствует действительности, стоит просто вспомнить как выглядит ходьба).
 - experiment: Во вкладке IC можно найти новую кнопку Face Direction. Позволяет блокировать направление куда будет повернута кукла во время движения что позволит лунно-походить хоть через всю станцию.
 - experiment: При стрельбе за спину добавляется разброс.