### PR TITLE
Фикс места занимаемого разбитыми бутылками в инвентаре.

### DIFF
--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -123,6 +123,7 @@
 
 	name = "Broken Bottle"
 	desc = "A bottle with a sharp broken bottom."
+	w_class = ITEM_SIZE_SMALL
 	icon = 'icons/obj/drinks.dmi'
 	icon_state = "broken_bottle"
 	force = 9.0


### PR DESCRIPTION
<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений

fix #3999 Теперь разбитые бутылки занимают в инвентаре столько же места, сколько и целые.

![бутылки](https://user-images.githubusercontent.com/55272302/64919940-4a331600-d7c2-11e9-82e2-7eb5b095d88a.png)

<!--
Опишите изменения данного ПР-а.
Если есть связные ишью (issues), или другие ПРы - укажите их тут, для автоматического закрытия ишью следует использовать ключевые слова https://help.github.com/en/articles/closing-issues-using-keywords
Если есть связное форумное обсуждение на тему изменений - укажите ссылку на эту тему.
-->

## Почему и что этот ПР улучшит

Пофиксит баг с разбитыми бутылками.
<!--
Опишите причину для изменений.
Этот пункт особенно важен для описания изменений баланса, новых механик.
-->

## Авторство

<!-- Опциональный пункт!
Если авторство не полностью ваше, вы делаете порт с другого билда - обязательно укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
-->

## Чеинжлог
:cl:
 - bugfix: исправлен размер места занимаемого в инвентаре разбитыми бутылками. 
<!-- Опциональный пункт!
Если это что-то, о чём следует сообщить игрокам - опишите по форме (https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies#Changelog) свои изменения для игрового чеинжлога, они будут отображены на специальной страничке http://changelog.taucetistation.org

Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment
  
Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
