### PR TITLE
Обновление кода операций

### DIFF
--- a/code/game/gamemodes/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/abduction/abduction_gear.dm
@@ -567,27 +567,33 @@
 /obj/item/weapon/scalpel/alien
 	name = "alien scalpel"
 	icon = 'icons/obj/abductor.dmi'
+	toolspeed = 0.3
 
 /obj/item/weapon/hemostat/alien
 	name = "alien hemostat"
 	icon = 'icons/obj/abductor.dmi'
+	toolspeed = 0.3
 
 /obj/item/weapon/retractor/alien
 	name = "alien retractor"
 	icon = 'icons/obj/abductor.dmi'
+	toolspeed = 0.3
 
 /obj/item/weapon/circular_saw/alien
 	name = "alien saw"
 	icon = 'icons/obj/abductor.dmi'
 	icon_state = "saw"
+	toolspeed = 0.3
 
 /obj/item/weapon/surgicaldrill/alien
 	name = "alien drill"
 	icon = 'icons/obj/abductor.dmi'
+	toolspeed = 0.3
 
 /obj/item/weapon/cautery/alien
 	name = "alien cautery"
 	icon = 'icons/obj/abductor.dmi'
+	toolspeed = 0.3
 
 
 // OPERATING TABLE / BEDS / LOCKERS	/ OTHER

--- a/code/game/objects/items/weapons/surgery_tools.dm
+++ b/code/game/objects/items/weapons/surgery_tools.dm
@@ -109,6 +109,7 @@
 	desc = "A scalpel augmented with a directed laser, for more precise cutting without blood entering the field.  This one looks basic and could be improved."
 	icon_state = "scalpel_laser1_on"
 	damtype = "fire"
+	toolspeed = 1.2
 
 /obj/item/weapon/scalpel/laser2
 	name = "laser scalpel"
@@ -123,12 +124,14 @@
 	icon_state = "scalpel_laser3_on"
 	damtype = "fire"
 	force = 15.0
+	toolspeed = 0.6
 
 /obj/item/weapon/scalpel/manager
 	name = "incision management system"
 	desc = "A true extension of the surgeon's body, this marvel instantly and completely prepares an incision allowing for the immediate commencement of therapeutic steps."
 	icon_state = "scalpel_manager_on"
 	force = 7.5
+	toolspeed = 0.6
 
 /*
  * Circular Saw

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -682,6 +682,7 @@
 	desc = "A long loose piece of clothing worn in a hospital by someone doing or having an operation. It can be used as clothing for bedridden patients."
 	icon_state = "patient_gown"
 	item_color = "patient_gown"
+	body_parts_covered = 0
 
 /obj/item/clothing/under/pretty_dress
 	name = "pretty dress"

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -1,13 +1,23 @@
 /* SURGERY STEPS */
 /datum/surgery_step
 	var/priority = 0	//steps with higher priority would be attempted first
-	var/list/allowed_tools = null // type path referencing tools that can be used for this step, and how well are they suited for it
-	var/list/allowed_species = list("exclude", IPC) // type paths referencing mutantraces that this step applies to.
-	var/min_duration = 0 // min duration of the step
-	var/max_duration = 0 // max duration of the step
-	var/can_infect = 0  // evil infection stuff that will make everyone hate me
-	var/blood_level = 0 //How much blood this step can get on surgeon. 1 - hands, 2 - full body.
-	var/clothless = 1 //Cloth check
+
+	//type path referencing tools that can be used for this step, and how well are they suited for it
+	var/list/allowed_tools = null
+	// type paths referencing mutantraces that this step applies to.
+	var/list/allowed_species = list("exclude", IPC)
+
+	//duration of the step
+	var/min_duration = 0
+	var/max_duration = 0
+
+	//evil infection stuff that will make everyone hate me
+	var/can_infect = 0
+	//How much blood this step can get on surgeon. 1 - hands, 2 - full body.
+	var/blood_level = 0
+
+	//Cloth check
+	var/clothless = 1
 
 // returns how well tool is suited for this step
 /datum/surgery_step/proc/tool_quality(obj/item/tool)
@@ -18,8 +28,9 @@
 
 // Checks if this step applies to the mutantrace of the user.
 /datum/surgery_step/proc/is_valid_mutantrace(mob/living/carbon/human/target)
-	if(ishuman(target) && allowed_species && ("exclude" in allowed_species) == (target.get_species() in allowed_species))
-		return FALSE
+	if(ishuman(target) && allowed_species)
+		if(("exclude" in allowed_species) == (target.get_species() in allowed_species))
+			return FALSE
 	return TRUE
 
 // checks whether this step can be applied with the given user and target
@@ -62,7 +73,7 @@
 /proc/do_surgery(mob/living/carbon/M, mob/living/user, obj/item/tool)
 	if(!istype(M))
 		return FALSE
-	if(user.a_intent == "hurt")	//check for Hippocratic Oath
+	if(user.a_intent == I_HURT)	//check for Hippocratic Oath
 		return FALSE
 	if(user.is_busy(null)) // No target so we allow multiple players to do surgeries on one pawn.
 		return FALSE

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -1,62 +1,42 @@
 /* SURGERY STEPS */
-
 /datum/surgery_step
 	var/priority = 0	//steps with higher priority would be attempted first
-
-	// type path referencing tools that can be used for this step, and how well are they suited for it
-	var/list/allowed_tools = null
-	// type paths referencing mutantraces that this step applies to.
-	var/list/allowed_species = list("exclude", IPC)
-
-	// duration of the step
-	var/min_duration = 0
-	var/max_duration = 0
-
-	// evil infection stuff that will make everyone hate me
-	var/can_infect = 0
-	//How much blood this step can get on surgeon. 1 - hands, 2 - full body.
-	var/blood_level = 0
-
-	//Cloth check
-	var/clothless = 1
+	var/list/allowed_tools = null // type path referencing tools that can be used for this step, and how well are they suited for it
+	var/list/allowed_species = list("exclude", IPC) // type paths referencing mutantraces that this step applies to.
+	var/min_duration = 0 // min duration of the step
+	var/max_duration = 0 // max duration of the step
+	var/can_infect = 0  // evil infection stuff that will make everyone hate me
+	var/blood_level = 0 //How much blood this step can get on surgeon. 1 - hands, 2 - full body.
+	var/clothless = 1 //Cloth check
 
 // returns how well tool is suited for this step
 /datum/surgery_step/proc/tool_quality(obj/item/tool)
-	for (var/T in allowed_tools)
-		if (istype(tool,T))
+	for(var/T in allowed_tools)
+		if(istype(tool, T))
 			return allowed_tools[T]
-	return 0
+	return FALSE
 
 // Checks if this step applies to the mutantrace of the user.
 /datum/surgery_step/proc/is_valid_mutantrace(mob/living/carbon/human/target)
-
-	if(!ishuman(target)) // Juuuuust making sure.
-		return TRUE
-
-	if(allowed_species)
-		var/exclusive = ("exclude" in allowed_species)
-		var/in_list = (target.get_species() in allowed_species)
-		if((exclusive || in_list) && !(exclusive && in_list))
-			return TRUE
+	if(ishuman(target) && allowed_species && ("exclude" in allowed_species) == (target.get_species() in allowed_species))
 		return FALSE
-
 	return TRUE
 
 // checks whether this step can be applied with the given user and target
 /datum/surgery_step/proc/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	return 0
+	return FALSE
 
 // does stuff to begin the step, usually just printing messages. Moved germs transfering and bloodying here too
 /datum/surgery_step/proc/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
-	if (can_infect && BP)
+	if(can_infect && BP)
 		spread_germs_to_organ(BP, user)
-	if (ishuman(user) && prob(60))
+	if(ishuman(user) && prob(60))
 		var/mob/living/carbon/human/H = user
-		if (blood_level)
-			H.bloody_hands(target,0)
-		if (blood_level > 1)
-			H.bloody_body(target,0)
+		if(blood_level)
+			H.bloody_hands(target, 0)
+		if(blood_level > 1)
+			H.bloody_body(target, 0)
 	return
 
 // does stuff to end the step, which is normally print a message + do whatever this step changes
@@ -81,49 +61,66 @@
 
 /proc/do_surgery(mob/living/carbon/M, mob/living/user, obj/item/tool)
 	if(!istype(M))
-		return 0
-	if (user.a_intent == "hurt")	//check for Hippocratic Oath
-		return 0
-	var/target_zone = user.zone_sel.selecting
-
+		return FALSE
+	if(user.a_intent == "hurt")	//check for Hippocratic Oath
+		return FALSE
 	if(user.is_busy(null)) // No target so we allow multiple players to do surgeries on one pawn.
 		return FALSE
 
+	var/target_zone = user.zone_sel.selecting
 	for(var/datum/surgery_step/S in surgery_steps)
 		//check, if target undressed for clothless operations
-		if(ishuman(M))
+		if(S.clothless && ishuman(M))
 			var/mob/living/carbon/human/T = M
-			if(S.clothless)
-				switch(target_zone)
-					if(BP_CHEST , BP_GROIN , BP_L_LEG , BP_R_LEG , BP_R_ARM , BP_L_ARM)
-						if(T.wear_suit || (T.w_uniform && !istype(T.w_uniform, /obj/item/clothing/under/patient_gown)))
-							return 0
-					if(BP_R_LEG , BP_L_LEG)
-						if(T.shoes)
-							return 0
-					if(O_EYES)
-						if(T.glasses)
-							return 0
-					if(BP_R_ARM , BP_L_ARM)
-						if(T.gloves)
-							return 0
+			var/covered
+			for(var/obj/item/I in list(T.wear_suit, T.w_uniform, T.gloves, T.glasses, T.head, T.wear_mask, T.shoes))
+				if(I && I.body_parts_covered)
+					covered |= I.body_parts_covered
+			switch(target_zone)
+				if(BP_CHEST)
+					if(covered & UPPER_TORSO)
+						return FALSE
+				if(BP_GROIN)
+					if(covered & LOWER_TORSO)
+						return FALSE
+				if(BP_L_LEG)
+					if(covered & LEG_LEFT)
+						return FALSE
+				if(BP_R_LEG)
+					if(covered & LEG_RIGHT)
+						return FALSE
+				if(BP_L_ARM)
+					if(covered & ARM_LEFT)
+						return FALSE
+				if(BP_R_ARM)
+					if(covered & ARM_RIGHT)
+						return FALSE
+				if(BP_HEAD)
+					if(covered & HEAD)
+						return FALSE
+				if(O_MOUTH)
+					if(covered & FACE)
+						return FALSE
+				if(O_EYES)
+					if(covered & EYES)
+						return FALSE
 
 		//check if tool is right or close enough and if this step is possible
-		if( S.tool_quality(tool) && S.can_use(user, M, target_zone, tool) && S.is_valid_mutantrace(M))
+		if(S.tool_quality(tool) && S.can_use(user, M, target_zone, tool) && S.is_valid_mutantrace(M))
 			S.begin_step(user, M, target_zone, tool)		//...start on it
 			//We had proper tools! (or RNG smiled.) and User did not move or change hands.
-			if(prob(S.tool_quality(tool)) &&  do_mob(user, M, rand(S.min_duration, S.max_duration)) && user.zone_sel.selecting && target_zone == user.zone_sel.selecting)
+			if(prob(S.tool_quality(tool)) && do_mob(user, M, rand(S.min_duration, S.max_duration) * tool.toolspeed) && user.zone_sel.selecting && target_zone == user.zone_sel.selecting)
 				S.end_step(user, M, target_zone, tool)		//finish successfully
 			else if((tool in user.contents) && user.Adjacent(M))		//or (also check for tool in hands and being near the target)
 				S.fail_step(user, M, target_zone, tool)		//malpractice~
 			else	// this failing silently was a pain.
 				to_chat(user, "<span class='warning'>You must remain close to your patient to conduct surgery.</span>")
 
-			if (ishuman(M))
+			if(ishuman(M))
 				var/mob/living/carbon/human/H = M
 				H.update_surgery()										//shows surgery results
-			return	1	  												//don't want to do weapony things after surgery
-	return 0
+			return	TRUE	  												//don't want to do weapony things after surgery
+	return FALSE
 
 /proc/sort_surgeries()
 	var/gap = surgery_steps.len


### PR DESCRIPTION
## Описание изменений
Переписывание кода операций, добавление точного определения возможности проведения операции на часть тела по флагам закрываемых частей тела у всех вещей, добавление расчёта скорости операции от типа инструмента (для вещей абдукторов нужно 30 процентов времени от обычного, у скальпелей: обычный и второго уровня - 100%, у первого уровня - 120%, третьего и девайса с кучей функций - 0.6)
## Почему и что этот ПР улучшит
Используемость toolspeed у вещей, неоперируемость головы через шлем и тому подобное (не считая одежд пациента)
## Авторство
Felix Ruin - Winter Schock
## Чеинжлог
:cl: Winter Schock
- bugfix: Операции на закрытые вещами части тела
- balance: Улучшенные хирургические инструменты из рнд имеют разную скорость работы