### PR TITLE
Исправления зума

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -181,7 +181,7 @@
 		if(istype(item_in_hand, /obj/item/weapon/gun/energy/sniperrifle))
 			var/obj/item/weapon/gun/energy/sniperrifle/s = item_in_hand
 			if(s.zoom)
-				s.zoom()
+				s.toggle_zoom()
 	src.hand = !( src.hand )
 	if(hud_used.l_hand_hud_object && hud_used.r_hand_hud_object)
 		if(hand)	//This being 1 means the left hand is in use

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -178,6 +178,10 @@
 			if(item_in_hand:wielded)
 				to_chat(usr, "<span class='warning'>Your other hand is too busy holding the [item_in_hand.name]</span>")
 				return
+		if(istype(item_in_hand, /obj/item/weapon/gun/energy/sniperrifle))
+			var/obj/item/weapon/gun/energy/sniperrifle/s = item_in_hand
+			if(s.zoom)
+				s.zoom()
 	src.hand = !( src.hand )
 	if(hud_used.l_hand_hud_object && hud_used.r_hand_hud_object)
 		if(hand)	//This being 1 means the left hand is in use

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1342,7 +1342,7 @@
 				if(locate(/obj/item/weapon/gun/energy/sniperrifle, contents))
 					var/obj/item/weapon/gun/energy/sniperrifle/s = locate() in src
 					if(s.zoom)
-						s.zoom()
+						s.toggle_zoom()
 
 	else
 		sight &= ~(SEE_TURFS|SEE_MOBS|SEE_OBJS)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -157,7 +157,7 @@
 				if(locate(/obj/item/weapon/gun/energy/sniperrifle, mob.contents))		// If mob moves while zoomed in with sniper rifle, unzoom them.
 					var/obj/item/weapon/gun/energy/sniperrifle/s = locate() in mob
 					if(s.zoom)
-						s.zoom()
+						s.toggle_zoom()
 
 	Process_Grab()
 

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -218,6 +218,11 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	to_chat(usr, "<font color='[zoom?"blue":"red"]'>Zoom mode [zoom?"en":"dis"]abled.</font>")
 	return
 
+/obj/item/weapon/gun/energy/sniperrifle/equipped(mob/user, slot)
+	if(zoom)
+		zoom
+	..(user, slot)
+
 /obj/item/weapon/gun/energy/sniperrifle/rails
 	name = "Rails rifle"
 	desc = "With this weapon you'll be the boss at any Arena."

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -220,7 +220,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 
 /obj/item/weapon/gun/energy/sniperrifle/equipped(mob/user, slot)
 	if(zoom)
-		zoom
+		zoom()
 	..(user, slot)
 
 /obj/item/weapon/gun/energy/sniperrifle/rails

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -189,9 +189,9 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 */
 
 /obj/item/weapon/gun/energy/sniperrifle/attack_self()
-	zoom()
+	toggle_zoom()
 
-/obj/item/weapon/gun/energy/sniperrifle/verb/zoom()
+/obj/item/weapon/gun/energy/sniperrifle/verb/toggle_zoom()
 	set category = "Object"
 	set name = "Use Sniper Scope"
 	set popup_menu = 0
@@ -220,7 +220,7 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 
 /obj/item/weapon/gun/energy/sniperrifle/equipped(mob/user, slot)
 	if(zoom)
-		zoom()
+		toggle_zoom()
 	..(user, slot)
 
 /obj/item/weapon/gun/energy/sniperrifle/rails


### PR DESCRIPTION
<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений
fix #3913 
<!--
Опишите изменения данного ПР-а.
Если есть связные ишью (issues), или другие ПРы - укажите их тут, для автоматического закрытия ишью следует использовать ключевые слова https://help.github.com/en/articles/closing-issues-using-keywords
Если есть связное форумное обсуждение на тему изменений - укажите ссылку на эту тему.
-->

## Почему и что этот ПР улучшит
Зум будет сбрасываться при смене активной руки
<!--
Опишите причину для изменений.
Этот пункт особенно важен для описания изменений баланса, новых механик.
-->

## Авторство

<!-- Опциональный пункт!
Если авторство не полностью ваше, вы делаете порт с другого билда - обязательно укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
-->

## Чеинжлог
:cl: Martinelli
 - bugfix: При смене активной руки, держа снайперскую винтовку, сбрасывается зум
<!-- Опциональный пункт!
Если это что-то, о чём следует сообщить игрокам - опишите по форме (https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies#Changelog) свои изменения для игрового чеинжлога, они будут отображены на специальной страничке http://changelog.taucetistation.org

Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment
  
Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
