### PR TITLE
Безголовых нельзя брать и держать в 3 и 4 грабе

### DIFF
--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -230,21 +230,20 @@
 	if(state >= GRAB_NECK)
 		if(ishuman(affecting))
 			var/mob/living/carbon/human/H = affecting
-			if(!istype(H.bodyparts_by_name[BP_HEAD], /obj/item/organ/external/head))
-				assailant.visible_message("<span class='info'>You grab a man differently</span>")
-				set_state(GRAB_AGGRESSIVE)
-		if(affecting.stat != DEAD)
-			affecting.Stun(1)
-			if(isliving(affecting))
-				var/mob/living/L = affecting
-				L.adjustOxyLoss(1)
+			var/obj/item/organ/external/BP = H.bodyparts_by_name[BP_HEAD]
+			if(!BP || BP.is_stump)
+				qdel(src)
+				return PROCESS_KILL
+		affecting.Stun(1)
+		if(isliving(affecting))
+			var/mob/living/L = affecting
+			L.adjustOxyLoss(1)
 
 	if(state >= GRAB_KILL)
-		if(affecting.stat != DEAD)
-			//affecting.apply_effect(STUTTER, 5) //would do this, but affecting isn't declared as mob/living for some stupid reason.
-			affecting.stuttering = max(affecting.stuttering, 5) //It will hamper your voice, being choked and all.
-			affecting.Weaken(5)	//Should keep you down unless you get help.
-			affecting.losebreath = max(affecting.losebreath + 2, 3)
+		//affecting.apply_effect(STUTTER, 5) //would do this, but affecting isn't declared as mob/living for some stupid reason.
+		affecting.stuttering = max(affecting.stuttering, 5) //It will hamper your voice, being choked and all.
+		affecting.Weaken(5)	//Should keep you down unless you get help.
+		affecting.losebreath = max(affecting.losebreath + 2, 3)
 
 	adjust_position()
 
@@ -330,7 +329,8 @@
 			return
 		if(ishuman(affecting))
 			var/mob/living/carbon/human/H = affecting
-			if(!istype(H.bodyparts_by_name[BP_HEAD], /obj/item/organ/external/head))
+			var/obj/item/organ/external/BP = H.bodyparts_by_name[BP_HEAD]
+			if(!BP || BP.is_stump)
 				assailant.visible_message("<span class='warning'>You can't take a headless man by the neck!</span>")
 				return
 		assailant.visible_message("<span class='warning'>[assailant] has reinforced \his grip on [affecting] (now neck)!</span>")

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -228,16 +228,18 @@
 				affecting.Weaken(2)
 
 	if(state >= GRAB_NECK)
-		affecting.Stun(1)
-		if(isliving(affecting))
-			var/mob/living/L = affecting
-			L.adjustOxyLoss(1)
+		if(affecting.stat != DEAD)
+			affecting.Stun(1)
+			if(isliving(affecting))
+				var/mob/living/L = affecting
+				L.adjustOxyLoss(1)
 
 	if(state >= GRAB_KILL)
-		//affecting.apply_effect(STUTTER, 5) //would do this, but affecting isn't declared as mob/living for some stupid reason.
-		affecting.stuttering = max(affecting.stuttering, 5) //It will hamper your voice, being choked and all.
-		affecting.Weaken(5)	//Should keep you down unless you get help.
-		affecting.losebreath = max(affecting.losebreath + 2, 3)
+		if(affecting.stat != DEAD)
+			//affecting.apply_effect(STUTTER, 5) //would do this, but affecting isn't declared as mob/living for some stupid reason.
+			affecting.stuttering = max(affecting.stuttering, 5) //It will hamper your voice, being choked and all.
+			affecting.Weaken(5)	//Should keep you down unless you get help.
+			affecting.losebreath = max(affecting.losebreath + 2, 3)
 
 	adjust_position()
 

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -228,6 +228,11 @@
 				affecting.Weaken(2)
 
 	if(state >= GRAB_NECK)
+		if(ishuman(affecting))
+			var/mob/living/carbon/human/H = affecting
+			if(!istype(H.bodyparts_by_name[BP_HEAD], /obj/item/organ/external/head))
+				assailant.visible_message("<span class='info'>You grab a man differently</span>")
+				set_state(GRAB_AGGRESSIVE)
 		if(affecting.stat != DEAD)
 			affecting.Stun(1)
 			if(isliving(affecting))
@@ -321,8 +326,13 @@
 
 	else if(state < GRAB_NECK)
 		if(isslime(affecting))
-			to_chat(assailant, "<span class='notice'>You squeeze [affecting], but nothing interesting happens.</span>")
+			assailant.visible_message("<span class='notice'>You squeeze [affecting], but nothing interesting happens.</span>")
 			return
+		if(ishuman(affecting))
+			var/mob/living/carbon/human/H = affecting
+			if(!istype(H.bodyparts_by_name[BP_HEAD], /obj/item/organ/external/head))
+				assailant.visible_message("<span class='warning'>You can't take a headless man by the neck!</span>")
+				return
 		assailant.visible_message("<span class='warning'>[assailant] has reinforced \his grip on [affecting] (now neck)!</span>")
 		assailant.set_dir(get_dir(assailant, affecting))
 		affecting.attack_log += "\[[time_stamp()]\] <font color='orange'>Has had their neck grabbed by [assailant.name] ([assailant.ckey])</font>"

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -325,13 +325,13 @@
 
 	else if(state < GRAB_NECK)
 		if(isslime(affecting))
-			assailant.visible_message("<span class='notice'>You squeeze [affecting], but nothing interesting happens.</span>")
+			to_chat(assailant, "<span class='notice'>You squeeze [affecting], but nothing interesting happens.</span>")
 			return
 		if(ishuman(affecting))
 			var/mob/living/carbon/human/H = affecting
 			var/obj/item/organ/external/BP = H.bodyparts_by_name[BP_HEAD]
 			if(!BP || BP.is_stump)
-				assailant.visible_message("<span class='warning'>You can't take a headless man by the neck!</span>")
+				to_chat(assailant, "<span class='warning'>You can't take a headless man by the neck!</span>")
 				return
 		assailant.visible_message("<span class='warning'>[assailant] has reinforced \his grip on [affecting] (now neck)!</span>")
 		assailant.set_dir(get_dir(assailant, affecting))


### PR DESCRIPTION
<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений
Безголовых нельзя брать и держать в 3 и 4 граб.
Fix #3981 
<!--
Опишите изменения данного ПР-а.
Если есть связные ишью (issues), или другие ПРы - укажите их тут, для автоматического закрытия ишью следует использовать ключевые слова https://help.github.com/en/articles/closing-issues-using-keywords
Если есть связное форумное обсуждение на тему изменений - укажите ссылку на эту тему.
-->

## Почему и что этот ПР улучшит

<!--
Опишите причину для изменений.
Этот пункт особенно важен для описания изменений баланса, новых механик.
-->

## Авторство

<!-- Опциональный пункт!
Если авторство не полностью ваше, вы делаете порт с другого билда - обязательно укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
-->

## Чеинжлог
:cl: Martinelli
 - bugfix: Безголовых нельзя брать и держать в 3 и 4 грабе.
<!-- Опциональный пункт!
Если это что-то, о чём следует сообщить игрокам - опишите по форме (https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies#Changelog) свои изменения для игрового чеинжлога, они будут отображены на специальной страничке http://changelog.taucetistation.org

Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment
  
Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
