### PR TITLE
Different age limits for different Xeno.

### DIFF
--- a/code/__DEFINES/mob.dm
+++ b/code/__DEFINES/mob.dm
@@ -40,9 +40,6 @@
 #define O_KIDNEYS  "kidneys"
 #define O_APPENDIX "appendix"
 
-#define AGE_MIN 25			//youngest a character can be
-#define AGE_MAX 85			//oldest a character can be
-
 #define LEFT  1
 #define RIGHT 2
 

--- a/code/game/gamemodes/heist/heist.dm
+++ b/code/game/gamemodes/heist/heist.dm
@@ -118,7 +118,7 @@
 		vox.real_name = newname
 		vox.name = vox.real_name
 		raider.name = vox.name
-		vox.age = rand(17,85)
+		vox.age = rand(vox.species.min_age, vox.species.max_age)
 		//vox.dna.mutantrace = "vox"
 		//vox.set_species(VOX)
 		vox.languages = list() // Removing language from chargen.
@@ -305,7 +305,7 @@
 	if(text)
 		antagonists_completion += list(list("mode" = "heist", "html" = text))
 		text = "<div class='block'>[text]</div>"
-		
+
 	return text
 
 /datum/game_mode/heist/check_finished()

--- a/code/game/gamemodes/heist/heist_old.dm
+++ b/code/game/gamemodes/heist/heist_old.dm
@@ -91,10 +91,11 @@ VOX HEIST ROUNDTYPE
 			newname += pick(list("ti","hi","ki","ya","ta","ha","ka","ya","chi","cha","kah"))
 
 		var/mob/living/carbon/human/vox = raider.current
+
 		vox.real_name = capitalize(newname)
 		vox.name = vox.real_name
 		raider.name = vox.name
-		vox.age = rand(12,20)
+		vox.age = rand(vox.species.min_age, vox.species.max_age)
 		vox.dna.mutantrace = "vox"
 		vox.set_species(VOX)
 		vox.languages = list() // Removing language from chargen.

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -23,7 +23,7 @@
 		if(4) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), SLOT_BACK)
 
 	var/obj/item/clothing/under/U = new /obj/item/clothing/under/rank/captain(H)
-	if(H.age > 49)
+	if(H.age > (H.species.min_age + H.species.max_age) / 2)
 		var/obj/item/clothing/accessory/medal/gold/captain/new_medal = new
 		U.accessories += new_medal
 		new_medal.on_attached(U, H, TRUE)
@@ -46,7 +46,7 @@
 	L.inject(H)
 	START_PROCESSING(SSobj, L)
 	to_chat(world, "<b>[H.real_name] is the captain!</b>")//maybe should be announcment, not OOC notification?
-	
+
 	score["captain"].Add(H.real_name)
 
 	return TRUE

--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -218,7 +218,7 @@ var/can_call_ert
 
 	M.real_name = commando_name
 	M.name = commando_name
-	M.age = !leader_selected ? rand(M.species.min_age, M.species.max_age) : rand(M.species.min_age * 1.25, M.species.max_age * 1.25)
+	M.age = !leader_selected ? rand(M.species.min_age, M.species.min_age * 1.5) : rand(M.species.min_age * 1.25, M.species.min_age * 1.75)
 
 	M.dna.ready_dna(M)//Creates DNA.
 

--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -218,7 +218,7 @@ var/can_call_ert
 
 	M.real_name = commando_name
 	M.name = commando_name
-	M.age = !leader_selected ? rand(23,35) : rand(35,45)
+	M.age = !leader_selected ? rand(M.species.min_age, M.species.max_age) : rand(M.species.min_age * 1.25, M.species.max_age * 1.25)
 
 	M.dna.ready_dna(M)//Creates DNA.
 

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -428,7 +428,7 @@
 	else
 		new_character.real_name = "[pick(first_names_female)] [pick(last_names)]"
 	new_character.name = new_character.real_name
-	new_character.age = rand(17,45)
+	new_character.age = rand(new_character.species.min_age, new_character.species.max_age)
 
 	new_character.dna.ready_dna(new_character)
 	new_character.key = G_found.key
@@ -448,7 +448,7 @@
 
 	new_syndicate_commando.real_name = "[!syndicate_leader_selected ? syndicate_commando_rank : syndicate_commando_leader_rank] [syndicate_commando_name]"
 	new_syndicate_commando.name = new_syndicate_commando.real_name
-	new_syndicate_commando.age = !syndicate_leader_selected ? rand(23,35) : rand(35,45)
+	new_syndicate_commando.age = !syndicate_leader_selected ? rand(new_syndicate_commando.species.min_age, new_syndicate_commando.species.max_age) : rand(new_syndicate_commando.species.min_age * 1.25, new_syndicate_commando.species.max_age * 1.25)
 
 	new_syndicate_commando.dna.ready_dna(new_syndicate_commando)//Creates DNA.
 
@@ -539,7 +539,7 @@
 
 	new_vox.real_name = capitalize(newname)
 	new_vox.name = new_vox.real_name
-	new_vox.age = rand(12,20)
+	new_vox.age = rand(new_vox.species.min_age, new_vox.species.max_age)
 
 	new_vox.dna.ready_dna(new_vox) // Creates DNA.
 	new_vox.dna.mutantrace = "vox"

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -428,7 +428,7 @@
 	else
 		new_character.real_name = "[pick(first_names_female)] [pick(last_names)]"
 	new_character.name = new_character.real_name
-	new_character.age = rand(new_character.species.min_age, new_character.species.max_age)
+	new_character.age = rand(new_character.species.min_age, new_character.species.min_age * 1.5)
 
 	new_character.dna.ready_dna(new_character)
 	new_character.key = G_found.key
@@ -448,7 +448,7 @@
 
 	new_syndicate_commando.real_name = "[!syndicate_leader_selected ? syndicate_commando_rank : syndicate_commando_leader_rank] [syndicate_commando_name]"
 	new_syndicate_commando.name = new_syndicate_commando.real_name
-	new_syndicate_commando.age = !syndicate_leader_selected ? rand(new_syndicate_commando.species.min_age, new_syndicate_commando.species.max_age) : rand(new_syndicate_commando.species.min_age * 1.25, new_syndicate_commando.species.max_age * 1.25)
+	new_syndicate_commando.age = !syndicate_leader_selected ? rand(new_syndicate_commando.species.min_age, new_syndicate_commando.species.min_age * 1.5) : rand(new_syndicate_commando.species.min_age * 1.25, new_syndicate_commando.species.min_age * 1.75)
 
 	new_syndicate_commando.dna.ready_dna(new_syndicate_commando)//Creates DNA.
 

--- a/code/modules/admin/verbs/striketeam.dm
+++ b/code/modules/admin/verbs/striketeam.dm
@@ -111,7 +111,7 @@ var/global/sent_strike_team = 0
 	A.randomize_appearance_for(new_commando)
 
 	new_commando.real_name = "[!leader_selected ? commando_rank : commando_leader_rank] [commando_name]"
-	new_commando.age = !leader_selected ? rand(23,35) : rand(35,45)
+	new_commando.age = !leader_selected ? rand(new_commando.species.min_age, new_commando.species.max_age) : rand(new_commando.species.min_age * 1.25, new_commando.species.max_age * 1.25)
 
 	new_commando.dna.ready_dna(new_commando)//Creates DNA.
 

--- a/code/modules/admin/verbs/striketeam.dm
+++ b/code/modules/admin/verbs/striketeam.dm
@@ -111,7 +111,7 @@ var/global/sent_strike_team = 0
 	A.randomize_appearance_for(new_commando)
 
 	new_commando.real_name = "[!leader_selected ? commando_rank : commando_leader_rank] [commando_name]"
-	new_commando.age = !leader_selected ? rand(new_commando.species.min_age, new_commando.species.max_age) : rand(new_commando.species.min_age * 1.25, new_commando.species.max_age * 1.25)
+	new_commando.age = !leader_selected ? rand(new_commando.species.min_age, new_commando.species.min_age * 1.5) : rand(new_commando.species.min_age * 1.25, new_commando.species.min_age * 1.75)
 
 	new_commando.dna.ready_dna(new_commando)//Creates DNA.
 

--- a/code/modules/admin/verbs/striketeam_syndicate.dm
+++ b/code/modules/admin/verbs/striketeam_syndicate.dm
@@ -114,7 +114,7 @@ var/global/sent_syndicate_strike_team = 0
 	A.randomize_appearance_for(new_syndicate_commando)
 
 	new_syndicate_commando.real_name = "[!syndicate_leader_selected ? syndicate_commando_rank : syndicate_commando_leader_rank] [syndicate_commando_name]"
-	new_syndicate_commando.age = !syndicate_leader_selected ? rand(23,35) : rand(35,45)
+	new_syndicate_commando.age = !syndicate_leader_selected ? rand(new_syndicate_commando.species.min_age, new_syndicate_commando.species.max_age) : rand(new_syndicate_commando.species.min_age * 1.25, new_syndicate_commando.species.max_age * 1.25)
 
 	new_syndicate_commando.dna.ready_dna(new_syndicate_commando)//Creates DNA.
 

--- a/code/modules/admin/verbs/striketeam_syndicate.dm
+++ b/code/modules/admin/verbs/striketeam_syndicate.dm
@@ -114,7 +114,7 @@ var/global/sent_syndicate_strike_team = 0
 	A.randomize_appearance_for(new_syndicate_commando)
 
 	new_syndicate_commando.real_name = "[!syndicate_leader_selected ? syndicate_commando_rank : syndicate_commando_leader_rank] [syndicate_commando_name]"
-	new_syndicate_commando.age = !syndicate_leader_selected ? rand(new_syndicate_commando.species.min_age, new_syndicate_commando.species.max_age) : rand(new_syndicate_commando.species.min_age * 1.25, new_syndicate_commando.species.max_age * 1.25)
+	new_syndicate_commando.age = !syndicate_leader_selected ? rand(new_syndicate_commando.species.min_age, new_syndicate_commando.species.min_age * 1.5) : rand(new_syndicate_commando.species.min_age * 1.25, new_syndicate_commando.species.min_age * 1.75)
 
 	new_syndicate_commando.dna.ready_dna(new_syndicate_commando)//Creates DNA.
 

--- a/code/modules/client/character menu/general.dm
+++ b/code/modules/client/character menu/general.dm
@@ -182,13 +182,15 @@
 					if(genmsg != null)
 						gen_record = genmsg
 
+	var/datum/species/specie_obj = all_species[species]
+
 	switch(href_list["task"])
 		if("random")
 			switch(href_list["preference"])
 				if("name")
 					real_name = random_name(gender)
 				if("age")
-					age = rand(AGE_MIN, AGE_MAX)
+					age = rand(specie_obj.min_age, specie_obj.max_age)
 				if("hair")
 					r_hair = rand(0,255)
 					g_hair = rand(0,255)
@@ -231,9 +233,9 @@
 						to_chat(user, "<font color='red'>Invalid name. Your name should be at least 2 and at most [MAX_NAME_LEN] characters long. It may only contain the characters A-Z, a-z, -, ' and .</font>")
 
 				if("age")
-					var/new_age = input(user, "Choose your character's age:\n([AGE_MIN]-[AGE_MAX])", "Character Preference") as num|null
+					var/new_age = input(user, "Choose your character's age:\n([specie_obj.min_age]-[specie_obj.max_age])", "Character Preference") as num|null
 					if(new_age)
-						age = max(min( round(text2num(new_age)), AGE_MAX),AGE_MIN)
+						age = max(min( round(text2num(new_age)), specie_obj.max_age), specie_obj.min_age)
 
 				if("species")
 					var/list/new_species = list(HUMAN)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -314,12 +314,14 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	if(needs_update >= 0)
 		update_character(needs_update, S) // needs_update == savefile_version if we need an update (positive integer)
 
-	var/datum/species/species_obj = all_species[species]
-
 	//Sanitize
 	metadata		= sanitize_text(metadata, initial(metadata))
 	real_name		= sanitize_name(real_name)
-	if(isnull(species)) species = HUMAN
+
+	if(isnull(species) || !all_species[species])
+		species = HUMAN
+
+	var/datum/species/species_obj = all_species[species]
 	if(isnull(language)) language = "None"
 	if(isnull(nanotrasen_relation)) nanotrasen_relation = initial(nanotrasen_relation)
 	if(!real_name) real_name = random_name(gender)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -314,6 +314,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	if(needs_update >= 0)
 		update_character(needs_update, S) // needs_update == savefile_version if we need an update (positive integer)
 
+	var/datum/species/species_obj = all_species[species]
+
 	//Sanitize
 	metadata		= sanitize_text(metadata, initial(metadata))
 	real_name		= sanitize_name(real_name)
@@ -325,7 +327,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	if(!custom_items) custom_items = list()
 	be_random_name	= sanitize_integer(be_random_name, 0, 1, initial(be_random_name))
 	gender			= sanitize_gender(gender)
-	age				= sanitize_integer(age, AGE_MIN, AGE_MAX, initial(age))
+	age				= sanitize_integer(age, species_obj.min_age, species_obj.max_age, initial(age))
 	r_hair			= sanitize_integer(r_hair, 0, 255, initial(r_hair))
 	g_hair			= sanitize_integer(g_hair, 0, 255, initial(g_hair))
 	b_hair			= sanitize_integer(b_hair, 0, 255, initial(b_hair))

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -318,10 +318,10 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	metadata		= sanitize_text(metadata, initial(metadata))
 	real_name		= sanitize_name(real_name)
 
-	if(isnull(species) || !all_species[species])
+	if(isnull(species))
 		species = HUMAN
-
 	var/datum/species/species_obj = all_species[species]
+
 	if(isnull(language)) language = "None"
 	if(isnull(nanotrasen_relation)) nanotrasen_relation = initial(nanotrasen_relation)
 	if(!real_name) real_name = random_name(gender)

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -16,7 +16,7 @@
 	undershirt = rand(1,undershirt_t.len)
 	socks = rand(1,socks_t.len)
 	backbag = 2
-	age = rand(AGE_MIN,AGE_MAX)
+	age = rand(H.species.min_age, H.species.max_age)
 	if(H)
 		copy_to(H)
 

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -124,6 +124,9 @@
 
 	var/list/prevent_survival_kit_items = list()
 
+	var/min_age = 25 // The default, for Humans.
+	var/max_age = 85
+
 /datum/species/New()
 	blood_datum = new blood_datum_path
 	unarmed = new unarmed_type()
@@ -223,6 +226,9 @@
 	//If you wanted to add a species-level ability:
 	/*abilities = list(/client/proc/test_ability)*/
 
+	min_age = 25
+	max_age = 85
+
 /datum/species/unathi
 	name = UNATHI
 	icobase = 'icons/mob/human_races/r_lizard.dmi'
@@ -257,6 +263,9 @@
 
 	flesh_color = "#34af10"
 	base_color = "#066000"
+
+	min_age = 25
+	max_age = 85
 
 /datum/species/unathi/after_job_equip(mob/living/carbon/human/H, datum/job/J)
 	..()
@@ -310,6 +319,9 @@
 	flesh_color = "#afa59e"
 	base_color = "#333333"
 
+	min_age = 25
+	max_age = 85
+
 /datum/species/tajaran/after_job_equip(mob/living/carbon/human/H, datum/job/J)
 	..()
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal(H), SLOT_SHOES, 1)
@@ -350,6 +362,9 @@
 	blood_datum_path = /datum/dirt_cover/purple_blood
 	flesh_color = "#8cd7a3"
 
+	min_age = 25
+	max_age = 150
+
 /datum/species/skrell/call_digest_proc(mob/living/M, datum/reagent/R)
 	return R.on_skrell_digest(M)
 
@@ -388,6 +403,9 @@
 		"feet" = 'icons/mob/species/vox/shoes.dmi',
 		"gloves" = 'icons/mob/species/vox/gloves.dmi'
 		)
+
+	min_age = 12
+	max_age = 20
 
 /datum/species/vox/after_job_equip(mob/living/carbon/human/H, datum/job/J)
 	H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/vox(src), SLOT_WEAR_MASK)
@@ -550,6 +568,9 @@
 
 	prevent_survival_kit_items = list(/obj/item/weapon/tank/emergency_oxygen) // So they don't get the big engi oxy tank, since they need no tank.
 
+	min_age = 1
+	max_age = 1000
+
 /datum/species/diona/handle_post_spawn(mob/living/carbon/human/H)
 	H.gender = NEUTER
 
@@ -665,6 +686,9 @@
 
 	prevent_survival_kit_items = list(/obj/item/weapon/tank/emergency_oxygen) // So they don't get the big engi oxy tank, since they need no tank.
 
+	min_age = 1
+	max_age = 125
+
 /datum/species/abductor
 	name = ABDUCTOR
 	darksight = 3
@@ -682,6 +706,9 @@
 	)
 
 	blood_datum_path = /datum/dirt_cover/gray_blood
+
+	min_age = 100
+	max_age = 500
 
 /datum/species/abductor/handle_post_spawn(mob/living/carbon/human/H)
 	H.gender = NEUTER
@@ -733,6 +760,9 @@
 		 O_BRAIN   = /obj/item/organ/internal/brain
 		,O_EYES    = /obj/item/organ/internal/eyes
 		)
+
+	min_age = 1
+	max_age = 1000
 
 /datum/species/skeleton/handle_post_spawn(mob/living/carbon/human/H)
 	H.gender = NEUTER
@@ -832,6 +862,8 @@
 
 	has_gendered_icons = FALSE
 
+	min_age = 1
+	max_age = 10000
 
 /datum/species/shadowling/handle_post_spawn(mob/living/carbon/human/H)
 	H.gender = NEUTER
@@ -878,6 +910,9 @@
 		)
 
 	has_gendered_icons = FALSE
+
+	min_age = 1
+	max_age = 1000
 
 /datum/species/golem/on_gain(mob/living/carbon/human/H)
 	H.status_flags &= ~(CANSTUN | CANWEAKEN | CANPARALYSE)
@@ -948,6 +983,9 @@
 
 	var/list/spooks = list('sound/voice/growl1.ogg', 'sound/voice/growl2.ogg', 'sound/voice/growl3.ogg')
 
+	min_age = 25
+	max_age = 85
+
 /datum/species/zombie/handle_post_spawn(mob/living/carbon/human/H)
 	return ..()
 
@@ -1003,6 +1041,9 @@
 	,HAS_TAIL = TRUE
 	)
 
+	min_age = 25
+	max_age = 85
+
 /datum/species/zombie/skrell
 	name = ZOMBIE_SKRELL
 
@@ -1013,6 +1054,9 @@
 	blood_datum_path = /datum/dirt_cover/purple_blood
 	flesh_color = "#8cd7a3"
 	base_color = "#000000"
+
+	min_age = 25
+	max_age = 150
 
 /datum/species/zombie/unathi
 	name = ZOMBIE_UNATHI
@@ -1039,6 +1083,9 @@
 	,HAS_TAIL = TRUE
 	)
 
+	min_age = 25
+	max_age = 85
+
 /datum/species/slime
 	name = SLIME
 	icobase = 'icons/mob/human_races/r_slime.dmi'
@@ -1062,3 +1109,6 @@
 	,RAD_IMMUNE = TRUE
 	,VIRUS_IMMUNE = TRUE
 	)
+
+	min_age = 1
+	max_age = 85


### PR DESCRIPTION
## Описание изменений

Сделал разные возрастные рамки для разной ксеноты.

Тенелинги - 1-10000
Дионы - 1-1000
Големы - 1-1000
Скелеты - 1-1000
Абдукторы - 100-500
СПУ - 1-125
Скреллы - 25-150
Воксы - 12-20

(У зомбей такие же рамки как у рас которым они принадлежат)

У всех остальных, старый, дефолтный 25-85.

<!--
Опишите изменения данного ПР-а.
Если есть связные ишью (issues), или другие ПРы - укажите их тут, для автоматического закрытия ишью следует использовать ключевые слова https://help.github.com/en/articles/closing-issues-using-keywords
Если есть связное форумное обсуждение на тему изменений - укажите ссылку на эту тему.
-->

## Почему и что этот ПР улучшит

Дионы смогут выбирать возраст который им подходит, как и к примеру СПУ.

## Чеинжлог
:cl: Luduk
- tweak: У разной ксеноты разные рамки по возрасту.