### PR TITLE
атакующие галлюцинации были у людей с квирком "Strong mind"

### DIFF
--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -262,9 +262,13 @@ Gunshots/explosions/opening doors/less rare audio (done)
 							if(client) client.images -= halbody
 							halbody = null
 
+			if(71 to 73)
+				if(!has_trait(TRAIT_STRONGMIND))
+					fake_attack(src)
+
         // FAKE DEATH
 
-			if(71 to 72)
+			if(74 to 75)
 				src.sleeping = 20
 				hal_crit = 1
 				hal_screwyhud = 1

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1156,8 +1156,6 @@
 
 		if(hallucination)
 			if(hallucination >= 20)
-				if(prob(3))
-					fake_attack(src)
 				if(hallucination > 1000)
 					hallucination = 1000
 				if(!handling_hal)


### PR DESCRIPTION
## Описание изменений
Странная вещь, есть "неактивные" и "активные" галлюциногенные мобы, но при этом "активные"(атакующие) мобы спавнятся каждый лайф прок с шансом 3 процента и паралельно с другими эффектами, но теперь нет, перенос "активных" атакующих галюцинаций в прок с галюцинациями, да, они исключаются квирком "Strong mind"
fix https://github.com/TauCetiStation/TauCetiClassic/issues/4059
## Почему и что этот ПР улучшит
Меньше насилия галлюцинациями и 1 эффект в свой прок, фикс бага
## Авторство
Felix Ruin - Winter Schock
## Чеинжлог
:cl: Winter Schock
 - bugfix: атакующие галлюцинации появлялись у людей с квирком "Strong mind" 