### PR TITLE
Добавление функции, определяющей толстый ли персонаж или нет. Измене…

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -47,6 +47,7 @@
 
 
 /datum/quirk/fatness
+
 	name = "Fatness"
 	desc = "You are incurably fat."
 	value = -1

--- a/code/game/dna/dn2_misc.dm
+++ b/code/game/dna/dn2_misc.dm
@@ -101,7 +101,7 @@
 							if(i < 3) M.pixel_y += 8
 							else M.pixel_y -= 8
 
-		if ((FAT in usr.mutations) && prob(66))
+		if ((is_fat()) && prob(66))
 			usr.visible_message("<span class='warning'><b>[usr.name]</b> crashes due to their heavy weight!</span>")
 			playsound(src, 'sound/misc/slip.ogg', VOL_EFFECTS_MASTER)
 			usr.weakened += 10
@@ -283,7 +283,7 @@
 				step(usr, cur_dir)
 			sleep(1)
 
-		if ((FAT in usr.mutations) && prob(66))
+		if ((is_fat()) && prob(66))
 			usr.visible_message("<span class='warning'><b>[usr.name]</b> crashes due to their heavy weight!</span>")
 			playsound(src, 'sound/misc/slip.ogg', VOL_EFFECTS_MASTER)
 			usr.weakened += 10
@@ -365,7 +365,7 @@
 				if(istype(H,/mob/living/carbon/human))
 					playsound(H, 'sound/weapons/tablehit1.ogg', VOL_EFFECTS_MASTER)
 					var/obj/item/organ/external/BP = H.bodyparts_by_name[pick(BP_CHEST , BP_L_ARM , BP_R_ARM , BP_R_LEG , BP_L_LEG , BP_HEAD , BP_GROIN)]
-					if(FAT in usr.mutations)
+					if(is_fat())
 						BP.take_damage(100, null, null, "Hulk Fat Arm")
 						H.Stun(10)
 						H.Weaken(10)
@@ -376,7 +376,7 @@
 					BP.fracture()
 				else
 					playsound(M, 'sound/weapons/tablehit1.ogg', VOL_EFFECTS_MASTER)
-					if(FAT in usr.mutations)
+					if(is_fat())
 						M.Stun(10)
 						M.Weaken(10)
 						M.take_overall_damage(130, used_weapon = "Hulk Fat Arm")

--- a/code/game/gamemodes/changeling/powers/stings.dm
+++ b/code/game/gamemodes/changeling/powers/stings.dm
@@ -271,7 +271,7 @@
 /obj/effect/proc_holder/changeling/sting/unfat/sting_action(mob/user, mob/living/carbon/target)
 	if(sting_fail(user,target))
 		return 0
-	if(FAT in target.mutations)
+	if(target.is_fat())
 		target.overeatduration = 0
 		target.nutrition -= 100
 		to_chat(target, "<span class='danger'>You feel a small prick as stomach churns violently and you become to feel skinnier.</span>")

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -480,7 +480,7 @@
 			return FALSE
 		//fat mutation
 		if(istype(src, /obj/item/clothing/under) || istype(src, /obj/item/clothing/suit))
-			if(FAT in H.mutations)
+			if(H.is_fat())
 				//testing("[M] TOO FAT TO WEAR [src]!")
 				if(!(flags & ONESIZEFITSALL))
 					if(!disable_warning)

--- a/code/modules/atmospheric/ZAS/Airflow.dm
+++ b/code/modules/atmospheric/ZAS/Airflow.dm
@@ -41,7 +41,7 @@ Contains helper procs for airflow, handled in /connection_group.
 		return FALSE
 	if(wear_suit && (wear_suit.flags & NOSLIP))
 		return FALSE
-	if(FAT in mutations)
+	if(is_fat())
 		to_chat(src, "<span class='notice'>Air suddenly rushes past you!</span>")
 		return FALSE
 	..()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -24,7 +24,7 @@
 				nutrition -= met_factor * getHalLoss() * (m_intent == "run" ? 0.02 : 0.01) // Which is actually a lot if you come to think of it.
 			if(m_intent == "run")
 				nutrition -= met_factor * 0.01
-		if((FAT in mutations) && m_intent == "run" && bodytemperature <= 360)
+		if((is_fat()) && m_intent == "run" && bodytemperature <= 360)
 			bodytemperature += 2
 
 		// Moving around increases germ_level faster

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -11,6 +11,9 @@
 		return -1 // It's hard to be slowed down in space by... anything
 
 	var/tally = species.speed_mod
+	var/speed_mod_no_shoes = 0
+	if (get_species() == DIONA)
+		speed_mod_no_shoes = -2
 
 	if(is_type_organ(O_HEART, /obj/item/organ/internal/heart/ipc)) // IPC's heart is a servomotor, damaging it influences speed.
 		var/obj/item/organ/internal/IO = organs_by_name[O_HEART]
@@ -58,6 +61,8 @@
 
 		if(shoes && shoes.slowdown && !(shoes.slowdown > 0 && chem_nullify_debuff))
 			tally += shoes.slowdown
+		else
+			tally += speed_mod_no_shoes
 
 		if(!chem_nullify_debuff)
 			for(var/x in list(l_hand, r_hand))
@@ -83,7 +88,7 @@
 	if(pull_debuff)
 		tally += pull_debuff
 
-	if(FAT in mutations)
+	if(is_fat())
 		tally += 1.5
 
 	if(bodytemperature < 283.222)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1057,24 +1057,25 @@
 			SetStunned(0)
 
 	//The fucking FAT mutation is the dumbest shit ever. It makes the code so difficult to work with
-	if(FAT in mutations)
-		if(!has_trait(TRAIT_FAT) && overeatduration < 100)
-			to_chat(src, "<span class='notice'>You feel fit again!</span>")
-			mutations.Remove(FAT)
-			update_body()
-			update_mutantrace()
-			update_mutations()
-			update_inv_w_uniform()
-			update_inv_wear_suit()
-	else
-		if((has_trait(TRAIT_FAT) || overeatduration > 500) && isturf(loc))
-			if(!species.flags[IS_SYNTHETIC] && !species.flags[IS_PLANT])
-				mutations.Add(FAT)
+	if (can_get_fit())
+		if(is_fat())
+			if(!has_trait(TRAIT_FAT) && overeatduration < 100)
+				to_chat(src, "<span class='notice'>You feel fit again!</span>")
+				mutations.Remove(FAT)
 				update_body()
 				update_mutantrace()
 				update_mutations()
 				update_inv_w_uniform()
 				update_inv_wear_suit()
+		else
+			if((has_trait(TRAIT_FAT) || overeatduration > 500) && isturf(loc))
+				if(!species.flags[IS_SYNTHETIC] && !species.flags[IS_PLANT])
+					mutations.Add(FAT)
+					update_body()
+					update_mutantrace()
+					update_mutations()
+					update_inv_w_uniform()
+					update_inv_wear_suit()
 
 
 	// nutrition decrease

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -183,7 +183,7 @@ Please contact me on #coderbus IRC. ~Carn x
 	remove_overlay(BODY_LAYER)
 	var/list/standing = list()
 
-	var/fat = (FAT in mutations) ? "fat" : null
+	var/fat = (is_fat()) ? "fat" : null
 	var/g = (gender == FEMALE ? "f" : "m")
 
 	var/mutable_appearance/base_icon = mutable_appearance(null, null, -BODY_LAYER)
@@ -270,7 +270,7 @@ Please contact me on #coderbus IRC. ~Carn x
 /mob/living/carbon/human/update_mutations()
 	remove_overlay(MUTATIONS_LAYER)
 	var/fat
-	if(FAT in mutations)
+	if(is_fat())
 		fat = "fat"
 
 	var/list/standing	= list()
@@ -308,7 +308,7 @@ Please contact me on #coderbus IRC. ~Carn x
 	remove_overlay(MUTANTRACE_LAYER)
 
 	var/fat
-	if(FAT in mutations)
+	if(is_fat())
 		fat = "fat"
 
 	var/list/standing	= list()
@@ -436,7 +436,7 @@ Please contact me on #coderbus IRC. ~Carn x
 				tie.color = A.color
 				standing.overlays += tie
 
-		if(FAT in mutations)
+		if(is_fat())
 			if(U.flags & ONESIZEFITSALL)
 				standing.icon	= 'icons/mob/uniform_fat.dmi'
 			else
@@ -674,7 +674,7 @@ Please contact me on #coderbus IRC. ~Carn x
 			drop_l_hand()
 			drop_r_hand()
 
-		if(FAT in mutations)
+		if(is_fat())
 			if(!(wear_suit.flags & ONESIZEFITSALL))
 				to_chat(src, "<span class='warning'>You burst out of \the [wear_suit]!</span>")
 				drop_from_inventory(wear_suit)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -53,7 +53,7 @@
 				return 1
 
 		//Fat
-		if(FAT in M.mutations)
+		if(is_fat())
 			var/ran = 40
 			if(isrobot(src))
 				ran = 20
@@ -1214,3 +1214,13 @@
 		T.add_vomit_floor(src, getToxLoss() > 0 ? TRUE : FALSE)
 
 	return TRUE
+
+/mob/living/proc/is_fat()
+
+	if ((FAT in mutations) || (get_species() == DIONA || has_trait(TRAIT_FAT)))
+		return TRUE
+
+
+/mob/living/proc/can_get_fit()
+	if (!get_species() == DIONA)
+		return TRUE

--- a/code/modules/mob/living/simple_animal/hulk_powers.dm
+++ b/code/modules/mob/living/simple_animal/hulk_powers.dm
@@ -87,7 +87,7 @@
 							if(i < 3) M.pixel_y += 8
 							else M.pixel_y -= 8
 
-		if ((FAT in usr.mutations) && prob(66))
+		if ((M.is_fat()) && prob(66))
 			usr.visible_message("<span class='warning'><b>[usr.name]</b> crashes due to their heavy weight!</span>")
 			playsound(usr, 'sound/misc/slip.ogg', VOL_EFFECTS_MASTER)
 			usr.weakened += 10
@@ -261,8 +261,8 @@
 			else if(i < 30)
 				step(usr, cur_dir)
 			sleep(1)
-
-		if ((FAT in usr.mutations) && prob(66))
+		var/mob/living/M = usr
+		if ((M.is_fat()) && prob(66))
 			usr.visible_message("<span class='warning'><b>[usr.name]</b> crashes due to their heavy weight!</span>")
 			playsound(usr, 'sound/misc/slip.ogg', VOL_EFFECTS_MASTER)
 			usr.weakened += 10
@@ -339,7 +339,7 @@
 					playsound(H, 'sound/weapons/tablehit1.ogg', VOL_EFFECTS_MASTER)
 					var/bodypart_name = pick(BP_CHEST , BP_L_ARM , BP_R_ARM , BP_R_LEG , BP_L_LEG , BP_HEAD , BP_GROIN)
 					var/obj/item/organ/external/BP = H.bodyparts_by_name[bodypart_name]
-					if(FAT in usr.mutations)
+					if(M.is_fat())
 						BP.take_damage(100, used_weapon = "Hulk Fat Arm")
 						H.Stun(10)
 						H.Weaken(10)
@@ -350,7 +350,7 @@
 					BP.fracture()
 				else
 					playsound(M, 'sound/weapons/tablehit1.ogg', VOL_EFFECTS_MASTER)
-					if(FAT in usr.mutations)
+					if(M.is_fat())
 						M.Stun(10)
 						M.Weaken(10)
 						M.take_overall_damage(130, used_weapon = "Hulk Fat Arm")

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -516,7 +516,7 @@
 						return
 
 	if(M == assailant && state >= GRAB_AGGRESSIVE)
-		if( (ishuman(user) && (FAT in user.mutations) && ismonkey(affecting) ) || ( isalien(user) && iscarbon(affecting) ) )
+		if( (ishuman(user) && (user.is_fat()) && ismonkey(affecting) ) || ( isalien(user) && iscarbon(affecting) ) )
 			var/mob/living/carbon/attacker = user
 			user.visible_message("<span class='danger'>[user] is attempting to devour [affecting]!</span>")
 			if(istype(user, /mob/living/carbon/alien/humanoid/hunter))

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -106,7 +106,7 @@
 	var/fat
 	var/g
 	if(body_zone == BP_CHEST)
-		fat = (FAT in mutations) ? "fat" : null
+		fat = (owner.is_fat()) ? "fat" : null
 	if(body_zone in list(BP_CHEST, BP_GROIN, BP_HEAD))
 		g = (gender == FEMALE ? "f" : "m")
 

--- a/code/modules/reagents/reagent_types/Chemistry-Toxic.dm
+++ b/code/modules/reagents/reagent_types/Chemistry-Toxic.dm
@@ -149,7 +149,7 @@
 
 /datum/reagent/toxin/minttoxin/on_general_digest(mob/living/M)
 	..()
-	if(FAT in M.mutations)
+	if(M.is_fat())
 		M.gib()
 
 /datum/reagent/toxin/carpotoxin

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -560,7 +560,7 @@
 		AM.loc = src
 		if(istype(AM, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = AM
-			if(FAT in H.mutations)		// is a human and fat?
+			if(H.is_fat())		// is a human and fat?
 				has_fat_guy = 1			// set flag on holder
 		if(istype(AM, /obj/structure/bigDelivery) && !hasmob)
 			var/obj/structure/bigDelivery/T = AM

--- a/code/modules/surgery/lipoplasty.dm
+++ b/code/modules/surgery/lipoplasty.dm
@@ -41,6 +41,7 @@
 	..()
 
 /datum/surgery_step/lipoplasty/cut_fat/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+
 	if(!target.has_trait(TRAIT_FAT))
 		if (target.overeatduration > 0)
 			user.visible_message("<span class='notice'>[user] cuts [target]'s excess fat loose with \the [tool].</span>",
@@ -50,6 +51,7 @@
 			user.visible_message("<span class='notice'>Unfortunately, there is nothing to cut on [target] with \the [tool].</span>",
 				"<span class='notice'>Unfortunately, there is nothing to cut on [target] with \the [tool].</span>")
 	else
+
 		user.visible_message("<span class='notice'>[user] realizes, that there is no known solution to resolve [target]'s fatness problem.</span>",
 			"<span class='notice'>Unfortunately, there is nothing you can do with the [target]'s excess fat.</span>")
 


### PR DESCRIPTION
…ние скорости Дионей



<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

Функция is_fat() возвращает TRUE, если персонаж толстый или Дионея. Дионы без обуви двигаются на 1 тик быстрее.

<!--
Функция is_fat() возвращает TRUE, если персонаж толстый или Дионея. Дионы без обуви двигаются на 1 тик быстрее.
Опишите изменения данного ПР-а.
Если есть связные ишью (issues), или другие ПРы - укажите их тут, для автоматического закрытия ишью следует использовать ключевые слова https://help.github.com/en/articles/closing-issues-using-keywords
Если есть связное форумное обсуждение на тему изменений - укажите ссылку на эту тему.
-->

## Почему и что этот ПР улучшит

<!--
Опишите причину для изменений.
Этот пункт особенно важен для описания изменений баланса, новых механик.
-->

Vaskozlov

<!-- Опциональный пункт!
Если авторство не полностью ваше, вы делаете порт с другого билда - обязательно укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
-->

## Чеинжлог

<!-- Опциональный пункт!
Если это что-то, о чём следует сообщить игрокам - опишите по форме (https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies#Changelog) свои изменения для игрового чеинжлога, они будут отображены на специальной страничке http://changelog.taucetistation.org

Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment
  
Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
