### PR TITLE
Оптимизация муз. инструментов (или спасение от возможных ограничений с выпилом).

### DIFF
--- a/code/datums/music_player.dm
+++ b/code/datums/music_player.dm
@@ -31,7 +31,7 @@
 #define MAX_DIONATEMPO_RATE 200
 
 // Cache holder for sound() instances.
-var/datum/notes_storage/note_cache_storage = new
+var/global/datum/notes_storage/note_cache_storage = new
 
 /datum/notes_storage
 	var/list/instrument_sound_notes = list() // associative list.
@@ -272,9 +272,9 @@ var/datum/notes_storage/note_cache_storage = new
 						// because this is the only case where we use dynamic path for sounds, as they should be avoided normally.
 						// Without cache dynamic paths eat 10~ times more CPU than doing same with hardcoded paths, so cache is required.
 
-						var/sound/S = note_cache_storage.instrument_sound_notes["[sound_path]/[current_note]"]
+						var/sound/S = global.note_cache_storage.instrument_sound_notes["[sound_path]/[current_note]"]
 						if(!S)
-							S = note_cache_storage.instrument_sound_notes["[sound_path]/[current_note]"] = sound("[sound_path]/[current_note].ogg")
+							S = global.note_cache_storage.instrument_sound_notes["[sound_path]/[current_note]"] = sound("[sound_path]/[current_note].ogg")
 
 						playsound(instrument, S, VOL_EFFECTS_INSTRUMENT, volume, FALSE, falloff = 5)
 

--- a/code/datums/music_player.dm
+++ b/code/datums/music_player.dm
@@ -30,6 +30,12 @@
 #define MAX_TEMPO_RATE   600
 #define MAX_DIONATEMPO_RATE 200
 
+// Cache holder for sound() instances.
+var/datum/notes_storage/note_cache_storage = new
+
+/datum/notes_storage
+	var/list/instrument_sound_notes = list() // associative list.
+
 /**
  * Method called before playing of every note, so it's some kinde of
  * 'process-like' check to stop, for example, playing song
@@ -259,7 +265,18 @@
 							cur_oct[cur_note] = ni
 
 					var/current_note = uppertext(copytext(note, 1, 2)) + cur_acc[cur_note] + cur_oct[cur_note]
-					playsound(instrument, "[sound_path]/[current_note].ogg", VOL_EFFECTS_INSTRUMENT, volume, FALSE, falloff = 5)
+
+					if(fexists("[sound_path]/[current_note].ogg"))
+						// ^ Since this is dynamic path, no point in running playsound without file (since it will play even "no file" and eat cpu for nothing)
+						// and no point in integrating this into playsound itself,
+						// because this is the only case where we use dynamic path for sounds, as they should be avoided normally.
+						// Without cache dynamic paths eat 10~ times more CPU than doing same with hardcoded paths, so cache is required.
+
+						var/sound/S = note_cache_storage.instrument_sound_notes["[sound_path]/[current_note]"]
+						if(!S)
+							S = note_cache_storage.instrument_sound_notes["[sound_path]/[current_note]"] = sound("[sound_path]/[current_note].ogg")
+
+						playsound(instrument, S, VOL_EFFECTS_INSTRUMENT, volume, FALSE, falloff = 5)
 
 				var/pause_time = COUNT_PAUSE(song_tempo)
 


### PR DESCRIPTION
## Описание изменений

Перед описанием и то что мне нужно от игроков в частности:
* Удостовериться что ничего по факту в плане игры не изменилось (я не о лагах, а там о звучании или что-то такое, вдруг ноты не те станут там играть или еще что). Т.к если вдруг звучание станет другим, значит придется на хардкодные пути линять.
* И само собой тест мерж.

---

Все уже и так знают, что при особенно большом скоплении людей в одном месте (отбытие например), а еще и когда лагач и без инструментов уже идет, один музыкант это как ходячий вредитель, у которого и игра на инструменте заикается и у всех остальных меньше комфорта (местами и в ушах).

Итак, не буду техническую соль здесь расписывать особо, но у бъенда очень плохо все с динамическими путями, это когда используются `" "` такие ковычки, вместо `' '`. Почему так, мы скорее всего можем разве что гадать (есть разные теории на эту тему), а правду знает тот, у кого есть доступ к исходникам бъенда.

Первый план был просто с откатом этого рефактора на возврат к хардкодным путям в коде (как и было когда-то). Но оказывается у нас есть люди, что планируют расширить инструменты и им показалось страшным расписывать сотни путей руками к каждому ogg файлу, хотя при желании можно генератор путей сделать (это не сложно).

Однако в последний момент пришла идея попробовать это все в кеш закинуть и результаты синтетических тестов обрадовали, жрать это все дело стало на уровне хардкодных путей (разве что самый первый запуск когда еще идет занос в кеш может быть чуть дороже).


И немного цифр из профилировщика интереса ради.
Примерно как если бы одного музыканта слушали еще 30 игроков рядом:

Как сейчас:
```
Proc Name                            Self CPU    Total CPU    Real Time        Calls
/datum/music_player/proc/playsong    0.002        0.437       15.009            1
/sound/New                           0.309        0.309        0.309         6392
```

Хардкодные пути прописанные руками:
```
/datum/music_player/proc/playsong    0.001        0.190       15.032            1
/sound/New                           0.013        0.013        0.013         6392
```

Динамические с кешем (этот ПР, но без проверки на существование ogg):
```
/datum/music_player/proc/playsong    0.000        0.190       15.016            1
/sound/New                           0.015        0.016        0.016         6392
```

Динамические с кешем и проверкой на существование ogg файла (этот ПР что идет на мерж):
```
/datum/music_player/proc/playsong    0.001        0.080       15.039            1
/sound/New                           0.005        0.006        0.007         2618
```

Касательно CPU (то что в табах клиента игры), инструменты до этого ПРа поднимали это число аж до 7-ми единиц местами. После оптимизации что с хардкодными что с динамическими это число было ровно 2 во время проигрывания. Это при 30 + музыкант слушателях.

## Почему и что этот ПР улучшит

Инструменты будут иметь намного меньшее влияние на общую нагрузку сервера, т.е будет сложнее скатить в троттлинг (повидло).
Спасет от возможных ограничений и выпила инструментов (второе конечно больше шутка, а вот ограничивать возможную игру до единицы-пары одновременных инструментов на сервере скорее всего рассматривали всерьез).

## Чеинжлог

:cl:
 - performance: Музыкальные инструменты оказывают меньшее влияние на нагрузку сервера.
