### PR TITLE
No red lighting presets

### DIFF
--- a/code/controllers/subsystem/nightshift.dm
+++ b/code/controllers/subsystem/nightshift.dm
@@ -53,8 +53,6 @@ var/datum/subsystem/nightshift/SSnightshift
 var/list/lighting_presets = list(
 	"soft" = list("color" = "#ffe4c9", "power" = 0.8, "range" = 8),
 	"hard" = list("color" = "#e8e9ff", "power" = 0.8, "range" = 8),
-	"1000K" = list("color" = "#ff3800", "power" = 0.8, "range" = 8),
-	"2000K" = list("color" = "#ff8a12", "power" = 0.8, "range" = 8),
 	"3000K" = list("color" = "#ffb46b", "power" = 0.8, "range" = 8),
 	"4000K" = list("color" = "#ffd1a3", "power" = 0.8, "range" = 8),
 	"5000K" = list("color" = "#ffe4ce", "power" = 0.8, "range" = 8),


### PR DESCRIPTION
<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений

Тут были жалобы на абуз этих пресетов, и он вроде как больше раздражают. Выпилить предложил тот, кто изначально их и придумал.

## Авторство

<!-- Опциональный пункт!
Если авторство не полностью ваше, вы делаете порт с другого билда - обязательно укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
-->

## Чеинжлог

<!-- Опциональный пункт!
Если это что-то, о чём следует сообщить игрокам - опишите по форме (https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies#Changelog) свои изменения для игрового чеинжлога, они будут отображены на специальной страничке http://changelog.taucetistation.org

Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment
  
Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->

:cl:
 - tweak: Из APC убраны настройки для "красного" света 1000K и 2000K.