### PR TITLE
Bandanas and flashlight added to loadout, security armbands tweak

### DIFF
--- a/code/modules/client/character menu/loadout/loadout_accessories.dm
+++ b/code/modules/client/character menu/loadout/loadout_accessories.dm
@@ -34,10 +34,6 @@
 	display_name = "Zhan Headscarf"
 	path = /obj/item/clothing/head/headscarf
 
-/datum/gear/accessory/bandana
-	display_name = "Bandana"
-	path = /obj/item/clothing/mask/bandana/red
-
 /datum/gear/accessory/haircomb
 	display_name = "Purple comb"
 	path = /obj/item/weapon/haircomb
@@ -71,7 +67,7 @@
 /datum/gear/accessory/armband
 	display_name = "Armband selection"
 	path = /obj/item/clothing/accessory/armband
-	allowed_roles = list("Security Officer")
+	allowed_roles = list("Security Officer", "Security Cadet", "Warden", "Detective", "Head of Security", "Forensic Technician" )
 
 /datum/gear/accessory/armband/New()
 	..()

--- a/code/modules/client/character menu/loadout/loadout_general.dm
+++ b/code/modules/client/character menu/loadout/loadout_general.dm
@@ -1,7 +1,6 @@
 /datum/gear/flashlight
-	display_name = "Falshlight"
+	display_name = "Flashlight"
 	path = /obj/item/device/flashlight
-	cost = 1
 
 /datum/gear/tabletop
 	display_name = "Tabletop Assistant"

--- a/code/modules/client/character menu/loadout/loadout_general.dm
+++ b/code/modules/client/character menu/loadout/loadout_general.dm
@@ -1,3 +1,8 @@
+/datum/gear/flashlight
+	display_name = "Falshlight"
+	path = /obj/item/device/flashlight
+	cost = 1
+
 /datum/gear/tabletop
 	display_name = "Tabletop Assistant"
 	path = /obj/item/device/tabletop_assistant

--- a/code/modules/client/character menu/loadout/loadout_hats.dm
+++ b/code/modules/client/character menu/loadout/loadout_hats.dm
@@ -1,6 +1,6 @@
 /datum/gear/head
-	display_name = "bandana"
-	path = /obj/item/clothing/head/bandana
+	display_name = "Top hat"
+	path = /obj/item/clothing/head/that
 	slot = SLOT_HEAD
 	sort_category = "Hats and Headwear"
 
@@ -21,9 +21,20 @@
 	colors["rainbow"] = /obj/item/clothing/head/soft/rainbow
 	gear_tweaks += new/datum/gear_tweak/path(colors)
 
-/datum/gear/head/that
-	display_name = "Top hat"
-	path = /obj/item/clothing/head/that
+/datum/gear/head/bandana
+	display_name = "Bandana selection"
+	path = /obj/item/clothing/head/bandana
+
+/datum/gear/head/bandana/New()
+	..()
+	var/bandanas = list()
+	bandanas["red"] = /obj/item/clothing/mask/bandana/red
+	bandanas["blue"] = /obj/item/clothing/mask/bandana/blue
+	bandanas["green"] = /obj/item/clothing/mask/bandana/green
+	bandanas["gold"] = /obj/item/clothing/mask/bandana/gold
+	bandanas["black"] = /obj/item/clothing/mask/bandana/black
+	bandanas["orange"] = /obj/item/clothing/head/helmet/greenbandana/fluff/taryn_kifer_1
+	gear_tweaks += new/datum/gear_tweak/path(bandanas)
 
 /datum/gear/head/flatcap
 	display_name = "Flat cap"


### PR DESCRIPTION
<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений

Добавил в лодаут разные банданы, фонарик, разрешил охранные повязки для всех работников охраны (что логично).

## Почему и что этот ПР улучшит

Банданы я заливал еще год назад на гамму, плюс здесь я несколько раз слышал, что они нужны, фонарик за один поинт - вполне неплохая мелочь из разряда зиппо и карт, плюс полезен техтоннельным змеям. Повязки наручные теперь могут все, а это значит, что какой-нибудь кадет теперь оправданно сможет носить яркую повязку. Плюс люди, которые юзают кастомные шмотки вместо сесурити униформы, смогут теперь помимо зудов и брони носить красную повязку, четко индентифицирующую хумана как работника охраны

## Чеинжлог

:cl:
 - tweak: В лодаут персонажа добавлены разные банданы, фонарик, наручные повязки доступны всем работникам охраны.


