### PR TITLE
Фикс прогрессбара ригов

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -513,7 +513,7 @@ var/list/slot_equipment_priority = list(
 
 	to_chat(usr, "<span class='notice'>You start unequipping the [C].</span>")
 	C.equipping = 1
-	if(do_after(usr, C.equip_time, target = C))
+	if(do_after(usr, C.equip_time, target = C.loc))
 		remove_from_mob(C)
 		to_chat(usr, "<span class='notice'>You have finished unequipping the [C].</span>")
 	else
@@ -538,7 +538,7 @@ var/list/slot_equipment_priority = list(
 
 	to_chat(usr, "<span class='notice'>You start equipping the [C].</span>")
 	C.equipping = 1
-	if(do_after(usr, C.equip_time, target = C))
+	if(do_after(usr, C.equip_time, target = C.loc))
 		equip_to_slot_if_possible(C, slot)
 		to_chat(usr, "<span class='notice'>You have finished equipping the [C].</span>")
 	else


### PR DESCRIPTION
**Описание изменений**

Просто смена места отрисовки прогрессбара.
Теперь риги и спесссьюты(все что одевается на слот `SLOT_WEAR_SUIT`), т.е. всякие разные `/obj/item/clothing/suit/space/`) отображаются так же как и остальные действия с
прогрессбарами, без ломания интерфейса над слотами рук.


**Почему и что этот ПР улучшит**
Интерфейс над руками больше не будет сломан при надевании ригов.
