### PR TITLE
IPC no glasses

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -13,6 +13,7 @@
 	var/toggleable = 0
 	var/off_state = "degoggles"
 	var/active = 1
+	species_restricted = list("exclude" , IPC)
 	var/activation_sound = 'sound/items/buttonclick.ogg'
 
 /obj/item/clothing/glasses/attack_self(mob/user)


### PR DESCRIPTION
## Описание изменений
СПУ теперь не могут носить очки

## Что улучшит ##
1) Бошки СПУ не предназначены для ношения очков
2) Спрайты очков выглядят некорректно на СПУ
3) СПУ отчасти боргоподобны, соответственно, было бы неплохо, если бы боялись они флеша  так же, как и борги (а сейчас они надевают санглассесы и спокойно бегают)
4) Делает СПУ менее человекоподобными.

## Ченжлог ##

🆑 
 - tweak: СПУ не могут носить очки.
