### PR TITLE
Rework wrappaper from var to contents and from contents to locate()

### DIFF
--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -65,7 +65,6 @@
 	icon = 'icons/obj/items.dmi'
 	icon_state = "gift3"
 	var/size = 3.0
-	var/obj/item/gift = null
 	item_state = "gift"
 	w_class = ITEM_SIZE_LARGE
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -577,16 +577,16 @@
 		//	L += get_contents(S)
 
 		for(var/obj/item/weapon/gift/G in Storage.return_inv()) //Check for gift-wrapped items
-			for(var/obj/I in G.contents)
-				L += I
-				if(istype(I, /obj/item/weapon/storage))
-					L += get_contents(I)
+			var/atom/movable/AM = locate() in G.contents
+			L += AM
+			if(istype(AM, /obj/item/weapon/storage))
+				L += get_contents(AM)
 
 		for(var/obj/item/smallDelivery/D in Storage.return_inv()) //Check for package wrapped items
-			for(var/obj/I in D.contents)
-				L += I
-				if(istype(I, /obj/item/weapon/storage)) //this should never happen
-					L += get_contents(I)
+			var/atom/movable/AM = locate() in D.contents
+			L += AM
+			if(istype(AM, /obj/item/weapon/storage)) //this should never happen
+				L += get_contents(AM)
 		return L
 
 	else
@@ -596,16 +596,16 @@
 			L += get_contents(S)
 
 		for(var/obj/item/weapon/gift/G in src.contents) //Check for gift-wrapped items
-			for(var/obj/I in G.contents)
-				L += I
-				if(istype(I, /obj/item/weapon/storage))
-					L += get_contents(I)
+			var/atom/movable/AM = locate() in G.contents
+			L += AM
+			if(istype(AM, /obj/item/weapon/storage))
+				L += get_contents(AM)
 
 		for(var/obj/item/smallDelivery/D in src.contents) //Check for package wrapped items
-			for(var/obj/I in D.contents)
-				L += I
-				if(istype(I, /obj/item/weapon/storage)) //this should never happen
-					L += get_contents(I)
+			var/atom/movable/AM = locate() in D.contents
+			L += AM
+			if(istype(AM, /obj/item/weapon/storage)) //this should never happen
+				L += get_contents(AM)
 		return L
 
 // Called after we wrench/unwrench this object

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -577,14 +577,16 @@
 		//	L += get_contents(S)
 
 		for(var/obj/item/weapon/gift/G in Storage.return_inv()) //Check for gift-wrapped items
-			L += G.gift
-			if(istype(G.gift, /obj/item/weapon/storage))
-				L += get_contents(G.gift)
+			for(var/obj/I in G.contents)
+				L += I
+				if(istype(I, /obj/item/weapon/storage))
+					L += get_contents(I)
 
 		for(var/obj/item/smallDelivery/D in Storage.return_inv()) //Check for package wrapped items
-			L += D.wrapped
-			if(istype(D.wrapped, /obj/item/weapon/storage)) //this should never happen
-				L += get_contents(D.wrapped)
+			for(var/obj/I in D.contents)
+				L += I
+				if(istype(I, /obj/item/weapon/storage)) //this should never happen
+					L += get_contents(I)
 		return L
 
 	else
@@ -594,14 +596,16 @@
 			L += get_contents(S)
 
 		for(var/obj/item/weapon/gift/G in src.contents) //Check for gift-wrapped items
-			L += G.gift
-			if(istype(G.gift, /obj/item/weapon/storage))
-				L += get_contents(G.gift)
+			for(var/obj/I in G.contents)
+				L += I
+				if(istype(I, /obj/item/weapon/storage))
+					L += get_contents(I)
 
 		for(var/obj/item/smallDelivery/D in src.contents) //Check for package wrapped items
-			L += D.wrapped
-			if(istype(D.wrapped, /obj/item/weapon/storage)) //this should never happen
-				L += get_contents(D.wrapped)
+			for(var/obj/I in D.contents)
+				L += I
+				if(istype(I, /obj/item/weapon/storage)) //this should never happen
+					L += get_contents(I)
 		return L
 
 // Called after we wrench/unwrench this object

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -578,15 +578,17 @@
 
 		for(var/obj/item/weapon/gift/G in Storage.return_inv()) //Check for gift-wrapped items
 			var/atom/movable/AM = locate() in G.contents
-			L += AM
-			if(istype(AM, /obj/item/weapon/storage))
-				L += get_contents(AM)
+			if(AM)
+				L += AM
+				if(istype(AM, /obj/item/weapon/storage))
+					L += get_contents(AM)
 
 		for(var/obj/item/smallDelivery/D in Storage.return_inv()) //Check for package wrapped items
 			var/atom/movable/AM = locate() in D.contents
-			L += AM
-			if(istype(AM, /obj/item/weapon/storage)) //this should never happen
-				L += get_contents(AM)
+			if(AM)
+				L += AM
+				if(istype(AM, /obj/item/weapon/storage)) //this should never happen
+					L += get_contents(AM)
 		return L
 
 	else
@@ -597,15 +599,17 @@
 
 		for(var/obj/item/weapon/gift/G in src.contents) //Check for gift-wrapped items
 			var/atom/movable/AM = locate() in G.contents
-			L += AM
-			if(istype(AM, /obj/item/weapon/storage))
-				L += get_contents(AM)
+			if(AM)
+				L += AM
+				if(istype(AM, /obj/item/weapon/storage))
+					L += get_contents(AM)
 
 		for(var/obj/item/smallDelivery/D in src.contents) //Check for package wrapped items
 			var/atom/movable/AM = locate() in D.contents
-			L += AM
-			if(istype(AM, /obj/item/weapon/storage)) //this should never happen
-				L += get_contents(AM)
+			if(AM)
+				L += AM
+				if(istype(AM, /obj/item/weapon/storage)) //this should never happen
+					L += get_contents(AM)
 		return L
 
 // Called after we wrench/unwrench this object

--- a/code/game/gamemodes/cult/cult_datums.dm
+++ b/code/game/gamemodes/cult/cult_datums.dm
@@ -667,7 +667,6 @@ var/list/cult_runes = list()
 		if(istype(closet.loc, /obj/structure/bigDelivery))
 			var/obj/structure/bigDelivery/D = closet.loc
 			closet.forceMove(get_turf(D.loc))
-			D.wrapped = null
 			qdel(D)
 		if(closet.welded || closet.locked || !closet.opened)
 			closet.welded = FALSE

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -24,14 +24,11 @@
 		icon_state = "gift[pick(1, 2, 3)]"
 
 /obj/item/weapon/gift/attack_self(mob/user)
-	user.drop_item()
+	user.drop_from_inventory(src)
 	if(src.contents.len) //sometimes items can disappear. For example, bombs. --rastaf0
-		if(ishuman(user))
-			for(var/obj/I in contents)
-				user.put_in_hands(I)
-		else
-			for(var/obj/I in contents)
-				I.forceMove(get_turf(src))
+		for(var/obj/I in contents)
+			user.put_in_active_hand(I)
+			I.add_fingerprint(user)
 	else
 		to_chat(user, "<span class='notice'>The gift was empty!</span>")
 	qdel(src)

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -25,12 +25,13 @@
 
 /obj/item/weapon/gift/attack_self(mob/user)
 	user.drop_from_inventory(src)
-	if(src.contents.len) //sometimes items can disappear. For example, bombs. --rastaf0
-		for(var/obj/I in contents)
-			user.put_in_active_hand(I)
-			I.add_fingerprint(user)
+	var/atom/movable/AM = locate() in contents
+	if(AM) //sometimes items can disappear. For example, bombs. --rastaf0
+		user.put_in_active_hand(AM)
+		AM.add_fingerprint(user)
 	else
 		to_chat(user, "<span class='notice'>The gift was empty!</span>")
+	playsound(src, 'sound/items/poster_ripped.ogg', VOL_EFFECTS_MASTER)
 	qdel(src)
 	return
 

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -25,9 +25,13 @@
 
 /obj/item/weapon/gift/attack_self(mob/user)
 	user.drop_item()
-	if(src.gift)
-		user.put_in_active_hand(gift)
-		src.gift.add_fingerprint(user)
+	if(src.contents.len) //sometimes items can disappear. For example, bombs. --rastaf0
+		if(ishuman(user))
+			for(var/obj/I in contents)
+				user.put_in_hands(I)
+		else
+			for(var/obj/I in contents)
+				I.loc = get_turf(src)
 	else
 		to_chat(user, "<span class='notice'>The gift was empty!</span>")
 	qdel(src)
@@ -153,7 +157,6 @@
 				G.size = W.w_class
 				G.w_class = G.size + 1
 				G.icon_state = text("gift[]", G.size)
-				G.gift = W
 				W.loc = G
 				G.add_fingerprint(user)
 				W.add_fingerprint(user)

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -31,7 +31,7 @@
 				user.put_in_hands(I)
 		else
 			for(var/obj/I in contents)
-				I.loc = get_turf(src)
+				I.forceMove(get_turf(src))
 	else
 		to_chat(user, "<span class='notice'>The gift was empty!</span>")
 	qdel(src)

--- a/code/modules/economy/Accounts.dm
+++ b/code/modules/economy/Accounts.dm
@@ -64,7 +64,6 @@
 		var/obj/item/smallDelivery/P = new /obj/item/smallDelivery(source_db.loc)
 
 		var/obj/item/weapon/paper/R = new /obj/item/weapon/paper(P)
-		P.wrapped = R
 		R.name = "Account information: [M.owner_name]"
 		R.info = "<b>Account details (confidential)</b><br><hr><br>"
 		R.info += "<i>Account holder:</i> [M.owner_name]<br>"

--- a/code/modules/economy/EFTPOS.dm
+++ b/code/modules/economy/EFTPOS.dm
@@ -71,7 +71,6 @@
 
 	var/obj/item/smallDelivery/D = new(R.loc)
 	R.loc = D
-	D.wrapped = R
 	D.name = "small parcel - 'EFTPOS access code'"
 
 /obj/item/device/eftpos/attack_self(mob/user)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -15,9 +15,6 @@
 				var/obj/structure/closet/O = I
 				O.welded = 0
 			I.forceMove(get_turf(src))
-	var/turf/T = get_turf(src)
-	for(var/atom/movable/AM in contents)
-		AM.loc = T
 	return ..()
 
 /obj/structure/bigDelivery/attack_hand(mob/user)
@@ -57,7 +54,7 @@
 	var/sortTag = ""
 
 /obj/item/smallDelivery/attack_self(mob/user)
-	user.drop_item()
+	user.drop_from_inventory(src)
 	if(src.contents.len) //sometimes items can disappear. For example, bombs. --rastaf0
 		if(ishuman(user))
 			for(var/obj/I in contents)
@@ -148,15 +145,17 @@
 			to_chat(user, "<span class='notice'>You need more paper.</span>")
 	else if (istype (target, /obj/structure/closet))
 		var/obj/structure/closet/O = target
-		if (src.amount > 3 && !O.opened && !O.welded)
+		if(src.amount < 3)
+			to_chat(user, "<span class='notice'>You need more paper.</span>")
+			return
+		else if(O.welded)
+			to_chat(user, "<span class='notice'>You cannot wrap a welded closet.</span>")
+			return
+		else if (!O.opened)
 			var/obj/structure/bigDelivery/P = new /obj/structure/bigDelivery(get_turf(O.loc))
 			O.welded = 1
 			O.loc = P
 			src.amount -= 3
-		else if(src.amount < 3)
-			to_chat(user, "<span class='notice'>You need more paper.</span>")
-		else
-			to_chat(user, "<span class='notice'>You cannot wrap are welded closet.</span>")
 	else
 		to_chat(user, "<span class='notice'>The object you are trying to wrap is unsuitable for the sorting machinery!</span>")
 	if (src.amount <= 0)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -9,21 +9,24 @@
 	mouse_drag_pointer = MOUSE_ACTIVE_POINTER
 
 /obj/structure/bigDelivery/Destroy()
-	if(src.contents.len) //sometimes items can disappear. For example, bombs. --rastaf0
-		for(var/obj/I in contents)
-			if(istype(I, /obj/structure/closet))
-				var/obj/structure/closet/O = I
-				O.welded = 0
-			I.forceMove(get_turf(src))
+	var/atom/movable/AM = locate() in contents
+	if(AM) //sometimes items can disappear. For example, bombs. --rastaf0
+		if(istype(AM, /obj/structure/closet))
+			var/obj/structure/closet/O = AM
+			O.welded = 0
+		AM.forceMove(get_turf(src))
 	return ..()
 
 /obj/structure/bigDelivery/attack_hand(mob/user)
-	if(src.contents.len) //sometimes items can disappear. For example, bombs. --rastaf0
-		for(var/obj/I in contents)
-			if(istype(I, /obj/structure/closet))
-				var/obj/structure/closet/O = I
-				O.welded = 0
-			I.forceMove(get_turf(src))
+	var/atom/movable/AM = locate() in contents
+	if(AM) //sometimes items can disappear. For example, bombs. --rastaf0
+		if(istype(AM, /obj/structure/closet))
+			var/obj/structure/closet/O = AM
+			O.welded = 0
+		AM.forceMove(get_turf(src))
+	else
+		to_chat(user, "<span class='notice'>The parcel was empty!</span>")
+	playsound(src, 'sound/items/poster_ripped.ogg', VOL_EFFECTS_MASTER)
 	qdel(src)
 	return
 
@@ -55,13 +58,13 @@
 
 /obj/item/smallDelivery/attack_self(mob/user)
 	user.drop_from_inventory(src)
-	if(src.contents.len) //sometimes items can disappear. For example, bombs. --rastaf0
-		if(ishuman(user))
-			for(var/obj/I in contents)
-				user.put_in_hands(I)
-		else
-			for(var/obj/I in contents)
-				I.forceMove(get_turf(src))
+	var/atom/movable/AM = locate() in contents
+	if(AM) //sometimes items can disappear. For example, bombs. --rastaf0
+		user.put_in_active_hand(AM)
+		AM.add_fingerprint(user)
+	else
+		to_chat(user, "<span class='notice'>The parcel was empty!</span>")
+	playsound(src, 'sound/items/poster_ripped.ogg', VOL_EFFECTS_MASTER)
 	qdel(src)
 	return
 

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -64,7 +64,7 @@
 				user.put_in_hands(I)
 		else
 			for(var/obj/I in contents)
-				I.loc = get_turf(src)
+				I.forceMove(get_turf(src))
 	qdel(src)
 	return
 

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -14,7 +14,7 @@
 			if(istype(I, /obj/structure/closet))
 				var/obj/structure/closet/O = I
 				O.welded = 0
-			I.loc = get_turf(src)
+			I.forceMove(get_turf(src))
 	var/turf/T = get_turf(src)
 	for(var/atom/movable/AM in contents)
 		AM.loc = T

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -3,29 +3,30 @@
 	name = "large parcel"
 	icon = 'icons/obj/storage.dmi'
 	icon_state = "deliverycloset"
-	var/obj/wrapped = null
 	density = 1
 	var/sortTag = ""
 	flags = NOBLUDGEON
 	mouse_drag_pointer = MOUSE_ACTIVE_POINTER
 
 /obj/structure/bigDelivery/Destroy()
-	if(wrapped) //sometimes items can disappear. For example, bombs. --rastaf0
-		wrapped.loc = (get_turf(loc))
-		if(istype(wrapped, /obj/structure/closet))
-			var/obj/structure/closet/O = wrapped
-			O.welded = 0
+	if(src.contents.len) //sometimes items can disappear. For example, bombs. --rastaf0
+		for(var/obj/I in contents)
+			if(istype(I, /obj/structure/closet))
+				var/obj/structure/closet/O = I
+				O.welded = 0
+			I.loc = get_turf(src)
 	var/turf/T = get_turf(src)
 	for(var/atom/movable/AM in contents)
 		AM.loc = T
 	return ..()
 
 /obj/structure/bigDelivery/attack_hand(mob/user)
-	if(wrapped) //sometimes items can disappear. For example, bombs. --rastaf0
-		wrapped.loc = (get_turf(src.loc))
-		if(istype(wrapped, /obj/structure/closet))
-			var/obj/structure/closet/O = wrapped
-			O.welded = 0
+	if(src.contents.len) //sometimes items can disappear. For example, bombs. --rastaf0
+		for(var/obj/I in contents)
+			if(istype(I, /obj/structure/closet))
+				var/obj/structure/closet/O = I
+				O.welded = 0
+			I.loc = get_turf(src)
 	qdel(src)
 	return
 
@@ -53,17 +54,17 @@
 	name = "small parcel"
 	icon = 'icons/obj/storage.dmi'
 	icon_state = "deliverycrateSmall"
-	var/obj/item/wrapped = null
 	var/sortTag = ""
 
 /obj/item/smallDelivery/attack_self(mob/user)
-	if (src.wrapped) //sometimes items can disappear. For example, bombs. --rastaf0
-		wrapped.loc = user.loc
+	user.drop_item()
+	if(src.contents.len) //sometimes items can disappear. For example, bombs. --rastaf0
 		if(ishuman(user))
-			user.put_in_hands(wrapped)
+			for(var/obj/I in contents)
+				user.put_in_hands(I)
 		else
-			wrapped.loc = get_turf_loc(src)
-
+			for(var/obj/I in contents)
+				I.loc = get_turf(src)
 	qdel(src)
 	return
 
@@ -128,7 +129,6 @@
 				P.icon_state = "deliverycrate3"
 			else
 				P.icon_state = "deliverycrate4"
-			P.wrapped = O
 			O.loc = P
 			var/i = round(O.w_class)
 			if(i in list(1,2,3,4,5))
@@ -142,21 +142,21 @@
 		if (src.amount > 3 && !O.opened)
 			var/obj/structure/bigDelivery/P = new /obj/structure/bigDelivery(get_turf(O.loc))
 			P.icon_state = "deliverycrate"
-			P.wrapped = O
 			O.loc = P
 			src.amount -= 3
 		else if(src.amount < 3)
 			to_chat(user, "<span class='notice'>You need more paper.</span>")
 	else if (istype (target, /obj/structure/closet))
 		var/obj/structure/closet/O = target
-		if (src.amount > 3 && !O.opened)
+		if (src.amount > 3 && !O.opened && !O.welded)
 			var/obj/structure/bigDelivery/P = new /obj/structure/bigDelivery(get_turf(O.loc))
-			P.wrapped = O
 			O.welded = 1
 			O.loc = P
 			src.amount -= 3
 		else if(src.amount < 3)
 			to_chat(user, "<span class='notice'>You need more paper.</span>")
+		else
+			to_chat(user, "<span class='notice'>You cannot wrap are welded closet.</span>")
 	else
 		to_chat(user, "<span class='notice'>The object you are trying to wrap is unsuitable for the sorting machinery!</span>")
 	if (src.amount <= 0)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -26,7 +26,7 @@
 			if(istype(I, /obj/structure/closet))
 				var/obj/structure/closet/O = I
 				O.welded = 0
-			I.loc = get_turf(src)
+			I.forceMove(get_turf(src))
 	qdel(src)
 	return
 


### PR DESCRIPTION
<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений

closes #2725

Заменил использование переменной в качестве контейнера для запакованного предмета на общую переменную "contents". Теперь нельзя вытащить предметы которые были уничтожены, находясь в упаковке.
В теории теперь в одну упаковку можно помещать множество предметов.
Сайд фикс - с помощью оберточной бумаги можно было "разваривать" шкафчики. Теперь 
 заваренные шкафчики нельзя обернуть. 
Эта проблема требует более глубокого изучения и фикса на стороне самих шкафчиков, по этому я завел ишью - https://github.com/TauCetiStation/TauCetiClassic/issues/4149
<!--
Опишите изменения данного ПР-а.
Если есть связные ишью (issues), или другие ПРы - укажите их тут, для автоматического закрытия ишью следует использовать ключевые слова https://help.github.com/en/articles/closing-issues-using-keywords
Если есть связное форумное обсуждение на тему изменений - укажите ссылку на эту тему.
-->

## Почему и что этот ПР улучшит
Парочка багфиксов никогда не помешает.
<!--
Опишите причину для изменений.
Этот пункт особенно важен для описания изменений баланса, новых механик.
-->

## Авторство

<!-- Опциональный пункт!
Если авторство не полностью ваше, вы делаете порт с другого билда - обязательно укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
-->

## Чеинжлог

:cl: 
- bugfix: Нельзя вытащить предметы из голодека с помощью подарочной или оберточной бумаги.
- bugfix: Нельзя обернуть в бумагу заваренный шкафчик.
- sound: Распаковка посылок и подарков теперь издает звук.
<!-- Опциональный пункт!
Если это что-то, о чём следует сообщить игрокам - опишите по форме (https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies#Changelog) свои изменения для игрового чеинжлога, они будут отображены на специальной страничке http://changelog.taucetistation.org

Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment
  
Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
