### PR TITLE
Язык Жестов Солнечной Системы

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -196,7 +196,7 @@
 		return
 
 	if(say_understands(speaker, language))
-		message = "<B>[src]</B> [verb], \"[language.format_message(message)]\""
+		message = "<B>[src]</B> [verb], [language.format_message(message)]"
 	else
 		message = "<B>[src]</B> [verb]."
 

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -191,6 +191,18 @@
 	allowed_species = list(IPC, HUMAN, DIONA, SKRELL, UNATHI, TAJARAN)
 	syllables = list ("gra","ba","ba","breh","bra","rah","dur","ra","ro","gro","go","ber","bar","geh","heh", "gra")
 
+/datum/language/solsign
+	name = "Sol Sign Language"
+	desc = "Universal Sol Sign language. Common language of deaf-muted people."
+	colour = "rough"
+	key = list("4")
+	allowed_species = list(HUMAN)
+	signlang_verb = list("making signs with hands", "signing", "waving hands", "gesticulates")
+	flags = SIGNLANG
+
+/datum/language/solsign/format_message(message, verb)
+	return "<span class='message'><span class='[colour]'>\"[capitalize(message)]\"</span></span>"
+
 // Language handling.
 /mob/proc/add_language(language)
 

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -16,6 +16,7 @@
 		return
 
 	message =  sanitize(message)
+	var/datum/language/speaking = parse_language(message)
 
 	if(stat == DEAD)
 		if(fake_death) //Our changeling with fake_death status must not speak in dead chat!!
@@ -31,8 +32,13 @@
 		return emote(copytext(message,2))
 
 	if((miming || has_trait(TRAIT_MUTE)) && !(message_mode == "changeling" || message_mode == "alientalk"))
-		to_chat(usr, "<span class='userdanger'>You are mute.</span>")
-		return
+		if (speaking)
+			if (!(speaking.flags & SIGNLANG) || miming)
+				to_chat(usr, "<span class='userdanger'>You are mute.</span>")
+				return
+		else
+			to_chat(usr, "<span class='userdanger'>You are mute.</span>")
+			return
 
 	if(!ignore_appearance && name != GetVoice())
 		alt_name = "(as [get_id_name("Unknown")])"
@@ -45,7 +51,6 @@
 			message = copytext(message,3)
 
 	//parse the language code and consume it or use default racial language if forced.
-	var/datum/language/speaking = parse_language(message)
 	if (speaking)
 		message = copytext(message,2+length(speaking.key))
 	else if(species.force_racial_language)


### PR DESCRIPTION
## Описание изменений
Добавлен язык жестов в пул дополнительных языков строго людям.<br>
На нем стоит флаг `SIGNLANG`, что не дает писать через него в радио (логично же). Также не нужен слух, чтобы его видеть.<br>
Также изменен механизм общения немых. Они могут использовать языки с `SIGNLANG`, а вот мим даже их не может.

## Почему и что этот PR улучшит
Эта фича поможет персонажам с врожденной глухотой/немотой общаться с людьми без ПДА

Чейнджлог
🆑 PervertGenius

rscadd: Добавлен "Sol Sign Language" людям как доступный из вторичных