### PR TITLE
Универсальный Язык Жестов

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -201,6 +201,10 @@
 	else
 		message = "<span class='game say'><span class='name'>[speaker_name]</span> [verb].</span>"
 
+	if(src.status_flags & PASSEMOTES)
+		for(var/obj/item/weapon/holder/H in src.contents)
+			H.show_message(message)
+
 	if (speaker != src)
 		show_message(message, 1)
 	else

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -192,22 +192,25 @@
 		to_chat(src, "[part_a][speaker_name][part_b][formatted][part_c]")
 
 /mob/proc/hear_signlang(message, verb = "gestures", datum/language/language, mob/speaker = null)
+	var/speaker_name = speaker.name
 	if(!client)
 		return
 
+	if (!speaker || (sdisabilities & BLIND || src.blinded) || !(speaker in view(src)))
+		if (speaker != src)
+			return
+
 	if(say_understands(speaker, language))
-		message = "<B>[src]</B> [verb], [language.format_message(message)]"
+		to_chat(src, "<span class='game say'><span class='name'>[speaker_name]</span> [language.format_message(message, verb)]</span>")
 	else
-		message = "<B>[src]</B> [verb]."
+		to_chat(src, "<span class='game say'><span class='name'>[speaker_name]</span> [verb].</span>")
 
-	if(src.status_flags & PASSEMOTES)
-		for(var/obj/item/weapon/holder/H in src.contents)
-			H.show_message(message)
-	show_message(message)
-
-/mob/proc/hear_sleep(message)
+/mob/proc/hear_sleep(message, datum/language/language)
 	var/heard = ""
-	if(prob(15))
+	if (language && (language.flags & NONVERBAL) && (language.flags & SIGNLANG))
+		return
+
+	else if(prob(15))
 		var/list/punctuation = list(",", "!", ".", ";", "?")
 		var/list/messages = splittext(message, " ")
 		var/R = rand(1, messages.len)

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -196,14 +196,15 @@
 	if(!client)
 		return
 
-	if (!speaker || (sdisabilities & BLIND || src.blinded) || !(speaker in view(src)))
-		if (speaker != src)
-			return
-
 	if(say_understands(speaker, language))
-		to_chat(src, "<span class='game say'><span class='name'>[speaker_name]</span> [language.format_message(message, verb)]</span>")
+		message = "<span class='game say'><span class='name'>[speaker_name]</span> [language.format_message(message, verb)]</span>"
 	else
-		to_chat(src, "<span class='game say'><span class='name'>[speaker_name]</span> [verb].</span>")
+		message = "<span class='game say'><span class='name'>[speaker_name]</span> [verb].</span>"
+
+	if (speaker != src)
+		show_message(message, 1)
+	else
+		show_message(message)
 
 /mob/proc/hear_sleep(message, datum/language/language)
 	var/heard = ""

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -196,7 +196,7 @@
 		return
 
 	if(say_understands(speaker, language))
-		message = "<B>[src]</B> [verb], \"[language.format_message(message)]\""
+		message = "<B>[src]</B> [verb], [language.format_message(message)]"
 	else
 		message = "<B>[src]</B> [verb]."
 

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -212,7 +212,7 @@
 
 /mob/proc/hear_sleep(message, datum/language/language)
 	var/heard = ""
-	if (language && (language.flags & NONVERBAL) && (language.flags & SIGNLANG))
+	if (language && ((language.flags & NONVERBAL) || (language.flags & SIGNLANG)))
 		return
 
 	else if(prob(15))

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -142,9 +142,6 @@
 	signlang_verb = list("emits a series of short beeps", "screeches in boops", "eminates short pings", "projects a series of screeches")
 	flags = SIGNLANG // For all intents and purposes, this is basically a sign language.
 
-/datum/language/diona_space/format_message(message, verb)
-	return "<span class='message'><span class='[colour]'>\"[capitalize(message)]\"</span></span>"
-
 /datum/language/human
 	name = "Sol Common"
 	desc = "A bastardized hybrid of informal English and elements of Mandarin Chinese; the common language of the Sol system."
@@ -197,11 +194,8 @@
 	colour = "rough"
 	key = list("4")
 	allowed_species = list(HUMAN)
-	signlang_verb = list("making signs with hands", "signing", "waving hands", "gesticulates")
+	signlang_verb = list("makes signs with hands", "gestures", "waves hands", "gesticulates")
 	flags = SIGNLANG
-
-/datum/language/solsign/format_message(message, verb)
-	return "<span class='message'><span class='[colour]'>\"[capitalize(message)]\"</span></span>"
 
 // Language handling.
 /mob/proc/add_language(language)

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -188,7 +188,7 @@
 	allowed_species = list(IPC, HUMAN, DIONA, SKRELL, UNATHI, TAJARAN)
 	syllables = list ("gra","ba","ba","breh","bra","rah","dur","ra","ro","gro","go","ber","bar","geh","heh", "gra")
 
-/datum/language/solsign
+/datum/language/unisign
 	name = "Universal Sign Language"
 	desc = "Standart language made of gestures. Common language of deaf and muted people."
 	colour = "rough"

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -191,6 +191,18 @@
 	allowed_species = list(IPC, HUMAN, DIONA, SKRELL, UNATHI, TAJARAN)
 	syllables = list ("gra","ba","ba","breh","bra","rah","dur","ra","ro","gro","go","ber","bar","geh","heh", "gra")
 
+/datum/language/solsign
+	name = "Sol Sign Language"
+	desc = "Universal Sol Sign language. Common language of deaf-muted people."
+	colour = "rough"
+	key = list("4")
+	allowed_species = list(HUMAN)
+	signlang_verb = list("making signs with hands", "signing", "waving hands", "gesticulates")
+	flags = SIGNLANG
+
+/datum/language/solsign/format_message(message, verb)
+	return "<span class='message'><span class='[colour]'>\"[capitalize(message)]\"</span></span>"
+
 // Language handling.
 /mob/proc/add_language(language)
 

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -189,11 +189,11 @@
 	syllables = list ("gra","ba","ba","breh","bra","rah","dur","ra","ro","gro","go","ber","bar","geh","heh", "gra")
 
 /datum/language/solsign
-	name = "Sol Sign Language"
-	desc = "Universal Sol Sign language. Common language of deaf-muted people."
+	name = "Universal Sign Language"
+	desc = "Standart language made of gestures. Common language of deaf and muted people."
 	colour = "rough"
 	key = list("4")
-	allowed_species = list(HUMAN)
+	allowed_species = list(IPC, HUMAN, DIONA, SKRELL, UNATHI, TAJARAN)
 	signlang_verb = list("makes signs with hands", "gestures", "waves hands", "gesticulates")
 	flags = SIGNLANG
 

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -56,7 +56,7 @@
 
 	if (speaking && (speaking.flags & SIGNLANG))
 		var/obj/item/organ/external/LH = src.get_bodypart(BP_L_ARM)
-		var/obj/item/organ/external/RH = src.get_bodypart(BP_L_ARM)
+		var/obj/item/organ/external/RH = src.get_bodypart(BP_R_ARM)
 		if (!(LH && LH.is_usable() && RH && RH.is_usable()))
 			to_chat(usr, "<span class='userdanger'>You tried to make a gesture, but your hands are not responding.</span>")
 			return

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -16,6 +16,7 @@
 		return
 
 	message =  sanitize(message)
+	var/datum/language/speaking = parse_language(message)
 
 	if(stat == DEAD)
 		if(fake_death) //Our changeling with fake_death status must not speak in dead chat!!
@@ -31,8 +32,13 @@
 		return emote(copytext(message,2))
 
 	if((miming || has_trait(TRAIT_MUTE)) && !(message_mode == "changeling" || message_mode == "alientalk"))
-		to_chat(usr, "<span class='userdanger'>You are mute.</span>")
-		return
+		if (speaking)
+			if (!(speaking.flags & SIGNLANG) || miming)
+				to_chat(usr, "<span class='userdanger'>You are mute.</span>")
+				return
+		else
+			to_chat(usr, "<span class='userdanger'>You are mute.</span>")
+			return
 
 	if(!ignore_appearance && name != GetVoice())
 		alt_name = "(as [get_id_name("Unknown")])"
@@ -45,7 +51,6 @@
 			message = copytext(message,3)
 
 	//parse the language code and consume it or use default racial language if forced.
-	var/datum/language/speaking = parse_language(message)
 	if (speaking)
 		message = copytext(message,2+length(speaking.key))
 	else if(species.force_racial_language)


### PR DESCRIPTION
## Описание изменений
Добавлен язык жестов в пул дополнительных языков.<br>
На нем стоит флаг `SIGNLANG`, что не дает писать через него в радио (логично же). Также не нужен слух, чтобы его видеть.<br>
Также изменен механизм общения немых. Они могут использовать языки с `SIGNLANG`, а вот мим даже их не может.

Слепые будут видеть только что они говорят на жестуре. В ответ они даже не узнают, были ли жесты. Если вы лежите в отключке, вы также не узнаете, были ли жесты.

## Почему и что этот PR улучшит
Эта фича поможет персонажам с врожденной глухотой/немотой общаться с людьми без PDA.

Мимокрокодилом пофикшен рутсонг, так как там была смысловая ошибка в механизме жестовых языков.

## Чейнджлог
🆑 PervertGenius
- rscadd: Добавлен "Universal Sign Language" людям, дионам, скреллам, таярам, унатхи и СПУ как доступный из вторичных