### PR TITLE
Возможность поглощать заряд батарей для IPC.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -202,6 +202,17 @@
 		if(W)
 			W.forceMove(src.loc)
 
+	else if(istype(W,/obj/item/weapon/changeling_hammer))
+		user.do_attack_animation(src)
+		user.SetNextMove(CLICK_CD_MELEE)
+		visible_message("<span class='userdanger'>[user] has punched the [src]!</span>")
+		playsound(src, 'sound/effects/grillehit.ogg', VOL_EFFECTS_MASTER)
+		if(W.use_charge(user) && prob(20))
+			playsound(src, pick('sound/effects/explosion1.ogg', 'sound/effects/bang.ogg'), VOL_EFFECTS_MASTER)
+			open()
+			qdel(src)
+		return
+
 	else if(istype(W, /obj/item/weapon/packageWrap) || istype(W, /obj/item/weapon/extraction_pack))
 		return
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -90,6 +90,18 @@
 		for(var/mob/O in viewers(user, 3))
 			O.show_message("<span class='warning'>The locker has been sliced open by [user] with an [W.name]!</span>", 1, "You hear metal being sliced and sparks flying.", 2)
 
+	else if(istype(W,/obj/item/weapon/changeling_hammer))
+		user.do_attack_animation(src)
+		user.SetNextMove(CLICK_CD_MELEE)
+		visible_message("<span class='userdanger'>[user] has punched the [src]!</span>")
+		playsound(src, 'sound/effects/grillehit.ogg', VOL_EFFECTS_MASTER)
+		if(W.use_charge(user) && prob(20))
+			playsound(src, pick('sound/effects/explosion1.ogg', 'sound/effects/bang.ogg'), VOL_EFFECTS_MASTER)
+			open()
+			src.dump_contents()
+			qdel(src)
+		return
+
 	else if(istype(W,/obj/item/weapon/packageWrap) || iswelder(W))
 		return ..(W,user)
 	else

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -65,24 +65,19 @@
 		if(istype(SNG) && SNG.candrain && !SNG.draining)
 			SNG.drain("CELL",src,H.wear_suit)
 			
-
 		if(H.species.flags[IS_SYNTHETIC] && H.a_intent == "grab")
 			user.SetNextMove(CLICK_CD_MELEE)
 			if(src.charge > 0)
 				if(H.nutrition < 450)
-
 					if(src.charge >= 500)
 						H.nutrition += 50
 						src.charge -= 500
 					else
 						H.nutrition += src.charge/10
 						src.charge = 0
-
 					to_chat(user, "<span class='notice'>You attach your fingers to the cell and siphon off some of the stored charge for your own use.</span>")
 					if(src.charge < 0) src.charge = 0
 					if(H.nutrition > 500) H.nutrition = 500
-					//src.charging = 1
-
 				else
 					to_chat(user, "<span class='notice'>You are already fully charged.</span>")
 			else

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -64,6 +64,30 @@
 		var/obj/item/clothing/gloves/space_ninja/SNG = H.gloves
 		if(istype(SNG) && SNG.candrain && !SNG.draining)
 			SNG.drain("CELL",src,H.wear_suit)
+			
+
+		if(H.species.flags[IS_SYNTHETIC] && H.a_intent == "grab")
+			user.SetNextMove(CLICK_CD_MELEE)
+			if(src.charge > 0)
+				if(H.nutrition < 450)
+
+					if(src.charge >= 500)
+						H.nutrition += 50
+						src.charge -= 500
+					else
+						H.nutrition += src.charge/10
+						src.charge = 0
+
+					to_chat(user, "<span class='notice'>You attach your fingers to the cell and siphon off some of the stored charge for your own use.</span>")
+					if(src.charge < 0) src.charge = 0
+					if(H.nutrition > 500) H.nutrition = 500
+					//src.charging = 1
+
+				else
+					to_chat(user, "<span class='notice'>You are already fully charged.</span>")
+			else
+				to_chat(user, "There is no charge to draw from that cell.")
+			return
 
 /obj/item/weapon/stock_parts/cell/attackby(obj/item/W, mob/user)
 	..()


### PR DESCRIPTION
<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений
Теперь можно съедать заряд батареи будучи СПУ.
<!--
Опишите изменения данного ПР-а.
Если есть связные ишью (issues), или другие ПРы - укажите их тут, для автоматического закрытия ишью следует использовать ключевые слова https://help.github.com/en/articles/closing-issues-using-keywords
Если есть связное форумное обсуждение на тему изменений - укажите ссылку на эту тему.
-->

## Почему и что этот ПР улучшит
Функция бесполезная, но почему бы и нет?
<!--
Опишите причину для изменений.
Этот пункт особенно важен для описания изменений баланса, новых механик.
-->

## Чеинжлог
:cl: Kortez90
- tweak: Возможность поглощать батарейки будучи СПУ через граб.
<!-- Опциональный пункт!
Если это что-то, о чём следует сообщить игрокам - опишите по форме (https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies#Changelog) свои изменения для игрового чеинжлога, они будут отображены на специальной страничке http://changelog.taucetistation.org

Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment
  
Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
