### PR TITLE
nullify_debuff у костюмов для IPC.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -62,12 +62,14 @@
 	if(!species.flags[NO_BLOOD] && (reagents.has_reagent("hyperzine") || reagents.has_reagent("nuka_cola")))
 		chem_nullify_debuff = TRUE
 	
-	if(species.flags[IS_SYNTHETIC])
-		chem_nullify_debuff = TRUE
+	if(wear_suit && wear_suit.slowdown && !species.flags[IS_SYNTHETIC] && !(wear_suit.slowdown > 0 && chem_nullify_debuff))
+		tally += wear_suit.slowdown
+			
+	if(back && back.slowdown && !(back.slowdown > 0 && chem_nullify_debuff))
+		tally += back.slowdown
 
-	for(var/obj/item/I in list(wear_suit, back, shoes))
-		if(!(I.slowdown > 0 && chem_nullify_debuff))
-			tally += I.slowdown
+	if(shoes && shoes.slowdown && !(shoes.slowdown > 0 && chem_nullify_debuff))
+		tally += shoes.slowdown
 
 	if(!chem_nullify_debuff)
 		for(var/x in list(l_hand, r_hand))

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -61,6 +61,9 @@
 	var/chem_nullify_debuff = FALSE
 	if(!species.flags[NO_BLOOD] && (reagents.has_reagent("hyperzine") || reagents.has_reagent("nuka_cola")))
 		chem_nullify_debuff = TRUE
+	
+	if(species.flags[IS_SYNTHETIC])
+		chem_nullify_debuff = TRUE
 
 	for(var/obj/item/I in list(wear_suit, back, shoes))
 		if(!(I.slowdown > 0 && chem_nullify_debuff))


### PR DESCRIPTION
<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений
Включен `nullify_debuf` для IPC, так как в отличии от мясных мешков, им не нужны мышцы. Не углублялся в строение тел СПУ настолько, чтобы искать у них искуственные мышцы, но насколько я помню, у тел второго поколения была неплохая сила и поддерживать позитронку они могли достаточно долго. Если тяжелые костюмы сказывались на подвижности и скорости мясных мешков, то для СПУ не составляет проблем двигаться также, как и человек в костюме под гиперцином. (Правда, по поводу баланса не уверен. Возможно, это слишком сильная фича. С  другой стороны, боевых СПУ в игре почти нет.)
<!--
Опишите изменения данного ПР-а.
Если есть связные ишью (issues), или другие ПРы - укажите их тут, для автоматического закрытия ишью следует использовать ключевые слова https://help.github.com/en/articles/closing-issues-using-keywords
Если есть связное форумное обсуждение на тему изменений - укажите ссылку на эту тему.
-->

## Почему и что этот ПР улучшит
Теперь скафандры для спу не тяжелые.
<!--
Опишите причину для изменений.
Этот пункт особенно важен для описания изменений баланса, новых механик.
-->

<!-- Опциональный пункт!
Если авторство не полностью ваше, вы делаете порт с другого билда - обязательно укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
-->

## Чеинжлог
:cl: Kortez90
- tweak: СПУ теперь могут бегать в скафандрах.
<!-- Опциональный пункт!
Если это что-то, о чём следует сообщить игрокам - опишите по форме (https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies#Changelog) свои изменения для игрового чеинжлога, они будут отображены на специальной страничке http://changelog.taucetistation.org

Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment
  
Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
