### PR TITLE
Статусная информация для IPC.

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -149,11 +149,9 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 		if(species.flags[IS_SYNTHETIC])
 			var/obj/item/organ/internal/liver/IO = organs_by_name[O_LIVER]
 			var/obj/item/weapon/stock_parts/cell/I = locate(/obj/item/weapon/stock_parts/cell) in IO
-			if(istype(I))
+			if(I)
 				stat(null, "Charge: [round(100.0*nutrition/I.maxcharge)]%")
 				stat(null, "Operating temp: [round(bodytemperature-T0C)]&deg;C")
-			else
-				return TRUE
 		if(internal)
 			if(!internal.air_contents)
 				qdel(internal)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -149,7 +149,7 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 		if(species.flags[IS_SYNTHETIC])
 			var/obj/item/organ/internal/liver/ipc/L = locate(/obj/item/organ/internal/liver/ipc) in organs
 			var/obj/item/weapon/stock_parts/cell/I = locate(/obj/item/weapon/stock_parts/cell) in L
-			stat(null, "Charge: [round(100.0*nutrition/I.maxcharge)%]")
+			stat(null, "Charge: [round(100.0*nutrition/I.maxcharge)]%")
 			stat(null, "Operating temp: [round(bodytemperature-T0C)]&deg;C")
 		if(internal)
 			if(!internal.air_contents)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -147,10 +147,13 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 		stat(null, "Move Mode: [m_intent]")
 		//Info for IPC
 		if(species.flags[IS_SYNTHETIC])
-			var/obj/item/organ/internal/liver/ipc/L = locate(/obj/item/organ/internal/liver/ipc) in organs
-			var/obj/item/weapon/stock_parts/cell/I = locate(/obj/item/weapon/stock_parts/cell) in L
-			stat(null, "Charge: [round(100.0*nutrition/I.maxcharge)]%")
-			stat(null, "Operating temp: [round(bodytemperature-T0C)]&deg;C")
+			var/obj/item/organ/internal/liver/IO = organs_by_name[O_LIVER]
+			var/obj/item/weapon/stock_parts/cell/I = locate(/obj/item/weapon/stock_parts/cell) in IO
+			if(istype(I))
+				stat(null, "Charge: [round(100.0*nutrition/I.maxcharge)]%")
+				stat(null, "Operating temp: [round(bodytemperature-T0C)]&deg;C")
+			else
+				return TRUE
 		if(internal)
 			if(!internal.air_contents)
 				qdel(internal)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -145,6 +145,12 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 	if(statpanel("Status"))
 		stat(null, "Intent: [a_intent]")
 		stat(null, "Move Mode: [m_intent]")
+		//Info for IPC
+		if(species.flags[IS_SYNTHETIC])
+			var/obj/item/organ/internal/liver/ipc/L = locate(/obj/item/organ/internal/liver/ipc) in organs
+			var/obj/item/weapon/stock_parts/cell/I = locate(/obj/item/weapon/stock_parts/cell) in L
+			stat(null, "Charge: [round(100.0*nutrition/I.maxcharge)%]")
+			stat(null, "Operating temp: [round(bodytemperature-T0C)]&deg;C")
 		if(internal)
 			if(!internal.air_contents)
 				qdel(internal)


### PR DESCRIPTION
<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений
Две новые строчки только у СПУ - `Charge` - остаток заряда и `Operating temp` - температура тела. Идикатором заряда atm выступал alert голода, но это не очень хорошо. К тому же, сомневаюсь что дорогостоящая установка будет просто набором палок и сервоприводов без датчиков и сенсоров. И уж тем более у СПУ должен быть датчик температуры, чтобы не допускать перегрева. В дальнейшем собирался перенести это в hud для ipc и заменить alert голода.
И пожалуйста, подскажите, как можно более компактно и удобно объявлять подобного рода переменные.
![ss13_hud_new_ipc_stat](https://user-images.githubusercontent.com/36198983/67955432-a54e8a00-fc03-11e9-9fc6-470797cdb417.png)
<!--
Опишите изменения данного ПР-а.
Если есть связные ишью (issues), или другие ПРы - укажите их тут, для автоматического закрытия ишью следует использовать ключевые слова https://help.github.com/en/articles/closing-issues-using-keywords
Если есть связное форумное обсуждение на тему изменений - укажите ссылку на эту тему.

-->

## Почему и что этот ПР улучшит
Жизнь СПУ.
<!--
Опишите причину для изменений.
Этот пункт особенно важен для описания изменений баланса, новых механик.
-->

<!-- Опциональный пункт!
Если авторство не полностью ваше, вы делаете порт с другого билда - обязательно укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
-->

## Чеинжлог
:cl: Kortez90
- tweak: Информация о зараде и температуре тела для спу.
<!-- Опциональный пункт!
Если это что-то, о чём следует сообщить игрокам - опишите по форме (https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies#Changelog) свои изменения для игрового чеинжлога, они будут отображены на специальной страничке http://changelog.taucetistation.org

Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment
  
Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
