### PR TITLE
Ребаланс плазменного дробовика.

### DIFF
--- a/code/modules/projectiles/guns/plasma/plasma.dm
+++ b/code/modules/projectiles/guns/plasma/plasma.dm
@@ -48,8 +48,10 @@
 		PLASMAGUN_OVERCHARGE = /obj/item/ammo_casing/plasma/overcharge/massive
 		)
 
+	w_class = ITEM_SIZE_HUGE
+	fire_delay = 15
 	number_of_shots = 7 // It can be more than that (but no more than 1 extra), if there is a bit of charge left after 7th shot.
-	max_projectile_per_fire = 9
+	max_projectile_per_fire = 5
 
 /obj/item/weapon/gun/plasma/atom_init()
 	. = ..()


### PR DESCRIPTION
## Описание изменений

* Весовой класс повышен на единицу (меняет только скорость передвижения). Но на мой взгляд это не слишком заметно.
* Кол.во прожектайлов снижено до 5-ти за выстрел (снижает урон со 162 на 90). Средний урон за выстрел на расстояние 5 тайлов составляет 36 единиц по голой кукле.

  * 5 тайлов это вот так:
![plas_r5](https://user-images.githubusercontent.com/8426718/68214187-a7d72800-ffe5-11e9-979a-3bd5e80e62d4.png)
  * В среднем будет 36 урона на такое расстояние.

* Понижена скорострельность в 2.5 раза.

Кол.во выстрелов я не стал трогать, а максимальный урон который может выбить - это 630 единиц. Т.е около 3-х голых кукол (речь естественно про стандартную батарейку и если все 5 прожектайлов попадали).
Выходит примерно как еган, но у которого бустится урон если цель ближе, и падает если далеко. Собственно сейчас одно полное попадание будет как два егана приблизительно.
Конечно это не выбивает дробовик из пула, он все еще очень злой если с ним биться на расстоянии 1-4 тайла и там он скорее всего обыграет большинство пушек, но учитывая пониженную скорострельность - будет чуть сложнее.

Надо ли будет его еще твикать? Вероятно да, из того что стоит дернуть следующим если все еще будет необходимость - это скорость зарядки магазина. А может наоборот кстати выйти - что после твика он станет резко "ниочем", но здесь у меня в данный момент сомнения.

## Почему и что этот ПР улучшит

Понизит мету на дробовик.

## Чеинжлог

:cl:
 - balance: Общий урон плазменного дробовика снижен со 162 до 90 урона. Повышен весовой класс, что понизит еще немного скорость передвижения с ним в руках. Скорострельность порезана в 2.5 раза.