### PR TITLE
Fixing a runtime in randomly generating a preference obj.

### DIFF
--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -16,7 +16,8 @@
 	undershirt = rand(1,undershirt_t.len)
 	socks = rand(1,socks_t.len)
 	backbag = 2
-	age = rand(H.species.min_age, H.species.max_age)
+	var/datum/species/S = all_species[species]
+	age = rand(S.min_age, S.max_age)
 	if(H)
 		copy_to(H)
 


### PR DESCRIPTION
## Описание изменений

```
				if("all")
					randomize_appearance_for()	//no params needed
```
character menu/general.dm

В случае нажатия на кнопку рандомизации преференсов получался рантайм, ведь я не учёл что эту функцию вызывают и без созданной куклы.

## Почему и что этот ПР улучшит

Исправляет рантайм.
