### PR TITLE
Исправления некоторых вызовов для повреждений частей тела

### DIFF
--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -192,7 +192,7 @@ Implant Specifics:<BR>"}
 					if (istype(part,/obj/item/organ/external/chest) ||	\
 						istype(part,/obj/item/organ/external/groin) ||	\
 						istype(part,/obj/item/organ/external/head))
-						part.createwound(BRUISE, 60)	//mangle them instead
+						part.take_damage(60, used_weapon = "Explosion") //mangle them instead
 						explosion(get_turf(imp_in), -1, -1, 2, 3)
 						qdel(src)
 					else
@@ -259,7 +259,7 @@ Implant Specifics:<BR>"}
 				if (istype(part,/obj/item/organ/external/chest) ||	\
 					istype(part,/obj/item/organ/external/groin) ||	\
 					istype(part,/obj/item/organ/external/head))
-					part.createwound(BRUISE, 60)	//mangle them instead
+					part.take_damage(60, used_weapon = "Explosion")	//mangle them instead
 				else
 					part.droplimb(null, null, DROPLIMB_BLUNT)
 			explosion(get_turf(imp_in), -1, -1, 2, 3)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -495,11 +495,12 @@
 	if(prob(30) && ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/BP = H.bodyparts_by_name[BP_HEAD]
-		BP.createwound(CUT, 15)
-		BP.embed(new /obj/item/weapon/shard)
+		var/obj/item/weapon/shard/S = new
+		BP.embed(S)
+		H.apply_damage(15, def_zone = BP_HEAD, damage_flags = DAM_SHARP|DAM_EDGE, used_weapon = S)
 		H.emote("scream",,, 1)
 	else
-		M.apply_damage(15,def_zone = BP_HEAD)
+		M.apply_damage(15, def_zone = BP_HEAD)
 	shatter()
 
 /*

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1734,8 +1734,8 @@
 			BP.hidden = surprise
 			BP.cavity = 0
 		else 		//someone is having a bad day
-			BP.createwound(CUT, 30)
 			BP.embed(surprise)
+			BP.take_damage(30, 0, DAM_SHARP|DAM_EDGE, "Animal escaping the ribcage")
 	else if (ismonkey(M))
 		M.visible_message("<span class='danger'>[M] suddenly tears in half!</span>")
 		var/mob/living/carbon/monkey/ook = new monkey_type(M.loc)

--- a/code/modules/surgery/appendix.dm
+++ b/code/modules/surgery/appendix.dm
@@ -48,7 +48,7 @@
 	var/obj/item/organ/external/BP = target.bodyparts_by_name[BP_GROIN]
 	user.visible_message("<span class='warning'>[user]'s hand slips, slicing an artery inside [target]'s abdomen with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, slicing an artery inside [target]'s abdomen with \the [tool]!</span>")
-	BP.createwound(CUT, 50, 1)
+	BP.take_damage(50, 0, DAM_SHARP|DAM_EDGE, tool)
 
 /datum/surgery_step/appendectomy/remove_appendix
 	allowed_tools = list(
@@ -87,4 +87,4 @@
 	var/obj/item/organ/external/BP = target.bodyparts_by_name[BP_GROIN]
 	user.visible_message("<span class='warning'>[user]'s hand slips, nicking organs in [target]'s abdomen with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, nicking organs in [target]'s abdomen with \the [tool]!</span>")
-	BP.createwound(BRUISE, 20)
+	BP.take_damage(20, 0, used_weapon = tool)

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -74,7 +74,7 @@
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, damaging the bone in [target]'s [BP.name] with \the [tool]!</span>" , \
 		"<span class='warning'>Your hand slips, damaging the bone in [target]'s [BP.name] with \the [tool]!</span>")
-	BP.createwound(BRUISE, 5)
+	BP.take_damage(5, 0, used_weapon = tool)
 
 /datum/surgery_step/mend_skull
 	allowed_tools = list(
@@ -106,7 +106,7 @@
 	user.visible_message("<span class='warning'>[user]'s hand slips, damaging [target]'s face with \the [tool]!</span>"  , \
 		"<span class='warning'>Your hand slips, damaging [target]'s face with \the [tool]!</span>")
 	var/obj/item/organ/external/head/H = BP
-	H.createwound(BRUISE, 10)
+	H.take_damage(10, 0, used_weapon = tool)
 	H.disfigured = 1
 
 /datum/surgery_step/finish_bone

--- a/code/modules/surgery/braincore.dm
+++ b/code/modules/surgery/braincore.dm
@@ -35,9 +35,11 @@
 	target.brain_op_stage = 2
 
 /datum/surgery_step/brain/saw_skull/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, cracking [target]'s skull with \the [tool]!</span>" , \
 	"<span class='warning'>Your hand slips, cracking [target]'s skull with \the [tool]!</span>" )
-	target.apply_damage(max(10, tool.force), BRUTE, BP_HEAD)
+	BP.fracture()
+	BP.take_damage(max(10, tool.force), 0, DAM_SHARP|DAM_EDGE, tool)
 
 /datum/surgery_step/brain/cut_brain
 	allowed_tools = list(
@@ -64,9 +66,10 @@
 	target.brain_op_stage = 3
 
 /datum/surgery_step/brain/cut_brain/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, cutting a vein in [target]'s brain with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, cutting a vein in [target]'s brain with \the [tool]!</span>")
-	target.apply_damage(50, BRUTE, BP_HEAD, 1, DAM_SHARP)
+	BP.take_damage(50, 0, DAM_SHARP|DAM_EDGE,  tool)
 
 /datum/surgery_step/brain/saw_spine
 	allowed_tools = list(
@@ -110,9 +113,10 @@
 	target.death()//You want them to die after the brain was transferred, so not to trigger client death() twice.
 
 /datum/surgery_step/brain/saw_spine/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, cutting a vein in [target]'s brain with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, cutting a vein in [target]'s brain with \the [tool]!</span>")
-	target.apply_damage(30, BRUTE, BP_HEAD, 1, DAM_SHARP)
+	BP.take_damage(30, 0, DAM_SHARP|DAM_EDGE, tool)
 	if (ishuman(user))
 		user:bloody_body(target)
 		user:bloody_hands(target, 0)
@@ -147,9 +151,10 @@
 
 
 /datum/surgery_step/brain/bone_chips/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, jabbing \the [tool] in [target]'s brain!</span>", \
 	"<span class='warning'>Your hand slips, jabbing \the [tool] in [target]'s brain!</span>")
-	target.apply_damage(30, BRUTE, BP_HEAD, 1, DAM_SHARP)
+	BP.take_damage(30, 0, DAM_SHARP, tool)
 
 /datum/surgery_step/brain/hematoma
 	allowed_tools = list(
@@ -177,9 +182,10 @@
 
 
 /datum/surgery_step/brain/hematoma/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, bruising [target]'s brain with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, bruising [target]'s brain with \the [tool]!</span>")
-	target.apply_damage(20, BRUTE, BP_HEAD, 1, DAM_SHARP)
+	BP.take_damage(20, 0, used_weapon = tool)
 
 //////////////////////////////////////////////////////////////////
 //				SLIME CORE EXTRACTION							//

--- a/code/modules/surgery/eye.dm
+++ b/code/modules/surgery/eye.dm
@@ -44,7 +44,7 @@
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, slicing [target]'s eyes wth \the [tool]!</span>" , \
 	"<span class='warning'>Your hand slips, slicing [target]'s eyes wth \the [tool]!</span>" )
-	BP.createwound(CUT, 10)
+	BP.take_damage(10, 0, DAM_SHARP|DAM_EDGE, tool)
 	IO.take_damage(5, 0)
 
 /datum/surgery_step/eye/lift_eyes
@@ -75,7 +75,7 @@
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, damaging [target]'s eyes with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, damaging [target]'s eyes with \the [tool]!</span>")
-	target.apply_damage(10, BRUTE, BP)
+	BP.take_damage(10, 0, used_weapon = tool)
 	IO.take_damage(5, 0)
 
 /datum/surgery_step/eye/mend_eyes
@@ -108,7 +108,7 @@
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, stabbing \the [tool] into [target]'s eye!</span>", \
 	"<span class='warning'>Your hand slips, stabbing \the [tool] into [target]'s eye!</span>")
-	target.apply_damage(10, BRUTE, BP, null, DAM_SHARP)
+	BP.take_damage(10, 0, DAM_SHARP|DAM_EDGE, tool)
 	IO.take_damage(5, 0)
 
 /datum/surgery_step/eye/cauterize
@@ -141,7 +141,7 @@
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips,  searing [target]'s eyes with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, searing [target]'s eyes with \the [tool]!</span>")
-	target.apply_damage(5, BURN, BP)
+	BP.take_damage(0, 5, used_weapon = tool)
 	IO.take_damage(5, 0)
 
 //////////////////////////////////////////////////////////////////
@@ -192,7 +192,7 @@
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, scratching [target]'s cameras wth \the [tool]!</span>" ,
 	"<span class='warning'>Your hand slips, scratching [target]'s cameras wth \the [tool]!</span>")
-	BP.createwound(CUT, 10)
+	BP.take_damage(10, 0, DAM_SHARP|DAM_EDGE, tool)
 	IO.take_damage(5, 0)
 
 /datum/surgery_step/ipc_eye/mend_cameras
@@ -226,12 +226,11 @@
 	var/dam_amt = 2
 
 	if(istype(tool, /obj/item/stack/nanopaste) || istype(tool, /obj/item/weapon/bonegel))
-		target.apply_damage(6, BURN, BP, null)
+		BP.take_damage(0, 6, used_weapon = tool)
 
 	else if(iswrench(tool))
-		target.apply_damage(12, BRUTE, BP, null)
-		BP.createwound(CUT, 5)
-
+		BP.take_damage(12, 0, used_weapon = tool)
+		BP.take_damage(5, 0, DAM_SHARP|DAM_EDGE, tool)
 	IO.take_damage(dam_amt,0)
 	if(!target.is_bruised_organ(O_KIDNEYS))
 		to_chat(target, "<span class='warning italics'>SEVERE VISUAL SENSOR DAMAGE DETECTED. %REACTION_OVERLOAD%.</span>")
@@ -267,5 +266,5 @@
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips,  denting [target]'s cameras with \the [tool]!</span>",
 	"<span class='warning'>Your hand slips, denting [target]'s cameras with \the [tool]!</span>")
-	target.apply_damage(5, BRUTE, BP)
+	BP.take_damage(5, 0, DAM_SHARP|DAM_EDGE, tool)
 	IO.take_damage(5, 0)

--- a/code/modules/surgery/face.dm
+++ b/code/modules/surgery/face.dm
@@ -45,7 +45,7 @@
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, slicing [target]'s throat wth \the [tool]!</span>" , \
 	"<span class='warning'>Your hand slips, slicing [target]'s throat wth \the [tool]!</span>" )
-	BP.createwound(CUT, 60)
+	BP.take_damage(60, 0, DAM_SHARP|DAM_EDGE, tool)
 	target.losebreath += 10
 
 /datum/surgery_step/face/mend_vocal
@@ -105,7 +105,7 @@
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, tearing skin on [target]'s face with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, tearing skin on [target]'s face with \the [tool]!</span>")
-	target.apply_damage(10, BRUTE, BP, null, DAM_SHARP | DAM_EDGE)
+	BP.take_damage(10, 0, DAM_SHARP|DAM_EDGE, tool)
 
 /datum/surgery_step/face/cauterize
 	allowed_tools = list(
@@ -141,7 +141,7 @@
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, leaving a small burn on [target]'s face with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, leaving a small burn on [target]'s face with \the [tool]!</span>")
-	target.apply_damage(4, BURN, BP)
+	BP.take_damage(0, 4, used_weapon = tool)
 //////////////////////////////////////////////////////////////////
 //				ROBOTIC FACE SURGERY							//
 //////////////////////////////////////////////////////////////////
@@ -190,7 +190,7 @@
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, scratching [target]'s screen with \the [tool]!</span>",
 	"<span class='warning'>Your hand slips, scratching [target]'s screen with \the [tool]!</span>")
-	BP.createwound(CUT, 60)
+	BP.take_damage(60, 0, DAM_SHARP|DAM_EDGE, tool)
 
 /datum/surgery_step/ipc_face/pry_screen
 	allowed_tools = list(
@@ -219,7 +219,7 @@
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, damaging [target]'s screen with \the [tool]!</span>",
 	"<span class='warning'>Your hand slips, damaging [target]'s screen with \the [tool]!</span>")
-	target.apply_damage(12, BRUTE, BP, null)
+	BP.take_damage(12, 0, used_weapon = tool)
 
 /datum/surgery_step/ipc_face/hack_face
 	allowed_tools = list(
@@ -255,7 +255,7 @@
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, scratching [target]'s screen with \the [tool]!</span>",
 	"<span class='warning'>Your hand slips, scratching [target]'s screen with \the [tool]!</span>")
-	target.apply_damage(10, BRUTE, BP)
+	BP.take_damage(10, 0, used_weapon = tool)
 
 /datum/surgery_step/ipc_face/fix_screen
 	allowed_tools = list(
@@ -285,11 +285,11 @@
 	user.visible_message("<span class='warning'>[user]'s hand slips, smearing [tool] on [target]'s screen, denting it up!</span>",
 	"<span class='warning'>Your hand slips, smearing [tool] on [target]'s screen, denting it up!</span>")
 	if(istype(tool, /obj/item/stack/nanopaste) || istype(tool, /obj/item/weapon/bonegel))
-		target.apply_damage(6, BURN, BP, null)
+		BP.take_damage(0, 6, used_weapon = tool)
 
 	else if(iswrench(tool))
-		target.apply_damage(12, BRUTE, BP, null)
-		BP.createwound(CUT, 5)
+		BP.take_damage(12, 0, used_weapon = tool)
+		BP.take_damage(5, 0, DAM_SHARP|DAM_EDGE, tool)
 
 /datum/surgery_step/ipc_face/close_shut
 	allowed_tools = list(
@@ -324,4 +324,4 @@
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, leaving a small dent on [target]'s screen with \the [tool]!</span>",
 	"<span class='warning'>Your hand slips, leaving a small dent on [target]'s screen with \the [tool]!</span>")
-	target.apply_damage(6, BRUTE, BP)
+	BP.take_damage(6, 0, used_weapon = tool)

--- a/code/modules/surgery/gender_reassignment.dm
+++ b/code/modules/surgery/gender_reassignment.dm
@@ -56,4 +56,4 @@
 	var/obj/item/organ/external/BP = target.bodyparts_by_name[BP_GROIN]
 	user.visible_message("<span class='warning'>[user]'s hand slips, slicing [target]'s genitals with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, slicing [target]'s genitals with \the [tool]!</span>")
-	BP.createwound(CUT, 20, 1)
+	BP.take_damage(20, 0, DAM_SHARP|DAM_EDGE, tool)

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -52,8 +52,7 @@
 	"<span class='notice'>You have made a bloodless incision on [target]'s [BP.name] with \the [tool].</span>",)
 	//Could be cleaner ...
 	BP.open = 1
-	BP.createwound(CUT, 1)
-	BP.createwound(BURN, 1)
+	BP.take_damage(1, 1, DAM_SHARP|DAM_EDGE, tool)
 	BP.clamp()
 	if (target_zone == BP_HEAD)
 		target.brain_op_stage = 1
@@ -62,8 +61,7 @@
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips as the blade sputters, searing a long gash in [target]'s [BP.name] with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips as the blade sputters, searing a long gash in [target]'s [BP.name] with \the [tool]!</span>")
-	BP.createwound(CUT, 7.5)
-	BP.createwound(BURN, 12.5)
+	BP.take_damage(7.5, 12.5, DAM_SHARP|DAM_EDGE, tool)
 
 /datum/surgery_step/generic/incision_manager
 	allowed_tools = list(
@@ -92,7 +90,7 @@
 	"<span class='notice'>You have constructed a prepared incision on and within [target]'s [BP.name] with \the [tool].</span>",)
 	BP.open = 1
 	BP.status |= ORGAN_BLEEDING
-	BP.createwound(CUT, 1)
+	BP.take_damage(1, 0, DAM_SHARP|DAM_EDGE, tool)
 	BP.clamp()
 	BP.open = 2
 	if (target_zone == BP_HEAD)
@@ -102,8 +100,7 @@
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand jolts as the system sparks, ripping a gruesome hole in [target]'s [BP.name] with \the [tool]!</span>", \
 	"<span class='warning'>Your hand jolts as the system sparks, ripping a gruesome hole in [target]'s [BP.name] with \the [tool]!</span>")
-	BP.createwound(CUT, 20)
-	BP.createwound(BURN, 15)
+	BP.take_damage(20, 15, DAM_SHARP|DAM_EDGE, tool)
 
 /datum/surgery_step/generic/cut_open
 	allowed_tools = list(
@@ -133,7 +130,7 @@
 	"<span class='notice'>You have made an incision on [target]'s [BP.name] with \the [tool].</span>",)
 	BP.open = 1
 	BP.status |= ORGAN_BLEEDING
-	BP.createwound(CUT, 1)
+	BP.take_damage(1, 0, DAM_SHARP|DAM_EDGE, tool)
 	if (target_zone == BP_HEAD)
 		target.brain_op_stage = 1
 
@@ -141,7 +138,7 @@
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, slicing open [target]'s [BP.name] in the wrong place with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, slicing open [target]'s [BP.name] in the wrong place with \the [tool]!</span>")
-	BP.createwound(CUT, 10)
+	BP.take_damage(10, 0, DAM_SHARP|DAM_EDGE, tool)
 
 /datum/surgery_step/generic/clamp_bleeders
 	allowed_tools = list(
@@ -177,7 +174,7 @@
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, tearing blood vessals and causing massive bleeding in [target]'s [BP.name] with \the [tool]!</span>",	\
 	"<span class='warning'>Your hand slips, tearing blood vessels and causing massive bleeding in [target]'s [BP.name] with \the [tool]!</span>",)
-	BP.createwound(CUT, 10)
+	BP.take_damage(10, 0, DAM_SHARP|DAM_EDGE, tool)
 
 /datum/surgery_step/generic/retract_skin
 	allowed_tools = list(
@@ -232,7 +229,7 @@
 		msg = "<span class='warning'>[user]'s hand slips, damaging several organs in [target]'s lower abdomen with \the [tool]</span>"
 		self_msg = "<span class='warning'>Your hand slips, damaging several organs in [target]'s lower abdomen with \the [tool]!</span>"
 	user.visible_message(msg, self_msg)
-	target.apply_damage(12, BRUTE, BP, null, DAM_SHARP)
+	BP.take_damage(12, 0, DAM_SHARP|DAM_EDGE, tool)
 
 /datum/surgery_step/generic/cauterize
 	allowed_tools = list(
@@ -268,7 +265,7 @@
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, leaving a small burn on [target]'s [BP.name] with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, leaving a small burn on [target]'s [BP.name] with \the [tool]!</span>")
-	target.apply_damage(3, BURN, BP)
+	BP.take_damage(0, 3, used_weapon = tool)
 
 /datum/surgery_step/generic/cut_limb
 	allowed_tools = list(
@@ -308,8 +305,8 @@
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, sawwing through the bone in [target]'s [BP.name] with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, sawwing through the bone in [target]'s [BP.name] with \the [tool]!</span>")
-	BP.createwound(CUT, 30)
 	BP.fracture()
+	BP.take_damage(30, 0, DAM_SHARP|DAM_EDGE, tool)
 //////////////////////////////////////////////////////////////////
 //						COMMON ROBOTIC STEPS					//
 //////////////////////////////////////////////////////////////////
@@ -360,13 +357,13 @@
 	user.visible_message("<span class='notice'>[user] has loosen bolts on [target]'s [BP.name]'s maintenance hatch with \the [tool].</span>",
 	"<span class='notice'>You have unscrewed [target]'s [BP.name]'s maintenance hatch with \the [tool].</span>",)
 	BP.open = 1
-	BP.createwound(CUT, 1)
+	BP.take_damage(1, 0, DAM_SHARP|DAM_EDGE, tool)
 
 /datum/surgery_step/ipcgeneric/screw_open/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, scratching [target]'s [BP.name]'s maintenance hatch with \the [tool]!</span>",
 	"<span class='warning'>Your hand slips, scratching [target]'s [BP.name]'s maintenance hatch with \the [tool]!</span>")
-	BP.createwound(CUT, 10)
+	BP.take_damage(10, 0, DAM_SHARP|DAM_EDGE, tool)
 
 /datum/surgery_step/ipcgeneric/pry_open
 	allowed_tools = list(
@@ -401,7 +398,7 @@
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, damaging [target]'s [BP.name]'s maintenance hatch with \the [tool]!</span>",
 	"<span class='warning'>Your hand slips, damaging [target]'s [BP.name]'s maintenance hatch with \the [tool]!</span>")
-	target.apply_damage(12, BRUTE, BP, null)
+	BP.take_damage(12, 0, used_weapon = tool)
 
 /datum/surgery_step/ipcgeneric/close_shut
 	allowed_tools = list(
@@ -435,4 +432,4 @@
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, denting [target]'s [BP.name]'s maintenance hatch with \the [tool]!</span>",
 	"<span class='warning'>Your hand slips, denting [target]'s [BP.name]'s maintenance hatch with \the [tool]!</span>")
-	target.apply_damage(5, BRUTE, BP)
+	BP.take_damage(5, 0, used_weapon = tool)

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -65,7 +65,7 @@
 	var/obj/item/organ/external/chest/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, scraping tissue inside [target]'s [BP.name] with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, scraping tissue inside [target]'s [BP.name] with \the [tool]!</span>")
-	BP.createwound(CUT, 20)
+	BP.take_damage(20, 0, DAM_SHARP|DAM_EDGE, tool)
 
 /datum/surgery_step/cavity/close_space
 	priority = 2
@@ -101,7 +101,7 @@
 	var/obj/item/organ/external/chest/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, scraping tissue inside [target]'s [BP.name] with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, scraping tissue inside [target]'s [BP.name] with \the [tool]!</span>")
-	BP.createwound(CUT, 20)
+	BP.take_damage(0, 20, used_weapon = tool)
 
 /datum/surgery_step/cavity/place_item
 	priority = 0
@@ -148,7 +148,7 @@
 	var/obj/item/organ/external/chest/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, scraping tissue inside [target]'s [BP.name] with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, scraping tissue inside [target]'s [BP.name] with \the [tool]!</span>")
-	BP.createwound(CUT, 20)
+	BP.take_damage(20, 0, DAM_SHARP|DAM_EDGE, tool)
 
 //////////////////////////////////////////////////////////////////
 //					IMPLANT/ITEM REMOVAL SURGERY						//
@@ -244,7 +244,7 @@
 	var/obj/item/organ/external/chest/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, scraping tissue inside [target]'s [BP.name] with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, scraping tissue inside [target]'s [BP.name] with \the [tool]!</span>")
-	BP.createwound(CUT, 20)
+	BP.take_damage(20, 0, DAM_SHARP|DAM_EDGE, tool)
 	if (BP.implants.len)
 		var/fail_prob = 10
 		fail_prob += 100 - tool_quality(tool)

--- a/code/modules/surgery/limbs.dm
+++ b/code/modules/surgery/limbs.dm
@@ -46,7 +46,7 @@
 	if (BP)
 		user.visible_message("<span class='warning'>[user]'s hand slips, cutting [target]'s [BP.name] open!</span>", \
 		"<span class='warning'>Your hand slips, cutting [target]'s [BP.name] open!</span>")
-		BP.createwound(CUT, 10)
+		target.apply_damage(10, BRUTE, BP, damage_flags = DAM_SHARP|DAM_EDGE)
 
 
 /datum/surgery_step/limb/mend
@@ -78,7 +78,7 @@
 	if (BP)
 		user.visible_message("<span class='warning'>[user]'s hand slips, tearing flesh on [target]'s [BP.name]!</span>", \
 		"<span class='warning'>Your hand slips, tearing flesh on [target]'s [BP.name]!</span>")
-		target.apply_damage(10, BRUTE, BP, null, DAM_SHARP)
+		target.apply_damage(10, BRUTE, BP, damage_flags = DAM_SHARP|DAM_EDGE)
 
 
 /datum/surgery_step/limb/prepare
@@ -192,7 +192,7 @@
 	var/obj/item/organ/external/BP = target.get_bodypart(BP_CHEST)
 	user.visible_message("<span class='warning'>[user]'s hand slips, damaging connectors on [target]'s [BP.name]!</span>",
 	"<span class='warning'>Your hand slips, damaging connectors on [target]'s [BP.name]!</span>")
-	target.apply_damage(10, BRUTE, BP, null, DAM_SHARP)
+	target.apply_damage(10, BRUTE, BP, damage_flags = DAM_SHARP)
 
 //////////////////////////////////////////////////////////////////
 //						ROBO LIMB SURGERY						//
@@ -242,7 +242,7 @@
 	if (BP)
 		user.visible_message("<span class='warning'>[user]'s hand slips, cutting [target]'s [BP.name] open!</span>",
 		"<span class='warning'>Your hand slips, cutting [target]'s [BP.name] open!</span>")
-		BP.createwound(CUT, 10)
+		target.apply_damage(10, BRUTE, BP, damage_flags = DAM_SHARP|DAM_EDGE)
 
 /datum/surgery_step/ipc_limb/ipc_prepare
 	allowed_tools = list(

--- a/code/modules/surgery/lipoplasty.dm
+++ b/code/modules/surgery/lipoplasty.dm
@@ -57,7 +57,7 @@
 	user.visible_message("<span class='red'>[user]'s hand slips, cutting [target]'s chest with \the [tool]!</span>",
 		"<span class='red'>Your hand slips, cutting [target]'s chest with \the [tool]!</span>")
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
-	BP.createwound(CUT, 30)
+	BP.take_damage(30, 0, DAM_SHARP|DAM_EDGE, tool)
 
 /datum/surgery_step/lipoplasty/remove_fat
 	allowed_tools = list(
@@ -109,4 +109,4 @@
 	user.visible_message("<span class='warning'>[user]'s hand slips, cutting [target]'s belly with \the [tool]!</span>" , \
 	"<span class='warning'>Your hand slips, cutting [target]'s belly with \the [tool]!</span>" )
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
-	BP.createwound(CUT, 30)
+	BP.take_damage(30, 0, DAM_SHARP|DAM_EDGE, tool)

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -44,7 +44,7 @@
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, smearing [tool] in the incision in [target]'s [BP.name]!</span>" , \
 	"<span class='warning'>Your hand slips, smearing [tool] in the incision in [target]'s [BP.name]!</span>")
-	BP.take_damage(5, 0)
+	BP.take_damage(5, 0, used_weapon = tool)
 
 //////////////////////////////////////////////////////////////////
 //					GROIN ORGAN PATCHING						//
@@ -150,7 +150,7 @@
 		else
 			dam_amt = 5
 			target.adjustToxLoss(10)
-			BP.createwound(CUT, 5)
+			BP.take_damage(5, 0, DAM_SHARP|DAM_EDGE, tool)
 
 	for(var/obj/item/organ/internal/IO in BP.bodypart_organs)
 		if(IO && IO.damage > 0)
@@ -207,11 +207,11 @@
 		"<span class='warning'>Your hand slips, smearing [tool] in the incision in [target]'s [IO], gumming it up!</span>")
 		var/dam_amt = 2
 		if(istype(tool, /obj/item/stack/nanopaste) || istype(tool, /obj/item/weapon/bonegel))
-			target.apply_damage(6, BURN, BP, null)
+			BP.take_damage(0, 6, used_weapon = tool)
 
 		else if(iswrench(tool))
-			target.apply_damage(12, BRUTE, BP, null)
-			BP.createwound(CUT, 5)
+			BP.take_damage(12, 0, used_weapon = tool)
+			BP.take_damage(5, 0, DAM_SHARP|DAM_EDGE, tool)
 
 		if(IO.damage > 0 && IO.robotic == 2)
 			IO.take_damage(dam_amt,0)

--- a/code/modules/surgery/plastic_surgery.dm
+++ b/code/modules/surgery/plastic_surgery.dm
@@ -41,7 +41,7 @@
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, tearing skin on [target]'s face with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, tearing skin on [target]'s face with \the [tool]!</span>")
-	target.apply_damage(10, BRUTE, BP, null, DAM_SHARP | DAM_EDGE)
+	BP.take_damage(10, 0, DAM_SHARP|DAM_EDGE, tool)
 
 /datum/surgery_step/plastic_surgery/adjust_vocal
 	allowed_tools = list(
@@ -122,9 +122,10 @@
 			i++
 
 /datum/surgery_step/plastic_surgery/reshape_face/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, tearing skin on [target]'s face with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, tearing skin on [target]'s face with \the [tool]!</span>")
-	target.apply_damage(20, BRUTE, BP_HEAD, 1, DAM_SHARP)
+	BP.take_damage(20, 0, DAM_SHARP|DAM_EDGE, tool)
 
 /datum/surgery_step/plastic_surgery/cauterize
 	allowed_tools = list(
@@ -161,4 +162,5 @@
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, leaving a small burn on [target]'s face with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, leaving a small burn on [target]'s face with \the [tool]!</span>")
-	target.apply_damage(4, BURN, BP)
+	BP.take_damage(0, 4, used_weapon = tool)
+	

--- a/code/modules/surgery/ribcage.dm
+++ b/code/modules/surgery/ribcage.dm
@@ -43,8 +43,8 @@
 	user.visible_message("<span class='warning'>[user]'s hand slips, cracking [target]'s ribcage with \the [tool]!</span>" , \
 	"<span class='warning'>Your hand slips, cracking [target]'s ribcage with \the [tool]!</span>" )
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
-	BP.createwound(CUT, 20)
 	BP.fracture()
+	BP.take_damage(20, 0, DAM_SHARP|DAM_EDGE, tool)
 
 
 /datum/surgery_step/ribcage/retract_ribcage
@@ -87,8 +87,8 @@
 	var/self_msg = "<span class='warning'>Your hand slips, breaking [target]'s ribcage!</span>"
 	user.visible_message(msg, self_msg)
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
-	BP.createwound(BRUISE, 20)
 	BP.fracture()
+	BP.take_damage(20, 0, used_weapon = tool)
 
 /datum/surgery_step/ribcage/close_ribcage
 	allowed_tools = list(
@@ -125,8 +125,8 @@
 	var/self_msg = "<span class='warning'>Your hand slips, bending [target]'s ribs the wrong way!</span>"
 	user.visible_message(msg, self_msg)
 	var/obj/item/organ/external/chest/BP = target.get_bodypart(BP_CHEST)
-	BP.createwound(BRUISE, 20)
 	BP.fracture()
+	BP.take_damage(20, 0, used_weapon = tool)
 	if (prob(40))
 		user.visible_message("<span class='warning'>A rib pierces the lung!</span>")
 		target.rupture_lung()
@@ -272,7 +272,7 @@
 		else
 			dam_amt = 5
 			target.adjustToxLoss(10)
-			BP.createwound(CUT, 5)
+			BP.take_damage(5, 0, DAM_SHARP|DAM_EDGE, tool)
 
 	for(var/obj/item/organ/internal/IO in BP.bodypart_organs)
 		if(IO && IO.damage > 0)
@@ -328,11 +328,11 @@
 		"<span class='warning'>Your hand slips, smearing [tool] in the incision in [target]'s [IO], gumming it up!</span>")
 		var/dam_amt = 2
 		if(istype(tool, /obj/item/stack/nanopaste) || istype(tool, /obj/item/weapon/bonegel))
-			target.apply_damage(6, BURN, BP, null)
+			BP.take_damage(0, 6, used_weapon = tool)
 
 		else if(iswrench(tool))
-			target.apply_damage(12, BRUTE, BP, null)
-			BP.createwound(CUT, 5)
+			BP.take_damage(12, 0, used_weapon = tool)
+			BP.take_damage(5, 0, DAM_SHARP|DAM_EDGE, tool)
 
 		if(IO.damage > 0 && IO.robotic == 2)
 			IO.take_damage(dam_amt,0)
@@ -365,9 +365,10 @@
 	target.chest_brain_op_stage = 1
 
 /datum/surgery_step/ribcage/cut_diona_brain/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, cutting a vein in [target]'s brain with \the [tool]!</span>",
 	"<span class='warning'>Your hand slips, cutting a vein in [target]'s brain with \the [tool]!</span>")
-	target.apply_damage(50, BRUTE, BP_CHEST, 1, DAM_SHARP)
+	BP.take_damage(50, 0, DAM_SHARP|DAM_EDGE, tool)
 
 /datum/surgery_step/ribcage/cut_diona_spine
 	allowed_tools = list(
@@ -404,9 +405,10 @@
 	target.death()
 
 /datum/surgery_step/ribcage/cut_diona_spine/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, cutting a vein in [target]'s brain with \the [tool]!</span>",
 	"<span class='warning'>Your hand slips, cutting a vein in [target]'s brain with \the [tool]!</span>")
-	target.apply_damage(30, BRUTE, BP_CHEST, 1, DAM_SHARP)
+	BP.take_damage(30, 0, DAM_SHARP|DAM_EDGE, tool)
 	if (ishuman(user))
 		var/mob/living/carbon/human/H = user
 		H.bloody_body(target)
@@ -438,9 +440,10 @@
 	target.chest_brain_op_stage = 1
 
 /datum/surgery_step/ipc_ribcage/cut_posibrain/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, severely denting [target]'s posi-brain with \the [tool]!</span>",
 	"<span class='warning'>Your hand slips, severely denting [target]'s posi-brain with \the [tool]!</span>")
-	target.apply_damage(50, BRUTE, BP_CHEST, 1, DAM_SHARP)
+	BP.take_damage(50, 0, DAM_SHARP, tool)
 
 /datum/surgery_step/ipc_ribcage/extract_posibrain
 	allowed_tools = list(
@@ -476,9 +479,10 @@
 	target.death()
 
 /datum/surgery_step/ipc_ribcage/extract_posibrain/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, severely denting [target]'s posi-brain with \the [tool]!</span>",
 	"<span class='warning'>Your hand slips, severely denting [target]'s posi-brain with \the [tool]!</span>")
-	target.apply_damage(30, BRUTE, BP_CHEST, 1, DAM_SHARP)
+	BP.take_damage(30, 0, DAM_SHARP, tool)
 
 /datum/surgery_step/ipc_ribcage/import_posibrain
 	allowed_tools = list(
@@ -550,8 +554,8 @@
 	user.visible_message("<span class='warning'>[user]'s hand slips, scratching [target]'s security panel with \the [tool]!</span>" ,
 	"<span class='warning'>Your hand slips, scratching [target]'s security panel with \the [tool]!</span>" )
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
-	BP.createwound(CUT, 20)
 	BP.fracture()
+	BP.take_damage(20, 0, DAM_SHARP|DAM_EDGE, tool)
 
 /datum/surgery_step/ipc_ribcage/pry_sec
 	allowed_tools = list(
@@ -586,8 +590,8 @@
 	user.visible_message("<span class='warning'>[user]'s hand slips, breaking [target]'s security panel!</span>",
 	"<span class='warning'>Your hand slips, breaking [target]'s security panel!</span>")
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
-	BP.createwound(BRUISE, 20)
 	BP.fracture()
+	BP.take_damage(20, 0, used_weapon = tool)
 
 /datum/surgery_step/ipc_ribcage/shut_sec
 	allowed_tools = list(
@@ -620,8 +624,8 @@
 	var/self_msg = "<span class='warning'>Your hand slips, bending [target]'s security panel the wrong way!</span>"
 	user.visible_message(msg, self_msg)
 	var/obj/item/organ/external/chest/BP = target.get_bodypart(BP_CHEST)
-	BP.createwound(BRUISE, 20)
 	BP.fracture()
+	BP.take_damage(20, 0, used_weapon = tool)
 	if(prob(40))
 		user.visible_message("<span class='warning'>A loud bang can be heard.</span>")
 		target.rupture_lung()
@@ -654,8 +658,8 @@
 	user.visible_message("<span class='warning'>[user]'s hand slips, scratching [target]'s security panel with \the [tool]!</span>",
 	"<span class='warning'>Your hand slips, scratching [target]'s security panel with \the [tool]!</span>" )
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
-	BP.createwound(CUT, 20)
 	BP.fracture()
+	BP.take_damage(20, 0, DAM_SHARP|DAM_EDGE, tool)
 
 /datum/surgery_step/ipc_ribcage/take_accumulator
 	allowed_tools = list(
@@ -696,7 +700,7 @@
 	var/obj/item/organ/internal/liver/ipc/A = target.organs_by_name[O_LIVER]
 	A.damage += 10
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
-	BP.createwound(CUT, 20)
+	BP.take_damage(20, 0, DAM_SHARP|DAM_EDGE, tool)
 
 /datum/surgery_step/ipc_ribcage/put_accumulator
 	allowed_tools = list(


### PR DESCRIPTION
<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений

<!--
Опишите изменения данного ПР-а.
Если есть связные ишью (issues), или другие ПРы - укажите их тут, для автоматического закрытия ишью следует использовать ключевые слова https://help.github.com/en/articles/closing-issues-using-keywords
Если есть связное форумное обсуждение на тему изменений - укажите ссылку на эту тему.
-->

Заменены некоторые использования /obj/item/organ/external/proc/createwound() и /mob/living/carbon/human/apply_damage() на /obj/item/organ/external/proc/take_damage() (практически все случаи относятся к хирургии), добавлена информация used_weapon во все эти случаи, добавлен перелом на голову при неудачной попытке вскрыть череп (хирургически), в хирургии изменено несколько damage_flags на более логичные.
Добавил информацию об оружии в аутопсию в том числе для раны от успешного хирургического разреза, что дает забавный эффект - при аутопсии можно будет узнать когда и на какой части тела мобу делали операции. Думал убрать, но выглядит как реалистичная и даже полезная фича.
## Почему и что этот ПР улучшит
Сейчас createwound() используется не всегда корректно. При вызове его напрямую теряются полезные проверки из take_damage(), например, дамаг внутренним органам или возможность потерять конечность. Последнее, пожалуй, можно даже назвать багом, а отсутствие вероятности повредить внутренние органы при той же операции на них выглядит как минимум нелепой недоработкой.

Вызов apply_damage(), напротив, не приводит к таким багам или проблемам, но в случае хирургической операции обычно выглядит лишним, поэтому я в таких случаях тоже использовал take_damage() для унификации, чтобы все проки fail_step() модуля выглядели в едином стиле.
<!--
Опишите причину для изменений.
Этот пункт особенно важен для описания изменений баланса, новых механик.
-->

## Чеинжлог

<!-- Опциональный пункт!
Если это что-то, о чём следует сообщить игрокам - опишите по форме (https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies#Changelog) свои изменения для игрового чеинжлога, они будут отображены на специальной страничке http://changelog.taucetistation.org

Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment
  
Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
:cl: Skvazarb
- tweak: В результатах вскрытия могут быть данные о хирургических разрезах и неудачных действиях при хирургических операциях.
