### PR TITLE
Добавлены дополнительные источники инфекции при операции

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -2030,6 +2030,21 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 	else
 		return 1
 
+/mob/living/carbon/human/proc/need_breathe()
+	if(NO_BREATH in src.mutations)
+		return FALSE
+	if(reagents.has_reagent("lexorin"))
+		return FALSE
+	if(istype(loc, /obj/machinery/atmospherics/components/unary/cryo_cell))
+		return FALSE
+	if(species && (species.flags[NO_BREATHE] || species.flags[IS_SYNTHETIC]))
+		return FALSE
+	if(dna && dna.mutantrace == "adamantine")
+		return FALSE
+	if(ismob(loc))
+		return FALSE
+	return TRUE
+
 /mob/living/carbon/human/CanObtainCentcommMessage()
 	return istype(l_ear, /obj/item/device/radio/headset) || istype(r_ear, /obj/item/device/radio/headset)
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -351,17 +351,7 @@
 						BP.add_autopsy_data("Radiation Poisoning", damage)
 
 /mob/living/carbon/human/proc/breathe()
-	if(NO_BREATH in src.mutations)
-		return //#Z2 We need no breath with this mutation
-	if(reagents.has_reagent("lexorin"))
-		return
-	if(istype(loc, /obj/machinery/atmospherics/components/unary/cryo_cell))
-		return
-	if(species && (species.flags[NO_BREATHE] || species.flags[IS_SYNTHETIC]))
-		return
-	if(dna && dna.mutantrace == "adamantine")
-		return
-	if(ismob(loc))
+	if(!need_breathe()) 
 		return
 
 	var/datum/gas_mixture/environment = loc.return_air()

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -71,11 +71,8 @@
 	if(tool.blood_DNA && tool.blood_DNA.len) //germs from blood-stained tools
 		germ_level += GERM_LEVEL_AMBIENT * 0.25
 
-	for(var/mob/living/carbon/human/H in view(2, BP.owner.loc)) //germs from people
-		if(isturf(H.loc))
-			if(AStar(BP.owner.loc, BP.owner.loc, /turf/proc/Distance, 2))
-				if(H.need_breathe() && !H.wear_mask) //wearing a mask helps preventing people from breathing cooties into open incisions
-					germ_level += H.germ_level * 0.25
+	if(ishuman(user) && user.need_breathe() && !user.wear_mask) //wearing a mask helps preventing people from breathing germs into open incisions
+		germ_level += user.germ_level * 0.25
 
 	BP.germ_level = max(germ_level, BP.germ_level)
 	if(BP.germ_level)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -41,7 +41,7 @@
 /datum/surgery_step/proc/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	if(can_infect && BP)
-		spread_germs_to_organ(BP, user)
+		spread_germs_to_organ(BP, user, tool)
 	if(ishuman(user) && prob(60))
 		var/mob/living/carbon/human/H = user
 		if(blood_level)
@@ -58,15 +58,26 @@
 /datum/surgery_step/proc/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return null
 
-/proc/spread_germs_to_organ(obj/item/organ/external/BP, mob/living/carbon/human/user)
+/proc/spread_germs_to_organ(obj/item/organ/external/BP, mob/living/carbon/human/user, obj/item/tool)
 	if(!istype(user) || !istype(BP))
 		return
 
-	var/germ_level = user.germ_level
+	var/germ_level = 0
 	if(user.gloves)
-		germ_level = user.gloves.germ_level
+		germ_level += user.gloves.germ_level
+	else 
+		germ_level += user.germ_level
 
-	BP.germ_level = max(germ_level, BP.germ_level) //as funny as scrubbing microbes out with clean gloves is - no.
+	if(tool.blood_DNA && tool.blood_DNA.len) //germs from blood-stained tools
+		germ_level += GERM_LEVEL_AMBIENT * 0.25
+
+	for(var/mob/living/carbon/human/H in view(2, BP.owner.loc)) //germs from people
+		if(isturf(H.loc))
+			if(AStar(BP.owner.loc, BP.owner.loc, /turf/proc/Distance, 2))
+				if(H.need_breathe() && !H.wear_mask) //wearing a mask helps preventing people from breathing cooties into open incisions
+					germ_level += H.germ_level * 0.25
+
+	BP.germ_level = max(germ_level, BP.germ_level)
 	if(BP.germ_level)
 		BP.owner.bad_bodyparts |= BP
 


### PR DESCRIPTION
<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений
Добавлена передача инфекции при операции без маски на враче в количестве germ_level врача* 0.25 и плюс к этому GERM_LEVEL_AMBIENT * 0.25, если инструмент испачкан в крови. Проверки на необходимость дышать для хуманов собраны в перемещены в отдельный прок.
<!--
Опишите изменения данного ПР-а.
Если есть связные ишью (issues), или другие ПРы - укажите их тут, для автоматического закрытия ишью следует использовать ключевые слова https://help.github.com/en/articles/closing-issues-using-keywords
Если есть связное форумное обсуждение на тему изменений - укажите ссылку на эту тему.
-->

## Почему и что этот ПР улучшит
Передача инфекции во время операции от врача без маски на лице является реалистичной моделью и полностью соответствует нашим текущим ролевым требованиям к врачам, поскольку от них и так требуется носить стерильные маски во время операций. В состоянии до изменений врач без перчаток, без маски и с инструментом в крови на практике передал бы органу GERM_LEVEL_AMBIENT, после изменений в этой же ситуации значение окажется GERM_LEVEL_AMBIENT * 1.5.

Изменение поощряет придерживаться ролевых соображений по поддержанию стерильности с помощью небольшого наказания за ее нарушение. Поскольку необходимых мер и так придерживается абсолютное большинство игроков, это не должно серьезно повлиять на ситуацию. Проблемы могут появиться только у горстки странных любителей игнорировать ролевую составляющую в угоду механу, но так им и надо.
<!--
Опишите причину для изменений.
Этот пункт особенно важен для описания изменений баланса, новых механик.
-->
## Авторство
Концепция самоочевидная, но идея реализации с небольшими изменениями взята с [Paradise](https://github.com/ParadiseSS13/Paradise/blob/master/code/modules/surgery/surgery.dm#L184)
<!-- Опциональный пункт!
Если авторство не полностью ваше, вы делаете порт с другого билда - обязательно укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
-->

## Чеинжлог
:cl: Skvazarb
- tweak: Добавлена передача инфекции при проведении хирургических операций с инструментами, запачканными кровью, или хирургом без маски на лице.

<!-- Опциональный пункт!
Если это что-то, о чём следует сообщить игрокам - опишите по форме (https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies#Changelog) свои изменения для игрового чеинжлога, они будут отображены на специальной страничке http://changelog.taucetistation.org

Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment
  
Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
