### PR TITLE
Сообщения о голодании при осмотре IPC.

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -244,17 +244,15 @@
 					to_chat(user, "<span class='deadsay'>[t_He] has a pulse!</span>")
 
 	msg += "<span class='warning'>"
-
-	if(nutrition < 100)
-		if(!species.flags[IS_SYNTHETIC])
+	
+	if(!species.flags[IS_SYNTHETIC])
+		if(nutrition < 100)
 			msg += "[t_He] [t_is] severely malnourished.\n"
-		else
-			msg += "His indicator blinks red.\n"
-	else if(nutrition >= 500)
-		if(!species.flags[IS_SYNTHETIC])
+		else if(nutrition >= 500)
 			msg += "[t_He] [t_is] quite chubby.\n"
-		else
-			msg += "His indicator blinks blue.\n"
+	else
+		if(nutrition < (nutrition*0.10))
+			msg += "His indicator of charge blinks red.\n"
 
 	msg += "</span>"
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -253,8 +253,10 @@
 	else
 		var/obj/item/organ/internal/liver/IO = organs_by_name[O_LIVER]
 		var/obj/item/weapon/stock_parts/cell/C = locate(/obj/item/weapon/stock_parts/cell) in IO
-		if(nutrition < (C.maxcharge*0.1))
+		if(nutrition < (C.maxcharge*0.1) && C)
 			msg += "His indicator of charge blinks red.\n"
+		else
+			msg += "[t_He] has no battery!\n"
 
 	msg += "</span>"
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -251,7 +251,9 @@
 		else if(nutrition >= 500)
 			msg += "[t_He] [t_is] quite chubby.\n"
 	else
-		if(nutrition < (nutrition*0.10))
+		var/obj/item/organ/internal/liver/IO = organs_by_name[O_LIVER]
+		var/obj/item/weapon/stock_parts/cell/C = locate(/obj/item/weapon/stock_parts/cell) in IO
+		if(nutrition < (C.maxcharge*0.1))
 			msg += "His indicator of charge blinks red.\n"
 
 	msg += "</span>"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -246,9 +246,15 @@
 	msg += "<span class='warning'>"
 
 	if(nutrition < 100)
-		msg += "[t_He] [t_is] severely malnourished.\n"
+		if(!species.flags[IS_SYNTHETIC])
+			msg += "[t_He] [t_is] severely malnourished.\n"
+		else
+			msg += "His indicator blinks red.\n"
 	else if(nutrition >= 500)
-		msg += "[t_He] [t_is] quite chubby.\n"
+		if(!species.flags[IS_SYNTHETIC])
+			msg += "[t_He] [t_is] quite chubby.\n"
+		else
+			msg += "His indicator blinks blue.\n"
 
 	msg += "</span>"
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -255,7 +255,7 @@
 		var/obj/item/weapon/stock_parts/cell/C = locate(/obj/item/weapon/stock_parts/cell) in IO
 		if(nutrition < (C.maxcharge*0.1) && C)
 			msg += "His indicator of charge blinks red.\n"
-		else
+		if(!C)
 			msg += "[t_He] has no battery!\n"
 
 	msg += "</span>"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -253,9 +253,10 @@
 	else
 		var/obj/item/organ/internal/liver/IO = organs_by_name[O_LIVER]
 		var/obj/item/weapon/stock_parts/cell/C = locate(/obj/item/weapon/stock_parts/cell) in IO
-		if(nutrition < (C.maxcharge*0.1) && C)
-			msg += "His indicator of charge blinks red.\n"
-		if(!C)
+		if(C)
+			if(nutrition < (C.maxcharge*0.1))
+				msg += "His indicator of charge blinks red.\n"
+		else
 			msg += "[t_He] has no battery!\n"
 
 	msg += "</span>"


### PR DESCRIPTION
<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений
Если осмотреть ipc, который зарядился и имеет батарейку больше, чем на 500, при учете снятых ограничений, он начинает выглядеть chubby. Мелочь, но все же.
И дополнительное сообщение, если батарейка извлечена.
<!--
Опишите изменения данного ПР-а.
Если есть связные ишью (issues), или другие ПРы - укажите их тут, для автоматического закрытия ишью следует использовать ключевые слова https://help.github.com/en/articles/closing-issues-using-keywords
Если есть связное форумное обсуждение на тему изменений - укажите ссылку на эту тему.
-->

## Почему и что этот ПР улучшит
Жизнь спу.
<!--
Опишите причину для изменений.
Этот пункт особенно важен для описания изменений баланса, новых механик.
-->

<!-- Опциональный пункт!
Если авторство не полностью ваше, вы делаете порт с другого билда - обязательно укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
-->

<!-- Опциональный пункт!
Если это что-то, о чём следует сообщить игрокам - опишите по форме (https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies#Changelog) свои изменения для игрового чеинжлога, они будут отображены на специальной страничке http://changelog.taucetistation.org

Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment
  
Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
