### PR TITLE
Bow rebalance

### DIFF
--- a/code/modules/projectiles/guns/projectile/bow.dm
+++ b/code/modules/projectiles/guns/projectile/bow.dm
@@ -49,8 +49,8 @@
 	w_class = ITEM_SIZE_NORMAL
 
 	var/tension = 0                       // Current draw on the bow.
-	var/max_tension = 5                   // Highest possible tension.
-	var/release_speed = 5                 // Speed per unit of tension.
+	var/max_tension = 3                   // Highest possible tension.
+	var/release_speed = 4                 // Speed per unit of tension.
 	var/mob/living/current_user = null    // Used to see if the person drawing the bow started drawing it.
 	var/obj/item/weapon/arrow = null      // Nocked arrow.
 	var/obj/item/weapon/stock_parts/cell/cell = null  // Used for firing special projectiles like rods.
@@ -287,3 +287,7 @@
 
 	else
 		..()
+
+/obj/item/weapon/crossbow/vox
+	max_tension = 5
+	release_speed = 5

--- a/maps/centcom/centcom.dmm
+++ b/maps/centcom/centcom.dmm
@@ -14728,7 +14728,7 @@
 /area/shuttle/vox/arkship)
 "aZr" = (
 /obj/structure/rack,
-/obj/item/weapon/crossbow,
+/obj/item/weapon/crossbow/vox,
 /obj/item/weapon/arrow,
 /obj/item/weapon/arrow,
 /obj/item/weapon/arrow,


### PR DESCRIPTION
<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений

Занерфлен самодельный арбалет. Максимальная сила натяга уменьшена с пяти до трех. Скорость полета снаряда за каждый уровень натяга уменьшена с пяти до четырех. В итоге суммарная скорость уменьшена с двадцати пяти до двенадцати. Как показывает тест, он уже не способен просто так прибить человека к стене.

<!--
Опишите изменения данного ПР-а.
Если есть связные ишью (issues), или другие ПРы - укажите их тут, для автоматического закрытия ишью следует использовать ключевые слова https://help.github.com/en/articles/closing-issues-using-keywords
Если есть связное форумное обсуждение на тему изменений - укажите ссылку на эту тему.
-->

## Почему и что этот ПР улучшит
Собранный на коленке арбалет перестанет быть одним из самых лучших оружий в билде, при этом воксовский арбалет не пострадает.
<!--
Опишите причину для изменений.
Этот пункт особенно важен для описания изменений баланса, новых механик.
-->

## Чеинжлог

:cl:
 - balance: самодельный арбалет стал в два раза слабее воксовского.
