### PR TITLE
Баг: овердоз дермалина не удаляет хаска

### DIFF
--- a/code/modules/reagents/reagent_types/Chemistry-Medicine.dm
+++ b/code/modules/reagents/reagent_types/Chemistry-Medicine.dm
@@ -172,7 +172,7 @@
 /datum/reagent/dermaline/on_general_digest(mob/living/M)
 	..()
 	M.heal_bodypart_damage(0,3 * REM)
-	if(volume >= overdose && HUSK in M.mutations && ishuman(M))
+	if(volume >= overdose && (HUSK in M.mutations) && ishuman(M))
 		var/mob/living/carbon/human/H = M
 		H.mutations.Remove(HUSK)
 		H.update_body()


### PR DESCRIPTION
<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений
Добавлены нужные скобочки.
<!--
Опишите изменения данного ПР-а.
Если есть связные ишью (issues), или другие ПРы - укажите их тут, для автоматического закрытия ишью следует использовать ключевые слова https://help.github.com/en/articles/closing-issues-using-keywords
Если есть связное форумное обсуждение на тему изменений - укажите ссылку на эту тему.
-->

## Почему и что этот ПР улучшит
Пофиксит баг
<!--
Опишите причину для изменений.
Этот пункт особенно важен для описания изменений баланса, новых механик.
-->

## Авторство

<!-- Опциональный пункт!
Если авторство не полностью ваше, вы делаете порт с другого билда - обязательно укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
-->

## Чеинжлог
:cl: Skvazarb
 - bugfix: Передозировка дермалина не удаляла внешность "хаска".

<!-- Опциональный пункт!
Если это что-то, о чём следует сообщить игрокам - опишите по форме (https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies#Changelog) свои изменения для игрового чеинжлога, они будут отображены на специальной страничке http://changelog.taucetistation.org

Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment
  
Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
