### PR TITLE
Добавление конвейров и шахтерского оборудования в быстрый процессинг

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -124,20 +124,31 @@ Class Procs:
 	var/datum/radio_frequency/radio_connection
 	var/radio_filter_out
 	var/radio_filter_in
+	var/speed_process = FALSE  // Process as fast as possible?
 
 /obj/machinery/atom_init()
 	. = ..()
 	machines += src
-	START_PROCESSING(SSmachine, src)
+
+	if (speed_process)
+		START_PROCESSING(SSfastprocess, src)
+	else
+		START_PROCESSING(SSmachine, src)
+
 	power_change()
 	update_power_use()
 
 /obj/machinery/Destroy()
 	if(frequency)
 		set_frequency(null)
+
 	set_power_use(NO_POWER_USE)
 	machines -= src
-	STOP_PROCESSING(SSmachine, src)
+
+	if (speed_process)
+		STOP_PROCESSING(SSfastprocess, src)
+	else
+		STOP_PROCESSING(SSmachine, src)
 
 	dropContents()
 	return ..()

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -161,6 +161,7 @@
 	density = 1
 	anchored = 1
 	light_range = 3
+	speed_process = TRUE
 	var/obj/machinery/mineral/input = null
 	var/obj/machinery/mineral/output = null
 	var/obj/machinery/mineral/processing_unit_console/console = null
@@ -276,5 +277,3 @@
 				new /obj/item/weapon/ore/slag(output.loc)
 		else
 			continue
-
-	console.updateUsrDialog()

--- a/code/modules/mining/machine_unloading.dm
+++ b/code/modules/mining/machine_unloading.dm
@@ -7,6 +7,7 @@
 	icon_state = "unloader"
 	density = 1
 	anchored = 1.0
+	speed_process = TRUE
 	var/obj/machinery/mineral/input = null
 	var/obj/machinery/mineral/output = null
 

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -9,6 +9,7 @@
 	anchored = 1
 	interact_offline = TRUE
 	layer = BELOW_CONTAINERS_LAYER
+	speed_process = TRUE
 	var/operating = 0	// 1 if running forward, -1 if backwards, 0 if off
 	var/operable = 1	// true if can operate (no broken segments in this belt run)
 	var/forwards		// this is the default (forward) direction, set by the map dir


### PR DESCRIPTION
## Описание изменений
Перенес шахтерское оборудование и конвейры в быстрый процессинг.
Убрал обновление юзеринтерфейса из "процессинг-консоли" во время `process()` метода, т.к. это немного не так должно работать и для таких штук нужно использовать наноюи (или тгуи, хех)

Это все уже вечность назад появилось на ТГ, теперь и у нас.

## Почему и что этот ПР улучшит
Полагаю, пользовательский опыт?
![oh_shieeeet](https://user-images.githubusercontent.com/12721311/69494916-0f401380-0ed2-11ea-9d21-8752357f52dd.gif)

## Чеинжлог
:cl:
 - rscadd: Конвейры тягают вещи быстрее
 - rscadd: Шахтерское оборудование стало обрабатывать руду быстрее.
