### PR TITLE
Нерф пневмопушки

### DIFF
--- a/code/modules/projectiles/guns/projectile/pneumatic.dm
+++ b/code/modules/projectiles/guns/projectile/pneumatic.dm
@@ -14,17 +14,12 @@
 	storage_slots = 7
 
 	var/obj/item/weapon/tank/tank = null                // Tank of gas for use in firing the cannon.
-	var/obj/item/weapon/storage/tank_container          // Something to hold the tank item so we don't accidentally fire it.
+	var/obj/item/weapon/storage/tank_container = new()  // Something to hold the tank item so we don't accidentally fire it.
 	var/pressure_setting = 10                           // Percentage of the gas in the tank used to fire the projectile.
 	var/possible_pressure_amounts = list(5,10,20,25,50) // Possible pressure settings.
 	var/minimum_tank_pressure = 10                      // Minimum pressure to fire the gun.
 	var/cooldown = 0                                    // Whether or not we're cooling down.
 	var/cooldown_time = 50                              // Time between shots.
-
-/obj/item/weapon/storage/pneumatic/atom_init()
-	. = ..()
-	tank_container = new(src)
-	tank_container.tag = "gas_tank_holder"
 
 /obj/item/weapon/storage/pneumatic/verb/set_pressure() //set amount of tank pressure.
 

--- a/code/modules/projectiles/guns/projectile/pneumatic.dm
+++ b/code/modules/projectiles/guns/projectile/pneumatic.dm
@@ -1,3 +1,6 @@
+#define PNEUMATIC_SPEED_CAP 40
+#define PNEUMATIC_SPEED_DIVISOR 800
+
 /obj/item/weapon/storage/pneumatic
 	name = "pneumatic cannon"
 	desc = "A large gas-powered cannon."
@@ -17,9 +20,7 @@
 	var/minimum_tank_pressure = 10                      // Minimum pressure to fire the gun.
 	var/cooldown = 0                                    // Whether or not we're cooling down.
 	var/cooldown_time = 50                              // Time between shots.
-	var/force_divisor = 400                             // Force equates to speed. Speed/5 equates to a damage multiplier for whoever you hit.
-	                                                    // For reference, a fully pressurized oxy tank at 50% gas release firing a health
-	                                                    // analyzer with a force_divisor of 10 hit with a damage multiplier of 3000+.
+
 /obj/item/weapon/storage/pneumatic/atom_init()
 	. = ..()
 	tank_container = new(src)
@@ -126,8 +127,7 @@
 		return 0
 
 	var/obj/item/object = contents[1]
-	var/speed = ((fire_pressure*tank.volume)/object.w_class)/force_divisor //projectile speed.
-	if(speed>80) speed = 80 //damage cap.
+	var/speed = min(PNEUMATIC_SPEED_CAP, ((fire_pressure*tank.volume)/object.w_class)/PNEUMATIC_SPEED_DIVISOR) //projectile speed.
 
 	playsound(src, 'sound/weapons/guns/gunshot_pneumaticgun.ogg', VOL_EFFECTS_MASTER, null, null, -2)
 	user.visible_message("<span class='danger'>[user] fires [src] and launches [object] at [target]!</span>","<span class='danger'>You fire [src] and launch [object] at [target]!</span>")
@@ -226,3 +226,6 @@
 		return
 	else
 		..()
+
+#undef PNEUMATIC_SPEED_CAP
+#undef PNEUMATIC_SPEED_DIVISOR

--- a/code/modules/projectiles/guns/projectile/pneumatic.dm
+++ b/code/modules/projectiles/guns/projectile/pneumatic.dm
@@ -14,12 +14,16 @@
 	storage_slots = 7
 
 	var/obj/item/weapon/tank/tank = null                // Tank of gas for use in firing the cannon.
-	var/obj/item/weapon/storage/tank_container = new()  // Something to hold the tank item so we don't accidentally fire it.
+	var/obj/item/weapon/storage/tank_container          // Something to hold the tank item so we don't accidentally fire it.
 	var/pressure_setting = 10                           // Percentage of the gas in the tank used to fire the projectile.
 	var/possible_pressure_amounts = list(5,10,20,25,50) // Possible pressure settings.
 	var/minimum_tank_pressure = 10                      // Minimum pressure to fire the gun.
 	var/cooldown = 0                                    // Whether or not we're cooling down.
 	var/cooldown_time = 50                              // Time between shots.
+
+/obj/item/weapon/storage/pneumatic/atom_init()
+	. = ..()
+	tank_container = new()
 
 /obj/item/weapon/storage/pneumatic/verb/set_pressure() //set amount of tank pressure.
 
@@ -138,6 +142,11 @@
 	spawn(cooldown_time)
 		cooldown = 0
 		to_chat(user, "[src]'s gauge informs you it's ready to be fired again.")
+
+/obj/item/weapon/storage/pneumatic/Destroy()
+	QDEL_NULL(tank)
+	QDEL_NULL(tank_container)
+	return ..()
 
 //Constructable pneumatic cannon.
 


### PR DESCRIPTION
<!--
Более подробно про оформление ПР-ов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->

## Описание изменений
Максимальная скорость снаряда из пнемопушки уменьшена вдвое, множитель скорости увеличен вдвое. Максимальный мультипликатор урона после изменений составит 8. Таким образом, максимальный урон при выстреле из пневмопушки падает вдвое.  Т.е. 120 урона против 240 раньше при использовании снаряда с throwforce=15, например, металл рода. Увеличение множителя скорости оставляет необходимое давление в баллоне на том же уровне, что был необходим для достижения значения капа до нерфа.
UPD: Заодно пофикшен баг с спавном /obj/item/weapon/storage в contents, которым еще и можно было выстрелить
>You fire the pneumatic cannon and launch the storage at the wall!
<!--
Опишите изменения данного ПР-а.
Если есть связные ишью (issues), или другие ПРы - укажите их тут, для автоматического закрытия ишью следует использовать ключевые слова https://help.github.com/en/articles/closing-issues-using-keywords
Если есть связное форумное обсуждение на тему изменений - укажите ссылку на эту тему.
-->

## Почему и что этот ПР улучшит
Цель нерфа - сбалансировать самодельное оружие доступное экипажу. 240 легкодоступного урона выглядит несопоставимыми по сравнению с другим оружием в игре, особенного для самодельного оружия. Тем более с учетом ожидающегося [ребаланса](https://github.com/TauCetiStation/TauCetiClassic/pull/4266) самодельного арбалета
<!--
Опишите причину для изменений.
Этот пункт особенно важен для описания изменений баланса, новых механик.
-->

## Авторство

<!-- Опциональный пункт!
Если авторство не полностью ваше, вы делаете порт с другого билда - обязательно укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
-->

## Чеинжлог
:cl: Skvazarb
 - balance: максимальная скорость снаряда пневмо-пушки уменьшена вдвое, множитель скорости увеличен вдвое.
<!-- Опциональный пункт!
Если это что-то, о чём следует сообщить игрокам - опишите по форме (https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies#Changelog) свои изменения для игрового чеинжлога, они будут отображены на специальной страничке http://changelog.taucetistation.org

Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment
  
Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
