### PR TITLE
Тэги для факса и доски

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -341,6 +341,54 @@
 		new_text += copytext(text, i, i+1)
 	return new_text
 
+/proc/parsebbcode(t, colour = "black")
+	t = replacetext(t, "\[center\]", "<center>")
+	t = replacetext(t, "\[/center\]", "</center>")
+	t = replacetext(t, "\[br\]", "<br>")
+	t = replacetext(t, "\[b\]", "<b>")
+	t = replacetext(t, "\[/b\]", "</b>")
+	t = replacetext(t, "\[i\]", "<i>")
+	t = replacetext(t, "\[/i\]", "</i>")
+	t = replacetext(t, "\[u\]", "<u>")
+	t = replacetext(t, "\[/u\]", "</u>")
+	t = replacetext(t, "\[large\]", "<font size=\"4\">")
+	t = replacetext(t, "\[/large\]", "</font>")
+	t = replacetext(t, "\[*\]", "<li>")
+	t = replacetext(t, "\[small\]", "<font size = \"1\">")
+	t = replacetext(t, "\[/small\]", "</font>")
+	t = replacetext(t, "\[list\]", "<ul>")
+	t = replacetext(t, "\[/list\]", "</ul>")
+	t = replacetext(t, "\[hr\]", "<hr>")
+	t = replacetext(t, "\n", "<br>")
+
+	// tables
+	t = replacetext(t, "\[table\]", "<table border=3px cellpadding=5px bordercolor=\"[colour]\">")
+	t = replacetext(t, "\[/table\]", "</table>")
+	t = replacetext(t, "\[tr\]", "<tr>")
+	t = replacetext(t, "\[/tr\]", "</tr>")
+	t = replacetext(t, "\[td\]", "<td><font color=\"[colour]\">")
+	t = replacetext(t, "\[/td\]", "</font></td>")
+	t = replacetext(t, "\[th\]", "<th><font color=\"[colour]\">")
+	t = replacetext(t, "\[/th\]", "</font></th>")
+
+	// standart head
+	t = replacetext(t, "\[h\]", "<h3 style=\"text-align:center;\">")
+	t = replacetext(t, "\[/h\]", "</h3>")
+
+	// bordered head;
+	t = replacetext(t, "\[bh\]", "<h3 style=\"border-width: 4px; border-style: solid; padding: 10px; text-align:center;\">")
+	t = replacetext(t, "\[/bh\]", "</h3>")
+
+	// blockquote
+	t = replacetext(t, "\[quote\]", "<blockquote style=\"line-height:normal; margin-bottom:10px; font-style:italic; letter-spacing: 1.25px; text-align:right;\">")
+	t = replacetext(t, "\[/quote\]", "</blockquote>")
+
+	// div
+	t = replacetext(t, "\[block\]", "<div style=\"border-width: 4px; border-style: dashed;\">")
+	t = replacetext(t, "\[/block\]", "</div>")
+
+	return t
+
 /*
  * Byond
  * (remove this when byond lern unicode)

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -372,12 +372,12 @@
 	t = replacetext(t, "\[/th\]", "</font></th>")
 
 	// standart head
-	t = replacetext(t, "\[h\]", "<h3 style=\"text-align:center;\">")
-	t = replacetext(t, "\[/h\]", "</h3>")
+	t = replacetext(t, "\[h\]", "<font size=\"4\"><center><b>")
+	t = replacetext(t, "\[/h\]", "</b></center></font>")
 
 	// bordered head;
-	t = replacetext(t, "\[bh\]", "<h3 style=\"border-width: 4px; border-style: solid; padding: 10px; text-align:center;\">")
-	t = replacetext(t, "\[/bh\]", "</h3>")
+	t = replacetext(t, "\[bh\]", "<div style=\"border-width: 4px; border-style: solid; padding: 10px;\"><font size=\"4\"><center><b>")
+	t = replacetext(t, "\[/bh\]", "</b></center></font></div>")
 
 	// blockquote
 	t = replacetext(t, "\[quote\]", "<blockquote style=\"line-height:normal; margin-bottom:10px; font-style:italic; letter-spacing: 1.25px; text-align:right;\">")

--- a/code/game/objects/structures/chalkboard.dm
+++ b/code/game/objects/structures/chalkboard.dm
@@ -70,7 +70,7 @@
 			return
 
 	//t = replacetext(t, "\n", "<BR>")
-	t = parsepencode(t) // Encode everything from pencode to html
+	t = parsebbcode(t) // Encode everything from pencode to html
 
 	if(!t)
 		return
@@ -132,53 +132,6 @@
 			desc = "Oh! Something offensive is written on a chalkboard!"
 			icon_state = "board_honk[rand(1, 5)]"
 			content = "HONK"
-
-/obj/structure/chalkboard/proc/parsepencode(t)
-
-	t = replacetext(t, "\[center\]", "<center>")
-	t = replacetext(t, "\[/center\]", "</center>")
-	t = replacetext(t, "\[br\]", "<BR>")
-	t = replacetext(t, "\[b\]", "<B>")
-	t = replacetext(t, "\[/b\]", "</B>")
-	t = replacetext(t, "\[i\]", "<I>")
-	t = replacetext(t, "\[/i\]", "</I>")
-	t = replacetext(t, "\[u\]", "<U>")
-	t = replacetext(t, "\[/u\]", "</U>")
-	t = replacetext(t, "\[large\]", "<font size=\"4\">")
-	t = replacetext(t, "\[/large\]", "</font>")
-	t = replacetext(t, "\[*\]", "<li>")
-	t = replacetext(t, "\[small\]", "<font size = \"1\">")
-	t = replacetext(t, "\[/small\]", "</font>")
-	t = replacetext(t, "\[list\]", "<ul>")
-	t = replacetext(t, "\[/list\]", "</ul>")
-
-	// tables
-	t = replacetext(t, "\[table\]", "<table border=3px cellpadding=5px bordercolor=\"black\">")
-	t = replacetext(t, "\[/table\]", "</table>")
-	t = replacetext(t, "\[tr\]", "<tr>")
-	t = replacetext(t, "\[/tr\]", "</tr>")
-	t = replacetext(t, "\[td\]", "<td>")
-	t = replacetext(t, "\[/td\]", "</td>")
-	t = replacetext(t, "\[th\]", "<th>")
-	t = replacetext(t, "\[/th\]", "</th>")
-
-	// standart head
-	t = replacetext(t, "\[h\]", "<h3 style=\"font-family: Arial; text-align:center;\">")
-	t = replacetext(t, "\[/h\]", "</h3>")
-
-	// bordered head;
-	t = replacetext(t, "\[bh\]", "<h3 style=\"border-width: 4px; border-style: solid; font-family: Arial; padding: 10px; text-align:center;\">")
-	t = replacetext(t, "\[/bh\]", "</h3>")
-
-	// blockquote
-	t = replacetext(t, "\[quote\]", "<blockquote style=\"line-height:normal; margin-bottom:10px; font-style:italic; letter-spacing: 1.25px; text-align:right;\">")
-	t = replacetext(t, "\[/quote\]", "</blockquote>")
-
-	// div
-	t = replacetext(t, "\[block\]", "<div style=\"border-width: 4px; border-style: dashed;\">")
-	t = replacetext(t, "\[/block\]", "</div>")
-
-	return t
 
 /obj/structure/chalkboard/proc/count_occurrences(string, substring)
 	var/count = 0

--- a/code/game/objects/structures/chalkboard.dm
+++ b/code/game/objects/structures/chalkboard.dm
@@ -152,6 +152,32 @@
 	t = replacetext(t, "\[list\]", "<ul>")
 	t = replacetext(t, "\[/list\]", "</ul>")
 
+	// tables
+	t = replacetext(t, "\[table\]", "<table border=3px cellpadding=5px bordercolor=\"black\">")
+	t = replacetext(t, "\[/table\]", "</table>")
+	t = replacetext(t, "\[tr\]", "<tr>")
+	t = replacetext(t, "\[/tr\]", "</tr>")
+	t = replacetext(t, "\[td\]", "<td>")
+	t = replacetext(t, "\[/td\]", "</td>")
+	t = replacetext(t, "\[th\]", "<th>")
+	t = replacetext(t, "\[/th\]", "</th>")
+
+	// standart head
+	t = replacetext(t, "\[h\]", "<h3 style=\"font-family: Arial; text-align:center;\">")
+	t = replacetext(t, "\[/h\]", "</h3>")
+
+	// bordered head;
+	t = replacetext(t, "\[bh\]", "<h3 style=\"border-width: 4px; border-style: solid; font-family: Arial; padding: 10px; text-align:center;\">")
+	t = replacetext(t, "\[/bh\]", "</h3>")
+
+	// blockquote
+	t = replacetext(t, "\[quote\]", "<blockquote style=\"line-height:normal; margin-bottom:10px; font-style:italic; letter-spacing: 1.25px; text-align:right;\">")
+	t = replacetext(t, "\[/quote\]", "</blockquote>")
+
+	// div
+	t = replacetext(t, "\[block\]", "<div style=\"border-width: 4px; border-style: dashed;\">")
+	t = replacetext(t, "\[/block\]", "</div>")
+
 	return t
 
 /obj/structure/chalkboard/proc/count_occurrences(string, substring)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1112,7 +1112,9 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 	var/obj/item/weapon/paper/P = new
 	P.name = sent_name
-	P.info = parsebbcode(sent_text)
+	var/parsed_text = parsebbcode(sent_text)
+	parsed_text = replacetext(parsed_text, "\[nt\]", "<img src = bluentlogo.png />")
+	P.info = parsed_text
 	P.update_icon()
 
 	if(stamp_type)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1074,6 +1074,53 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		message_admins("Admin [key_name_admin(usr)] has disabled random events.")
 	feedback_add_details("admin_verb","TRE") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/client/proc/parsepencode(t)
+	t = replacetext(t, "\[center\]", "<center>")
+	t = replacetext(t, "\[/center\]", "</center>")
+	t = replacetext(t, "\[br\]", "<BR>")
+	t = replacetext(t, "\[b\]", "<B>")
+	t = replacetext(t, "\[/b\]", "</B>")
+	t = replacetext(t, "\[i\]", "<I>")
+	t = replacetext(t, "\[/i\]", "</I>")
+	t = replacetext(t, "\[u\]", "<U>")
+	t = replacetext(t, "\[/u\]", "</U>")
+	t = replacetext(t, "\[large\]", "<font size=\"4\">")
+	t = replacetext(t, "\[/large\]", "</font>")
+
+	// tables
+	t = replacetext(t, "\[table\]", "<table border=3px cellpadding=5px bordercolor=\"black\">")
+	t = replacetext(t, "\[/table\]", "</table>")
+	t = replacetext(t, "\[tr\]", "<tr>")
+	t = replacetext(t, "\[/tr\]", "</tr>")
+	t = replacetext(t, "\[td\]", "<td>")
+	t = replacetext(t, "\[/td\]", "</td>")
+	t = replacetext(t, "\[th\]", "<th>")
+	t = replacetext(t, "\[/th\]", "</th>")
+
+	// standart head
+	t = replacetext(t, "\[h\]", "<h3 style=\"text-align:center;\">")
+	t = replacetext(t, "\[/h\]", "</h3>")
+
+	// bordered head;
+	t = replacetext(t, "\[bh\]", "<h3 style=\"border-width: 4px; border-style: solid; padding: 10px; text-align:center;\">")
+	t = replacetext(t, "\[/bh\]", "</h3>")
+
+	// blockquote
+	t = replacetext(t, "\[quote\]", "<blockquote style=\"line-height:normal; margin-bottom:10px; font-style:italic; letter-spacing: 1.25px; text-align:right;\">")
+	t = replacetext(t, "\[/quote\]", "</blockquote>")
+
+	// div
+	t = replacetext(t, "\[block\]", "<div style=\"border-width: 4px; border-style: dashed;\">")
+	t = replacetext(t, "\[/block\]", "</div>")
+
+	t = replacetext(t, "\[*\]", "<li>")
+	t = replacetext(t, "\[hr\]", "<HR>")
+	t = replacetext(t, "\[small\]", "<font size = \"1\">")
+	t = replacetext(t, "\[/small\]", "</font>")
+	t = replacetext(t, "\[list\]", "<ul>")
+	t = replacetext(t, "\[/list\]", "</ul>")
+
+	return t
 
 /client/proc/send_fax_message()
 	set name = "Send Fax Message"
@@ -1113,7 +1160,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 	var/obj/item/weapon/paper/P = new
 	P.name = sent_name
-	P.info = sent_text
+	P.info = parsepencode(sent_text)
 	P.update_icon()
 
 	if(stamp_type)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1074,54 +1074,6 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		message_admins("Admin [key_name_admin(usr)] has disabled random events.")
 	feedback_add_details("admin_verb","TRE") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-/client/proc/parsepencode(t)
-	t = replacetext(t, "\[center\]", "<center>")
-	t = replacetext(t, "\[/center\]", "</center>")
-	t = replacetext(t, "\[br\]", "<BR>")
-	t = replacetext(t, "\[b\]", "<B>")
-	t = replacetext(t, "\[/b\]", "</B>")
-	t = replacetext(t, "\[i\]", "<I>")
-	t = replacetext(t, "\[/i\]", "</I>")
-	t = replacetext(t, "\[u\]", "<U>")
-	t = replacetext(t, "\[/u\]", "</U>")
-	t = replacetext(t, "\[large\]", "<font size=\"4\">")
-	t = replacetext(t, "\[/large\]", "</font>")
-
-	// tables
-	t = replacetext(t, "\[table\]", "<table border=3px cellpadding=5px bordercolor=\"black\">")
-	t = replacetext(t, "\[/table\]", "</table>")
-	t = replacetext(t, "\[tr\]", "<tr>")
-	t = replacetext(t, "\[/tr\]", "</tr>")
-	t = replacetext(t, "\[td\]", "<td>")
-	t = replacetext(t, "\[/td\]", "</td>")
-	t = replacetext(t, "\[th\]", "<th>")
-	t = replacetext(t, "\[/th\]", "</th>")
-
-	// standart head
-	t = replacetext(t, "\[h\]", "<h3 style=\"text-align:center;\">")
-	t = replacetext(t, "\[/h\]", "</h3>")
-
-	// bordered head;
-	t = replacetext(t, "\[bh\]", "<h3 style=\"border-width: 4px; border-style: solid; padding: 10px; text-align:center;\">")
-	t = replacetext(t, "\[/bh\]", "</h3>")
-
-	// blockquote
-	t = replacetext(t, "\[quote\]", "<blockquote style=\"line-height:normal; margin-bottom:10px; font-style:italic; letter-spacing: 1.25px; text-align:right;\">")
-	t = replacetext(t, "\[/quote\]", "</blockquote>")
-
-	// div
-	t = replacetext(t, "\[block\]", "<div style=\"border-width: 4px; border-style: dashed;\">")
-	t = replacetext(t, "\[/block\]", "</div>")
-
-	t = replacetext(t, "\[*\]", "<li>")
-	t = replacetext(t, "\[hr\]", "<HR>")
-	t = replacetext(t, "\[small\]", "<font size = \"1\">")
-	t = replacetext(t, "\[/small\]", "</font>")
-	t = replacetext(t, "\[list\]", "<ul>")
-	t = replacetext(t, "\[/list\]", "</ul>")
-
-	return t
-
 /client/proc/send_fax_message()
 	set name = "Send Fax Message"
 	set category = "Special Verbs"
@@ -1129,7 +1081,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!check_rights(R_ADMIN))
 		return
 
-	var/sent_text = sanitize(input(usr, "Please, enter the text you want to send.", "What?", "") as message|null, MAX_PAPER_MESSAGE_LEN)
+	var/sent_text = sanitize(input(usr, "Please, enter the text you want to send.", "What?", "") as message|null, MAX_PAPER_MESSAGE_LEN, extra = FALSE)
 	if(!sent_text)
 		return
 
@@ -1160,7 +1112,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 
 	var/obj/item/weapon/paper/P = new
 	P.name = sent_name
-	P.info = parsepencode(sent_text)
+	P.info = parsebbcode(sent_text)
 	P.update_icon()
 
 	if(stamp_type)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -281,64 +281,20 @@
 	if(findtext(t, "\[sign\]"))
 		t = replacetext(t, "\[sign\]", "<font face=\"[signfont]\"><i>[get_signature(P, user)]</i></font>")
 
-	t = replacetext(t, "\[center\]", "<center>")
-	t = replacetext(t, "\[/center\]", "</center>")
-	t = replacetext(t, "\[br\]", "<BR>")
-	t = replacetext(t, "\[b\]", "<B>")
-	t = replacetext(t, "\[/b\]", "</B>")
-	t = replacetext(t, "\[i\]", "<I>")
-	t = replacetext(t, "\[/i\]", "</I>")
-	t = replacetext(t, "\[u\]", "<U>")
-	t = replacetext(t, "\[/u\]", "</U>")
-	t = replacetext(t, "\[large\]", "<font size=\"4\">")
-	t = replacetext(t, "\[/large\]", "</font>")
-	t = replacetext(t, "\[field\]", "<span class=\"paper_field\"></span>")
-
-	// tables
-	t = replacetext(t, "\[table\]", "<table border=3px cellpadding=5px bordercolor=\"black\">")
-	t = replacetext(t, "\[/table\]", "</table>")
-	t = replacetext(t, "\[tr\]", "<tr>")
-	t = replacetext(t, "\[/tr\]", "</tr>")
-	t = replacetext(t, "\[td\]", "<td>")
-	t = replacetext(t, "\[/td\]", "</td>")
-	t = replacetext(t, "\[th\]", "<th>")
-	t = replacetext(t, "\[/th\]", "</th>")
-
-	// standart head
-	t = replacetext(t, "\[h\]", "<h3 style=\"font-family: Arial; text-align:center;\">")
-	t = replacetext(t, "\[/h\]", "</h3>")
-
-	// bordered head;
-	t = replacetext(t, "\[bh\]", "<h3 style=\"border-width: 4px; border-style: solid; font-family: Arial; padding: 10px; text-align:center;\">")
-	t = replacetext(t, "\[/bh\]", "</h3>")
-
-	// blockquote
-	t = replacetext(t, "\[quote\]", "<blockquote style=\"line-height:normal; margin-bottom:10px; font-style:italic; letter-spacing: 1.25px; text-align:right;\">")
-	t = replacetext(t, "\[/quote\]", "</blockquote>")
-
-	// div
-	t = replacetext(t, "\[block\]", "<div style=\"border-width: 4px; border-style: dashed;\">")
-	t = replacetext(t, "\[/block\]", "</div>")
-
-	if(!iscrayon)
-		t = replacetext(t, "\[*\]", "<li>")
-		t = replacetext(t, "\[hr\]", "<HR>")
-		t = replacetext(t, "\[small\]", "<font size = \"1\">")
-		t = replacetext(t, "\[/small\]", "</font>")
-		t = replacetext(t, "\[list\]", "<ul>")
-		t = replacetext(t, "\[/list\]", "</ul>")
-
-		t = "<font face=\"[deffont]\" color=[P.colour]>[t]</font>"
-	else // If it is a crayon, and he still tries to use these, make them empty!
+	var/font = deffont
+	if(iscrayon) // If it is a crayon, and he still tries to use these, make them empty!
 		t = replacetext(t, "\[*\]", "")
 		t = replacetext(t, "\[hr\]", "")
 		t = replacetext(t, "\[small\]", "")
 		t = replacetext(t, "\[/small\]", "")
 		t = replacetext(t, "\[list\]", "")
 		t = replacetext(t, "\[/list\]", "")
+		t = "<b>[t]</b>"
+		font = crayonfont
 
-		t = "<font face=\"[crayonfont]\" color=[P.colour]><b>[t]</b></font>"
-
+	t = parsebbcode(t, P.colour)
+	t = replacetext(t, "\[field\]", "<span class=\"paper_field\"></span>")
+	t = "<font face=\"[font]\" color=\"[P.colour]\">[t]</font>"
 //	t = replacetext(t, "#", "") // Junk converted to nothing!
 
 //Count the fields


### PR DESCRIPTION
## Описание изменений
![image](https://user-images.githubusercontent.com/14612180/69888041-e1583600-12fa-11ea-9b8d-b0baaa8903cf.png)
Вкорячены тэги от бумажек к факсу ЦК. Также новые тэги из #2410 добавлены доске в РнД.

## Почему и что этот ПР улучшит
Ответы от ЦК будут не просто стеной текста, а оформленной стеной текста.

## Чеинжлог
:cl: PervertGenius
- rscadd: Добавлены новые тэги доске в Исследовательском Отделе.
- tweak: ЦК получило возможность использовать тэги форматирования текста.