### PR TITLE
Изменение количество минут необходимых для открытия цивилов

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -10,7 +10,7 @@
 	selection_color = "#d7b088"
 	idtype = /obj/item/weapon/card/id/cargoGold
 	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mint, access_mining, access_mining_station, access_recycler)
-	minimal_player_ingame_minutes = 1200
+	minimal_player_ingame_minutes = 960
 	restricted_species = list(TAJARAN, DIONA)
 
 /datum/job/qm/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -42,7 +42,7 @@
 	selection_color = "#d7b088"
 	idtype = /obj/item/weapon/card/id/cargo
 	access = list(access_maint_tunnels, access_cargo, access_cargo_bot, access_mailsorting)
-	minimal_player_ingame_minutes = 960
+	minimal_player_ingame_minutes = 480
 	restricted_species = list(SKRELL, DIONA)
 
 
@@ -71,7 +71,7 @@
 	selection_color = "#d7b088"
 	idtype = /obj/item/weapon/card/id/cargo
 	access = list(access_mining, access_mint, access_mining_station, access_mailsorting)
-	minimal_player_ingame_minutes = 960
+	minimal_player_ingame_minutes = 480
 	restricted_species = list(SKRELL)
 
 /datum/job/mining/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -106,7 +106,7 @@
 	selection_color = "#d7b088"
 	idtype = /obj/item/weapon/card/id/cargo
 	access = list(access_mining, access_mint, access_mailsorting, access_recycler)
-	minimal_player_ingame_minutes = 960
+	minimal_player_ingame_minutes = 480
 	restricted_species = list(SKRELL)
 
 /datum/job/recycler/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -135,7 +135,7 @@
 	selection_color = "#bbe291"
 	idtype = /obj/item/weapon/card/id/civ
 	access = list(access_bar)
-	minimal_player_ingame_minutes = 480
+	minimal_player_ingame_minutes = 240
 	restricted_species = list(TAJARAN)
 
 	survival_kit_items = list(/obj/item/ammo_casing/shotgun/beanbag,
@@ -177,7 +177,7 @@
 	idtype = /obj/item/weapon/card/id/civ
 	access = list(access_kitchen)
 	alt_titles = list("Cook")
-	minimal_player_ingame_minutes = 480
+	minimal_player_ingame_minutes = 240
 	restricted_species = list(TAJARAN, SKRELL)
 
 /datum/job/chef/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -205,7 +205,7 @@
 	idtype = /obj/item/weapon/card/id/civ
 	access = list(access_hydroponics) // Removed tox and chem access because STOP PISSING OFF THE CHEMIST GUYS // //Removed medical access because WHAT THE FUCK YOU AREN'T A DOCTOR YOU GROW WHEAT //Given Morgue access because they have a viable means of cloning.
 	alt_titles = list("Hydroponicist")
-	minimal_player_ingame_minutes = 480
+	minimal_player_ingame_minutes = 120
 	restricted_species = list(SKRELL)
 
 /datum/job/hydro/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -240,7 +240,7 @@
 	selection_color = "#bbe291"
 	idtype = /obj/item/weapon/card/id/civ
 	access = list(access_janitor, access_maint_tunnels)
-	minimal_player_ingame_minutes = 480
+	minimal_player_ingame_minutes = 120
 	restricted_species = list(SKRELL)
 
 /datum/job/janitor/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -269,7 +269,7 @@
 	idtype = /obj/item/weapon/card/id/civ
 	access = list(access_barber)
 	alt_titles = list("Stylist")
-	minimal_player_ingame_minutes = 480
+	minimal_player_ingame_minutes = 120
 
 /datum/job/barber/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(!H)
@@ -304,7 +304,7 @@
 	idtype = /obj/item/weapon/card/id/civ
 	access = list(access_library)
 	alt_titles = list("Journalist")
-	minimal_player_ingame_minutes = 480
+	minimal_player_ingame_minutes = 120
 
 /datum/job/librarian/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(!H)	return 0
@@ -373,7 +373,7 @@
 	selection_color = "#dddddd"
 	idtype = /obj/item/weapon/card/id/clown
 	access = list(access_clown, access_theatre)
-	minimal_player_ingame_minutes = 480
+	minimal_player_ingame_minutes = 120
 	restricted_species = list(SKRELL)
 
 /datum/job/clown/equip(mob/living/carbon/human/H, visualsOnly = FALSE)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Изменение количество минуток необходимое для открытия гражданских должностей

## Почему и что этот ПР улучшит
Ощущение от игры новичков, которым больше не придется играть восемь с половиной часов чтобы открыть уборщика. 

## Авторство

## Чеинжлог
:cl: 
- tweak: Уменьшен временной порог необходимый для открытия гражданских должностей. 