### PR TITLE
Подсчет денег в конце раунда

### DIFF
--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -47,7 +47,7 @@
 			//for (var/obj/item/weapon/card/id/C1 in get_contents_in_object(E, /obj/item/weapon/card/id))
 			//	cashscore += C1.money
 
-			cashscore += E.mind.initial_account.money 	//Добавить деньги на личном счету
+			cashscore += E.mind.initial_account.money
 
 			for (var/obj/item/weapon/spacecash/C2 in get_contents_in_object(E, /obj/item/weapon/spacecash))
 				cashscore += C2.worth
@@ -76,7 +76,7 @@
 				score["opkilled"]++
 				continue
 			var/turf/T = M.current.loc
-			if (T && istype(T.loc, /area/security/brig))
+			if (T && istype(T.loc, /area/station/security/brig))
 				score["arrested"] += 1
 			else if (M.current.stat == DEAD)
 				score["opkilled"]++
@@ -89,8 +89,8 @@
 			if(A.loc != /mob/living/carbon) continue
 			var/turf/location = get_turf(A.loc)
 			var/area/bad_zone1 = locate(/area)
-			var/area/bad_zone2 = locate(/area/syndicate_station)
-			var/area/bad_zone3 = locate(/area/wizard_station)
+			var/area/bad_zone2 = locate(/area/shuttle/syndicate)
+			var/area/bad_zone3 = locate(/area/custom/wizard_station)
 			if (location in bad_zone1) score["disc"] = 0
 			if (location in bad_zone2) score["disc"] = 0
 			if (location in bad_zone3) score["disc"] = 0
@@ -102,11 +102,11 @@
 				if (NUKE.detonated == 0)
 					continue
 				var/turf/T = NUKE.loc
-				if (istype(T,/area/syndicate_station) || istype(T,/area/wizard_station) || istype(T,/area/solar))
+				if (istype(T,/area/shuttle/syndicate) || istype(T,/area/custom/wizard_station) || istype(T,/area/station/solar))
 					nukedpenalty = 1000
-				else if (istype(T,/area/security/main) || istype(T,/area/security/brig) || istype(T,/area/security/armoury) || istype(T,/area/security/checkpoint))
+				else if (istype(T,/area/station/security/main) || istype(T,/area/station/security/brig) || istype(T,/area/station/security/armoury) || istype(T,/area/station/security/checkpoint))
 					nukedpenalty = 50000
-				else if (istype(T,/area/engine))
+				else if (istype(T,/area/station/engineering))
 					nukedpenalty = 100000
 				else
 					nukedpenalty = 10000
@@ -120,7 +120,7 @@
 				score["opkilled"]++
 				continue
 			var/turf/T = M.current.loc
-			if (istype(T.loc, /area/security/brig))
+			if (istype(T.loc, /area/station/security/brig))
 				score["arrested"] += 1
 			else if (M.current.stat == DEAD)
 				score["opkilled"]++
@@ -288,11 +288,11 @@
 				continue
 			var/turf/T = NUKE.loc
 			bombdat = T.loc
-			if (istype(T,/area/syndicate_station) || istype(T,/area/wizard_station) || istype(T,/area/solar))
+			if (istype(T,/area/shuttle/syndicate) || istype(T,/area/custom/wizard_station) || istype(T,/area/station/solar))
 				nukedpenalty = 1000
-			else if (istype(T,/area/security/main) || istype(T,/area/security/brig) || istype(T,/area/security/armoury) || istype(T,/area/security/checkpoint))
+			else if (istype(T,/area/station/security/main) || istype(T,/area/station/security/brig) || istype(T,/area/station/security/armoury) || istype(T,/area/station/security/checkpoint))
 				nukedpenalty = 50000
-			else if (istype(T,/area/engine))
+			else if (istype(T,/area/station/engineering))
 				nukedpenalty = 100000
 			else
 				nukedpenalty = 10000

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -47,6 +47,8 @@
 			//for (var/obj/item/weapon/card/id/C1 in get_contents_in_object(E, /obj/item/weapon/card/id))
 			//	cashscore += C1.money
 
+			cashscore += E.mind.initial_account.money 	//Добавить деньги на личном счету
+
 			for (var/obj/item/weapon/spacecash/C2 in get_contents_in_object(E, /obj/item/weapon/spacecash))
 				cashscore += C2.worth
 
@@ -74,7 +76,7 @@
 				score["opkilled"]++
 				continue
 			var/turf/T = M.current.loc
-			if (T && istype(T.loc, /area/station/security/brig))
+			if (T && istype(T.loc, /area/security/brig))
 				score["arrested"] += 1
 			else if (M.current.stat == DEAD)
 				score["opkilled"]++
@@ -87,8 +89,8 @@
 			if(A.loc != /mob/living/carbon) continue
 			var/turf/location = get_turf(A.loc)
 			var/area/bad_zone1 = locate(/area)
-			var/area/bad_zone2 = locate(/area/shuttle/syndicate)
-			var/area/bad_zone3 = locate(/area/custom/wizard_station)
+			var/area/bad_zone2 = locate(/area/syndicate_station)
+			var/area/bad_zone3 = locate(/area/wizard_station)
 			if (location in bad_zone1) score["disc"] = 0
 			if (location in bad_zone2) score["disc"] = 0
 			if (location in bad_zone3) score["disc"] = 0
@@ -100,11 +102,11 @@
 				if (NUKE.detonated == 0)
 					continue
 				var/turf/T = NUKE.loc
-				if (istype(T,/area/shuttle/syndicate) || istype(T,/area/custom/wizard_station) || istype(T,/area/station/solar))
+				if (istype(T,/area/syndicate_station) || istype(T,/area/wizard_station) || istype(T,/area/solar))
 					nukedpenalty = 1000
-				else if (istype(T,/area/station/security/main) || istype(T,/area/station/security/brig) || istype(T,/area/station/security/armoury) || istype(T,/area/station/security/checkpoint))
+				else if (istype(T,/area/security/main) || istype(T,/area/security/brig) || istype(T,/area/security/armoury) || istype(T,/area/security/checkpoint))
 					nukedpenalty = 50000
-				else if (istype(T,/area/station/engineering))
+				else if (istype(T,/area/engine))
 					nukedpenalty = 100000
 				else
 					nukedpenalty = 10000
@@ -118,7 +120,7 @@
 				score["opkilled"]++
 				continue
 			var/turf/T = M.current.loc
-			if (istype(T.loc, /area/station/security/brig))
+			if (istype(T.loc, /area/security/brig))
 				score["arrested"] += 1
 			else if (M.current.stat == DEAD)
 				score["opkilled"]++
@@ -286,11 +288,11 @@
 				continue
 			var/turf/T = NUKE.loc
 			bombdat = T.loc
-			if (istype(T,/area/shuttle/syndicate) || istype(T,/area/custom/wizard_station) || istype(T,/area/station/solar))
+			if (istype(T,/area/syndicate_station) || istype(T,/area/wizard_station) || istype(T,/area/solar))
 				nukedpenalty = 1000
-			else if (istype(T,/area/station/security/main) || istype(T,/area/station/security/brig) || istype(T,/area/station/security/armoury) || istype(T,/area/station/security/checkpoint))
+			else if (istype(T,/area/security/main) || istype(T,/area/security/brig) || istype(T,/area/security/armoury) || istype(T,/area/security/checkpoint))
 				nukedpenalty = 50000
-			else if (istype(T,/area/station/engineering))
+			else if (istype(T,/area/engine))
 				nukedpenalty = 100000
 			else
 				nukedpenalty = 10000


### PR DESCRIPTION
# Описание изменений
Раньше в статистике раунда при подсчете Most Richest Escapee учитывались только деньги, взятые с собой на ЦК. Теперь будут учитываться и деньги, лежащие на банковском счету персонажа.

## Почему и что этот ПР улучшит
Теперь будет видно кто действительно был самым богатым на станции.

## Авторство

## Чеинжлог
:cl: Ahio
 - tweak: В статистике раунда при подсчете Most Richest Escapee теперь учитываются и деньги в инвентаре, и деньги на счету персонажа.