### PR TITLE
Добавляет бинтик в начальную коробку.

### DIFF
--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -119,7 +119,8 @@
 
 	var/list/survival_kit_items = list(/obj/item/clothing/mask/breath,
 	                                   /obj/item/weapon/tank/emergency_oxygen,
-	                                   /obj/item/weapon/reagent_containers/hypospray/autoinjector
+	                                   /obj/item/weapon/reagent_containers/hypospray/autoinjector,
+	                                   /obj/item/stack/medical/bruise_pack
 	                                   )
 
 	var/list/prevent_survival_kit_items = list()


### PR DESCRIPTION
## Описание изменений
Добавляет в emergency box bruise pack.


## Почему и что этот ПР улучшит
Является частичным фиксом проблемы, описанной в https://forum.taucetistation.org/t/discussion-vote-nanomed/13939

НаноТразен заботится о своих сотрудниках: если вы порезались в процессе смены, вам не обязательно идти в мед - перевяжите порез сами.

## Чеинжлог
:cl:
 - tweak: В emergency box добавлен бинтик.