### PR TITLE
Название сервера отражено в заголовке окна клиента

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -268,6 +268,12 @@ var/list/blacklisted_builds = list(
 
 	generate_clickcatcher()
 
+	// Set config based title for main window
+	if (config.server_name)
+		winset(src, "mainwindow", "title='[world.name]: [config.server_name]'")
+	else
+		winset(src, "mainwindow", "title='[world.name]'")
+
 	if(prefs.lastchangelog != changelog_hash) // Bolds the changelog button on the interface so we know there are updates.
 		to_chat(src, "<span class='info'>You have unread updates in the changelog.</span>")
 		winset(src, "rpane.changelog", "font-style=bold;background-color=#B1E477")


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Заменяет после подключения к серверу стандарный заголовок окна игры на название сервера через winset.
Например:
> Tau Ceti Station: Tau Ceti Classic I

## Почему и что этот ПР улучшит
Close #4190 

