### PR TITLE
Даёт парамедикам доступ к аварийным створкам.

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -3,7 +3,7 @@
 	desc = "Emergency air-tight shutter, capable of sealing off breached areas."
 	icon = 'icons/obj/doors/DoorHazard.dmi'
 	icon_state = "door_open"
-	req_one_access = list(access_atmospherics, access_engine_equip)
+	req_one_access = list(access_atmospherics, access_engine_equip, access_paramedic)
 	opacity = 0
 	density = 0
 	layer = FIREDOOR_LAYER


### PR DESCRIPTION
## Описание изменений
fixes #4385
Учитывая, что у парамедиков есть всё необходимое оборудование, чтобы спасать членов экипажа из критических ситуаций, доступ к аварийным створкам будет ОЧЕНЬ кстати, плюс  сейчас они отрывают створки ломом => створки НЕ ЗАКРЫВАЮТСЯ, если их снова не закрыть ломом (что обычно забывают сделать, конечно же), а если будет доступ, они будут закрываться автоматически.

## Почему и что этот ПР улучшит
Удобство работы парамедиком, таскать с собой лом более не обязательно, плюс створки будут закрываться сами.

## Чеинжлог
:cl: Richard Jones
- tweak: Парамедики получили доступ к аварийным створкам.