### PR TITLE
remove redundant check

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -425,8 +425,6 @@ body
 	if(usr.client != src || !holder)
 		return
 	if(href_list["Vars"])
-		if(!check_rights(R_DEBUG|R_VAREDIT|R_LOG))
-			return
 		debug_variables(locate(href_list["Vars"]))
 
 	//~CARN: for renaming mobs (updates their name, real_name, mind.name, their ID/PDA and datacore records).


### PR DESCRIPTION
## Описание изменений
Удалил чек перед открытием вью вэриэбла из другого окошка вью вэриэбла. Собственно, он создавал проблему из-за которой кандидаты не могли открывать ВВ по ссылке.

## Почему и что этот ПР улучшит
Теперь кандидаты смогут нормально пользоваться ВВ
Действительно фиксит #3196
## Авторство

## Чеинжлог
