### PR TITLE
Девайс нюки для объявления войны доступен без админов

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -1,6 +1,6 @@
 #define CHALLENGE_TELECRYSTALS 200
 #define CHALLENGE_TIME_LIMIT 6000
-#define CHALLENGE_MIN_PLAYERS 30
+#define CHALLENGE_MIN_PLAYERS 40
 
 var/global/obj/item/device/nuclear_challenge/Challenge
 

--- a/code/game/machinery/computer/intruder_station.dm
+++ b/code/game/machinery/computer/intruder_station.dm
@@ -37,7 +37,7 @@
 
 	for(var/datum/intruder_tools/T in tools)
 		dat += "[T.name] ([T.cost]):"
-		var/buyable = (available_telecrystalls >= T.cost)
+		var/buyable = (stored_uplink && stored_uplink.hidden_uplink && available_telecrystalls >= T.cost)
 		dat += "<a href ='?src=\ref[src];buy=\ref[T]'>[buyable ? "Buy"  : "<font color='grey'>Buy</font>"]</a> | "
 		dat += "<a href ='?src=\ref[src];desc=\ref[T]'>Show Desc</a><BR>"
 		if(show_tool_desc == T)
@@ -87,6 +87,15 @@
 	if(delete_dat_after_buying)
 		console.tools -= src
 		qdel(src)
+
+
+/datum/intruder_tools/war_device
+	name = "War Device"
+	desc = "Device to send a declaration of hostilities to the target, delaying your shuttle departure for 20 minutes while they prepare for your assault.  \
+			Such a brazen move will attract the attention of powerful benefactors within the Syndicate, who will supply your team with a massive amount of bonus telecrystals.  \
+			Must be used within five minutes, or your benefactors will lose interest."
+	delete_dat_after_buying = TRUE
+	item = /obj/item/device/nuclear_challenge
 
 /datum/intruder_tools/shuttle_unlocker
 	name = "Shuttle Unlocker"

--- a/maps/centcom/centcom.dmm
+++ b/maps/centcom/centcom.dmm
@@ -3459,14 +3459,6 @@
 	icon_state = "podhatch"
 	},
 /area/custom/syndicate_mothership)
-"ana" = (
-/obj/machinery/door/poddoor/shutters/syndi{
-	id = "nukeop_war"
-	},
-/turf/unsimulated/floor{
-	icon_state = "bar"
-	},
-/area/custom/syndicate_mothership)
 "anb" = (
 /obj/machinery/door/window{
 	dir = 1;
@@ -13646,19 +13638,6 @@
 	icon_state = "white"
 	},
 /area/centcom/tdome)
-"aWx" = (
-/obj/machinery/door_control{
-	id = "nukeop_war";
-	name = "War door-control";
-	pixel_x = -30;
-	req_access = list(151)
-	},
-/obj/structure/table,
-/obj/item/device/nuclear_challenge,
-/turf/unsimulated/floor{
-	icon_state = "bar"
-	},
-/area/custom/syndicate_mothership)
 "aWy" = (
 /obj/structure/table/reinforced{
 	dir = 4;
@@ -81500,7 +81479,7 @@ akQ
 akQ
 aie
 aie
-aie
+alt
 aaM
 aaM
 aaM
@@ -81755,9 +81734,9 @@ akQ
 akQ
 akQ
 akQ
-ana
-aWx
 aie
+aie
+alt
 aaM
 aaM
 aaM
@@ -82014,7 +81993,7 @@ alF
 als
 aie
 aie
-aie
+alt
 aaM
 aaM
 aaM


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений

В соответствии с последними изменениями нюки больше нету смысла прятать девайс.
К тому же сейчас мы в процессе балансировки режима, а её желательно делать с оглядкой на девайс и войну.

:cl:
 - tweak: В режим нюки больше не требуются админы для объявления войны, девайс доступен для покупки в консоли.
 - tweak: Для объявления войны требуется минимум 40 игроков, было 30.
