### PR TITLE
Генерация имени позитронки и нормальный доступ в бинарный чат

### DIFF
--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -49,12 +49,13 @@
 
 
 /obj/item/device/mmi/posibrain/transfer_identity(mob/living/carbon/H)
-	name = "positronic brain ([H])"
-	brainmob.name = H.real_name
-	brainmob.real_name = H.real_name
+	brainmob.name = "[pick(list("PBU","HIU","SINA","ARMA","OSI","HBL","MSO","CHRI","CDB","XSI","ORNG","GUN","KOR","MET","FRE","XIS","SLI","PKP","HOG","RZH","MRPR","JJR","FIRC","INC","PHL","BGB","ANTR","MIW","JRD","CHOC","ANCL","JLLO","JNLG","KOS","TKRG","XAL","STLP","CBOS","DUNC","FXMC","DRSD","XHS","BOB","EXAD","JMAD"))]-[rand(100, 999)]"
+	brainmob.real_name = brainmob.name
 	brainmob.dna = H.dna
 	brainmob.timeofhostdeath = H.timeofdeath
 	brainmob.stat = CONSCIOUS
+	brainmob.robot_talk_understand = 1
+	name = "positronic brain ([brainmob.name])"
 	if(brainmob.mind)
 		brainmob.mind.assigned_role = "Positronic Brain"
 	if(H.mind)

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -212,6 +212,8 @@
 			if(istype(S , /mob/living/silicon/ai))
 				var/renderedAI = "<i><span class='binarysay'>Robotic Talk, <a href='byond://?src=\ref[S];track2=\ref[S];track=\ref[src];trackname=[html_encode(src.name)]'><span class='name'>[name]</span></a> <span class='message'>[verb], \"[message]\"</span></span></i>"
 				S.show_message(renderedAI, SHOWMSG_AUDIO)
+			if(istype(S, /mob/living/carbon/brain))
+				S.show_message(rendered, SHOWMSG_AUDIO)
 			else
 				var/mob/living/silicon/robot/borg = S
 				//if(istype(borg) && borg.is_component_functioning("comms"))

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -212,7 +212,7 @@
 			if(istype(S , /mob/living/silicon/ai))
 				var/renderedAI = "<i><span class='binarysay'>Robotic Talk, <a href='byond://?src=\ref[S];track2=\ref[S];track=\ref[src];trackname=[html_encode(src.name)]'><span class='name'>[name]</span></a> <span class='message'>[verb], \"[message]\"</span></span></i>"
 				S.show_message(renderedAI, SHOWMSG_AUDIO)
-			if(istype(S, /mob/living/carbon/brain))
+			else if(istype(S, /mob/living/carbon/brain))
 				S.show_message(rendered, SHOWMSG_AUDIO)
 			else
 				var/mob/living/silicon/robot/borg = S


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений

Этот ПР #4082 с небольшим изменением + фикшены конфликты

resolve #4082
fix #988

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог

🆑 Martinelli:
 - bugfix: Позитронки, которые при старте раунда находятся в андроидах, больше не имеют имена персонажей
 - bugfix: Позитронка не только пишет в бинарный чат, но и видит его
