### PR TITLE
Больше нельзя рисовать руны, стоя на столе.

### DIFF
--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -316,7 +316,10 @@ var/list/cult_datums = list()
 	if (!isturf(user.loc))
 		to_chat(user, "<span class='userdanger'>You do not have enough space to write a proper rune.</span>")
 		return
-
+	for(var/obj/structure/obj_to_check in user.loc)
+		if(obj_to_check.density == 1)
+			to_chat(user, "<span class='warning'>There is not enough space to write a proper rune.</span>")
+			return
 	if (length(cult_runes) >= CULT_RUNES_LIMIT + length(ticker.mode.cult)) //including the useless rune at the secret room, shouldn't count against the limit of 25 runes - Urist
 		alert("The cloth of reality can't take that much of a strain. Remove some runes first!")
 		return

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -317,7 +317,7 @@ var/list/cult_datums = list()
 		to_chat(user, "<span class='userdanger'>You do not have enough space to write a proper rune.</span>")
 		return
 	for(var/obj/structure/obj_to_check in user.loc)
-		if(obj_to_check.density == 1)
+		if(obj_to_check.density)
 			to_chat(user, "<span class='warning'>There is not enough space to write a proper rune.</span>")
 			return
 	if (length(cult_runes) >= CULT_RUNES_LIMIT + length(ticker.mode.cult)) //including the useless rune at the secret room, shouldn't count against the limit of 25 runes - Urist


### PR DESCRIPTION
## Описание изменений
Если у **структуры** в турфе, на котором стоит культист, density 1, рисовать руну на этом турфе не выйдет. Почему: если объект нельзя передвинуть, то как персонаж смог нарисовать под ней руну?

## Почему и что этот ПР улучшит
Сделано, чтобы культисты не могли рисовать руны, стоя на столе (и других непередвигаемых объектах)
fixes #4394

## Чеинжлог
:cl: Richard Jones
 - bugfix: Культисты больше не могут рисовать руны, стоя на столе (и других непередвигаемых объектах)