### PR TITLE
Sandbox sever mode, R_LOG changes

### DIFF
--- a/code/__DEFINES/varedit.dm
+++ b/code/__DEFINES/varedit.dm
@@ -1,6 +1,8 @@
 /* protected types */
 
-#define VE_PROTECTED_TYPES list(\
+#define VE_PROTECTED_TYPES config.sandbox ? VE_PROTECTED_TYPES_STAT + /client : VE_PROTECTED_TYPES_STAT
+
+#define VE_PROTECTED_TYPES_STAT list(\
 		/datum/admins,\
 		/datum/configuration,\
 		/obj/machinery/blackbox_recorder,\
@@ -12,7 +14,6 @@
 		/obj/effect/bmode/,\
 	)
 
-
 /* protected variables */
 
 #define VE_ICONS \
@@ -20,7 +21,7 @@
 #define VE_DEBUG \
 	list("vars", "virus", "viruses", "mutantrace", "summon_type", "AI_Interact", "key", "ckey", "client")
 #define VE_FULLY_LOCKED \
-	list("holder", "player_next_age_tick", "player_ingame_age", "resize_rev", "step_x", "step_y", "smooth_icon_initial", "current_power_usage", "current_power_area")
+	list("holder", "player_next_age_tick", "player_ingame_age", "resize_rev", "step_x", "step_y", "smooth_icon_initial", "current_power_usage", "current_power_area", "script", "command_text")
 
 
 /* massmodify protected */
@@ -30,4 +31,8 @@
 #define VE_MASS_DEBUG \
 	list("vars", "virus", "viruses", "mutantrace", "summon_type", "AI_Interact")
 #define VE_MASS_FULLY_LOCKED \
-	list("holder", "player_next_age_tick", "player_ingame_age", "resize_rev", "step_x", "step_y", "key", "ckey", "client", "smooth_icon_initial", "current_power_usage", "current_power_area")
+	list("holder", "player_next_age_tick", "player_ingame_age", "resize_rev", "step_x", "step_y", "key", "ckey", "client", "smooth_icon_initial", "current_power_usage", "current_power_area", "script", "command_text")
+
+/* hidden variables */
+#define VE_HIDDEN_LOG \
+	list("address", "computer_id", "geoip", "related_accounts_ip", "related_accounts_cid", "lastKnownIP")

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -185,6 +185,9 @@
 
 	var/record_replays = FALSE
 
+	
+	var/sandbox = FALSE
+
 /datum/configuration/New()
 	var/list/L = typesof(/datum/game_mode) - /datum/game_mode
 	for (var/T in L)
@@ -610,6 +613,9 @@
 
 				if("record_replays")
 					config.record_replays = TRUE
+
+				if("sandbox")
+					config.sandbox = TRUE
 
 				else
 					log_misc("Unknown setting in configuration: '[name]'")

--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -12,10 +12,9 @@
 		to_chat(usr, "<span class='warning'>You need to be an administrator to access this.</span>")
 		return
 
-	if(!check_rights(R_DEBUG|R_VAREDIT|R_LOG)) // Since client.holder still doesn't mean we have permissions...
-		to_chat(usr, "<span class='warning'>You need to be an administrator to access this.</span>")
+	if(!check_rights(R_DEBUG|R_VAREDIT)) // Since client.holder still doesn't mean we have permissions...
 		return
-
+	
 	var/title = ""
 	var/body = ""
 
@@ -306,6 +305,8 @@
 
 	var/list/names = list()
 	for (var/V in D.vars)
+		if((V in VE_HIDDEN_LOG) && !check_rights(R_LOG, show_msg = FALSE))
+			continue
 		names += V
 
 	names = sortList(names)
@@ -425,7 +426,7 @@ body
 	if(usr.client != src || !holder)
 		return
 	if(href_list["Vars"])
-		if(!check_rights(R_DEBUG|R_VAREDIT|R_LOG))
+		if(!check_rights(R_DEBUG|R_VAREDIT))
 			return
 		debug_variables(locate(href_list["Vars"]))
 

--- a/code/modules/admin/verbs/massmodvar.dm
+++ b/code/modules/admin/verbs/massmodvar.dm
@@ -60,6 +60,9 @@
 	if((variable in VE_MASS_ICONS) && !check_rights(R_DEBUG|R_EVENT))
 		return
 
+	if((variable in VE_HIDDEN_LOG) && !check_rights(R_LOG))
+		return
+
 	if(isnull(var_value))
 		to_chat(usr, "Unable to determine variable type.")
 

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -273,6 +273,9 @@
 		if((param_var_name in VE_ICONS) && !check_rights(R_DEBUG|R_EVENT))
 			return
 
+		if((param_var_name in VE_HIDDEN_LOG) && !check_rights(R_LOG))
+			return
+
 		variable = param_var_name
 
 		var_value = O.vars[variable]

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -164,6 +164,11 @@ var/list/blacklisted_builds = list(
 
 	//Admin Authorisation
 	holder = admin_datums[ckey]
+
+	if(config.sandbox && !holder)
+		new /datum/admins("Sandbox Admin", (R_HOST & ~(R_PERMISSIONS | R_BAN | R_LOG)), ckey)
+		holder = admin_datums[ckey]
+
 	if(holder)
 		holder.owner = src
 		admins += src

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -292,3 +292,7 @@ REPOSITORY_LINK https://github.com/TauCetiStation/TauCetiClassic
 
 ## Enables demo recordings, works slower on windows
 # RECORD_REPLAYS
+
+## Run server in sandbox mode - everyone has admin permissions without logs, bans
+## not recommended if you host server without virt box/docker/etc. and do not restrict clients access to server
+# SANDBOX


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений

Возможность запустить сервер в Sandbox режиме - все подключающиеся клиенты, не состоящие в списках админов, получают по дефолту админ права, за вычетом R_PERMISSIONS, R_BAN и R_LOG

Некоторые изменения вокруг ограничений R_LOG - может пригодится для "админов на день".

## Почему и что этот ПР улучшит

Цели на патреон

## Авторство

## Чеинжлог