### PR TITLE
extinguisher off

### DIFF
--- a/code/modules/reagents/reagent_containers/extinguisher.dm
+++ b/code/modules/reagents/reagent_containers/extinguisher.dm
@@ -12,7 +12,7 @@
 	throw_range = 10
 	force = 10.0
 	m_amt = 90
-	safety = 1
+	safety = TRUE
 	attack_verb = list("slammed", "whacked", "bashed", "thunked", "battered", "bludgeoned", "thrashed")
 
 	triple_shot = TRUE

--- a/code/modules/reagents/reagent_containers/extinguisher.dm
+++ b/code/modules/reagents/reagent_containers/extinguisher.dm
@@ -12,6 +12,7 @@
 	throw_range = 10
 	force = 10.0
 	m_amt = 90
+	safety = 1
 	attack_verb = list("slammed", "whacked", "bashed", "thunked", "battered", "bludgeoned", "thrashed")
 
 	triple_shot = TRUE


### PR DESCRIPTION
fix #4437 
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Огнетушители теперь изначально на предохранителе.
## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
:cl:
 - bugfix: Огнетушитель теперь изначально на предохранителе.
