### PR TITLE
Fixing a bunch of wizard-tophat related bugs

### DIFF
--- a/code/datums/spells/summon_item.dm
+++ b/code/datums/spells/summon_item.dm
@@ -39,6 +39,24 @@
 		name = initial(name)
 		marked_item = null
 	else	//Getting previously marked item
+		// Preventing a nasty exlpoit where wizard traps himself in the hat with the hat.
+		// Note: probably should've been in area/custom/tophat/Entered(), but it gets called before Moved()
+		// And so the hat is put into wizard's hands *after* it teleports somewhere
+		// which leads to whole bunch of other problems
+		// so it resides here.
+
+		if(istype(marked_item, /obj/item/clothing/head/wizard/tophat) && istype(get_area(user), /area/custom/tophat))
+			var/obj/item/clothing/head/wizard/tophat/TP = marked_item
+			TP.jump_out()
+			var/area/new_area = teleportlocs[pick(teleportlocs)]
+			user.visible_message("<span class='danger'>[TP] becomes unstable as it enters itself, and now resides somewhere in [new_area]!</span>")
+
+			var/list/all_turfs = get_area_turfs(new_area.type)
+			var/turf/T = pick(all_turfs)
+
+			TP.forceMove(T)
+			return
+
 		var/obj/item_to_retrieve = marked_item
 		while(isobj(item_to_retrieve.loc))
 			item_to_retrieve = item_to_retrieve.loc

--- a/code/game/objects/random/random_cloth.dm
+++ b/code/game/objects/random/random_cloth.dm
@@ -94,7 +94,7 @@
 	icon = 'icons/obj/clothing/hats.dmi'
 	icon_state = "santa"
 /obj/random/cloth/head/item_to_spawn()
-	return pick(subtypesof(/obj/item/clothing/head) - list(/obj/item/clothing/head/shadowling, /obj/item/clothing/head/collectable/tophat/badmin_magic_hat) - (subtypesof(/obj/item/clothing/head/helmet) + subtypesof(/obj/item/clothing/head/helmet/space)))
+	return pick(subtypesof(/obj/item/clothing/head) - list(/obj/item/clothing/head/shadowling, /obj/item/clothing/head/collectable/tophat/badmin_magic_hat, /obj/item/clothing/head/wizard/tophat) - (subtypesof(/obj/item/clothing/head/helmet) + subtypesof(/obj/item/clothing/head/helmet/space)))
 
 /obj/random/cloth/gloves
 	name = "random gloves"

--- a/code/modules/clothing/head/wiz_tophat.dm
+++ b/code/modules/clothing/head/wiz_tophat.dm
@@ -297,7 +297,7 @@ var/global/list/tophats_list = list()
 			else
 				visible_message("<span class='warning'>[src] jumps out of [M_loc]!</span>")
 
-			M_loc.drop_from_inventory(src, M_loc)
+			M_loc.drop_from_inventory(src, M_loc.loc)
 
 			return jump_out(rec_level = rec_level - 1)
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений

Исправил:
- То что шляпу мага можно было найти в мусоре
- То что шляпу мага можно было засаммонить внутри шляпы мага из-за чего маг не мог выбраться из шляпы мага
- То что шляпа мага могла застрять в игроке если он положил её в контейнер внутри контейнера

## Почему и что этот ПР улучшит

Меньше багов

## Авторство

## Чеинжлог
:cl: Luduk
- bugfix: Шляпу мага(Wabbajack Hat) больше нельзя найти в мусоре.
- bugfix: Шляпу мага(Wabbajack Hat) нельзя засаммонить с помощью Summon Item спелла будучи внутри шляпы мага.
- bugfix: Шляпа мага(Wabbajack Hat) не застревает в куклах если вылезать из неё пока она в контейнере внутри контейнера.