### PR TITLE
Фикс Cannot execute null.ClientLogout()

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -307,7 +307,7 @@ var/list/blacklisted_builds = list(
 	if(holder)
 		holder.owner = null
 		admins -= src
-	global.ahelp_tickets.ClientLogout(src)
+	global.ahelp_tickets?.ClientLogout(src)
 	directory -= ckey
 	mentors -= src
 	clients -= src

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -160,7 +160,7 @@ var/list/blacklisted_builds = list(
 	clients += src
 	directory[ckey] = src
 
-	global.ahelp_tickets.ClientLogin(src)
+	global.ahelp_tickets?.ClientLogin(src)
 
 	//Admin Authorisation
 	holder = admin_datums[ckey]


### PR DESCRIPTION
```
Runtime in client procs.dm,310: Cannot execute null.ClientLogout().
  proc name: Del (/client/Del)
  src: Ckey (/client)
  call stack:
  Ckey (/client): Del()
  Ckey (/client): Del()
```
<hr>

```
Runtime in client procs.dm,163: Cannot execute null.ClientLogin().
  proc name: New (/client/New)
  src: Ckey (/client)
  call stack:
  Ckey (/client): New(null)
  Ckey (/client): New()
```
