### PR TITLE
"Водяной пистолет стал быстрее"

### DIFF
--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -467,3 +467,6 @@
 	origin_tech = "combat=1;materials=1"
 	spray_size = 4
 	spray_sizes = list(4)
+
+	spray_cloud_move_delay = 1
+	spray_cloud_react_delay = 0


### PR DESCRIPTION
## Описание изменений

Из-за меня эту классную фичу зажали, и я не хочу чтобы это было так.

Водяной пистолетик делает пшик-пшик очень быстро, в отличии от спрея.

![U5ObeqXeZw](https://user-images.githubusercontent.com/17705613/71836146-14d96d80-30bc-11ea-955b-93faab6affa0.gif)

## Почему и что этот ПР улучшит

"Водяной пистолет получил еще одну компенсацию своей слабости и стал оружием фана и доминирования. Поскользнуться на его лужах у меня все равно не удалось."

## Авторство

#3792

(в ченжлоге меня попросили не указывать автора)

## Чеинжлог
:cl: Anonymous
- balance: Изменена скорость водяного пистолета.