### PR TITLE
Fixes sechud displaying agent card's assignment as an unknown profession.

### DIFF
--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -519,7 +519,7 @@
 	return joblist + list("Prisoner")
 
 /obj/proc/GetJobName() //Used in secHUD icon generation
-	if (!istype(src, /obj/item/device/pda) && !istype(src,/obj/item/weapon/card/id))
+	if (!istype(src, /obj/item/device/pda) && !istype(src,/obj/item/weapon/card/id) && !istype(src,/obj/item/weapon/card/id/syndicate))
 		return
 
 	var/jobName
@@ -533,6 +533,10 @@
 		var/obj/item/weapon/card/id/I = src
 		jobName = I.rank
 		alt = I.assignment
+	if(istype(src, /obj/item/weapon/card/id/syndicate))
+		var/obj/item/weapon/card/id/syndicate/S = src
+		jobName = S.assignment
+		alt = S.assignment
 	if(alt in get_alternate_titles(jobName))
 		return alt
 	if(jobName in get_all_job_icons()) //Check if the job has a hud icon

--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -519,7 +519,7 @@
 	return joblist + list("Prisoner")
 
 /obj/proc/GetJobName() //Used in secHUD icon generation
-	if (!istype(src, /obj/item/device/pda) && !istype(src,/obj/item/weapon/card/id) && !istype(src,/obj/item/weapon/card/id/syndicate))
+	if (!istype(src, /obj/item/device/pda) && !istype(src,/obj/item/weapon/card/id))
 		return
 
 	var/jobName


### PR DESCRIPTION
## Описание изменений
fixes #4233

Проверял на локалке

## Чеинжлог
:cl:
 - bugfix: Трейторская карта агента снова распознаётся на секхудах значком заданной игроком профессии.