### PR TITLE
fixed nades

### DIFF
--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -54,12 +54,20 @@
 		user.remove_from_mob(det)
 		det.loc = src
 		detonator = det
+		if(istimer(det.a_left))
+			var/obj/item/device/assembly/timer/T = det.a_left
+			det_time = T.time * 10
+		else if(istimer(det.a_right))
+			var/obj/item/device/assembly/timer/T = det.a_right
+			det_time = T.time * 10
 		icon_state = initial(icon_state) +"_ass"
 		name = "unsecured grenade with [beakers.len] containers[detonator?" and detonator":""]"
 		stage = 1
 	else if(isscrewdriver(W) && path != 2)
 		if(stage == 1)
 			path = 1
+			if(!detonator)
+				det_time = 1
 			if(beakers.len)
 				to_chat(user, "<span class='notice'>You lock the assembly.</span>")
 				name = "grenade"

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -26,7 +26,8 @@
 
 /obj/item/weapon/grenade/examine(mob/user)
 	..()
-	to_chat(user, "The timer is set [det_time = 1 ? "for instant detonation" : "to [det_time/10]  seconds"].")
+	if(!istype(src, /obj/item/weapon/grenade/cancasing)) // ghetto bomb examine verb: > You can't tell when it will explode!
+		to_chat(user, "The timer is set [det_time == 1 ? "for instant detonation" : "to [det_time/10]  seconds"].")
 
 /obj/item/weapon/grenade/attack_self(mob/user)
 	if(active)
@@ -34,7 +35,7 @@
 	if(!clown_check(user))
 		return
 
-	to_chat(user, "<span class='warning'>You prime \the [name]! [det_time/10] seconds!</span>")
+	to_chat(user, "<span class='warning'>You prime \the [name]![det_time != 1 ? " [det_time/10] seconds!" : ""]</span>")
 	activate(user)
 	add_fingerprint(user)
 	if(iscarbon(user))

--- a/code/game/objects/items/weapons/grenades/smokebomb.dm
+++ b/code/game/objects/items/weapons/grenades/smokebomb.dm
@@ -15,7 +15,7 @@
 
 /obj/item/weapon/grenade/smokebomb/prime()
 	playsound(src, 'sound/effects/smoke.ogg', VOL_EFFECTS_MASTER, null, null, -3)
-	smoke.set_up(10, 0, usr.loc)
+	smoke.set_up(10, 0, src.loc)
 	spawn(0)
 		smoke.start()
 		sleep(10)


### PR DESCRIPTION
## Описание изменений
Пофиксил рантайм ошибку которая приводила к тому, что самодельные гранаты не взрывались после экзамайна (привет @FelixRuin)
Теперь нельзя посмотреть время активации иеда (как и задумывалось, судя по его экзамайн проку)
Пофиксил рантайм ошибку в дымовой гранате которая не позволяла ей взорваться

## Почему и что этот ПР улучшит
fixes #4452, fixes #4467 

## Авторство

## Чеинжлог
:cl: Getup1
- bugfix: Самодельные гранаты снова работают исправно!
