### PR TITLE
Исправлен вывод проверки своего здоровья

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -247,7 +247,7 @@
 					status = "weirdly shapen."
 				if(status == "")
 					status = "OK"
-				to_chat("\t <span class='[status == "OK" ? "notice " : "warning"]'>My [BPname] is [status].</span>")
+				to_chat(src, "\t <span class='[status == "OK" ? "notice " : "warning"]'>My [BPname] is [status].</span>")
 
 			if(roundstart_quirks.len)
 				to_chat(src, "<span class='notice'>You have these traits: [get_trait_string()].</span>")


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Был пропушен аргумент в выводе своего здоровья, поправил.
## Почему и что этот ПР улучшит
Close #4470 
## Авторство
TechCat
## Чеинжлог
:cl: TechCat
 - bugfix: Самодиагонстика теперь работает