### PR TITLE
Fixing explicit rand() float usages

### DIFF
--- a/code/modules/power/fusion/core/core_field.dm
+++ b/code/modules/power/fusion/core/core_field.dm
@@ -187,7 +187,7 @@
 			if(percent_unstable > 1)
 				percent_unstable = 1
 			if(percent_unstable > 0)
-				percent_unstable = max(0, percent_unstable - rand(0.01, 0.03))
+				percent_unstable = max(0, percent_unstable - rand(10, 30) * 0.001)
 
 	if(percent_unstable >= 1)
 		owned_core.Shutdown(force_rupture = 1)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -469,7 +469,7 @@
 			s.start()
 			//if(!user.mutations & COLD_RESISTANCE)
 			if (prob(75))
-				electrocute_mob(user, get_area(src), src, rand(0.7,1.0))
+				electrocute_mob(user, get_area(src), src, rand(70, 100) * 0.01)
 
 
 // returns whether this light has power


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений

В целых двух местах в билде явно указывались rand() с флоатами, но он работает только с целочисленными.

## Почему и что этот ПР улучшит

Вероятно ничего если никто этого не заметил.
