### PR TITLE
Убрана орбита обзервера со статпанели

### DIFF
--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -25,7 +25,7 @@
 		to_chat(src, "<span class='notice'>You will no longer interact with machines you click on.</span>")
 
 /mob/dead/observer/DblClickOn(atom/A, params)
-	if(client.buildmode) // handled in normal click.
+	if(client.buildmode || istype(A, /obj/effect/statclick)) // handled in normal click.
 		return
 	if(can_reenter_corpse && mind && mind.current)
 		if(A == mind.current || (mind.current in A)) // double click your corpse or whatever holds it


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Кнопки на панели со статистикой это объекты. Добавил в исключения при орбите на atom.
## Почему и что этот ПР улучшит
Fix #4492 
## Авторство
TechCat
