### PR TITLE
Стилистические правки отправки на мостик

### DIFF
--- a/code/game/machinery/fax.dm
+++ b/code/game/machinery/fax.dm
@@ -197,7 +197,7 @@ var/list/alldepartments = list("Central Command")
 	world.send2bridge(
 		type = list(BRIDGE_ADMINCOM),
 		attachment_title = ":fax: **[key_name(sender)]** sent fax to ***Centcomm***",
-		attachment_msg = strip_html_properly(replacetext(replacetext((P.info + P.stamp_text), "<br>", "\n"), "<hr>", "\n")),
+		attachment_msg = strip_html_properly(replace_characters(P.info + P.stamp_text, list("<br>"="\n", "<hr>"="\n"))),
 		attachment_color = BRIDGE_COLOR_ADMINCOM,
 	)
 

--- a/code/game/machinery/fax.dm
+++ b/code/game/machinery/fax.dm
@@ -197,7 +197,7 @@ var/list/alldepartments = list("Central Command")
 	world.send2bridge(
 		type = list(BRIDGE_ADMINCOM),
 		attachment_title = ":fax: **[key_name(sender)]** sent fax to ***Centcomm***",
-		attachment_msg = strip_html_properly(replace_characters(P.info + "\n" + P.stamp_text, list("<br>"="\n", "<hr>"="\n"))),
+		attachment_msg = strip_html_properly(replacetext((P.info + "\n" + P.stamp_text),"<br>", "\n")),
 		attachment_color = BRIDGE_COLOR_ADMINCOM,
 	)
 

--- a/code/game/machinery/fax.dm
+++ b/code/game/machinery/fax.dm
@@ -197,7 +197,7 @@ var/list/alldepartments = list("Central Command")
 	world.send2bridge(
 		type = list(BRIDGE_ADMINCOM),
 		attachment_title = ":fax: **[key_name(sender)]** sent fax to ***Centcomm***",
-		attachment_msg = strip_html_properly(replace_characters(P.info + P.stamp_text, list("<br>"="\n", "<hr>"="\n"))),
+		attachment_msg = strip_html_properly(replace_characters(P.info + "\n" + P.stamp_text, list("<br>"="\n", "<hr>"="\n"))),
 		attachment_color = BRIDGE_COLOR_ADMINCOM,
 	)
 

--- a/code/game/machinery/fax.dm
+++ b/code/game/machinery/fax.dm
@@ -197,7 +197,7 @@ var/list/alldepartments = list("Central Command")
 	world.send2bridge(
 		type = list(BRIDGE_ADMINCOM),
 		attachment_title = ":fax: **[key_name(sender)]** sent fax to ***Centcomm***",
-		attachment_msg = strip_html_properly(replacetext((P.info + P.stamp_text), "<br>", "\n")),
+		attachment_msg = strip_html_properly(replacetext(replacetext((P.info + P.stamp_text), "<br>", "\n"), "<hr>", "\n")),
 		attachment_color = BRIDGE_COLOR_ADMINCOM,
 	)
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1133,7 +1133,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	message_admins("Fax message was created by [key_name_admin(usr)] and sent to [department]")
 	world.send2bridge(
 		type = list(BRIDGE_ADMINCOM),
-		attachment_title = ":fax: Fax message was created by **[key_name_admin(usr)]** and sent to ***[department]***",
+		attachment_title = ":fax: Fax message was created by **[key_name(usr)]** and sent to ***[department]***",
 		attachment_msg = sent_text,
 		attachment_color = BRIDGE_COLOR_ADMINCOM,
 	)

--- a/code/modules/bridge/chat_bridge.dm
+++ b/code/modules/bridge/chat_bridge.dm
@@ -25,7 +25,7 @@
 	if(mention)
 		json["mention"] = mention
 
-	var/encoded_json = replacetext(list2json(json), "'", "`")//todo: replace on json_encode() after unicode update
+	var/encoded_json = replacetext(list2json(json), "'", "\`")//todo: replace on json_encode() after unicode update
 	//world.log << "send2bridge json: [encoded_json]"
 
 	spawn()

--- a/code/modules/bridge/chat_bridge.dm
+++ b/code/modules/bridge/chat_bridge.dm
@@ -4,7 +4,7 @@
 		return 0
 
 	var/list/json = list()
-	
+
 	json["type"] = type
 
 	if(msg)
@@ -25,7 +25,7 @@
 	if(mention)
 		json["mention"] = mention
 
-	var/encoded_json = replacetext(list2json(json), "'", "\`")//todo: replace on json_encode() after unicode update
+	var/encoded_json = replacetext(list2json(json), "'", "\\`")//todo: replace on json_encode() after unicode update
 	//world.log << "send2bridge json: [encoded_json]"
 
 	spawn()


### PR DESCRIPTION
## Описание изменений
Добавлено экранирование для символа \`, ибо Markdown.
Добавлена замена `<hr>` на `\n`. Улучшит поведение штампов и текста и не только.
Заменен метод вывода CKEY администратора, отправившего факс.
## Почему и что этот ПР улучшит
Не будет странного форматирования в уведомлениях от сервера в Discord
## Чеинжлог
Он не нужен