### PR TITLE
OOC color normalization

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -828,16 +828,6 @@ The _flatIcons list is a cache for generated icon files.
 		composite.Blend(icon(I.icon, I.icon_state, I.dir, 1), ICON_OVERLAY)
 	return composite
 
-/proc/adjust_brightness(color, value)
-	if (!color) return "#ffffff"
-	if (!value) return color
-
-	var/list/RGB = ReadRGB(color)
-	RGB[1] = CLAMP(RGB[1]+value,0,255)
-	RGB[2] = CLAMP(RGB[2]+value,0,255)
-	RGB[3] = CLAMP(RGB[3]+value,0,255)
-	return rgb(RGB[1],RGB[2],RGB[3])
-
 /proc/sort_atoms_by_layer(list/atoms)
 	// Comb sort icons based on levels
 	var/list/result = atoms.Copy()

--- a/code/__HELPERS/normalize.dm
+++ b/code/__HELPERS/normalize.dm
@@ -29,3 +29,13 @@
 	//Set complete normalize hex color
 	final_hex = "#" + rh_color + gh_color + bh_color
 	return final_hex
+
+/proc/adjust_brightness(color, value)
+	if (!color) return "#ffffff"
+	if (!value) return color
+
+	var/list/RGB = ReadRGB(color)
+	RGB[1] = CLAMP(RGB[1]+value,0,255)
+	RGB[2] = CLAMP(RGB[2]+value,0,255)
+	RGB[3] = CLAMP(RGB[3]+value,0,255)
+	return rgb(RGB[1],RGB[2],RGB[3])

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -104,7 +104,7 @@ var/global/bridge_ooc_colour = "#7b804f"
 
 	var/new_ooccolor = input(src, "Please select your OOC colour.", "OOC colour") as color|null
 	if(new_ooccolor)
-		prefs.ooccolor = new_ooccolor
+		prefs.ooccolor = normalize_color(new_ooccolor)
 		prefs.save_preferences()
 
 /client/verb/looc(msg as text)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -490,7 +490,7 @@ var/list/admin_verbs_hideable = list(
 		to_chat(usr, "<span class='warning'>Currently disabled by config.</span>")
 	var/new_aooccolor = input(src, "Please select your OOC colour.", "OOC colour") as color|null
 	if(new_aooccolor)
-		prefs.aooccolor = new_aooccolor
+		prefs.aooccolor = normalize_color(new_aooccolor)
 		prefs.save_preferences()
 	feedback_add_details("admin_verb","OC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	return

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -157,8 +157,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		update_preferences(needs_update, S) // needs_update = savefile_version if we need an update (positive integer)
 
 	//Sanitize
-	ooccolor		= sanitize_hexcolor(ooccolor, initial(ooccolor))
-	aooccolor		= sanitize_hexcolor(aooccolor, initial(aooccolor))
+	ooccolor		= normalize_color(sanitize_hexcolor(ooccolor, initial(ooccolor)))
+	aooccolor		= normalize_color(sanitize_hexcolor(aooccolor, initial(aooccolor)))
 	lastchangelog	= sanitize_text(lastchangelog, initial(lastchangelog))
 	UI_style		= sanitize_inlist(UI_style, global.available_ui_styles, global.available_ui_styles[1])
 	default_slot	= sanitize_integer(default_slot, 1, MAX_SAVE_SLOTS, initial(default_slot))


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений

"Нормализация" OOC-цветов, выставляемых админами и патронами. Больше не будут слишком яркими. Вроде бы.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
- fix: Белфогор больше не ругается