### PR TITLE
Отдельный таймер задержки для рестарт воута

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -269,8 +269,9 @@ var/datum/subsystem/ticker/ticker
 			//Deleting Startpoints but we need the ai point to AI-ize people later
 			if (S.name != "AI")
 				qdel(S)
-
-		SSvote.started_time = world.time
+		if (length(SSvote.delay_after_start))
+			for (var/DT in SSvote.delay_after_start)
+				SSvote.last_vote_time[DT] = world.time
 
 		//Print a list of antagonists to the server log
 		antagonist_announce()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Добавляет отдельный таймер между голосованиями для рестарта.
## Почему и что этот ПР улучшит
Голосование за рестарт больше не будет блокировать голосование за крю трансфер.
Close #4513 
## Авторство
TechCat
## Чеинжлог
:cl: TechCat
 - tweak: Голосование за рестарт не блокирует крю трансфер