### PR TITLE
Установлены округления для значения урона куклы

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -70,7 +70,7 @@
 		if(BP.is_robotic() && !BP.vital)
 			continue // robot limbs don't count towards shock and crit
 		amount += BP.brute_dam
-	return amount
+	return round(amount, 0.01)
 
 /mob/living/carbon/human/adjustBruteLoss(amount)
 	if(amount > 0)
@@ -86,7 +86,7 @@
 		if(BP.is_robotic() && !BP.vital)
 			continue // robot limbs don't count towards shock and crit
 		amount += BP.burn_dam
-	return amount
+	return round(amount, 0.01)
 
 /mob/living/carbon/human/adjustFireLoss(amount)
 	if(amount > 0)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Убраны очень маленькие значения из отображения урона куклы. Больше не будет в интерфейсах страшных чисел вида 0.00000000234454385354.
## Почему и что этот ПР улучшит
Close #4312 
## Авторство
TechCat
## Чеинжлог
:cl: TechCat
 - bugfix: Точность показаний слипера и сканера 0.01%