### PR TITLE
Огнетушитель в мехе не выкидывает куклу

### DIFF
--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -257,8 +257,15 @@
 		ext.afterattack(target, chassis.occupant)
 	return 1
 
+/obj/item/mecha_parts/mecha_equipment/tool/extinguisher/Topic(href, href_list)
+	..()
+	if (href_list["switch"])
+		ext.safety = !ext.safety
+		occupant_message("The [name] now [ext.safety ? "locked" : "ready"].")
+		update_equip_info()
+
 /obj/item/mecha_parts/mecha_equipment/tool/extinguisher/get_equip_info()
-	return "[..()] \[[ext.reagents.total_volume]\]"
+	return "[..()] \[[ext.reagents.total_volume]\]\[<a href='?src=\ref[src];switch=1'>[src.ext.safety ? "Safe" : "Ready"]</a>\]"
 
 /obj/item/mecha_parts/mecha_equipment/tool/extinguisher/on_reagent_change()
 	return

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -134,6 +134,10 @@
 			step(buckled_to, movementdirection)
 			sleep(3)
 			step(buckled_to, movementdirection)
+	else if (loc && istype(loc, /obj/item/mecha_parts/mecha_equipment/tool/extinguisher))
+		var/obj/item/mecha_parts/mecha_equipment/tool/extinguisher/ext = loc
+		if (ext.chassis)
+			ext.chassis.newtonian_move(movementdirection)
 	else
 		user.newtonian_move(movementdirection)
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Исправлен баг с использованием в космосе огнетушителя на мехе. Добавлена возможность снять лок с него, изначально не было возможности включить/отключить лок безопасности на огнетушителе. В космосе корректно перемещает мех, а не куклу в нем, в случае использования огнетушителя.
## Почему и что этот ПР улучшит
Fix #4371 
## Авторство
TechCat
## Чеинжлог
:cl: TechCat
 - bugfix: Огнетушитель в мехе можно включить
 - bugfix: Использование огнетушителя меха в космосе работает корректно