### PR TITLE
Ризон мута корректно записывается в заметки игрока.

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -218,7 +218,7 @@
 			to_chat(M, "<span class='notice'>You have been [mute_string] unmuted from [usr.key].</span>")
 	else
 		if(alert("Would you like to make it permament?","Permamute?","Yes","No, round only") == "Yes")
-			var/permmutreason = input("Permamute Reason") as text
+			var/permmutreason = input("Permamute Reason") as text|null
 			if(permmutreason)
 				muteunmute = "permamuted"
 				M.client.prefs.permamuted |= mute_type
@@ -232,7 +232,7 @@
 				return
 
 		else if (alert("Add a notice for round mute?", "Mute Notice?", "Yes","No") == "Yes")
-			var/mutereason = input("Mute Reason") as text
+			var/mutereason = input("Mute Reason") as text|null
 			if(mutereason)
 				notes_add(M.key, "Muted from [mute_string]: [mutereason]", usr.client)
 				mutereason = sanitize(mutereason)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Ризон мута стал записываться в заметки игрока. 

## Почему и что этот ПР улучшит
Удобство при работе. 
close #4444

## Авторство

## Чеинжлог
:cl: 
- bugfix: Ризон мута стал записываться в заметки игрока. 