### PR TITLE
Запрещены голосования до запуска подсистем

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -545,19 +545,10 @@ var/datum/subsystem/ticker/ticker
 	return TRUE
 
 /world/proc/has_round_started()
-	if (ticker && ticker.current_state >= GAME_STATE_PLAYING)
-		return TRUE
-	return FALSE
+	return (ticker && ticker.current_state >= GAME_STATE_PLAYING)
 
 /world/proc/has_round_finished()
-	if (ticker && ticker.current_state >= GAME_STATE_FINISHED)
-		return TRUE
-	return FALSE
+	return (ticker && ticker.current_state >= GAME_STATE_FINISHED)
 
-/world/proc/has_round_preparing()
-	if (ticker && ticker.current_state <= GAME_STATE_SETTING_UP)
-		return TRUE
-	// Still no intialized?
-	else if(!ticker)
-		return TRUE
-	return FALSE
+/world/proc/is_round_preparing()
+	return (ticker && ticker.current_state == GAME_STATE_PREGAME)

--- a/code/controllers/subsystem/voting.dm
+++ b/code/controllers/subsystem/voting.dm
@@ -288,7 +288,7 @@ var/datum/subsystem/vote/SSvote
 			. += "\t(<a href='?src=\ref[src];vote=toggle_crew'>[config.allow_vote_mode?"Allowed":"Disallowed"]</a>)"
 		. += "</li><li>"
 		//gamemode
-		if(admin || config.allow_vote_mode && world.has_round_preparing())
+		if(admin || config.allow_vote_mode && world.is_round_preparing())
 			. += "<a href='?src=\ref[src];vote=gamemode'>GameMode</a>"
 		else
 			. += "<font color='grey'>GameMode (Disallowed)</font>"
@@ -325,17 +325,14 @@ var/datum/subsystem/vote/SSvote
 			if(usr.client.holder)
 				config.allow_vote_mode = !config.allow_vote_mode
 		if("restart")
-			if(config.allow_vote_restart || usr.client.holder)
-				if(!SSshuttle.online && SSshuttle.location == 0)
-					initiate_vote("restart",usr.key)
+			if((config.allow_vote_restart || usr.client.holder) && !SSshuttle.online && SSshuttle.location == 0)
+				initiate_vote("restart",usr.key)
 		if("crew_transfer")
-			if(config.allow_vote_mode || usr.client.holder)
-				if(crew_transfer_available())
-					initiate_vote("crew_transfer",usr.key)
+			if((config.allow_vote_mode || usr.client.holder) && crew_transfer_available())
+				initiate_vote("crew_transfer",usr.key)
 		if("gamemode")
-			if(config.allow_vote_mode || usr.client.holder)
-				if(world.has_round_preparing())
-					initiate_vote("gamemode",usr.key)
+			if((config.allow_vote_mode || usr.client.holder) && world.is_round_preparing())
+				initiate_vote("gamemode",usr.key)
 		if("custom")
 			if(usr.client.holder)
 				initiate_vote("custom",usr.key)
@@ -359,6 +356,4 @@ var/datum/subsystem/vote/SSvote
 		ooc_allowed = TRUE
 
 /datum/subsystem/vote/proc/crew_transfer_available()
-	if (world.has_round_started() && !world.has_round_finished() && !SSshuttle.online && SSshuttle.location == 0)
-		return TRUE
-	return FALSE
+	return (world.has_round_started() && !world.has_round_finished() && !SSshuttle.online && SSshuttle.location == 0)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -78,7 +78,7 @@ commented cause polls are kinda broken now, needs refactoring */
 	if(statpanel("Lobby"))
 		stat("Game Mode:", (ticker.hide_mode) ? "Secret" : "[master_mode]")
 
-		if(ticker.current_state == GAME_STATE_PREGAME)
+		if(world.is_round_preparing())
 			stat("Time To Start:", (ticker.timeLeft >= 0) ? "[round(ticker.timeLeft / 10)]s" : "DELAYED")
 
 			stat("Players:", "[ticker.totalPlayers]")


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Для пользователей запрещен запуск голосований до инициализации подсистем. Со сторны администраторов осталась возможность запуска своего голосования или голосования за перезагрузку. Если запустить до старта подсистем их просто не будет работать показ таймера голосования, остальное работает корректно.
## Почему и что этот ПР улучшит
Исправляет неполный список режимов в голосовании и блокирует потенциальные баги.
## Авторство
TechCat
## Чеинжлог
:cl: TechCat
 - bugfix: Запуск голосования во время загрузки сервера запрещен