### PR TITLE
Исправление несмываемой крови на предметах в инвентаре

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -908,11 +908,13 @@
 	return
 
 /obj/item/clean_blood()
-	. = ..()
+	. = ..() // FIX: If item is `uncleanable` we shouldn't nullify `dirt_overlay`
 	if(uncleanable)
 		return
 	if(blood_overlay)
-		overlays.Remove(blood_overlay)
+		cut_overlay(blood_overlay)
+		blood_overlay.color = null
+		blood_overlay = null
 	if(istype(src, /obj/item/clothing/gloves))
 		var/obj/item/clothing/gloves/G = src
 		G.transfer_blood = 0
@@ -923,7 +925,7 @@
 	..()
 	if(dirt_overlay)
 		if(blood_overlay.color != dirt_overlay.color)
-			overlays.Remove(blood_overlay)
+			cut_overlay(blood_overlay)
 			blood_overlay.color = dirt_overlay.color
 			add_overlay(blood_overlay)
 


### PR DESCRIPTION
## Описание изменений
Удаление оверлея крови с картинок предметов в инвентаре теперь происходит с помощью SSoverlays.

Closes #4473 
Closes #4358 
Closes #4325 
Closes #2831 

## Почему и что этот ПР улучшит
Кровь/грязь при смывании удалялись с точки зрения механики игры, а также удалялись с куклы игрока. Но оставались на предметах в его инвентаре. Данный ПР это исправляет.

## Changelog
:cl:
 - bugfix: Теперь кровь смывается и с предметов в инвентаре.