### PR TITLE
No more talking when in crit.

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1158,7 +1158,7 @@
 			stat = UNCONSCIOUS
 			if(halloss > 0)
 				adjustHalLoss(-3)
-		if(IsSleeping())
+		else if(IsSleeping())
 			blinded = TRUE
 		//CONSCIOUS
 		else


### PR DESCRIPTION
## Описание изменений

Люди в параличе("крите") не могут говорить.

(для программистов, и тех кого касается:)

из-за отсутствия вот такого ветвления паралич накидывал stat = UNCONSCIOUS, а потом он ниже сразу и снимался.

## Почему и что этот ПР улучшит

Люди в параличе не могут говорить, как и не могли до ПР-а на реворк слипа.
