### PR TITLE
Добавлен вывод банов из базы в нотисы

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -21,6 +21,13 @@
 #define BANTYPE_ANY_FULLBAN	5 //used to locate stuff to unban.
 #define BANTYPE_ANY_JOB		9 //used to remove jobbans
 
+#define BANTYPE_PERMA_STR		"PERMABAN"
+#define BANTYPE_TEMP_STR		"TEMPBAN"
+#define BANTYPE_JOB_PERMA_STR	"JOB_PERMABAN"
+#define BANTYPE_JOB_TEMP_STR	"JOB_TEMPBAN"
+#define BANTYPE_ANY_FULLBAN_STR	"ANY"
+#define BANTYPE_ANY_JOB_STR		"ANYJOB"
+
 //Please don't edit these values without speaking to Errorage first	~Carn
 //Admin Permissions
 #define R_BUILDMODE		1

--- a/code/__HELPERS/time.dm
+++ b/code/__HELPERS/time.dm
@@ -102,3 +102,6 @@ var/last_round_duration = 0
 	if(hour)
 		hourT = " and [hour] hour[(hour != 1)? "s":""]"
 	return "[day] day[(day != 1)? "s":""][hourT][minuteT][secondT]"
+
+/proc/is_leap_year(year)
+	return (year && isnum(year) && (((year % 400) == 0) || ((year % 100 != 0) && (year % 4 == 0))))

--- a/code/modules/admin/DB ban/functions.dm
+++ b/code/modules/admin/DB ban/functions.dm
@@ -14,18 +14,18 @@
 	var/bantype_str
 	switch(bantype)
 		if(BANTYPE_PERMA)
-			bantype_str = "PERMABAN"
+			bantype_str = BANTYPE_PERMA_STR
 			duration = -1
 			bantype_pass = 1
 		if(BANTYPE_TEMP)
-			bantype_str = "TEMPBAN"
+			bantype_str = BANTYPE_TEMP_STR
 			bantype_pass = 1
 		if(BANTYPE_JOB_PERMA)
-			bantype_str = "JOB_PERMABAN"
+			bantype_str = BANTYPE_JOB_PERMA_STR
 			duration = -1
 			bantype_pass = 1
 		if(BANTYPE_JOB_TEMP)
-			bantype_str = "JOB_TEMPBAN"
+			bantype_str = BANTYPE_JOB_TEMP_STR
 			bantype_pass = 1
 	if( !bantype_pass ) return
 	if( !istext(reason) ) return
@@ -108,22 +108,22 @@
 		var/bantype_pass = 0
 		switch(bantype)
 			if(BANTYPE_PERMA)
-				bantype_str = "PERMABAN"
+				bantype_str = BANTYPE_PERMA_STR
 				bantype_pass = 1
 			if(BANTYPE_TEMP)
-				bantype_str = "TEMPBAN"
+				bantype_str = BANTYPE_TEMP_STR
 				bantype_pass = 1
 			if(BANTYPE_JOB_PERMA)
-				bantype_str = "JOB_PERMABAN"
+				bantype_str = BANTYPE_JOB_PERMA_STR
 				bantype_pass = 1
 			if(BANTYPE_JOB_TEMP)
-				bantype_str = "JOB_TEMPBAN"
+				bantype_str = BANTYPE_JOB_TEMP_STR
 				bantype_pass = 1
 			if(BANTYPE_ANY_FULLBAN)
-				bantype_str = "ANY"
+				bantype_str = BANTYPE_ANY_FULLBAN_STR
 				bantype_pass = 1
 			if(BANTYPE_ANY_JOB)
-				bantype_str = "ANYJOB"
+				bantype_str = BANTYPE_ANY_JOB_STR
 				bantype_pass = 1
 		if( !bantype_pass ) return
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -188,10 +188,41 @@ proc/message_admins(msg, reg_flag = R_ADMIN)
 	feedback_add_details("admin_verb","SPP") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 
-/datum/player_info/var/author // admin who authored the information
-/datum/player_info/var/rank //rank of admin who made the notes
-/datum/player_info/var/content // text content of the information
-/datum/player_info/var/timestamp // Because this is bloody annoying
+#define PLAYER_INFO_MISSING_CONTENT_TEXT    "Missing Data"
+#define PLAYER_INFO_MISSING_AUTHOR_TEXT     "N/A"
+#define PLAYER_INFO_MISSING_RANK_TEXT       "N/A"
+#define PLAYER_INFO_MISSING_TIMESTAMP_TEXT  "N/A"
+#define PLAYER_INFO_MISSING_JOB_TEXT        "N/A"
+
+/datum/player_info
+	var/author     // admin who authored the information
+	var/rank       // rank of admin who made the notes
+	var/content    // text content of the information
+	var/timestamp  // Because this is bloody annoying
+
+/datum/player_info/proc/get_days_timestamp()
+	if (!timestamp || timestamp == PLAYER_INFO_MISSING_TIMESTAMP_TEXT)
+		return 0
+	return parse_notes_date_timestamp(timestamp)
+
+/datum/player_info/proc/get_remove_index()
+	return 0
+
+/datum/player_info/indexed
+	var/remove_index
+
+/datum/player_info/indexed/get_remove_index()
+	return remove_index
+
+/datum/player_info/outside
+	author = PLAYER_INFO_MISSING_AUTHOR_TEXT
+	rank = PLAYER_INFO_MISSING_RANK_TEXT
+	content = PLAYER_INFO_MISSING_CONTENT_TEXT
+	timestamp = PLAYER_INFO_MISSING_TIMESTAMP_TEXT
+	var/days_timestamp = 0 // number of day after 1 Jan 2000
+
+/datum/player_info/outside/get_days_timestamp()
+	return isnum(days_timestamp) ? days_timestamp : 0
 
 #define PLAYER_NOTES_ENTRIES_PER_PAGE 50
 /datum/admins/proc/PlayerNotes()
@@ -209,7 +240,7 @@ proc/message_admins(msg, reg_flag = R_ADMIN)
 	var/savefile/S=new("data/player_notes.sav")
 	var/list/note_keys
 	S >> note_keys
-	if(!note_keys)
+	if(!length(note_keys))
 		dat += "No notes found."
 	else
 		dat += "<table>"
@@ -242,28 +273,26 @@ proc/message_admins(msg, reg_flag = R_ADMIN)
 				dat += "</b>"
 
 	usr << browse(entity_ja(dat), "window=player_notes;size=400x400")
-
+#undef PLAYER_NOTES_ENTRIES_PER_PAGE
 
 /datum/admins/proc/player_has_info(key)
 	var/savefile/info = new("data/player_saves/[copytext(key, 1, 2)]/[key]/info.sav")
 	var/list/infos
 	info >> infos
-	if(!infos || !infos.len) return 0
-	else return 1
-
+	return (length(infos))
 
 /datum/admins/proc/show_player_info(key as text)
 	set category = "Admin"
 	set name = "Show Player Info"
-	key = ckey(key)
-	if (!istype(src,/datum/admins))
+
+	// Check admin rights
+	if(!istype(src,/datum/admins))
 		src = usr.client.holder
-	if (!istype(src,/datum/admins))
+	if(!istype(src,/datum/admins))
 		to_chat(usr, "Error: you are not an admin!")
 		return
-	var/dat = "<html><head><title>Info on [key]</title></head>"
-	dat += "<body>"
 
+	key = ckey(key)
 	//Display player age and player warn bans
 	var/p_age
 	var/p_ingame_age
@@ -272,37 +301,174 @@ proc/message_admins(msg, reg_flag = R_ADMIN)
 			p_age = C.player_age
 			p_ingame_age = C.player_ingame_age
 
+	// Gather data
+	var/list/savefile_info = load_info_player_data(key)
+	var/list/db_info = load_info_player_data_db(key)
+	// Start render info page
+	var/dat = "<html><head><title>Info on [key]</title></head>"
+	dat += "<body>"
 	dat +="<span style='color:#000000; font-weight: bold'>Player age: [p_age] / In-game age: [p_ingame_age]</span><hr>"
 
-	var/savefile/info = new("data/player_saves/[copytext(key, 1, 2)]/[key]/info.sav")
-	var/list/infos
-	info >> infos
-	if(!infos)
+	if(!length(savefile_info) && !length(db_info))
 		dat += "No information found on the given key.<br>"
 	else
-		var/update_file = 0
-		var/i = 0
+		var/list/infos = generalized_players_info(savefile_info, db_info)
 		for(var/datum/player_info/I in infos)
-			i += 1
-			if(!I.timestamp)
-				I.timestamp = "Pre-4/3/2012"
-				update_file = 1
-			if(!I.rank)
-				I.rank = "N/A"
-				update_file = 1
 			dat += "<font color=#008800>[I.content]</font> <i>by [I.author] ([I.rank])</i> on <i><font color=blue>[I.timestamp]</i></font> "
-			if(I.author == usr.key || I.author == "Adminbot" || check_rights(R_PERMISSIONS, FALSE))
-				dat += "<A href='?src=\ref[src];remove_player_info=[key];remove_index=[i]'>Remove</A>"
+			if(I.get_remove_index() && (I.author == usr.key || I.author == "Adminbot" || check_rights(R_PERMISSIONS, FALSE)))
+				dat += "<A href='?src=\ref[src];remove_player_info=[key];remove_index=[I.get_remove_index()]'>Remove</A>"
 			dat += "<br><br>"
-		if(update_file)
-			info << infos
-
 	dat += "<br>"
 	dat += "<A href='?src=\ref[src];add_player_info=[key]'>Add Comment</A><br>"
-
 	dat += "</body></html>"
 	usr << browse(entity_ja(dat), "window=adminplayerinfo;size=480x480")
 
+/datum/admins/proc/generalized_players_info(list/file_notes, list/db_notes)
+	var/list/datum/player_info/merged = list()
+	var/index = 0
+	for(var/datum/player_info/P in file_notes)
+		var/datum/player_info/indexed/I = new()
+		index += 1
+		I.author = P.author
+		I.rank = P.rank
+		I.content = P.content
+		I.timestamp = P.timestamp
+		I.remove_index = index
+		merged += I
+	if(length(db_notes))
+		merged += db_notes
+	merged = sortMerge(merged, /proc/cmp_days_timestamp, FALSE)
+	return merged
+
+/proc/cmp_days_timestamp(datum/player_info/a, datum/player_info/b)
+	return a.get_days_timestamp() - b.get_days_timestamp()
+
+/datum/admins/proc/load_info_player_data(player_ckey)
+	if(!player_ckey)
+		return
+	var/savefile/info_file = new("data/player_saves/[copytext(player_ckey, 1, 2)]/[player_ckey]/info.sav")
+	var/list/data
+	info_file >> data
+	if(!length(data))
+		return
+	var/missing_fixed = FALSE
+	for(var/datum/player_info/I in data)
+		if(!I.timestamp)
+			I.timestamp = PLAYER_INFO_MISSING_TIMESTAMP_TEXT
+			missing_fixed = TRUE
+		if(!I.rank)
+			I.rank = PLAYER_INFO_MISSING_RANK_TEXT
+			missing_fixed = TRUE
+	if(missing_fixed)
+		info_file << data
+	return data
+
+/datum/admins/proc/load_info_player_data_db(player_ckey)
+	// Get player ckey and generate list of players_notes
+	// Return null if errors
+	var/list/db_player_notes = list()
+	if(!player_ckey || config.ban_legacy_system || !config.sql_enabled)
+		return
+	if(!establish_db_connection())
+		usr.show_message("Notes [player_ckey] from DB don't available.")
+		return
+	var/timestamp_format = "%a, %M %D of %Y"
+	var/days_ago_start_date = "1999-12-31"
+	var/list/sql_fields = list(
+		"a_ckey",
+		"bantype",
+		"reason",
+		"DATE_FORMAT(bantime, '[timestamp_format]')",
+		"ip",
+		"computerid",
+		"duration",
+		"job",
+		"DATEDIFF(bantime, '[days_ago_start_date]')",
+		"unbanned",
+		"DATE_FORMAT(unbanned_datetime, '[timestamp_format]')",
+		"DATEDIFF(unbanned_datetime, '[days_ago_start_date]')",
+		"unbanned_ckey",
+		"rounds"
+	 )
+	var/DBQuery/query = dbcon.NewQuery("SELECT " + sql_fields.Join(", ") + " FROM erro_ban WHERE (ckey = '[player_ckey]') ORDER BY id LIMIT 100")
+	if(!query.Execute())
+		return
+	while(query.NextRow())
+		var/datum/player_info/outside/notes_record = new()
+		var/datum/player_info/outside/unban_notes_record
+		var/list/ip_cid = list()
+		var/a_ckey = query.item[1]
+		var/bantype = query.item[2]
+		var/reason = query.item[3]
+		var/timestamp = query.item[4]
+		if(query.item[5])
+			ip_cid += query.item[5]
+		if(query.item[6])
+			ip_cid += query.item[6]
+		var/duration = text2num(query.item[7])
+		var/job = query.item[8] ? query.item[8] : PLAYER_INFO_MISSING_JOB_TEXT
+		var/days_ago = text2num(query.item[9])
+		var/is_unbanned = query.item[10] ? TRUE : FALSE
+		var/unbanned_timestamp = query.item[11]
+		var/unbanned_days_ago = text2num(query.item[12])
+		var/unbanned_a_ckey = query.item[13]
+		var/rounds_ban_counter = text2num(query.item[14])  // legacy field, but it can be in DB now
+
+		// -1 = perma, duration in minutes come
+		if(!duration)
+			duration = "N/A"
+		else if(duration < 0)
+			duration = "infinity"
+		else
+			duration = DisplayTimeText((duration MINUTE), 1)
+
+		// Ban Record creating
+		if(length(a_ckey))
+			notes_record.author = a_ckey
+		if(rounds_ban_counter)
+			duration += " and [rounds_ban_counter] rounds"
+		var/description = "([ip_cid.Join(", ")]): [reason]"
+		switch(bantype)
+			if (BANTYPE_JOB_PERMA_STR)
+				notes_record.content = "Permanent JOB BAN [job] [description]"
+			if (BANTYPE_JOB_TEMP_STR)
+				notes_record.content = "Temporal JOB BAN [job] for [duration] [description]"
+			if (BANTYPE_PERMA_STR)
+				notes_record.content = "Permanent BAN [description]"
+			if (BANTYPE_TEMP_STR)
+				notes_record.content = "Temporal BAN for [duration] [description]"
+		if(length(timestamp))
+			notes_record.timestamp = timestamp
+		if(days_ago)
+			notes_record.days_timestamp = days_ago
+		db_player_notes += notes_record
+
+		// Unban record creating
+		if(is_unbanned)
+			unban_notes_record = new()
+			if(length(unbanned_a_ckey))
+				unban_notes_record.author =  unbanned_a_ckey
+			switch(bantype)
+				if(BANTYPE_JOB_PERMA_STR)
+					unban_notes_record.content = "Unban. Permanent JOB BAN [job] was [timestamp]"
+				if(BANTYPE_JOB_TEMP_STR)
+					unban_notes_record.content = "Unban. Temporal JOB BAN [job] was [timestamp]"
+				if(BANTYPE_PERMA_STR)
+					unban_notes_record.content = "Unban. Permanent BAN was [timestamp]"
+				if(BANTYPE_TEMP_STR)
+					unban_notes_record.content = "Unban. Temporal BAN was [timestamp]"
+			if(length(unbanned_timestamp))
+				unban_notes_record.timestamp = unbanned_timestamp
+			if(unbanned_days_ago)
+				unban_notes_record.days_timestamp = unbanned_days_ago
+			db_player_notes += unban_notes_record
+	return db_player_notes
+
+#undef PLAYER_INFO_MISSING_CONTENT_TEXT
+#undef PLAYER_INFO_MISSING_AUTHOR_TEXT
+#undef PLAYER_INFO_MISSING_RANK_TEXT
+#undef PLAYER_INFO_MISSING_TIMESTAMP_TEXT
+#undef PLAYER_INFO_MISSING_JOB_TEXT
 
 
 /datum/admins/proc/access_news_network() //MARKER
@@ -386,21 +552,21 @@ proc/message_admins(msg, reg_flag = R_ADMIN)
 		if(6)
 			dat+="<B><FONT COLOR='maroon'>ERROR: Could not submit Feed story to Network.</B></FONT><HR><BR>"
 			if(src.admincaster_feed_channel.channel_name=="")
-				dat+="<FONT COLOR='maroon'>ï¿½Invalid receiving channel name.</FONT><BR>"
+				dat+="<FONT COLOR='maroon'>˜Invalid receiving channel name.</FONT><BR>"
 			if(src.admincaster_feed_message.body == "" || src.admincaster_feed_message.body == "\[REDACTED\]")
-				dat+="<FONT COLOR='maroon'>ï¿½Invalid message body.</FONT><BR>"
+				dat+="<FONT COLOR='maroon'>˜Invalid message body.</FONT><BR>"
 			dat+="<BR><A href='?src=\ref[src];ac_setScreen=[3]'>Return</A><BR>"
 		if(7)
 			dat+="<B><FONT COLOR='maroon'>ERROR: Could not submit Feed Channel to Network.</B></FONT><HR><BR>"
 			if(src.admincaster_feed_channel.channel_name =="" || src.admincaster_feed_channel.channel_name == "\[REDACTED\]")
-				dat+="<FONT COLOR='maroon'>ï¿½Invalid channel name.</FONT><BR>"
+				dat+="<FONT COLOR='maroon'>˜Invalid channel name.</FONT><BR>"
 			var/check = 0
 			for(var/datum/feed_channel/FC in news_network.network_channels)
 				if(FC.channel_name == src.admincaster_feed_channel.channel_name)
 					check = 1
 					break
 			if(check)
-				dat+="<FONT COLOR='maroon'>ï¿½Channel name already in use.</FONT><BR>"
+				dat+="<FONT COLOR='maroon'>˜Channel name already in use.</FONT><BR>"
 			dat+="<BR><A href='?src=\ref[src];ac_setScreen=[2]'>Return</A><BR>"
 		if(9)
 			dat+="<B>[src.admincaster_feed_channel.channel_name]: </B><FONT SIZE=1>\[created by: <FONT COLOR='maroon'>[src.admincaster_feed_channel.author]</FONT>\]</FONT><HR>"
@@ -514,9 +680,9 @@ proc/message_admins(msg, reg_flag = R_ADMIN)
 		if(16)
 			dat+="<B><FONT COLOR='maroon'>ERROR: Wanted Issue rejected by Network.</B></FONT><HR><BR>"
 			if(src.admincaster_feed_message.author =="" || src.admincaster_feed_message.author == "\[REDACTED\]")
-				dat+="<FONT COLOR='maroon'>ï¿½Invalid name for person wanted.</FONT><BR>"
+				dat+="<FONT COLOR='maroon'>˜Invalid name for person wanted.</FONT><BR>"
 			if(src.admincaster_feed_message.body == "" || src.admincaster_feed_message.body == "\[REDACTED\]")
-				dat+="<FONT COLOR='maroon'>ï¿½Invalid description.</FONT><BR>"
+				dat+="<FONT COLOR='maroon'>˜Invalid description.</FONT><BR>"
 			dat+="<BR><A href='?src=\ref[src];ac_setScreen=[0]'>Return</A><BR>"
 		if(17)
 			dat+={"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -430,9 +430,12 @@ proc/message_admins(msg, reg_flag = R_ADMIN)
 		var/description = "([ip_cid.Join(", ")]): [reason]"
 		switch(bantype)
 			if (BANTYPE_JOB_PERMA_STR)
-				notes_record.content = "Permanent JOB BAN [job] [description]"
+				// notes_record.content = "Permanent JOB BAN [job] [description]"
+				// already in notes by Adminbot
+				continue
 			if (BANTYPE_JOB_TEMP_STR)
-				notes_record.content = "Temporal JOB BAN [job] for [duration] [description]"
+				// notes_record.content = "Temporal JOB BAN [job] for [duration] [description]"
+				continue
 			if (BANTYPE_PERMA_STR)
 				notes_record.content = "Permanent BAN [description]"
 			if (BANTYPE_TEMP_STR)

--- a/code/modules/admin/player_notes.dm
+++ b/code/modules/admin/player_notes.dm
@@ -140,6 +140,58 @@
 	note_list << note_keys
 	del(note_list)	// savefile, so NOT qdel
 
+/proc/parse_notes_date_timestamp(datestamp)
+	// return number of day after 1 Jan 2000
+	// if date before 1 Jan 2000 or errors return 0
+	//
+	// Example of datestamp
+	// Tue, January 28th of 2020
+	// Wed, January 8th of 2020
+	if (!length(datestamp) || !istext(datestamp))
+		return 0
+	var/list/month_names = list(
+		"January"   = 1,
+		"February"  = 2,
+		"March"     = 3,
+		"April"     = 4,
+		"May"       = 5,
+		"June"      = 6,
+		"July"      = 7,
+		"August"    = 8,
+		"September" = 9,
+		"October"   = 10,
+		"November"  = 11,
+		"December"  = 12
+	)
+	var/list/month_days = list(31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
+	var/regex/pattern = regex(@"^\l{3},\s(\l+)\s(\d{1,2})\l{2}\sof\s(\d{4})$")
+	if (!pattern.Find(datestamp) || length(pattern.group) < 3)
+		return 0
+	var/day = pattern.group[2]
+	var/month = pattern.group[1]
+	var/year = pattern.group[3]
+	if (!length(day) || !length(month) || !length(year) || !(month in month_names))
+		return 0
+	day = text2num(day)
+	month = month_names[month]
+	year = text2num(year)
+	if (!day || !year || year < 2000 || day < 1)
+		return 0
+	var/days_passed = 0
+	// past years to days
+	if (year != 2000)
+		for (var/Y in 2000 to year-1)
+			if (is_leap_year(Y))
+				days_passed += 366
+			else
+				days_passed += 365
+	// past month to days
+	if (month > 1)
+		for (var/M in 1 to month-1)
+			days_passed += month_days[M]
+			if (M == 2 && is_leap_year(year))
+				days_passed++
+	return days_passed + day
 
 /proc/notes_del(key, index, admin)
 	var/savefile/info = new("data/player_saves/[copytext(key, 1, 2)]/[key]/info.sav")

--- a/code/modules/admin/player_notes.dm
+++ b/code/modules/admin/player_notes.dm
@@ -140,14 +140,14 @@
 	note_list << note_keys
 	del(note_list)	// savefile, so NOT qdel
 
-/proc/parse_notes_date_timestamp(datestamp)
+/proc/parse_notes_date_timestamp(note_timestamp_text)
 	// return number of day after 1 Jan 2000
 	// if date before 1 Jan 2000 or errors return 0
 	//
-	// Example of datestamp
+	// Example of note_timestamp_text
 	// Tue, January 28th of 2020
 	// Wed, January 8th of 2020
-	if (!length(datestamp) || !istext(datestamp))
+	if (!length(note_timestamp_text) || !istext(note_timestamp_text))
 		return 0
 	var/list/month_names = list(
 		"January"   = 1,
@@ -165,7 +165,7 @@
 	)
 	var/list/month_days = list(31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)
 	var/regex/pattern = regex(@"^\l{3},\s(\l+)\s(\d{1,2})\l{2}\sof\s(\d{4})$")
-	if (!pattern.Find(datestamp) || length(pattern.group) < 3)
+	if (!pattern.Find(note_timestamp_text) || length(pattern.group) < 3)
 		return 0
 	var/day = pattern.group[2]
 	var/month = pattern.group[1]


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Показывает в нотисах так же баны из базы данных во время их открытия. Установлен лимит на первые 100 записей о банах в базе.

В связи с тем, что в файле нету информации о времени бана при совпадении даты сначала идут нотисы, потом баны из базы.

Тут запросы так же о джоббанах, не уверен что их требуется показывать. Либо они идут так же в лимит 100 записей по одной джобке на запись и дублируются текущими нотисами в файле. Отличие от нотисов из базы в наличии IP адреса, CID если игрок был онлайн, а так же длительности бана.

Изначально была задумка сделать просто добавление информации при бане в сами нотисы. Это привело бы к необходимости перепроверять файл с нотисами и вставлять старые. Либо старые записи не были доступны. Дублирование данных на сервере не есть хорошо, возможны ошибки синхронизации.

Пример вывода https://yadi.sk/i/cHd-7YWpYkvnOQ
## Почему и что этот ПР улучшит
Close #3189 
## Авторство
TechCat
