### PR TITLE
Обновление паникбункера и релоад конфигов

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -64,6 +64,7 @@
 	var/automute_on = 0					//enables automuting/spam prevention
 
 	var/registration_panic_bunker_age = null
+	var/allowed_by_bunker_player_age = 60
 	var/client_limit_panic_bunker_count = null
 	var/client_limit_panic_bunker_link = null
 
@@ -600,6 +601,9 @@
 
 				if("registration_panic_bunker_age")
 					config.registration_panic_bunker_age = value
+
+				if("allowed_by_bunker_player_age")
+					config.allowed_by_bunker_player_age = value
 
 				if("client_limit_panic_bunker_count")
 					config.client_limit_panic_bunker_count = text2num(value)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -168,6 +168,7 @@ var/list/admin_verbs_debug = list(
 	/client/proc/investigate_show,
 	/client/proc/reload_admins,
 	/client/proc/reload_mentors,
+	/client/proc/reload_config,
 	/client/proc/reload_nanoui_resources,
 //	/client/proc/remake_distribution_map,
 //	/client/proc/show_distribution_map,

--- a/code/modules/admin/verbs/diagnostics.dm
+++ b/code/modules/admin/verbs/diagnostics.dm
@@ -70,7 +70,7 @@
 	set name = "Reload Admins"
 	set category = "Debug"
 
-	if(!check_rights(R_SERVER))
+	if(!check_rights(R_DEBUG))
 		return
 
 	message_admins("[usr] manually reloaded admins")
@@ -81,8 +81,18 @@
 	set name = "Reload Mentors"
 	set category = "Debug"
 
-	if(!check_rights(R_SERVER))
+	if(!check_rights(R_DEBUG))
 		return
 
 	message_admins("[usr] manually reloaded Mentors")
 	world.load_mentors()
+
+/client/proc/reload_config()
+	set name = "Reload Configuration"
+	set category = "Debug"
+
+	if (!check_rights(R_DEBUG))
+		return
+
+	message_admins("[usr] manually reloaded configuration")
+	world.load_configuration()

--- a/code/modules/admin/verbs/diagnostics.dm
+++ b/code/modules/admin/verbs/diagnostics.dm
@@ -73,7 +73,8 @@
 	if(!check_rights(R_DEBUG))
 		return
 
-	message_admins("[usr] manually reloaded admins")
+	message_admins("[key_name_admin(usr)] manually reloaded admins")
+	log_debug("[key_name(usr)] manually reloaded admins")
 	load_admins()
 	feedback_add_details("admin_verb","RLDA") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
@@ -84,15 +85,17 @@
 	if(!check_rights(R_DEBUG))
 		return
 
-	message_admins("[usr] manually reloaded Mentors")
+	message_admins("[key_name_admin(usr)] manually reloaded mentors")
+	log_debug("[key_name(usr)] manually reloaded mentors")
 	world.load_mentors()
 
 /client/proc/reload_config()
 	set name = "Reload Configuration"
 	set category = "Debug"
 
-	if (!check_rights(R_DEBUG))
+	if (!check_rights(R_PERMISSIONS))
 		return
 
-	message_admins("[usr] manually reloaded configuration")
+	message_admins("[key_name_admin(usr)] manually reloaded configuration")
+	log_debug("[key_name(usr)] manually reloaded configuration")
 	world.load_configuration()

--- a/code/modules/admin/verbs/panicbunker.dm
+++ b/code/modules/admin/verbs/panicbunker.dm
@@ -13,8 +13,10 @@
 	var/month = sanitize_integer(input("Registration month", "Minimal registration month (min: 1, max: 12)", 1) as num, 1, 12, 1)
 	var/day = sanitize_integer(input("Registration day", "Minimal registration day (min: 1, max: 31)", 1) as num, 1, 31, 1)
 	var/active_hours = input("Hours from current moment to keep panic bunker active (-1 to enable for current round only)", "Active hours (min: -1 or 1, max: 24)", -1) as num
-
 	var/panic_age = "[year]-[month]-[day]"
+
+	if (alert("Apply registration bunker, age:[panic_age] active hours: [active_hours]", "Are you sure about that?", "Yes!", "No") != "Yes!")
+		return
 
 	config.registration_panic_bunker_age = panic_age
 

--- a/code/modules/admin/verbs/panicbunker.dm
+++ b/code/modules/admin/verbs/panicbunker.dm
@@ -9,10 +9,10 @@
 		message_admins("[key_name_admin(src)] disable regisration panic bunker")
 		return
 	
-	var/year = sanitize_integer(input("Registration year", "Year (min: 2000, max: [game_year])", game_year) as num, 2000, game_year, game_year)
-	var/month = sanitize_integer(input("Registration month", "Month (min: 1, max: 12)", 1) as num, 1, 12, 1)
-	var/day = sanitize_integer(input("Registration day", "Day (min: 1, max: 31)", 1) as num, 1, 31, 1)
-	var/active_hours = sanitize_integer(input("Hours from current moment to keep panic bunker active (-1 to enable for current round only)", "Active hours (min: -1 or 1, max: 24)", -1) as num, -1, 24, -1)
+	var/year = sanitize_integer(input("Registration year", "Minimal registration year (min: 2000, max: [game_year])", game_year) as num, 2000, game_year, game_year)
+	var/month = sanitize_integer(input("Registration month", "Minimal registration month (min: 1, max: 12)", 1) as num, 1, 12, 1)
+	var/day = sanitize_integer(input("Registration day", "Minimal registration day (min: 1, max: 31)", 1) as num, 1, 31, 1)
+	var/active_hours = input("Hours from current moment to keep panic bunker active (-1 to enable for current round only)", "Active hours (min: -1 or 1, max: 24)", -1) as num
 
 	var/panic_age = "[year]-[month]-[day]"
 

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -294,13 +294,11 @@ var/list/blacklisted_builds = list(
 
 	if(config.registration_panic_bunker_age)
 		if(!(ckey in admin_datums) && !(src in mentors) && is_blocked_by_regisration_panic_bunker())
-			to_chat(src, "<span class='danger'>Sorry, but server is currently not accepting new players with registration date after [config.registration_panic_bunker_age]. Try to connect later.</span>")
+			to_chat(src, "<span class='danger'>Sorry, but server is currently not accepting new players. Try to connect later.</span>")
 			message_admins("<span class='adminnotice'>[key_name(src)] has been blocked by panic bunker. Connection rejected.</span>")
 			log_access("Failed Login: [key] [computer_id] [address] - blocked by panic bunker")
 			QDEL_IN(src, 2 SECONDS)
 			return
-		if(holder)
-			to_chat("<span class='adminnotice'>Round with registration panic bunker! Panic age: [config.registration_panic_bunker_age]</span>")
 
 	if(config.byond_version_min && byond_version < config.byond_version_min)
 		to_chat(src, "<span class='warning bold'>Your version of Byond is too old. Update to the [config.byond_version_min] or later for playing on our server.</span>")
@@ -578,4 +576,9 @@ var/list/blacklisted_builds = list(
 	var/bunker_month = text2num(bunker_date_regex.group[2])
 	var/bunker_day = text2num(bunker_date_regex.group[3])
 
-	return (user_year > bunker_year) || (user_year == bunker_year && user_month > bunker_month) || (user_year == bunker_year && user_month == bunker_month && user_day > bunker_day) || (isnum(player_ingame_age) && player_ingame_age < 60)
+	var/is_invalid_year = user_year > bunker_year
+	var/is_invalid_month = user_year == bunker_year && user_month > bunker_month
+	var/is_invalid_day = user_year == bunker_year && user_month == bunker_month && user_day > bunker_day
+	var/is_invalid_ingame_age = isnum(player_ingame_age) && player_ingame_age < config.allowed_by_bunker_player_age
+
+	return is_invalid_year || is_invalid_month || is_invalid_day || is_invalid_ingame_age

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -653,6 +653,8 @@ note dizziness decrements automatically in the mob's Life() proc.
 			if(cached)
 				stat(null, "Next Map: [cached.map_name]")
 			if(client.holder)
+				if (config.registration_panic_bunker_age)
+					stat(null, "Registration panic bunker age: [config.registration_panic_bunker_age]")
 				if(ticker.mode && ticker.mode.config_tag == "malfunction")
 					var/datum/game_mode/malfunction/GM = ticker.mode
 					if(GM.malf_mode_declared)

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -283,6 +283,9 @@ REPOSITORY_LINK https://github.com/TauCetiStation/TauCetiClassic
 ## Registration panic bunker won't allow user with registration date less than that. (format: year-month-day)
 # REGISTRATION_PANIC_BUNKER_AGE 2000-1-1
 
+## If user played more than this value (in minutes), bunker will let him in
+# ALLOWED_BY_BUNKER_PLAYER_AGE 60
+
 ## Panic bunker configured by players limit. This value is a maximum number of players.
 # CLIENT_LIMIT_PANIC_BUNKER_COUNT 60
 


### PR DESCRIPTION
- Добавил вывод состояние бункера админам в stat (я, на самом деле, ни разу в чате это увидеть так и не смог 😄 )
- Добавил прок релоада конфигов
- Перенес время, наиграв которое, пользователь проходит через бункер
