### PR TITLE
Фикс задержки перед войной

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -2,10 +2,9 @@
 #define CHALLENGE_TIME_LIMIT 6000
 #define CHALLENGE_MIN_PLAYERS 40
 
-var/global/Challenge
-var/global/Dropod_used
-var/global/Gateway_hack
-var/global/shuttle_moved
+var/global/war_device_activated
+var/global/war_device_activation_forbidden
+
 
 
 /obj/item/device/nuclear_challenge
@@ -57,7 +56,7 @@ var/global/shuttle_moved
 	to_chat(user, "You've attracted the attention of powerful forces within the syndicate. \
 	A bonus bundle of telecrystals has been granted to your team. Great things await you if you complete the mission.")
 
-	Challenge = TRUE
+	war_device_activated = TRUE
 
 	var/obj/item/device/radio/uplink/U = new(get_turf(user))
 	U.hidden_uplink.uses = CHALLENGE_TELECRYSTALS
@@ -82,14 +81,8 @@ var/global/shuttle_moved
 	if(world.time-round_start_time > CHALLENGE_TIME_LIMIT)
 		to_chat(user, "It's too late to declare hostilities. Your benefactors are already busy with other schemes. You'll have to make do with what you have on hand.")
 		return 0
-	if(Dropod_used)
-		to_chat(user, "The Droppod has already been launch! You have forfeited the right to declare war.")
-		return 0
-	if(Gateway_hack)
-		to_chat(user, "The Gateway hack has already been in progress! You have forfeited the right to declare war.")
-		return 0
-	if(shuttle_moved)
-		to_chat(user, "The shuttle has already been moved! You have forfeited the right to declare war.")
+	if(war_device_activation_forbidden)
+		to_chat(user, "The invasion has already begun. War can not be declared at this point.")
 		return 0
 	return 1
 

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -2,7 +2,11 @@
 #define CHALLENGE_TIME_LIMIT 6000
 #define CHALLENGE_MIN_PLAYERS 40
 
-var/global/obj/item/device/nuclear_challenge/Challenge
+var/global/Challenge
+var/global/Dropod_used
+var/global/Gateway_hack
+var/global/shuttle_moved
+
 
 /obj/item/device/nuclear_challenge
 	name = "Declaration of War (Challenge Mode)"
@@ -13,18 +17,6 @@ var/global/obj/item/device/nuclear_challenge/Challenge
 			Such a brazen move will attract the attention of powerful benefactors within the Syndicate, who will supply your team with a massive amount of bonus telecrystals.  \
 			Must be used within five minutes, or your benefactors will lose interest."
 	var/declaring_war = FALSE
-	var/static/Gateway_hack = FALSE
-	var/static/Dropod_used = FALSE
-	var/static/shuttle_moved = FALSE
-
-/obj/item/device/nuclear_challenge/atom_init()
-	. = ..()
-	Challenge = src
-
-/obj/item/device/nuclear_challenge/Destroy()
-	if(Challenge == src)
-		Challenge = null
-	return ..()
 
 
 /obj/item/device/nuclear_challenge/attack_self(mob/living/user)
@@ -65,6 +57,8 @@ var/global/obj/item/device/nuclear_challenge/Challenge
 	to_chat(user, "You've attracted the attention of powerful forces within the syndicate. \
 	A bonus bundle of telecrystals has been granted to your team. Great things await you if you complete the mission.")
 
+	Challenge = TRUE
+
 	var/obj/item/device/radio/uplink/U = new(get_turf(user))
 	U.hidden_uplink.uses = CHALLENGE_TELECRYSTALS
 	U.hidden_uplink.uplink_type = "nuclear"
@@ -89,13 +83,13 @@ var/global/obj/item/device/nuclear_challenge/Challenge
 		to_chat(user, "It's too late to declare hostilities. Your benefactors are already busy with other schemes. You'll have to make do with what you have on hand.")
 		return 0
 	if(Dropod_used)
-		to_chat(user, "The Droppod has already been launch! You have forfeit the right to declare war.")
+		to_chat(user, "The Droppod has already been launch! You have forfeited the right to declare war.")
 		return 0
 	if(Gateway_hack)
-		to_chat(user, "The Gateway hack has already been in progress! You have forfeit the right to declare war.")
+		to_chat(user, "The Gateway hack has already been in progress! You have forfeited the right to declare war.")
 		return 0
 	if(shuttle_moved)
-		to_chat(user, "The shuttle has already been moved! You have forfeit the right to declare war.")
+		to_chat(user, "The shuttle has already been moved! You have forfeited the right to declare war.")
 		return 0
 	return 1
 

--- a/code/game/machinery/computer/syndicate_shuttle.dm
+++ b/code/game/machinery/computer/syndicate_shuttle.dm
@@ -67,14 +67,14 @@
 	. = ..()
 	if(!. || !allowed(usr))
 		return
-	if(!Challenge)
+	if(Challenge)
 		if(world.time < SYNDICATE_CHALLENGE_TIMER)
 			to_chat(usr, "<span class='warning'>You've issued a combat challenge to the station! You've got to give them at least \
 		 	[round(((SYNDICATE_CHALLENGE_TIMER - world.time) / 10) / 60)] \
 		 	more minutes to allow them to prepare.</span>")
 			return
 	else
-		Challenge.shuttle_moved = TRUE
+		shuttle_moved = TRUE
 
 	if(href_list["syndicate"])
 		syndicate_move_to(/area/shuttle/syndicate/start)

--- a/code/game/machinery/computer/syndicate_shuttle.dm
+++ b/code/game/machinery/computer/syndicate_shuttle.dm
@@ -67,14 +67,14 @@
 	. = ..()
 	if(!. || !allowed(usr))
 		return
-	if(Challenge)
+	if(war_device_activated)
 		if(world.time < SYNDICATE_CHALLENGE_TIMER)
 			to_chat(usr, "<span class='warning'>You've issued a combat challenge to the station! You've got to give them at least \
 		 	[round(((SYNDICATE_CHALLENGE_TIMER - world.time) / 10) / 60)] \
 		 	more minutes to allow them to prepare.</span>")
 			return
 	else
-		shuttle_moved = TRUE
+		war_device_activation_forbidden = TRUE
 
 	if(href_list["syndicate"])
 		syndicate_move_to(/area/shuttle/syndicate/start)

--- a/code/game/machinery/droppod.dm
+++ b/code/game/machinery/droppod.dm
@@ -248,14 +248,14 @@
 	if(!isturf(loc))
 		to_chat(intruder, "<span class='userdanger'>You must be on ground to drop!</span>")
 		return
-	if(Challenge)
+	if(war_device_activated)
 		if(world.time < SYNDICATE_CHALLENGE_TIMER)
 			to_chat(intruder, "<span class='warning'>You've issued a combat challenge to the station! You've got to give them at least \
 		 	[round(((SYNDICATE_CHALLENGE_TIMER - world.time) / 10) / 60)] \
 		 	more minutes to allow them to prepare.</span>")
 			return
 	else
-		Dropod_used = TRUE
+		war_device_activation_forbidden = TRUE
 	var/area/area_to_deploy = allowed_areas.areas[pick(allowed_areas.areas)]
 	var/list/L = list()
 	for(var/turf/T in get_area_turfs(area_to_deploy.type))
@@ -693,14 +693,14 @@
 	flags = POOR_AIMING
 
 /obj/structure/droppod/Syndi/Aiming()
-	if(Challenge)
+	if(war_device_activated)
 		if(world.time < SYNDICATE_CHALLENGE_TIMER)
 			to_chat(intruder, "<span class='warning'>You've issued a combat challenge to the station! You've got to give them at least \
 		 		[round(((SYNDICATE_CHALLENGE_TIMER - world.time) / 10) / 60)] \
 		 		more minutes to allow them to prepare.</span>")
 			return
 	else
-		Dropod_used = TRUE
+		war_device_activation_forbidden = TRUE
 
 	if(droped)
 		if(!(flags & IS_LOCKED))

--- a/code/game/machinery/droppod.dm
+++ b/code/game/machinery/droppod.dm
@@ -248,14 +248,14 @@
 	if(!isturf(loc))
 		to_chat(intruder, "<span class='userdanger'>You must be on ground to drop!</span>")
 		return
-	if(!Challenge)
+	if(Challenge)
 		if(world.time < SYNDICATE_CHALLENGE_TIMER)
 			to_chat(intruder, "<span class='warning'>You've issued a combat challenge to the station! You've got to give them at least \
 		 	[round(((SYNDICATE_CHALLENGE_TIMER - world.time) / 10) / 60)] \
 		 	more minutes to allow them to prepare.</span>")
 			return
 	else
-		Challenge.Dropod_used = TRUE
+		Dropod_used = TRUE
 	var/area/area_to_deploy = allowed_areas.areas[pick(allowed_areas.areas)]
 	var/list/L = list()
 	for(var/turf/T in get_area_turfs(area_to_deploy.type))
@@ -693,14 +693,14 @@
 	flags = POOR_AIMING
 
 /obj/structure/droppod/Syndi/Aiming()
-	if(!Challenge)
+	if(Challenge)
 		if(world.time < SYNDICATE_CHALLENGE_TIMER)
 			to_chat(intruder, "<span class='warning'>You've issued a combat challenge to the station! You've got to give them at least \
 		 		[round(((SYNDICATE_CHALLENGE_TIMER - world.time) / 10) / 60)] \
 		 		more minutes to allow them to prepare.</span>")
 			return
 	else
-		Challenge.Dropod_used = TRUE
+		Dropod_used = TRUE
 
 	if(droped)
 		if(!(flags & IS_LOCKED))

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -1141,7 +1141,7 @@
 		chassis.occupant_message("<span class='notice'>Automatic Aim System cannot find an appropriate target!</span>")
 		aiming = FALSE
 		return
-	if(!Challenge)
+	if(Challenge)
 		if(world.time < SYNDICATE_CHALLENGE_TIMER)
 			chassis.occupant_message("<span class='warning'>You've issued a combat challenge to the station! \
 			You've got to give them at least [round(((SYNDICATE_CHALLENGE_TIMER - world.time) / 10) / 60)] \
@@ -1149,7 +1149,7 @@
 			aiming = FALSE
 			return
 	else
-		Challenge.Dropod_used = TRUE
+		Dropod_used = TRUE
 	chassis.occupant_message("<span class='notice'>You succesfully selected target!</span>")
 	chassis.loc = pick(L)
 	uses--

--- a/code/game/mecha/equipment/tools/tools.dm
+++ b/code/game/mecha/equipment/tools/tools.dm
@@ -1141,7 +1141,7 @@
 		chassis.occupant_message("<span class='notice'>Automatic Aim System cannot find an appropriate target!</span>")
 		aiming = FALSE
 		return
-	if(Challenge)
+	if(war_device_activated)
 		if(world.time < SYNDICATE_CHALLENGE_TIMER)
 			chassis.occupant_message("<span class='warning'>You've issued a combat challenge to the station! \
 			You've got to give them at least [round(((SYNDICATE_CHALLENGE_TIMER - world.time) / 10) / 60)] \
@@ -1149,7 +1149,7 @@
 			aiming = FALSE
 			return
 	else
-		Dropod_used = TRUE
+		war_device_activation_forbidden = TRUE
 	chassis.occupant_message("<span class='notice'>You succesfully selected target!</span>")
 	chassis.loc = pick(L)
 	uses--

--- a/code/game/objects/items/devices/gateway_locker.dm
+++ b/code/game/objects/items/devices/gateway_locker.dm
@@ -25,14 +25,14 @@
 		stationgate.blocked = !stationgate.blocked
 		to_chat(user, "<span class='warning'>You [stationgate.blocked ? "dis" :""]allowed entering [stationgate]!</span>")
 		return
-	if(!Challenge)
+	if(Challenge)
 		if(world.time < SYNDICATE_CHALLENGE_TIMER - GATEWAY_HACK_TIME)
 			to_chat(user, "<span class='warning'>You've issued a combat challenge to the station! You've got to give them at least \
 		 	[round(((SYNDICATE_CHALLENGE_TIMER - GATEWAY_HACK_TIME - world.time) / 10) / 60)] \
 		 	more minutes to allow them to prepare.</span>")
 			return
 	else
-		Challenge.Gateway_hack = TRUE
+		Gateway_hack = TRUE
 	var/obj/effect/landmark/syndie_gateway/Syndie_landmark = locate(/obj/effect/landmark/syndie_gateway) in landmarks_list
 	if(!istype(Syndie_landmark))
 		to_chat(user,"<span class='danger'>You already perform hack process</span>")
@@ -40,8 +40,6 @@
 	used = TRUE
 	var/turf/turf = Syndie_landmark.loc
 	qdel(Syndie_landmark)
-	if(Challenge)
-		Challenge.Gateway_hack = TRUE
 	var/obj/item/device/radio/intercom/radio = new(null)
 	radio.autosay("Unregistered logon in the System in Progress.", "Gateway Message System", "Common")
 	addtimer(CALLBACK(src, .proc/perform_gate, turf, radio), GATEWAY_HACK_TIME)

--- a/code/game/objects/items/devices/gateway_locker.dm
+++ b/code/game/objects/items/devices/gateway_locker.dm
@@ -25,14 +25,14 @@
 		stationgate.blocked = !stationgate.blocked
 		to_chat(user, "<span class='warning'>You [stationgate.blocked ? "dis" :""]allowed entering [stationgate]!</span>")
 		return
-	if(Challenge)
+	if(war_device_activated)
 		if(world.time < SYNDICATE_CHALLENGE_TIMER - GATEWAY_HACK_TIME)
 			to_chat(user, "<span class='warning'>You've issued a combat challenge to the station! You've got to give them at least \
 		 	[round(((SYNDICATE_CHALLENGE_TIMER - GATEWAY_HACK_TIME - world.time) / 10) / 60)] \
 		 	more minutes to allow them to prepare.</span>")
 			return
 	else
-		Gateway_hack = TRUE
+		war_device_activation_forbidden = TRUE
 	var/obj/effect/landmark/syndie_gateway/Syndie_landmark = locate(/obj/effect/landmark/syndie_gateway) in landmarks_list
 	if(!istype(Syndie_landmark))
 		to_chat(user,"<span class='danger'>You already perform hack process</span>")


### PR DESCRIPTION
## Описание изменений
У нюки сейчас идёт задержка даже если они не объявляли никакой войны. Этот ПР фиксит данное дело. Задержку можно обойти заказав War Device, НО не использовав его.
Этот баг можно было пофиксить и вторым методом - просто добавив War Device на карту, и удалив его из меню. Но всё таки, если он будет на карте изначально, могут найтись приколисты которые будут подбирать девайс и объявлять войну.
## Почему и что этот ПР улучшит
Багофикс
## Авторство
Я
## Чеинжлог
:cl: 
- bugfix: Исправлена задержка у нюкеров когда война не объявлена