### PR TITLE
Кик за афк всех и всегда, кроме педалей и донатеров

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -253,11 +253,10 @@ var/shutdown_processed = FALSE
 
 /world/proc/KickInactiveClients()
 	for (var/client/C in clients)
-		if (C.is_afk())
-			if (!istype(C.mob, /mob/dead))
-				log_access("AFK: [key_name(C)]")
-				to_chat(C, "<span class='userdanger'>You have been inactive for more than [config.afk_time_bracket / 600] minutes and have been disconnected.</span>")
-				QDEL_IN(C, 2 SECONDS)
+		if (!(C.holder || C.supporter) && C.is_afk())
+			log_access("AFK: [key_name(C)]")
+			to_chat(C, "<span class='userdanger'>You have been inactive for more than [config.afk_time_bracket / 600] minutes and have been disconnected.</span>")
+			QDEL_IN(C, 2 SECONDS)
 	addtimer(CALLBACK(GLOBAL_PROC, .proc/KickInactiveClients), 5 MINUTES)
 
 /world/proc/load_stealth_keys()


### PR DESCRIPTION
:cl: Совет Уполномоченных Лиц РУВД Московского района, г. Чебоксары
 - tweak: После АФК в N-минут (может отличаться на разных серверах) кикает <b>всех</b>. Раньше госты игнорировались. Сейчас же <b>не кикает</b> лишь <b>админов</b> и <b>поддержавших</b> сервер на Patreon.