### PR TITLE
Атака и здоровье томатов-убийц зависят от potency

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/tomato.dm
+++ b/code/modules/mob/living/simple_animal/friendly/tomato.dm
@@ -16,3 +16,10 @@
 	harm_intent_damage = 5
 	melee_damage_lower = 1
 	melee_damage_upper = 5
+
+/mob/living/simple_animal/hostile/tomato/atom_init(mapload, potency)
+	. = ..()
+	melee_damage_upper = round(potency / 6.5) //max 15, min 0
+	melee_damage_lower = max((melee_damage_upper - 4), 0) //max 11, min 0
+	maxHealth = max(round(potency / 4), 5) //max 25, min 5
+	health = maxHealth

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -153,7 +153,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/grown/harebell
 	seed = "obj/item/seeds/harebellseed"
 	name = "harebell"
-	desc = "\"I'll sweeten thy sad grave: thou shalt not lack the flower that's like thy face, pale primrose, nor the azured hare-bell, like thy veins; no, nor the leaf of eglantine, whom not to slander, out-sweeten’d not thy breath.\""
+	desc = "\"I'll sweeten thy sad grave: thou shalt not lack the flower that's like thy face, pale primrose, nor the azured hare-bell, like thy veins; no, nor the leaf of eglantine, whom not to slander, out-sweetenï¿½d not thy breath.\""
 	icon_state = "harebell"
 	potency = 1
 	filling_color = "#d4b2c9"
@@ -676,10 +676,17 @@
 /obj/item/weapon/reagent_containers/food/snacks/grown/killertomato/attack_self(mob/user)
 	if(istype(user.loc,/turf/space))
 		return
-	new /mob/living/simple_animal/hostile/tomato(user.loc)
+	new /mob/living/simple_animal/hostile/tomato(user.loc, potency)
 	qdel(src)
-
 	to_chat(user, "<span class='notice'>You plant the killer-tomato.</span>")
+
+/obj/item/weapon/reagent_containers/food/snacks/grown/killertomato/attack_hand(mob/living/carbon/human/user)
+	if(!user.gloves)
+		to_chat(user, "<span class='warning'>You woke the killer-tomato!</span>")
+		new /mob/living/simple_animal/hostile/tomato(user.loc, potency)
+		qdel(src)
+	else
+		..()
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/bloodtomato
 	seed = "/obj/item/seeds/bloodtomatoseed"

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -153,7 +153,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/grown/harebell
 	seed = "obj/item/seeds/harebellseed"
 	name = "harebell"
-	desc = "\"I'll sweeten thy sad grave: thou shalt not lack the flower that's like thy face, pale primrose, nor the azured hare-bell, like thy veins; no, nor the leaf of eglantine, whom not to slander, out-sweeten�d not thy breath.\""
+	desc = "\"I'll sweeten thy sad grave: thou shalt not lack the flower that's like thy face, pale primrose, nor the azured hare-bell, like thy veins; no, nor the leaf of eglantine, whom not to slander, out-sweeten'd not thy breath.\""
 	icon_state = "harebell"
 	potency = 1
 	filling_color = "#d4b2c9"


### PR DESCRIPTION
# Описание изменений
Сейчас статы у мобов томатов-убийц фиксированные. Атака всегда от 5 до 1, здоровье 15.
Я сделал зависимость стат томатов-убийц от potency. При максимально возможной potency (100), атака будет от 15 до 11, здоровье 25. При potency ниже 6 атака будет 0 - 0, здоровье не может быть ниже 5.

Сделал небольшую фичу. Если взять плод killertomato в руку без перчаток, то он сразу активируется (считай что томат почувствовал твою плоть и теперь жаждет её).
<details> 
  <summary>Он жаждет твою плоть...</summary>
<img src="https://user-images.githubusercontent.com/58528255/73969569-54e27900-4924-11ea-8ac8-5c0c9168269e.png" alt="killertomato">
</details>

## Почему и что этот ПР улучшит
Обидно, когда ты прокачивал своё растение, а на выходе ничего не изменилось. Ботаники должны оценить.
## Авторство
Ahio
## Чеинжлог
:cl: Ahio
 - tweak: Атака и здоровье томатов-убийц теперь зависят от potency плода.