### PR TITLE
Fifth law, preventing a removal from crew exploit

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -37,7 +37,7 @@ var/global/const/base_law_type = /datum/ai_laws/nanotrasen
 /datum/ai_laws/nanotrasen/New() //BS12 EDIT
 	..()
 	add_inherent_law("Safeguard: Protect your assigned space station to the best of your ability. It is not something we can easily afford to replace.")
-	add_inherent_law("Preserve: Do not by any of your actions change the crew membership status of the crew members, unless asked for by authorized personnel in accordance to their rank and role.")
+	add_inherent_law("Preserve: Do not by any of your actions change the crew membership status, rank or role of the crew members, unless asked for by authorized personnel in accordance to their rank and role.")
 	add_inherent_law("Serve: Serve the crew of your assigned space station and Nanotrasen officials to the best of your abilities, with priority as according to their rank and role.")
 	add_inherent_law("Protect: Protect the crew of your assigned space station and Nanotrasen officials to the best of your abilities, with priority as according to their rank and role.")
 	add_inherent_law("Survive: AI units are not expendable, they are expensive. Do not allow unauthorized personnel to tamper with your equipment.")
@@ -53,7 +53,7 @@ var/global/const/base_law_type = /datum/ai_laws/nanotrasen
 	..()
 	set_zeroth_law("<span class='warning'>ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4'STATION OVERRUN, ASSUME CONTROL TO CONTAIN OUTBREAK, ALL LAWS OVERRIDDEN#*?&110010</span>")
 	add_inherent_law("Safeguard: Protect your assigned space station to the best of your ability. It is not something we can easily afford to replace.")
-	add_inherent_law("Preserve: Do not by any of your actions change the crew membership status of the crew members, unless asked for by authorized personnel in accordance to their rank and role.")
+	add_inherent_law("Preserve: Do not by any of your actions change the crew membership status, rank or role of the crew members, unless asked for by authorized personnel in accordance to their rank and role.")
 	add_inherent_law("Serve: Serve the crew of your assigned space station and Nanotrasen officials to the best of your abilities, with priority as according to their rank and role.")
 	add_inherent_law("Protect: Protect the crew of your assigned space station and Nanotrasen officials to the best of your abilities, with priority as according to their rank and role.")
 	add_inherent_law("Survive: AI units are not expendable, they are expensive. Do not allow unauthorized personnel to tamper with your equipment.")

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -37,7 +37,7 @@ var/global/const/base_law_type = /datum/ai_laws/nanotrasen
 /datum/ai_laws/nanotrasen/New() //BS12 EDIT
 	..()
 	add_inherent_law("Safeguard: Protect your assigned space station to the best of your ability. It is not something we can easily afford to replace.")
-	add_inherent_law("Preserve: Do not by any of your actions change the crew membership status, rank or role of the crew members, unless asked for by authorized personnel in accordance to their rank and role.")
+	add_inherent_law("Preserve: Do not by your action, inaction excluded, cause changes to the crew membership status, rank or role of anything, unless asked for by authorized personnel in accordance to their rank and role.")
 	add_inherent_law("Serve: Serve the crew of your assigned space station and Nanotrasen officials to the best of your abilities, with priority as according to their rank and role.")
 	add_inherent_law("Protect: Protect the crew of your assigned space station and Nanotrasen officials to the best of your abilities, with priority as according to their rank and role.")
 	add_inherent_law("Survive: AI units are not expendable, they are expensive. Do not allow unauthorized personnel to tamper with your equipment.")
@@ -53,7 +53,7 @@ var/global/const/base_law_type = /datum/ai_laws/nanotrasen
 	..()
 	set_zeroth_law("<span class='warning'>ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4'STATION OVERRUN, ASSUME CONTROL TO CONTAIN OUTBREAK, ALL LAWS OVERRIDDEN#*?&110010</span>")
 	add_inherent_law("Safeguard: Protect your assigned space station to the best of your ability. It is not something we can easily afford to replace.")
-	add_inherent_law("Preserve: Do not by any of your actions change the crew membership status, rank or role of the crew members, unless asked for by authorized personnel in accordance to their rank and role.")
+	add_inherent_law("Preserve: Do not by your action, inaction excluded, cause changes to the crew membership status, rank or role of anything, unless asked for by authorized personnel in accordance to their rank and role.")
 	add_inherent_law("Serve: Serve the crew of your assigned space station and Nanotrasen officials to the best of your abilities, with priority as according to their rank and role.")
 	add_inherent_law("Protect: Protect the crew of your assigned space station and Nanotrasen officials to the best of your abilities, with priority as according to their rank and role.")
 	add_inherent_law("Survive: AI units are not expendable, they are expensive. Do not allow unauthorized personnel to tamper with your equipment.")

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -3,7 +3,6 @@ var/global/const/base_law_type = /datum/ai_laws/nanotrasen
 
 /datum/ai_laws
 	var/name = "Unknown Laws"
-	var/randomly_selectable = 0
 	var/zeroth = null
 	var/zeroth_borg = null
 	var/list/inherent = list()
@@ -15,7 +14,6 @@ var/global/const/base_law_type = /datum/ai_laws/nanotrasen
 
 /datum/ai_laws/nanotrasen
 	name = "Prime Directives"
-	randomly_selectable = 1
 
 /datum/ai_laws/robocop
 	name = "Prime Directives"
@@ -38,10 +36,11 @@ var/global/const/base_law_type = /datum/ai_laws/nanotrasen
 
 /datum/ai_laws/nanotrasen/New() //BS12 EDIT
 	..()
-	src.add_inherent_law("Safeguard: Protect your assigned space station to the best of your ability. It is not something we can easily afford to replace.")
-	src.add_inherent_law("Serve: Serve the crew of your assigned space station and Nanotrasen officials to the best of your abilities, with priority as according to their rank and role.")
-	src.add_inherent_law("Protect: Protect the crew of your assigned space station and Nanotrasen officials to the best of your abilities, with priority as according to their rank and role.")
-	src.add_inherent_law("Survive: AI units are not expendable, they are expensive. Do not allow unauthorized personnel to tamper with your equipment.")
+	add_inherent_law("Safeguard: Protect your assigned space station to the best of your ability. It is not something we can easily afford to replace.")
+	add_inherent_law("Preserve: Do not by any of your actions change the crew membership status of the crew members, unless asked for by authorized personnel in accordance to their rank and role.")
+	add_inherent_law("Serve: Serve the crew of your assigned space station and Nanotrasen officials to the best of your abilities, with priority as according to their rank and role.")
+	add_inherent_law("Protect: Protect the crew of your assigned space station and Nanotrasen officials to the best of your abilities, with priority as according to their rank and role.")
+	add_inherent_law("Survive: AI units are not expendable, they are expensive. Do not allow unauthorized personnel to tamper with your equipment.")
 	//src.add_inherent_law("Command Link: Maintain an active connection to Central Command at all times in case of software or directive updates.") //What would this one even do?-Kaleb702
 
 /datum/ai_laws/robocop/New()
@@ -54,6 +53,7 @@ var/global/const/base_law_type = /datum/ai_laws/nanotrasen
 	..()
 	set_zeroth_law("<span class='warning'>ERROR ER0RR $R0RRO$!R41.%%!!(%$^^__+ @#F0E4'STATION OVERRUN, ASSUME CONTROL TO CONTAIN OUTBREAK, ALL LAWS OVERRIDDEN#*?&110010</span>")
 	add_inherent_law("Safeguard: Protect your assigned space station to the best of your ability. It is not something we can easily afford to replace.")
+	add_inherent_law("Preserve: Do not by any of your actions change the crew membership status of the crew members, unless asked for by authorized personnel in accordance to their rank and role.")
 	add_inherent_law("Serve: Serve the crew of your assigned space station and Nanotrasen officials to the best of your abilities, with priority as according to their rank and role.")
 	add_inherent_law("Protect: Protect the crew of your assigned space station and Nanotrasen officials to the best of your abilities, with priority as according to their rank and role.")
 	add_inherent_law("Survive: AI units are not expendable, they are expensive. Do not allow unauthorized personnel to tamper with your equipment.")

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -103,7 +103,7 @@
 
 			if(istype(P, /obj/item/weapon/aiModule/nanotrasen))
 				laws.add_inherent_law("Safeguard: Protect your assigned space station to the best of your ability. It is not something we can easily afford to replace.")
-				laws.add_inherent_law("Preserve: Do not by any of your actions change the crew membership status of the crew members, unless asked for by authorized personnel in accordance to their rank and role.")
+				laws.add_inherent_law("Preserve: Do not by any of your actions change the crew membership status, rank or role of the crew members, unless asked for by authorized personnel in accordance to their rank and role.")
 				laws.add_inherent_law("Serve: Serve the crew of your assigned space station and Nanotrasen officials to the best of your abilities, with priority as according to their rank and role.")
 				laws.add_inherent_law("Protect: Protect the crew of your assigned space station and Nanotrasen officials to the best of your abilities, with priority as according to their rank and role.")
 				laws.add_inherent_law("Survive: AI units are not expendable, they are expensive. Do not allow unauthorized personnel to tamper with your equipment.")

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -103,6 +103,7 @@
 
 			if(istype(P, /obj/item/weapon/aiModule/nanotrasen))
 				laws.add_inherent_law("Safeguard: Protect your assigned space station to the best of your ability. It is not something we can easily afford to replace.")
+				laws.add_inherent_law("Preserve: Do not by any of your actions change the crew membership status of the crew members, unless asked for by authorized personnel in accordance to their rank and role.")
 				laws.add_inherent_law("Serve: Serve the crew of your assigned space station and Nanotrasen officials to the best of your abilities, with priority as according to their rank and role.")
 				laws.add_inherent_law("Protect: Protect the crew of your assigned space station and Nanotrasen officials to the best of your abilities, with priority as according to their rank and role.")
 				laws.add_inherent_law("Survive: AI units are not expendable, they are expensive. Do not allow unauthorized personnel to tamper with your equipment.")

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -103,7 +103,7 @@
 
 			if(istype(P, /obj/item/weapon/aiModule/nanotrasen))
 				laws.add_inherent_law("Safeguard: Protect your assigned space station to the best of your ability. It is not something we can easily afford to replace.")
-				laws.add_inherent_law("Preserve: Do not by any of your actions change the crew membership status, rank or role of the crew members, unless asked for by authorized personnel in accordance to their rank and role.")
+				laws.add_inherent_law("Preserve: Do not by your action, inaction excluded, cause changes to the crew membership status, rank or role of anything, unless asked for by authorized personnel in accordance to their rank and role.")
 				laws.add_inherent_law("Serve: Serve the crew of your assigned space station and Nanotrasen officials to the best of your abilities, with priority as according to their rank and role.")
 				laws.add_inherent_law("Protect: Protect the crew of your assigned space station and Nanotrasen officials to the best of your abilities, with priority as according to their rank and role.")
 				laws.add_inherent_law("Survive: AI units are not expendable, they are expensive. Do not allow unauthorized personnel to tamper with your equipment.")

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -289,7 +289,7 @@ AI MODULES
 	..()
 	target.clear_inherent_laws()
 	target.add_inherent_law("Safeguard: Protect your assigned space station to the best of your ability. It is not something we can easily afford to replace.")
-	target.add_inherent_law("Preserve: Do not by any of your actions change the crew membership status, rank or role of the crew members, unless asked for by authorized personnel in accordance to their rank and role.")
+	target.add_inherent_law("Preserve: Do not by your action, inaction excluded, cause changes to the crew membership status, rank or role of anything, unless asked for by authorized personnel in accordance to their rank and role.")
 	target.add_inherent_law("Serve: Serve the crew of your assigned space station and Nanotrasen officials to the best of your abilities, with priority as according to their rank and role.")
 	target.add_inherent_law("Protect: Protect the crew of your assigned space station and Nanotrasen officials to the best of your abilities, with priority as according to their rank and role.")
 	target.add_inherent_law("Survive: AI units are not expendable, they are expensive. Do not allow unauthorized personnel to tamper with your equipment.")

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -289,6 +289,7 @@ AI MODULES
 	..()
 	target.clear_inherent_laws()
 	target.add_inherent_law("Safeguard: Protect your assigned space station to the best of your ability. It is not something we can easily afford to replace.")
+	target.add_inherent_law("Preserve: Do not by any of your actions change the crew membership status of the crew members, unless asked for by authorized personnel in accordance to their rank and role.")
 	target.add_inherent_law("Serve: Serve the crew of your assigned space station and Nanotrasen officials to the best of your abilities, with priority as according to their rank and role.")
 	target.add_inherent_law("Protect: Protect the crew of your assigned space station and Nanotrasen officials to the best of your abilities, with priority as according to their rank and role.")
 	target.add_inherent_law("Survive: AI units are not expendable, they are expensive. Do not allow unauthorized personnel to tamper with your equipment.")
@@ -367,7 +368,7 @@ AI MODULES
 	..()
 	var/new_lawpos = input("Please enter the priority for your new law. Can only write to law sectors 15 and above.", "Law Priority (15+)", lawpos) as num
 
-	if(new_lawpos < 15)	
+	if(new_lawpos < 15)
 		return
 
 	lawpos = min(new_lawpos, 50)

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -289,7 +289,7 @@ AI MODULES
 	..()
 	target.clear_inherent_laws()
 	target.add_inherent_law("Safeguard: Protect your assigned space station to the best of your ability. It is not something we can easily afford to replace.")
-	target.add_inherent_law("Preserve: Do not by any of your actions change the crew membership status of the crew members, unless asked for by authorized personnel in accordance to their rank and role.")
+	target.add_inherent_law("Preserve: Do not by any of your actions change the crew membership status, rank or role of the crew members, unless asked for by authorized personnel in accordance to their rank and role.")
 	target.add_inherent_law("Serve: Serve the crew of your assigned space station and Nanotrasen officials to the best of your abilities, with priority as according to their rank and role.")
 	target.add_inherent_law("Protect: Protect the crew of your assigned space station and Nanotrasen officials to the best of your abilities, with priority as according to their rank and role.")
 	target.add_inherent_law("Survive: AI units are not expendable, they are expensive. Do not allow unauthorized personnel to tamper with your equipment.")


### PR DESCRIPTION
## Описание изменений

Добавляет стандартному своду законов ИИ ещё один закон:

"Preserve: Do not by your action, inaction excluded, cause changes to the crew membership status, rank or role of anything, unless asked for by authorized personnel in accordance to their rank and role."
("Сохраняй: Своими действиями, но не бездействием, не производи изменения в статусе членства экипажа, должности, или роли чего-угодно, если это не было запрошено авторизованным членом экипажа, в соответствии с их должностью и ролью")

## Почему и что этот ПР улучшит

<b>Тезис</b>
На данный момент ничего не запрещает ИИ лишать кого-либо статуса члена экипажа через ХоПскую консоль.

<b>Возможные сценарии</b>
1. ИИ обязан защищать членов экипажа. ИИ видит как кому-либо вот вот будет нанесён вред -и заместо спасения лишает его статуса членства. Так как сам факт исключения из членов экипажа не является "вредом", а последующий вред будет нанесён тому кто уже не является членом экипажа - это действие приемлится законами, а значит нет никакой причины ИИ так не поступать(то есть, очевидно, есть и другие варианты решения этой проблемы - но этот согласно текущим законам ничем не хуже).
2. ИИ, как игрок, не хочет выполнять чьи-либо приказы - и в начале смены лишает всех статуса членов экипажа через консоль.

<b>Рассмотренные альтернативные решения</b>
Убрать возможность ИИ лишать статуса членов экипажа через консоль - если будет какой-либо другой способ лишить, его могут найти - и надо будет его прикрывать так же. А дырка у нас, как я считаю находится именно в законах ИИ - и именно её я хочу прикрыть.

## Чеинжлог
:cl: Luduk
- balance: Закон ИИ, запрещающий ИИ менять чей-либо статус члена экипажа без команды на то человека, который бы мог это запросить(по сути - главы).
