### PR TITLE
Bunker logic fix

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -575,6 +575,8 @@ var/list/blacklisted_builds = list(
 	var/is_invalid_year = user_year > bunker_year
 	var/is_invalid_month = user_year == bunker_year && user_month > bunker_month
 	var/is_invalid_day = user_year == bunker_year && user_month == bunker_month && user_day > bunker_day
+
+	var/is_invalid_date = is_invalid_year || is_invalid_month || is_invalid_day
 	var/is_invalid_ingame_age = isnum(player_ingame_age) && player_ingame_age < config.allowed_by_bunker_player_age
 
-	return is_invalid_year || is_invalid_month || is_invalid_day || is_invalid_ingame_age
+	return is_invalid_date && is_invalid_ingame_age


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог

:cl:
 - bugfix: Исправление логики паник-бункера, который по ошибке не учитывал дату регистрации и просто не пускал новых игроков с наигранным временем меньше часа. Прошу прощения за эту ошибку, бывают дни когда я хуже Белфогора.