### PR TITLE
Access not split for sub-proffesions of scientist

### DIFF
--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -80,11 +80,6 @@
 
 	H.equip_to_slot_or_del(new /obj/item/device/radio/headset/headset_sci(H), SLOT_L_EAR)
 	H.equip_to_slot_or_del(new /obj/item/device/pda/science(H), SLOT_BELT)
-	switch(H.mind.role_alt_title)
-		if("Scientist")
-			access = list(access_tox, access_research)
-		if("Phoron Researcher")
-			access = list(access_research, access_tox_storage)
 
 	return TRUE
 


### PR DESCRIPTION
## Описание изменений

Учёные и форон ресерчи не специализированы по своему доступу.

## Почему и что этот ПР улучшит

Так как оператор деструктор-протолатного набора больше не профа учёным """было нечем заниматься""".

С этим ПР-ом будет чем.

:cl: Luduk
- balance: Учёные и Исследователи Форона не отличаются по доступу.
