### PR TITLE
запрещает писать анонсы с реквест консоли криминалиста

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -67758,7 +67758,6 @@
 "cQb" = (
 /obj/machinery/computer/secure_data,
 /obj/machinery/requests_console{
-	announcementConsole = 1;
 	department = "Forensic's Desk";
 	departmentType = 5;
 	name = "Forensic RC";


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
запрещает писать анонсы с реквест консоли криминалиста
## Почему и что этот ПР улучшит
почему не глава может это делать?!?!
## Авторство

## Чеинжлог
