### PR TITLE
Исправлен runtime в examine

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -449,7 +449,7 @@
 
 	if(!skipface)
 		var/obj/item/organ/external/head/BP = bodyparts_by_name[BP_HEAD]
-		if(BP && istype(BP) && BP.disfigured)
+		if(istype(BP) && BP.disfigured)
 			msg += "<span class='warning'><b>[t_His] face is violently disfigured!</b></span>\n"
 
 	if((!skipface || !skipjumpsuit || !skipgloves) && (HUSK in mutations))

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -449,7 +449,7 @@
 
 	if(!skipface)
 		var/obj/item/organ/external/head/BP = bodyparts_by_name[BP_HEAD]
-		if(BP && BP.disfigured)
+		if(BP && istype(BP) && BP.disfigured)
 			msg += "<span class='warning'><b>[t_His] face is violently disfigured!</b></span>\n"
 
 	if((!skipface || !skipjumpsuit || !skipgloves) && (HUSK in mutations))


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Был runtime error в examine, если голова была потеряна по причине урона по ней. В таком случае это был /obj/item/organ/external/stump, что не имеет переменной disfigured
## Почему и что этот ПР улучшит
Меньше ошибок во время выполнения.
