### PR TITLE
Spritesheet-based species restriction

### DIFF
--- a/code/__DEFINES/clothing.dm
+++ b/code/__DEFINES/clothing.dm
@@ -51,6 +51,19 @@
 #define SLOT_TIE           21
 #define SLOT_EARS          22 // Used in obscured checks
 
+//sprite sheet slot types(as also seen in update_icon.dm)
+#define SPRITE_SHEET_HELD "held"
+#define SPRITE_SHEET_UNIFORM "uniform"
+#define SPRITE_SHEET_SUIT "suit"
+#define SPRITE_SHEET_BELT "belt"
+#define SPRITE_SHEET_HEAD "head"
+#define SPRITE_SHEET_BACK "back"
+#define SPRITE_SHEET_MASK "mask"
+#define SPRITE_SHEET_EARS "ears"
+#define SPRITE_SHEET_EYES "eyes"
+#define SPRITE_SHEET_FEET "feet"
+#define SPRITE_SHEET_GLOVES "gloves"
+
 //Sol translation for dog slots.
 #define SLOT_MOUTH SLOT_WEAR_MASK  // 2
 #define SLOT_NECK  SLOT_HANDCUFFED // 3 (Ian actually is a cat! ~if you know what i mean)

--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -67,6 +67,7 @@
 #define NO_FINGERPRINT     "no_fingerprint"
 #define NO_MINORCUTS	   "no_minorcuts"
 #define NO_BLOOD_TRAILS    "no_blood_trails"
+#define SPRITE_SHEET_RESTRICTION "sprite_sheet_restriction" // If specie has this flag, all clothing which icon_state is in the sprite sheet will be awearable.
 
 //Species Diet Flags
 #define DIET_MEAT		1 // Meat.

--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -58,6 +58,8 @@
 
 		if(S.flags[IS_WHITELISTED])
 			whitelisted_species += S.name
+		if(S.flags[SPRITE_SHEET_RESTRICTION])
+			global.sprite_sheet_restricted += S.name
 
 	//Chemical Reagents - Initialises all /datum/reagent into a list indexed by reagent id
 	global.chemical_reagents_list = list()

--- a/code/_globalvars/lists/mob.dm
+++ b/code/_globalvars/lists/mob.dm
@@ -3,6 +3,7 @@ var/global/list/all_species[0]
 var/global/list/all_languages[0]
 var/global/list/language_keys[0]					//table of say codes for all languages
 var/global/list/whitelisted_species = list(HUMAN)
+var/global/list/sprite_sheet_restricted = list()
 
 var/list/clients = list()							//list of all clients
 var/list/admins = list()							//list of all clients whom are admins

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -62,14 +62,6 @@
 
 	var/obj/item/device/uplink/hidden/hidden_uplink = null // All items can have an uplink hidden inside, just remember to add the triggers.
 
-	/* Species-specific sprites, concept stolen from Paradise//vg/.
-	ex:
-	sprite_sheets = list(
-		TAJARAN = 'icons/cat/are/bad'
-		)
-	If index term exists and icon_override is not set, this sprite sheet will be used.
-	*/
-	var/list/sprite_sheets = null
 	var/icon_override = null  //Used to override hardcoded clothing dmis in human clothing proc.
 
 	/* Species-specific sprite sheets for inventory sprites

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -11,6 +11,9 @@
 	attack_verb = list("whipped", "lashed", "disciplined")
 	use_to_pickup = TRUE
 
+	// since belt is not considered "clothing", we can't enforce species-bodytype-based restrictions on it. YET. ~Luduk
+	// sprite_sheet_slot = SPRITE_SHEET_BELT
+
 /obj/item/weapon/storage/belt/utility
 	name = "tool-belt" //Carn: utility belt is nicer, but it bamboozles the text parsing.
 	desc = "Can hold various tools."

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -72,9 +72,13 @@ var/global/list/icon_state_allowed_cache = list()
 					global.specie_sprite_sheet_cache[specie] = sheet_icon_states
 
 			if(icons_exist)
-				var/t_state = item_color
-				if(!t_state && (sprite_sheet_slot == SPRITE_SHEET_HELD || sprite_sheet_slot == SPRITE_SHEET_GLOVES))
+				var/t_state
+				if(sprite_sheet_slot == SPRITE_SHEET_HELD || sprite_sheet_slot == SPRITE_SHEET_GLOVES)
 					t_state = item_state
+
+				if(sprite_sheet_slot == SPRITE_SHEET_UNIFORM)
+					t_state = item_color
+
 				if(!t_state)
 					t_state = icon_state
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -73,7 +73,7 @@ var/global/list/icon_state_allowed_cache = list()
 
 			if(icons_exist)
 				var/t_state
-				if(sprite_sheet_slot == SPRITE_SHEET_HELD || sprite_sheet_slot == SPRITE_SHEET_GLOVES)
+				if(sprite_sheet_slot == SPRITE_SHEET_HELD || sprite_sheet_slot == SPRITE_SHEET_GLOVES || sprite_sheet_slot == SPRITE_SHEET_BELT)
 					t_state = item_state
 
 				if(sprite_sheet_slot == SPRITE_SHEET_UNIFORM)

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -17,6 +17,75 @@
 	lefthand_file = 'icons/mob/inhands/clothing_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/clothing_righthand.dmi'
 
+	// Which slot should we use on species.sprite_sheets, as for the species specified above.
+	var/sprite_sheet_slot
+
+/obj/item/clothing/atom_init()
+	. = ..()
+	update_species_restrictions()
+
+/*
+	This is for the Vox among you.
+	Finds whether a sprite for this piece of clothing for a Vox exists, and if it does
+	allows Vox to wear this.
+*/
+var/global/list/specie_sprite_sheet_cache = list()
+var/global/list/icon_state_allowed_cache = list()
+
+/obj/item/clothing/proc/update_species_restrictions()
+	return
+	if(!species_restricted)
+		species_restricted = list()
+
+	var/exclusive = ("excluded" in species_restricted)
+
+	for(var/specie in global.sprite_sheet_restricted)
+		if(exclusive)
+			species_restricted -= specie
+		else
+			species_restricted += specie
+
+	if(!sprite_sheet_slot)
+		if(!species_restricted.len || (species_restricted.len == 1 && exclusive))
+			species_restricted = null
+		return
+
+	for(var/specie in global.sprite_sheet_restricted)
+		var/allowed = FALSE
+		var/cache_key = "[specie]|[icon_state]"
+
+		if(global.icon_state_allowed_cache[cache_key])
+			allowed = TRUE
+		else
+			var/specie_cache = "[specie]"
+			var/list/icons_exist
+			if(global.specie_sprite_sheet_cache[specie_cache])
+				icons_exist = global.specie_sprite_sheet_cache[specie_cache]
+			else
+				var/datum/species/S = all_species[specie]
+				var/icon_path = S.sprite_sheets[sprite_sheet_slot]
+				// If you specified the mob as sprite_sheet_restricted, but
+				// want to use default sprite sheets for some "slots"
+				// then specify it.
+				if(icon_path)
+					var/list/sheet_icon_states = icon_states(icon_path)
+					icons_exist = sheet_icon_states
+					global.specie_sprite_sheet_cache[specie] = sheet_icon_states
+
+			if(icons_exist && "[icon_state]_s" in icons_exist)
+				allowed = TRUE
+
+		if(allowed)
+			if(exclusive)
+				species_restricted |= specie
+			else
+				species_restricted -= specie
+
+			icon_state_allowed_cache[cache_key] = TRUE
+
+	if(!species_restricted.len || (species_restricted.len == 1 && exclusive))
+		species_restricted = null
+
 //BS12: Species-restricted clothing check.
 /obj/item/clothing/mob_can_equip(M, slot)
 
@@ -51,7 +120,7 @@
 	//Set species_restricted list
 	switch(target_species)
 		if(HUMAN , SKRELL)	//humanoid bodytypes
-			species_restricted = list("exclude" , UNATHI , TAJARAN , DIONA , VOX)
+			species_restricted = list("exclude" , UNATHI , TAJARAN , DIONA , VOX, VOX_ARMALIS)
 		else
 			species_restricted = list(target_species)
 
@@ -71,9 +140,9 @@
 	//Set species_restricted list
 	switch(target_species)
 		if(SKRELL)
-			species_restricted = list("exclude" , UNATHI , TAJARAN , DIONA , VOX)
+			species_restricted = list("exclude" , UNATHI , TAJARAN , DIONA , VOX, VOX_ARMALIS)
 		if(HUMAN)
-			species_restricted = list("exclude" , SKRELL , UNATHI , TAJARAN , DIONA , VOX)
+			species_restricted = list("exclude" , SKRELL , UNATHI , TAJARAN , DIONA , VOX, VOX_ARMALIS)
 		else
 			species_restricted = list(target_species)
 
@@ -95,6 +164,8 @@
 	w_class = ITEM_SIZE_NORMAL
 	throwforce = 2
 	slot_flags = SLOT_FLAGS_EARS
+
+	sprite_sheet_slot = SPRITE_SHEET_EARS
 
 /obj/item/clothing/ears/attack_hand(mob/user)
 	if (!user) return
@@ -165,7 +236,6 @@
 	var/vision_flags = 0
 	var/darkness_view = 0//Base human is 2
 	var/invisa_view = 0
-	sprite_sheets = list(VOX = 'icons/mob/species/vox/eyes.dmi')
 /*
 SEE_SELF  // can see self, no matter what
 SEE_MOBS  // can see all mobs, no matter what
@@ -192,8 +262,9 @@ BLIND     // can't see anything
 	slot_flags = SLOT_FLAGS_GLOVES
 	hitsound = list('sound/items/misc/glove-slap.ogg')
 	attack_verb = list("challenged")
-	species_restricted = list("exclude" , UNATHI , TAJARAN)
-	sprite_sheets = list(VOX = 'icons/mob/species/vox/gloves.dmi')
+	species_restricted = list("exclude" , UNATHI , TAJARAN, VOX, VOX_ARMALIS)
+
+	sprite_sheet_slot = SPRITE_SHEET_GLOVES
 
 /obj/item/clothing/gloves/emp_act(severity)
 	if(cell)
@@ -216,7 +287,6 @@ BLIND     // can't see anything
 	body_parts_covered = HEAD
 	slot_flags = SLOT_FLAGS_HEAD
 	w_class = ITEM_SIZE_SMALL
-	sprite_sheets = list(VOX = 'icons/mob/species/vox/head.dmi')
 	var/blockTracking = 0
 
 
@@ -226,7 +296,6 @@ BLIND     // can't see anything
 	icon = 'icons/obj/clothing/masks.dmi'
 	slot_flags = SLOT_FLAGS_MASK
 	body_parts_covered = FACE|EYES
-	sprite_sheets = list(VOX = 'icons/mob/species/vox/masks.dmi')
 
 /obj/item/clothing/proc/speechModification(message)
 	return message
@@ -244,8 +313,7 @@ BLIND     // can't see anything
 
 	permeability_coefficient = 0.50
 	slowdown = SHOES_SLOWDOWN
-	species_restricted = list("exclude" , UNATHI , TAJARAN)
-	sprite_sheets = list(VOX = 'icons/mob/species/vox/shoes.dmi')
+	species_restricted = list("exclude" , UNATHI , TAJARAN, VOX, VOX_ARMALIS)
 
 //Cutting shoes
 /obj/item/clothing/shoes/attackby(obj/item/weapon/W, mob/user)
@@ -290,7 +358,6 @@ BLIND     // can't see anything
 	var/blood_overlay_type = "suit"
 	siemens_coefficient = 0.9
 	w_class = ITEM_SIZE_NORMAL
-	sprite_sheets = list(VOX = 'icons/mob/species/vox/suit.dmi')
 
 /obj/item/clothing/proc/attack_reaction(mob/living/carbon/human/H, reaction_type, mob/living/carbon/human/T = null)
 	return
@@ -312,8 +379,7 @@ BLIND     // can't see anything
 	cold_protection = HEAD
 	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.2
-	species_restricted = list("exclude" , DIONA , VOX)
-	sprite_sheets = list(VOX = 'icons/mob/species/vox/head.dmi')
+	species_restricted = list("exclude", DIONA, VOX, VOX_ARMALIS)
 
 /obj/item/clothing/suit/space
 	name = "space suit"
@@ -334,7 +400,7 @@ BLIND     // can't see anything
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | ARMS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0.2
-	species_restricted = list("exclude" , DIONA , VOX)
+	species_restricted = list("exclude", DIONA, VOX, VOX_ARMALIS)
 
 	var/list/supporting_limbs //If not-null, automatically splints breaks. Checked when removing the suit.
 
@@ -387,7 +453,6 @@ BLIND     // can't see anything
 	var/displays_id = 1
 	var/rolled_down = 0
 	var/basecolor
-	sprite_sheets = list(VOX = 'icons/mob/species/vox/uniform.dmi')
 
 /obj/item/clothing/under/emp_act(severity)
 	..()

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -61,7 +61,7 @@ var/global/list/icon_state_allowed_cache = list()
 			if(global.specie_sprite_sheet_cache[specie_cache])
 				icons_exist = global.specie_sprite_sheet_cache[specie_cache]
 			else
-				var/datum/species/S = all_species[specie]
+				var/datum/species/S = global.all_species[specie]
 				var/icon_path = S.sprite_sheets[sprite_sheet_slot]
 				// If you specified the mob as sprite_sheet_restricted, but
 				// want to use default sprite sheets for some "slots"
@@ -87,7 +87,7 @@ var/global/list/icon_state_allowed_cache = list()
 			else
 				species_restricted -= specie
 
-			icon_state_allowed_cache[cache_key] = TRUE
+			global.icon_state_allowed_cache[cache_key] = TRUE
 
 	if(!species_restricted.len || (species_restricted.len == 1 && exclusive))
 		species_restricted = null

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -34,7 +34,7 @@ var/global/list/icon_state_allowed_cache = list()
 
 /obj/item/clothing/proc/update_species_restrictions()
 	if(!species_restricted)
-		species_restricted = list()
+		species_restricted = list("excluded", VOX, VOX_ARMALIS)
 
 	var/exclusive = ("excluded" in species_restricted)
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -33,7 +33,6 @@ var/global/list/specie_sprite_sheet_cache = list()
 var/global/list/icon_state_allowed_cache = list()
 
 /obj/item/clothing/proc/update_species_restrictions()
-	return
 	if(!species_restricted)
 		species_restricted = list()
 
@@ -72,8 +71,15 @@ var/global/list/icon_state_allowed_cache = list()
 					icons_exist = sheet_icon_states
 					global.specie_sprite_sheet_cache[specie] = sheet_icon_states
 
-			if(icons_exist && "[icon_state]_s" in icons_exist)
-				allowed = TRUE
+			if(icons_exist)
+				var/t_state = item_color
+				if(!t_state && (sprite_sheet_slot == SPRITE_SHEET_HELD || sprite_sheet_slot == SPRITE_SHEET_GLOVES))
+					t_state = item_state
+				if(!t_state)
+					t_state = icon_state
+
+				if("[t_state]_s" in icons_exist)
+					allowed = TRUE
 
 		if(allowed)
 			if(exclusive)
@@ -289,6 +295,7 @@ BLIND     // can't see anything
 	w_class = ITEM_SIZE_SMALL
 	var/blockTracking = 0
 
+	sprite_sheet_slot = SPRITE_SHEET_HEAD
 
 //Mask
 /obj/item/clothing/mask
@@ -296,6 +303,8 @@ BLIND     // can't see anything
 	icon = 'icons/obj/clothing/masks.dmi'
 	slot_flags = SLOT_FLAGS_MASK
 	body_parts_covered = FACE|EYES
+
+	sprite_sheet_slot = SPRITE_SHEET_MASK
 
 /obj/item/clothing/proc/speechModification(message)
 	return message
@@ -314,6 +323,8 @@ BLIND     // can't see anything
 	permeability_coefficient = 0.50
 	slowdown = SHOES_SLOWDOWN
 	species_restricted = list("exclude" , UNATHI , TAJARAN, VOX, VOX_ARMALIS)
+
+	sprite_sheet_slot = SPRITE_SHEET_FEET
 
 //Cutting shoes
 /obj/item/clothing/shoes/attackby(obj/item/weapon/W, mob/user)
@@ -358,6 +369,8 @@ BLIND     // can't see anything
 	var/blood_overlay_type = "suit"
 	siemens_coefficient = 0.9
 	w_class = ITEM_SIZE_NORMAL
+
+	sprite_sheet_slot = SPRITE_SHEET_SUIT
 
 /obj/item/clothing/proc/attack_reaction(mob/living/carbon/human/H, reaction_type, mob/living/carbon/human/T = null)
 	return
@@ -453,6 +466,8 @@ BLIND     // can't see anything
 	var/displays_id = 1
 	var/rolled_down = 0
 	var/basecolor
+
+	sprite_sheet_slot = SPRITE_SHEET_UNIFORM
 
 /obj/item/clothing/under/emp_act(severity)
 	..()

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -15,6 +15,8 @@
 	var/active = 1
 	var/activation_sound = 'sound/items/buttonclick.ogg'
 
+	sprite_sheet_slot = SPRITE_SHEET_EYES
+
 /obj/item/clothing/glasses/attack_self(mob/user)
 	if(toggleable)
 		if(ishuman(usr))

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -84,7 +84,7 @@
 	item_state = "fingerless_black"
 	item_color="black"
 	clipped = TRUE
-	species_restricted = list("exclude","stunglove")
+	species_restricted = list("exclude", "stunglove", VOX, VOX_ARMALIS)
 
 /obj/item/clothing/gloves/fingerless/red
 	name = "red fingerless gloves"

--- a/code/modules/clothing/gloves/ninja.dm
+++ b/code/modules/clothing/gloves/ninja.dm
@@ -40,12 +40,12 @@ var/global/list/drain_atoms = list(
 	For the drain proc, see events/ninja.dm
 */
 /obj/item/clothing/gloves/space_ninja/Touch(atom/A, proximity)
-	if(!candrain || draining || isturf(A) || !proximity) 
+	if(!candrain || draining || isturf(A) || !proximity)
 		return FALSE
 
 	var/mob/living/carbon/human/H = loc
 
-	if(!istype(H)) 
+	if(!istype(H))
 		return FALSE // what
 
 	var/obj/item/clothing/suit/space/space_ninja/suit = H.wear_suit

--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -216,7 +216,7 @@
 	item_state = "zhan_scarf"
 	desc = "White headscarf"
 	body_parts_covered = 0
-	species_restricted = list(UNATHI , TAJARAN , HUMAN , DIONA , IPC)
+	species_restricted = list(UNATHI, TAJARAN, HUMAN, DIONA, IPC)
 
 /obj/item/clothing/head/skrell_headwear
 	name = "skrell yellow headwear"

--- a/code/modules/clothing/masks/gasmask.dm
+++ b/code/modules/clothing/masks/gasmask.dm
@@ -294,7 +294,6 @@
 	gas_transfer_coefficient = 0.10
 	filter = list("phoron", "sleeping_agent", "oxygen")
 	species_restricted = list(VOX , VOX_ARMALIS)
-	sprite_sheets = list(VOX_ARMALIS = 'icons/mob/species/armalis/mask.dmi')
 
 /obj/item/clothing/mask/gas/German
 	name = "German Gas Mask"

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -44,7 +44,7 @@
 	desc = "When you REALLY want to turn up the heat<br>They have the toe caps cut off of them."
 	icon_state = "swat_cut"
 	clipped_status = CLIPPED
-	species_restricted = list("exclude", DIONA, VOX)
+	species_restricted = list("exclude", DIONA, VOX, VOX_ARMALIS)
 
 /obj/item/clothing/shoes/space_ninja
 	name = "ninja shoes"

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -132,19 +132,11 @@
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	species_restricted = list(VOX , VOX_ARMALIS)
-	sprite_sheets = list(
-		VOX = 'icons/mob/species/vox/suit.dmi',
-		VOX_ARMALIS = 'icons/mob/species/armalis/suit.dmi',
-		)
 
 /obj/item/clothing/head/helmet/space/vox
 	armor = list(melee = 60, bullet = 50, laser = 40, energy = 15, bomb = 30, bio = 30, rad = 30)
 	flags = HEADCOVERSEYES
 	species_restricted = list(VOX , VOX_ARMALIS)
-	sprite_sheets = list(
-		VOX = 'icons/mob/species/vox/head.dmi',
-		VOX_ARMALIS = 'icons/mob/species/armalis/head.dmi',
-		)
 
 /obj/item/clothing/head/helmet/space/vox/pressure
 	name = "alien helmet"
@@ -408,22 +400,14 @@
 	permeability_coefficient = 0.05
 	item_color = "gloves-vox"
 	species_restricted = list(VOX , VOX_ARMALIS)
-	sprite_sheets = list(
-		VOX = 'icons/mob/species/vox/gloves.dmi',
-		VOX_ARMALIS = 'icons/mob/species/armalis/gloves.dmi',
-		)
-/obj/item/clothing/shoes/magboots/vox
 
+/obj/item/clothing/shoes/magboots/vox
 	desc = "A pair of heavy, jagged armoured foot pieces, seemingly suitable for a velociraptor."
 	name = "vox magclaws"
 	item_state = "boots-vox"
 	icon_state = "boots-vox"
 
 	species_restricted = list(VOX , VOX_ARMALIS)
-	sprite_sheets = list(
-		VOX_ARMALIS = 'icons/mob/species/armalis/feet.dmi'
-		)
-
 	action_button_name = "Toggle the magclaws"
 
 /obj/item/clothing/shoes/magboots/vox/attack_self(mob/user)

--- a/code/modules/clothing/suits/alien.dm
+++ b/code/modules/clothing/suits/alien.dm
@@ -23,10 +23,6 @@
 	item_state = "zhan_furs"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 
-	sprite_sheets = list(
-		TAJARAN = 'icons/mob/species/tajaran/suit.dmi',
-		)
-
 /obj/item/clothing/head/tajaran/scarf
 	name = "headscarf"
 	desc = "A scarf of coarse fabric. Seems to have ear-holes."

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -36,7 +36,6 @@
 	icon_state = "chaplain_hoodie"
 	item_state = "chaplain_hoodie"
 	body_parts_covered = UPPER_TORSO|ARMS
-	sprite_sheets = list(VOX = 'icons/mob/species/vox/suit.dmi')
 
 //Chaplain
 /obj/item/clothing/suit/nun

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -140,9 +140,10 @@ Please contact me on #coderbus IRC. ~Carn x
 /obj/item/proc/get_standing_overlay(mob/living/carbon/human/H, def_icon_path, sprite_sheet_slot, layer, bloodied_icon_state = null, icon_state_appendix = null)
 	var/icon_path = def_icon_path
 
-	var/t_state = item_color
-	if(!t_state && (sprite_sheet_slot == SPRITE_SHEET_HELD || sprite_sheet_slot == SPRITE_SHEET_GLOVES))
+	var/t_state
+	if(sprite_sheet_slot == SPRITE_SHEET_HELD || sprite_sheet_slot == SPRITE_SHEET_GLOVES)
 		t_state = item_state
+
 	if(!t_state)
 		t_state = icon_state
 
@@ -164,9 +165,10 @@ Please contact me on #coderbus IRC. ~Carn x
 	return I
 
 /obj/item/clothing/get_standing_overlay(mob/living/carbon/human/H, sprite_sheet_slot, layer, bloodied_icon_state = null, icon_state_appendix = null)
-	var/t_state = item_color
-	if(!t_state && (sprite_sheet_slot == SPRITE_SHEET_HELD || sprite_sheet_slot == SPRITE_SHEET_GLOVES))
+	var/t_state
+	if(sprite_sheet_slot == SPRITE_SHEET_HELD || sprite_sheet_slot == SPRITE_SHEET_GLOVES)
 		t_state = item_state
+
 	if(!t_state)
 		t_state = icon_state
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -144,6 +144,9 @@ Please contact me on #coderbus IRC. ~Carn x
 	if(sprite_sheet_slot == SPRITE_SHEET_HELD || sprite_sheet_slot == SPRITE_SHEET_GLOVES)
 		t_state = item_state
 
+	if(sprite_sheet_slot == SPRITE_SHEET_UNIFORM)
+		t_state = item_color
+
 	if(!t_state)
 		t_state = icon_state
 

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -143,6 +143,8 @@ Please contact me on #coderbus IRC. ~Carn x
 	var/t_state
 	if(sprite_sheet_slot == SPRITE_SHEET_HELD || sprite_sheet_slot == SPRITE_SHEET_GLOVES)
 		t_state = item_state
+		if(!icon_custom)
+			icon_state_appendix = null
 
 	if(sprite_sheet_slot == SPRITE_SHEET_UNIFORM)
 		t_state = item_color
@@ -152,7 +154,11 @@ Please contact me on #coderbus IRC. ~Carn x
 
 	var/datum/species/S = H.species
 
-	if(icon_override)
+	if(icon_custom)
+		if(sprite_sheet_slot != SPRITE_SHEET_HELD)
+			icon_state_appendix = "_mob"
+		icon_path = icon_custom
+	else if(icon_override)
 		icon_path = icon_override
 	else if(S.sprite_sheets[sprite_sheet_slot])
 		icon_path = S.sprite_sheets[sprite_sheet_slot]
@@ -166,26 +172,6 @@ Please contact me on #coderbus IRC. ~Carn x
 		I.add_overlay(bloodsies)
 
 	return I
-
-/obj/item/clothing/get_standing_overlay(mob/living/carbon/human/H, sprite_sheet_slot, layer, bloodied_icon_state = null, icon_state_appendix = null)
-	var/t_state
-	if(sprite_sheet_slot == SPRITE_SHEET_HELD || sprite_sheet_slot == SPRITE_SHEET_GLOVES)
-		t_state = item_state
-
-	if(!t_state)
-		t_state = icon_state
-
-	if(icon_custom)
-		var/image/I = image(icon = icon_custom, icon_state = "[t_state]_mob_[icon_state_appendix]", layer = layer)
-		I.color = color
-
-		if(dirt_overlay && bloodied_icon_state)
-			var/image/bloodsies = image(icon = 'icons/effects/blood.dmi', icon_state = bloodied_icon_state)
-			bloodsies.color = dirt_overlay.color
-			I.add_overlay(bloodsies)
-
-		return I
-	return ..()
 
 /mob/living/carbon/human
 	var/list/overlays_standing[TOTAL_LAYERS]
@@ -752,7 +738,7 @@ Please contact me on #coderbus IRC. ~Carn x
 		if(client && hud_used)
 			client.screen += r_hand
 
-		var/image/standing = r_hand.get_standing_overlay(src, r_hand.lefthand_file, SPRITE_SHEET_HELD, -R_HAND_LAYER, icon_state_appendix = "_r")
+		var/image/standing = r_hand.get_standing_overlay(src, r_hand.righthand_file, SPRITE_SHEET_HELD, -R_HAND_LAYER, icon_state_appendix = "_r")
 		overlays_standing[R_HAND_LAYER] = standing
 		if(handcuffed)
 			drop_r_hand()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -137,6 +137,51 @@ Please contact me on #coderbus IRC. ~Carn x
 #define TOTAL_LIMB_LAYERS		7
 //////////////////////////////////
 
+/obj/item/proc/get_standing_overlay(mob/living/carbon/human/H, def_icon_path, sprite_sheet_slot, layer, bloodied_icon_state = null, icon_state_appendix = null)
+	var/icon_path = def_icon_path
+
+	var/t_state = item_color
+	if(!t_state && (sprite_sheet_slot == SPRITE_SHEET_HELD || sprite_sheet_slot == SPRITE_SHEET_GLOVES))
+		t_state = item_state
+	if(!t_state)
+		t_state = icon_state
+
+	var/datum/species/S = H.species
+
+	if(icon_override)
+		icon_path = icon_override
+	else if(S.sprite_sheets[sprite_sheet_slot])
+		icon_path = S.sprite_sheets[sprite_sheet_slot]
+
+	var/image/I = image(icon = icon_path, icon_state = "[t_state][icon_state_appendix]", layer = layer)
+	I.color = color
+
+	if(dirt_overlay && bloodied_icon_state)
+		var/image/bloodsies = image(icon = 'icons/effects/blood.dmi', icon_state = bloodied_icon_state)
+		bloodsies.color = dirt_overlay.color
+		I.add_overlay(bloodsies)
+
+	return I
+
+/obj/item/clothing/get_standing_overlay(mob/living/carbon/human/H, sprite_sheet_slot, layer, bloodied_icon_state = null, icon_state_appendix = null)
+	var/t_state = item_color
+	if(!t_state && (sprite_sheet_slot == SPRITE_SHEET_HELD || sprite_sheet_slot == SPRITE_SHEET_GLOVES))
+		t_state = item_state
+	if(!t_state)
+		t_state = icon_state
+
+	if(icon_custom)
+		var/image/I = image(icon = icon_custom, icon_state = "[t_state]_mob_[icon_state_appendix]", layer = layer)
+		I.color = color
+
+		if(dirt_overlay && bloodied_icon_state)
+			var/image/bloodsies = image(icon = 'icons/effects/blood.dmi', icon_state = bloodied_icon_state)
+			bloodsies.color = dirt_overlay.color
+			I.add_overlay(bloodsies)
+
+		return I
+	return ..()
+
 /mob/living/carbon/human
 	var/list/overlays_standing[TOTAL_LAYERS]
 	var/list/overlays_damage[TOTAL_LIMB_LAYERS]
@@ -400,20 +445,8 @@ Please contact me on #coderbus IRC. ~Carn x
 			client.screen += w_uniform				//Either way, add the item to the HUD
 
 		var/obj/item/clothing/under/U = w_uniform
-		var/t_color = U.item_color
-		if(!t_color)		t_color = icon_state
-		var/image/standing = image("icon_state"="[t_color]_s", "layer"=-UNIFORM_LAYER)
-		if(!U.icon_custom || U.icon_override || species.sprite_sheets["uniform"])
-			standing.icon	= (U.icon_override ? U.icon_override : (species.sprite_sheets["uniform"] ? species.sprite_sheets["uniform"] : 'icons/mob/uniform.dmi'))
-		else
-			standing = image("icon"=U.icon_custom, "icon_state"="[t_color]_mob", "layer"=-UNIFORM_LAYER)
-		standing.color = U.color
+		var/image/standing = U.get_standing_overlay(src, 'icons/mob/uniform.dmi', SPRITE_SHEET_UNIFORM, -UNIFORM_LAYER, "uniformblood", "_s")
 		overlays_standing[UNIFORM_LAYER] = standing
-
-		if(U.dirt_overlay)
-			var/image/bloodsies	= image("icon"='icons/effects/blood.dmi', "icon_state"="uniformblood")
-			bloodsies.color		= U.dirt_overlay.color
-			standing.overlays	+= bloodsies
 
 		if(U.accessories.len)
 			for(var/obj/item/clothing/accessory/A in w_uniform:accessories)
@@ -467,20 +500,8 @@ Please contact me on #coderbus IRC. ~Carn x
 				gloves.screen_loc = ui_gloves		//...draw the item in the inventory screen
 			client.screen += gloves					//Either way, add the item to the HUD
 
-		var/t_state = gloves.item_state
-		if(!t_state)	t_state = gloves.icon_state
-		var/image/standing
-		if(!gloves:icon_custom || gloves.icon_override || species.sprite_sheets["gloves"])
-			standing = image("icon"=((gloves.icon_override) ? gloves.icon_override : (species.sprite_sheets["gloves"] ? species.sprite_sheets["gloves"] : 'icons/mob/hands.dmi')), "icon_state"="[t_state]", "layer"=-GLOVES_LAYER)
-		else
-			standing = image("icon"=gloves:icon_custom, "icon_state"="[t_state]_mob", "layer"=-GLOVES_LAYER)
-		standing.color = gloves.color
-		overlays_standing[GLOVES_LAYER]	= standing
-
-		if(gloves.dirt_overlay)
-			var/image/bloodsies	= image("icon"='icons/effects/blood.dmi', "icon_state"="bloodyhands")
-			bloodsies.color = gloves.dirt_overlay.color
-			standing.overlays	+= bloodsies
+		var/image/standing = gloves.get_standing_overlay(src, 'icons/mob/hands.dmi', SPRITE_SHEET_GLOVES, -GLOVES_LAYER, "bloodyhands")
+		overlays_standing[GLOVES_LAYER] = standing
 	else
 		if(blood_DNA)
 			var/image/bloodsies	= image("icon"='icons/effects/blood.dmi', "icon_state"="bloodyhands")
@@ -498,12 +519,8 @@ Please contact me on #coderbus IRC. ~Carn x
 			if(hud_used.inventory_shown)			//if the inventory is open ...
 				glasses.screen_loc = ui_glasses		//...draw the item in the inventory screen
 			client.screen += glasses				//Either way, add the item to the HUD
-		var/image/standing
-		if(!glasses:icon_custom || glasses.icon_override || species.sprite_sheets["eyes"])
-			standing = image("icon"=((glasses.icon_override) ? glasses.icon_override : (species.sprite_sheets["eyes"] ? species.sprite_sheets["eyes"] : 'icons/mob/eyes.dmi')), "icon_state"="[glasses.icon_state]", "layer"=-GLASSES_LAYER)
-		else
-			standing = image("icon"=glasses:icon_custom, "icon_state"="[glasses.icon_state]_mob", "layer"=-GLASSES_LAYER)
-		standing.color = glasses.color
+
+		var/image/standing = glasses.get_standing_overlay(src, 'icons/mob/eyes.dmi', SPRITE_SHEET_EYES, -GLASSES_LAYER)
 		overlays_standing[GLASSES_LAYER] = standing
 
 	apply_overlay(GLASSES_LAYER)
@@ -518,24 +535,16 @@ Please contact me on #coderbus IRC. ~Carn x
 				if(hud_used.inventory_shown)			//if the inventory is open ...
 					l_ear.screen_loc = ui_l_ear			//...draw the item in the inventory screen
 				client.screen += l_ear					//Either way, add the item to the HUD
-			var/image/standing
-			if(!l_ear:icon_custom || l_ear.icon_override || species.sprite_sheets["ears"])
-				standing = image("icon"=((l_ear.icon_override) ? l_ear.icon_override : (species.sprite_sheets["ears"] ? species.sprite_sheets["ears"] : 'icons/mob/ears.dmi')), "icon_state"="[l_ear.icon_state]", "layer"=-EARS_LAYER)
-			else
-				standing = image("icon"=l_ear:icon_custom, "icon_state"="[l_ear.icon_state]_mob", "layer"=-EARS_LAYER)
-			standing.color = l_ear.color
+
+			var/image/standing = l_ear.get_standing_overlay(src, 'icons/mob/ears.dmi', SPRITE_SHEET_EARS, -EARS_LAYER)
 			overlays_standing[EARS_LAYER] = standing
 		if(r_ear)
 			if(client && hud_used && hud_used.hud_shown)
 				if(hud_used.inventory_shown)		//if the inventory is open ...
 					r_ear.screen_loc = ui_r_ear		//...draw the item in the inventory screen
 				client.screen += r_ear				//Either way, add the item to the HUD
-			var/image/standing
-			if(!r_ear:icon_custom || r_ear.icon_override || species.sprite_sheets["ears"])
-				standing = image("icon"=((r_ear.icon_override) ? r_ear.icon_override : (species.sprite_sheets["ears"] ? species.sprite_sheets["ears"] : 'icons/mob/ears.dmi')), "icon_state"="[r_ear.icon_state]", "layer"=-EARS_LAYER)
-			else
-				standing = image("icon"=r_ear:icon_custom, "icon_state"="[r_ear.icon_state]_mob", "layer"=-EARS_LAYER)
-			standing.color = r_ear.color
+
+			var/image/standing = r_ear.get_standing_overlay(src, 'icons/mob/ears.dmi', SPRITE_SHEET_EARS, -EARS_LAYER)
 			overlays_standing[EARS_LAYER] = standing
 
 	apply_overlay(EARS_LAYER)
@@ -550,18 +559,8 @@ Please contact me on #coderbus IRC. ~Carn x
 				shoes.screen_loc = ui_shoes			//...draw the item in the inventory screen
 			client.screen += shoes					//Either way, add the item to the HUD
 
-		var/image/standing
-		if(!shoes:icon_custom || shoes.icon_override || species.sprite_sheets["feet"])
-			standing = image("icon"=((shoes.icon_override) ? shoes.icon_override : (species.sprite_sheets["feet"] ? species.sprite_sheets["feet"] : 'icons/mob/feet.dmi')), "icon_state"="[shoes.icon_state]", "layer"=-SHOES_LAYER)
-		else
-			standing = image("icon"=shoes:icon_custom, "icon_state"="[shoes.icon_state]_mob", "layer"=-SHOES_LAYER)
-		standing.color = shoes.color
+		var/image/standing = shoes.get_standing_overlay(src, 'icons/mob/feet.dmi', SPRITE_SHEET_FEET, -SHOES_LAYER, "shoeblood")
 		overlays_standing[SHOES_LAYER] = standing
-
-		if(shoes.dirt_overlay)
-			var/image/bloodsies = image("icon"='icons/effects/blood.dmi', "icon_state"="shoeblood")
-			bloodsies.color = shoes.dirt_overlay.color
-			standing.add_overlay(bloodsies)
 	else
 		if(feet_blood_DNA)
 			var/image/bloodsies = image("icon"='icons/effects/blood.dmi', "icon_state"="shoeblood")
@@ -602,19 +601,16 @@ Please contact me on #coderbus IRC. ~Carn x
 		var/image/standing
 		if(istype(head,/obj/item/clothing/head/kitty))
 			var/obj/item/clothing/head/kitty/K = head
-			standing	= image("icon"=K.mob, "layer"=-HEAD_LAYER)
-		else
-			if(!head:icon_custom || head.icon_override || species.sprite_sheets["head"])
-				standing = image("icon"=((head.icon_override) ? head.icon_override : (species.sprite_sheets["head"] ? species.sprite_sheets["head"] : 'icons/mob/head.dmi')), "icon_state"="[head.icon_state]", "layer"=-HEAD_LAYER)
-			else
-				standing = image("icon"=head:icon_custom, "icon_state"="[head.icon_state]_mob", "layer"=-HEAD_LAYER)
-		standing.color = head.color
-		overlays_standing[HEAD_LAYER]	= standing
+			standing = image("icon"=K.mob, "layer"=-HEAD_LAYER)
+			standing.color = K.color
 
-		if(head.dirt_overlay)
-			var/image/bloodsies = image("icon"='icons/effects/blood.dmi', "icon_state"="helmetblood")
-			bloodsies.color = head.dirt_overlay.color
-			standing.overlays	+= bloodsies
+			if(K.dirt_overlay)
+				var/image/bloodsies = image("icon"='icons/effects/blood.dmi', "icon_state"="helmetblood")
+				bloodsies.color = K.dirt_overlay.color
+				standing.overlays += bloodsies
+		else
+			standing = head.get_standing_overlay(src, 'icons/mob/head.dmi', SPRITE_SHEET_HEAD, -HEAD_LAYER, "helmetblood")
+		overlays_standing[HEAD_LAYER] = standing
 
 	apply_overlay(HEAD_LAYER)
 
@@ -627,15 +623,9 @@ Please contact me on #coderbus IRC. ~Carn x
 		if(client && hud_used)
 			client.screen += belt
 
-		var/t_state = belt.item_state
-		if(!t_state)	t_state = belt.icon_state
-		var/image/standing
-		if(!belt:icon_custom || belt.icon_override || species.sprite_sheets["belt"])
-			standing = image("icon"=((belt.icon_override) ? belt.icon_override : (species.sprite_sheets["belt"] ? species.sprite_sheets["belt"] : 'icons/mob/belt.dmi')), "icon_state"="[t_state]", "layer"=-BELT_LAYER)
-		else
-			standing = image("icon"=belt:icon_custom, "icon_state"="[belt.icon_state]_mob", "layer"=-BELT_LAYER)
-		standing.color = belt.color
+		var/image/standing = belt.get_standing_overlay(src, 'icons/mob/belt.dmi', SPRITE_SHEET_BELT, -BELT_LAYER)
 		overlays_standing[BELT_LAYER] = standing
+
 	apply_overlay(BELT_LAYER)
 
 /mob/living/carbon/human/update_inv_wear_suit()
@@ -647,18 +637,9 @@ Please contact me on #coderbus IRC. ~Carn x
 				wear_suit.screen_loc = ui_oclothing	//...draw the item in the inventory screen
 			client.screen += wear_suit				//Either way, add the item to the HUD
 
-		var/image/standing
-		if(!wear_suit:icon_custom || wear_suit.icon_override || species.sprite_sheets["suit"])
-			standing = image("icon"=((wear_suit.icon_override) ? wear_suit.icon_override : (species.sprite_sheets["suit"] ? species.sprite_sheets["suit"] : 'icons/mob/suit.dmi')), "icon_state"="[wear_suit.icon_state]", "layer"=-SUIT_LAYER)
-		else
-			standing = image("icon"=wear_suit:icon_custom, "icon_state"="[wear_suit.icon_state]_mob", "layer"=-SUIT_LAYER)
+		var/obj/item/clothing/suit/S = wear_suit
 
-		if(wear_suit.dirt_overlay)
-			var/obj/item/clothing/suit/S = wear_suit
-			var/image/bloodsies = image("icon"='icons/effects/blood.dmi', "icon_state"="[S.blood_overlay_type]blood")
-			bloodsies.color = wear_suit.dirt_overlay.color
-			standing.add_overlay(bloodsies)
-		standing.color = wear_suit.color
+		var/image/standing = S.get_standing_overlay(src, 'icons/mob/suit.dmi', SPRITE_SHEET_SUIT, -SUIT_LAYER, "[S.blood_overlay_type]blood")
 		overlays_standing[SUIT_LAYER] = standing
 
 		if(istype(wear_suit, /obj/item/clothing/suit/straight_jacket))
@@ -706,18 +687,8 @@ Please contact me on #coderbus IRC. ~Carn x
 				wear_mask.screen_loc = ui_mask		//...draw the item in the inventory screen
 			client.screen += wear_mask				//Either way, add the item to the HUD
 
-		var/image/standing
-		if(!wear_mask:icon_custom || wear_mask.icon_override || species.sprite_sheets["mask"])
-			standing = image("icon"=((wear_mask.icon_override) ? wear_mask.icon_override : (species.sprite_sheets["mask"] ? species.sprite_sheets["mask"] : 'icons/mob/mask.dmi')), "icon_state"="[wear_mask.icon_state]", "layer"=-FACEMASK_LAYER)
-		else
-			standing = image("icon"=wear_mask:icon_custom, "icon_state"="[wear_mask.icon_state]_mob", "layer"=-FACEMASK_LAYER)
-		standing.color = wear_mask.color
+		var/image/standing = wear_mask.get_standing_overlay(src, 'icons/mob/mask.dmi', SPRITE_SHEET_MASK, -FACEMASK_LAYER, "maskblood")
 		overlays_standing[FACEMASK_LAYER]	= standing
-
-		if(wear_mask.dirt_overlay && !istype(wear_mask, /obj/item/clothing/mask/cigarette))
-			var/image/bloodsies = image("icon"='icons/effects/blood.dmi', "icon_state"="maskblood")
-			bloodsies.color = wear_mask.dirt_overlay.color
-			standing.overlays	+= bloodsies
 
 	apply_overlay(FACEMASK_LAYER)
 
@@ -729,12 +700,8 @@ Please contact me on #coderbus IRC. ~Carn x
 		back.screen_loc = ui_back
 		if(client && hud_used && hud_used.hud_shown)
 			client.screen += back
-		var/image/standing
-		if(!back:icon_custom || back.icon_override || species.sprite_sheets["back"])
-			standing = image("icon"=((back.icon_override) ? back.icon_override : (species.sprite_sheets["back"] ? species.sprite_sheets["back"] : 'icons/mob/back.dmi')), "icon_state"="[back.icon_state]", "layer"=-BACK_LAYER)
-		else
-			standing = image("icon"=back:icon_custom, "icon_state"="[back.icon_state]_mob", "layer"=-BACK_LAYER)
-		standing.color = back.color
+
+		var/image/standing = back.get_standing_overlay(src, 'icons/mob/back.dmi', SPRITE_SHEET_BACK, -BACK_LAYER)
 		overlays_standing[BACK_LAYER] = standing
 	apply_overlay(BACK_LAYER)
 
@@ -780,16 +747,7 @@ Please contact me on #coderbus IRC. ~Carn x
 		if(client && hud_used)
 			client.screen += r_hand
 
-		var/t_state = r_hand.item_state
-		if(!t_state)
-			t_state = r_hand.icon_state
-		var/image/standing
-		if(!r_hand:icon_custom || r_hand.icon_override || species.sprite_sheets["held"])
-			if(r_hand.icon_override || species.sprite_sheets["held"]) t_state = "[t_state]_r"
-			standing = image("icon"=((r_hand.icon_override) ? r_hand.icon_override : (species.sprite_sheets["held"] ? species.sprite_sheets["held"] : r_hand.righthand_file)), "icon_state"="[t_state]", "layer"=-R_HAND_LAYER)
-		else
-			standing = image("icon"=r_hand:icon_custom, "icon_state"="[t_state]_r", "layer"=-R_HAND_LAYER)
-		standing.color = r_hand.color
+		var/image/standing = r_hand.get_standing_overlay(src, r_hand.lefthand_file, SPRITE_SHEET_HELD, -R_HAND_LAYER, icon_state_appendix = "_r")
 		overlays_standing[R_HAND_LAYER] = standing
 		if(handcuffed)
 			drop_r_hand()
@@ -808,13 +766,7 @@ Please contact me on #coderbus IRC. ~Carn x
 		var/t_state = l_hand.item_state
 		if(!t_state)
 			t_state = l_hand.icon_state
-		var/image/standing
-		if(!l_hand:icon_custom || l_hand.icon_override || species.sprite_sheets["held"])
-			if(l_hand.icon_override || species.sprite_sheets["held"]) t_state = "[t_state]_l"
-			standing = image("icon"=((l_hand.icon_override) ? l_hand.icon_override : (species.sprite_sheets["held"] ? species.sprite_sheets["held"] : l_hand.lefthand_file)), "icon_state"="[t_state]", "layer"=-L_HAND_LAYER)
-		else
-			standing = image("icon"=l_hand:icon_custom, "icon_state"="[t_state]_l", "layer"=-L_HAND_LAYER)
-		standing.color = l_hand.color
+		var/image/standing = l_hand.get_standing_overlay(src, l_hand.lefthand_file, SPRITE_SHEET_HELD, -L_HAND_LAYER, icon_state_appendix = "_l")
 		overlays_standing[L_HAND_LAYER] = standing
 		if(handcuffed)
 			drop_l_hand()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -141,7 +141,7 @@ Please contact me on #coderbus IRC. ~Carn x
 	var/icon_path = def_icon_path
 
 	var/t_state
-	if(sprite_sheet_slot == SPRITE_SHEET_HELD || sprite_sheet_slot == SPRITE_SHEET_GLOVES)
+	if(sprite_sheet_slot == SPRITE_SHEET_HELD || sprite_sheet_slot == SPRITE_SHEET_GLOVES || sprite_sheet_slot == SPRITE_SHEET_BELT)
 		t_state = item_state
 		if(!icon_custom)
 			icon_state_appendix = null

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -398,9 +398,15 @@
 	flesh_color = "#808d11"
 
 	sprite_sheets = list(
+		// SPRITE_SHEET_HELD = 'icons/mob/species/vox/held.dmi',
+		SPRITE_SHEET_UNIFORM = 'icons/mob/species/vox/uniform.dmi',
 		SPRITE_SHEET_SUIT = 'icons/mob/species/vox/suit.dmi',
+		SPRITE_SHEET_BELT = 'icons/mob/belt.dmi',
 		SPRITE_SHEET_HEAD = 'icons/mob/species/vox/head.dmi',
+		SPRITE_SHEET_BACK = 'icons/mob/back.dmi',
 		SPRITE_SHEET_MASK = 'icons/mob/species/vox/masks.dmi',
+		SPRITE_SHEET_EARS = 'icons/mob/ears.dmi',
+		SPRITE_SHEET_EYES = 'icons/mob/species/vox/eyes.dmi',
 		SPRITE_SHEET_FEET = 'icons/mob/species/vox/shoes.dmi',
 		SPRITE_SHEET_GLOVES = 'icons/mob/species/vox/gloves.dmi'
 		)
@@ -497,20 +503,6 @@
 		SPRITE_SHEET_HEAD = 'icons/mob/species/armalis/head.dmi',
 		SPRITE_SHEET_HELD = 'icons/mob/species/armalis/held.dmi'
 		)
-
-	sprite_sheets = list(
-		// SPRITE_SHEET_HELD = 'icons/mob/species/vox/held.dmi',
-		SPRITE_SHEET_UNIFORM = 'icons/mob/species/vox/uniform.dmi',
-		SPRITE_SHEET_SUIT = 'icons/mob/species/vox/suit.dmi',
-		SPRITE_SHEET_BELT = 'icons/mob/belt.dmi',
-        SPRITE_SHEET_HEAD = 'icons/mob/species/vox/head.dmi',
-		SPRITE_SHEET_BACK = 'icons/mob/back.dmi',
-		SPRITE_SHEET_MASK = 'icons/mob/species/vox/masks.dmi',
-		SPRITE_SHEET_EARS = 'icons/mob/ears.dmi',
-		SPRITE_SHEET_EYES = 'icons/mob/species/vox/eyes.dmi',
-		SPRITE_SHEET_FEET = 'icons/mob/species/vox/shoes.dmi',
-		SPRITE_SHEET_GLOVES = 'icons/mob/species/vox/gloves.dmi'
-        )
 
 /datum/species/diona
 	name = DIONA

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -76,17 +76,17 @@
 	/* Species-specific sprites, concept stolen from Paradise//vg/.
 	ex:
 	sprite_sheets = list(
-		"held" = 'icons/mob/path',
-		"uniform" = 'icons/mob/path',
-		"suit" = 'icons/mob/path',
-		"belt" = 'icons/mob/path'
-		"head" = 'icons/mob/path',
-		"back" = 'icons/mob/path',
-		"mask" = 'icons/mob/path',
-		"ears" = 'icons/mob/path',
-		"eyes" = 'icons/mob/path',
-		"feet" = 'icons/mob/path',
-		"gloves" = 'icons/mob/path'
+		SPRITE_SHEET_HELD = 'icons/mob/path',
+		SPRITE_SHEET_UNIFORM = 'icons/mob/path',
+		SPRITE_SHEET_SUIT = 'icons/mob/path',
+		SPRITE_SHEET_BELT = 'icons/mob/path'
+		SPRITE_SHEET_HEAD = 'icons/mob/path',
+		SPRITE_SHEET_BACK = 'icons/mob/path',
+		SPRITE_SHEET_MASK = 'icons/mob/path',
+		SPRITE_SHEET_EARS = 'icons/mob/path',
+		SPRITE_SHEET_EYES = 'icons/mob/path',
+		SPRITE_SHEET_FEET = 'icons/mob/path',
+		SPRITE_SHEET_GLOVES = 'icons/mob/path'
 		)
 	If index term exists and icon_override is not set, this sprite sheet will be used.
 	*/
@@ -391,17 +391,18 @@
 
 	flags = list(
 		NO_SCAN = TRUE
+		,SPRITE_SHEET_RESTRICTION = TRUE
 	)
 
 	blood_datum_path = /datum/dirt_cover/blue_blood
 	flesh_color = "#808d11"
 
 	sprite_sheets = list(
-		"suit" = 'icons/mob/species/vox/suit.dmi',
-		"head" = 'icons/mob/species/vox/head.dmi',
-		"mask" = 'icons/mob/species/vox/masks.dmi',
-		"feet" = 'icons/mob/species/vox/shoes.dmi',
-		"gloves" = 'icons/mob/species/vox/gloves.dmi'
+		SPRITE_SHEET_SUIT = 'icons/mob/species/vox/suit.dmi',
+		SPRITE_SHEET_HEAD = 'icons/mob/species/vox/head.dmi',
+		SPRITE_SHEET_MASK = 'icons/mob/species/vox/masks.dmi',
+		SPRITE_SHEET_FEET = 'icons/mob/species/vox/shoes.dmi',
+		SPRITE_SHEET_GLOVES = 'icons/mob/species/vox/gloves.dmi'
 		)
 
 	min_age = 12
@@ -481,6 +482,7 @@
 	,NO_BLOOD = TRUE
 	,HAS_TAIL = TRUE
 	,NO_PAIN = TRUE
+	,SPRITE_SHEET_RESTRICTION = TRUE
 	)
 
 	blood_datum_path = /datum/dirt_cover/blue_blood
@@ -489,12 +491,26 @@
 	icon_template = 'icons/mob/human_races/r_armalis.dmi'
 
 	sprite_sheets = list(
-		"suit" = 'icons/mob/species/armalis/suit.dmi',
-		"gloves" = 'icons/mob/species/armalis/gloves.dmi',
-		"feet" = 'icons/mob/species/armalis/feet.dmi',
-		"head" = 'icons/mob/species/armalis/head.dmi',
-		"held" = 'icons/mob/species/armalis/held.dmi'
+		SPRITE_SHEET_SUIT = 'icons/mob/species/armalis/suit.dmi',
+		SPRITE_SHEET_GLOVES = 'icons/mob/species/armalis/gloves.dmi',
+		SPRITE_SHEET_FEET = 'icons/mob/species/armalis/feet.dmi',
+		SPRITE_SHEET_HEAD = 'icons/mob/species/armalis/head.dmi',
+		SPRITE_SHEET_HELD = 'icons/mob/species/armalis/held.dmi'
 		)
+
+	sprite_sheets = list(
+		// SPRITE_SHEET_HELD = 'icons/mob/species/vox/held.dmi',
+		SPRITE_SHEET_UNIFORM = 'icons/mob/species/vox/uniform.dmi',
+		SPRITE_SHEET_SUIT = 'icons/mob/species/vox/suit.dmi',
+		SPRITE_SHEET_BELT = 'icons/mob/belt.dmi',
+        SPRITE_SHEET_HEAD = 'icons/mob/species/vox/head.dmi',
+		SPRITE_SHEET_BACK = 'icons/mob/back.dmi',
+		SPRITE_SHEET_MASK = 'icons/mob/species/vox/masks.dmi',
+		SPRITE_SHEET_EARS = 'icons/mob/ears.dmi',
+		SPRITE_SHEET_EYES = 'icons/mob/species/vox/eyes.dmi',
+		SPRITE_SHEET_FEET = 'icons/mob/species/vox/shoes.dmi',
+		SPRITE_SHEET_GLOVES = 'icons/mob/species/vox/gloves.dmi'
+        )
 
 /datum/species/diona
 	name = DIONA


### PR DESCRIPTION
## Описание изменений

Любая раса с флажком SPRITE_SHEET_RESTRICTION не сможет носить одежду, спрайтов которой нет в файле, указанном для конкретного слота в sprite_sheets у /datum/species.

Если хочется чтобы для некоторых слотов юзался кастомный спрайт расы, а для некоторых дефолтных, для тех которые дефолтные надо будет в sprite_sheets это указывать, на подобие
sprite_sheets(SPRITE_SHEET_MASK = 'icons/mob/mask.dmi', SPRITE_SHEET_HEAD = 'icons/custom_bullshit.dmi'

тестирование проводилось путём спавна 100 штук /obj/item/clothing/mask/gas/clown_hat

До ПР-а:
Initialized Atoms subsystem within 7 seconds!
```
(всё по нулям, потому-что этот прок пустой)
```
После:
(для этого поля брал среднее за 10 запусков)
Initialized Atoms subsystem within 7.1 seconds!
```
Proc Name                                                                                       Self CPU    Total CPU    Real Time     Overtime
-------------------------------------------------------------------------------------------    ---------    ---------    ---------    ---------
/obj/item/clothing/atom_init                                                                       0.000        0.001        0.002        0.000
/obj/item/clothing/proc/update_species_restrictions                                                0.001        0.001        0.001        0.000

```

## Почему и что этот ПР улучшит

В связи с не слишком за горизонтом возможным введением воксов как постоянной играбельной расы, решил сделать для удобства вот это.
