### PR TITLE
Возвращаем инхенды Стечкина и Стан-револьвера

### DIFF
--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -46,6 +46,7 @@
 	name = "stun revolver"
 	desc = "A high-tech revolver that fires stun cartridges. The stun cartridges can be recharged using a conventional energy weapon recharger."
 	icon_state = "stunrevolver"
+	item_state = "taser"
 	origin_tech = "combat=3;materials=3;powerstorage=2"
 	ammo_type = list(/obj/item/ammo_casing/energy/stun/gun, /obj/item/ammo_casing/energy/electrode/gun)
 	cell_type = "/obj/item/weapon/stock_parts/cell"

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -1,8 +1,7 @@
 /obj/item/weapon/gun/projectile/automatic //Hopefully someone will find a way to make these fire in bursts or something. --Superxpdude
 	name = "submachine gun"
 	desc = "A lightweight, fast firing gun. Uses 9mm rounds."
-	icon_state = "saber"
-	item_state = "saber"	//ugly
+	icon_state = "saber"	//ugly
 	w_class = ITEM_SIZE_NORMAL
 	origin_tech = "combat=4;materials=2"
 	mag_type = /obj/item/ammo_box/magazine/msmg9mm


### PR DESCRIPTION
## Описание изменений
Немного пошаманил с item_state задав таковой у стан-револьвера на инхенд тазера (раньше он и был, насколько я понял) и убрал пропись этого же у ПП, так как от него этот стейт наследовала остальная ветка, не только Стечкин, к слову.
## Почему и что этот ПР улучшит
Fix #4635
Fix #4678
## Авторство
:cl: Dred1792
## Чеинжлог
- bugfix: Стан-револьвер не отображался в руках.
- bugfix: Стечкин в руках отображался как ПП.