### PR TITLE
Убил спам зажигалкой

### DIFF
--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -419,7 +419,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 //ZIPPO//
 /////////
 /obj/item/weapon/lighter
-	var/next_click
 	name = "cheap lighter"
 	desc = "A cheap-as-free lighter."
 	icon = 'icons/obj/items.dmi'
@@ -460,26 +459,26 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		return 0
 
 /obj/item/weapon/lighter/attack_self(mob/living/user)
-	if((user.r_hand == src || user.l_hand == src) && (next_click < world.time))
-		next_click = world.time + 10
+	if(user.r_hand == src || user.l_hand == src)
+		user.SetNextMove(CLICK_CD_MELEE)
 		if(!lit)
 			lit = 1
 			icon_state = icon_on
 			item_state = icon_on
 			if(istype(src, /obj/item/weapon/lighter/zippo) )
 				playsound(src, 'sound/items/zippo.ogg', VOL_EFFECTS_MASTER, 20)
-				user.visible_message("<span class='notice'>[user] flips open and lights [src].</span>")
+				user.visible_message("<span class='notice'>[user] clicks and lights a [src].</span>")
 			else
 				playsound(src, 'sound/items/lighter.ogg', VOL_EFFECTS_MASTER, 20)
 				if(prob(95))
-					user.visible_message("<span class='notice'>After a few attempts, [user] light the [src].</span>")
+					user.visible_message("<span class='notice'>[user] clicks and lights a [src].</span>")
 				else
 					to_chat(user, "<span class='warning'>You burn yourself while lighting the lighter.</span>")
 					if (user.l_hand == src)
 						user.apply_damage(2, BURN, BP_L_ARM)
 					else
 						user.apply_damage(2, BURN, BP_R_ARM)
-					user.visible_message("<span class='warning'>After a few attempts, [user] manages to light the [src], they however burn their finger.</span>")
+					user.visible_message("<span class='warning'>[user] tries to light [src], but burn their finger!</span>")
 
 			set_light(2)
 			START_PROCESSING(SSobj, src)
@@ -487,11 +486,10 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			lit = 0
 			icon_state = icon_off
 			item_state = icon_off
+			user.visible_message("<span class='notice'>[user] clicks and extinguishes [src].</span>")
 			if(istype(src, /obj/item/weapon/lighter/zippo) )
 				playsound(src, 'sound/items/zippo.ogg', VOL_EFFECTS_MASTER, 20)
-				user.visible_message("<span class='notice'>You hear a quiet click, as [user] shuts off [src].</span>")
 			else
-				user.visible_message("<span class='notice'>[user] shuts off the [src].</span>")
 				playsound(src, 'sound/items/lighter.ogg', VOL_EFFECTS_MASTER, 20)
 
 			set_light(0)

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -466,19 +466,19 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			icon_state = icon_on
 			item_state = icon_on
 			if(istype(src, /obj/item/weapon/lighter/zippo) )
-				playsound(src, 'sound/items/zippo.ogg', VOL_EFFECTS_MASTER, 20)
-				user.visible_message("<span class='notice'>[user] clicks and lights a [src].</span>")
+				playsound(src, 'sound/items/zippo.ogg', VOL_EFFECTS_MASTER, 25)
+				user.visible_message("<span class='notice''>Without even breaking stride, [user] flips open and lights [src] in one smooth movement.</span>")
 			else
-				playsound(src, 'sound/items/lighter.ogg', VOL_EFFECTS_MASTER, 20)
+				playsound(src, 'sound/items/lighter.ogg', VOL_EFFECTS_MASTER, 25)
 				if(prob(95))
-					user.visible_message("<span class='notice'>[user] clicks and lights a [src].</span>")
+					user.visible_message("<span class='notice'>After a few attempts, [user] manages to light the [src].</span>")
 				else
 					to_chat(user, "<span class='warning'>You burn yourself while lighting the lighter.</span>")
 					if (user.l_hand == src)
 						user.apply_damage(2, BURN, BP_L_ARM)
 					else
 						user.apply_damage(2, BURN, BP_R_ARM)
-					user.visible_message("<span class='warning'>[user] tries to light [src], but burn their finger!</span>")
+					user.visible_message("<span class='warning'>After a few attempts, [user] manages to light the [src], they however burn their finger in the process.</span>")
 
 			set_light(2)
 			START_PROCESSING(SSobj, src)
@@ -486,11 +486,12 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			lit = 0
 			icon_state = icon_off
 			item_state = icon_off
-			user.visible_message("<span class='notice'>[user] clicks and extinguishes [src].</span>")
 			if(istype(src, /obj/item/weapon/lighter/zippo) )
-				playsound(src, 'sound/items/zippo.ogg', VOL_EFFECTS_MASTER, 20)
+				playsound(src, 'sound/items/zippo.ogg', VOL_EFFECTS_MASTER, 25)
+				user.visible_message("<span class='notice'>You hear a quiet click, as [user] shuts off [src] without even looking at what they're doing.</span>")
 			else
-				playsound(src, 'sound/items/lighter.ogg', VOL_EFFECTS_MASTER, 20)
+				user.visible_message("<span class='notice'>[user] quietly shuts off the [src].</span>")
+				playsound(src, 'sound/items/lighter.ogg', VOL_EFFECTS_MASTER, 25)
 
 			set_light(0)
 			STOP_PROCESSING(SSobj, src)

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -467,7 +467,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			item_state = icon_on
 			if(istype(src, /obj/item/weapon/lighter/zippo) )
 				playsound(src, 'sound/items/zippo.ogg', VOL_EFFECTS_MASTER, 25)
-				user.visible_message("<span class='notice''>Without even breaking stride, [user] flips open and lights [src] in one smooth movement.</span>")
+				user.visible_message("<span class='notice'>Without even breaking stride, [user] flips open and lights [src] in one smooth movement.</span>")
 			else
 				playsound(src, 'sound/items/lighter.ogg', VOL_EFFECTS_MASTER, 25)
 				if(prob(95))

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -122,7 +122,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 	else if(istype(W, /obj/item/device/assembly/igniter))
 		light("<span class='notice'>[user] fiddles with [W], and manages to light their [name].</span>")
-		
+
 	else if(istype(W, /obj/item/weapon/pen/edagger))
 		var/obj/item/weapon/pen/edagger/E = W
 		if(E.on)
@@ -419,6 +419,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 //ZIPPO//
 /////////
 /obj/item/weapon/lighter
+	var/next_click
 	name = "cheap lighter"
 	desc = "A cheap-as-free lighter."
 	icon = 'icons/obj/items.dmi'
@@ -459,25 +460,26 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		return 0
 
 /obj/item/weapon/lighter/attack_self(mob/living/user)
-	if(user.r_hand == src || user.l_hand == src)
+	if((user.r_hand == src || user.l_hand == src) && (next_click < world.time))
+		next_click = world.time + 10
 		if(!lit)
 			lit = 1
 			icon_state = icon_on
 			item_state = icon_on
 			if(istype(src, /obj/item/weapon/lighter/zippo) )
 				playsound(src, 'sound/items/zippo.ogg', VOL_EFFECTS_MASTER, 20)
-				user.visible_message("<span class='rose'>Without even breaking stride, [user] flips open and lights [src] in one smooth movement.</span>")
+				user.visible_message("<span class='notice'>[user] flips open and lights [src].</span>")
 			else
 				playsound(src, 'sound/items/lighter.ogg', VOL_EFFECTS_MASTER, 20)
 				if(prob(95))
-					user.visible_message("<span class='notice'>After a few attempts, [user] manages to light the [src].</span>")
+					user.visible_message("<span class='notice'>After a few attempts, [user] light the [src].</span>")
 				else
 					to_chat(user, "<span class='warning'>You burn yourself while lighting the lighter.</span>")
 					if (user.l_hand == src)
 						user.apply_damage(2, BURN, BP_L_ARM)
 					else
 						user.apply_damage(2, BURN, BP_R_ARM)
-					user.visible_message("<span class='notice'>After a few attempts, [user] manages to light the [src], they however burn their finger in the process.</span>")
+					user.visible_message("<span class='warning'>After a few attempts, [user] manages to light the [src], they however burn their finger.</span>")
 
 			set_light(2)
 			START_PROCESSING(SSobj, src)
@@ -487,9 +489,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			item_state = icon_off
 			if(istype(src, /obj/item/weapon/lighter/zippo) )
 				playsound(src, 'sound/items/zippo.ogg', VOL_EFFECTS_MASTER, 20)
-				user.visible_message("<span class='rose'>You hear a quiet click, as [user] shuts off [src] without even looking at what they're doing.</span>")
+				user.visible_message("<span class='notice'>You hear a quiet click, as [user] shuts off [src].</span>")
 			else
-				user.visible_message("<span class='notice'>[user] quietly shuts off the [src].</span>")
+				user.visible_message("<span class='notice'>[user] shuts off the [src].</span>")
 				playsound(src, 'sound/items/lighter.ogg', VOL_EFFECTS_MASTER, 20)
 
 			set_light(0)


### PR DESCRIPTION
Убрал возможность сильно спамить зажигалками, добавив КД 0.8 секунд и сменив цвет на синий

<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Теперь вместо такого:
![dreamseeker_0T4TJwf8wX](https://user-images.githubusercontent.com/43725089/74749117-b71f7000-527a-11ea-8c08-dd35757b0d04.png)

Будет такое:
![dreamseeker_alT1A0eZL3](https://user-images.githubusercontent.com/43725089/74837334-505d8d80-5332-11ea-820d-c1cd0eb03ab9.png)




## Почему и что этот ПР улучшит
Уберёт лишнюю возможность спамить и раздражать игроков.
## Авторство

## Чеинжлог
🆑 
 - spellcheck: Ослабил спам зажигалкой: цвет сменён на синеватый и добавлен КД в 0.8 сек.