### PR TITLE
Фикс телепортации в стену

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -1,5 +1,5 @@
 //wrapper
-/proc/do_teleport(ateleatom, adestination, aprecision=0, afteleport=1, aeffectin=null, aeffectout=null, asoundin=null, asoundout=null, adest_checkdensity=null, arespect_entrydir=null, aentrydir=null)
+/proc/do_teleport(ateleatom, adestination, aprecision=0, afteleport=1, aeffectin=null, aeffectout=null, asoundin=null, asoundout=null, adest_checkdensity = 1, arespect_entrydir=null, aentrydir=null, checkspace=null)
 	var/datum/teleport/instant/science/D = new
 	if(D.start(arglist(args)))
 		return 1
@@ -15,17 +15,18 @@
 	var/soundout //soundfile to play after teleportation
 	var/force_teleport = 1 //if false, teleport will use Move() proc (dense objects will prevent teleportation)
 	var/dest_checkdensity = TELE_CHECK_NONE //if we can't teleport onto dense atoms (more advanced method of the above).
+	var/dest_checkspace = 0
 	                                        //NONE means - yes, we can! TURFS - yes, if no dense turfs. ALL - no, we can't at all.
 	var/respect_entrydir = FALSE            //respects atom entry dir (if we enter from north, then we can exit only from south).
 	var/entrydir = SOUTH
 
 
-/datum/teleport/proc/start(ateleatom, adestination, aprecision=0, afteleport=1, aeffectin=null, aeffectout=null, asoundin=null, asoundout=null, adest_checkdensity=null, arespect_entrydir=null, aentrydir=null)
+/datum/teleport/proc/start(ateleatom, adestination, aprecision=0, afteleport=1, aeffectin=null, aeffectout=null, asoundin=null, asoundout=null, adest_checkdensity=null, arespect_entrydir=null, aentrydir=null, checkspace=null)
 	if(!initTeleport(arglist(args)))
 		return 0
 	return 1
 
-/datum/teleport/proc/initTeleport(ateleatom,adestination,aprecision,afteleport,aeffectin,aeffectout,asoundin,asoundout,adest_checkdensity,arespect_entrydir,aentrydir)
+/datum/teleport/proc/initTeleport(ateleatom,adestination,aprecision,afteleport,aeffectin,aeffectout,asoundin,asoundout,adest_checkdensity,arespect_entrydir,aentrydir,checkspace)
 	if(!setTeleatom(ateleatom))
 		return 0
 	if(!setDestination(adestination))
@@ -34,6 +35,8 @@
 		return 0
 	if(adest_checkdensity)
 		dest_checkdensity = adest_checkdensity
+	if(checkspace)
+		dest_checkspace = checkspace
 	if(arespect_entrydir)
 		respect_entrydir = arespect_entrydir
 	if(aentrydir)
@@ -115,10 +118,14 @@
 			var/turf/T = get_step(destination, entrydir)
 			if(!density_checks(T))
 				return 0
+			if(dest_checkspace && istype(T, /turf/space))
+				return 0
 			posturfs += T
 		else
 			for(var/turf/T in RANGE_TURFS(precision,center))
 				if(!density_checks(T))
+					continue
+				if(dest_checkspace && istype(T, /turf/space))
 					continue
 				posturfs += T
 		destturf = safepick(posturfs - center)
@@ -157,8 +164,6 @@
 /datum/teleport/proc/density_checks(turf/T)
 	var/turf/center = get_turf(destination)
 	if(T == center)
-		return FALSE
-	if(get_dir(T, center) in list(NORTHEAST, NORTHWEST, SOUTHEAST, SOUTHWEST)) //No diagonal teleports!
 		return FALSE
 	if(istype(T, /turf/space) && (T.x <= TRANSITIONEDGE || T.x >= (world.maxx - TRANSITIONEDGE - 1) || T.y <= TRANSITIONEDGE || T.y >= (world.maxy - TRANSITIONEDGE - 1)))
 		return FALSE //No teleports into the void, dunno how to fix that with another method.

--- a/code/datums/spells/ethereal_jaunt.dm
+++ b/code/datums/spells/ethereal_jaunt.dm
@@ -70,12 +70,30 @@
 			target.client.images -= I
 			target.client.eye = target
 		target.status_flags ^= GODMODE	//Turn off this cheat
+		mobloc = get_turf(target.loc)
+		var/can_move_in = 1
+		if(mobloc.density)
+			can_move_in = 0
+		else
+			for(var/atom/on_turf in mobloc.contents)
+				if(on_turf == target)
+					continue
+				if(on_turf in companions)
+					continue
+				if(on_turf.density)
+					if(istype(on_turf, /obj/structure/window))
+						continue
+					if(istype(on_turf, /obj/machinery/door))
+						continue
+					if(istype(on_turf, /obj/structure/table))
+						continue
+					can_move_in = 0
+					break
 		if(companions)
 			for(var/M in companions)
 				var/mob/living/L = M
 				L.status_flags ^= GODMODE
-		mobloc = get_turf(target.loc)
-		if(mobloc.density)
+		if(!can_move_in)
 			do_teleport(target, mobloc, 8, asoundin='sound/effects/phasein.ogg', checkspace = 1)
 		qdel(holder)
 

--- a/code/datums/spells/ethereal_jaunt.dm
+++ b/code/datums/spells/ethereal_jaunt.dm
@@ -72,23 +72,8 @@
 		target.status_flags ^= GODMODE	//Turn off this cheat
 		mobloc = get_turf(target.loc)
 		var/can_move_in = 1
-		if(mobloc.density)
+		if(!mobloc.is_mob_placeable(target))
 			can_move_in = 0
-		else
-			for(var/atom/on_turf in mobloc.contents)
-				if(on_turf == target)
-					continue
-				if(on_turf in companions)
-					continue
-				if(on_turf.density)
-					if(istype(on_turf, /obj/structure/window))
-						continue
-					if(istype(on_turf, /obj/machinery/door))
-						continue
-					if(istype(on_turf, /obj/structure/table))
-						continue
-					can_move_in = 0
-					break
 		if(companions)
 			for(var/M in companions)
 				var/mob/living/L = M

--- a/code/datums/spells/ethereal_jaunt.dm
+++ b/code/datums/spells/ethereal_jaunt.dm
@@ -74,6 +74,9 @@
 			for(var/M in companions)
 				var/mob/living/L = M
 				L.status_flags ^= GODMODE
+		mobloc = get_turf(target.loc)
+		if(mobloc.density)
+			do_teleport(target, mobloc, 8, asoundin='sound/effects/phasein.ogg', checkspace = 1)
 		qdel(holder)
 
 /obj/effect/dummy/spell_jaunt

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -87,6 +87,9 @@
 		user.visible_message("<span class='warning'>[user] suddenly manifests!</span>", "<span class='shadowling'>The pressure becomes too much and you vacate the interdimensional darkness.</span>")
 		user.incorporeal_move = 0
 		user.alpha = 255
+		var/turf/mobloc = get_turf(user.loc)
+		if(!mobloc.is_mob_placeable(user))
+			do_teleport(user, mobloc, 8, asoundin='sound/effects/phasein.ogg', checkspace = 1)
 
 
 

--- a/code/game/objects/effects/portals.dm
+++ b/code/game/objects/effects/portals.dm
@@ -48,9 +48,9 @@
 	if (istype(M, /atom/movable))
 		if(prob(failchance)) //oh dear a problem, put em in deep space
 			src.icon_state = "portal1"
-			return do_teleport(M, locate(rand(5, world.maxx - 5), rand(5, world.maxy -5), 3), 0, use_forceMove, adest_checkdensity = density_check, arespect_entrydir = respect_entrydir, aentrydir = get_dir(M, src))
+			return do_teleport(M, locate(rand(5, world.maxx - 5), rand(5, world.maxy -5), 3), 0, use_forceMove, arespect_entrydir = respect_entrydir, aentrydir = get_dir(M, src))
 		else
-			return do_teleport(M, target, 1, use_forceMove, adest_checkdensity = density_check, arespect_entrydir = respect_entrydir, aentrydir = get_dir(M, src))
+			return do_teleport(M, target, 1, use_forceMove, arespect_entrydir = respect_entrydir, aentrydir = get_dir(M, src))
 
 //Telescience wormhole
 /obj/effect/portal/tsci_wormhole

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -116,6 +116,25 @@
 				return 0
 	return 1 //Nothing found to block so return success!
 
+/turf/proc/is_mob_placeable(mob/M)
+	if(density)
+		return FALSE
+	for(var/atom/movable/on_turf in contents)
+		if(on_turf == M)
+			continue
+		if(istype(on_turf, /mob) && !on_turf.anchored)
+			continue
+		if(on_turf.density)
+			if(istype(on_turf, /obj/structure/window))
+				continue
+			if(istype(on_turf, /obj/machinery/door))
+				continue
+			if(istype(on_turf, /obj/structure/table))
+				continue
+			if(istype(on_turf, /obj/structure/grille))
+				continue
+			return FALSE
+	return TRUE
 
 /turf/Entered(atom/movable/AM)
 	if(!istype(AM, /atom/movable))


### PR DESCRIPTION
## Описание изменений
при попытке Джаунта в стену (это есть у мага, линга, конструктов культа) моба телепортирует в радиусе 8 на турф не космоса (тоесть если где-то посреди космоса запрыгнуть в одинокую стену, то это ещё сработает)
А ещё это скорее всего пофиксил телепорт в стену при помощи вормхолов (при всех попытках это не получилось попасть в стену), да и вообще весь код, который работает на системе телепортации стандартной)
(я мог что-то и забыть, ибо не слишком часту ищу способы попасть в стену, а не за неё)
## Почему и что этот ПР улучшит
Маги не будут стрелять из стен фаерболами
Вормхолы не будут телепортировать в стену, что потом не выберешься
## Авторство
Felix Ruin - Winter Schock
## Чеинжлог
:cl: Winter Schock
- tweak: Убрана телепортация в стену из-за блюспейс
- bugfix: Перемещение в стену при помощи магии
