### PR TITLE
Время для игры на нимфе и доп проверки на доступность нимф для игры

### DIFF
--- a/code/_globalvars/lists/misc.dm
+++ b/code/_globalvars/lists/misc.dm
@@ -13,7 +13,7 @@ var/list/RESTRICTED_CAMERA_NETWORKS = list( //Those networks can only be accesse
 
 var/list/roles_ingame_minute_unlock = list(
 	ROLE_PAI = 0,
-	ROLE_PLANT = 0,
+	ROLE_PLANT = 40000,
 	ROLE_TRAITOR = 720,
 	ROLE_OPERATIVE = 2160,
 	ROLE_CHANGELING = 2160,

--- a/code/game/machinery/podmen.dm
+++ b/code/game/machinery/podmen.dm
@@ -93,9 +93,9 @@ Growing it to term with nothing injected will grab a ghost from the observers. *
 	for(var/mob/dead/observer/O in observer_list)
 		if(O.has_enabled_antagHUD && config.antag_hud_restricted)
 			continue
-		if(jobban_isbanned(O, ROLE_PLANT))
+		if(jobban_isbanned(O, ROLE_PLANT) || is_alien_whitelisted_banned(O, DIONA))
 			continue
-		if((!is_alien_whitelisted(O, DIONA) && !role_available_in_minutes(O, ROLE_PLANT)) && config.usealienwhitelist)
+		if(!is_alien_whitelisted(O, DIONA) && !role_available_in_minutes(O, ROLE_PLANT))
 			continue
 		if(O.client)
 			var/client/C = O.client

--- a/code/game/machinery/podmen.dm
+++ b/code/game/machinery/podmen.dm
@@ -95,7 +95,7 @@ Growing it to term with nothing injected will grab a ghost from the observers. *
 			continue
 		if(jobban_isbanned(O, ROLE_PLANT))
 			continue
-		if(role_available_in_minutes(O, ROLE_PLANT))
+		if((!is_alien_whitelisted(O, DIONA) && !role_available_in_minutes(O, ROLE_PLANT)) && config.usealienwhitelist)
 			continue
 		if(O.client)
 			var/client/C = O.client


### PR DESCRIPTION
## Описание изменений
Нимфы получили ограничение в 40к минут (ксеновизор по дионам попросил) и теперь дополнительно проверяется бан на дион, а вдобавок к пункту про 40к минут для нимф, владельцы ксеновайтлиста на диону могут играть за них независимо от игрового времени
## Почему и что этот ПР улучшит
Ксеновизор по дионам не будет мучать просьбами забанить нимфу
## Авторство
Felix Ruin - Winter Schock
## Чеинжлог
:cl: Winter Schock
- tweak: Нимфами могут стать игроки без бана на дион и с вайтлистом на дион или с 40к минутами игры