### PR TITLE
Исправления работы с счетами

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -291,8 +291,8 @@
 						if(transaction_amount <= D.money)
 
 							//transfer the money
-							D.remove_money(transaction_amount)
-							vendor_account.add_money(transaction_amount)
+							D.adjust_money(-transaction_amount)
+							vendor_account.adjust_money(transaction_amount)
 
 							//create entries in the two account transaction logs
 							var/datum/transaction/T = new()

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -291,8 +291,8 @@
 						if(transaction_amount <= D.money)
 
 							//transfer the money
-							D.money -= transaction_amount
-							vendor_account.money += transaction_amount
+							D.remove_money(transaction_amount)
+							vendor_account.add_money(transaction_amount)
 
 							//create entries in the two account transaction logs
 							var/datum/transaction/T = new()

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -321,7 +321,7 @@
 			for (var/atom/movable/G in src.loc)
 				G.clean_blood()
 		else
-			is_payed = 0 //      -   .
+			is_payed = 0 // Если игрок выключил раньше времени - принудительное аннулирование платы.
 	else
 		to_chat(user, "You didn't pay for that. Swipe a card against [src].")
 

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -321,7 +321,7 @@
 			for (var/atom/movable/G in src.loc)
 				G.clean_blood()
 		else
-			is_payed = 0 // Если игрок выключил раньше времени - принудительное аннулирование платы.
+			is_payed = 0 //      -   .
 	else
 		to_chat(user, "You didn't pay for that. Swipe a card against [src].")
 
@@ -358,8 +358,8 @@
 						var/transaction_amount = cost_per_activation
 						if(transaction_amount <= D.money)
 							//transfer the money
-							D.money -= transaction_amount
-							station_account.money += transaction_amount
+							D.remove_money(transaction_amount)
+							station_account.add_money(transaction_amount)
 
 							//create entries in the two account transaction logs
 							var/datum/transaction/T = new()

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -358,8 +358,8 @@
 						var/transaction_amount = cost_per_activation
 						if(transaction_amount <= D.money)
 							//transfer the money
-							D.remove_money(transaction_amount)
-							station_account.add_money(transaction_amount)
+							D.adjust_money(-transaction_amount)
+							station_account.adjust_money(transaction_amount)
 
 							//create entries in the two account transaction logs
 							var/datum/transaction/T = new()

--- a/code/modules/economy/ATM.dm
+++ b/code/modules/economy/ATM.dm
@@ -93,7 +93,7 @@ log transactions
 					return
 				else
 					money_stock += SC.worth
-			authenticated_account.add_money(SC.worth)
+			authenticated_account.adjust_money(SC.worth)
 			if(prob(50))
 				playsound(src, 'sound/items/polaroid1.ogg', VOL_EFFECTS_MASTER)
 			else
@@ -248,7 +248,7 @@ log transactions
 						var/transfer_purpose = href_list["purpose"]
 						if(charge_to_account(target_account_number, authenticated_account.owner_name, transfer_purpose, machine_id, transfer_amount))
 							to_chat(usr, "[bicon(src)]<span class='info'>Funds transfer successful.</span>")
-							authenticated_account.remove_money(transfer_amount)
+							authenticated_account.adjust_money(-transfer_amount)
 
 							//create an entry in the account transaction log
 							var/datum/transaction/T = new()
@@ -331,7 +331,7 @@ log transactions
 				else if(authenticated_account && amount > 0)
 					var/response = alert(usr.client, "In what way would you like to recieve your money?", "Choose money format", "Chip", "Cash")
 					if(amount <= authenticated_account.money)
-						authenticated_account.remove_money(amount)
+						authenticated_account.adjust_money(-amount)
 						playsound(src, 'sound/machines/chime.ogg', VOL_EFFECTS_MASTER)
 						if(response == "Chip")
 							spawn_ewallet(amount,src.loc)

--- a/code/modules/economy/ATM.dm
+++ b/code/modules/economy/ATM.dm
@@ -93,7 +93,7 @@ log transactions
 					return
 				else
 					money_stock += SC.worth
-			authenticated_account.money += SC.worth
+			authenticated_account.add_money(SC.worth)
 			if(prob(50))
 				playsound(src, 'sound/items/polaroid1.ogg', VOL_EFFECTS_MASTER)
 			else
@@ -248,7 +248,7 @@ log transactions
 						var/transfer_purpose = href_list["purpose"]
 						if(charge_to_account(target_account_number, authenticated_account.owner_name, transfer_purpose, machine_id, transfer_amount))
 							to_chat(usr, "[bicon(src)]<span class='info'>Funds transfer successful.</span>")
-							authenticated_account.money -= transfer_amount
+							authenticated_account.remove_money(transfer_amount)
 
 							//create an entry in the account transaction log
 							var/datum/transaction/T = new()
@@ -331,7 +331,7 @@ log transactions
 				else if(authenticated_account && amount > 0)
 					var/response = alert(usr.client, "In what way would you like to recieve your money?", "Choose money format", "Chip", "Cash")
 					if(amount <= authenticated_account.money)
-						authenticated_account.money -= amount
+						authenticated_account.remove_money(amount)
 						playsound(src, 'sound/machines/chime.ogg', VOL_EFFECTS_MASTER)
 						if(response == "Chip")
 							spawn_ewallet(amount,src.loc)

--- a/code/modules/economy/Accounts.dm
+++ b/code/modules/economy/Accounts.dm
@@ -14,11 +14,8 @@
 							//1 - require manual login / account number and pin
 							//2 - require card and manual login
 
-/datum/money_account/proc/add_money(amount)
+/datum/money_account/proc/adjust_money(amount)
 	money = CLAMP(money + amount, MIN_MONEY_ON_ACCOUNT, MAX_MONEY_ON_ACCOUNT)
-
-/datum/money_account/proc/remove_money(amount)
-	money = CLAMP(money - amount, MIN_MONEY_ON_ACCOUNT, MAX_MONEY_ON_ACCOUNT)
 
 /datum/transaction
 	var/target_name = ""
@@ -48,7 +45,7 @@
 	var/datum/money_account/M = new()
 	M.owner_name = new_owner_name
 	M.remote_access_pin = rand(1111, 111111)
-	M.add_money(starting_funds)
+	M.adjust_money(starting_funds)
 
 	//create an entry in the account transaction log for when it was created
 	var/datum/transaction/T = new()
@@ -98,7 +95,7 @@
 /proc/charge_to_account(attempt_account_number, source_name, purpose, terminal_id, amount)
 	for(var/datum/money_account/D in all_money_accounts)
 		if(D.account_number == attempt_account_number && !D.suspended)
-			D.add_money(amount)
+			D.adjust_money(amount)
 
 			//create a transaction log entry
 			var/datum/transaction/T = new()

--- a/code/modules/economy/Accounts.dm
+++ b/code/modules/economy/Accounts.dm
@@ -1,4 +1,8 @@
 
+// 2^24 - 1. 24bit. Others lost, sadly
+#define MAX_MONEY_ON_ACCOUNT 16777215
+#define MIN_MONEY_ON_ACCOUNT -16777215
+
 /datum/money_account
 	var/owner_name = ""
 	var/account_number = 0
@@ -9,6 +13,12 @@
 	var/security_level = 0	//0 - auto-identify from worn ID, require only account number
 							//1 - require manual login / account number and pin
 							//2 - require card and manual login
+
+/datum/money_account/proc/add_money(amount)
+	money = CLAMP(money + amount, MIN_MONEY_ON_ACCOUNT, MAX_MONEY_ON_ACCOUNT)
+
+/datum/money_account/proc/remove_money(amount)
+	money = CLAMP(money - amount, MIN_MONEY_ON_ACCOUNT, MAX_MONEY_ON_ACCOUNT)
 
 /datum/transaction
 	var/target_name = ""
@@ -38,7 +48,7 @@
 	var/datum/money_account/M = new()
 	M.owner_name = new_owner_name
 	M.remote_access_pin = rand(1111, 111111)
-	M.money = starting_funds
+	M.add_money(starting_funds)
 
 	//create an entry in the account transaction log for when it was created
 	var/datum/transaction/T = new()
@@ -88,7 +98,7 @@
 /proc/charge_to_account(attempt_account_number, source_name, purpose, terminal_id, amount)
 	for(var/datum/money_account/D in all_money_accounts)
 		if(D.account_number == attempt_account_number && !D.suspended)
-			D.money += amount
+			D.add_money(amount)
 
 			//create a transaction log entry
 			var/datum/transaction/T = new()
@@ -118,3 +128,6 @@
 	for(var/datum/money_account/D in all_money_accounts)
 		if(D.account_number == account_number)
 			return D
+
+#undef MAX_MONEY_ON_ACCOUNT
+#undef MIN_MONEY_ON_ACCOUNT

--- a/code/modules/economy/Accounts.dm
+++ b/code/modules/economy/Accounts.dm
@@ -1,5 +1,5 @@
 
-// 2^24 - 1. 24bit. Others lost, sadly
+// float 1-8-23 bits. More then 16777216 lost accuracy in $1
 #define MAX_MONEY_ON_ACCOUNT 16777215
 #define MIN_MONEY_ON_ACCOUNT -16777215
 

--- a/code/modules/economy/Accounts_DB.dm
+++ b/code/modules/economy/Accounts_DB.dm
@@ -1,4 +1,3 @@
-
 /obj/machinery/account_database
 	name = "Accounts uplink terminal"
 	desc = "Access transaction logs, account data and all kinds of other financial records."
@@ -122,12 +121,12 @@
 			if("add_funds")
 				var/amount = input("Enter the amount you wish to add", "Silently add funds") as num
 				if(detailed_account_view)
-					detailed_account_view.money += amount
+					detailed_account_view.add_money(amount)
 
 			if("remove_funds")
 				var/amount = input("Enter the amount you wish to remove", "Silently remove funds") as num
 				if(detailed_account_view)
-					detailed_account_view.money -= amount
+					detailed_account_view.remove_money(amount)
 
 			if("toggle_suspension")
 				if(detailed_account_view)
@@ -182,7 +181,7 @@
 				var/account_trx = create_transation(station_account.owner_name, "Revoke payroll", "([funds])")
 				var/station_trx = create_transation(detailed_account_view.owner_name, "Revoke payroll", funds)
 
-				station_account.money += funds
+				station_account.add_money(funds)
 				detailed_account_view.money = 0
 
 				detailed_account_view.transaction_log.Add(account_trx)

--- a/code/modules/economy/Accounts_DB.dm
+++ b/code/modules/economy/Accounts_DB.dm
@@ -121,12 +121,12 @@
 			if("add_funds")
 				var/amount = input("Enter the amount you wish to add", "Silently add funds") as num
 				if(detailed_account_view)
-					detailed_account_view.add_money(amount)
+					detailed_account_view.adjust_money(amount)
 
 			if("remove_funds")
 				var/amount = input("Enter the amount you wish to remove", "Silently remove funds") as num
 				if(detailed_account_view)
-					detailed_account_view.remove_money(amount)
+					detailed_account_view.adjust_money(-amount)
 
 			if("toggle_suspension")
 				if(detailed_account_view)
@@ -181,7 +181,7 @@
 				var/account_trx = create_transation(station_account.owner_name, "Revoke payroll", "([funds])")
 				var/station_trx = create_transation(detailed_account_view.owner_name, "Revoke payroll", funds)
 
-				station_account.add_money(funds)
+				station_account.adjust_money(funds)
 				detailed_account_view.money = 0
 
 				detailed_account_view.transaction_log.Add(account_trx)

--- a/code/modules/economy/EFTPOS.dm
+++ b/code/modules/economy/EFTPOS.dm
@@ -229,8 +229,8 @@
 								transaction_paid = 1
 
 								//transfer the money
-								D.money -= transaction_amount
-								linked_account.money += transaction_amount
+								D.remove_money(transaction_amount)
+								linked_account.add_money(transaction_amount)
 
 								//create entries in the two account transaction logs
 								var/datum/transaction/T = new()

--- a/code/modules/economy/EFTPOS.dm
+++ b/code/modules/economy/EFTPOS.dm
@@ -229,8 +229,8 @@
 								transaction_paid = 1
 
 								//transfer the money
-								D.remove_money(transaction_amount)
-								linked_account.add_money(transaction_amount)
+								D.adjust_money(-transaction_amount)
+								linked_account.adjust_money(transaction_amount)
 
 								//create entries in the two account transaction logs
 								var/datum/transaction/T = new()

--- a/code/modules/events/money_hacker.dm
+++ b/code/modules/events/money_hacker.dm
@@ -57,7 +57,7 @@
 
 		//subtract the money
 		var/lost = affected_account.money * 0.8 + (rand(2,4) - 2) / 10
-		affected_account.remove_money(lost)
+		affected_account.adjust_money(-lost)
 
 		//create a taunting log entry
 		var/datum/transaction/T = new()

--- a/code/modules/events/money_hacker.dm
+++ b/code/modules/events/money_hacker.dm
@@ -57,7 +57,7 @@
 
 		//subtract the money
 		var/lost = affected_account.money * 0.8 + (rand(2,4) - 2) / 10
-		affected_account.money -= lost
+		affected_account.remove_money(lost)
 
 		//create a taunting log entry
 		var/datum/transaction/T = new()

--- a/code/modules/events/money_lotto.dm
+++ b/code/modules/events/money_lotto.dm
@@ -9,7 +9,7 @@
 		var/datum/money_account/D = pick(all_money_accounts)
 		winner_name = D.owner_name
 		if(!D.suspended)
-			D.money += winner_sum
+			D.add_money(winner_sum)
 
 			var/datum/transaction/T = new()
 			T.target_name = "[system_name()] Daily Grand Slam -Stellar- Lottery"

--- a/code/modules/events/money_lotto.dm
+++ b/code/modules/events/money_lotto.dm
@@ -9,7 +9,7 @@
 		var/datum/money_account/D = pick(all_money_accounts)
 		winner_name = D.owner_name
 		if(!D.suspended)
-			D.add_money(winner_sum)
+			D.adjust_money(winner_sum)
 
 			var/datum/transaction/T = new()
 			T.target_name = "[system_name()] Daily Grand Slam -Stellar- Lottery"

--- a/code/modules/stock_market/computer.dm
+++ b/code/modules/stock_market/computer.dm
@@ -222,7 +222,7 @@
 	if(!amt)
 		return
 	if(!S.buyShares(logged_in, amt))
-		to_chat(user, "<<span class='danger'>Could not complete transaction.</span>")
+		to_chat(user, "<span class='danger'>Could not complete transaction.</span>")
 		return
 
 	var/total = amt * S.current_value

--- a/code/modules/stock_market/stocks.dm
+++ b/code/modules/stock_market/stocks.dm
@@ -107,14 +107,12 @@
 		fluctuation_counter = 0
 		fluctuate()
 
-/datum/stock/proc/modifyAccount(whose, by, force = 0)
-	if (SSshuttle.points)
-		if (by < 0 && SSshuttle.points + by < 0 && !force)
-			return 0
-		SSshuttle.points += by
-		stockExchange.balanceLog(whose, by)
-		return 1
-	return 0
+/datum/stock/proc/modifyAccount(whose, amount)
+	. = FALSE
+	if (SSshuttle && isnum(SSshuttle.points) && (amount > 0 || SSshuttle.points + amount > 0))
+		SSshuttle.points += amount
+		stockExchange.balanceLog(whose, amount)
+		. = TRUE
 
 /datum/stock/proc/buyShares(who, howmany)
 	if (howmany <= 0)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Исправлено два бага работы с счетами.
Первый связан с счетами станции. При вводе большого значения на пополнение NanoUI принимал значение "бесконечность" и не могу отобразить его как число. Так же при значении выше 24bit int переставали учитываться младшие биты при изменения в малых значениях. Ограничил счета в c - 16777215 по 16777215 кредитов. Дальше просто не будет изменятся. При данных значениях корректно можно списывать или пополнять по 1$.
Второй с биржей. При нулевом счете возможна продажа акций для его пополнения.
## Почему и что этот ПР улучшит
Close #4689
Close #4737
## Авторство
TechCat
## Чеинжлог
:cl: TechCat
 - bugfix: Счета ограничены +-16 777 215$. Транзакции в этих пределах считаются без потерь.
 - bugfix: Можно продавать акции при нулевом счете в карго.