### PR TITLE
Фильтрация O2 и N2 в Scrubber'ах

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -677,6 +677,8 @@
 					"adjust_external_pressure",
 					"set_external_pressure",
 					"checks",
+					"o2_scrub",
+					"n2_scrub",
 					"co2_scrub",
 					"tox_scrub",
 					"n2o_scrub",

--- a/code/modules/atmospheric/machinery/components/unary_devices/vent_scrubber.dm
+++ b/code/modules/atmospheric/machinery/components/unary_devices/vent_scrubber.dm
@@ -60,13 +60,13 @@
 	if (frequency)
 		set_frequency(frequency)
 
-	broadcast_status()
-
 	if(!scrubbing_gas)
 		scrubbing_gas = list()
 		for(var/g in gas_data.gases)
 			if(g != "oxygen" && g != "nitrogen")
 				scrubbing_gas += g
+
+	broadcast_status()
 
 	..()
 


### PR DESCRIPTION
## Описание изменений
Closes #4555


## Почему и что этот ПР улучшит
Стало возможно фильтровать O2 и N2 через интерфейс Air alarm, также как и другие газы (CO2, Toxin, N2O) ранее.

Кнопки уже установленной фильтрации становятся зелеными (включенными) сразу, а не после нажатия по одной из них.


## Changelog
:cl:
 - tweak: Можно включать отбор кислорода и азота в Scrubber'ах через интерфейс Air alarm.
 - bugfix: Статус фильтрации Scrubber'ов в интерфейсе Air alarm теперь отображается сразу, а не после нажатия.