### PR TITLE
Фикс ботов починки плитки

### DIFF
--- a/code/game/machinery/bots/floorbot.dm
+++ b/code/game/machinery/bots/floorbot.dm
@@ -23,6 +23,20 @@
 	w_class = ITEM_SIZE_NORMAL
 	var/created_name = "Floorbot"
 
+// Floorbot states
+#define FLOORBOT_IDLE                0
+#define FLOORBOT_MOVING_TO_REPAIR    1
+#define FLOORBOT_MOVING_TO_PICKUP    2
+#define FLOORBOT_BUSY                3
+#define FLOORBOT_BRIDGE              4
+
+// Floorbot tasks
+#define FLOORBOT_TASK_NOTHING        0
+#define FLOORBOT_TASK_FIXHOLE        1
+#define FLOORBOT_TASK_PLACETILE      2
+#define FLOORBOT_TASK_FIXTILE        3
+#define FLOORBOT_TASK_BREAKTILE      4
+
 //Floorbot
 /obj/machinery/bot/floorbot
 	name = "Floorbot"
@@ -30,22 +44,23 @@
 	icon = 'icons/obj/aibots.dmi'
 	icon_state = "floorbot0"
 	layer = 5.0
-	density = 0
-	anchored = 0
+	density = FALSE
+	anchored = FALSE
 	health = 25
 	maxhealth = 25
 	//weight = 1.0E7
 	var/amount = 10
-	var/repairing = 0
-	var/improvefloors = 0
-	var/eattiles = 0
-	var/maketiles = 0
+	var/eattiles = FALSE
+	var/maketiles = FALSE
 	var/turf/target
-	var/turf/oldtarget
-	var/oldloc = null
 	req_access = list(access_construction)
 	var/path[] = new()
 	var/targetdirection
+	var/state = FLOORBOT_IDLE
+	var/task = FLOORBOT_TASK_NOTHING
+	var/fixtiles = FALSE
+	var/placetiles = FALSE
+	var/boringness = 0
 
 
 /obj/machinery/bot/floorbot/atom_init()
@@ -54,54 +69,57 @@
 
 /obj/machinery/bot/floorbot/turn_on()
 	. = ..()
-	src.updateicon()
-	src.updateUsrDialog()
+	updateicon()
+	updateUsrDialog()
+	state = FLOORBOT_IDLE
 
 /obj/machinery/bot/floorbot/turn_off()
 	..()
-	src.target = null
-	src.oldtarget = null
-	src.oldloc = null
-	src.updateicon()
-	src.path = new()
-	src.updateUsrDialog()
+	target = null
+	updateicon()
+	path = new()
+	updateUsrDialog()
 
 /obj/machinery/bot/floorbot/ui_interact(mob/user)
 	var/dat
 	dat += "<TT><B>Automatic Station Floor Repairer v1.0</B></TT><BR><BR>"
-	dat += "Status: <A href='?src=\ref[src];operation=start'>[src.on ? "On" : "Off"]</A><BR>"
-	dat += "Maintenance panel panel is [src.open ? "opened" : "closed"]<BR>"
-	dat += "Tiles left: [src.amount]<BR>"
-	dat += "Behvaiour controls are [src.locked ? "locked" : "unlocked"]<BR>"
-	if(!src.locked || issilicon(user) ||isobserver(user))
-		dat += "Improves floors: <A href='?src=\ref[src];operation=improve'>[src.improvefloors ? "Yes" : "No"]</A><BR>"
-		dat += "Finds tiles: <A href='?src=\ref[src];operation=tiles'>[src.eattiles ? "Yes" : "No"]</A><BR>"
-		dat += "Make singles pieces of metal into tiles when empty: <A href='?src=\ref[src];operation=make'>[src.maketiles ? "Yes" : "No"]</A><BR>"
+	dat += "Status: <A href='?src=\ref[src];operation=start'>[on ? "On" : "Off"]</A><BR>"
+	dat += "Maintenance panel panel is [open ? "opened" : "closed"]<BR>"
+	dat += "Tiles left: [amount]<BR>"
+	dat += "Behvaiour controls are [locked ? "locked" : "unlocked"]<BR>"
+	if(!src.locked || issilicon(user) || isobserver(user))
+		dat += "Repair damaged tiles and platings: <A href='?src=\ref[src];operation=fixtiles'>[fixtiles ? "Yes" : "No"]</A><BR>"
+		dat += "Place floor tiles: <A href='?src=\ref[src];operation=placetiles'>[placetiles ? "Yes" : "No"]</A><BR>"
+		dat += "Finds tiles: <A href='?src=\ref[src];operation=tiles'>[eattiles ? "Yes" : "No"]</A><BR>"
+		dat += "Make singles pieces of metal into tiles when empty: <A href='?src=\ref[src];operation=make'>[maketiles ? "Yes" : "No"]</A><BR>"
 		var/bmode
-		if (src.targetdirection)
-			bmode = dir2text(src.targetdirection)
+		if (targetdirection)
+			bmode = dir2text(targetdirection)
 		else
 			bmode = "Disabled"
 		dat += "<BR><BR>Bridge Mode : <A href='?src=\ref[src];operation=bridgemode'>[bmode]</A><BR>"
 
-	user << browse("<HEAD><TITLE>Repairbot v1.0 controls</TITLE></HEAD>[entity_ja(dat)]", "window=autorepair")
+	var/datum/browser/popup = new(user, "autorepair", "Repairbot v1.0 controls", 300, 400)
+	popup.set_content(dat)
+	popup.open()
+
 	onclose(user, "autorepair")
 
 
 /obj/machinery/bot/floorbot/attackby(obj/item/W , mob/user)
 	if(istype(W, /obj/item/stack/tile/plasteel))
 		var/obj/item/stack/tile/plasteel/T = W
-		if(src.amount >= 50)
+		if(amount >= 50)
 			return
-		var/loaded = min(50-src.amount, T.get_amount())
+		var/loaded = min(50-amount, T.get_amount())
 		T.use(loaded)
-		src.amount += loaded
+		amount += loaded
 		to_chat(user, "<span class='notice'>You load [loaded] tiles into the floorbot. He now contains [src.amount] tiles.</span>")
-		src.updateicon()
+		updateicon()
 	else if(istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))
-		if(src.allowed(usr) && !open && !emagged)
-			src.locked = !src.locked
-			to_chat(user, "<span class='notice'>You [src.locked ? "lock" : "unlock"] the [src] behaviour controls.</span>")
+		if(allowed(usr) && !open && !emagged)
+			locked = !locked
+			to_chat(user, "<span class='notice'>You [locked ? "lock" : "unlock"] the [src] behaviour controls.</span>")
 		else
 			if(emagged)
 				to_chat(user, "<span class='warning'>ERROR</span>")
@@ -109,7 +127,7 @@
 				to_chat(user, "<span class='warning'>Please close the access panel before locking it.</span>")
 			else
 				to_chat(user, "<span class='warning'>Access denied.</span>")
-		src.updateUsrDialog()
+		updateUsrDialog()
 	else
 		..()
 
@@ -124,218 +142,296 @@
 		return
 	switch(href_list["operation"])
 		if("start")
-			if (src.on)
+			if (on)
 				turn_off()
 			else
 				turn_on()
-		if("improve")
-			src.improvefloors = !src.improvefloors
+		if("fixtiles")
+			fixtiles = !fixtiles
+		if("placetiles")
+			placetiles = !placetiles
 		if("tiles")
-			src.eattiles = !src.eattiles
+			eattiles = !eattiles
 		if("make")
-			src.maketiles = !src.maketiles
+			maketiles = !maketiles
 		if("bridgemode")
-			switch(src.targetdirection)
-				if(null)
+			var/setdir = input("Select construction direction:") as null|anything in list("north","east","south","west","disable")
+			switch(setdir)
+				if("north")
 					targetdirection = 1
-				if(1)
+				if("south")
 					targetdirection = 2
-				if(2)
+				if("east")
 					targetdirection = 4
-				if(4)
+				if("west")
 					targetdirection = 8
-				if(8)
+				if("disable")
 					targetdirection = null
-				else
-					targetdirection = null
-	src.updateUsrDialog()
-
-/obj/machinery/bot/floorbot/process()
-	//set background = 1
-
-	if(!src.on)
-		return
-	if(src.repairing)
-		return
-	var/list/floorbottargets = list()
-	if(src.amount <= 0 && ((src.target == null) || !src.target))
-		if(src.eattiles)
-			for(var/obj/item/stack/tile/plasteel/T in view(7, src))
-				if(T != src.oldtarget && !(target in floorbottargets))
-					src.oldtarget = T
-					src.target = T
-					return
-		if(src.target == null || !src.target)
-			if(src.maketiles)
-				for(var/obj/item/stack/sheet/metal/M in view(7, src))
-					if(!(M in floorbottargets) && M != src.oldtarget && M.get_amount() == 1 && !(istype(M.loc, /turf/simulated/wall)))
-						src.oldtarget = M
-						src.target = M
-						return
-		else
-			return
-	if(prob(5))
-		visible_message("[src] makes an excited booping beeping sound!")
-
-	if((!src.target || src.target == null) && emagged < 2)
-		if(targetdirection != null)
-			/*
-			for (var/turf/space/D in view(7,src))
-				if(!(D in floorbottargets) && D != src.oldtarget)			// Added for bridging mode -- TLE
-					if(get_dir(src, D) == targetdirection)
-						src.oldtarget = D
-						src.target = D
-						break
-			*/
-			var/turf/T = get_step(src, targetdirection)
-			if(istype(T, /turf/space))
-				src.oldtarget = T
-				src.target = T
-		if(!src.target || src.target == null)
-			for (var/turf/space/D in view(7,src))
-				if(!(D in floorbottargets) && D != src.oldtarget && (D.loc.name != "Space"))
-					src.oldtarget = D
-					src.target = D
-					break
-		if((!src.target || src.target == null ) && src.improvefloors)
-			for (var/turf/simulated/floor/F in view(7,src))
-				if(!(F in floorbottargets) && F != src.oldtarget && F.icon_state == "Floor1" && !(istype(F, /turf/simulated/floor/plating)))
-					src.oldtarget = F
-					src.target = F
-					break
-		if((!src.target || src.target == null) && src.eattiles)
-			for(var/obj/item/stack/tile/plasteel/T in view(7, src))
-				if(!(T in floorbottargets) && T != src.oldtarget)
-					src.oldtarget = T
-					src.target = T
-					break
-
-	if((!src.target || src.target == null) && emagged == 2)
-		if(!src.target || src.target == null)
-			for (var/turf/simulated/floor/D in view(7,src))
-				if(!(D in floorbottargets) && D != src.oldtarget && D.floor_type)
-					src.oldtarget = D
-					src.target = D
-					break
-
-	if(!src.target || src.target == null)
-		if(src.loc != src.oldloc)
-			src.oldtarget = null
-		return
-
-	if(src.target && (src.target != null) && src.path.len == 0)
-		spawn(0)
-			if(!istype(src.target, /turf))
-				src.path = get_path_to(src, get_turf(src.target), /turf/proc/Distance_cardinal, 0, 30, id=botcard, simulated_only = FALSE)
-			else
-				src.path = get_path_to(src, get_turf(src.target), /turf/proc/Distance_cardinal, 0, 30, id=botcard, simulated_only = FALSE)
-			if(src.path.len == 0)
-				src.oldtarget = src.target
-				src.target = null
-		return
-	if(src.path.len > 0 && src.target && (src.target != null))
-		step_to(src, src.path[1])
-		src.path -= src.path[1]
-	else if(src.path.len == 1)
-		step_to(src, target)
-		src.path = new()
-
-	if(src.loc == src.target || src.loc == src.target.loc)
-		if(istype(src.target, /obj/item/stack/tile/plasteel))
-			src.eattile(src.target)
-		else if(istype(src.target, /obj/item/stack/sheet/metal))
-			src.maketile(src.target)
-		else if(istype(src.target, /turf) && emagged < 2)
-			repair(src.target)
-		else if(emagged == 2 && istype(src.target,/turf/simulated/floor))
-			var/turf/simulated/floor/F = src.target
-			src.anchored = 1
-			src.repairing = 1
-			if(prob(90))
-				F.break_tile_to_plating()
-			else
-				F.ReplaceWithLattice()
-			visible_message("<span class='warning'>[src] makes an excited booping sound.</span>")
-			spawn(50)
-				src.amount ++
-				src.anchored = 0
-				src.repairing = 0
-				src.target = null
-		src.path = new()
-		return
-
-	src.oldloc = src.loc
+	updateUsrDialog()
 
 
-/obj/machinery/bot/floorbot/proc/repair(turf/target)
-	if(istype(target, /turf/space))
-		if(target.loc.name == "Space")
-			return
-	else if(!istype(target, /turf/simulated/floor))
-		return
-	if(src.amount <= 0)
-		return
-	src.anchored = 1
-	src.icon_state = "floorbot-c"
-	if(istype(target, /turf/space))
-		visible_message("<span class='warning'>[src] begins to repair the hole</span>")
-		var/obj/item/stack/tile/plasteel/T = new /obj/item/stack/tile/plasteel
-		src.repairing = 1
-		spawn(50)
-			T.build(src.loc)
-			src.repairing = 0
-			src.amount -= 1
-			src.updateicon()
-			src.anchored = 0
-			src.target = null
+/obj/machinery/bot/floorbot/proc/is_hull_breach(turf/t) //Ignore space tiles not considered part of a structure, also ignores shuttle docking areas.
+	if(!t || !istype(t, /turf/space))
+		return FALSE
+
+	if(targetdirection) // Bridge mode, ignore areas
+		return TRUE
+
+	var/area/t_area = get_area(t)
+
+	if(t_area && (t_area.name == "Space" || findtext(t_area.name, "huttle")))
+		return FALSE
 	else
-		visible_message("<span class='warning'>[src] begins to improve the floor.</span>")
-		src.repairing = 1
-		spawn(50)
-			src.loc.icon_state = "floor"
-			src.repairing = 0
-			src.amount -= 1
-			src.updateicon()
-			src.anchored = 0
-			src.target = null
+		return TRUE
 
-/obj/machinery/bot/floorbot/proc/eattile(obj/item/stack/tile/plasteel/T)
-	if(!istype(T))
-		return
-	visible_message("<span class='warning'>[src] begins to collect tiles.</span>")
-	src.repairing = 1
-	spawn(20)
-		if(QDELETED(T))
-			src.target = null
-			src.repairing = 0
-			return
-		if(src.amount + T.get_amount() > 50)
-			var/i = 50 - src.amount
-			src.amount += i
-			T.use(i)
+/obj/machinery/bot/floorbot/proc/is_broken(turf/simulated/floor/t)
+	if(!t || !istype(t, /turf/simulated/floor))
+		return FALSE
+	return t.broken || t.burnt
+
+/obj/machinery/bot/floorbot/proc/is_plating(turf/simulated/floor/t)
+	if(!t || !istype(t, /turf/simulated/floor))
+		return FALSE
+	return t.is_plating() && !is_broken(t)
+
+
+/obj/machinery/bot/floorbot/proc/do_task(turf/t, new_task)
+	state = FLOORBOT_MOVING_TO_REPAIR
+	task = new_task
+	target = t
+	path = new()
+
+/obj/machinery/bot/floorbot/proc/attempt_move(atom)
+	if(get_turf(atom) == get_turf(src))
+		return TRUE
+
+	if(!path || path.len == 0)
+		path = get_path_to(src, get_turf(atom), /turf/proc/Distance_cardinal, 0, 30, id=botcard, simulated_only = FALSE)
+	else if(path.len > 0)
+		step_to(src, path[1])
+		path -= path[1]
+
+	return FALSE
+
+/obj/machinery/bot/floorbot/proc/start_task()
+	var/turf/t = target
+
+	if(task == FLOORBOT_TASK_FIXHOLE && is_hull_breach(t))
+		state = FLOORBOT_BUSY
+		if(targetdirection)
+			visible_message("<span class='warning'>[src] begins installing a bridge plating</span>")
 		else
-			src.amount += T.get_amount()
-			qdel(T)
-		src.updateicon()
-		src.target = null
-		src.repairing = 0
+			visible_message("<span class='warning'>[src] begins to repair the hole</span>")
+		anchored = TRUE
+		icon_state = "floorbot-c"
 
-/obj/machinery/bot/floorbot/proc/maketile(obj/item/stack/sheet/metal/M)
+		addtimer(CALLBACK(src, .proc/finish_task), 50)
+	else if(task == FLOORBOT_TASK_PLACETILE && placetiles && is_plating(t))
+		state = FLOORBOT_BUSY
+		visible_message("<span class='warning'>[src] begins to place the floor tiles.</span>")
+		anchored = TRUE
+		icon_state = "floorbot-c"
+
+		addtimer(CALLBACK(src, .proc/finish_task), 20)
+	else if(task == FLOORBOT_TASK_FIXTILE && fixtiles && is_broken(t))
+		state = FLOORBOT_BUSY
+		visible_message("<span class='warning'>[src] begins repairing the floor.</span>")
+		anchored = TRUE
+		icon_state = "floorbot-c"
+
+		addtimer(CALLBACK(src, .proc/finish_task), 50)
+	else if(task == FLOORBOT_TASK_BREAKTILE && istype(t, /turf/simulated/floor))
+		state = FLOORBOT_BUSY
+		visible_message("<span class='warning'>[src] begins repairing the floor.</span>") // troll message
+		anchored = TRUE
+		icon_state = "floorbot-c"
+
+		addtimer(CALLBACK(src, .proc/finish_task), 50)
+	else
+		state = FLOORBOT_IDLE
+
+/obj/machinery/bot/floorbot/proc/finish_task()
+	var/turf/t = target
+
+	if(task == FLOORBOT_TASK_FIXHOLE && is_hull_breach(t))
+		var/obj/item/stack/tile/plasteel/T = new /obj/item/stack/tile/plasteel
+		T.build(t)
+		amount -= 1
+	else if(task == FLOORBOT_TASK_PLACETILE && placetiles && is_plating(t))
+		var/turf/simulated/floor/F = t
+		F.make_plasteel_floor()
+		amount -= 1
+	else if(task == FLOORBOT_TASK_FIXTILE && fixtiles && is_broken(t))
+		var/turf/simulated/floor/F = t
+		if(F.is_plating())
+			if(!F.floor_type)
+				F.floor_type = /obj/item/stack/tile/plasteel
+			F.make_plating()
+		else
+			F.make_plasteel_floor()
+			amount -= 1
+	else if(task == FLOORBOT_TASK_BREAKTILE && istype(t, /turf/simulated/floor))
+		var/turf/simulated/floor/F = t
+		if(prob(90))
+			F.break_tile_to_plating()
+		else
+			F.ReplaceWithLattice()
+		amount += 1
+		visible_message("<span class='warning'>[src] makes an excited booping sound.</span>")
+
+	updateicon()
+	anchored = FALSE
+	target = null
+	if(targetdirection)
+		state = FLOORBOT_BRIDGE
+	else
+		state = FLOORBOT_IDLE
+	task = FLOORBOT_TASK_NOTHING
+
+/obj/machinery/bot/floorbot/proc/create_tiles(obj/item/stack/sheet/metal/M)
 	if(!istype(M))
+		state = FLOORBOT_IDLE
+		return
+	if(get_turf(M) != get_turf(src))
+		state = FLOORBOT_IDLE
 		return
 	if(M.get_amount() > 1)
+		state = FLOORBOT_IDLE
 		return
-	visible_message("<span class='warning'>[src] begins to create tiles.</span>")
-	src.repairing = 1
-	spawn(20)
-		if(QDELETED(M))
-			src.target = null
-			src.repairing = 0
+	visible_message("<span class='warning'>[src] created some tiles from a metal sheet.</span>")
+	new /obj/item/stack/tile/plasteel(M.loc, 4)
+	qdel(M)
+	state = FLOORBOT_IDLE
+
+/obj/machinery/bot/floorbot/process()
+	if(!on)
+		return
+
+	if(state == FLOORBOT_MOVING_TO_REPAIR && state == FLOORBOT_MOVING_TO_PICKUP)
+		boringness += 1
+		if(boringness > 15)
+			visible_message("<span class='warning'>[src] makes an angry beeping noise.</span>")
+			state = FLOORBOT_IDLE
 			return
-		new /obj/item/stack/tile/plasteel(M.loc, 4)
-		qdel(M)
-		src.target = null
-		src.repairing = 0
+
+	if(prob(5))
+		visible_message("<span class='notice'>[src] makes an excited booping beeping sound!</span>")
+
+	if(state == FLOORBOT_IDLE)
+
+		if(emagged == 2)
+			for (var/turf/simulated/floor/F in shuffle(view(7,src)))
+				if(F.floor_type)
+					do_task(F, FLOORBOT_TASK_BREAKTILE)
+			return
+
+		if(targetdirection)
+			state = FLOORBOT_BRIDGE
+			return
+
+
+		if(amount > 0)
+			for (var/turf/space/D in shuffle(view(7,src)))
+				if(is_hull_breach(D))
+					boringness = 0
+					do_task(D, FLOORBOT_TASK_FIXHOLE)
+					return
+
+			if(placetiles || fixtiles)
+				for (var/turf/simulated/floor/F in shuffle(view(7,src)))
+					if(placetiles && is_plating(F))
+						boringness = 0
+						do_task(F, FLOORBOT_TASK_PLACETILE)
+						return
+					if(fixtiles && is_broken(F))
+						boringness = 0
+						do_task(F, FLOORBOT_TASK_FIXTILE)
+						return
+		else
+			if(eattiles)
+				for(var/obj/item/stack/tile/plasteel/T in shuffle(view(7, src)))
+					state = FLOORBOT_MOVING_TO_PICKUP
+					boringness = 0
+					target = T
+					path = new()
+					return
+			if(maketiles)
+				for(var/obj/item/stack/sheet/metal/M in shuffle(view(7, src)))
+					if(M.get_amount() == 1 && !(istype(M.loc, /turf/simulated/wall)))
+						state = FLOORBOT_MOVING_TO_PICKUP
+						boringness = 0
+						target = M
+						path = new()
+						return
+
+
+	if(state == FLOORBOT_MOVING_TO_REPAIR)
+
+		if(!target)
+			state = FLOORBOT_IDLE
+
+		if(task == FLOORBOT_TASK_FIXHOLE && !is_hull_breach(target))
+			state = FLOORBOT_IDLE
+		if(task == FLOORBOT_TASK_PLACETILE && (!is_plating(target) || !placetiles))
+			state = FLOORBOT_IDLE
+		if(task == FLOORBOT_TASK_FIXTILE && (!is_broken(target) || !fixtiles))
+			state = FLOORBOT_IDLE
+
+		if(attempt_move(target)) // If we reached the destination
+			start_task()
+			return
+
+	if(state == FLOORBOT_MOVING_TO_PICKUP)
+		if(!target)
+			state = FLOORBOT_IDLE
+
+		if(attempt_move(target)) // If we reached the destination
+			if(istype(target, /obj/item/stack/tile/plasteel))
+				var/obj/item/stack/tile/plasteel/T = target
+
+				visible_message("<span class='notice'>[src] collects some tiles.</span>")
+				if(amount + T.get_amount() > 50)
+					var/i = 50 - amount
+					amount += i
+					T.use(i)
+				else
+					amount += T.get_amount()
+					qdel(T)
+				updateicon()
+				state = FLOORBOT_IDLE
+				return
+			else if(istype(target, /obj/item/stack/sheet/metal))
+				var/obj/item/stack/sheet/metal/M = target
+				visible_message("<span class='warning'>[src] begins to create tiles from a metal sheet.</span>")
+				state = FLOORBOT_BUSY
+				addtimer(CALLBACK(src, .proc/create_tiles, M), 20)
+				return
+			else
+				state = FLOORBOT_IDLE
+				return
+
+	if(state == FLOORBOT_BRIDGE)
+		if(!targetdirection || amount == 0)
+			state = FLOORBOT_IDLE
+			targetdirection = null
+			return
+
+		var/turf/s = get_turf(src)
+		if(istype(s, /turf/space))
+			task = FLOORBOT_TASK_FIXHOLE
+			target = s
+			start_task()
+			return
+
+		var/turf/T = get_step(src, targetdirection)
+		if(T.density)
+			visible_message("<span class='warning'>[src] beeps as it hits the wall and stops.</span>")
+			state = FLOORBOT_IDLE
+			targetdirection = null
+			return
+
+		step_to(src, T)
+
 
 /obj/machinery/bot/floorbot/proc/updateicon()
 	if(src.amount > 0)

--- a/code/game/machinery/bots/floorbot.dm
+++ b/code/game/machinery/bots/floorbot.dm
@@ -307,7 +307,7 @@
 	if(!on)
 		return
 
-	if(state == FLOORBOT_MOVING_TO_REPAIR && state == FLOORBOT_MOVING_TO_PICKUP)
+	if(state == FLOORBOT_MOVING_TO_REPAIR || state == FLOORBOT_MOVING_TO_PICKUP)
 		boringness += 1
 		if(boringness > 15)
 			visible_message("<span class='warning'>[src] makes an angry beeping noise.</span>")

--- a/code/game/machinery/bots/floorbot.dm
+++ b/code/game/machinery/bots/floorbot.dm
@@ -323,6 +323,7 @@
 			for (var/turf/simulated/floor/F in shuffle(view(7,src)))
 				if(F.floor_type)
 					do_task(F, FLOORBOT_TASK_BREAKTILE)
+					return
 			return
 
 		if(targetdirection)

--- a/code/game/machinery/bots/floorbot.dm
+++ b/code/game/machinery/bots/floorbot.dm
@@ -185,12 +185,12 @@
 		return TRUE
 
 /obj/machinery/bot/floorbot/proc/is_broken(turf/simulated/floor/t)
-	if(!t || !istype(t, /turf/simulated/floor))
+	if(!istype(t))
 		return FALSE
 	return t.broken || t.burnt
 
 /obj/machinery/bot/floorbot/proc/is_plating(turf/simulated/floor/t)
-	if(!t || !istype(t, /turf/simulated/floor))
+	if(!istype(t))
 		return FALSE
 	return t.is_plating() && !is_broken(t)
 

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -59,9 +59,10 @@
 #define INTERACTION_FARMBOT_TOGGLE_WEEDS_IGNORING		7
 #define INTERACTION_FARMBOT_TOGGLE_MUSHROOMS_IGNORING	8
 
-#define INTERACTION_FLOORBOT_TOGGLE_FLOOR_IMPROVMENT	3
-#define INTERACTION_FLOORBOT_TOGGLE_SEARCHING			4
-#define INTERACTION_FLOORBOT_TOGGLE_TILES_FABRICATION	5
+#define INTERACTION_FLOORBOT_TOGGLE_FLOOR_FIXTILES		3
+#define INTERACTION_FLOORBOT_TOGGLE_FLOOR_PLACETILES	4
+#define INTERACTION_FLOORBOT_TOGGLE_SEARCHING			5
+#define INTERACTION_FLOORBOT_TOGGLE_TILES_FABRICATION	6
 
 
 /mob/living/silicon/pai/var/list/available_software = list(
@@ -548,8 +549,10 @@
 			if(istype(hackobj, /obj/machinery/bot/floorbot))
 				var/obj/machinery/bot/floorbot/Bot = hackobj
 				switch(interaction_type)
-					if(INTERACTION_FLOORBOT_TOGGLE_FLOOR_IMPROVMENT) //floorbot - Toggle floor improving
-						Bot.improvefloors = !Bot.improvefloors
+					if(INTERACTION_FLOORBOT_TOGGLE_FLOOR_FIXTILES) //floorbot - Toggle tiles fixing
+						Bot.fixtiles = !Bot.fixtiles
+					if(INTERACTION_FLOORBOT_TOGGLE_FLOOR_PLACETILES) //floorbot - Toggle tiles placement
+						Bot.placetiles = !Bot.placetiles
 					if(INTERACTION_FLOORBOT_TOGGLE_SEARCHING) //floorbot - Toggle tiles searching
 						Bot.eattiles = !Bot.eattiles
 					if(INTERACTION_FLOORBOT_TOGGLE_TILES_FABRICATION) //floorbot - Toggle metal to tiles transformation
@@ -962,7 +965,8 @@
 					botchecked = 1
 					dat += "Floor Bot.<br>"
 					var/obj/machinery/bot/floorbot/Temp = hackobj
-					dat += "<a href='byond://?src=\ref[src];software=interaction;interactwith=[INTERACTION_FLOORBOT_TOGGLE_FLOOR_IMPROVMENT];sub=0'>Toggle Floor Improvment</a> (Currently [Temp.improvefloors ? "Active" : "Disabled"]) <br>"
+					dat += "<a href='byond://?src=\ref[src];software=interaction;interactwith=[INTERACTION_FLOORBOT_TOGGLE_FLOOR_FIXTILES];sub=0'>Toggle Floor Fixing</a> (Currently [Temp.fixtiles ? "Active" : "Disabled"]) <br>"
+					dat += "<a href='byond://?src=\ref[src];software=interaction;interactwith=[INTERACTION_FLOORBOT_TOGGLE_FLOOR_PLACETILES];sub=0'>Toggle Floor Tiles Placement</a> (Currently [Temp.placetiles ? "Active" : "Disabled"]) <br>"
 					dat += "<a href='byond://?src=\ref[src];software=interaction;interactwith=[INTERACTION_FLOORBOT_TOGGLE_SEARCHING];sub=0'>Toggle Searching Tiles</a> (Currently [Temp.eattiles ? "Active" : "Disabled"]) <br>"
 					dat += "<a href='byond://?src=\ref[src];software=interaction;interactwith=[INTERACTION_FLOORBOT_TOGGLE_TILES_FABRICATION];sub=0'>Toggle Tiles Fabrication</a> (Currently [Temp.maketiles ? "Active" : "Disabled"]) <br>"
 				if(!botchecked)
@@ -1116,6 +1120,7 @@
 #undef INTERACTION_FARMBOT_TOGGLE_WEEDS_IGNORING
 #undef INTERACTION_FARMBOT_TOGGLE_MUSHROOMS_IGNORING
 
-#undef INTERACTION_FLOORBOT_TOGGLE_FLOOR_IMPROVMENT
+#undef INTERACTION_FLOORBOT_TOGGLE_FLOOR_FIXTILES
+#undef INTERACTION_FLOORBOT_TOGGLE_FLOOR_PLACETILES
 #undef INTERACTION_FLOORBOT_TOGGLE_SEARCHING
 #undef INTERACTION_FLOORBOT_TOGGLE_TILES_FABRICATION


### PR DESCRIPTION
## Описание изменений
Сколько себя помню они никогда не работали. Переписал их код на некое подобие машины состояний, наверно выглядит не супер, но точно лучше чем то что было

Все функции работают, но большинство изначально выключено. Сам по себе бот будет только заделывать дырки в космос. Но можно включить ему ремонт сломанной плитки, режим установки плитки там где её нет, автоматический подъём рядом лежащих тайлов плитки и автоматический режим создания плитки из лежащих рядом листов металла.

![изображение](https://user-images.githubusercontent.com/14040378/75914982-be43a200-5e66-11ea-8c0f-b4b0542fac60.png)

Демонстрация: https://gfycat.com/ru/limitedsingledowitcher

Плюс есть режим создания мостов при котором бот будет топать в определенную сторону, делая под собой пол пока запас плитки не кончится

Создание мостов: https://gfycat.com/ru/pertinentcheapewe

Емаганье тоже работает. Первый раз емаг снимает защиту доступа, если потом тыкнуть отверткой и емагнуть опять то бот начнём разбирать плитку вокруг
Хотел ещё впилить патруль по станции, но там такой страшный код что я не захотел лезть

## Почему и что этот ПР улучшит
Флурботы больше не будут грустно смотреть на разгерму вокруг и наконец-то начнут работать
## Авторство
ЙА
## Чеинжлог
:cl:
 - bugfix: Боты починки плитки заработали