### PR TITLE
Изменения аутопсии

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -647,8 +647,7 @@ var/list/airlock_overlays = list()
 				var/obj/item/organ/external/BP = H.bodyparts_by_name[BP_HEAD]
 				H.Stun(8)
 				H.Weaken(5)
-				BP.take_damage(10, 0)
-				BP.add_autopsy_data("Hematoma", 10, BRUISE)
+				BP.take_damage(10, 0, used_weapon = "Hematoma")
 			else
 				visible_message("<span class='userdanger'> [user] headbutts the airlock. Good thing they're wearing a helmet.</span>")
 			return

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -648,6 +648,7 @@ var/list/airlock_overlays = list()
 				H.Stun(8)
 				H.Weaken(5)
 				BP.take_damage(10, 0)
+				BP.add_autopsy_data("Hematoma", 10, "bruise")
 			else
 				visible_message("<span class='userdanger'> [user] headbutts the airlock. Good thing they're wearing a helmet.</span>")
 			return

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -648,7 +648,7 @@ var/list/airlock_overlays = list()
 				H.Stun(8)
 				H.Weaken(5)
 				BP.take_damage(10, 0)
-				BP.add_autopsy_data("Hematoma", 10, "bruise")
+				BP.add_autopsy_data("Hematoma", 10, BRUISE)
 			else
 				visible_message("<span class='userdanger'> [user] headbutts the airlock. Good thing they're wearing a helmet.</span>")
 			return

--- a/code/modules/detectivework/autopsy.dm
+++ b/code/modules/detectivework/autopsy.dm
@@ -57,13 +57,13 @@
 			if(prob(40 + (W.hits * 10 + W.damage)))
 				W.pretend_weapon = W.weapon
 			else
-				if(W.type_damage == "brute" || W.type_damage == null || W.type_damage == "")
+				if(W.type_damage == BRUTE || W.type_damage == null || W.type_damage == "")
 					W.pretend_weapon = pick("The mechanical toolbox", "The wirecutters", "The revolver", "The crowbar", "The fire extinguisher", "The tomato soup", "The oxygen tank", "The emergency oxygen tank", "The bullet", "The table", "The chair", "The ERROR")
-				if(W.type_damage == "burn")
+				if(W.type_damage == BURN)
 					W.pretend_weapon = pick("The laser", "The cigarette", "The lighter", "The ERROR", "The fire", "The hydrogen peroxide", "The steam", "The water", "The lava")
 				if(W.type_damage == "mixed")
 					W.pretend_weapon = pick("The nuclear explosion", "The explosion")
-				if(W.type_damage == "bruise")
+				if(W.type_damage == BRUISE)
 					W.pretend_weapon = pick("The paper", "The nail", "The pen", "The shard", "The PDA", "The cat", "The dog", "The door", "The monkey", "The air", "The coin")
 
 		if(!D.trauma[tdata])
@@ -108,13 +108,13 @@
 			if(W.damage < 1)
 				W.damage = 1
 
-			if(W.type_damage == "brute")
+			if(W.type_damage == BRUTE)
 				type_damage = " wound" //this space is really needed that table does not grow
-			if(W.type_damage == "burn")
+			if(W.type_damage == BURN)
 				type_damage = " burn"
 			if(W.type_damage == "mixed")
 				type_damage = " scorched wound"
-			if(W.type_damage == "bruise")
+			if(W.type_damage == BRUISE)
 				type_damage = " bruise"
 
 			switch(W.damage)

--- a/code/modules/detectivework/autopsy.dm
+++ b/code/modules/detectivework/autopsy.dm
@@ -90,7 +90,7 @@
 
 	for(var/data in organs)
 		var/datum/autopsy_body_part/D = organs[data]
-		scan_data += "<table border=\"2\">"
+		scan_data += "<table border=\"2\", style=\"text-align:center;\", width=\"100%\", table-layout: fixed;>"
 		scan_data += "<tr><th colspan=\"5\">[D.organ]</th></tr>"
 		scan_data += "<tr>"
 		scan_data += "<th>Severity</th>"
@@ -148,7 +148,7 @@
 			scan_data += "<td>"
 			scan_data += "[W.pretend_weapon]"
 			scan_data += "</td>"
-			scan_data += "<td>"
+			scan_data += "<td style=\"text-align:left;\">"
 			scan_data += "-<font size = \"2\"><span class=\"paper_field\"></span></font>"
 			scan_data += "</td>"
 			scan_data += "</tr>"

--- a/code/modules/detectivework/autopsy.dm
+++ b/code/modules/detectivework/autopsy.dm
@@ -12,7 +12,7 @@
 	w_class = ITEM_SIZE_SMALL
 	origin_tech = "materials=1;biotech=1"
 	var/list/datum/autopsy_body_part/organs = list()
-	var/list/datum/autopsy_data/chemtraces = list()
+	var/list/datum/autopsy_body_part/chemtraces = list()
 	var/target_name = null
 	var/timeofdeath = null
 

--- a/code/modules/detectivework/autopsy.dm
+++ b/code/modules/detectivework/autopsy.dm
@@ -186,11 +186,9 @@
 		usr:update_inv_r_hand()
 
 /obj/item/weapon/autopsy_scanner/attack(mob/living/carbon/human/M, mob/living/carbon/user, def_zone)
-	if(!istype(M))
+	if(!istype(M) &!can_operate(M))
 		return
 
-	if(!can_operate(M))
-		return
 	if(do_after(user,15,target = M))
 		if(target_name != M.name)
 			target_name = M.name

--- a/code/modules/detectivework/autopsy.dm
+++ b/code/modules/detectivework/autopsy.dm
@@ -27,7 +27,6 @@
 
 /datum/autopsy_data
 	var/weapon = null
-	var/pretend_weapon = null
 	var/damage = 0
 	var/type_damage = ""
 	var/hits = 0
@@ -36,7 +35,6 @@
 /datum/autopsy_data/proc/copy()
 	var/datum/autopsy_data/W = new()
 	W.weapon = weapon
-	W.pretend_weapon = pretend_weapon
 	W.damage = damage
 	W.hits = hits
 	W.time_inflicted = time_inflicted
@@ -48,20 +46,6 @@
 
 	for(var/V in BP.autopsy_data)
 		var/datum/autopsy_data/W = BP.autopsy_data[V]
-
-		if(!W.pretend_weapon)
-			/*
-			// the more hits, the more likely it is that we get the right weapon type
-			if(prob(50 + W.hits * 10 + W.damage))
-			*/
-
-			// Buffing this stuff up for now!
-			if(1)
-				W.pretend_weapon = W.weapon
-			else
-				W.pretend_weapon = pick("mechanical toolbox", "wirecutters", "revolver", "crowbar", "fire extinguisher", "tomato soup", "oxygen tank", "emergency oxygen tank", "laser", "bullet")
-
-
 		var/datum/autopsy_data_scanner/D = wdata[V]
 		if(!D)
 			D = new()
@@ -96,7 +80,6 @@
 	if(timeofdeath)
 		scan_data += "<b>Time of death:</b> [worldtime2text(timeofdeath)]<br><br>"
 
-	var/n = 1
 	for(var/wdata_idx in wdata)
 		var/datum/autopsy_data_scanner/D = wdata[wdata_idx]
 		var/total_hits = 0
@@ -107,11 +90,6 @@
 		for(var/wound_idx in D.bodyparts_scanned)
 			var/datum/autopsy_data/W = D.bodyparts_scanned[wound_idx]
 			total_hits += W.hits
-
-			var/wname = W.pretend_weapon
-
-			if(wname in weapon_chances) weapon_chances[wname] += W.damage
-			else weapon_chances[wname] = max(W.damage, 1)
 			total_score += W.damage
 			time = W.time_inflicted
 
@@ -133,7 +111,7 @@
 				damage_desc = "<font color='red'>severe</font>"
 
 		if(!total_score) total_score = D.bodyparts_scanned.len
-
+/*
 		scan_data += "<b>Weapon #[n]</b><br>"
 		if(damaging_weapon)
 			scan_data += "Severity: [damage_desc]<br>"
@@ -143,10 +121,33 @@
 		scan_data += "Possible weapons:<br>"
 		for(var/weapon_name in weapon_chances)
 			scan_data += "\t[100*weapon_chances[weapon_name]/total_score]% [weapon_name]<br>"
+*/
+
+		scan_data += "<table border=\"3\">"
+		scan_data += "<tr><th colspan=\"4\">[D.organ_names]</th></tr>"
+		scan_data += "<tr>"
+		scan_data += "<th>Severity</th>"
+		scan_data += "<th>Hits by weapon</th>"
+		scan_data += "<th>The approximate time</th>"
+		scan_data += "<th>Possible weapons</th>"
+		scan_data += "</tr>"
+		scan_data += "<tr>"
+		scan_data += "<td>"
+		if(damaging_weapon)
+			scan_data += "[damage_desc]"
+		scan_data += "</td>"
+		scan_data += "<td>"
+		if(damaging_weapon)
+			scan_data += "[total_hits]"
+		scan_data += "</td>"
+		scan_data += "<td>[time]</td>"
+		scan_data += "<td>"
+		for(var/weapon_name in weapon_chances)
+			scan_data += "\t[100*weapon_chances[weapon_name]/total_score]% [weapon_name]<br>"
+		scan_data += "</td>"
+		scan_data += "</tr>"
 
 		scan_data += "<br>"
-
-		n++
 
 	if(chemtraces.len)
 		scan_data += "<b>Trace Chemicals: </b><br>"

--- a/code/modules/detectivework/autopsy.dm
+++ b/code/modules/detectivework/autopsy.dm
@@ -29,8 +29,9 @@
 	var/weapon = null
 	var/pretend_weapon = null
 	var/damage = 0
+	var/type_damage = ""
 	var/hits = 0
-	var/time_inflicted = 0
+	var/time_inflicted = ""
 
 /datum/autopsy_data/proc/copy()
 	var/datum/autopsy_data/W = new()
@@ -101,7 +102,7 @@
 		var/total_hits = 0
 		var/total_score = 0
 		var/list/weapon_chances = list() // maps weapon names to a score
-		var/age = 0
+		var/time = ""
 
 		for(var/wound_idx in D.bodyparts_scanned)
 			var/datum/autopsy_data/W = D.bodyparts_scanned[wound_idx]
@@ -111,11 +112,8 @@
 
 			if(wname in weapon_chances) weapon_chances[wname] += W.damage
 			else weapon_chances[wname] = max(W.damage, 1)
-			total_score+=W.damage
-
-
-			var/wound_age = W.time_inflicted
-			age = max(age, wound_age)
+			total_score += W.damage
+			time = W.time_inflicted
 
 		var/damage_desc
 
@@ -140,7 +138,7 @@
 		if(damaging_weapon)
 			scan_data += "Severity: [damage_desc]<br>"
 			scan_data += "Hits by weapon: [total_hits]<br>"
-		scan_data += "Approximate time of wound infliction: [worldtime2text(age)]<br>"
+		scan_data += "Approximate time of wound infliction: [time]<br>"
 		scan_data += "Affected limbs: [D.organ_names]<br>"
 		scan_data += "Possible weapons:<br>"
 		for(var/weapon_name in weapon_chances)

--- a/code/modules/detectivework/autopsy.dm
+++ b/code/modules/detectivework/autopsy.dm
@@ -11,7 +11,7 @@
 	flags = CONDUCT
 	w_class = ITEM_SIZE_SMALL
 	origin_tech = "materials=1;biotech=1"
-	var/list/obj/item/organ/external/organs = list()
+	var/list/datum/autopsy_body_part/organs = list()
 	var/list/datum/autopsy_data/chemtraces = list()
 	var/target_name = null
 	var/timeofdeath = null
@@ -32,19 +32,27 @@
 	W.weapon = weapon
 	W.pretend_weapon = pretend_weapon
 	W.damage = damage
+	W.type_damage = type_damage
 	W.hits = hits
 	W.time_inflicted = time_inflicted
 	return W
+
+/datum/autopsy_body_part
+	var/organ = ""
+	var/list/datum/autopsy_data/trauma = list()
 
 /obj/item/weapon/autopsy_scanner/proc/add_data(obj/item/organ/external/BP)
 	if(!BP.autopsy_data.len && !BP.trace_chemicals.len)
 		return
 
-	if(!(BP in organs))
-		organs += BP
+	var/datum/autopsy_body_part/D = organs[BP.name]
+	if(!D)
+		D = new()
+		D.organ = BP.name
+		organs[BP.name] = D
 
-	for(var/adata in BP.autopsy_data)
-		var/datum/autopsy_data/W = BP.autopsy_data[adata]
+	for(var/tdata in BP.autopsy_data)
+		var/datum/autopsy_data/W = BP.autopsy_data[tdata]
 		if(!W.pretend_weapon)
 			if(prob(40 + (W.hits * 10 + W.damage)))
 				W.pretend_weapon = W.weapon
@@ -57,6 +65,9 @@
 					W.pretend_weapon = pick("The nuclear explosion", "The explosion")
 				if(W.type_damage == "bruise")
 					W.pretend_weapon = pick("The paper", "The nail", "The pen", "The shard", "The PDA", "The cat", "The dog", "The door", "The monkey", "The air", "The coin")
+
+		if(!D.trauma[tdata])
+			D.trauma[tdata] = W.copy()
 
 	for(var/V in BP.trace_chemicals)
 		if(BP.trace_chemicals[V] > 0 && !chemtraces.Find(V))
@@ -77,18 +88,19 @@
 	if(timeofdeath)
 		scan_data += "<b>Time of death:</b> [worldtime2text(timeofdeath)]<br>"
 
-	for(var/organ in organs)
-		var/obj/item/organ/external/BP = organ
+	for(var/data in organs)
+		var/datum/autopsy_body_part/D = organs[data]
 		scan_data += "<table border=\"2\">"
-		scan_data += "<tr><th colspan=\"4\">[BP.name]</th></tr>"
+		scan_data += "<tr><th colspan=\"5\">[D.organ]</th></tr>"
 		scan_data += "<tr>"
 		scan_data += "<th>Severity</th>"
 		scan_data += "<th>Hits by weapon</th>"
 		scan_data += "<th>Possible time</th>"
 		scan_data += "<th>Possible weapon</th>"
+		scan_data += "<th>Notes</th>"
 		scan_data += "</tr>"
-		for(var/adata in BP.autopsy_data)
-			var/datum/autopsy_data/W = BP.autopsy_data[adata]
+		for(var/tdata in D.trauma)
+			var/datum/autopsy_data/W = D.trauma[tdata]
 			var/damage_desc = ""
 			var/type_damage = ""
 			var/hits_desc = ""
@@ -136,9 +148,14 @@
 			scan_data += "<td>"
 			scan_data += "[W.pretend_weapon]"
 			scan_data += "</td>"
+			scan_data += "<td>"
+			scan_data += "-<font size = \"2\"><span class=\"paper_field\"></span></font>"
+			scan_data += "</td>"
 			scan_data += "</tr>"
 
+		scan_data += "</table>"
 		scan_data += "<br>"
+
 
 	if(chemtraces.len)
 		scan_data += "<b>Trace Chemicals: </b><br>"
@@ -151,14 +168,17 @@
 	sleep(10)
 
 	var/obj/item/weapon/paper/autopsy_report/P = new(usr.loc)
+	P.fields = 0
 	P.name = "Autopsy Data ([target_name])"
 	P.info = "<tt>[scan_data]</tt>"
 	P.autopsy_data = list() // Copy autopsy data for science tool
-	for(var/organ in organs)
-		var/obj/item/organ/external/BP = organ
-		for(var/adata in BP.autopsy_data)
-			var/datum/autopsy_data/W = BP.autopsy_data[adata]
+	for(var/data in organs)
+		var/datum/autopsy_body_part/D = organs[data]
+		for(var/tdata in D.trauma)
+			var/datum/autopsy_data/W =  D.trauma[tdata]
+			P.fields += 1 //we dont call needed proc, therefore var is necessary
 			P.autopsy_data += W.copy()
+	P.updateinfolinks()
 	P.update_icon()
 
 	if(istype(usr,/mob/living/carbon))

--- a/code/modules/detectivework/autopsy.dm
+++ b/code/modules/detectivework/autopsy.dm
@@ -46,17 +46,17 @@
 	for(var/adata in BP.autopsy_data)
 		var/datum/autopsy_data/W = BP.autopsy_data[adata]
 		if(!W.pretend_weapon)
-			if(prob(50 + (W.hits * 10 + W.damage)))
+			if(prob(40 + (W.hits * 10 + W.damage)))
 				W.pretend_weapon = W.weapon
 			else
-				if(W.type_damage == "brute")
+				if(W.type_damage == "brute" || W.type_damage == null || W.type_damage == "")
 					W.pretend_weapon = pick("The mechanical toolbox", "The wirecutters", "The revolver", "The crowbar", "The fire extinguisher", "The tomato soup", "The oxygen tank", "The emergency oxygen tank", "The bullet", "The table", "The chair", "The ERROR")
 				if(W.type_damage == "burn")
-					W.pretend_weapon = pick("The laser", "The cigarette", "The lighter", "The ERROR", "The fire", "The hydrogen peroxide")
+					W.pretend_weapon = pick("The laser", "The cigarette", "The lighter", "The ERROR", "The fire", "The hydrogen peroxide", "The steam", "The water", "The lava")
 				if(W.type_damage == "mixed")
-					W.pretend_weapon = pick("nuclear explosion", "explosion")
+					W.pretend_weapon = pick("The nuclear explosion", "The explosion")
 				if(W.type_damage == "bruise")
-					W.pretend_weapon = pick("The paper", "The nail", "The pen", "The shard", "The PDA", "The cat", "The dog", "The door", "The monkey")
+					W.pretend_weapon = pick("The paper", "The nail", "The pen", "The shard", "The PDA", "The cat", "The dog", "The door", "The monkey", "The air", "The coin")
 
 	for(var/V in BP.trace_chemicals)
 		if(BP.trace_chemicals[V] > 0 && !chemtraces.Find(V))

--- a/code/modules/detectivework/autopsy.dm
+++ b/code/modules/detectivework/autopsy.dm
@@ -21,6 +21,7 @@
 
 /datum/autopsy_data
 	var/weapon = null
+	var/pretend_weapon = null
 	var/damage = 0
 	var/type_damage = ""
 	var/hits = 0
@@ -29,6 +30,7 @@
 /datum/autopsy_data/proc/copy()
 	var/datum/autopsy_data/W = new()
 	W.weapon = weapon
+	W.pretend_weapon = pretend_weapon
 	W.damage = damage
 	W.hits = hits
 	W.time_inflicted = time_inflicted
@@ -37,8 +39,24 @@
 /obj/item/weapon/autopsy_scanner/proc/add_data(obj/item/organ/external/BP)
 	if(!BP.autopsy_data.len && !BP.trace_chemicals.len)
 		return
+
 	if(!(BP in organs))
 		organs += BP
+
+	for(var/adata in BP.autopsy_data)
+		var/datum/autopsy_data/W = BP.autopsy_data[adata]
+		if(!W.pretend_weapon)
+			if(prob(50 + (W.hits * 10 + W.damage)))
+				W.pretend_weapon = W.weapon
+			else
+				if(W.type_damage == "brute")
+					W.pretend_weapon = pick("The mechanical toolbox", "The wirecutters", "The revolver", "The crowbar", "The fire extinguisher", "The tomato soup", "The oxygen tank", "The emergency oxygen tank", "The bullet", "The table", "The chair", "The ERROR")
+				if(W.type_damage == "burn")
+					W.pretend_weapon = pick("The laser", "The cigarette", "The lighter", "The ERROR", "The fire", "The hydrogen peroxide")
+				if(W.type_damage == "mixed")
+					W.pretend_weapon = pick("nuclear explosion", "explosion")
+				if(W.type_damage == "bruise")
+					W.pretend_weapon = pick("The paper", "The nail", "The pen", "The shard", "The PDA", "The cat", "The dog", "The door", "The monkey")
 
 	for(var/V in BP.trace_chemicals)
 		if(BP.trace_chemicals[V] > 0 && !chemtraces.Find(V))
@@ -66,8 +84,8 @@
 		scan_data += "<tr>"
 		scan_data += "<th>Severity</th>"
 		scan_data += "<th>Hits by weapon</th>"
-		scan_data += "<th>The approximate time</th>"
-		scan_data += "<th>Weapons</th>"
+		scan_data += "<th>Possible time</th>"
+		scan_data += "<th>Possible weapon</th>"
 		scan_data += "</tr>"
 		for(var/adata in BP.autopsy_data)
 			var/datum/autopsy_data/W = BP.autopsy_data[adata]
@@ -75,8 +93,11 @@
 			var/type_damage = ""
 			var/hits_desc = ""
 
+			if(W.damage < 1)
+				W.damage = 1
+
 			if(W.type_damage == "brute")
-				type_damage = " wound"
+				type_damage = " wound" //this space is really needed that table does not grow
 			if(W.type_damage == "burn")
 				type_damage = " burn"
 			if(W.type_damage == "mixed")
@@ -85,7 +106,7 @@
 				type_damage = " bruise"
 
 			switch(W.damage)
-				if(0) //Strangled comes in here
+				if(0) //strangled comes in here
 					damage_desc = "Unknown"
 				if(1 to 5)
 					damage_desc = "<font color='green'>negligible[type_damage]</font>"
@@ -113,7 +134,7 @@
 			scan_data += "</td>"
 			scan_data += "<td>[W.time_inflicted]</td>"
 			scan_data += "<td>"
-			scan_data += "[W.weapon]"
+			scan_data += "[W.pretend_weapon]"
 			scan_data += "</td>"
 			scan_data += "</tr>"
 

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -72,6 +72,7 @@
 			if(damage >= 9)
 				visible_message("<span class='warning'><B>[M] has weakened [src]!</B></span>")
 				apply_effect(4, WEAKEN, armor_block)
+			BP.add_autopsy_data("Hematoma", damage, "bruise")
 
 			return
 	else
@@ -129,6 +130,7 @@
 
 			damage += attack.damage
 			apply_damage(damage, BRUTE, BP, armor_block, attack.damage_flags())
+			BP.add_autopsy_data("Hematoma", damage, "bruise")
 
 
 		if("disarm")

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -72,7 +72,7 @@
 			if(damage >= 9)
 				visible_message("<span class='warning'><B>[M] has weakened [src]!</B></span>")
 				apply_effect(4, WEAKEN, armor_block)
-			BP.add_autopsy_data("Hematoma", damage, "bruise")
+			BP.add_autopsy_data("Hematoma", damage, BRUISE)
 
 			return
 	else
@@ -130,7 +130,7 @@
 
 			damage += attack.damage
 			apply_damage(damage, BRUTE, BP, armor_block, attack.damage_flags())
-			BP.add_autopsy_data("Hematoma", damage, "bruise")
+			BP.add_autopsy_data("Hematoma", damage, BRUISE)
 
 
 		if("disarm")

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -72,7 +72,6 @@
 			if(damage >= 9)
 				visible_message("<span class='warning'><B>[M] has weakened [src]!</B></span>")
 				apply_effect(4, WEAKEN, armor_block)
-			BP.add_autopsy_data("Hematoma", damage, BRUISE)
 
 			return
 	else
@@ -129,8 +128,7 @@
 				apply_effect(2, WEAKEN, armor_block)
 
 			damage += attack.damage
-			apply_damage(damage, BRUTE, BP, armor_block, attack.damage_flags())
-			BP.add_autopsy_data("Hematoma", damage, BRUISE)
+			apply_damage(damage, BRUTE, BP, armor_block, attack.damage_flags(), used_weapon = "Hematoma")
 
 
 		if("disarm")

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -231,7 +231,7 @@
 		if(ishuman(affecting))
 			var/mob/living/carbon/human/H = affecting
 			var/obj/item/organ/external/BP = H.bodyparts_by_name[BP_HEAD]
-			BP.add_autopsy_data("Strangled", 0, "bruise") //if 0, then unknow
+			BP.add_autopsy_data("Strangled", 0, BRUISE) //if 0, then unknow
 			if(!BP || BP.is_stump)
 				qdel(src)
 				return PROCESS_KILL

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -231,6 +231,7 @@
 		if(ishuman(affecting))
 			var/mob/living/carbon/human/H = affecting
 			var/obj/item/organ/external/BP = H.bodyparts_by_name[BP_HEAD]
+			BP.add_autopsy_data("Strangled", 0, "bruise") //if 0, then unknow
 			if(!BP || BP.is_stump)
 				qdel(src)
 				return PROCESS_KILL

--- a/code/modules/organs/external/flesh.dm
+++ b/code/modules/organs/external/flesh.dm
@@ -52,7 +52,12 @@
 			burn /= 2
 
 	if(used_weapon)
-		BP.add_autopsy_data("[used_weapon]", brute + burn)
+		if(brute > 0 && burn == 0)
+			BP.add_autopsy_data("[used_weapon]", brute, type_damage = "brute")
+		else if(brute == 0 && burn > 0)
+			BP.add_autopsy_data("[used_weapon]", burn, type_damage = "burn")
+		else if(brute > 0 && burn > 0)
+			BP.add_autopsy_data("[used_weapon]", brute + burn, type_damage = "mixed")
 
 	var/can_cut = (prob(brute * 2) || sharp) && (bodypart_type != BODYPART_ROBOTIC)
 

--- a/code/modules/organs/external/flesh.dm
+++ b/code/modules/organs/external/flesh.dm
@@ -53,9 +53,9 @@
 
 	if(used_weapon)
 		if(brute > 0 && burn == 0)
-			BP.add_autopsy_data("[used_weapon]", brute, type_damage = "brute")
+			BP.add_autopsy_data("[used_weapon]", brute, type_damage = BRUTE)
 		else if(brute == 0 && burn > 0)
-			BP.add_autopsy_data("[used_weapon]", burn, type_damage = "burn")
+			BP.add_autopsy_data("[used_weapon]", burn, type_damage = BURN)
 		else if(brute > 0 && burn > 0)
 			BP.add_autopsy_data("[used_weapon]", brute + burn, type_damage = "mixed")
 

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -84,7 +84,7 @@
 		BP.trace_chemicals[A.name] = 100
 
 //Adds autopsy data for used_weapon. Use type: brute, burn, mixed, bruise (weak punch, e.g. fist punch)
-/obj/item/organ/proc/add_autopsy_data(used_weapon, damage, type_damage = "brute")
+/obj/item/organ/proc/add_autopsy_data(used_weapon, damage, type_damage)
 	var/datum/autopsy_data/W = autopsy_data[used_weapon + worldtime2text()]
 	if(!W)
 		W = new()

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -83,7 +83,7 @@
 		var/obj/item/organ/external/BP = pick(bodyparts)
 		BP.trace_chemicals[A.name] = 100
 
-//Adds autopsy data for used_weapon.
+//Adds autopsy data for used_weapon. Use type: brute, burn, mixed, bruise (weak punch, e.g. fist punch)
 /obj/item/organ/proc/add_autopsy_data(used_weapon, damage, type_damage = "brute")
 	var/datum/autopsy_data/W = autopsy_data[used_weapon + worldtime2text()]
 	if(!W)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -83,7 +83,7 @@
 		var/obj/item/organ/external/BP = pick(bodyparts)
 		BP.trace_chemicals[A.name] = 100
 
-//Adds autopsy data for used_weapon. Use type: brute, burn, mixed, bruise (weak punch, e.g. fist punch)
+//Adds autopsy data for used_weapon. Use type damage: brute, burn, mixed, bruise (weak punch, e.g. fist punch)
 /obj/item/organ/proc/add_autopsy_data(used_weapon, damage, type_damage)
 	var/datum/autopsy_data/W = autopsy_data[used_weapon + worldtime2text()]
 	if(!W)

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -84,16 +84,23 @@
 		BP.trace_chemicals[A.name] = 100
 
 //Adds autopsy data for used_weapon.
-/obj/item/organ/proc/add_autopsy_data(used_weapon, damage)
-	var/datum/autopsy_data/W = autopsy_data[used_weapon]
+/obj/item/organ/proc/add_autopsy_data(used_weapon, damage, type_damage = "brute")
+	var/datum/autopsy_data/W = autopsy_data[used_weapon + worldtime2text()]
 	if(!W)
 		W = new()
 		W.weapon = used_weapon
-		autopsy_data[used_weapon] = W
+		autopsy_data[used_weapon + worldtime2text()] = W
+
+	var/time = W.time_inflicted
+	if(time != worldtime2text())
+		W = new()
+		W.weapon = used_weapon
+		autopsy_data[used_weapon + worldtime2text()] = W
 
 	W.hits += 1
 	W.damage += damage
-	W.time_inflicted = world.time
+	W.time_inflicted = worldtime2text()
+	W.type_damage = type_damage
 
 // Takes care of bodypart and their organs related updates, such as broken and missing limbs
 /mob/living/carbon/human/proc/handle_bodyparts()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Это не совсем рефатор, но все же аутопси сканер работает иначе.

- Теперь в отчете идет статистика не по оружию, а по травме в определенной части тела. 

- Новый объект с ранением может создаваться каждую минуту, что чревато очень длинным строчкам в ВВ(не уверен, будет ли это как-то влиять на лаги), но теперь повторные увечия не обновляют время нанесения.

- Добавлены типы урона, но это больше эстетическое

- В отчете будет писаться о удушение

- При небольшом дамаге и количестве ударов аутопси сканер не всегда сможет распознать оружие

(возможно что-то упустил)

<details> 
  <summary>Пример</summary>

![new_autops](https://user-images.githubusercontent.com/26389417/76207841-1c8acf00-6231-11ea-8d0d-a83dff9ff9e8.JPG)



</details>

close #4708 

#4709 насчет этого ишью. `BP.take_damage()` всегда содержал `add_autopsy_data()`. `take_overall_damage()` по дефолту не содержит `BP.take_damage()`, но у хуманов оно есть(но не везде по коду юзается прок хуманов). Как решение можно самому мобу добавлять повреждение, но заниматься я этим не стану.

UPD: Обновил скриншот-пример

## Почему и что этот ПР улучшит
К каждой ране теперь идет время, но не всегда само оружие будет показано точно.
Более точная и удобная аутопсия станет полезнее 

## Авторство
Я
## Чеинжлог
:cl:
 - tweak: Изменена форма отчета о вскрытие, больше информации в нем