### PR TITLE
Фикс стата в проверках CanHug() и is_facehuggable()

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -906,6 +906,3 @@
 	if(IsSleeping())
 		stat = UNCONSCIOUS
 		blinded = TRUE
-
-/mob/living/carbon/proc/is_facehuggable()
-	return FALSE

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -2046,7 +2046,7 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 		blinded = TRUE
 
 /mob/living/carbon/human/is_facehuggable()
-	return species.flags[FACEHUGGABLE] && !stat && !(locate(/obj/item/alien_embryo) in contents)
+	return species.flags[FACEHUGGABLE] && stat != DEAD && !(locate(/obj/item/alien_embryo) in contents)
 
 /mob/living/carbon/human/verb/remove_bandages()
 	set category = "IC"

--- a/code/modules/mob/living/carbon/monkey/monkey.dm
+++ b/code/modules/mob/living/carbon/monkey/monkey.dm
@@ -445,4 +445,4 @@
 	return race
 
 /mob/living/carbon/monkey/is_facehuggable()
-	return !stat && !(locate(/obj/item/alien_embryo) in contents)
+	return stat != DEAD && !(locate(/obj/item/alien_embryo) in contents)

--- a/code/modules/mob/living/carbon/xenomorph/special/facehugger/facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/special/facehugger/facehugger.dm
@@ -197,7 +197,7 @@
 		Attach(hit_atom)
 
 /obj/item/clothing/mask/facehugger/proc/CanHug(mob/living/carbon/C, check = 1)
-	if(!C.is_facehuggable() || istype(C.wear_mask, src) || loc == C)
+	if(!C.is_facehuggable() || stat || istype(C.wear_mask, src) || loc == C)
 		return FALSE
 	if(check)
 		if(isturf(src.loc))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1105,3 +1105,6 @@ note dizziness decrements automatically in the mob's Life() proc.
 
 /mob/proc/can_pickup(obj/O)
 	return TRUE
+
+/atom/movable/proc/is_facehuggable()
+	return FALSE


### PR DESCRIPTION
**Это бы поскорее на сервер. Баг позволяет игрокам делать режим аленей когда им захочется**

##  Описание изменений

fixes #4824 

- Фикс некрофилии людей к мертвым лицехватам - мертвые лицехваты могли заражать людей. Из за этого игроки могли стартовать режим аленей когда им захочется. Лолон, прости, меня раскрыли!!!!!!!!!
- Лицехваты брезгали заражать людей без сознания
- Фикс рантайма, вызванный тем, что, на мое удивление, фейсхаггер пытался нацепиться также и на объекты, включая самого себя. Прок же был предусмотрен только для карбонов(попался в ловушку джокера над которой сам смеялся в прошлом пре). Теперь он предусмотрен для мувабл атомов.

## Почему и что этот ПР улучшит

Фикс багов

## Чеинжлог

:cl: Lizzzard
 - bugfix: Мертвые лицехваты больше не заражают людей
 - bugfix: Лицехваты вновь заражают людей без сознания(кроме мертвых)