### PR TITLE
Runtime in door.dm:149 : Cannot execute null.SetNextMove()

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -146,7 +146,8 @@
 		user = null
 	if(!src.requiresID())
 		user = null
-	user.SetNextMove(CLICK_CD_INTERACT)
+	if(user)
+		user.SetNextMove(CLICK_CD_INTERACT)
 	if(src.allowed(user) || emergency)
 		if(src.density)
 			open()


### PR DESCRIPTION
Тупая затычка. Я не совсем понимаю, зачем в целом сбрасывать user в нулл а потом гонять это в allowed().
Следует немного отрефакторить, но у меня в данный момент нету желения тестить, так что наименее инвазивный фикс.