### PR TITLE
Fixing runtimes on simple_animal deletion kills.

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -197,17 +197,16 @@
 					M.adjustBrainLoss(power)
 
 				else
-
+					if(prob(33)) // Added blood for whacking non-humans too
+						var/turf/simulated/T = M.loc
+						if(istype(T))
+							T.add_blood_floor(M)
 					M.take_bodypart_damage(power)
-					if (prob(33)) // Added blood for whacking non-humans too
-						var/turf/location = M.loc
-						if (istype(location, /turf/simulated))
-							location:add_blood_floor(M)
 			if("fire")
 				if (!(COLD_RESISTANCE in M.mutations))
-					M.take_bodypart_damage(0, power)
 					to_chat(M, "Aargh it burns!")
-		M.updatehealth()
+					M.take_bodypart_damage(0, power)
+
 	add_fingerprint(user)
 	SSdemo.mark_dirty(src)
 	SSdemo.mark_dirty(M)

--- a/code/modules/mob/living/silicon/robot/drone/drone_damage.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_damage.dm
@@ -3,6 +3,8 @@
 	bruteloss += brute
 	fireloss += burn
 
+	updatehealth()
+
 /mob/living/silicon/robot/drone/heal_overall_damage(brute, burn)
 
 	bruteloss -= brute

--- a/code/modules/mob/living/silicon/robot/robot_damage.dm
+++ b/code/modules/mob/living/silicon/robot/robot_damage.dm
@@ -92,6 +92,8 @@
 	var/datum/robot_component/C = pick(components)
 	C.take_damage(brute,burn,sharp,edge)
 
+	updatehealth()
+
 /mob/living/silicon/robot/heal_overall_damage(brute, burn)
 	var/list/datum/robot_component/parts = get_damaged_components(brute,burn)
 
@@ -146,3 +148,5 @@
 		burn	-= (picked.electronics_damage - burn_was)
 
 		parts -= picked
+
+	updatehealth()


### PR DESCRIPTION
## Описание изменений

Все вещи которые нужно провести с мобом который получает урон проходят *до* получения урона, так как некоторые мобы реагируя на урон могут удаляться.

Так же я убрал обновление здоровья моба, так как оно хендлится в функции take_bodypart_damage.

## Почему и что этот ПР улучшит

fixes #4643 
