### PR TITLE
Иммунитет Спу против части типов урона и вычёркивание их из целей слаймов 

### DIFF
--- a/code/modules/mob/living/carbon/metroid/life.dm
+++ b/code/modules/mob/living/carbon/metroid/life.dm
@@ -447,7 +447,7 @@
 				var/list/targets = list()
 
 				for(var/mob/living/L in view(7,src))
-					if(L.get_species() == IPC)
+					if(L.get_species() == IPC) //Ignore IPC
 						continue
 
 					if(L.get_species() == SLIME || L.stat == DEAD) // Ignore other slimes and dead mobs
@@ -461,9 +461,6 @@
 
 					if(issilicon(L) && (rabid || attacked)) // They can't eat silicons, but they can glomp them in defence
 						targets += L // Possible target found!
-
-					if(istype(L, /mob/living/carbon/human)) //Ignore slime(wo)men and IPC
-						var/mob/living/carbon/human/H = L
 
 					if(!L.canmove) // Only one slime can latch on at a time.
 						var/notarget = 0

--- a/code/modules/mob/living/carbon/metroid/life.dm
+++ b/code/modules/mob/living/carbon/metroid/life.dm
@@ -460,11 +460,10 @@
 					if(issilicon(L) && (rabid || attacked)) // They can't eat silicons, but they can glomp them in defence
 						targets += L // Possible target found!
 
-					if(istype(L, /mob/living/carbon/human)) //Ignore slime(wo)men
+					if(istype(L, /mob/living/carbon/human)) //Ignore slime(wo)men and IPC
 						var/mob/living/carbon/human/H = L
-						if(H.dna)
-							if(H.dna.mutantrace == "slime")
-								continue
+						if(H.get_species() == SLIME || H.get_species() == IPC)
+							continue
 
 					if(!L.canmove) // Only one slime can latch on at a time.
 						var/notarget = 0

--- a/code/modules/mob/living/carbon/metroid/life.dm
+++ b/code/modules/mob/living/carbon/metroid/life.dm
@@ -447,8 +447,10 @@
 				var/list/targets = list()
 
 				for(var/mob/living/L in view(7,src))
+					if(L.get_species() == IPC)
+						continue
 
-					if(isslime(L) || L.stat == DEAD) // Ignore other slimes and dead mobs
+					if(L.get_species() == SLIME || L.stat == DEAD) // Ignore other slimes and dead mobs
 						continue
 
 					if(HAS_TRAIT(L, TRAIT_NATURECHILD) && L.naturechild_check())
@@ -462,8 +464,6 @@
 
 					if(istype(L, /mob/living/carbon/human)) //Ignore slime(wo)men and IPC
 						var/mob/living/carbon/human/H = L
-						if(H.get_species() == SLIME || H.get_species() == IPC)
-							continue
 
 					if(!L.canmove) // Only one slime can latch on at a time.
 						var/notarget = 0

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -678,6 +678,10 @@
 
 	brute_mod = 1.5
 	burn_mod = 1
+	oxy_mod = 0
+	tox_mod = 0
+	clone_mod = 0
+
 	siemens_coefficient = 1.3 // ROBUTT.
 
 	butcher_drops = list(/obj/item/stack/sheet/plasteel = 3)


### PR DESCRIPTION
## Описание изменений
Теперь спу имеют иммунитет против Окси, Токс и Клон урона.
Слаймы не выбирают Спу как цель при голоде. (как Слаймолюдей)
fix #4863 
## Почему и что этот ПР улучшит
Теперь Спу будут идеальны при работе со слаймами.
Слаймы не будут пытаться поесть металл.
Защита от каких-то непонятных уронов, невозможных для спу
## Авторство
Felix Ruin - Winter Schock
## Чеинжлог
:cl: Winter Schock
- bugfix: Слаймы нападали на Спу при голоде