### PR TITLE
Апдейт причуд

### DIFF
--- a/code/controllers/subsystem/quirks.dm
+++ b/code/controllers/subsystem/quirks.dm
@@ -34,13 +34,18 @@ var/datum/subsystem/quirks/SSquirks
 		)
 
 	quirk_blacklist_species = list(
-		"Fatness" = list(DIONA, IPC),
+		"Fatness" = list(DIONA, IPC, VOX),
 		"Child of Nature" = list(HUMAN, SKRELL, TAJARAN, UNATHI, IPC, VOX),
 		"Stress Eater" = list(DIONA, IPC),
 		"High pain threshold" = list(DIONA, IPC),
 		"Low pain threshold" = list(DIONA, IPC),
 		"Alcohol Tolerance" = list(DIONA, IPC),
-		"Light Drinker" = list(DIONA, IPC)
+		"Light Drinker" = list(DIONA, IPC),
+		"Coughing" = list(DIONA, IPC),
+		"Seizures" = list(DIONA, IPC),
+		"Tourette" = list(DIONA, VOX),
+		"Nervous" = list(DIONA),
+		"Strong mind" = list(DIONA, IPC)
 		)
 
 	..()


### PR DESCRIPTION
## Описание изменений
Пофиксил выбор квирков для рас воксов, спу, дион
## Почему и что этот ПР улучшит
Квирки теперь соответствуют механу/беку рас. Ксеновизоры согласны с изменениями
## Авторство
@Akellazp 
## Чеинжлог
:cl:
- bugfix: Неподходящие расам квирки запрещены. Никаких кашляющих, трясущихся, турретящих дион и СПУ. Воксы не могут быть жирными.