### PR TITLE
Grab removed from vox leap for balance reasons; weaken effect reduced

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1858,10 +1858,8 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 			L.Weaken(1) //Only brief stun
 			step_towards(src, L)
 		else
-			L.Weaken(5)
-			sleep(2) // Runtime prevention (infinite bump() calls on hulks)
+			L.Weaken(2)
 			step_towards(src, L)
-			Grab(L, GRAB_AGGRESSIVE)
 
 	else if(hit_atom.density)
 		visible_message("<span class='danger'>[src] smashes into [hit_atom]!</span>", "<span class='danger'>You smash into [hit_atom]!</span>")


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений

Убран граб у прыжка вокса, уменьшен стан, о причинах балансных и роеплейных вот здесь в моем комментарии https://github.com/TauCetiStation/TauCetiClassic/pull/4735

Жду ваших предложений

## Почему и что этот ПР улучшит

Уберет сомнительное преимущество у расы

## Чеинжлог

:cl:
 - balance: Прыжок воксов теперь не захватывает цель; уменьшена продолжительность падения от прыжка воксов