### PR TITLE
Candles boxes now fits bibles

### DIFF
--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -128,6 +128,7 @@
 	item_state = "black_candlebox5"
 	storage_slots = 5
 	throwforce = 2
+	w_class = ITEM_SIZE_SMALL
 	slot_flags = SLOT_FLAGS_BELT
 	var/cooldown = 0
 	var/teleporter_delay = 0

--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -85,6 +85,7 @@
 	item_state = "candlebox"
 	storage_slots = 5
 	throwforce = 2
+	w_class = ITEM_SIZE_SMALL
 	slot_flags = SLOT_FLAGS_BELT
 	var/candle_type = "white"
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Коробки свечей теперь влезают в библию
![EXAMPLE_candle](https://user-images.githubusercontent.com/41844545/77225693-7caf3880-6b82-11ea-8220-f811c9b8767e.png)

## Почему и что этот ПР улучшит
closes #4895
Улучшит игру на священнике, глубокий отыгрыш, важные изменения.
## Авторство
TheReaperOfSouls
## Чеинжлог
:cl: Fukfuk
- tweak: коробка свечей теперь влезает внутрь библии. 

