### PR TITLE
Dorms toilet APC and camera fix by Kildjen

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -18463,10 +18463,9 @@
 	},
 /area/station/civilian/toilet)
 "aGh" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	name = "Dormitory Bathrooms APC";
-	pixel_y = -24
+/obj/machinery/camera{
+	c_tag = "Dormitory Toilets";
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
@@ -21033,6 +21032,11 @@
 /obj/structure/sink{
 	dir = 8;
 	pixel_x = -12
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
@@ -77345,6 +77349,16 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/office)
+"uHq" = (
+/obj/machinery/power/apc{
+	name = "Dormitory Bathrooms APC";
+	pixel_y = -24
+	},
+/obj/structure/cable,
+/turf/simulated/floor{
+	icon_state = "freezerfloor"
+	},
+/area/station/civilian/toilet)
 "uIb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -113161,7 +113175,7 @@ tkb
 aEa
 aGH
 aLr
-thb
+uHq
 aEa
 bfp
 aKx


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Добавлена камера в дормиториях, которая была утеряна в результате прошлого ремапа. Провод теперь подведён к АПЦ, а не мимо. 
![camera](https://user-images.githubusercontent.com/41844545/77230549-0cb2a980-6ba6-11ea-8f6e-8134cca85157.png)

## Почему и что этот ПР улучшит
Исправит недочет с расположением камеры, которая стояла внутри стены.
Исправит проблему с АПЦ, который не заряжался из-за неправильно положенного кабеля.
## Авторство
@Enerty & Nejdlik
## Чеинжлог
:cl: Nejdlik
- map: туалет дорм снова подключен к общей сети электропитания. ранее он не был подключен. Ранее стоявшая в стене дорм, камера, передвинута на положенное ей место.