### PR TITLE
Из загрузки в кэш убраны картинки для game_kit и space_ninja

### DIFF
--- a/code/controllers/subsystem/assets.dm
+++ b/code/controllers/subsystem/assets.dm
@@ -10,7 +10,7 @@ var/datum/subsystem/assets/SSasset
 	NEW_SS_GLOBAL(SSasset)
 
 /datum/subsystem/assets/Initialize(timeofday)
-	for(var/type in typesof(/datum/asset))
+	for(var/type in subtypesof(/datum/asset))
 		var/datum/asset/A = new type()
 		if (type != initial(A._abstract)) //no need to register an abstract asset
 			A.register()

--- a/code/controllers/subsystem/assets.dm
+++ b/code/controllers/subsystem/assets.dm
@@ -10,7 +10,7 @@ var/datum/subsystem/assets/SSasset
 	NEW_SS_GLOBAL(SSasset)
 
 /datum/subsystem/assets/Initialize(timeofday)
-	for(var/type in typesof(/datum/asset) - list(/datum/asset, /datum/asset/simple))
+	for(var/type in typesof(/datum/asset))
 		var/datum/asset/A = new type()
 		if (type != initial(A._abstract)) //no need to register an abstract asset
 			A.register()

--- a/code/game/gamemodes/events/ninja_equipment.dm
+++ b/code/game/gamemodes/events/ninja_equipment.dm
@@ -247,6 +247,7 @@ ________________________________________________________________________________
 	var/display_to = s_control ? U : A//Who do we want to display certain messages to?
 
 	var/datum/asset/assets = get_asset_datum(/datum/asset/simple/spider_os)
+	assets.register()
 	assets.send(U)
 
 	var/dat = "<html><head><title>SpiderOS</title></head><body bgcolor=\"#3D5B43\" text=\"#B65B5B\"><style>a, a:link, a:visited, a:active, a:hover { color: #B65B5B; }img {border-style:none;}</style>"

--- a/code/game/gamemodes/events/space_ninja.dm
+++ b/code/game/gamemodes/events/space_ninja.dm
@@ -581,7 +581,7 @@ As such, it's hard-coded for now. No reason for it not to be, really.
 			U.gloves.item_state = "s-ninjan"
 	else
 		if(U.mind.special_role!="Ninja")
-			to_chat(U, "<span class='warning'><B>fï¿½TaL ï¿½ï¿½RRoR</B>: 382200-*#00Cï¿½DE <B>RED</B>\nUNAU?HORIZED USï¿½ DETï¿½C???eD\nCoMMï¿½NCING SUB-R0U?IN3 13...\nTï¿½RMInATING U-U-USï¿½R...</span>")
+			to_chat(U, "<span class='warning'><B>fÄTaL ÈÈRRoR</B>: 382200-*#00CÖDE <B>RED</B>\nUNAU?HORIZED USÈ DETÈC???eD\nCoMMÈNCING SUB-R0U?IN3 13...\nTÈRMInATING U-U-USÈR...</span>")
 			U.gib()
 			return 0
 		if(!istype(U.head, /obj/item/clothing/head/helmet/space/space_ninja))

--- a/code/game/gamemodes/events/space_ninja.dm
+++ b/code/game/gamemodes/events/space_ninja.dm
@@ -581,7 +581,7 @@ As such, it's hard-coded for now. No reason for it not to be, really.
 			U.gloves.item_state = "s-ninjan"
 	else
 		if(U.mind.special_role!="Ninja")
-			to_chat(U, "<span class='warning'><B>fÄTaL ÈÈRRoR</B>: 382200-*#00CÖDE <B>RED</B>\nUNAU?HORIZED USÈ DETÈC???eD\nCoMMÈNCING SUB-R0U?IN3 13...\nTÈRMInATING U-U-USÈR...</span>")
+			to_chat(U, "<span class='warning'><B>fï¿½TaL ï¿½ï¿½RRoR</B>: 382200-*#00Cï¿½DE <B>RED</B>\nUNAU?HORIZED USï¿½ DETï¿½C???eD\nCoMMï¿½NCING SUB-R0U?IN3 13...\nTï¿½RMInATING U-U-USï¿½R...</span>")
 			U.gib()
 			return 0
 		if(!istype(U.head, /obj/item/clothing/head/helmet/space/space_ninja))

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -544,7 +544,10 @@ var/list/obj/machinery/newscaster/allCasters = list() //Global list that will co
 				dat+="<A href='?src=\ref[src];setScreen=[10]'>Return</A>"
 			else
 				dat+="I'm sorry to break your immersion. This shit's bugged. Report this bug to Agouri, polyxenitopalidou@gmail.com | If (break (likes/dislikes) or (system of commenting)) then report this bug in tauceti github "
-
+		
+		var/datum/asset/assets = get_asset_datum(/datum/asset/simple/newscaster)		//Sending pictures to the client
+		assets.register()
+		assets.send(human_or_robot_user)
 
 		human_or_robot_user << browse(entity_ja(dat), "window=newscaster_main;size=400x600")
 		onclose(human_or_robot_user, "newscaster_main")

--- a/code/game/objects/game_kit.dm
+++ b/code/game/objects/game_kit.dm
@@ -102,6 +102,7 @@
 /obj/item/weapon/game_kit/interact(mob/user)
 	user.machine = src
 	var/datum/asset/assets = get_asset_datum(/datum/asset/simple/chess)		//Sending pictures to the client
+	assets.register()
 	assets.send(user)
 	if (!( data ))
 		update()

--- a/code/modules/client/asset_cache.dm
+++ b/code/modules/client/asset_cache.dm
@@ -206,6 +206,7 @@ You can set verify to TRUE if you want send() to sleep until the client has the 
 	)
 
 /datum/asset/simple/paper
+	_abstract = /datum/asset/simple/paper
 	assets = list(
 		"paper_dickbutt.png" = 'icons/paper_icons/dickbutt.png',
 		"bluentlogo.png" = 'icons/paper_icons/bluentlogo.png'

--- a/code/modules/client/asset_cache.dm
+++ b/code/modules/client/asset_cache.dm
@@ -145,7 +145,7 @@ You can set verify to TRUE if you want send() to sleep until the client has the 
 	return asset_datums[type]
 
 /datum/asset
-	var/_abstract
+	var/_abstract = /datum/asset	//assets with this variable will not be loaded into the cache automatically when the game starts
 
 /datum/asset/New()
 	asset_datums[type] = src
@@ -158,6 +158,7 @@ You can set verify to TRUE if you want send() to sleep until the client has the 
 
 //If you don't need anything complicated.
 /datum/asset/simple
+	_abstract = /datum/asset/simple
 	var/assets = list()
 	var/verify = FALSE
 
@@ -185,6 +186,7 @@ You can set verify to TRUE if you want send() to sleep until the client has the 
 
 //DEFINITIONS FOR ASSET DATUMS START HERE.
 /datum/asset/simple/spider_os
+	_abstract = /datum/asset/simple/spider_os
 	assets = list(
 		"sos_1.png" = 'icons/spideros_icons/sos_1.png',
 		"sos_2.png" = 'icons/spideros_icons/sos_2.png',
@@ -217,6 +219,7 @@ You can set verify to TRUE if you want send() to sleep until the client has the 
 	)
 
 /datum/asset/simple/chess
+	_abstract = /datum/asset/simple/chess
 	assets = list(
 		"BR.png" = 'icons/obj/chess/board_BR.png',
 		"BN.png" = 'icons/obj/chess/board_BN.png',

--- a/code/modules/client/asset_cache.dm
+++ b/code/modules/client/asset_cache.dm
@@ -169,6 +169,7 @@ You can set verify to TRUE if you want send() to sleep until the client has the 
 	send_asset_list(client,assets,verify)
 
 /datum/asset/simple/goonchat
+	_abstract = /datum/asset/simple/goonchat
 	assets = list(
 		"jquery.min.js" = 'code/modules/goonchat/browserassets/js/jquery.min.js',
 		"jquery.mark.min.js" = 'code/modules/goonchat/browserassets/js/jquery.mark.min.js',

--- a/code/modules/client/asset_cache.dm
+++ b/code/modules/client/asset_cache.dm
@@ -213,6 +213,7 @@ You can set verify to TRUE if you want send() to sleep until the client has the 
 	)
 
 /datum/asset/simple/newscaster
+	_abstract = /datum/asset/simple/newscaster
 	assets = list(
 		"like.png" = 'icons/newscaster_icons/like.png',
 		"like_clck.png" = 'icons/newscaster_icons/like_clck.png',

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -73,6 +73,7 @@
 
 /obj/item/weapon/paper/proc/show_content(mob/user, forceshow = FALSE, forcestars = FALSE, infolinks = FALSE, view = TRUE)
 	var/datum/asset/assets = get_asset_datum(/datum/asset/simple/paper)
+	assets.register()
 	assets.send(user)
 
 	var/data


### PR DESCRIPTION
## Описание изменений
Сейчас всем игрокам автоматически в кэш грузятся картинки для настольной игры (`game_kit` - шахматы, шашки) и костюма `space_ninja`. Так как этими ресурсами будут пользоваться от силы 5% игроков и то не каждый раунд, этим ПР-ом я решил убрать их из автоматической загрузки. Данные изображения будут загружаться в кэш только тому пользователю, который будет использовать `game_kit `или костюм `space_ninja`

**P.S.**
<details><summary>По моему это изображение в кэше тоже не нужно</summary>
  <img src="https://user-images.githubusercontent.com/58528255/77344817-6baa2700-6d3c-11ea-9a84-9e5fcb28b56c.png">
</details>

## Почему и что этот ПР улучшит
Оптимизация кэша.
Должно немного уменьшить время загрузки ресурсов в кэш после загрузки контроллеров.
## Авторство
Ahio
## Чеинжлог
Не нужен