### PR TITLE
Фикс направления мусорки

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -47444,8 +47444,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2"
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/starboard)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Перевернул тройник у мусорки между моргом и библиотекой
## Почему и что этот ПР улучшит
fixes #4909
## Авторство
Remind me
## Чеинжлог
:cl: Remind me
 - fix: Мусорка между моргом и библиотекой теперь отправляет вещи, куда надо
