### PR TITLE
Fix bug where BYOND members don't count as supporters due to operator precedence issues

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -358,7 +358,7 @@ var/shutdown_processed = FALSE
 		C.update_supporter_status()
 
 /client/proc/update_supporter_status()
-	if(ckey in donators || config.allow_byond_membership && IsByondMember())
+	if((ckey in donators) || config.allow_byond_membership && IsByondMember())
 		supporter = 1
 
 /world/proc/load_configuration()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Проблем здесь что `if(ckey in donators || config.allow_byond_membership && IsByondMember())` станет `if(ckey in (donators || config.allow_byond_membership && IsByondMember()))` и не `if((ckey in donators) || config.allow_byond_membership && IsByondMember())` в Бьенда.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
:cl: monster860
- fix: Бьенда саппортеры теперь саппортеры
