### PR TITLE
Фикс предметов в крио

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -173,31 +173,7 @@ var/global/list/frozen_items = list()
 			//Drop all items into the pod.
 			for(var/obj/item/W in occupant)
 				occupant.drop_from_inventory(W)
-				W.loc = src
-
-				if(W.contents.len) //Make sure we catch anything not handled by del() on the items.
-					for(var/obj/item/O in W.contents)
-						O.loc = src
-
-			//Delete all items not on the preservation list.
-			var/list/items = contents
-			items -= occupant // Don't delete the occupant
-			items -= announce // or the autosay radio.
-
-			for(var/obj/item/W in items)
-				var/preserve = FALSE
-				for(var/T in preserve_items)
-					if(istype(W, T))
-						preserve = TRUE
-						break
-
-				if(!preserve)
-					qdel(W)
-				else
-					if(storage)
-						frozen_items += W
-					else
-						qdel(W)
+				preserve_item(W)
 
 			//Update any existing objectives involving this mob.
 			for(var/datum/objective/O in all_objectives)
@@ -305,6 +281,24 @@ var/global/list/frozen_items = list()
 
 				//Despawning occurs when process() is called with an occupant without a client.
 				add_fingerprint(M)
+
+/obj/machinery/cryopod/proc/preserve_item(obj/item/O)
+	O.loc = src
+
+	var/preserve = FALSE
+	for(var/T in preserve_items)
+		if(istype(O, T))
+			preserve = TRUE
+			break
+
+	if (!preserve || !storage)
+		if (O.contents.len)
+			for (var/obj/item/object in O.contents)
+				preserve_item(object)
+		qdel(O)
+	else
+		frozen_items += O
+
 
 /obj/machinery/cryopod/proc/insert(mob/M)
 	M.forceMove(src)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -291,13 +291,13 @@ var/global/list/frozen_items = list()
 			preserve = TRUE
 			break
 
-	if (!preserve || !storage)
+	if (preserve && storage)
+		frozen_items += O
+	else
 		if (O.contents.len)
 			for (var/obj/item/object in O.contents)
 				preserve_item(object)
 		qdel(O)
-	else
-		frozen_items += O
 
 
 /obj/machinery/cryopod/proc/insert(mob/M)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Теперь при удалении предметов из крио учитывается, откуда были предметы. Если предметы были из важного предмета(простите за тавтологию), то эти предметы не удалятся. Фиксит баг с удалением кармашков у бронежилетов, из-за чего они багались и их нельзя было подобрать, так же карманная пушка из РнД не сломается, если заснуть с ней в крио и ее вытащит ассистуха. Ишью на эту тему не нашел, но баг частый и известный.
## Почему и что этот ПР улучшит
Больше не будет неподнимаемых курточек и бронежилетов около крио. Улучшит игру ассистухам, которые смогут надевать проклятые бронежилеты.
## Авторство
AirBlack - код
## Чеинжлог
:cl: AirBlack
 - bugfix: После ухода в крио у важных предметов удалялись все предметы в contents.