### PR TITLE
Убрал удаление контента окна настроек персонажа

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -210,7 +210,7 @@ var/const/MAX_SAVE_SLOTS = 10
 		return
 
 	if(href_list["preference"] == "close")
-		user << browse(null, "window=preferences_window")
+		winshow(user, "preferences_window", FALSE)
 		var/client/C = user.client
 		if(C)
 			C.clear_character_previews()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Плавающая ошибка с обновлением кэша приводила к блокировке обновления окна после отправки на него контента через client/screen. Убрал сброс контента окна после его закрытия, тем самым оставив кнопки для обновления. Ошибка плавающая и воспроизвелась только в момент пересылки ресурсов на клиент.

## Почему и что этот ПР улучшит
Правит #4924 (надеюсь)
