### PR TITLE
Уменьшение огнеопасности фороновых дверей

### DIFF
--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -238,7 +238,7 @@
 /obj/structure/mineral_door/transparent/phoron/proc/TemperatureAct(temperature)
 	for(var/turf/simulated/floor/target_tile in range(2, loc))
 
-		var/phoronToDeduce = temperature * 0.1
+		var/phoronToDeduce = temperature * 0.012
 
 		target_tile.assume_gas("phoron", phoronToDeduce)
 		target_tile.hotspot_expose(temperature, 400)


### PR DESCRIPTION
## Описание изменений
Fixes #4972 
Немного, почти в 10 раз уменьшает драматичность горения фороновых дверей. Однако, горение такой двери все еще представляет смертельную опасность для находящихся рядом, и, при неудачном стечении обстоятельств, для персонажей в соседних помещениях.
## Почему и что этот ПР улучшит
Не позволит с помощью одной фороновой двери посеять на станции хаос и пламя.

:cl:
 - tweak: Огнеопасность фороновых дверей уменьшена