### PR TITLE
delete target and add cutout

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -67,6 +67,9 @@
 /area/station/security/range)
 "aam" = (
 /obj/structure/target_stake,
+/obj/item/cardboard_cutout{
+	icon_state = "cutout_clown"
+	},
 /turf/simulated/floor{
 	icon_state = "delivery"
 	},
@@ -126,7 +129,6 @@
 	},
 /obj/structure/table,
 /obj/machinery/recharger,
-/obj/item/weapon/paper/firing_range,
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -178,9 +180,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/closet/crate,
-/obj/item/target,
-/obj/item/target,
-/obj/item/target,
+/obj/item/cardboard_cutout,
+/obj/item/cardboard_cutout,
+/obj/item/weapon/storage/fancy/crayons,
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
@SpaiR  сказал что вылеты в оружейке происходили из-за забагованных мишенек там. Поскольку фиксить кодом никто не собирается я пофиксил при помощи карты
## Почему и что этот ПР улучшит
Никаких вылетов в бриге
## Авторство

## Чеинжлог
:cl:
- bugfix: Вылетов в бриге больше не будет #2987
- map: Удалены мишени в тире брига, вместо них добавлены картонные манекены и пачка мелков.