### PR TITLE
Модификация гриппера и сервисного борга. 

### DIFF
--- a/code/game/machinery/kitchen/kitchen_machines.dm
+++ b/code/game/machinery/kitchen/kitchen_machines.dm
@@ -158,7 +158,8 @@
 				"<span class='notice'>[user] has added one of [O] to \the [src].</span>", \
 				"<span class='notice'>You add one of [O] to \the [src].</span>")
 		else
-			user.drop_item(src)
+			user.drop_item()
+			O.forceMove(src)
 			user.visible_message( \
 				"<span class='notice'>[user] has added \the [O] to \the [src].</span>", \
 				"<span class='notice'>You add \the [O] to \the [src].</span>")
@@ -177,13 +178,15 @@
 		var/obj/item/weapon/grab/G = O
 		to_chat(user, "<span class='danger'>You can not fit \the [G.affecting] in this [src].</span>")
 		return 1
+	else if(istype(O,/obj/item/weapon/gripper))
+		return // let gripper's afterattack handle this
 	else
 		to_chat(user, "<span class='danger'>You have no idea what you can cook with this [O].</span>")
 		return 1
 	src.updateUsrDialog()
 
 /obj/machinery/kitchen_machine/attack_ai(mob/user)
-	if(IsAdminGhost(user))
+	if(IsAdminGhost(user) || isrobot(user)) // let robots cook
 		return ..()
 	return 0
 

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -266,7 +266,10 @@
 			destroy()
 		return
 
-	if(isrobot(user))
+	var/mob/living/silicon/robot/R = user
+	if(istype(R) && (!R.module || (W in R.module.modules))) // allow putting stuff from grippers
+		if (istype(W, /obj/item/weapon/gripper) || istype(W, /obj/item/weapon/rsf))
+			return FALSE // to allow gripper's afterattack
 		return
 	if(!W.canremove || W.flags & NODROP)
 		return
@@ -289,7 +292,7 @@
 			return FALSE
 
 	if(!(W.flags & ABSTRACT))
-		if(user.drop_item())
+		if(user.drop_item() || isrobot(user))
 			W.Move(loc)
 			var/list/click_params = params2list(params)
 			//Center the icon where the user clicked.

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -265,8 +265,10 @@
 	modules += new /obj/item/device/flash(src)
 	modules += new /obj/item/weapon/gripper/service(src)
 	modules += new /obj/item/weapon/gripper/paperwork(src)
-	modules += new /obj/item/weapon/reagent_containers/food/drinks/shaker(src)
 	modules += new /obj/item/weapon/reagent_containers/food/condiment/enzyme(src)
+	
+	modules += new /obj/item/weapon/kitchenknife(src)
+	modules += new /obj/item/weapon/kitchen/rollingpin(src)
 
 	var/obj/item/weapon/rsf/M = new /obj/item/weapon/rsf(src)
 	M.matter = 30
@@ -276,10 +278,11 @@
 
 	var/obj/item/weapon/lighter/zippo/L = new /obj/item/weapon/lighter/zippo(src)
 	L.lit = 1
+	L.icon_state = L.icon_on
+	L.item_state = L.icon_on
 	modules += L
 
 	modules += new /obj/item/weapon/tray/robotray(src)
-	modules += new /obj/item/weapon/reagent_containers/food/drinks/shaker(src)
 	modules += new /obj/item/weapon/pen/robopen(src)
 	modules += new /obj/item/weapon/razor(src)
 

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -63,7 +63,7 @@
 	if((usr.stat || usr.restrained()))
 		return
 
-	if(usr.contents.Find(src))
+	if(usr.contents.Find(src) || (isrobot(usr) && (src.loc in usr.contents)))
 
 		if(href_list["remove"])
 			var/obj/item/P = locate(href_list["remove"])

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -124,9 +124,8 @@
 
 		var/trans = src.reagents.trans_to(A, amount_per_transfer_from_this)
 		to_chat(user, "<span class='notice'>You transfer [trans] units of the solution to [A].</span>")
-
-		if(isrobot(user)) //Cyborg modules that include drinks automatically refill themselves, but drain the borg's cell
-			var/mob/living/silicon/robot/bro = user
+		var/mob/living/silicon/robot/bro = user
+		if(istype(bro) && bro.module && (src in bro.module.modules)) //Cyborg modules that include drinks automatically refill themselves, but drain the borg's cell
 			var/chargeAmount = max(30,4*trans)
 			bro.cell.use(chargeAmount)
 			to_chat(user, "Now synthesizing [trans] units of [refillName]...")
@@ -206,7 +205,6 @@
 	icon = 'icons/obj/food.dmi'
 	icon_state = "flour"
 	item_state = "flour"
-
 /obj/item/weapon/reagent_containers/food/drinks/flour/atom_init()
 	. = ..()
 	reagents.add_reagent("flour", 30)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -189,6 +189,8 @@
 			istype(W, /obj/item/weapon/shard) \
 		)
 		inaccurate = 1
+	else if(istype(W, /obj/item/weapon/gripper))
+		return
 	else if(W.w_class <= ITEM_SIZE_SMALL && istype(src,/obj/item/weapon/reagent_containers/food/snacks/sliceable))
 		if(!iscarbon(user))
 			return 1


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Пофикшена иконка у RSF(аналог РСД у сервис борга который спавнит деньги, бумажки, ручки, игральные кости, сигареты и стаканы).
Зафоршена иконка зажженной зажигалки у сервис киборга.
Добавлен вызов afterattack у предмета в борговском гриппере(теперь можно наливать реагенты из контейнера в гриппере в другой контейнер и всякие другие штуки). 
Теперь у борговских модулей вызывается afterattack на стол, что позволит класть предметы из грипперов на стол или же спавнить фигню из RSF.
Сервисному боргу добавлены нож и скалка в модули.
Теперь борги могут готовить.
Папер гриппер может подымать печати и собственно ставить эти печати на бумагу.
## Почему и что этот ПР улучшит
Игру за киборгов. Гриппер был неудобен в использовании. Сейчас хотя бы что-то может. Сервисный борг больше не такой бесполезный и может заменить шефа в случае его отсутствия.
## Авторство
AirBlack
## Чеинжлог
:cl: AirBlack
 - tweak: Модификация гриппера.
 - tweak: Сервисному боргу добавлены кухонные принадлежности.
 - tweak: Борги могут готовить еду.
 - bugfix: Фикс и рефактор RSF
