### PR TITLE
Sycode spaces between words

### DIFF
--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -200,6 +200,7 @@
 					  "nadazero", "unaone", "bissatwo", "terrathree", "kartefour", "pantafive", "soxisix", "setteseven", "oktoeight", "novenine",
 					  "ale", "cognac", "kahlua", "soda", "tequila", "vermouth", "whiskey", "beer", "gin", "rum", "lemon lime", "vodka", "wine")
 	flags = RESTRICTED
+	space_chance = 100
 
 /datum/language/unisign
 	name = "Universal Sign Language"


### PR DESCRIPTION
## Описание изменений

В сикоде не будет слов составленных слов("Vodkaalpha whiskeybravo" -> "Vodka alpha whiskey bravo")

## Почему и что этот ПР улучшит

Выглядит поприятней на мой взгляд

## Чеинжлог
:cl: Luduk
- tweak: Пробелы между словами в Си-коде.