### PR TITLE
Temp-banish god out of the staff

### DIFF
--- a/code/game/objects/items/weapons/chaplain_weapons.dm
+++ b/code/game/objects/items/weapons/chaplain_weapons.dm
@@ -149,7 +149,8 @@
 			S.transfer_soul("SHADE", brainmob, user)
 	else if(istype(W, /obj/item/weapon/storage/bible)) //force kick god from staff
 		if(brainmob)
-			brainmob.client.prefs.ignore_question += "chstaff"
+			if(brainmob.client)
+				brainmob.client.prefs.ignore_question += "chstaff"
 			qdel(brainmob)
 			searching = FALSE
 			icon_state = "talking_staff"

--- a/code/game/objects/items/weapons/chaplain_weapons.dm
+++ b/code/game/objects/items/weapons/chaplain_weapons.dm
@@ -184,10 +184,10 @@
 	var/response = alert(C, "Someone is requesting a your soul in divine staff?", "Staff request", "No", "Yeeesss", "Never for this round")
 	if(!C || (brainmob && brainmob.ckey) || !searching)
 		return		//handle logouts that happen whilst the alert is waiting for a response, and responses issued after a brain has been located.
-	if(next_apply[C.ckey] > world.time)
-		to_chat(C.mob, "You were forcibly kicked from staff, left [round((next_apply[C.ckey] - world.time) / 600)] minutes")
-		return
 	if(response == "Yeeesss")
+		if(next_apply[C.ckey] > world.time)
+			to_chat(C.mob, "You were forcibly kicked from staff, left [round((next_apply[C.ckey] - world.time) / 600)] minutes")
+			return
 		transfer_personality(C.mob, user)
 	else if (response == "Never for this round")
 		C.prefs.ignore_question += "chstaff"

--- a/code/game/objects/items/weapons/chaplain_weapons.dm
+++ b/code/game/objects/items/weapons/chaplain_weapons.dm
@@ -151,6 +151,7 @@
 			S.transfer_soul("SHADE", brainmob, user)
 	else if(istype(W, /obj/item/weapon/storage/bible)) //force kick god from staff
 		if(brainmob)
+			next_apply[brainmob.ckey] = world.time + 10 MINUTES
 			qdel(brainmob)
 			searching = FALSE
 			icon_state = "talking_staff"
@@ -212,7 +213,6 @@
 
 	brainmob.mind = candidate.mind
 	brainmob.ckey = candidate.ckey
-	next_apply[brainmob.ckey] = world.time + 10 MINUTES
 	brainmob.name = "[god_name] [pick("II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X", "XI", "XII", "XIII", "XIV", "XV", "XVI", "XVII", "XVIII", "XIX", "XX")]"
 	brainmob.real_name = name
 	brainmob.mind.assigned_role = "Chaplain`s staff"

--- a/code/game/objects/items/weapons/chaplain_weapons.dm
+++ b/code/game/objects/items/weapons/chaplain_weapons.dm
@@ -107,6 +107,8 @@
 
 	var/image/god_image
 
+	var/list/next_apply = list()
+
 /obj/item/weapon/nullrod/staff/Destroy()
 	// Damn... He's free now.
 	brainmob.invisibility = 0
@@ -149,8 +151,6 @@
 			S.transfer_soul("SHADE", brainmob, user)
 	else if(istype(W, /obj/item/weapon/storage/bible)) //force kick god from staff
 		if(brainmob)
-			if(brainmob.client)
-				brainmob.client.prefs.ignore_question += "chstaff"
 			qdel(brainmob)
 			searching = FALSE
 			icon_state = "talking_staff"
@@ -184,6 +184,9 @@
 	var/response = alert(C, "Someone is requesting a your soul in divine staff?", "Staff request", "No", "Yeeesss", "Never for this round")
 	if(!C || (brainmob && brainmob.ckey) || !searching)
 		return		//handle logouts that happen whilst the alert is waiting for a response, and responses issued after a brain has been located.
+	if(next_apply[C.ckey] > world.time)
+		to_chat(C.mob, "You were forcibly kicked from staff, left [round((next_apply[C.ckey] - world.time) / 600)] minutes")
+		return
 	if(response == "Yeeesss")
 		transfer_personality(C.mob, user)
 	else if (response == "Never for this round")
@@ -209,6 +212,7 @@
 
 	brainmob.mind = candidate.mind
 	brainmob.ckey = candidate.ckey
+	next_apply[brainmob.ckey] = world.time + 10 MINUTES
 	brainmob.name = "[god_name] [pick("II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X", "XI", "XII", "XIII", "XIV", "XV", "XVI", "XVII", "XVIII", "XIX", "XX")]"
 	brainmob.real_name = name
 	brainmob.mind.assigned_role = "Chaplain`s staff"

--- a/code/game/objects/items/weapons/chaplain_weapons.dm
+++ b/code/game/objects/items/weapons/chaplain_weapons.dm
@@ -149,6 +149,7 @@
 			S.transfer_soul("SHADE", brainmob, user)
 	else if(istype(W, /obj/item/weapon/storage/bible)) //force kick god from staff
 		if(brainmob)
+			brainmob.client.prefs.ignore_question += "chstaff"
 			qdel(brainmob)
 			searching = FALSE
 			icon_state = "talking_staff"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
closes #5127
Больше бог-брейнрот после первого кика не войдет в посох в течение 10 минут.
## Почему и что этот ПР улучшит
Люди которых выкинули из палки за плохой отыгрыш не могут снова отыгрывать Божка
## Авторство
## Чеинжлог
:cl:
 - tweak: Кикнутый из посоха бога игрок сможет попытать попытку только через 10 минут.