### PR TITLE
mouse opacity on human overlays

### DIFF
--- a/code/game/objects/items/devices/whistle.dm
+++ b/code/game/objects/items/devices/whistle.dm
@@ -32,6 +32,7 @@
 				halt_recipients.Add(M.client)
 		var/image/I = image('icons/mob/talk.dmi', user, "halt", MOB_LAYER+1)
 		I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
+		I.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 		flick_overlay(I, halt_recipients, 14)
 	spamcheck = 1
 	spawn(20)

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -125,6 +125,7 @@
 	I.invisibility = invisibility
 	I.loc = src
 	I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
+	I.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 	var/list/viewing = list()
 	for(var/mob/M in viewers(src))

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -388,6 +388,7 @@
 
 	if(cloud_emote)
 		var/image/emote_bubble = image('icons/mob/emote.dmi', src, cloud_emote, EMOTE_LAYER)
+		emote_bubble.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 		flick_overlay(emote_bubble, clients, 30)
 		QDEL_IN(emote_bubble, 3 SECONDS)
 

--- a/code/modules/mob/living/carbon/human/whisper.dm
+++ b/code/modules/mob/living/carbon/human/whisper.dm
@@ -124,6 +124,7 @@
 	var/speech_bubble_test = say_test(message)
 	var/image/I = image('icons/mob/talk.dmi', src, "h[speech_bubble_test]", MOB_LAYER+1)
 	I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
+	I.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	spawn(0)
 		flick_overlay(I, speech_bubble_recipients, 30)
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1034,6 +1034,7 @@
 			I = image(r_hand.icon,A,r_hand.icon_state,A.layer+1)
 	if(I)
 		I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
+		I.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 		var/list/viewing = list()
 		for(var/mob/M in viewers(A))
 			if(M.client && (M.client.prefs.toggles & SHOW_ANIMATIONS))

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -181,6 +181,7 @@ var/list/department_radio_keys = list(
 	var/speech_bubble_test = say_test(message)
 	var/image/I = image('icons/mob/talk.dmi', src, "h[speech_bubble_test]", MOB_LAYER+1)
 	I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
+	I.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	spawn(0)
 		flick_overlay(I, speech_bubble_recipients, 30)
 	for(var/mob/M in listening)


### PR DESCRIPTION
## Описание изменений

Оверлеи облачка при разговоре, прея, и эмоута - больше не кликабельны.

## Почему и что этот ПР улучшит

Хитзона игрока не будет зависеть от того говорил, молился, или эмоутил он.

## Чеинжлог
:cl: Luduk
- tweak: Кликая по облачку которое появляется во время некоторых эмоутов, разговора нельзя попасть по кукле.