### PR TITLE
Moghes playlist name fixed; New skrellian vaporfunk playlist added

### DIFF
--- a/code/modules/media/jukebox.dm
+++ b/code/modules/media/jukebox.dm
@@ -285,8 +285,8 @@ var/global/loopModeNames=list(
 	// Must be defined on your server.
 	playlists=list(
 		"bar"  = "Bar Mix",
-		"mogesfm84"  = "Moges FM-84",
-		"moges" = "Moges Club Music",
+		"mogesfm84"  = "Moghes FM-84",
+		"moges" = "Moghes Club Music",
 		"club" = "Club Mix",
 		"customs" = "Customs Music",
 		"japan" = "Banzai Radio",
@@ -299,6 +299,7 @@ var/global/loopModeNames=list(
 		"finland" = "Suomi wave",
 		"dreamsofvenus" = "Dreams of Venus",
 		"hiphop" = "Hip-Hop for Space Gangstas",
+		"vaporfunk" = "Qerrbalak VaporFunkFM",
 	)
 
 // Relaxing elevator music~
@@ -312,8 +313,8 @@ var/global/loopModeNames=list(
 	// Must be defined on your server.
 	playlists=list(
 		"bar"  = "Bar Mix",
-		"mogesfm84"  = "Moges FM-84",
-		"moges" = "Moges Club Music",
+		"mogesfm84"  = "Moghes FM-84",
+		"moges" = "Moghes Club Music",
 		"club" = "Club Mix",
 		"customs" = "Customs Music",
 		"japan" = "Banzai Radio",
@@ -326,6 +327,7 @@ var/global/loopModeNames=list(
 		"finland" = "Suomi wave",
 		"dreamsofvenus" = "Dreams of Venus",
 		"hiphop" = "Hip-Hop for Space Gangstas",
+		"vaporfunk" = "Qerrbalak VaporFunkFM",
 	)
 
 /obj/machinery/media/jukebox/techno


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Добавлен новый плейлист со скрелльским фанком и вапорвейвом.
Заодно пофиксил неправильное написание планеты Moghes на английском языке.

![image](https://user-images.githubusercontent.com/6051766/80128457-5c6a0380-859e-11ea-8a15-152f323de84b.png)

## Почему и что этот ПР улучшит
слуховые ощущения

## Чеинжлог
:cl:
 - sound: В джукбоксе появился новый плейлист со скрелльским вапорвейвом и фанком