### PR TITLE
Детектив Бипски, вы разжалованы!

### DIFF
--- a/code/game/machinery/bots/secbot.dm
+++ b/code/game/machinery/bots/secbot.dm
@@ -68,8 +68,8 @@
 /obj/machinery/bot/secbot/atom_init()
 	. = ..()
 	botcard = new /obj/item/weapon/card/id(src)
-	var/datum/job/detective/J = new/datum/job/detective
-	botcard.access = J.get_access()
+	var/datum/job/cadet/C = new/datum/job/cadet
+	botcard.access = C.get_access()
 	if(radio_controller)
 		radio_controller.add_object(src, control_freq, filter = RADIO_SECBOT)
 		radio_controller.add_object(src, beacon_freq, filter = RADIO_NAVBEACONS)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Почему-то у бипского был доступ детектива(!), что позволяло ассистухам, которые бы его разнесли, получить не только станбатон, но и доступ к большей части брига, а также к офису детектива (Да, к его пистолету тоже). Теперь, после разжалования бипски в кадеты, из него будет падать соответствующая карта
## Почему и что этот ПР улучшит
Усложнит жизнь ассистухам, которые, заполучив карту бипски с детективским доступом, могли попасть во многие КПП СБ, а также в офис детектива (И могли открыть его шкафчик). Теперь такого не будет
## Авторство
Cool20141
## Чеинжлог
:cl:

- tweak: Бипски не имеет доступа детектива, так как понижен до звания кадета.