### PR TITLE
scrambled god message fix

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -32,15 +32,12 @@
 /obj/item/device/taperecorder/hear_talk(mob/living/M, msg, verb="says")
 	if(recording)
 		timestamp+= timerecorded
-		if(isanimal(M)) // Taken from say(). Temporary fix before refactor. Needs to actually pass languages or something like that here and when we see paper or hear audioplayback it depends whenever we can actually understand that language.
-			var/mob/living/simple_animal/S = M
-			msg = pick(S.speak)
-		else if(isIAN(M))
-			var/mob/living/carbon/ian/IAN = M
-			msg = pick(IAN.speak)
+		if(isanimal(M) || isIAN(M)) // Temporary fix before refactor. Needs to actually pass languages or something like that here and when we see paper or hear audioplayback it depends whenever we can actually understand that language.
+			msg = M.get_scrambled_message()
+		if(!msg)
+			return
 
 		storedinfo += "\[[time2text(timerecorded*10,"mm:ss")]\] [M.name] [verb], \"[msg]\""
-		return
 
 /obj/item/device/taperecorder/emag_act(mob/user)
 	if(emagged == 0)

--- a/code/modules/admin/verbs/pray.dm
+++ b/code/modules/admin/verbs/pray.dm
@@ -41,6 +41,12 @@
 		prayer_type = "cultist prayer"
 		deity = "Nar'Sie"
 
+	else if(isgod(usr))
+		cross.icon_state = "necronomicon"
+		font_color = "purple"
+		prayer_type = "god's call"
+		deity = "their progenitor"
+
 	//parse the language code and consume it
 	var/datum/language/speaking = parse_language(msg)
 	if(speaking)
@@ -60,7 +66,9 @@
 	var/gods_msg = "<span class='notice'>[bicon(cross)] <b>[src]'s</b> <b><font color=[font_color]>[prayer_type]:</b></font></span> <span class='game say'>\"[msg]\"</span>"
 
 	var/scrambled_msg = get_scrambled_message(speaking, msg)
-	var/god_not_understand_msg = "<span class='notice'>[bicon(cross)] <b>[src]'s</b> <b><font color=[font_color]>[prayer_type]</b>:</font> \"[scrambled_msg]\"</span>"
+	var/god_not_understand_msg = ""
+	if(scrambled_msg)
+		god_not_understand_msg = "<span class='notice'>[bicon(cross)] <b>[src]'s</b> <b><font color=[font_color]>[prayer_type]</b>:</font> \"[scrambled_msg]\"</span>"
 
 	for(var/mob/M in player_list)
 		if(isnewplayer(M))
@@ -82,10 +90,12 @@
 
 	for(var/mob/living/simple_animal/shade/god/G in gods_list)
 		if(G.client && (G.client.prefs.chat_toggles & CHAT_PRAYER))
-			if(!G.say_understands(src, speaking))
-				to_chat(G, god_not_understand_msg)
-			else
+			if(G == src) // Don't hear your own prayer.
+				continue
+			if(G.say_understands(src, speaking))
 				to_chat(G, gods_msg)
+			else if(god_not_understand_msg)
+				to_chat(G, god_not_understand_msg)
 
 	pray_act(msg, speaking, alt_name, "prays")
 

--- a/code/modules/mob/living/carbon/ian/ian.dm
+++ b/code/modules/mob/living/carbon/ian/ian.dm
@@ -687,4 +687,6 @@
 	..(message, null, verb, sanitize = 0)
 
 /mob/living/carbon/ian/get_scrambled_message(datum/language/speaking, message)
+	if(!speak.len)
+		return null
 	return pick(speak)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -445,4 +445,6 @@
 		blinded = TRUE
 
 /mob/living/simple_animal/get_scrambled_message(datum/language/speaking, message)
+	if(!speak.len)
+		return null
 	return pick(speak)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1109,5 +1109,6 @@ note dizziness decrements automatically in the mob's Life() proc.
 /atom/movable/proc/is_facehuggable()
 	return FALSE
 
+// Return null if mob of this type can not scramble messages.
 /mob/proc/get_scrambled_message(datum/language/speaking, message)
 	return speaking ? speaking.scramble(message) : stars(message)


### PR DESCRIPTION
## Описание изменений

Исправляет рантаймы вызываемые когда мобы с пустым speak() пытаются молиться.
Делает чтобы молящийся аватар б-га не видел собственного текста.

:cl: Luduk
- bugfix: Молящийся аватар божка у капеллана видит текст собственной молитвы.