### PR TITLE
Extinguishers are "closed" containers by default

### DIFF
--- a/code/modules/reagents/reagent_containers/extinguisher.dm
+++ b/code/modules/reagents/reagent_containers/extinguisher.dm
@@ -36,7 +36,7 @@
 
 /obj/item/weapon/reagent_containers/spray/extinguisher/atom_init()
 	. = ..()
-	flags ^= OPENCONTAINER|NOBLUDGEON
+	flags &= ~OPENCONTAINER|NOBLUDGEON
 	if(random_overlay)
 		cut_overlays()
 		var/image/I = new(icon, "FE_overlay_[pick(1, 2, 3, 4)]")
@@ -52,7 +52,7 @@
 /obj/item/weapon/reagent_containers/spray/extinguisher/attackby(obj/item/weapon/W, mob/user)
 	if(istype(W, /obj/item/weapon/wrench))
 		if(is_open_container())
-			flags ^= OPENCONTAINER
+			flags &= ~OPENCONTAINER
 		else
 			flags |= OPENCONTAINER
 		to_chat(user, "<span class='notice'>You [is_open_container() ? "open" : "close"] the fill cap.</span>")


### PR DESCRIPTION
## Описание изменений

Огнетушителям нельзя будет залить другие реагенты, не расскрутив их гаечным ключом.

p.s.: Может стоит сделать, чтобы когда уже открутил хотя бы один раз огнетушитель то он - "сломан", и заливать ты в него можешь в два раза меньше реагентов, и то они будут "выкапывать"?

## Почему и что этот ПР улучшит

Чуть меньше людей заливающих воду в огнетушители.

## Чеинжлог
:cl: Luduk
- bugfix: Огнетушители по-дефолту "закручены", и реагенты в них нельзя менять не расскрутив их.