### PR TITLE
Фикс вытаскивания ПДА из покрасчика

### DIFF
--- a/code/game/machinery/PDApainter.dm
+++ b/code/game/machinery/PDApainter.dm
@@ -89,7 +89,7 @@
 	set name = "Eject PDA"
 	set category = "Object"
 	set src in oview(1)
-	if(!usr.incapacitated())
+	if(usr.incapacitated())
 		return
 
 	if(storedpda)


### PR DESCRIPTION
## Описание изменений
Мелкофикс ПДА раскрасчика

## Почему и что этот ПР улучшит
Живые и в сознании существа с руками могут вытащить ПДА из покрасчика через верб вместо мертвых, впавшие в сон/кому существ с руками

## Авторство
Miracler

## Чеинжлог
🆑 Miracler
- bugfix: ПДА из раскрасчика вытаскивается