### PR TITLE
Butcher bodyparts

### DIFF
--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -32,6 +32,9 @@
 	var/punch_damage = 0              // Extra empty hand attack damage.
 	var/mutantrace                    // Safeguard due to old code.
 	var/list/butcher_drops = list(/obj/item/weapon/reagent_containers/food/snacks/meat/human = 5)
+	// Perhaps one day make this an assoc list of BODYPART_NAME = list(drops) ? ~Luduk
+	// Is used when a bodypart of this race is butchered. Otherwise there are overrides for flesh, robot, and bone bodyparts.
+	var/list/bodypart_butcher_results
 
 	var/list/restricted_inventory_slots = list() // Slots that the race does not have due to biological differences.
 
@@ -578,6 +581,7 @@
 
 	body_temperature = T0C + 15		//make the plant people have a bit lower body temperature, why not
 	butcher_drops = list(/obj/item/stack/sheet/wood = 5)
+	bodypart_butcher_results = list(/obj/item/stack/sheet/wood = 1)
 
 	flags = list(
 	 IS_WHITELISTED = TRUE
@@ -816,6 +820,7 @@
 	siemens_coefficient = 0
 
 	butcher_drops = list()
+	bodypart_butcher_results = list()
 
 	flags = list(
 	 NO_BREATHE = TRUE
@@ -924,6 +929,7 @@
 	darksight = 8
 
 	butcher_drops = list() // They are just shadows. Why should they drop anything?
+	bodypart_butcher_results = list()
 
 	restricted_inventory_slots = list(SLOT_BELT, SLOT_WEAR_ID, SLOT_L_EAR, SLOT_R_EAR, SLOT_BACK, SLOT_L_STORE, SLOT_R_STORE)
 
@@ -974,6 +980,7 @@
 	flesh_color = "#137e8f"
 
 	butcher_drops = list(/obj/item/weapon/ore/diamond = 1, /obj/item/weapon/ore/slag = 3)
+	bodypart_butcher_results = list(/obj/item/weapon/ore/slag = 1)
 
 	flags = list(
 		NO_BLOOD = TRUE,

--- a/code/modules/organs/external/flesh.dm
+++ b/code/modules/organs/external/flesh.dm
@@ -8,6 +8,13 @@
 /datum/bodypart_controller/New(obj/item/organ/external/B)
 	BP = B
 
+	if(BP.species && BP.species.bodypart_butcher_results)
+		BP.butcher_results = BP.species.bodypart_butcher_results
+	else if(bodypart_type == BODYPART_ORGANIC)
+		BP.butcher_results = list(/obj/item/weapon/reagent_containers/food/snacks/meat/human = 1)
+	else if(bodypart_type == BODYPART_ROBOTIC)
+		BP.butcher_results = list(/obj/item/stack/sheet/plasteel = 1)
+
 /datum/bodypart_controller/Destroy()
 	BP = null
 

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -103,6 +103,8 @@
 		harvest(I, user)
 	else if(istype(I, /obj/item/weapon/kitchenknife))
 		harvest(I, user)
+	else
+		..()
 
 /obj/item/organ/external/insert_organ(mob/living/carbon/human/H, surgically = FALSE)
 	..()

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -99,9 +99,7 @@
 	qdel(src)
 
 /obj/item/organ/external/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/weapon/butch))
-		harvest(I, user)
-	else if(istype(I, /obj/item/weapon/kitchenknife))
+	if(istype(I, /obj/item/weapon/butch) || istype(I, /obj/item/weapon/kitchenknife))
 		harvest(I, user)
 	else
 		..()

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -52,6 +52,9 @@
 	var/cavity = 0
 	var/atom/movable/applied_pressure
 
+	// Misc
+	var/list/butcher_results
+
 	// Will be removed, moved or refactored.
 	var/obj/item/hidden = null // relation with cavity
 	var/tmp/perma_injury = 0
@@ -82,6 +85,24 @@
 			owner.bodyparts_by_name -= body_zone
 		owner.bad_bodyparts -= src
 	return ..()
+
+/obj/item/organ/external/proc/harvest(obj/item/I, mob/user)
+	if(!locate(/obj/structure/table) in loc)
+		return
+	if(!butcher_results)
+		return
+
+	for(var/path in butcher_results)
+		for(var/i in 1 to butcher_results[path])
+			new path(loc)
+	visible_message("<span class='notice'>[user] butchers [src].</span>")
+	qdel(src)
+
+/obj/item/organ/external/attackby(obj/item/I, mob/user)
+	if(istype(I, /obj/item/weapon/butch))
+		harvest(I, user)
+	else if(istype(I, /obj/item/weapon/kitchenknife))
+		harvest(I, user)
 
 /obj/item/organ/external/insert_organ(mob/living/carbon/human/H, surgically = FALSE)
 	..()


### PR DESCRIPTION
## Описание изменений

![image](https://user-images.githubusercontent.com/17705613/80765893-ccebc400-8b4c-11ea-8bbd-cc5a858328ad.png)

Позволяет разделывать конечности тесаком или кухонным ножём, если те лежат на столе.

С головой есть некоторые беды - ты её сначала вскрываешь, но второй клик - разделывает.

!!! БАЛАНС !!!
Грубо говоря увеличивает количество получаемого мяса с туши вдвое - с 5 кусков(2 сойлент грина) до 10 кусков(4 сойлент грина).

## Почему и что этот ПР улучшит

Повара получают больше мясо из кукол, лалиплей или что-то такое.

## Чеинжлог
:cl: Luduk
- rscadd: Клик ножем или тесаком по конечности на столе разделывает её на мясо.