### PR TITLE
allows all xenos to wear boxing gloves

### DIFF
--- a/code/modules/clothing/gloves/boxing.dm
+++ b/code/modules/clothing/gloves/boxing.dm
@@ -4,6 +4,8 @@
 	icon_state = "boxing"
 	item_state = "boxing"
 
+	species_restricted = null
+
 /obj/item/clothing/gloves/boxing/green
 	icon_state = "boxinggreen"
 	item_state = "boxinggreen"


### PR DESCRIPTION
## Описание изменений

Вся ксенота(кроме воксов(если им спрайты не завезли конечно же)) может носить боксёрские перчатки.

## Почему и что этот ПР улучшит

Унатхи на ринге дерутся не когтями.

closes #5217

## Чеинжлог
:cl: Luduk
- tweak: Ксенорасы могут надевать боксёрские перчатки.