### PR TITLE
Батон в maintenance луте заменен на станпрод

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -146,7 +146,7 @@ var/global/list/uncommon_loot = list(
 		/obj/item/weapon/twohanded/spear = 1,
 		/obj/item/weapon/shield/riot = 1,
 		/obj/item/weapon/grenade/cancasing = 1,
-		/obj/item/weapon/melee/baton = 1,
+		/obj/item/weapon/melee/cattleprod = 1,
 		/obj/item/weapon/throwing_star = 1,
 		) = 8,
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Наличие станбатона в uncommon луте - ошибка. В оригинальном коде там cattleprod, спасибо Luduk'у за обнаружение косяка
## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
