### PR TITLE
Xenos role restrictions

### DIFF
--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -20,6 +20,8 @@ var/list/blob_nodes = list()
 
 	restricted_jobs = list("Cyborg", "AI")
 
+	restricted_species_flags = list(IS_SYNTHETIC)
+
 	var/declared = 0
 
 	var/cores_to_spawn = 1

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -15,6 +15,8 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 	required_enemies = 1
 	recommended_enemies = 4
 
+	restricted_specie_flags = list(IS_PLANT, IS_SYNTHETIC, NO_SCAN)
+
 	votable = 0
 
 	uplink_welcome = "Syndicate Uplink Console:"

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -15,7 +15,7 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 	required_enemies = 1
 	recommended_enemies = 4
 
-	restricted_specie_flags = list(IS_PLANT, IS_SYNTHETIC, NO_SCAN)
+	restricted_species_flags = list(IS_PLANT, IS_SYNTHETIC, NO_SCAN)
 
 	votable = 0
 

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -33,7 +33,7 @@
 	uplink_welcome = "Nar-Sie Uplink Console:"
 	uplink_uses = 20
 
-	restricted_specie_flags = list(NO_BLOOD)
+	restricted_species_flags = list(NO_BLOOD)
 
 	var/datum/mind/sacrifice_target = null
 	var/finished = 0

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -33,6 +33,8 @@
 	uplink_welcome = "Nar-Sie Uplink Console:"
 	uplink_uses = 20
 
+	restricted_specie_flags = list(NO_BLOOD)
+
 	var/datum/mind/sacrifice_target = null
 	var/finished = 0
 

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -352,6 +352,10 @@ var/list/cult_datums = list()
 	if(usr.get_active_hand() != src)
 		return
 
+	if(user.species.flags[NO_BLOOD])
+		to_chat(user, "<span class='warning'>You don't have any blood, how do you suppose to write a blood rune?</span>")
+		return
+
 	var/w1
 	var/w2
 	var/w3

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -30,7 +30,7 @@
 
 	// Specie flags that for any amount of reasons can cause this role to not be available.
 	// TO-DO: use traits? ~Luduk
-	var/list/restricted_specie_flags = list()
+	var/list/restricted_species_flags = list()
 
 	var/required_players = 0
 	var/required_players_secret = 0 //Minimum number of players for that game mode to be chose in Secret
@@ -331,7 +331,7 @@ Implants;
 	if(!S.can_be_role(role))
 		return FALSE
 
-	for(var/specie_flag in restricted_specie_flags)
+	for(var/specie_flag in restricted_species_flags)
 		if(S.flags[specie_flag])
 			return FALSE
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -27,6 +27,11 @@
 	var/list/datum/mind/modePlayer = new // list of current antags.
 	var/list/restricted_jobs = list()	// Jobs it doesn't make sense to be.  I.E chaplain or AI cultist
 	var/list/protected_jobs = list("Velocity Officer", "Velocity Chief", "Velocity Medical Doctor")	// Jobs that can't be traitors because
+
+	// Specie flags that for any amount of reasons can cause this role to not be available.
+	// TO-DO: use traits? ~Luduk
+	var/list/restricted_specie_flags = list()
+
 	var/required_players = 0
 	var/required_players_secret = 0 //Minimum number of players for that game mode to be chose in Secret
 	var/required_enemies = 0
@@ -314,6 +319,23 @@ Implants;
 	if(security_level < SEC_LEVEL_BLUE)
 		set_security_level(SEC_LEVEL_BLUE)*/
 
+/datum/game_mode/proc/can_be_antag(datum/mind/player, role)
+	if(restricted_jobs)
+		if(player.assigned_role in restricted_jobs)
+			return FALSE
+
+	var/datum/preferences/prefs = player.current.client.prefs
+
+	var/datum/species/S = all_species[prefs.species]
+
+	if(!S.can_be_role(role))
+		return FALSE
+
+	for(var/specie_flag in restricted_specie_flags)
+		if(S.flags[specie_flag])
+			return FALSE
+
+	return TRUE
 
 /datum/game_mode/proc/get_players_for_role(role)
 	var/list/players = list()
@@ -336,12 +358,9 @@ Implants;
 			candidates += player.mind
 			players -= player
 
-	// Remove candidates who want to be antagonist but have a job that precludes it
-	if(restricted_jobs)
-		for(var/datum/mind/player in candidates)
-			for(var/job in restricted_jobs)
-				if(player.assigned_role == job)
-					candidates -= player
+	for(var/datum/mind/player in candidates)
+		if(!can_be_antag(player, role))
+			candidates -= player
 
 	return candidates		// Returns: The number of people who had the antagonist role set to yes, regardless of recomended_enemies, if that number is greater than recommended_enemies
 							//			recommended_enemies if the number of people with that role set to yes is less than recomended_enemies,

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -7,9 +7,9 @@
 
 /obj/effect/proc_holder/spell/targeted/glare/cast(list/targets)
 	for(var/mob/living/carbon/human/target in targets)
-		if(!ishuman(target) || target.get_species() == IPC)
+		if(target.species.flags[NO_SCAN] || target.species.flags[IS_SYNTHETIC])
 			charge_counter = charge_max
-			to_chat(usr, "<span class='warning'>You can use this ability only on humans.</span>")
+			to_chat(usr, "<span class='warning'>Your glare does not seem to affect [target].</span>")
 			return
 		if(target.stat)
 			charge_counter = charge_max
@@ -18,7 +18,7 @@
 			to_chat(usr, "<span class='danger'>You don't see why you would want to paralyze an ally.</span>")
 			charge_counter = charge_max
 			return
-		var/mob/living/carbon/human/M = target
+
 		usr.visible_message("<span class='warning'><b>[usr]'s eyes flash a blinding red!</b></span>")
 		target.visible_message("<span class='danger'>[target] freezes in place, their eyes glazing over...</span>")
 		if(in_range(target, usr))
@@ -26,7 +26,7 @@
 		else //Only alludes to the shadowling if the target is close by
 			to_chat(target, "<span class='userdanger'>Red lights suddenly dance in your vision, and you are mesmerized by their heavenly beauty...</span>")
 		target.Stun(10)
-		M.silent += 10
+		target.silent += 10
 
 
 

--- a/code/modules/client/character menu/roles.dm
+++ b/code/modules/client/character menu/roles.dm
@@ -1,4 +1,4 @@
-/datum/preferences/proc/CanBeRole(mob/user, role)
+/datum/preferences/proc/CanBeRole(role)
 	if(!species)
 		return FALSE
 
@@ -24,7 +24,7 @@
 					. +="<tr><td width='45%'>[i]: </td><td><font color=red><b> \[BANNED]</b></font><br></td></tr>"
 			else if(available_in_minutes && !(i == ROLE_PLANT && is_alien_whitelisted(user, DIONA)))
 				. += "<tr><td width='45%'><del>[i]</del>: </td><td> \[IN [(available_in_minutes)] MINUTES]</td></tr>"
-			else if(!CanBeRole(user, i))
+			else if(!CanBeRole(i))
 				. +="<tr><td width='45%'>[i]: </td><td><font color=red><b> \[RESTRICTED]</b></font><br></td></tr>"
 			else
 				if(i in be_role)
@@ -61,6 +61,9 @@
 
 		if("be_role")
 			var/be_role_type = href_list["be_role_type"]
+			if(!CanBeRole(be_role_type))
+				return
+
 			if(be_role_type in be_role)
 				be_role -= be_role_type
 			else

--- a/code/modules/client/character menu/roles.dm
+++ b/code/modules/client/character menu/roles.dm
@@ -1,3 +1,10 @@
+/datum/preferences/proc/CanBeRole(mob/user, role)
+	if(!species)
+		return FALSE
+
+	var/datum/species/S = all_species[species]
+	return S.can_be_role(role)
+
 /datum/preferences/proc/ShowRoles(mob/user)
 	. =  "<table cellspacing='0' width='100%'>"
 	. += 	"<tr>"
@@ -17,6 +24,8 @@
 					. +="<tr><td width='45%'>[i]: </td><td><font color=red><b> \[BANNED]</b></font><br></td></tr>"
 			else if(available_in_minutes && !(i == ROLE_PLANT && is_alien_whitelisted(user, DIONA)))
 				. += "<tr><td width='45%'><del>[i]</del>: </td><td> \[IN [(available_in_minutes)] MINUTES]</td></tr>"
+			else if(!CanBeRole(user, i))
+				. +="<tr><td width='45%'>[i]: </td><td><font color=red><b> \[RESTRICTED]</b></font><br></td></tr>"
 			else
 				if(i in be_role)
 					. +="<tr><td width='45%'>[i]: </td><td><b>Yes</b> / <a href='?_src_=prefs;preference=be_role;be_role_type=[i]'>No</a></td></tr>"

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -2,7 +2,7 @@
 #define SAVEFILE_VERSION_MIN 8
 
 //This is the current version, anything below this will attempt to update (if it's not obsolete)
-#define SAVEFILE_VERSION_MAX 25
+#define SAVEFILE_VERSION_MAX 26
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -58,6 +58,11 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 		toggles &= ~(SOUND_ADMINHELP|SOUND_MIDI|SOUND_AMBIENCE|SOUND_LOBBY|SOUND_STREAMING)
 		S["toggles"] << toggles
+
+	if(current_version < 26)
+		for(var/role in be_role)
+			if(!CanBeRole(role))
+				be_role -= role
 
 /datum/preferences/proc/update_character(current_version, savefile/S)
 	if(current_version < 17)

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -132,12 +132,19 @@
 	var/min_age = 25 // The default, for Humans.
 	var/max_age = 85
 
+	var/list/prohibit_roles
+
 /datum/species/New()
 	blood_datum = new blood_datum_path
 	unarmed = new unarmed_type()
 
 	if(!has_organ[O_HEART])
 		flags[NO_BLOOD] = TRUE // this status also uncaps vital body parts damage, since such species otherwise will be very hard to kill.
+
+/datum/species/proc/can_be_role(role)
+	if(!prohibit_roles)
+		return TRUE
+	return !(role in prohibit_roles)
 
 /datum/species/proc/create_organs(mob/living/carbon/human/H, deleteOld = FALSE) //Handles creation of mob organs.
 	if(deleteOld)
@@ -450,6 +457,8 @@
 	min_age = 12
 	max_age = 20
 
+	prohibit_roles = list(ROLE_CHANGELING)
+
 /datum/species/vox/after_job_equip(mob/living/carbon/human/H, datum/job/J, visualsOnly = FALSE)
 	..()
 	if(H.wear_mask)
@@ -628,6 +637,8 @@
 	min_age = 1
 	max_age = 1000
 
+	prohibit_roles = list(ROLE_CHANGELING, ROLE_CULTIST)
+
 /datum/species/diona/handle_post_spawn(mob/living/carbon/human/H)
 	H.gender = NEUTER
 
@@ -751,6 +762,8 @@
 
 	min_age = 1
 	max_age = 125
+
+	prohibit_roles = list(ROLE_CHANGELING, ROLE_CULTIST)
 
 /datum/species/machine/on_gain(mob/living/carbon/human/H)
 	H.verbs += /mob/living/carbon/human/proc/IPC_change_screen

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -763,7 +763,7 @@
 	min_age = 1
 	max_age = 125
 
-	prohibit_roles = list(ROLE_CHANGELING, ROLE_CULTIST)
+	prohibit_roles = list(ROLE_CHANGELING, ROLE_CULTIST, ROLE_BLOB)
 
 /datum/species/machine/on_gain(mob/living/carbon/human/H)
 	H.verbs += /mob/living/carbon/human/proc/IPC_change_screen

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -457,7 +457,7 @@
 	min_age = 12
 	max_age = 20
 
-	prohibit_roles = list(ROLE_CHANGELING)
+	prohibit_roles = list(ROLE_CHANGELING, ROLE_WIZARD)
 
 /datum/species/vox/after_job_equip(mob/living/carbon/human/H, datum/job/J, visualsOnly = FALSE)
 	..()


### PR DESCRIPTION
## Описание изменений

Дионы и СПУ не могут быть генокрадами и культистами, генокрадами потому-что не могли быть поглощены ими, культистами потому-что не имеют крови.
- Они всё ещё могут быть конвертнуты в культ, просто не смогут рисовать.

СПУ не могут быть блобами, потому-что техника.

Воксы не могут быть генокрадами, потому-что генокрады не могли их поглощать.
Воксы не могут быть магами, потому-что ???
Воксы не могут быть треллами, потому-что ???

![image](https://user-images.githubusercontent.com/17705613/81211034-77e00000-8fdb-11ea-8514-bb42837cc65d.png)

## Почему и что этот ПР улучшит

Не нужно будет банить шкурки людей которые забыли дёрнуть галочку в префах.

## Чеинжлог
:cl: Luduk
- tweak: Дионы не могут быть культистами, генками. СПУ не могут быть культистами, генками, блобами. Воксы не могут быть генками, магами, и треллами.