### PR TITLE
clown doesn't get slowed down by his own shoes

### DIFF
--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -113,18 +113,29 @@
 
 /obj/item/clothing/shoes/clown_shoes/Destroy()
 	if(slot_equipped == SLOT_SHOES)
-		qdel(loc.GetComponent(/datum/component/waddle))
+		// Since slot_equipped is changed only when item is worn
+		// it's safe to assume loc is a mob.
+		stop_waddling(loc)
 	return ..()
+
+/obj/item/clothing/shoes/clown_shoes/proc/start_waddling(mob/user)
+	if(CLUMSY in user.mutations)
+		slowdown = SHOES_SLOWDOWN
+	user.AddComponent(/datum/component/waddle, 4, list(-14, 0, 14), list(COMSIG_MOVABLE_MOVED))
+
+/obj/item/clothing/shoes/clown_shoes/proc/stop_waddling(mob/user)
+	slowdown = SHOES_SLOWDOWN + 1.0
+	qdel(user.GetComponent(/datum/component/waddle))
 
 /obj/item/clothing/shoes/clown_shoes/equipped(mob/user, slot)
 	if(slot == SLOT_SHOES)
-		user.AddComponent(/datum/component/waddle, 4, list(-14, 0, 14), list(COMSIG_MOVABLE_MOVED))
+		start_waddling(user)
 	else if(slot_equipped == SLOT_SHOES)
-		qdel(user.GetComponent(/datum/component/waddle))
+		stop_waddling(user)
 
 /obj/item/clothing/shoes/clown_shoes/dropped(mob/user)
 	if(slot_equipped == SLOT_SHOES)
-		qdel(user.GetComponent(/datum/component/waddle))
+		stop_waddling(user)
 
 /obj/item/clothing/shoes/clown_shoes/play_unique_footstep_sound()
 	..()


### PR DESCRIPTION
## Описание изменений

Ботинки клоуна замедляют всех кроме клоуна(Технически - клоун - человек с кламзи)

## Почему и что этот ПР улучшит

Я не уверен почему оно должно было замедлять клоуна в первую очередь, но теперь клоуну будет проще "шутить" над вором его ботинок.

## Чеинжлог
:cl: Luduk
- tweak: Ботинки клоуна не замедляют клоуна.
- balance: Ботинки клоуна замедляют всех(кроме клоуна) на уровне с каблуками.