### PR TITLE
minor multi_carry, waddle code cleanup

### DIFF
--- a/code/datums/components/multi_carry.dm
+++ b/code/datums/components/multi_carry.dm
@@ -353,7 +353,7 @@
 	next_move = carrier.client.move_delay
 
 	var/lying_am = 0
-	for(var/mob/walker in carriers.len)
+	for(var/mob/walker in carriers)
 		if(!walker.canmove) // Buckled or something stupid like that.
 			stop_carry()
 			return NONE

--- a/code/datums/components/waddle.dm
+++ b/code/datums/components/waddle.dm
@@ -32,7 +32,7 @@
 
 	RegisterSignal(parent, waddle_on, .proc/try_waddle)
 
-/datum/component/waddle/proc/try_waddle(atom/movable/AM, dir)
+/datum/component/waddle/proc/try_waddle()
 	var/atom/movable/waddler = parent
 	if(waddler.can_waddle())
 		var/waddle_angle = pick(waddle_angles)


### PR DESCRIPTION
## Описание изменений

waddle компонента подразумевает что существо ваддлит независимо от сигнала, и потому иметь какие-либо аргументы в её единственном проке выглядит не резонно

multi_carry компонента имела (дурацкую) ошибку в цикле

## Почему и что этот ПР улучшит

качество кода
