### PR TITLE
waddle when doing dance moves with coffin

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -59,6 +59,11 @@
 
 #define COMSIG_MOVABLE_WADDLE "movable_waddle"		//from atom/movable/proc/waddle(): (waddle_angle, waddle_height)
 
+#define COMSIG_MOVABLE_GRABBED "movable_grabbed"	//from mob/Grab(): (mob/grabber, force_state, show_warnings)
+	#define COMPONENT_PREVENT_GRAB 1
+
+#define COMSIG_MOVABLE_PIXELMOVE "movable_pixelmove" // hopefully called from all places where pixel_x and pixel_y is set. used by multi_carry, and waddle. (): ()
+
 // living signals
 #define COMSIG_LIVING_START_PULL "living_start_pull"			//from base of /mob/start_pulling(): (/atom/movable/target)
 #define COMSIG_LIVING_STOP_PULL "living_stop_pull"				//from base of /mob/stop_pulling(): (/atom/movable/target)

--- a/code/datums/components/waddle.dm
+++ b/code/datums/components/waddle.dm
@@ -1,17 +1,23 @@
+#define WADDLE_ANIM_DELAY 2
+
+/atom/movable/var/next_waddle = 0
+
 /atom/movable/proc/waddle(waddle_angle, waddle_height)
+	next_waddle = world.time + WADDLE_ANIM_DELAY
+
 	var/matrix/old_transform = transform
 	var/old_pixel_z = pixel_z
 	animate(src, pixel_z = pixel_z + waddle_height, time = 0)
-	animate(pixel_z = old_pixel_z, transform = turn(transform, waddle_angle), time=2)
+	animate(pixel_z = old_pixel_z, transform = turn(transform, waddle_angle), time=WADDLE_ANIM_DELAY)
 	animate(transform = old_transform, time = 0)
 
 	SEND_SIGNAL(src, COMSIG_MOVABLE_WADDLE, waddle_angle, waddle_height)
 
 /atom/movable/proc/can_waddle()
-	return !anchored
+	return !anchored && next_waddle <= world.time
 
 /mob/can_waddle()
-	return !notransform && !anchored && !incapacitated()
+	return ..() && !notransform && !incapacitated()
 
 
 /*
@@ -37,3 +43,5 @@
 	if(waddler.can_waddle())
 		var/waddle_angle = pick(waddle_angles)
 		waddler.waddle(waddle_angle, waddle_height)
+
+#undef WADDLE_ANIM_DELAY

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -121,7 +121,7 @@
 /obj/item/clothing/shoes/clown_shoes/proc/start_waddling(mob/user)
 	if(CLUMSY in user.mutations)
 		slowdown = SHOES_SLOWDOWN
-	user.AddComponent(/datum/component/waddle, 4, list(-14, 0, 14), list(COMSIG_MOVABLE_MOVED))
+	user.AddComponent(/datum/component/waddle, 4, list(-14, 0, 14), list(COMSIG_MOVABLE_MOVED, COMSIG_MOVABLE_PIXELMOVE))
 
 /obj/item/clothing/shoes/clown_shoes/proc/stop_waddling(mob/user)
 	slowdown = SHOES_SLOWDOWN + 1.0
@@ -158,7 +158,7 @@
 	RegisterSignal(user, list(COMSIG_LIVING_STOP_PULL), .proc/stop_waddling)
 	UnregisterSignal(user, list(COMSIG_LIVING_START_PULL))
 
-	user.AddComponent(/datum/component/waddle, 4, list(-14, 0, 14), list(COMSIG_MOVABLE_MOVED))
+	user.AddComponent(/datum/component/waddle, 4, list(-14, 0, 14), list(COMSIG_MOVABLE_MOVED, COMSIG_MOVABLE_PIXELMOVE))
 	waddling = TRUE
 
 /obj/item/clothing/shoes/jolly_gravedigger/proc/stop_waddling(mob/user)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -45,6 +45,10 @@
 		if(show_warnings)
 			to_chat(src, "<span class='warning'>You are holding too many stuff already.</span>")
 		return
+
+	if(SEND_SIGNAL(target, COMSIG_MOVABLE_GRABBED, src, force_state, show_warnings) & COMPONENT_PREVENT_GRAB)
+		return
+
 	if(ismob(target))
 		var/mob/M = target
 		if(!(M.status_flags & CANPUSH))


### PR DESCRIPTION
## Описание изменений

Когда носители гроба "крутятся", или меняются местами они ваддлят.

Дал возможность выбрать "направление" ротацие(правая рука крутит по часовой, левая против часовой)

![Er6GR8gZwu](https://user-images.githubusercontent.com/17705613/81320678-3d896800-909a-11ea-822f-6922dea3bc6a.gif)

![fS6UMBOi8K](https://user-images.githubusercontent.com/17705613/81320707-49752a00-909a-11ea-8edd-a0e88efd1166.gif)

Поправил баги с тем что если грабать кого-то из несущих гроб - то он смешно смещается.

## Почему и что этот ПР улучшит

Фан?

## Чеинжлог
:cl: Luduk
- tweak: Во время выполнения "танцев" с гробом, танцующие ваддлят.
- rscadd: Можно выбрать направление хоровода во время танцев с гробом - меняя руки.