### PR TITLE
занятый chem_dispenser и мультитул

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -185,6 +185,7 @@
 		else
 			to_chat(user, msg_hack_disable)
 			dispensable_reagents -= premium_reagents
+		return
 	if(default_unfasten_wrench(user, B))
 		power_change()
 		return


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Теперь не пишется "Something is already loaded into the machine.", когда нажимаешь по chem_dispenser'у мультитулом при уже загруженном контейнере в него
## Почему и что этот ПР улучшит
Исправит баг
## Авторство
Cool20141
## Чеинжлог
:cl:
- bugfix: Теперь не пишется глупого сообщения о том, что что-то уже в chem_dispenser'е, если нажимаешь мультитулом