### PR TITLE
Job prefs revamp

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -42,3 +42,9 @@
 #define GET_RANDOM_JOB 0
 #define BE_ASSISTANT 1
 #define RETURN_TO_LOBBY 2
+
+// Job preference levels.
+#define JP_LOW 1
+#define JP_MEDIUM 2
+#define JP_HIGH 3
+#define JP_LEVELS list(JP_LOW, JP_MEDIUM, JP_HIGH)

--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -8,6 +8,8 @@ var/datum/subsystem/job/SSjob
 	flags = SS_NO_FIRE
 
 	var/list/occupations = list()		//List of all jobs
+	var/list/datum/job/name_occupations = list()	//Dict of all jobs, keys are titles
+	var/list/type_occupations = list()	//Dict of al jobs, keys are types
 	var/list/unassigned = list()		//Players who need jobs
 	var/list/job_debug = list()			//Debug info
 	var/obj/effect/landmark/start/fallback_landmark
@@ -38,6 +40,8 @@ var/datum/subsystem/job/SSjob
 		if(job.faction != faction)
 			continue
 		occupations += job
+		name_occupations[job.title] = job
+		type_occupations[J] = job
 
 	return 1
 
@@ -48,16 +52,15 @@ var/datum/subsystem/job/SSjob
 	job_debug.Add(text)
 	return 1
 
-
 /datum/subsystem/job/proc/GetJob(rank)
-	if(!rank)
-		return null
-	for(var/datum/job/J in occupations)
-		if(!J)
-			continue
-		if(J.title == rank)
-			return J
-	return null
+	if(!occupations.len)
+		SetupOccupations()
+	return name_occupations[rank]
+
+/datum/subsystem/job/proc/GetJobType(jobtype)
+	if(!occupations.len)
+		SetupOccupations()
+	return type_occupations[jobtype]
 
 /datum/subsystem/job/proc/GetPlayerAltTitle(mob/dead/new_player/player, rank)
 	return player.client.prefs.GetPlayerAltTitle(GetJob(rank))
@@ -109,7 +112,7 @@ var/datum/subsystem/job/SSjob
 		if(flag && (!(flag in player.client.prefs.be_role)))
 			Debug("FOC flag failed, Player: [player], Flag: [flag], ")
 			continue
-		if(player.client.prefs.GetJobDepartment(job, level) & job.flag)
+		if(player.client.prefs.job_preferences[job.title] == level)
 			Debug("FOC pass, Player: [player], Level:[level]")
 			candidates += player
 	return candidates
@@ -166,7 +169,7 @@ var/datum/subsystem/job/SSjob
 //it locates a head or runs out of levels to check
 //This is basically to ensure that there's atleast a few heads in the round
 /datum/subsystem/job/proc/FillHeadPosition()
-	for(var/level = 1 to 3)
+	for(var/level in JP_LEVELS)
 		for(var/command_position in command_positions)
 			var/datum/job/job = GetJob(command_position)
 			if(!job)
@@ -211,7 +214,7 @@ var/datum/subsystem/job/SSjob
 		job.total_positions = job.spawn_positions
 		job.spawn_positions = 0
 	for(var/i = job.total_positions, i > 0, i--)
-		for(var/level = 1 to 3)
+		for(var/level in JP_LEVELS)
 			var/list/candidates = list()
 			if(ticker.mode.name == "AI malfunction")//Make sure they want to malf if its malf
 				candidates = FindOccupationCandidates(job, level, ROLE_MALF)
@@ -288,7 +291,7 @@ var/datum/subsystem/job/SSjob
 	Debug("DO, Running Head Check")
 	FillHeadPosition()
 	Debug("DO, Head Check end")
-	
+
 	//Check for an AI
 	if(!(ticker.mode.name == "AI malfunction"))
 		Debug("DO, Running AI Check")
@@ -305,7 +308,7 @@ var/datum/subsystem/job/SSjob
 
 	// Loop through all levels from high to low
 	var/list/shuffledoccupations = shuffle(occupations)
-	for(var/level = 1 to 3)
+	for(var/level in JP_LEVELS)
 		//Check the head jobs first each level
 		CheckHeadPositions(level)
 
@@ -330,7 +333,7 @@ var/datum/subsystem/job/SSjob
 
 
 				// If the player wants that job on this level, then try give it to him.
-				if(player.client.prefs.GetJobDepartment(job, level) & job.flag)
+				if(player.client.prefs.job_preferences[job.title] == level)
 
 					// If the job isn't filled
 					if((job.current_positions < job.spawn_positions) || job.spawn_positions == -1)
@@ -635,29 +638,29 @@ var/datum/subsystem/job/SSjob
 	for(var/datum/job/job in occupations)
 		var/tmp_str = "|[job.title]|"
 
-		var/level1 = 0 //high
-		var/level2 = 0 //medium
-		var/level3 = 0 //low
-		var/level4 = 0 //never
-		var/level5 = 0 //banned
-		var/level6 = 0 //account too young
+		var/high = 0
+		var/medium = 0
+		var/low = 0
+		var/never = 0
+		var/banned = 0
+		var/young = 0
 		for(var/mob/dead/new_player/player in player_list)
 			if(!(player.ready && player.mind && !player.mind.assigned_role))
 				continue //This player is not ready
 			if(jobban_isbanned(player, job.title))
-				level5++
+				banned++
 				continue
 			if(!job.player_old_enough(player.client))
-				level6++
+				young++
 				continue
-			if(player.client.prefs.GetJobDepartment(job, 1) & job.flag)
-				level1++
-			else if(player.client.prefs.GetJobDepartment(job, 2) & job.flag)
-				level2++
-			else if(player.client.prefs.GetJobDepartment(job, 3) & job.flag)
-				level3++
-			else
-				level4++ //not selected
-
-		tmp_str += "HIGH=[level1]|MEDIUM=[level2]|LOW=[level3]|NEVER=[level4]|BANNED=[level5]|YOUNG=[level6]|-"
+			switch(player.client.prefs.job_preferences[job.title])
+				if(JP_HIGH)
+					high++
+				if(JP_MEDIUM)
+					medium++
+				if(JP_LOW)
+					low++
+				else
+					never++
+		tmp_str += "HIGH=[high]|MEDIUM=[medium]|LOW=[low]|NEVER=[never]|BANNED=[banned]|YOUNG=[young]|-"
 		feedback_add_details("job_preferences",tmp_str)

--- a/code/game/gamemodes/malfunction/malfunction.dm
+++ b/code/game/gamemodes/malfunction/malfunction.dm
@@ -43,13 +43,13 @@
 		if (player.mind in antag_candidates)
 			var/malf_possible = FALSE
 			for (var/lvl in 1 to 3)
-				if ((player.client.prefs.GetJobDepartment(ai_job, lvl) & ai_job.flag) && (!jobban_isbanned(player, ai_job.title)))
+				if (player.client.prefs.job_preferences[ai_job.title] == lvl && (!jobban_isbanned(player, ai_job.title)))
 					malf_possible = TRUE
 					break
 			if (!malf_possible)
 				antag_candidates -= player.mind
 	return length(antag_candidates)
-					
+
 
 /datum/game_mode/malfunction/pre_setup()
 	for(var/mob/dead/new_player/player in player_list)

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -5,9 +5,9 @@
 
 	var/list/access = list()
 
-	//Bitflags for the job
-	var/flag = 0
-	var/department_flag = 0
+	//Bitflags for the job  (Ha-ha we no longer use bitflags this is useless)
+	var/flag = 0 // Deprecated (is here only for savefile compatibility)
+	var/department_flag = 0 // Deprecated (is here only for savefile compatibility)
 
 	//Players will be allowed to spawn in as jobs that are set to "Station"
 	var/faction = "None"

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -1,6 +1,5 @@
 /datum/job
-
-	//The name of the job
+	//The name of the job, used for preferences, bans and more. Make sure you know what you're doing before changing this.
 	var/title = "NOPE"
 
 	var/list/access = list()

--- a/code/modules/client/character menu/occupation.dm
+++ b/code/modules/client/character menu/occupation.dm
@@ -59,7 +59,7 @@
 		if(!job.is_species_permitted(user.client))
 			. += "<del>[rank]</del></td><td><b> \[SPECIES RESTRICTED]</b></td></tr>"
 			continue
-		if((job_civilian_low & ASSISTANT) && (rank != "Test Subject"))
+		if(job_preferences["Test Subject"] == JP_LOW && (rank != "Test Subject"))
 			. += "<font color=orange>[rank]</font></td><td></td></tr>"
 			continue
 		if((rank in command_positions) || (rank == "AI"))//Bold head jobs
@@ -69,10 +69,10 @@
 
 		. += "</td><td width='40%'>"
 
-		. += "<a class='white' href='?_src_=prefs;preference=job;task=input;text=[rank]'>"
+		. += "<a class='white' href='?_src_=prefs;preference=job;task=setJobLevel;text=[rank]'>"
 
 		if(rank == "Test Subject")//Assistant is special
-			if(job_civilian_low & ASSISTANT)
+			if(job_preferences["Test Subject"])
 				. += " <font color=green size=2>Yes</font>"
 			else
 				. += " <font color=red size=2>No</font>"
@@ -81,11 +81,11 @@
 				. += "</a></td></tr><tr bgcolor='[lastJob.selection_color]'><td width='60%' align='center'><a>&nbsp</a></td><td><a href=\"byond://?src=\ref[user];preference=job;task=alt_title;job=\ref[job]\">\[[GetPlayerAltTitle(job)]\]</a></td></tr>"
 			continue
 
-		if(GetJobDepartment(job, 1) & job.flag)
+		if(job_preferences[job.title] == JP_HIGH)
 			. += " <font color=blue size=2>High</font>"
-		else if(GetJobDepartment(job, 2) & job.flag)
+		else if(job_preferences[job.title] == JP_MEDIUM)
 			. += " <font color=green size=2>Medium</font>"
-		else if(GetJobDepartment(job, 3) & job.flag)
+		else if(job_preferences[job.title] == JP_LOW)
 			. += " <font color=orange size=2>Low</font>"
 		else
 			. += " <font color=red size=2>NEVER</font>"
@@ -118,8 +118,8 @@
 					var/choice = input("Pick a title for [job.title].", "Character Generation", GetPlayerAltTitle(job)) as anything in choices | null
 					if(choice)
 						SetPlayerAltTitle(job, choice)
-			if("input")
-				SetJob(user, href_list["text"])
+			if("setJobLevel")
+				UpdateJobPreference(user, href_list["text"])
 
 /datum/preferences/proc/GetPlayerAltTitle(datum/job/job)
 	return player_alt_titles.Find(job.title) > 0 \
@@ -134,116 +134,41 @@
 	if(job.title != new_title)
 		player_alt_titles[job.title] = new_title
 
-/datum/preferences/proc/SetJob(mob/user, role)
+/datum/preferences/proc/UpdateJobPreference(mob/user, role)
 	var/datum/job/job = SSjob.GetJob(role)
 	if(!job)
 		return
 
+	var/jpval = JP_LOW
+	switch(job_preferences[job.title])
+		if(JP_LOW)
+			jpval = JP_MEDIUM
+		if(JP_MEDIUM)
+			jpval = JP_HIGH
+		if(JP_HIGH)
+			jpval = null
+
 	if(role == "Test Subject")
-		if(job_civilian_low & job.flag)
-			job_civilian_low &= ~job.flag
+		if(job_preferences["Test Subject"] == JP_LOW)
+			jpval = null
 		else
-			job_civilian_low |= job.flag
-		return 1
+			jpval = JP_LOW
 
-	if(GetJobDepartment(job, 1) & job.flag)
-		SetJobDepartment(job, 1)
-	else if(GetJobDepartment(job, 2) & job.flag)
-		SetJobDepartment(job, 2)
-	else if(GetJobDepartment(job, 3) & job.flag)
-		SetJobDepartment(job, 3)
-	else//job = Never
-		SetJobDepartment(job, 4)
-
-	return 1
+	SetJobPreferenceLevel(job, jpval)
+	return TRUE
 
 /datum/preferences/proc/ResetJobs()
-	job_civilian_high = 0
-	job_civilian_med = 0
-	job_civilian_low = 0
+	job_preferences = list()
 
-	job_medsci_high = 0
-	job_medsci_med = 0
-	job_medsci_low = 0
+/datum/preferences/proc/SetJobPreferenceLevel(datum/job/job, level)
+	if(!job)
+		return FALSE
 
-	job_engsec_high = 0
-	job_engsec_med = 0
-	job_engsec_low = 0
+	if(level == JP_HIGH)
+		// Set all other high to medium
+		for(var/j in job_preferences)
+			if(job_preferences[j] == JP_HIGH)
+				job_preferences[j] = JP_MEDIUM
 
-
-/datum/preferences/proc/GetJobDepartment(datum/job/job, level)
-	if(!job || !level)	return 0
-	switch(job.department_flag)
-		if(CIVILIAN)
-			switch(level)
-				if(1)
-					return job_civilian_high
-				if(2)
-					return job_civilian_med
-				if(3)
-					return job_civilian_low
-		if(MEDSCI)
-			switch(level)
-				if(1)
-					return job_medsci_high
-				if(2)
-					return job_medsci_med
-				if(3)
-					return job_medsci_low
-		if(ENGSEC)
-			switch(level)
-				if(1)
-					return job_engsec_high
-				if(2)
-					return job_engsec_med
-				if(3)
-					return job_engsec_low
-	return 0
-
-/datum/preferences/proc/SetJobDepartment(datum/job/job, level)
-	if(!job || !level)	return 0
-	switch(level)
-		if(1)//Only one of these should ever be active at once so clear them all here
-			job_civilian_high = 0
-			job_medsci_high = 0
-			job_engsec_high = 0
-			return 1
-		if(2)//Set current highs to med, then reset them
-			job_civilian_med |= job_civilian_high
-			job_medsci_med |= job_medsci_high
-			job_engsec_med |= job_engsec_high
-			job_civilian_high = 0
-			job_medsci_high = 0
-			job_engsec_high = 0
-
-	switch(job.department_flag)
-		if(CIVILIAN)
-			switch(level)
-				if(2)
-					job_civilian_high = job.flag
-					job_civilian_med &= ~job.flag
-				if(3)
-					job_civilian_med |= job.flag
-					job_civilian_low &= ~job.flag
-				else
-					job_civilian_low |= job.flag
-		if(MEDSCI)
-			switch(level)
-				if(2)
-					job_medsci_high = job.flag
-					job_medsci_med &= ~job.flag
-				if(3)
-					job_medsci_med |= job.flag
-					job_medsci_low &= ~job.flag
-				else
-					job_medsci_low |= job.flag
-		if(ENGSEC)
-			switch(level)
-				if(2)
-					job_engsec_high = job.flag
-					job_engsec_med &= ~job.flag
-				if(3)
-					job_engsec_med |= job.flag
-					job_engsec_low &= ~job.flag
-				else
-					job_engsec_low |= job.flag
+	job_preferences[job.title] = level
+	return TRUE

--- a/code/modules/client/character menu/occupation.dm
+++ b/code/modules/client/character menu/occupation.dm
@@ -170,5 +170,8 @@
 			if(job_preferences[j] == JP_HIGH)
 				job_preferences[j] = JP_MEDIUM
 
-	job_preferences[job.title] = level
+	if(level)
+		job_preferences[job.title] = level
+	else
+		job_preferences -= job.title
 	return TRUE

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -88,18 +88,8 @@ var/const/MAX_SAVE_SLOTS = 10
 	var/religion = "None"               //Religious association.
 	var/nanotrasen_relation = "Neutral"
 
-	//Jobs, uses bitflags
-	var/job_civilian_high = 0
-	var/job_civilian_med = 0
-	var/job_civilian_low = 0
-
-	var/job_medsci_high = 0
-	var/job_medsci_med = 0
-	var/job_medsci_low = 0
-
-	var/job_engsec_high = 0
-	var/job_engsec_med = 0
-	var/job_engsec_low = 0
+	//Job preferences 2.0 - indexed by job title , no key or value implies never
+	var/list/job_preferences = list()
 
 	//Keeps track of preferrence for not getting any wanted jobs
 	var/alternate_option = RETURN_TO_LOBBY

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -136,21 +136,24 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 			switch(initial(J.department_flag))
 				if(CIVILIAN)
 					if(job_civilian_high & fval)
-						new_value = JP_HIGH
+						// Since we can have only one high pref now, let the user pick which of the bunch they want.
+						new_value = JP_MEDIUM
 					else if(job_civilian_med & fval)
 						new_value = JP_MEDIUM
 					else if(job_civilian_low & fval)
 						new_value = JP_LOW
 				if(MEDSCI)
 					if(job_medsci_high & fval)
-						new_value = JP_HIGH
+						// Since we can have only one high pref now, let the user pick which of the bunch they want.
+						new_value = JP_MEDIUM
 					else if(job_medsci_med & fval)
 						new_value = JP_MEDIUM
 					else if(job_medsci_low & fval)
 						new_value = JP_LOW
 				if(ENGSEC)
 					if(job_engsec_high & fval)
-						new_value = JP_HIGH
+						// Since we can have only one high pref now, let the user pick which of the bunch they want.
+						new_value = JP_MEDIUM
 					else if(job_engsec_med & fval)
 						new_value = JP_MEDIUM
 					else if(job_engsec_low & fval)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -2,7 +2,7 @@
 #define SAVEFILE_VERSION_MIN 8
 
 //This is the current version, anything below this will attempt to update (if it's not obsolete)
-#define SAVEFILE_VERSION_MAX 26
+#define SAVEFILE_VERSION_MAX 30
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -103,6 +103,61 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 			(player_alt_titles[J.title] in list("Technical Assistant", "Medical Intern", "Research Assistant", "Security Cadet")))
 
 			player_alt_titles -= J.title
+
+	if(current_version < 30)
+		job_preferences = list() //It loaded null from nonexistant savefile field.
+		var/job_civilian_high = 0
+		var/job_civilian_med = 0
+		var/job_civilian_low = 0
+
+		var/job_medsci_high = 0
+		var/job_medsci_med = 0
+		var/job_medsci_low = 0
+
+		var/job_engsec_high = 0
+		var/job_engsec_med = 0
+		var/job_engsec_low = 0
+
+		S["job_civilian_high"]	>> job_civilian_high
+		S["job_civilian_med"]	>> job_civilian_med
+		S["job_civilian_low"]	>> job_civilian_low
+		S["job_medsci_high"]	>> job_medsci_high
+		S["job_medsci_med"]		>> job_medsci_med
+		S["job_medsci_low"]		>> job_medsci_low
+		S["job_engsec_high"]	>> job_engsec_high
+		S["job_engsec_med"]		>> job_engsec_med
+		S["job_engsec_low"]		>> job_engsec_low
+
+		//Can't use SSjob here since this happens right away on login
+		for(var/job in subtypesof(/datum/job))
+			var/datum/job/J = job
+			var/new_value
+			var/fval = initial(J.flag)
+			switch(initial(J.department_flag))
+				if(CIVILIAN)
+					if(job_civilian_high & fval)
+						new_value = JP_HIGH
+					else if(job_civilian_med & fval)
+						new_value = JP_MEDIUM
+					else if(job_civilian_low & fval)
+						new_value = JP_LOW
+				if(MEDSCI)
+					if(job_medsci_high & fval)
+						new_value = JP_HIGH
+					else if(job_medsci_med & fval)
+						new_value = JP_MEDIUM
+					else if(job_medsci_low & fval)
+						new_value = JP_LOW
+				if(ENGSEC)
+					if(job_engsec_high & fval)
+						new_value = JP_HIGH
+					else if(job_engsec_med & fval)
+						new_value = JP_MEDIUM
+					else if(job_engsec_low & fval)
+						new_value = JP_LOW
+			if(new_value)
+				job_preferences[initial(J.title)] = new_value
+		S["job_preferences"]	<< job_preferences
 
 /datum/preferences/proc/load_path(ckey, filename = "preferences.sav")
 	if(!ckey)
@@ -276,17 +331,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["backbag"]			>> backbag
 	S["b_type"]				>> b_type
 
-	//Jobs
-	S["alternate_option"]	>> alternate_option
-	S["job_civilian_high"]	>> job_civilian_high
-	S["job_civilian_med"]	>> job_civilian_med
-	S["job_civilian_low"]	>> job_civilian_low
-	S["job_medsci_high"]	>> job_medsci_high
-	S["job_medsci_med"]		>> job_medsci_med
-	S["job_medsci_low"]		>> job_medsci_low
-	S["job_engsec_high"]	>> job_engsec_high
-	S["job_engsec_med"]		>> job_engsec_med
-	S["job_engsec_low"]		>> job_engsec_low
+	//Load prefs
+	S["job_preferences"] >> job_preferences
 
 	//Traits
 	S["all_quirks"]			>> all_quirks
@@ -357,15 +403,11 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	backbag			= sanitize_integer(backbag, 1, backbaglist.len, initial(backbag))
 	b_type			= sanitize_text(b_type, initial(b_type))
 	alternate_option = sanitize_integer(alternate_option, 0, 2, initial(alternate_option))
-	job_civilian_high = sanitize_integer(job_civilian_high, 0, 16777215, initial(job_civilian_high))
-	job_civilian_med = sanitize_integer(job_civilian_med, 0, 16777215, initial(job_civilian_med))
-	job_civilian_low = sanitize_integer(job_civilian_low, 0, 16777215, initial(job_civilian_low))
-	job_medsci_high = sanitize_integer(job_medsci_high, 0, 16777215, initial(job_medsci_high))
-	job_medsci_med = sanitize_integer(job_medsci_med, 0, 16777215, initial(job_medsci_med))
-	job_medsci_low = sanitize_integer(job_medsci_low, 0, 16777215, initial(job_medsci_low))
-	job_engsec_high = sanitize_integer(job_engsec_high, 0, 16777215, initial(job_engsec_high))
-	job_engsec_med = sanitize_integer(job_engsec_med, 0, 16777215, initial(job_engsec_med))
-	job_engsec_low = sanitize_integer(job_engsec_low, 0, 16777215, initial(job_engsec_low))
+	//Validate job prefs
+	// Do we really need this? ~Luduk
+	for(var/j in job_preferences)
+		if(job_preferences[j] != JP_LOW && job_preferences[j] != JP_MEDIUM && job_preferences[j] != JP_HIGH)
+			job_preferences -= j
 
 	all_quirks = SANITIZE_LIST(all_quirks)
 	positive_quirks = SANITIZE_LIST(positive_quirks)
@@ -465,17 +507,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["backbag"]			<< backbag
 	S["b_type"]				<< b_type
 
-	//Jobs
+	//Write prefs
 	S["alternate_option"]	<< alternate_option
-	S["job_civilian_high"]	<< job_civilian_high
-	S["job_civilian_med"]	<< job_civilian_med
-	S["job_civilian_low"]	<< job_civilian_low
-	S["job_medsci_high"]	<< job_medsci_high
-	S["job_medsci_med"]		<< job_medsci_med
-	S["job_medsci_low"]		<< job_medsci_low
-	S["job_engsec_high"]	<< job_engsec_high
-	S["job_engsec_med"]		<< job_engsec_med
-	S["job_engsec_low"]		<< job_engsec_low
+	S["job_preferences"]	<< job_preferences
 
 	//Traits
 	S["all_quirks"]			<< all_quirks

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -2,7 +2,7 @@
 #define SAVEFILE_VERSION_MIN 8
 
 //This is the current version, anything below this will attempt to update (if it's not obsolete)
-#define SAVEFILE_VERSION_MAX 30
+#define SAVEFILE_VERSION_MAX 27
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -104,7 +104,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 			player_alt_titles -= J.title
 
-	if(current_version < 30)
+	if(current_version < 27)
 		job_preferences = list() //It loaded null from nonexistant savefile field.
 		var/job_civilian_high = 0
 		var/job_civilian_med = 0

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -403,11 +403,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	backbag			= sanitize_integer(backbag, 1, backbaglist.len, initial(backbag))
 	b_type			= sanitize_text(b_type, initial(b_type))
 	alternate_option = sanitize_integer(alternate_option, 0, 2, initial(alternate_option))
-	//Validate job prefs
-	// Do we really need this? ~Luduk
-	for(var/j in job_preferences)
-		if(job_preferences[j] != JP_LOW && job_preferences[j] != JP_MEDIUM && job_preferences[j] != JP_HIGH)
-			job_preferences -= j
 
 	all_quirks = SANITIZE_LIST(all_quirks)
 	positive_quirks = SANITIZE_LIST(positive_quirks)

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -183,27 +183,30 @@
 
 
 /datum/preferences/proc/update_preview_icon()		//seriously. This is horrendous.
-	// Silicons only need a very basic preview since there is no customization for them.
-	var/datum/job/J = SSjob.GetJobType(/datum/job/ai)
-	if(job_preferences[J.title] == JP_HIGH)
-		parent.show_character_previews(image('icons/mob/AI.dmi', "AI", dir = SOUTH))
-		return
-	J = SSjob.GetJobType(/datum/job/cyborg)
-	if(job_preferences[J.title] == JP_HIGH)
-		parent.show_character_previews(image('icons/mob/robots.dmi', "robot", dir = SOUTH))
-		return
+	// Determine what job is marked as 'High' priority, and dress them up as such.
+	var/datum/job/previewJob
+
+	if(job_preferences["Test Subject"] == JP_LOW)
+		previewJob = SSjob.GetJob("Test Subject")
+
+	if(!previewJob)
+		var/highest_pref = 0
+		for(var/job in job_preferences)
+			if(job_preferences[job] > highest_pref)
+				previewJob = SSjob.GetJob(job)
+				highest_pref = job_preferences[job]
+
+	if(previewJob)
+		if(istype(previewJob, /datum/job/ai))
+			parent.show_character_previews(image('icons/mob/AI.dmi', "AI", dir = SOUTH))
+			return
+		if(istype(previewJob, /datum/job/cyborg))
+			parent.show_character_previews(image('icons/mob/robots.dmi', "robot", dir = SOUTH))
+			return
 
 	// Set up the dummy for its photoshoot
 	var/mob/living/carbon/human/dummy/mannequin = new(null, species)
 	copy_to(mannequin)
-
-	// Determine what job is marked as 'High' priority, and dress them up as such.
-	var/datum/job/previewJob
-	var/highest_pref = 0
-	for(var/job in job_preferences)
-		if(job_preferences[job] > highest_pref)
-			previewJob = SSjob.GetJob(job)
-			highest_pref = job_preferences[job]
 
 	var/datum/species/S = all_species[species]
 	if(S)

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -184,14 +184,14 @@
 
 /datum/preferences/proc/update_preview_icon()		//seriously. This is horrendous.
 	// Silicons only need a very basic preview since there is no customization for them.
-	if(job_engsec_high)
-		switch(job_engsec_high)
-			if(AI)
-				parent.show_character_previews(image('icons/mob/AI.dmi', "AI", dir = SOUTH))
-				return
-			if(CYBORG)
-				parent.show_character_previews(image('icons/mob/robots.dmi', "robot", dir = SOUTH))
-				return
+	var/datum/job/J = SSjob.GetJobType(/datum/job/ai)
+	if(job_preferences[J.title] == JP_HIGH)
+		parent.show_character_previews(image('icons/mob/AI.dmi', "AI", dir = SOUTH))
+		return
+	J = SSjob.GetJobType(/datum/job/cyborg)
+	if(job_preferences[J.title] == JP_HIGH)
+		parent.show_character_previews(image('icons/mob/robots.dmi', "robot", dir = SOUTH))
+		return
 
 	// Set up the dummy for its photoshoot
 	var/mob/living/carbon/human/dummy/mannequin = new(null, species)
@@ -199,23 +199,11 @@
 
 	// Determine what job is marked as 'High' priority, and dress them up as such.
 	var/datum/job/previewJob
-	var/highRankFlag = job_civilian_high | job_medsci_high | job_engsec_high
-
-	if(job_civilian_low & ASSISTANT)
-		previewJob = SSjob.GetJob("Test Subject")
-	else if(highRankFlag)
-		var/highDeptFlag
-		if(job_civilian_high)
-			highDeptFlag = CIVILIAN
-		else if(job_medsci_high)
-			highDeptFlag = MEDSCI
-		else if(job_engsec_high)
-			highDeptFlag = ENGSEC
-
-		for(var/datum/job/job in SSjob.occupations)
-			if(job.flag == highRankFlag && job.department_flag == highDeptFlag)
-				previewJob = job
-				break
+	var/highest_pref = 0
+	for(var/job in job_preferences)
+		if(job_preferences[job] > highest_pref)
+			previewJob = SSjob.GetJob(job)
+			highest_pref = job_preferences[job]
 
 	var/datum/species/S = all_species[species]
 	if(S)


### PR DESCRIPTION
## Описание изменений

Обновляет код профессий к чему-то более актуальному...

Я думаю черед месяц или два стоит убрать код обновления префов, чтобы из билда можно было выпилить все эти ненужные департмент флаги которые тоже могут чутка конфузить (@volas, мне интересно твоё мнение об этом)

## Почему и что этот ПР улучшит

Эти игры с битфлагами это был какой-то бред человека который только узнал о битмасках...

## Авторство
@AnturK вот этот дядя с ТГ, вот этот ПР с ТГ
https://github.com/tgstation/tgstation/pull/43559


## Чеинжлог
:cl: Luduk
- performance: Улучшения кода относительно приоритетов профессий, игрокам нужно проверить свои настройки и заново выбрать HIGH приоритеты. С приоритетом HIGH может быть только одна профессия.