### PR TITLE
order of pref levels

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -47,4 +47,5 @@
 #define JP_LOW 1
 #define JP_MEDIUM 2
 #define JP_HIGH 3
+// Order is of the essence apperantly. From highest order to lowest.
 #define JP_LEVELS list(JP_HIGH, JP_MEDIUM, JP_LOW)

--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -47,4 +47,4 @@
 #define JP_LOW 1
 #define JP_MEDIUM 2
 #define JP_HIGH 3
-#define JP_LEVELS list(JP_LOW, JP_MEDIUM, JP_HIGH)
+#define JP_LEVELS list(JP_HIGH, JP_MEDIUM, JP_LOW)

--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -273,7 +273,7 @@ var/datum/subsystem/job/SSjob
 	//People who wants to be assistants, sure, go on.
 	Debug("DO, Running Assistant Check 1")
 	var/datum/job/assist = new /datum/job/assistant()
-	var/list/assistant_candidates = FindOccupationCandidates(assist, 3)
+	var/list/assistant_candidates = FindOccupationCandidates(assist, JP_LOW)
 	Debug("AC1, Candidates: [assistant_candidates.len]")
 	for(var/mob/dead/new_player/player in assistant_candidates)
 		Debug("AC1 pass, Player: [player]")


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений

fixes #5284

Предпочитались префы с низким приоритетом, над теми которые с высоким. Больше не так.

## Почему и что этот ПР улучшит

Чинит баг

## Чеинжлог
:cl: Luduk
- bugfix: Корректно выбираются профы из префов