### PR TITLE
Component tips

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -46,6 +46,9 @@
 #define COMSIG_PARENT_ATTACKBY "atom_attackby"			        ///from base of atom/attackby(): (/obj/item, /mob/living, params)
 	#define COMPONENT_NO_AFTERATTACK 1								//Return this in response if you don't want afterattack to be called
 
+#define COMSIG_PARENT_EXAMINE "atom_examine"                               ///from base of atom/examine(): (/mob)
+#define COMSIG_PARENT_POST_EXAMINE "atom_post_examine"                     ///from base of mob/examinate(): (/mob)
+
 // /atom/movable signals
 #define COMSIG_MOVABLE_PRE_MOVE "movable_pre_move"					///from base of atom/movable/Move(): (/atom/newLoc)
 	#define COMPONENT_MOVABLE_BLOCK_PRE_MOVE 1
@@ -83,3 +86,6 @@
 #define COMSIG_XENO_TURF_CLICK_SHIFT "xeno_turf_click_shift"				//from turf ShiftClickOn(): (/mob)
 #define COMSIG_XENO_TURF_CLICK_CTRL "xeno_turf_click_alt"					//from turf AltClickOn(): (/mob)
 #define COMSIG_XENO_MONKEY_CLICK_CTRL "xeno_monkey_click_ctrl"				//from monkey CtrlClickOn(): (/mob)
+
+// Component specific signals.
+#define COMSIG_TIPS_REMOVE "comsig_tip_remove"		// send this signal to remove a list of tip ids(use tip_names as tip ids): (/list/tip_ids_to_remove)

--- a/code/datums/components/bound.dm
+++ b/code/datums/components/bound.dm
@@ -1,3 +1,21 @@
+#define BOUNDED_TIP "Bounded"
+#define BOUNDS_TIP(B) "Bounds [B.parent]"
+
+/datum/mechanic_tip/bounded
+	tip_name = BOUNDED_TIP
+
+/datum/mechanic_tip/bounded/New(datum/component/bounded/B)
+	description = "Appears to not be able to get too far away from [B.bound_to]."
+
+/datum/mechanic_tip/bound
+	tip_name = "Bound"
+
+/datum/mechanic_tip/bound/New(datum/component/B)
+	tip_name = BOUNDS_TIP(B)
+	description = "Appears to not allow [B.parent] to get too far away from itself."
+
+
+
 // A component you put on things you want to be bounded to other things.
 // Warning! Can only be bounded to one thing at once.
 /datum/component/bounded
@@ -22,12 +40,23 @@
 	RegisterSignal(parent, list(COMSIG_MOVABLE_MOVED), .proc/check_bounds)
 	RegisterSignal(parent, list(COMSIG_MOVABLE_PRE_MOVE), .proc/on_try_move)
 
+	var/datum/mechanic_tip/bounded/bounded_tip = new(src)
+	var/datum/mechanic_tip/bound/bound_tip = new(src)
+
+	parent.AddComponent(/datum/component/mechanic_desc, list(bounded_tip))
+	bound_to.AddComponent(/datum/component/mechanic_desc, list(bound_tip))
+
 	// First bounds update.
 	check_bounds()
 
-/datum/component/bounded/_RemoveFromParent()
+/datum/component/bounded/Destroy()
 	UnregisterSignal(bound_to, list(COMSIG_MOVABLE_MOVED, COMSIG_MOVABLE_LOC_MOVED))
+
+	SEND_SIGNAL(parent, COMSIG_TIPS_REMOVE, list(BOUNDED_TIP))
+	SEND_SIGNAL(bound_to, COMSIG_TIPS_REMOVE, list(BOUNDS_TIP(src)))
+
 	bound_to = null
+	return ..()
 
 // This proc is called when we are for some reason out of bounds.
 // The default bounds resolution does not take in count density, or etc.
@@ -113,3 +142,6 @@
 /datum/component/bounded/proc/on_bound_destroyed(force, qdel_hint)
 	// Perhaps add an abilities to resolve this situation with a callback? ~Luduk
 	qdel(src)
+
+#undef BOUNDED_TIP
+#undef BOUNDS_TIP

--- a/code/datums/components/clickplace.dm
+++ b/code/datums/components/clickplace.dm
@@ -1,3 +1,11 @@
+#define CLICKPLACE_TIP "Clickplace"
+
+/datum/mechanic_tip/clickplace
+	tip_name = CLICKPLACE_TIP
+
+/datum/mechanic_tip/clickplace/New()
+	description = "Clicking on this object with any intent selected except [I_HURT] will cause the item in currently selected hand to be placed onto it."
+
 /*
  * This component allows items to be placed on other items
  * in "precise" click coordinates with just a simple click!
@@ -22,6 +30,13 @@
 	on_place = _on_place
 
 	RegisterSignal(parent, list(COMSIG_PARENT_ATTACKBY), .proc/try_place)
+
+	var/datum/mechanic_tip/clickplace/clickplace_tip = new
+	parent.AddComponent(/datum/component/mechanic_desc, list(clickplace_tip))
+
+/datum/component/clickplace/Destroy()
+	SEND_SIGNAL(parent, COMSIG_TIPS_REMOVE, list(CLICKPLACE_TIP))
+	return ..()
 
 /datum/component/clickplace/proc/try_place(datum/source, obj/item/I, mob/user, params)
 	if(user.a_intent == I_HURT)
@@ -53,3 +68,5 @@
 
 	// Prevent hitting the thing if we're just putting it.
 	return COMPONENT_NO_AFTERATTACK
+
+#undef CLICKPLACE_TIP

--- a/code/datums/components/mechanic_description.dm
+++ b/code/datums/components/mechanic_description.dm
@@ -1,0 +1,74 @@
+/datum/mechanic_tip
+	// The name of the tip to display.
+	var/tip_name
+	// The description embedded in the tiip.
+	var/description
+
+	// Whether the tip should be re-generated on each examine.
+	var/dyn_generation = FALSE
+
+	// This var is generated if dyn_generation = FALSE
+	var/tip_cache
+
+/datum/mechanic_tip/proc/get_tip(mob/inspector, atom/inspected)
+	if(dyn_generation)
+		return generate_tip(inspector, inspected)
+
+	if(tip_cache)
+		return tip_cache
+
+	tip_cache = generate_tip(inspector, inspected)
+	return tip_cache
+
+/datum/mechanic_tip/proc/generate_tip(mob/inspector, atom/inspected)
+	return "<i>[tip_name]:</i>" + EMBED_TIP("•••", get_description(inspector, inspected))
+
+/datum/mechanic_tip/proc/get_description(mob/inspector, atom/inspected)
+	return description
+
+
+
+/datum/component/mechanic_desc
+	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
+
+	var/datum/tip_handler
+	var/list/datum/mechanic_tip/tips
+
+/datum/component/mechanic_desc/Initialize(list/datum/mechanic_tip/tips_to_add)
+	if(!istype(parent, /atom))
+		return COMPONENT_INCOMPATIBLE
+
+	for(var/datum/mechanic_tip/tip in tips_to_add)
+		add_tip(tip)
+
+	RegisterSignal(parent, list(COMSIG_PARENT_POST_EXAMINE), .proc/show_tips)
+	RegisterSignal(parent, list(COMSIG_TIPS_REMOVE), .proc/remove_tips)
+
+/datum/component/mechanic_desc/InheritComponent(datum/component/mechanic_desc/C, i_am_original, list/datum/mechanic_tip/tips_to_add)
+	for(var/datum/mechanic_tip/tip in tips_to_add)
+		add_tip(tip)
+
+/datum/component/mechanic_desc/Destroy()
+	QDEL_LIST_ASSOC_VAL(tips)
+	return ..()
+
+/datum/component/mechanic_desc/proc/add_tip(datum/mechanic_tip/tip)
+	LAZYSET(tips, tip.tip_name, tip)
+
+/datum/component/mechanic_desc/proc/remove_tip(tip_name)
+	qdel(tips[tip_name])
+	tips -= tip_name
+	UNSETEMPTY(tips)
+	if(!tips)
+		qdel(src)
+
+/datum/component/mechanic_desc/proc/remove_tips(list/tip_ids_to_remove)
+	for(var/tip_name in tip_ids_to_remove)
+		if(QDELING(src))
+			return
+		remove_tip(tip_name)
+
+/datum/component/mechanic_desc/proc/show_tips(datum/source, mob/user)
+	for(var/tip_name in tips)
+		var/datum/mechanic_tip/tip = tips[tip_name]
+		to_chat(user, tip.get_tip(user, source))

--- a/code/datums/components/multi_carry.dm
+++ b/code/datums/components/multi_carry.dm
@@ -114,6 +114,25 @@
 			list("px"=15, "py"=6, "layer"=MOB_LAYER),
 		)
 
+#define MULTI_CARRY_TIP "Carry"
+
+/datum/mechanic_tip/multi_carry
+	tip_name = MULTI_CARRY_TIP
+
+/datum/mechanic_tip/multi_carry/New(datum/component/multi_carry/MC)
+	var/positions_desc = ""
+	var/dances_desc = ""
+
+	var/datum/carry_positions/CP = MC.positions
+	positions_desc = "Carry requires [CP.pos_count] people to pull on [MC.carry_obj] simultaneously. "
+
+	if(MC.dance_moves)
+		dances_desc = "There are several \"moves\" that can be performed, if appropriate conditions are met."
+
+	description = "This object appears to be carriable. [positions_desc][dances_desc]"
+
+
+
 // A component you put on things you want to be bounded to other things.
 // Warning! Can only be bounded to one thing at once.
 /datum/component/multi_carry
@@ -158,12 +177,18 @@
 	RegisterSignal(carry_obj, list(COMSIG_ATOM_START_PULL), .proc/carrier_join)
 	RegisterSignal(carry_obj, list(COMSIG_ATOM_STOP_PULL), .proc/carrier_leave)
 
-/datum/component/multi_carry/_RemoveFromParent()
+	var/datum/mechanic_tip/clickplace/carry_tip = new(src)
+	parent.AddComponent(/datum/component/mechanic_desc, list(carry_tip))
+
+/datum/component/multi_carry/Destroy()
 	if(carried)
 		stop_carry()
 	carry_obj = null
 	QDEL_NULL(positions)
 	QDEL_LIST_ASSOC_VAL(dance_moves)
+
+	SEND_SIGNAL(parent, COMSIG_TIPS_REMOVE, list(MULTI_CARRY_TIP))
+	return ..()
 
 // Whether the carry structure can indeed move.
 /datum/component/multi_carry/proc/can_carry_move()
@@ -509,3 +534,5 @@
 #undef DANCE_MOVE_CARRYWADDLE
 #undef DANCE_MOVE_ROTATE
 #undef DANCE_MOVE_SWAP
+
+#undef MULTI_CARRY_TIP

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -18,7 +18,7 @@
 	RegisterSignal(parent, list(COMSIG_MOVABLE_CROSSED, COMSIG_ATOM_ENTERED), .proc/Slip)
 
 	var/datum/mechanic_tip/slippery/slip_tip = new
-	AddComponent(/datum/component/mechanic_desc, list(slip_tip))
+	parent.AddComponent(/datum/component/mechanic_desc, list(slip_tip))
 
 /datum/component/slippery/Destroy()
 	SEND_SIGNAL(parent, COMSIG_TIPS_REMOVE, list(SLIPPERY_TIP))
@@ -29,4 +29,4 @@
 	if(istype(victim) && victim.slip(weaken_time, parent, lube_flags) && callback)
 		callback.Invoke(victim)
 
-#undef SLIPPER_TIP
+#undef SLIPPERY_TIP

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -1,3 +1,11 @@
+#define SLIPPERY_TIP "Slippery"
+
+/datum/mechanic_tip/slippery
+	tip_name = SLIPPERY_TIP
+	description = "This object will cause you to slip up if stepped on."
+
+
+
 /datum/component/slippery
 	var/weaken_time = 0
 	var/lube_flags
@@ -9,7 +17,16 @@
 	callback = _callback
 	RegisterSignal(parent, list(COMSIG_MOVABLE_CROSSED, COMSIG_ATOM_ENTERED), .proc/Slip)
 
+	var/datum/mechanic_tip/slippery/slip_tip = new
+	AddComponent(/datum/component/mechanic_desc, list(slip_tip))
+
+/datum/component/slippery/Destroy()
+	SEND_SIGNAL(parent, COMSIG_TIPS_REMOVE, list(SLIPPERY_TIP))
+	return ..()
+
 /datum/component/slippery/proc/Slip(datum/source, atom/movable/AM)
 	var/mob/victim = AM
 	if(istype(victim) && victim.slip(weaken_time, parent, lube_flags) && callback)
 		callback.Invoke(victim)
+
+#undef SLIPPER_TIP

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -239,6 +239,7 @@
 		else
 			to_chat(user, "Nothing.")
 
+	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, user)
 	return distance == -1 || isobserver(user) || (get_dist(src, user) <= distance)
 
 /atom/proc/dirt_description()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -305,6 +305,7 @@
 
 	face_atom(A)
 	A.examine(src)
+	SEND_SIGNAL(A, COMSIG_PARENT_POST_EXAMINE, src)
 
 /mob/verb/pointed(atom/A as mob|obj|turf in oview())
 	set name = "Point To"

--- a/taucetistation.dme
+++ b/taucetistation.dme
@@ -210,6 +210,7 @@
 #include "code\datums\components\bound.dm"
 #include "code\datums\components\clickplace.dm"
 #include "code\datums\components\footstep.dm"
+#include "code\datums\components\mechanic_description.dm"
 #include "code\datums\components\multi_carry.dm"
 #include "code\datums\components\slippery.dm"
 #include "code\datums\components\waddle.dm"


### PR DESCRIPTION
## Описание изменений

Добавил компонентам которым имеет смысл подсказку в чатик о том что этот предмет каким-то образом особенный, выглядит это примерно так:

![image](https://user-images.githubusercontent.com/17705613/81862291-28b54480-9572-11ea-828e-bc3f2e3d889e.png)

![image](https://user-images.githubusercontent.com/17705613/81862712-c577e200-9572-11ea-8a1f-35d23e5d2a68.png)

## Почему и что этот ПР улучшит

Игрок получает чуть больше информации об игровой среде.

## Чеинжлог
:cl: Luduk
- rscadd: Подсказки для вещей которые "привязаны" к другим вещам, для столов, полок, и скольких предметов.