### PR TITLE
фороновое стекло в печку

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -62,6 +62,25 @@
 	else
 		return ..()
 
+/obj/item/stack/sheet/glass/phoronglass/attackby(obj/item/W, mob/user)
+	if(istype(W, /obj/item/stack/rods))
+		var/list/resources_to_use = list()
+		resources_to_use[W] = 1
+		resources_to_use[src] = 1
+		if(!use_multi(user, resources_to_use))
+			return
+
+		var/obj/item/stack/sheet/glass/phoronrglass/FG = new (user.loc)
+		FG.add_fingerprint(user)
+		for(var/obj/item/stack/sheet/glass/phoronrglass/G in user.loc)
+			if(G == FG)
+				continue
+			if(G.get_amount() >= G.max_amount)
+				continue
+			G.attackby(FG, user)
+	else
+		return ..()
+
 /obj/item/stack/sheet/glass/proc/construct_window(mob/user)
 	if(!user || !src)
 		return 0

--- a/code/modules/mining/alloys.dm
+++ b/code/modules/mining/alloys.dm
@@ -28,3 +28,12 @@
 		)
 	product = /obj/item/stack/sheet/metal
 	points = 5
+
+/datum/alloy/phoron_glass
+	metaltag = "phoron glass"
+	requires = list(
+		"phoron" = 1,
+		"sand" = 1
+		)
+	product = /obj/item/stack/sheet/glass/phoronglass
+	points = 25

--- a/code/modules/mining/machine_processing.dm
+++ b/code/modules/mining/machine_processing.dm
@@ -16,17 +16,19 @@
 
 	var/show_value_list = 0
 	var/list/ore_values = list(
-							"glass" = 	1,
-							"iron" = 	1,
-							"coal" = 	1,
-							"steel" =	5,
-							"hydrogen"=	10,
-							"uranium" = 20,
-							"silver" = 	25,
-							"gold" = 	30,
-							"platinum"= 45,
-							"plasteel"= 50,
-							"diamond" = 70)
+							"glass" 			= 1,
+							"iron" 				= 1,
+							"coal" 				= 1,
+							"steel" 			= 5,
+							"hydrogen"			= 10,
+							"uranium" 			= 20,
+							"phoron" 			= 20,
+							"phoron glass"		= 25,
+							"silver" 			= 25,
+							"gold" 				= 30,
+							"platinum"			= 45,
+							"plasteel"			= 50,
+							"diamond" 			= 70)
 
 /obj/machinery/mineral/processing_unit_console/atom_init()
 	..()

--- a/code/modules/mining/machine_stacking.dm
+++ b/code/modules/mining/machine_stacking.dm
@@ -80,6 +80,8 @@
 	stack_paths["metal"] = /obj/item/stack/sheet/metal
 	stack_storage["plasteel"] = 0
 	stack_paths["plasteel"] = /obj/item/stack/sheet/plasteel
+	stack_storage["phoron glass"] = 0
+	stack_paths["phoron glass"] = /obj/item/stack/sheet/glass/phoronglass
 	return INITIALIZE_HINT_LATELOAD
 
 /obj/machinery/mineral/stacking_machine/atom_init_late()

--- a/code/modules/mining/ore_datum.dm
+++ b/code/modules/mining/ore_datum.dm
@@ -30,12 +30,14 @@
 	start = /obj/item/weapon/ore/glass
 	smelts_to = /obj/item/stack/sheet/glass
 	compresses_to = /obj/item/stack/sheet/mineral/sandstone
+	alloy = 1
 	oretag = "sand"
 	points = 1
 
 /datum/ore/phoron
 	start = /obj/item/weapon/ore/phoron
 	compresses_to = /obj/item/stack/sheet/mineral/phoron
+	alloy = 1
 	oretag = "phoron"
 	points = 20
 


### PR DESCRIPTION
Теперь можно легально получить фороновое стекло через сплав 1 руды форона и 1 стекла(песка), так же добавил сам форон и фороновое стекло в панельку для просмотра их стоимости поинтов, раньше их, почему то не было.
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Добавлено фороновое стекло, вот так оно выглядит, если кто не знал или забыл, а его сплав начисляет 25 шахтёрских поинтов.
![dreamseeker_K76E91pMjQ](https://user-images.githubusercontent.com/43725089/82024483-8348c080-9698-11ea-9253-393c5810d7b2.png)

## Почему и что этот ПР улучшит
Больше разнообразия в серой жизни!
## Авторство

## Чеинжлог
🆑 
- tweak: добавлено фороновое стекло. Можно получить путём сплава 1 руды форона и 1 песка.
- bugfix: Фороновое стекло теперь нормально укрепляется, а не превращается в обычное укреплённое стекло.