### PR TITLE
Спаун позиция бэкап блекбокса

### DIFF
--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -203,7 +203,8 @@ var/obj/machinery/blackbox_recorder/blackbox
 	blackbox = src
 
 /obj/machinery/blackbox_recorder/Destroy()
-	var/turf/T = locate(1,1,2)
+	var/centcom_z = SSmapping.level_by_trait(ZTRAIT_CENTCOM)
+	var/turf/T = locate(1,1, centcom_z)
 	if(T)
 		blackbox = null
 		var/obj/machinery/blackbox_recorder/BR = new/obj/machinery/blackbox_recorder(T)


### PR DESCRIPTION
## Описание изменений
Насколько я понял планировалось спаунить его на карте ЦК, но после #3640 z координата ЦК слоя изменилась. Не то, чтобы это многое меняло, но теперь блэкбокс после дестроя появится там, где и планировалось.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
