### PR TITLE
adjacency and incapacitation checks for altclick macro

### DIFF
--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -415,7 +415,11 @@
 		photo_size = 1
 		to_chat(usr, "<span class='info'>You set the camera zoom to small.</span>")
 
-/obj/item/device/camera/AltClick()
+/obj/item/device/camera/AltClick(mob/user)
+	if(!Adjacent(user))
+		return
+	if(user.incapacitated())
+		return
 	set_zoom()
 
 /obj/item/device/camera/big_photos

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -118,6 +118,10 @@
 	select_fire(usr)
 
 /obj/item/weapon/gun/energy/AltClick(mob/user)
+	if(!Adjacent(user))
+		return
+	if(user.incapacitated())
+		return
 	select_fire(user)
 
 /obj/item/weapon/gun/energy/attack_self(mob/living/user)

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -13,6 +13,10 @@
 	var/possible_transfer_amounts = list(10,25,50,100)
 
 /obj/structure/reagent_dispensers/AltClick(mob/user)
+	if(!Adjacent(user))
+		return
+	if(user.incapacitated())
+		return
 	transfer_from = !transfer_from
 	to_chat(user, "<span class = 'notice'>You transfer [transfer_from ? "from" : "into"] [src]</span>")
 
@@ -210,7 +214,7 @@
 	desc = "A fueltank."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "weldtank"
-	
+
 /obj/structure/reagent_dispensers/fueltank/atom_init()
 	. = ..()
 	reagents.add_reagent("fuel",300)


### PR DESCRIPTION
## Описание изменений

Еган, камеру, и контейнер реагентов нельзя переключать альткликом издалека.

## Почему и что этот ПР улучшит

fixes #5059

## Чеинжлог
:cl: Luduk
- bugfix: Нельзя переключать еган, камеру, и контейнеры реагентов издалека альткликом.