### PR TITLE
fixing charge-teleport through doors via charge

### DIFF
--- a/code/modules/unarmed_combat/combos/combos.dm
+++ b/code/modules/unarmed_combat/combos/combos.dm
@@ -726,7 +726,7 @@
 							continue
 
 						var/obj/structure/table/facetable = locate() in T
-						if(facetable)
+						if(facetable && facetable.Adjacent(attacker))
 							facetable.attackby(victim_G, attacker)
 							playsound(victim, 'sound/weapons/thudswoosh.ogg', VOL_EFFECTS_MASTER)
 							victim.visible_message("<span class='danger'>[attacker] slams [victim] into an obstacle!</span>")


### PR DESCRIPTION
## Описание изменений

fixes #5342 

## Чеинжлог
:cl: Luduk
- bugfix: Телепортация через стеклянные дверки и стёкла на стол используя Charge комбо невозможна.