### PR TITLE
light aspect fixes, holy turf rebalance

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -22,7 +22,7 @@
 #define COMSIG_PARENT_QDELETED "parent_qdeleted"
 
 // light related signals
-/// from base of /atom/movable/lighting_object/update(): ()
+/// from base of /atom/movable/lighting_object/update(): (turf/my_turf)
 #define COMSIG_LIGHT_UPDATE_OBJECT "light_update_object"
 
 // /datum/reagent signals

--- a/code/modules/lighting/lighting_object.dm
+++ b/code/modules/lighting/lighting_object.dm
@@ -127,7 +127,7 @@
 
 	luminosity = set_luminosity
 
-	SEND_SIGNAL(src, COMSIG_LIGHT_UPDATE_OBJECT)
+	SEND_SIGNAL(src, COMSIG_LIGHT_UPDATE_OBJECT, myturf)
 
 // Variety of overrides so the overlays don't get affected by weird things.
 

--- a/code/modules/religion/aspect.dm
+++ b/code/modules/religion/aspect.dm
@@ -255,7 +255,7 @@
 	desc = "Dark, darkness, obcurse, evil"
 
 /datum/aspect/lightbending/darkness/get_light_gain(turf/simulated/floor/F)
-	return (0.5 - F.get_lumcount()) * power * 0.05
+	return (0.7 - F.get_lumcount()) * power * 0.05
 
 //Gives mana from: light levels on holy turfs
 //Needed for: spells and rituals related to the theme of receiving light
@@ -264,7 +264,7 @@
 	desc = "Light interaction"
 
 /datum/aspect/lightbending/light/get_light_gain(turf/simulated/floor/F)
-	return (F.get_lumcount() - 0.5) * power * 0.03
+	return (F.get_lumcount() - 0.3) * power * 0.03
 
 //Gives mana for economical cost of an item.
 //Needed for: anything economy related

--- a/code/modules/religion/aspect.dm
+++ b/code/modules/religion/aspect.dm
@@ -217,7 +217,7 @@
 /datum/aspect/lightbending/register_holy_turf(turf/simulated/floor/F, datum/religion/R)
 	..()
 	RegisterSignal(F.lighting_object, list(COMSIG_LIGHT_UPDATE_OBJECT), .proc/recalc_favor_gain)
-	recalc_favor_gain(F)
+	recalc_favor_gain(F.lighting_object, F)
 
 /datum/aspect/lightbending/unregister_holy_turf(turf/simulated/floor/F, datum/religion/R)
 	..()
@@ -230,8 +230,10 @@
 /datum/aspect/lightbending/proc/get_light_gain(turf/simulated/floor/F)
 	return 0.0
 
-/datum/aspect/lightbending/proc/recalc_favor_gain(datum/source)
-	var/turf/simulated/floor/F = source
+/datum/aspect/lightbending/proc/recalc_favor_gain(datum/source, turf/myturf)
+	var/turf/simulated/floor/F = myturf
+	if(!istype(F))
+		return
 
 	var/prev_gain = 0.0
 	if(favor_for_turf)
@@ -253,7 +255,7 @@
 	desc = "Dark, darkness, obcurse, evil"
 
 /datum/aspect/lightbending/darkness/get_light_gain(turf/simulated/floor/F)
-	return (1.0 - F.get_lumcount()) * power * 0.05
+	return (0.5 - F.get_lumcount()) * power * 0.05
 
 //Gives mana from: light levels on holy turfs
 //Needed for: spells and rituals related to the theme of receiving light
@@ -262,7 +264,7 @@
 	desc = "Light interaction"
 
 /datum/aspect/lightbending/light/get_light_gain(turf/simulated/floor/F)
-	return F.get_lumcount() * power * 0.05
+	return (F.get_lumcount() - 0.5) * power * 0.03
 
 //Gives mana for economical cost of an item.
 //Needed for: anything economy related

--- a/code/modules/religion/holy_turf.dm
+++ b/code/modules/religion/holy_turf.dm
@@ -7,7 +7,7 @@
 	var/timer_id
 	var/expiration_time
 
-	var/max_time = 10 MINUTES
+	var/max_time = 15 MINUTES
 
 /datum/holy_turf/New(turf/simulated/floor/F, datum/religion/R, reagent_volume)
 	turf = F

--- a/code/modules/religion/holy_turf.dm
+++ b/code/modules/religion/holy_turf.dm
@@ -7,6 +7,8 @@
 	var/timer_id
 	var/expiration_time
 
+	var/max_time = 10 MINUTES
+
 /datum/holy_turf/New(turf/simulated/floor/F, datum/religion/R, reagent_volume)
 	turf = F
 	religion = R
@@ -24,6 +26,7 @@
 	religion.holy_turfs[turf] = src
 
 	var/time_to_expire = reagent_volume * 1 MINUTE
+	time_to_expire = min(time_to_expire, max_time)
 
 	expiration_time = world.time + time_to_expire
 
@@ -53,5 +56,6 @@
 
 /datum/holy_turf/proc/update(reagent_volume)
 	var/time_to_expire = expiration_time - world.time + reagent_volume * 1 MINUTE
+	time_to_expire = min(time_to_expire, max_time)
 	deltimer(timer_id)
 	timer_id = create_timer(time_to_expire)

--- a/code/modules/religion/religion.dm
+++ b/code/modules/religion/religion.dm
@@ -141,7 +141,7 @@
 		STOP_PROCESSING(SSreligion, src)
 		return
 
-	favor += passive_favor_gain
+	adjust_favor(passive_favor_gain)
 
 /datum/religion/proc/reset_religion()
 	lore = initial(lore)
@@ -189,7 +189,7 @@
 
 	deity_names = deity_names_by_name[name]
 	if(!deity_names)
-		world.log << "ERROR IN SETTING UP RELIGION: [name] HAS NO DEITIES WHATSOVER. HAVE YOU SET UP RELIGIONS CORRECTLY?"
+		warning("ERROR IN SETTING UP RELIGION: [name] HAS NO DEITIES WHATSOVER. HAVE YOU SET UP RELIGIONS CORRECTLY?")
 		deity_names = list("Error")
 
 	gen_bible_info()


### PR DESCRIPTION
##  Описание изменений

-  Если ты получаешь очки за свет, а на турфе темно - ты теряешь очки.
- Ты получаешь меньше очков за свет чем за тьму, так как свет поддерживать проще.
- Священная земля может максимум существовать 15 минут на одном тайле если её не поливать заново.

## Чеинжлог
:cl: Luduk
- balance: Если твой аспект даёт благосклонность за свет на турфе, а на турфе темно - ты теряешь благосклонность.
- balance: Lux даёт меньше благосклонности чем Obscurum за свет на тайлах, так как поддерживать свет проще, чем тьму.
- balance: Священная земля может существовать на одном тайле максимум 15 минут если её не "обновлять".