### PR TITLE
Drinks runtime

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -28,11 +28,7 @@
 	SSdemo.mark_dirty(user)
 
 /mob/living/attackby(obj/item/I, mob/user, params)
-	if(!istype(I) || !ismob(user))
-		return
 	user.SetNextMove(CLICK_CD_MELEE)
-
-	I.attack(src, user, user.get_targetzone())
 
 	if(ishuman(user))	//When abductor will hit someone from stelth he will reveal himself
 		var/mob/living/carbon/human/H = user
@@ -45,9 +41,11 @@
 		if(istype(H.wear_suit, /obj/item/clothing/suit))
 			var/obj/item/clothing/suit/V = H.wear_suit
 			V.attack_reaction(src, REACTION_ATACKED, user)
+
 	SSdemo.mark_dirty(src)
 	SSdemo.mark_dirty(I)
 	SSdemo.mark_dirty(user)
+	return I.attack(src, user, user.get_targetzone())
 
 // Proximity_flag is 1 if this afterattack was called on something adjacent, in your square, or on your person.
 // Click parameters is the params string from byond Click() code, see that documentation.

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -705,9 +705,6 @@ var/list/airlock_overlays = list()
 	if(wires.interact(user))
 		return
 	else
-		if(isElectrified() && !issilicon(user) && !isobserver(user))
-			if(shock(user, 100))
-				return
 		if(HULK in user.mutations)
 			hulk_break_reaction(user)
 			return
@@ -915,8 +912,13 @@ var/list/airlock_overlays = list()
 	if(!no_window)
 		updateUsrDialog()
 
-/obj/machinery/door/airlock/attackby(obj/item/C, mob/user)
+/obj/machinery/door/airlock/try_open(mob/user, obj/item/tool = null)
+	if(isElectrified() && !issilicon(user) && !isobserver(user))
+		if(shock(user, tool ? 75 : 100))
+			return
+	..()
 
+/obj/machinery/door/airlock/attackby(obj/item/C, mob/user)
 	if(istype(C,/obj/item/weapon/changeling_hammer) && !operating && density) // yeah, hammer ignore electrify
 		var/obj/item/weapon/changeling_hammer/W = C
 		user.do_attack_animation(src)
@@ -928,14 +930,8 @@ var/list/airlock_overlays = list()
 			door_rupture(user)
 		return
 
-	if(!(issilicon(user) || isobserver(user)))
-		if(isElectrified())
-			if(shock(user, 75))
-				return
 	if(istype(C, /obj/item/device/detective_scanner) || istype(C, /obj/item/taperoll))
 		return
-
-	add_fingerprint(user)
 
 	if(iswelder(C) && !(operating > 0) && density)
 		var/obj/item/weapon/weldingtool/W = C
@@ -1028,8 +1024,7 @@ var/list/airlock_overlays = list()
 	else if(istype(C, /obj/item/weapon/airlock_painter)) 		//airlock painter
 		change_paintjob(C, user)
 	else
-		..()
-	return
+		return ..()
 
 /obj/machinery/door/airlock/phoron/attackby(obj/item/I, mob/user)
 	ignite(I.get_current_temperature())

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -688,20 +688,6 @@ var/list/airlock_overlays = list()
 		close()
 
 /obj/machinery/door/airlock/attack_hand(mob/user)
-	if(ishuman(user) && prob(40) && density)
-		var/mob/living/carbon/human/H = user
-		if(H.getBrainLoss() >= 60)
-			playsound(src, 'sound/effects/bang.ogg', VOL_EFFECTS_MASTER, 25)
-			if(!istype(H.head, /obj/item/clothing/head/helmet))
-				visible_message("<span class='userdanger'> [user] headbutts the airlock.</span>")
-				var/obj/item/organ/external/BP = H.bodyparts_by_name[BP_HEAD]
-				H.Stun(8)
-				H.Weaken(5)
-				BP.take_damage(10, 0, used_weapon = "Hematoma")
-			else
-				visible_message("<span class='userdanger'> [user] headbutts the airlock. Good thing they're wearing a helmet.</span>")
-			return
-
 	if(wires.interact(user))
 		return
 	else

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -367,7 +367,7 @@
 	if(istype(C, /obj/item/weapon/airlock_painter))
 		to_chat(user, "<span class='red'>This airlock cannot be painted.</span>")
 	else
-		..()
+		return ..()
 
 
 /*******************

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -117,6 +117,20 @@
 	if(operating)
 		return
 
+	if(ishuman(user) && prob(40) && density)
+		var/mob/living/carbon/human/H = user
+		if(H.getBrainLoss() >= 60)
+			playsound(src, 'sound/effects/bang.ogg', VOL_EFFECTS_MASTER, 25)
+			if(!istype(H.head, /obj/item/clothing/head/helmet))
+				visible_message("<span class='userdanger'> [user] headbutts the [src].</span>")
+				var/obj/item/organ/external/BP = H.bodyparts_by_name[BP_HEAD]
+				H.Stun(8)
+				H.Weaken(5)
+				BP.take_damage(10, 0, used_weapon = "Hematoma")
+			else
+				visible_message("<span class='userdanger'> [user] headbutts the [src]. Good thing they're wearing a helmet.</span>")
+			return
+
 	add_fingerprint(user)
 	user.SetNextMove(CLICK_CD_INTERACT)
 	var/atom/check_access = user

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -113,8 +113,30 @@
 	src.open()
 	return
 
+/obj/machinery/door/proc/try_open(mob/user)
+	if(operating)
+		return
+
+	add_fingerprint(user)
+	user.SetNextMove(CLICK_CD_INTERACT)
+	var/atom/check_access = user
+	if(!Adjacent(user))
+		check_access = null
+	if(!requiresID())
+		check_access = null
+
+	if(allowed(check_access) || emergency)
+		if(density)
+			open()
+		else
+			close()
+		return
+
+	if(density)
+		do_animate("deny")
+
 /obj/machinery/door/attack_hand(mob/user)
-	return attackby(user, user)
+	try_open(user)
 
 /obj/machinery/door/attack_tk(mob/user)
 	if(requiresID() && !allowed(null))
@@ -142,21 +164,7 @@
 		return 1
 	if(isrobot(user))
 		return //borgs can't attack doors open because it conflicts with their AI-like interaction with them.
-	if(!Adjacent(user))
-		user = null
-	if(!src.requiresID())
-		user = null
-	if(user)
-		user.SetNextMove(CLICK_CD_INTERACT)
-	if(src.allowed(user) || emergency)
-		if(src.density)
-			open()
-		else
-			close()
-		return
-	if(src.density)
-		do_animate("deny")
-	return
+	try_open(user, I)
 
 /obj/machinery/door/emag_act(mob/user)
 	if(src.density && hasPower())

--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -15,8 +15,7 @@
 		return
 	if(locked)
 		return
-	..()
-	return
+	return ..()
 
 /obj/machinery/door/unpowered/emag_act(mob/user)
 	return FALSE

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -366,21 +366,7 @@
 			take_damage(aforce)
 		return
 
-	src.add_fingerprint(user)
-	if (!src.requiresID())
-		//don't care who they are or what they have, act as if they're NOTHING
-		user = null
-
-	if (src.allowed(user))
-		if (src.density)
-			open()
-		else
-			close()
-
-	else if (src.density)
-		do_animate("deny")
-
-	return
+	try_open(user)
 
 /obj/machinery/door/window/emag_act(mob/user)
 	if(density)

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -82,7 +82,8 @@
 
 
 /obj/item/weapon/reagent_containers/food/drinks/afterattack(atom/target, mob/user, proximity, params)
-	if(!proximity) return
+	if(!proximity)
+		return
 
 	if (!is_open_container())
 		to_chat(user, "<span class='notice'>You need to open [src]!</span>")

--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -163,7 +163,8 @@
 	//Finally, smash the bottle. This kills (del) the bottle.
 	src.smash(target, user)
 
-	return
+	// We're smashing the bottle into mob's face. There's no need for an afterattack.
+	return TRUE
 
 /obj/item/weapon/reagent_containers/food/drinks/bottle/after_throw(datum/callback/callback)
 	..()


### PR DESCRIPTION
## Описание изменений

Фиксит рантайм с разбиванием бутылки об чужую голову.

Из-за того что я решил пойти "хорошим" путём, и возвращать значение из attack() чтобы подавлять аттак бай, я переделал attack. Из-за того что я убрал проверки-затычки(Чтобы знать где могут быть проблемы) я прошелся по билду в поисках мест где вызывается attackby() и куда может закрасться плохое значение. Увидел двери. Двери не вызывали родителя, но нарушали новую логику, поэтому их чутка переделал.

## Почему и что этот ПР улучшит

Исправит рантайм.

:cl: Luduk
- bugfix: Тычки предметом по шлюзу с брейдамагом заставляют испытывать эффекты брейндамага, а не открывать шлюз.