### PR TITLE
a fix for toys that delete themselves after time

### DIFF
--- a/code/modules/roguelike/mob_modifiers/positive.dm
+++ b/code/modules/roguelike/mob_modifiers/positive.dm
@@ -119,6 +119,9 @@
 	RegisterSignal(possessed, list(COMSIG_PARENT_QDELETED), .proc/on_phylactery_destroyed)
 	possessed.forceMove(H.loc)
 
+	if(QDELING(possessed) || !get_turf(possessed))
+		return FALSE
+
 	var/list/allowed_name_mods = list(
 		RL_GROUP_PREFIX = 2,
 		RL_GROUP_SUFFIX = 2,


### PR DESCRIPTION
## Описание изменений

Модификатор гостли мог создавать игрушку которые самоудаляются со временем, из-за чего могли вызывать рантайм.

## Почему и что этот ПР улучшит

Больше не будут.
