### PR TITLE
fixing a signal override on putting the jolly gravedigger shoes

### DIFF
--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -170,9 +170,10 @@
 
 /obj/item/clothing/shoes/jolly_gravedigger/equipped(mob/user, slot)
 	if(slot == SLOT_SHOES)
-		RegisterSignal(user, list(COMSIG_LIVING_START_PULL), .proc/check_coffin)
 		if(user.pulling)
 			check_coffin(user, user.pulling)
+		else
+			RegisterSignal(user, list(COMSIG_LIVING_START_PULL), .proc/check_coffin)
 	else if(waddling)
 		stop_waddling(user)
 


### PR DESCRIPTION
## Описание изменений

Надевание кому-то ботинок пока он пуллит ящик, или снимание пока не пуллит дважды подписывалось на один сигнал что вызывало к "рантайму"(стак-трейсу, предупреждению) о перезаписи сигнала.

## Почему и что этот ПР улучшит

Меньше сообщений в лог рантаймов.
