### PR TITLE
emagged robo-bodyparts go boom

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -333,7 +333,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			if(bodypart)
 				//Robotic limbs explode if sabotaged.
 				if(is_robotic() && !no_explode && sabotaged)
-					explosion(get_turf(owner), -1, -1, 2, 3)
+					explosion(get_turf(owner), 0, 0, 2, 3)
 					var/datum/effect/effect/system/spark_spread/spark_system = new
 					spark_system.set_up(5, 0, owner)
 					spark_system.attach(owner)


### PR DESCRIPTION
## Описание изменений

![image](https://user-images.githubusercontent.com/17705613/83364367-943c4600-a3a9-11ea-8392-0b7a1323d2fd.png)

Емаг робо-конечности с последующим её лишением заставляет её возрваться.

## Почему и что этот ПР улучшит

fixes #295 

## Чеинжлог
:cl: Luduk
- bugfix: Емагнутые робоконечности вновь взрываются при отрезании.