### PR TITLE
Fixing scientist spawn positions

### DIFF
--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -52,7 +52,7 @@
 	department_flag = MEDSCI
 	faction = "Station"
 	total_positions = 3
-	spawn_positions = 2
+	spawn_positions = 3
 	supervisors = "the research director"
 	selection_color = "#ffeeff"
 	idtype = /obj/item/weapon/card/id/sci


### PR DESCRIPTION
## Описание изменений

Там целых 6 маркеров спавна, так что проблем возникать не должно.

Ставлю корректное кол-во раундстарт ученых = 3. Столько же, сколько и ученых быть может всего.

## Почему и что этот ПР улучшит

fixes #2586

## Чеинжлог
:cl: Luduk
- bugfix: Кол-во ученых раундстартом такое же, как и максимальное кол-во ученых - три.