### PR TITLE
enviromental damage combos deal brute damage, dropkick fix

### DIFF
--- a/code/modules/unarmed_combat/combos/combos.dm
+++ b/code/modules/unarmed_combat/combos/combos.dm
@@ -620,10 +620,11 @@
 			var/cur_movers = list() + collected - list(victim)
 
 			var/atom/old_V_loc = victim.loc
+			var/turf/target_turf = get_step(get_turf(victim), dropkick_dir)
 			step(victim, dropkick_dir)
 
-			if(old_V_loc != victim.loc)
-				var/list/candidates = victim.loc.contents - list(victim)
+			if(old_V_loc == victim.loc)
+				var/list/candidates = target_turf.contents - list(victim)
 				new_movers:
 					for(var/mob/living/new_mover in candidates)
 						if(new_mover == attacker)

--- a/code/modules/unarmed_combat/combos/combos.dm
+++ b/code/modules/unarmed_combat/combos/combos.dm
@@ -365,6 +365,8 @@
 
 	heavy_animation = TRUE
 
+	force_dam_type = BRUTE
+
 /datum/combat_combo/suplex/animate_combo(mob/living/victim, mob/living/attacker)
 	if(!do_combo(victim, attacker, 3))
 		return
@@ -453,6 +455,8 @@
 	require_arm_to_perform = TRUE
 
 	heavy_animation = TRUE
+
+	force_dam_type = BRUTE
 
 /datum/combat_combo/diving_elbow_drop/animate_combo(mob/living/victim, mob/living/attacker)
 	if(!do_combo(victim, attacker, 3))
@@ -681,6 +685,8 @@
 
 	heavy_animation = TRUE
 
+	force_dam_type = BRUTE
+
 /datum/combat_combo/charge/animate_combo(mob/living/victim, mob/living/attacker)
 	if(!do_combo(victim, attacker, 3))
 		return
@@ -767,6 +773,8 @@
 	allowed_target_zones = list(BP_CHEST)
 
 	heavy_animation = TRUE
+
+	force_dam_type = BRUTE
 
 /datum/combat_combo/spin_throw/animate_combo(mob/living/victim, mob/living/attacker)
 	if(!do_combo(victim, attacker, 3))


### PR DESCRIPTION
## Описание изменений

Комбо предполагающие урон от окружения - саплекс, чардж, спин энд троу, дайвинг елбоу панч не зависят от типа урона с руки куклы, а наносят брут урон.

Дропкик опрокидывает всех мобов стоящих за целью.

## Почему и что этот ПР улучшит

closes #5353 

## Чеинжлог
:cl: Luduk
- tweak: Комбо предполагающие урон от окружения - саплекс, чардж, спин энд троу, дайвинг елбоу панч не зависят от типа урона с руки куклы, а наносят брут урон.
- bugfix: Дропкик опрокпидывает всех мобов стоящих за "жертвой" дропкика.