### PR TITLE
Fixing items in coffins

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/coffin.dm
+++ b/code/game/objects/structures/crates_lockers/closets/coffin.dm
@@ -63,6 +63,8 @@
 		buckle_mob(M)
 		M.instant_vision_update(0)
 
+	..()
+
 /obj/structure/closet/coffin/collect_contents()
 	for(var/mob/M in loc)
 		if(M == buckled_mob)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -493,7 +493,7 @@ var/list/slot_equipment_priority = list(
 		return ..()
 
 /mob/proc/CanUseTopicInventory(mob/target)
-	if(is_busy() || !in_range(src, target) || isdrone(src) || incapacitated() || !Adjacent(target))
+	if(is_busy() || || isdrone(src) || incapacitated() || !isturf(target.loc) || !Adjacent(target))
 		return FALSE
 
 	if(ishuman(src) || isrobot(src) || ismonkey(src) || isIAN(src) || isxenoadult(src))

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -493,7 +493,7 @@ var/list/slot_equipment_priority = list(
 		return ..()
 
 /mob/proc/CanUseTopicInventory(mob/target)
-	if(is_busy() || || isdrone(src) || incapacitated() || !isturf(target.loc) || !Adjacent(target))
+	if(is_busy() || isdrone(src) || incapacitated() || !isturf(target.loc) || !Adjacent(target))
 		return FALSE
 
 	if(ishuman(src) || isrobot(src) || ismonkey(src) || isIAN(src) || isxenoadult(src))


### PR DESCRIPTION
## Описание изменений

1. Не позволяет раздевать людей в гробах, шкафах, машинерии.
2. Дампает все предметы из гроба.

## Почему и что этот ПР улучшит

Исправляет баги.

## Чеинжлог
:cl: Luduk
- bugfix: Нельзя раздевать людей в гробах, шкафах, машинерии, чем-либо кроме турфа.
- bugfix: Гробы на шахтерке дропают предметы после открывания.