### PR TITLE
removing stupid var thingy, naming consistency

### DIFF
--- a/code/datums/components/swiping.dm
+++ b/code/datums/components/swiping.dm
@@ -208,11 +208,12 @@
 	SEND_SIGNAL(parent, COMSIG_TIPS_REMOVE, list(SWIPING_TIP))
 	return ..()
 
-/datum/component/swiping/proc/get_sweep_objects(turf/start, obj/item/I, mob/user, list/directions, sweep_image)
+/datum/component/swiping/proc/get_sweep_objects(turf/start, obj/item/I, mob/user, list/directions, sweep_delay)
 	if(on_get_sweep_objects)
-		return on_get_sweep_objects.Invoke(start, I, user, directions)
+		return on_get_sweep_objects.Invoke(start, I, user, directions, sweep_delay)
+
 	var/list/sweep_objects = list()
-	sweep_objects += new /obj/effect/effect/weapon_sweep(start, I, directions, sweep_image)
+	sweep_objects += new /obj/effect/effect/weapon_sweep(start, I, directions, sweep_delay)
 	return sweep_objects
 
 /datum/component/swiping/proc/move_sweep_image(turf/target, obj/effect/effect/weapon_sweep/sweep_image)

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -56,7 +56,6 @@
 	return (BRUTELOSS|FIRELOSS)
 
 /obj/item/weapon/melee/energy/sword
-	color
 	name = "energy sword"
 	desc = "May the force be within you."
 	icon_state = "sword0"

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -222,14 +222,14 @@
 /obj/item/weapon/twohanded/dualsaber/proc/can_spin(mob/user)
 	return wielded
 
-/obj/item/weapon/twohanded/dualsaber/proc/get_sweep_objs(turf/start, obj/item/I, mob/user, list/directions, obj/effect/effect/weapon_sweep/sweep_image)
+/obj/item/weapon/twohanded/dualsaber/proc/get_sweep_objs(turf/start, obj/item/I, mob/user, list/directions, sweep_delay)
 	var/list/directions_opposite = list()
 	for(var/dir_ in directions)
 		directions_opposite += turn(dir_, 180)
 
 	var/list/sweep_objects = list()
-	sweep_objects += new /obj/effect/effect/weapon_sweep(start, I, directions, sweep_image)
-	sweep_objects += new /obj/effect/effect/weapon_sweep(start, I, directions_opposite, sweep_image)
+	sweep_objects += new /obj/effect/effect/weapon_sweep(start, I, directions, sweep_delay)
+	sweep_objects += new /obj/effect/effect/weapon_sweep(start, I, directions_opposite, sweep_delay)
 	return sweep_objects
 
 /obj/item/weapon/twohanded/dualsaber/update_icon()


### PR DESCRIPTION
## Описание изменений

Убирает какую-то невероятно идиотскую ошибку с объявлением переменной относительным путём(по-другому не могу объяснить почему компилятор не ругается),

нормально называю аргументы в свайп-относящейся функции и яда-яда

## Почему и что этот ПР улучшит

Чистота кода.
