### PR TITLE
dead indicator for hostile mobs

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -38,7 +38,9 @@
 
 /mob/living/simple_animal/hostile/examine(mob/user)
 	..()
-	if(health <= maxHealth * 0.2)
+	if(health == 0)
+		to_chat(user, "<span class='danger'>Is dead.</span>")
+	else if(health <= maxHealth * 0.2)
 		to_chat(user, "<span class='danger'>Is almost dead.</span>")
 	else if(health <= maxHealth * 0.6)
 		to_chat(user, "<span class='warning'>Appears badly wounded.</span>")

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -38,7 +38,7 @@
 
 /mob/living/simple_animal/hostile/examine(mob/user)
 	..()
-	if(health == 0)
+	if(stat == DEAD)
 		to_chat(user, "<span class='danger'>Is dead.</span>")
 	else if(health <= maxHealth * 0.2)
 		to_chat(user, "<span class='danger'>Is almost dead.</span>")


### PR DESCRIPTION
## Описание изменений

Мёртвым хостайл мобам прикручен индикатор того что они сдёхли.

Возможно в будущем лучше будет прикрутить сюда систему пульса, и ран. Но пока что то что есть.

## Почему и что этот ПР улучшит

Люди видят дохлых мобов как дохлых а не как "близких к смерти"

## Чеинжлог
:cl: Luduk
- bugfix: Мёртвые мобы показывают что они мертвы, а не "близки к смерти".