### PR TITLE
Нельзя спамить проджектайлами дальнобойных заклинаний

### DIFF
--- a/code/datums/spells/in_hand.dm
+++ b/code/datums/spells/in_hand.dm
@@ -51,6 +51,10 @@
 		return FALSE
 
 	if(!touch_spell)
+		var/turf/U = get_turf(user)
+		var/turf/T = get_turf(target)
+		if(U == T)
+			return
 		if(!cast_throw(target, user))
 			return FALSE
 	else
@@ -198,7 +202,6 @@
 		var/obj/item/weapon/magic/arcane_barrage/Arcane = new type(Spell)
 		Arcane.uses = uses
 		drop_activate_recharge = FALSE
-
 		C.drop_item()
 		C.swap_hand()
 		C.drop_item()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Нельзя заспавнить под собой кучу проджектайлов от заклинаний, которые, по-сути, никуда не летят, а просто стоят на месте
## Почему и что этот ПР улучшит
Никаких больше багнутых проджектайлов 
## Авторство
Cool20141
## Чеинжлог
:cl:
- bugfix: Нельзя спавнить багнутые проджектайлы от заклинаний