### PR TITLE
Манкикубы раскрываются в воде

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1381,6 +1381,9 @@
 		return Expand()
 	..()
 
+/obj/item/weapon/reagent_containers/food/snacks/monkeycube/entered_water_turf()
+	Expand()
+
 /obj/item/weapon/reagent_containers/food/snacks/monkeycube/attack_self(mob/user)
 	if(wrapped)
 		Unwrap(user)


### PR DESCRIPTION
## Описание изменений

## Почему и что этот ПР улучшит
fixes #5257 

## Авторство

## Чеинжлог
:cl: Getup1
- bugfix: Обезьяньи кубы теперь раскрываются в воде из бассейна.