### PR TITLE
removing player ability to vote

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -28,7 +28,6 @@ var/list/net_announcer_secret = list()
 	var/log_qdel = 0						// same but for debug qdel logs
 	var/sql_enabled = 0					// for sql switching
 	var/allow_admin_ooccolor = 0		// Allows admins with relevant permissions to have their own ooc colour
-	var/allow_vote_restart = 0 			// allow votes to restart
 	var/ert_admin_call_only = 0
 	var/allow_vote_mode = 0				// allow votes to change mode
 	var/allow_admin_jump = 1			// allows admin jumping
@@ -343,9 +342,6 @@ var/list/net_announcer_secret = list()
 
 				if("allow_admin_ooccolor")
 					config.allow_admin_ooccolor = 1
-
-				if ("allow_vote_restart")
-					config.allow_vote_restart = 1
 
 				if ("allow_vote_mode")
 					config.allow_vote_mode = 1

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -95,9 +95,6 @@ ALLOW_ADMIN_OOCCOLOR
 ## If metadata is supported
 # ALLOW_METADATA
 
-## allow players to initiate a restart vote
-ALLOW_VOTE_RESTART
-
 ## allow players to initate a mode-change start
 ALLOW_VOTE_MODE
 


### PR DESCRIPTION
## Описание изменений

Меня хед админ попросил это сделать.

Где-то в середине работы я заметил конфиг опцию и подумал о том насколько я всё таки бесполезен он я решил довести дело до конца.

## Почему и что этот ПР улучшит

Наверное люди не смогут багать-делать говно с рестартом раунда

## Авторство

@Sadmadowl

## Чеинжлог
:cl: Sadmadowl
- rscdel: Игроки не могут голосовать за рестарт раунда.