### PR TITLE
storage attackby proper parent call, hitting clothing on HARM

### DIFF
--- a/code/modules/clothing/suits/storage.dm
+++ b/code/modules/clothing/suits/storage.dm
@@ -20,9 +20,9 @@
 		..(over_object)
 
 /obj/item/clothing/suit/storage/attackby(obj/item/W, mob/user)
-	..()
-	if(pockets)
-		pockets.attackby(W, user)
+	if(pockets && user.a_intent != INTENT_HARM && pockets.attackby(W, user))
+		return
+	return ..()
 
 /obj/item/clothing/suit/storage/emp_act(severity)
 	if(pockets)


### PR DESCRIPTION
## Описание изменений

Решение с тычками по одежде хармом принято по тому же принципу как это сейчас работает со столами. Харм-клик - пытается сделать с одеждой чтобы там игрок не хотел сделать, остальные клики - попытка положить в карманы, если такие есть(Лаб. халаты, и т.д.), если нет - тоже ударит.

## Почему и что этот ПР улучшит

Не будут показываться сообщения об ударе одежды когда просто кладёшь в карман.

## Чеинжлог
:cl: Luduk
- bugfix: Когда кладёшь в карманы одежды с карманами(к примеру, лаб. халат) предметы не показывается что ты бьёшь его.
- tweak: На интент харм нельзя класть вещи в лаб. халат, только бить его.