### PR TITLE
rejuvenate() заставит сердце биться

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -510,6 +510,8 @@
 			var/mob/living/carbon/human/H = src
 			H.restore_blood()
 			H.full_prosthetic = null
+			var/obj/item/organ/internal/heart/Heart = H.organs_by_name[O_HEART]
+			Heart.heart_normalize()
 
 	restore_all_bodyparts()
 	cure_all_viruses()


### PR DESCRIPTION
## Описание изменений
[Regenerate] генокрадов, а также админские [Heal] и [rejuvenate] завязаны на функции rejuvenate(), которая хоть и отхиливала/воскрешала полностью, но не запускала сердце, обрекая человека на скорую смерть от не бьющегося сердца. 
Данный ПР добаляет в эту функцию запуск сердца, устраняя тем самым данную проблему.
## Почему и что этот ПР улучшит
fixes #5453 
fixes #5497 
## Авторство
T6751
## Чеинжлог
:cl: T6751
 - bugfix: Стазис генокрадов не запускал сердце