### PR TITLE
Трубы не будут пропадать при ударе об что-либо

### DIFF
--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -284,11 +284,6 @@ Buildable meters
 	)
 	icon_state = islist[pipe_type + 1]
 
-//called when a turf is attacked with a pipe item
-/obj/item/pipe/afterattack(atom/target, mob/user, proximity, params)
-	if(!proximity)
-		return
-
 // rotate the pipe item clockwise
 /obj/item/pipe/verb/rotate()
 	set category = "Object"

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -285,11 +285,11 @@ Buildable meters
 	icon_state = islist[pipe_type + 1]
 
 //called when a turf is attacked with a pipe item
-/obj/item/pipe/afterattack(turf/simulated/floor/target, mob/user, proximity, params)
+/obj/item/pipe/afterattack(atom/target, mob/user, proximity, params)
 	if(!proximity)
 		return
 
-	if(istype(target))
+	if(istype(target, /turf/simulated/floor))
 		user.drop_from_inventory(src, target)
 	else
 		return ..()

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -284,6 +284,16 @@ Buildable meters
 	)
 	icon_state = islist[pipe_type + 1]
 
+//called when a turf is attacked with a pipe item
+/obj/item/pipe/afterattack(turf/simulated/floor/target, mob/user, proximity, params)
+	if(!proximity)
+		return
+
+	if(istype(target))
+		user.drop_from_inventory(src, target)
+	else
+		return ..()
+
 // rotate the pipe item clockwise
 /obj/item/pipe/verb/rotate()
 	set category = "Object"

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -285,19 +285,11 @@ Buildable meters
 	icon_state = islist[pipe_type + 1]
 
 //called when a turf is attacked with a pipe item
-
-//called when a turf is attacked with a pipe item
 /obj/item/pipe/afterattack(atom/target, mob/user, proximity, params)
 	if(!proximity)
 		return
 
-	if(istype(target))
-		user.drop_from_inventory(src, target)
-	else
-		return ..()
-
 // rotate the pipe item clockwise
-
 /obj/item/pipe/verb/rotate()
 	set category = "Object"
 	set name = "Rotate Pipe"


### PR DESCRIPTION
## Описание изменений
Кликая по полу трубы должны были ставиться на пол, но что-то пошло не так и при ударе об что-угодно они пропадали. 
## Почему и что этот ПР улучшит
fixes #5507
fixes #5196 

## Чеинжлог
:cl:
 - bugfix: при ударе трубами об что-угодно они пропадали