### PR TITLE
Поля [sfield] теперь копируются принтером

### DIFF
--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -212,6 +212,7 @@
 	P.info += "</font>"//</font>
 	P.name = copy.name // -- Doohl
 	P.fields = copy.fields
+	P.sfields = copy.sfields
 	P.stamp_text = replacetext(copy.stamp_text, "color:", "nocolor:") // Russian server? I hope nobody will write this on paper
 	P.stamped = LAZYCOPY(copy.stamped)
 	P.ico = LAZYCOPY(copy.ico)


### PR DESCRIPTION
## Описание изменений
Поля [sfield] не копировались принтером. Данный ПР исправляет эту проблему.
## Почему и что этот ПР улучшит
fixes #5509
## Авторство
T6751
## Чеинжлог
:cl: 
 - bugfix: поля [sfield] теперь копируются принтером