### PR TITLE
allowing flags check in jobs, special species check in jobs

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -129,7 +129,7 @@ var/datum/subsystem/job/SSjob
 		if(job.title in command_positions) //If you want a command position, select it!
 			continue
 
-		if(!job.is_species_permitted(player.client))
+		if(!job.is_species_permitted(player.client.prefs.species))
 			continue
 
 		if(!job.map_check())

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -13,14 +13,10 @@
 	salary = 300
 	minimal_player_age = 14
 	minimal_player_ingame_minutes = 3900
-	/*
-		HEY YOU!
-		ANY TIME YOU TOUCH THIS, PLEASE CONSIDER GOING TO preferences_savefile.dm
-		AND BUMPING UP THE SAVEFILE_VERSION_MAX, AND ALSO LOCATING THE "job_loop:" THINGY AND CHANGING
-		THE VERSION THERE. CURRENTLY THE VERSION THERE IS 26.
-		~Luduk
-	*/
-	restricted_species = list(SKRELL, UNATHI, TAJARAN, DIONA, VOX, IPC)
+
+// Non-human species can't be captains.
+/datum/job/captain/special_species_check(datum/species/S)
+	return S.name == HUMAN
 
 /datum/job/captain/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(!H)	return 0
@@ -62,7 +58,6 @@
 
 /datum/job/captain/get_access()
 	return get_all_accesses()
-
 
 /datum/job/hop
 	title = "Head of Personnel"

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -55,7 +55,10 @@
 		THE VERSION THERE. CURRENTLY THE VERSION THERE IS 26.
 		~Luduk
 	*/
+	/// Species that can not be this job.
 	var/list/restricted_species = list()
+	/// Species flags that can not do this job.
+	var/list/restricted_species_flags = list()
 
 	var/list/survival_kit_items = list()
 
@@ -77,11 +80,25 @@
 			return 1	//Available in 0 days = available right now = player is old enough to play.
 	return 0
 
-
-/datum/job/proc/is_species_permitted(client/C)
+/datum/job/proc/is_species_permitted(species)
 	if(!config.use_alien_job_restriction)
 		return TRUE
-	return !(C.prefs.species in restricted_species)
+	if(species in restricted_species)
+		return FALSE
+
+	var/datum/species/S = all_species[species]
+	if(S && special_species_check(S))
+		for(var/flag in restricted_species_flags)
+			if(S.flags[flag] == restricted_species_flags[flag])
+				return FALSE
+
+		return TRUE
+
+	return FALSE
+
+/// Return TRUE to allow the species S to be this job.
+/datum/job/proc/special_species_check(datum/species/S)
+	return TRUE
 
 /datum/job/proc/available_in_days(client/C)
 	if(!C)

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -138,7 +138,11 @@
 		THE VERSION THERE. CURRENTLY THE VERSION THERE IS 26.
 		~Luduk
 	*/
-	restricted_species = list(IPC, DIONA)
+	restricted_species = list(IPC)
+
+// Slow species shouldn't be paramedics.
+/datum/job/paramedic/special_species_check(datum/species/S)
+	return S.speed_mod <= 1
 
 /datum/job/paramedic/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(!H)	return 0

--- a/code/modules/client/character menu/occupation.dm
+++ b/code/modules/client/character menu/occupation.dm
@@ -56,7 +56,7 @@
 				var/available_in_days = job.available_in_days(user.client)
 				. += "<del>[rank]</del></td><td> \[IN [(available_in_days)] DAYS]</td></tr>"
 			continue
-		if(!job.is_species_permitted(user.client))
+		if(!job.is_species_permitted(user.client.prefs.species))
 			. += "<del>[rank]</del></td><td><b> \[SPECIES RESTRICTED]</b></td></tr>"
 			continue
 		if(job_preferences["Test Subject"] == JP_LOW && (rank != "Test Subject"))

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -2,7 +2,7 @@
 #define SAVEFILE_VERSION_MIN 8
 
 //This is the current version, anything below this will attempt to update (if it's not obsolete)
-#define SAVEFILE_VERSION_MAX 29
+#define SAVEFILE_VERSION_MAX 30
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -177,10 +177,10 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 		S["be_role"] << be_role
 
-	if(current_version < 29)
+	if(current_version < 30)
 		if(species != HUMAN)
 			for(var/datum/job/job in SSjob.occupations)
-				if(!job.is_species_permitted(parent))
+				if(job.is_species_permitted(species))
 					SetJobPreferenceLevel(job, 0)
 			S["job_preferences"] << job_preferences
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -2,7 +2,7 @@
 #define SAVEFILE_VERSION_MIN 8
 
 //This is the current version, anything below this will attempt to update (if it's not obsolete)
-#define SAVEFILE_VERSION_MAX 30
+#define SAVEFILE_VERSION_MAX 29
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -177,7 +177,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 		S["be_role"] << be_role
 
-	if(current_version < 30)
+	if(current_version < 29)
 		if(species != HUMAN)
 			for(var/datum/job/job in SSjob.occupations)
 				if(job.is_species_permitted(species))

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -292,7 +292,7 @@ commented cause polls are kinda broken now, needs refactoring */
 		return FALSE
 	if(!job.player_old_enough(client))
 		return FALSE
-	if(!job.is_species_permitted(client))
+	if(!job.is_species_permitted(client.prefs.species))
 		return FALSE
 	if(!job.map_check())
 		return FALSE


### PR DESCRIPTION
## Описание изменений

Добавляет больше возможностей для проверки всякого-всякого в профах. К примеру флаги расы, и даже какие-то переменные расы в отдельной функции.

## Почему и что этот ПР улучшит

В случае если ограничения будут диктоваться не по желанию левой пятки а исключительно исходя из механопотребностей расы(медленные дионы не могут быть парамедиками), это можно будет очень просто реализовать.
