### PR TITLE
clickplace drag target jumping

### DIFF
--- a/code/datums/components/clickplace.dm
+++ b/code/datums/components/clickplace.dm
@@ -97,6 +97,21 @@
 	// Prevent hitting the thing if we're just putting it.
 	return COMPONENT_NO_AFTERATTACK
 
+/datum/component/clickplace/proc/jump_out(obj/item/I, atom/target, rec_limit = 3)
+	if(I.loc == target || rec_limit == 0)
+		return
+
+	if(istype(I.loc, /obj/item/weapon/storage))
+		var/obj/item/weapon/storage/S = I.loc
+		S.remove_from_storage(I, target)
+	else if(ismob(I.loc))
+		var/mob/M = I.loc
+		M.drop_from_inventory(I, target)
+	else
+		I.forceMove(target)
+
+	jump_out(I, target, rec_limit - 1)
+
 /datum/component/clickplace/proc/try_place_drag(datum/source, atom/dropping, mob/living/user)
 	if(!istype(dropping, /obj/item))
 		return
@@ -137,14 +152,10 @@
 	if(spare_slots <= 0)
 		return
 
-	// Just in case.
-	if(I.loc == user)
-		user.drop_from_inventory(I)
-	else if(istype(I.loc, /obj/item/weapon/storage))
-		var/obj/item/weapon/storage/S = I.loc
-		S.remove_from_storage(I, S.loc)
+	jump_out(I, user.loc)
 
-	if(!isturf(I.loc))
+	// Bounding component took over or something.
+	if(I.loc != user.loc)
 		return
 
 	var/atom/A = parent


### PR DESCRIPTION
## Описание изменений

Выпрыгивание из инвентарей и мобов работает корректно при драге на кликплейс объекты(столы)

## Почему и что этот ПР улучшит

fixes #5536 
