### PR TITLE
изменен plane паутины на -1

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -67,6 +67,7 @@
 	desc = "Somebody should remove that."
 	density = 0
 	anchored = 1
+	plane = -1
 	layer = 3
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "cobweb1"
@@ -85,6 +86,7 @@
 	desc = "Somebody should remove that."
 	density = 0
 	anchored = 1
+	plane = -1
 	layer = 3
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "cobweb2"

--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -67,7 +67,7 @@
 	desc = "Somebody should remove that."
 	density = 0
 	anchored = 1
-	plane = -1
+	plane = GAME_PLANE
 	layer = 3
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "cobweb1"
@@ -86,7 +86,7 @@
 	desc = "Somebody should remove that."
 	density = 0
 	anchored = 1
-	plane = -1
+	plane = GAME_PLANE
 	layer = 3
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "cobweb2"


### PR DESCRIPTION
## Описание изменений
plane декалей по умолчанию равен FLOOR_PLANE, то есть -2. 
Поднял plane паутины.

Было:
![20200612 182537](https://user-images.githubusercontent.com/66636084/84519918-6aedb500-acdb-11ea-9c55-99b68b547234.png)
Стало:
![20200612 182550](https://user-images.githubusercontent.com/66636084/84519931-704aff80-acdb-11ea-8472-915e4c909296.png)

## Почему и что этот ПР улучшит
fixes #5174