### PR TITLE
Проверка состояния locked дверей шаттла в  try_open()

### DIFF
--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -418,6 +418,7 @@ var/datum/subsystem/shuttle/SSshuttle
 			else if(istype(DOOR, /obj/machinery/door/unpowered))
 				var/obj/machinery/door/unpowered/D = DOOR
 				D.locked = 0
+				D.bolted = 0
 				D.open()
 
 /datum/subsystem/shuttle/proc/undock_act(area_type, door_tag)
@@ -433,6 +434,7 @@ var/datum/subsystem/shuttle/SSshuttle
 				var/obj/machinery/door/unpowered/D = DOOR
 				D.close()
 				D.locked = 1
+				D.bolted = 1
 
 /datum/subsystem/shuttle/proc/send()
 	var/area/from

--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -418,7 +418,6 @@ var/datum/subsystem/shuttle/SSshuttle
 			else if(istype(DOOR, /obj/machinery/door/unpowered))
 				var/obj/machinery/door/unpowered/D = DOOR
 				D.locked = 0
-				D.bolted = 0
 				D.open()
 
 /datum/subsystem/shuttle/proc/undock_act(area_type, door_tag)
@@ -434,7 +433,6 @@ var/datum/subsystem/shuttle/SSshuttle
 				var/obj/machinery/door/unpowered/D = DOOR
 				D.close()
 				D.locked = 1
-				D.bolted = 1
 
 /datum/subsystem/shuttle/proc/send()
 	var/area/from

--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -7,6 +7,8 @@
 /obj/machinery/door/unpowered/Bumped(atom/AM)
 	if(locked)
 		return
+	if(bolted)
+		return
 	..()
 	return
 

--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -7,8 +7,6 @@
 /obj/machinery/door/unpowered/Bumped(atom/AM)
 	if(locked)
 		return
-	if(bolted)
-		return
 	..()
 	return
 

--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -1,7 +1,6 @@
 /obj/machinery/door/unpowered
 	autoclose = 0
 	var/locked = 0
-	var/bolted = 0
 
 
 /obj/machinery/door/unpowered/Bumped(atom/AM)
@@ -15,8 +14,6 @@
 	if(istype(I, /obj/item/weapon/melee/energy/blade))
 		return
 	if(locked)
-		return
-	if(bolted)
 		return
 	return ..()
 

--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -1,6 +1,7 @@
 /obj/machinery/door/unpowered
 	autoclose = 0
 	var/locked = 0
+	var/bolted = 0
 
 
 /obj/machinery/door/unpowered/Bumped(atom/AM)
@@ -14,6 +15,8 @@
 	if(istype(I, /obj/item/weapon/melee/energy/blade))
 		return
 	if(locked)
+		return
+	if(bolted)
 		return
 	return ..()
 

--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -4,8 +4,6 @@
 
 
 /obj/machinery/door/unpowered/Bumped(atom/AM)
-	if(locked)
-		return
 	..()
 	return
 
@@ -13,13 +11,15 @@
 /obj/machinery/door/unpowered/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/weapon/melee/energy/blade))
 		return
-	if(locked)
-		return
 	return ..()
 
 /obj/machinery/door/unpowered/emag_act(mob/user)
 	return FALSE
 
+/obj/machinery/door/unpowered/try_open(user)
+	if(locked)
+		return
+	return ..()
 
 /obj/machinery/door/unpowered/shuttle
 	icon = 'icons/turf/shuttle.dmi'


### PR DESCRIPTION
## Описание изменений
Проверка состояния locked перенесена в try_open()
<details>
проблема появилась после #5380, когда attack_hand() дверей перестал возвращать attackby() и вместо этого вызывать try_open()
</details>

## Почему и что этот ПР улучшит
fixes #5525 
## Авторство
T6751
## Чеинжлог
:cl:
 - bugfix: двери шаттла в космос можно было открыть