### PR TITLE
изменена стартовая аварийная коробка на survival у nuclear агентов

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -265,7 +265,7 @@
 		synd_mob.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(synd_mob), SLOT_BACK)
 	synd_mob.equip_to_slot_or_del(new /obj/item/device/radio/uplink(synd_mob), SLOT_IN_BACKPACK)
 	synd_mob.equip_to_slot_or_del(new /obj/item/weapon/reagent_containers/pill/cyanide(synd_mob), SLOT_IN_BACKPACK)
-	synd_mob.equip_to_slot_or_del(new /obj/item/weapon/storage/box/engineer(synd_mob.back), SLOT_IN_BACKPACK)
+	synd_mob.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(synd_mob.back), SLOT_IN_BACKPACK)
 	if(boss)
 		synd_mob.equip_to_slot_or_del(new /obj/item/weapon/card/id/syndicate/commander(synd_mob), SLOT_WEAR_ID)
 		synd_mob.equip_to_slot_or_del(new /obj/item/weapon/gun/projectile/revolver(synd_mob), SLOT_BELT)


### PR DESCRIPTION
## Описание изменений
Дионы, воксы, IPC, будучи nuclear агентами вместо surivival бокса с предметами для своей расы получали engineer box с баллоном и маской.
## Почему и что этот ПР улучшит
fixes #4926
## Чеинжлог
:cl:
 - bugfix: nuclear агенты получали инженерный аварийный бокс (маска+баллон), а не аварийный бокс для выживания с предметами для своей расы