### PR TITLE
добавлен зум в CtrlClick() камеры

### DIFF
--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -190,6 +190,9 @@
 	to_chat(user, "You switch the camera [on ? "on" : "off"].")
 	return
 
+/obj/item/device/camera/CtrlClick(src)
+	set_zoom()
+
 /obj/item/device/camera/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/device/camera_film))
 		user.SetNextMove(CLICK_CD_INTERACT)


### PR DESCRIPTION
## Описание изменений
Зумить через пкм > [set Zoom] неудобно. Теперь зумить можно в один клик, если зажат контрол
## Почему и что этот ПР улучшит
удобство
## Авторство
T6751
## Чеинжлог
:cl:
 - tweak: добавлен зум камеры на контрол клик