### PR TITLE
Изменение названия станции для соответствия названия к содержанию

### DIFF
--- a/code/_globalvars/configuration.dm
+++ b/code/_globalvars/configuration.dm
@@ -4,7 +4,7 @@ var/host = null
 var/join_motd = null
 var/host_announcements
 var/join_test_merge = null
-var/station_name = "NSS Exodus"
+var/station_name = "Prometheus"
 var/system_name = "Tau Ceti"
 var/game_version = "TauCetiStation"
 var/game_year = (text2num(time2text(world.realtime, "YYYY")) + 200)


### PR DESCRIPTION
## Описание изменений
Изменёно название станции с NSS Exodus на Prometheus для соответствия происходящего на станции 
## Почему и что этот ПР улучшит
Уменьшит путаницу в происходящем на станции
## Авторство
Felix Ruin - Winter Schock
## Чеинжлог
:cl: Winter Schock
- balance: изменение названия станции на Prometheus