### PR TITLE
Медботы больше не триггерятся на существ с NO_BLOOD

### DIFF
--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -264,8 +264,11 @@
 			speak(message)
 			playsound(src, messagevoice[message], VOL_EFFECTS_MASTER, null, FALSE)
 
-		for (var/mob/living/carbon/C in view(7,src)) //Time to find a patient!
-			if ((C.stat == DEAD) || !istype(C, /mob/living/carbon/human))
+		for (var/mob/living/carbon/human/C in view(7,src)) //Time to find a patient!
+			if (C.stat == DEAD)
+				continue
+
+			if(C.species.flags[NO_BLOOD])	
 				continue
 
 			if ((C == oldpatient) && (world.time < last_found + 100))

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -103,7 +103,7 @@
 	dat += "Status: <A href='?src=\ref[src];power=1'>[on ? "On" : "Off"]</A><BR>"
 	dat += "Maintenance panel panel is [open ? "opened" : "closed"]<BR>"
 	dat += "Beaker: "
-	if (reagent_glass)
+	if(reagent_glass)
 		dat += "<A href='?src=\ref[src];eject=1'>Loaded \[[reagent_glass.reagents.total_volume]/[reagent_glass.reagents.maximum_volume]\]</a>"
 	else
 		dat += "None Loaded"
@@ -138,8 +138,8 @@
 	if(!.)
 		return
 
-	if ((href_list["power"]) && (allowed(usr)))
-		if (on)
+	if((href_list["power"]) && (allowed(usr)))
+		if(on)
 			turn_off()
 		else
 			turn_on()
@@ -166,21 +166,21 @@
 	else if(href_list["use_beaker"])
 		use_beaker = !use_beaker
 
-	else if (href_list["eject"] && reagent_glass)
+	else if(href_list["eject"] && reagent_glass)
 		reagent_glass.loc = get_turf(src)
 		reagent_glass = null
 
-	else if (href_list["togglevoice"])
+	else if(href_list["togglevoice"])
 		shut_up = !shut_up
 
-	else if (href_list["declaretreatment"])
+	else if(href_list["declaretreatment"])
 		declare_treatment = !declare_treatment
 
 	updateUsrDialog()
 
 /obj/machinery/bot/medbot/attackby(obj/item/weapon/W, mob/user)
-	if (istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))
-		if (allowed(user) && !open && !emagged)
+	if(istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))
+		if(allowed(user) && !open && !emagged)
 			locked = !locked
 			to_chat(user, "<span class='notice'>Controls are now [locked ? "locked." : "unlocked."]</span>")
 			updateUsrDialog()
@@ -192,7 +192,7 @@
 			else
 				to_chat(user, "<span class='warning'>Access denied.</span>")
 
-	else if (istype(W, /obj/item/weapon/reagent_containers/glass))
+	else if(istype(W, /obj/item/weapon/reagent_containers/glass))
 		if(locked)
 			to_chat(user, "<span class='notice'>You cannot insert a beaker because the panel is locked.</span>")
 			return
@@ -209,7 +209,7 @@
 
 	else
 		..()
-		if (health < maxhealth && !isscrewdriver(W) && W.force)
+		if(health < maxhealth && !isscrewdriver(W) && W.force)
 			step_to(src, (get_step_away(src,user)))
 
 /obj/machinery/bot/medbot/emag_act(mob/user)
@@ -264,14 +264,14 @@
 			speak(message)
 			playsound(src, messagevoice[message], VOL_EFFECTS_MASTER, null, FALSE)
 
-		for (var/mob/living/carbon/human/C in view(7,src)) //Time to find a patient!
-			if (C.stat == DEAD)
+		for(var/mob/living/carbon/human/C in view(7,src)) //Time to find a patient!
+			if(C.stat == DEAD)
 				continue
 
 			if(C.species.flags[NO_BLOOD])	
 				continue
 
-			if ((C == oldpatient) && (world.time < last_found + 100))
+			if((C == oldpatient) && (world.time < last_found + 100))
 				continue
 
 			if(assess_patient(C))
@@ -364,7 +364,7 @@
 	for(var/datum/disease/D in C.viruses)
 		if((D.stage > 1) || (D.spread_type == AIRBORNE))
 
-			if (!C.reagents.has_reagent(treatment_virus))
+			if(!C.reagents.has_reagent(treatment_virus))
 				return 1 //STOP DISEASE FOREVER
 
 	return 0
@@ -404,23 +404,23 @@
 	for(var/datum/disease/D in C.viruses)
 		virus = 1
 
-	if (!reagent_id && (virus))
+	if(!reagent_id && (virus))
 		if(!C.reagents.has_reagent(treatment_virus))
 			reagent_id = treatment_virus
 
-	if (!reagent_id && (C.getBruteLoss() >= heal_threshold))
+	if(!reagent_id && (C.getBruteLoss() >= heal_threshold))
 		if(!C.reagents.has_reagent(treatment_brute))
 			reagent_id = treatment_brute
 
-	if (!reagent_id && (C.getOxyLoss() >= (15 + heal_threshold)))
+	if(!reagent_id && (C.getOxyLoss() >= (15 + heal_threshold)))
 		if(!C.reagents.has_reagent(treatment_oxy))
 			reagent_id = treatment_oxy
 
-	if (!reagent_id && (C.getFireLoss() >= heal_threshold))
+	if(!reagent_id && (C.getFireLoss() >= heal_threshold))
 		if(!C.reagents.has_reagent(treatment_fire))
 			reagent_id = treatment_fire
 
-	if (!reagent_id && (C.getToxLoss() >= heal_threshold))
+	if(!reagent_id && (C.getToxLoss() >= heal_threshold))
 		if(!C.reagents.has_reagent(treatment_tox))
 			reagent_id = treatment_tox
 
@@ -438,7 +438,7 @@
 		icon_state = "medibots"
 		visible_message("<span class='warning'><B>[src] is trying to inject [patient]!</B></span>")
 		spawn(30)
-			if ((get_dist(src, patient) <= 1) && (on))
+			if((get_dist(src, patient) <= 1) && (on))
 				if((reagent_id == "internal_beaker") && (reagent_glass) && (reagent_glass.reagents.total_volume))
 					reagent_glass.reagents.trans_to(patient,injection_amount) //Inject from beaker instead.
 					reagent_glass.reagents.reaction(patient, 2)
@@ -481,7 +481,7 @@
 		reagent_glass.loc = Tsec
 		reagent_glass = null
 
-	if (prob(50))
+	if(prob(50))
 		new /obj/item/robot_parts/l_arm(Tsec)
 
 	if(emagged && prob(25))
@@ -494,12 +494,12 @@
 	return
 
 /obj/machinery/bot/medbot/Bump(atom/M) //Leave no door unopened!
-	if ((istype(M, /obj/machinery/door)) && (!isnull(botcard)))
+	if((istype(M, /obj/machinery/door)) && (!isnull(botcard)))
 		var/obj/machinery/door/D = M
-		if (!istype(D, /obj/machinery/door/firedoor) && D.check_access(botcard) && !istype(D,/obj/machinery/door/poddoor))
+		if(!istype(D, /obj/machinery/door/firedoor) && D.check_access(botcard) && !istype(D,/obj/machinery/door/poddoor))
 			D.open()
 			frustration = 0
-	else if ((istype(M, /mob/living)) && (!anchored))
+	else if((istype(M, /mob/living)) && (!anchored))
 		loc = M.loc
 		frustration = 0
 	return
@@ -507,7 +507,7 @@
 /* terrible
 /obj/machinery/bot/medbot/Bumped(atom/movable/M)
 	spawn(0)
-		if (M)
+		if(M)
 			var/turf/T = get_turf(src)
 			M:loc = T
 */
@@ -533,7 +533,7 @@
 		if(O.density && !istype(O, /obj/structure/window) && !istype(O, /obj/machinery/door))
 			return 1
 
-		if (O.density && (istype(O, /obj/machinery/door)) && (access.len))
+		if(O.density && (istype(O, /obj/machinery/door)) && (access.len))
 			var/obj/machinery/door/D = O
 			for(var/req in D.req_access)
 				if(!(req in access)) //doesn't have this access
@@ -548,7 +548,7 @@
 
 /obj/item/weapon/storage/firstaid/attackby(obj/item/robot_parts/S, mob/user)
 
-	if ((!istype(S, /obj/item/robot_parts/l_arm)) && (!istype(S, /obj/item/robot_parts/r_arm)))
+	if((!istype(S, /obj/item/robot_parts/l_arm)) && (!istype(S, /obj/item/robot_parts/r_arm)))
 		..()
 		return
 
@@ -576,9 +576,9 @@
 	..()
 	if(istype(W, /obj/item/weapon/pen))
 		var/t = sanitize_safe(input(user, "Enter new robot name", name, input_default(created_name)), MAX_NAME_LEN)
-		if (!t)
+		if(!t)
 			return
-		if (!in_range(src, usr) && loc != usr)
+		if(!in_range(src, usr) && loc != usr)
 			return
 		created_name = t
 	else

--- a/code/game/machinery/bots/medbot.dm
+++ b/code/game/machinery/bots/medbot.dm
@@ -179,7 +179,7 @@
 	updateUsrDialog()
 
 /obj/machinery/bot/medbot/attackby(obj/item/weapon/W, mob/user)
-	if(istype(W, /obj/item/weapon/card/id)||istype(W, /obj/item/device/pda))
+	if(istype(W, /obj/item/weapon/card/id) || istype(W, /obj/item/device/pda))
 		if(allowed(user) && !open && !emagged)
 			locked = !locked
 			to_chat(user, "<span class='notice'>Controls are now [locked ? "locked." : "unlocked."]</span>")


### PR DESCRIPTION
## Описание изменений
Скорректировал цикл на поиск пациентов с "**var/mob/living/carbon/C**" на "**var/mob/living/carbon/human/C**", а также добавил проверку на трейт "**NO_BLOOD**", чтобы медботы не триггерились также на дион и прочих существ с данным трейтом. Сделал код ближе к Code Convention виду
## Почему и что этот ПР улучшит
fixes #4982
## Чеинжлог
:cl:
 - bugfix: медботы триггерились на раненых СПУ