### PR TITLE
mice can no longer interact with complex items via altClick or mouse drop

### DIFF
--- a/code/game/gamemodes/abduction/machinery/experiment.dm
+++ b/code/game/gamemodes/abduction/machinery/experiment.dm
@@ -18,6 +18,9 @@
 		return
 	if(IsAbductor(target))
 		return
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='warning'>You can not comprehend what to do with this.</span>")
+		return
 	close_machine(target)
 
 /obj/machinery/abductor/experiment/allow_drop()

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -73,7 +73,8 @@
 /obj/machinery/sleeper/MouseDrop_T(mob/target, mob/user)
 	if(user.incapacitated() || !Adjacent(user) || !target.Adjacent(user) || !iscarbon(target) || target.buckled)
 		return
-	if(!iscarbon(usr) && !isrobot(usr))
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='warning'>You can not comprehend what to do with this.</span>")
 		return
 	close_machine(target)
 

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -71,7 +71,8 @@
 /obj/machinery/bodyscanner/MouseDrop_T(mob/target, mob/user)
 	if(user.incapacitated() || !Adjacent(user) || !target.Adjacent(user))
 		return
-	if(!iscarbon(user) && !isrobot(user))
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='warning'>You can not comprehend what to do with this.</span>")
 		return
 	if(!move_inside_checks(target, user))
 		return

--- a/code/game/machinery/barber.dm
+++ b/code/game/machinery/barber.dm
@@ -341,7 +341,7 @@ A proc that does all the animations before mix()-ing.
 		return
 	if(target.buckled || !in_range(user, src) || !in_range(user, target))
 		return
-	if(isanimal(user) && target != user)
+	if(!user.IsAdvancedToolUser() && target != user)
 		return
 	if(isessence(user))
 		return

--- a/code/game/machinery/bots/mulebot.dm
+++ b/code/game/machinery/bots/mulebot.dm
@@ -347,12 +347,11 @@
 			playsound(src, 'sound/machines/ping.ogg', VOL_EFFECTS_MASTER, null, FALSE)
 
 /obj/machinery/bot/mulebot/MouseDrop_T(atom/movable/AM, mob/user)
-	if(!iscarbon(user) && !isrobot(user))
-		return
-	if(user.stat)
+	if(user.incapacitated() || user.lying)
 		return
 
-	if(user.incapacitated() || user.lying)
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='warning'>You can not comprehend what to do with this.</span>")
 		return
 
 	if (!istype(AM))
@@ -363,12 +362,16 @@
 // mousedrop a crate to load the bot
 // can load anything if emagged
 /obj/machinery/bot/mulebot/MouseDrop_T(atom/movable/AM, mob/user)
-	if(!iscarbon(usr) && !isrobot(usr))
-		return
 	if(user.incapacitated() || user.lying)
 		return
+
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='warning'>You can not comprehend what to do with this.</span>")
+		return
+
 	if (!istype(AM))
 		return
+
 	load(AM)
 
 // called to load a crate

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -34,6 +34,9 @@
 	return formatted
 
 /obj/machinery/computer/card/AltClick(mob/user)
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='warning'>You can not comprehend what to do with this.</span>")
+		return
 	if(in_range(user, src))
 		eject_id()
 

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -114,10 +114,13 @@
 
 
 /obj/machinery/gibber/MouseDrop_T(mob/target, mob/user)
-	if(!iscarbon(user) && !isrobot(user))
-		return
 	if(user.incapacitated())
 		return
+
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='warning'>You can not comprehend what to do with this.</span>")
+		return
+
 	move_into_gibber(user,target)
 
 /obj/machinery/gibber/proc/move_into_gibber(mob/user,mob/living/victim)

--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -152,9 +152,11 @@ Nah
 
 //Allow you to drag-drop disposal pipes into it
 /obj/machinery/pipedispenser/disposal/MouseDrop_T(obj/structure/disposalconstruct/pipe, mob/usr)
-	if(!iscarbon(usr) && !isrobot(usr))
-		return
 	if(usr.incapacitated())
+		return
+
+	if(!usr.IsAdvancedToolUser())
+		to_chat(usr, "<span class='warning'>You can not comprehend what to do with this.</span>")
 		return
 
 	if (!istype(pipe) || get_dist(usr, src) > 1 || get_dist(src,pipe) > 1 )

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -649,6 +649,11 @@ REAGENT SCANNER
 /obj/item/device/contraband_finder/MouseDrop_T(atom/dropping, mob/user)
 	if(!dropping.Adjacent(user))
 		return
+
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='warning'>You can not comprehend what to do with this.</span>")
+		return
+
 	scan(dropping, user)
 
 /obj/item/device/contraband_finder/proc/scan(atom/target, mob/user)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -292,6 +292,9 @@
 		return
 	if(!in_range(src, user))
 		return
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='warning'>You can not comprehend what to do with this.</span>")
+		return
 	if(is_cyborg())
 		return
 	else

--- a/code/game/objects/structures/crates_lockers/closets/coffin.dm
+++ b/code/game/objects/structures/crates_lockers/closets/coffin.dm
@@ -49,6 +49,10 @@
 	if(!Adjacent(user))
 		return
 
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='warning'>You can not comprehend what to do with this.</span>")
+		return
+
 	add_fingerprint(user)
 	user.SetNextMove(CLICK_CD_RAPID)
 	toggle(user)

--- a/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/secure_closets.dm
@@ -29,7 +29,7 @@
 		return 0
 
 /obj/structure/closet/secure_closet/AltClick(mob/user)
-	if(!user.incapacitated() && in_range(user, src))
+	if(!user.incapacitated() && in_range(user, src) && user.IsAdvancedToolUser())
 		src.togglelock(user)
 	..()
 

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -143,7 +143,7 @@
 	return !locked
 
 /obj/structure/closet/crate/secure/AltClick(mob/user)
-	if(!user.incapacitated() && in_range(user, src))
+	if(!user.incapacitated() && in_range(user, src) && user.IsAdvancedToolUser())
 		src.togglelock(user)
 	..()
 

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -67,6 +67,10 @@
 	if(user.next_move > world.time || user.incapacitated() || !Adjacent(user))
 		return
 
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='warning'>You can not comprehend what to do with this.</span>")
+		return
+
 	var/obj/item/I = user.get_active_hand()
 	if(istype(I, /obj/item/weapon/reagent_containers) && mybucket)
 		var/obj/item/weapon/reagent_containers/C = I

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -33,7 +33,10 @@
 
 /obj/structure/morgue/AltClick(mob/user)
 	..()
-	if(!CanUseTopic(user) || !user.IsAdvancedToolUser())
+	if(!CanUseTopic(user))
+		return
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='warning'>You can not comprehend what to do with this.</span>")
 		return
 	beeper = !beeper
 	to_chat(user, "<span class='notice'>You turn the speaker function [beeper ? "on" : "off"].</span>")

--- a/code/modules/atmospheric/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospheric/machinery/components/unary_devices/cryo.dm
@@ -249,6 +249,10 @@
 			update_icon()
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/AltClick(mob/user)
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='warning'>You can not comprehend what to do with this.</span>")
+		return
+
 	if(!user.incapacitated() && in_range(user, src))
 		if(state_open)
 			close_machine()

--- a/code/modules/atmospheric/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospheric/machinery/components/unary_devices/cryo.dm
@@ -127,6 +127,9 @@
 /obj/machinery/atmospherics/components/unary/cryo_cell/MouseDrop_T(mob/target, mob/user)
 	if(user.incapacitated() || !Adjacent(user) || !target.Adjacent(user) || !iscarbon(target))
 		return
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='warning'>You can not comprehend what to do with this.</span>")
+		return
 	close_machine(target)
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/allow_drop()
@@ -243,6 +246,10 @@
 		return
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/CtrlClick(mob/user)
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='warning'>You can not comprehend what to do with this.</span>")
+		return
+
 	if(!user.incapacitated() && in_range(user, src))
 		if(!state_open)
 			on = !on

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -539,6 +539,10 @@ BLIND     // can't see anything
 	if(!istype(usr, /mob/living))
 		return
 
+	if(!usr.IsAdvancedToolUser())
+		to_chat(usr, "<span class='warning'>You can not comprehend what to do with this.</span>")
+		return
+
 	var/obj/item/clothing/accessory/A
 	if(accessories.len > 1)
 		A = input("Select an accessory to remove from [src]") as null|anything in accessories

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -751,6 +751,9 @@
 	DropOre()
 
 /mob/living/simple_animal/hostile/mining_drone/AltClick(mob/user)
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='warning'>You can not comprehend what to do with this.</span>")
+		return
 	if(in_range(user, src))
 		to_chat(user, "<span class='notice'>You unloaded ore to the floor.</span>")
 		DropOre()

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -421,6 +421,9 @@
 		return
 	if(user.incapacitated())
 		return
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='warning'>You can not comprehend what to do with this.</span>")
+		return
 	set_zoom()
 
 /obj/item/device/camera/big_photos

--- a/code/modules/power/fusion/fuel_assembly/fuel_compressor.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_compressor.dm
@@ -9,6 +9,9 @@
 /obj/machinery/fusion_fuel_compressor/MouseDrop_T(atom/movable/target, mob/user)
 	if(user.incapacitated() || !user.Adjacent(src))
 		return
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='warning'>You can not comprehend what to do with this.</span>")
+		return
 	return do_fuel_compression(target, user)
 
 /obj/machinery/fusion_fuel_compressor/attackby(obj/item/thing, mob/user)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -122,6 +122,9 @@
 		return
 	if(user.incapacitated())
 		return
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='warning'>You can not comprehend what to do with this.</span>")
+		return
 	select_fire(user)
 
 /obj/item/weapon/gun/energy/attack_self(mob/living/user)

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -17,6 +17,9 @@
 		return
 	if(user.incapacitated())
 		return
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='warning'>You can not comprehend what to do with this.</span>")
+		return
 	transfer_from = !transfer_from
 	to_chat(user, "<span class = 'notice'>You transfer [transfer_from ? "from" : "into"] [src]</span>")
 

--- a/code/modules/vehicles/spacebike.dm
+++ b/code/modules/vehicles/spacebike.dm
@@ -63,6 +63,9 @@
 		return
 	if(user.incapacitated() || user.lying)
 		return
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='warning'>You can not comprehend what to do with this.</span>")
+		return
 	if(!load(M))
 		to_chat(user, "<span class='warning'>You were unable to load \the [M] onto \the [src].</span>")
 		return


### PR DESCRIPTION
## Описание изменений

С введением взаимодействия с миром на АльтКлик забыли о некоторых проверках, к примеру до этого - incapacitated, а так же как оказалось - IsAdvancedToolUser, в связи с чем, мыши к примеру могли строить используя альт-клик для подъема предмета из стака материалов.

С MouseDrop_T те же беди, прошелся по тем где это имеет смысл. Но есть места где мыши не должны мочь перетаскивать человека куда-нибудь не из-за того что тупые, а из-за размера. Этот ПР пока такие места не трогал. Ведь есть недалеко рядом ПР который вводит понятие веса. #5557 

## Почему и что этот ПР улучшит

Мыши не смогут строить.

fixes #5591

## Чеинжлог
:cl: Luduk
- bugfix: Мыши не могут строить, закрывать-октрывать крио, закрывать-открывать гробь с помощью альт клика.
- bugfix: Мыши не могут перетягивать игроков в крио.