### PR TITLE
removing redundant cargo cult copypasta material

### DIFF
--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -414,7 +414,6 @@
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			var/hit_zone = assailant.zone_sel.selecting
-			flick(hud.icon_state, hud)
 			switch(assailant.a_intent)
 				if(INTENT_HELP)
 					if(force_down)


### PR DESCRIPTION
## Описание изменений

Убирает ненужную строчку кода которую некоторые космонавты сочли за обязательное к копированию.

Анимации грабов - часть айкон стейта каждого из апгрейда граба, и не нуждаются в подобной бессмыслице. Что вообще должен делать flick(моя картинка, мне), когда у hud уже стоит нужное значение айкон стейта ?? ??? ??

## Почему и что этот ПР улучшит

Качество кода

