### PR TITLE
запрещает менять гранатам таймер

### DIFF
--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -62,22 +62,6 @@
 	if(T)
 		T.hotspot_expose(700,125)
 
-/obj/item/weapon/grenade/attackby(obj/item/I, mob/user, params)
-	if(isscrewdriver(I))
-		switch(det_time)
-			if(1)
-				det_time = 1 SECOND
-			if(1 SECONDS)
-				det_time = 3 SECONDS
-			if(3 SECONDS)
-				det_time = 5 SECONDS
-			if(5 SECONDS)
-				det_time = 1
-		to_chat(user, "<span class='notice'>You set the [name] for [det_time == 1 ? "instant detonation" : "[det_time * 0.1] second detonation time"].</span>")
-		add_fingerprint(user)
-		return
-	return ..()
-
 /obj/item/weapon/grenade/syndieminibomb
 	desc = "A syndicate manufactured explosive used to sow destruction and chaos."
 	name = "syndicate minibomb"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
запрещает протыкивать гранаты отвертками чтобы менять у них таймер
## Почему и что этот ПР улучшит
невероятно часто вижу как повергеи на охранке берут отвертку и идут тыкать каждую светошумовую в коробке на стрельбище чтобы уменьшить таймер до одной секунды и не париться с nade cooking, что является очевидной и популярной механикой, требующей хоть какого-то скилла.
## Авторство

## Чеинжлог
:cl:
- rscdel: Гранатам больше нельзя менять таймер.