### PR TITLE
[WiP] Simple Skills. 

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -84,3 +84,21 @@
 #define ROUNDSTART_TRAIT   "roundstart" //cannot be removed without admin intervention
 #define OBESITY_TRAIT      "obesity"
 #define LIFE_ASSIST_MACHINES_TRAIT            "life_assist_machines"
+
+// Skill Traits.
+
+#define SKILLS_ENG_LOW             "skills_eng_low"
+#define SKILLS_ENG_HIGH            "skills_eng_high"
+
+#define SKILLS_MED_LOW             "skills_med_low"
+#define SKILLS_MED_HIGH            "skills_med_high"
+#define SKILLS_MED_SURGERY         "skills_med_surgery"
+
+#define SKILLS_SEC_LOW             "skills_sec_low"
+#define SKILLS_SEC_HIGH            "skills_sec_high"
+
+#define SKILLS_SCI_LOW             "skills_sci_low"
+#define SKILLS_SCI_HIGH            "skill_sci_high"
+
+#define SKILLS_COMMAND             "skills_command"
+


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
(Пока что это просто анонс для обсуждения баланса и вообще нужно ли это.)
Собственно, давняя идея с системой скиллов, но если кто об этом думал (по крайней мере публично), то представлял это как сложную систему настройки персонажа с заданием конкретных параметров самим игроком. 
Здесь же все гораздо проще: 
Каждая профессия получает свои трейты, на которые идет проверка при выполнении каких-то специфический действий. Например, тех.ассистент получает трейт "Низкий инженерный скилл", и умеет делать относительно простые инженерные действия вроде постройки/разборки простых стен, разбора всяких стульев на металл и так далее. Полноценный инженер получает трейт "Высокий инженерный скилл" и уже умеет разбирать укрепленные стены, строить и разбирать шлюзы, настраивать ускоритель частиц и так далее. 
Ролькам же выдавать все скиллы сразу как вариант.

Кроме этого, думал о внедрении трейтов через систему квирков, где за один балл можно получить низкий скилл, дополнительно к тем, что дает профессия.

А потом можно будет и через мемы учить других людей каким-то скиллам, если Людук сделает и мемы одобрят.

Список скиллов на данный момент (перезалью, если ссылка не работает):

https://docs.google.com/document/d/e/2PACX-1vT0zHsRuV6a972jC9f-XLhSzAmOtVHRcEHtscq2ohgM3KzI2hqXRKbV1fYUczt0kub9iH5Uw3s8PkcY/pub

Главная проблема с внедрением: потребуется перелопатить много взаимодействий, добавив туда проверку на трейт, и решить что делать с теми, кто не имеет скилла. Запретить вообще делать то, что требует скилл, или добавить шанс на успех(что может превратиться в закликивание до успеха)?

## Описание изменений
Добавлена система скиллов для профессий.

## Почему и что этот ПР улучшит
Специализация будет чем-то более РП ограничения.

## Авторство
Shudyn
## Чеинжлог
:cl:
- rscadd[link]: Добавлена система скиллов.