### PR TITLE
Изменение кд от взаимодействия с колокольчиком

### DIFF
--- a/code/game/objects/items/weapons/bell.dm
+++ b/code/game/objects/items/weapons/bell.dm
@@ -8,18 +8,19 @@
 	flags = NOBLUDGEON
 	hitsound = list('sound/items/oneding.ogg')
 	m_amt = 75
-	var/cooldown
+	var/next_ring
 
 /obj/item/weapon/bell/attack_hand(mob/user)
 	if(user.a_intent == INTENT_GRAB)
 		return ..()
-	else if(cooldown >= world.time)
+	if(next_ring >= world.time)
 		return
-	else if(user.a_intent == INTENT_HARM)
+
+	if(user.a_intent == INTENT_HARM)
 		user.visible_message("<span class='warning'>\The [user] hammers \the [src]!</span>")
 		playsound(user, 'sound/items/manydings.ogg', VOL_EFFECTS_MASTER)
 	else
 		user.visible_message("<span class='notice'>\The [user] rings \the [src].</span>")
 		playsound(user, 'sound/items/oneding.ogg', VOL_EFFECTS_MASTER, 20)
 	user.SetNextMove(CLICK_CD_INTERACT)
-	cooldown = world.time + 32
+	next_ring = world.time + 32

--- a/code/game/objects/items/weapons/bell.dm
+++ b/code/game/objects/items/weapons/bell.dm
@@ -23,4 +23,4 @@
 		user.visible_message("<span class='notice'>\The [user] rings \the [src].</span>")
 		playsound(user, 'sound/items/oneding.ogg', VOL_EFFECTS_MASTER, 20)
 	user.SetNextMove(CLICK_CD_INTERACT)
-	next_ring = world.time + 32
+	next_ring = world.time + 3 SECONDS

--- a/code/game/objects/items/weapons/bell.dm
+++ b/code/game/objects/items/weapons/bell.dm
@@ -8,7 +8,7 @@
 	flags = NOBLUDGEON
 	hitsound = list('sound/items/oneding.ogg')
 	m_amt = 75
-	var/next_ring
+	var/next_ring = 0
 
 /obj/item/weapon/bell/attack_hand(mob/user)
 	if(user.a_intent == INTENT_GRAB)

--- a/code/game/objects/items/weapons/bell.dm
+++ b/code/game/objects/items/weapons/bell.dm
@@ -8,14 +8,18 @@
 	flags = NOBLUDGEON
 	hitsound = list('sound/items/oneding.ogg')
 	m_amt = 75
+	var/cooldown
 
 /obj/item/weapon/bell/attack_hand(mob/user)
-	if (user.a_intent == INTENT_GRAB)
+	if(user.a_intent == INTENT_GRAB)
 		return ..()
-	else if (user.a_intent == INTENT_HARM)
+	else if(cooldown >= world.time)
+		return
+	else if(user.a_intent == INTENT_HARM)
 		user.visible_message("<span class='warning'>\The [user] hammers \the [src]!</span>")
 		playsound(user, 'sound/items/manydings.ogg', VOL_EFFECTS_MASTER)
 	else
 		user.visible_message("<span class='notice'>\The [user] rings \the [src].</span>")
 		playsound(user, 'sound/items/oneding.ogg', VOL_EFFECTS_MASTER, 20)
-	user.SetNextMove(CLICK_CD_INTERACT * 8)
+	user.SetNextMove(CLICK_CD_INTERACT)
+	cooldown = world.time + 32


### PR DESCRIPTION
## Описание изменений
При прозвоне по колокольчику персонаж вместо 32 тиков кд получает всего 4 (кд интерактов)
30 тиков кд ставятся не на моба, а на звонок
## Почему и что этот ПР улучшит
2 человека не смогут звенеть в 2 раза чаще 
не будет 32 тиковой анемии рук у персонажа, который позвонил в звонок
fix https://github.com/TauCetiStation/TauCetiClassic/issues/3024
## Авторство
Felix Ruin - Winter Schock
## Чеинжлог
:cl: Winter Schock
- bugfix: 3-ех секундная невозможность делать что-либо после удара по звонку