### PR TITLE
Фиксы фотокамеры

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -676,10 +676,7 @@ The _flatIcons list is a cache for generated icon files.
 	//Try to remove/optimize this section ASAP, CPU hog.
 	//Determines if there's directionals.
 	if(!noIcon && curdir != SOUTH)
-		var/exist = FALSE
-		if(length(icon_states(icon(curicon, curstate, curdir))))
-			exist = TRUE
-		if(!exist)
+		if(!length(icon_states(icon(curicon, curstate, curdir))))
 			base_icon_dir = SOUTH
 
 	if(!base_icon_dir)

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -665,12 +665,28 @@ The _flatIcons list is a cache for generated icon files.
 			noIcon = TRUE // Do not render this object.
 
 	var/curdir
+	var/base_icon_dir	//We'll use this to get the icon state to display if not null BUT NOT pass it to overlays as the dir we have
 	if(!exact && (!A.dir || A.dir == SOUTH))
 		curdir = defdir
 	else if(exact)
 		curdir = SOUTH
 	else
 		curdir = A.dir
+
+	//Try to remove/optimize this section ASAP, CPU hog.
+	//Determines if there's directionals.
+	if(!noIcon && curdir != SOUTH)
+		var/exist = FALSE
+		var/static/list/checkdirs = list(NORTH, EAST, WEST)
+		for(var/i in checkdirs)		//Not using GLOB for a reason.
+			if(length(icon_states(icon(curicon, curstate, i))))
+				exist = TRUE
+				break
+		if(!exist)
+			base_icon_dir = SOUTH
+
+	if(!base_icon_dir)
+		base_icon_dir = curdir
 
 	var/curblend
 	if(A.blend_mode == BLEND_DEFAULT)
@@ -683,7 +699,7 @@ The _flatIcons list is a cache for generated icon files.
 	var/image/copy
 	// Add the atom's icon itself, without pixel_x/y offsets.
 	if(!noIcon)
-		copy = image(icon=curicon, icon_state=curstate, layer=A.layer, dir=curdir)
+		copy = image(icon=curicon, icon_state=curstate, layer=A.layer, dir=base_icon_dir)
 		copy.color = A.color
 		copy.alpha = A.alpha
 		copy.blend_mode = curblend

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -677,11 +677,8 @@ The _flatIcons list is a cache for generated icon files.
 	//Determines if there's directionals.
 	if(!noIcon && curdir != SOUTH)
 		var/exist = FALSE
-		var/static/list/checkdirs = list(NORTH, EAST, WEST)
-		for(var/i in checkdirs)		//Not using GLOB for a reason.
-			if(length(icon_states(icon(curicon, curstate, i))))
-				exist = TRUE
-				break
+		if(length(icon_states(icon(curicon, curstate, curdir))))
+			exist = TRUE
 		if(!exist)
 			base_icon_dir = SOUTH
 

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -224,6 +224,7 @@
 						var/mob/dead/observer/O = A
 						if(O.orbiting) //so you dont see ghosts following people like antags, etc.
 							continue
+					else continue
 				else
 					continue
 			atoms.Add(A)

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -224,7 +224,8 @@
 						var/mob/dead/observer/O = A
 						if(O.orbiting) //so you dont see ghosts following people like antags, etc.
 							continue
-					else continue
+					else 
+						continue
 				else
 					continue
 			atoms.Add(A)

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -218,17 +218,8 @@
 	for(var/turf/T in turfs)
 		atoms.Add(T)
 		for(var/atom/movable/A in T)
-			if(A.invisibility)
-				if(see_ghosts)
-					if(istype(A, /mob/dead/observer))
-						var/mob/dead/observer/O = A
-						if(O.orbiting) //so you dont see ghosts following people like antags, etc.
-							continue
-					else 
-						continue
-				else
-					continue
-			atoms.Add(A)
+			if(!A.invisibility || (see_ghosts && isobserver(A)))
+				atoms.Add(A)
 
 	var/list/sorted = list()
 	var/j


### PR DESCRIPTION
## Описание изменений
1. _Гостли камера теперь не фотографирует невидимые объекты, которые не являются гостами_

Камера обскура фотографировала все A.invisibility объекты (кроме орбитящих призраков) из-за чего и появлялись белые артефакты, трубы на фото. Исправил. 

2. _Теперь на фото не будет не сфотографировавшихся объектов и черных плиток_

Добавил в getFlatIcon() корректировку направления иконки с [ТГ](https://github.com/tgstation/tgstation) и немного убрал лишнего кода из нее.

| Было | Стало |
| ------ | ------ |
| ![20200619 070459](https://user-images.githubusercontent.com/66636084/85095892-6ead9a00-b1fb-11ea-846a-ca29b69545cf.png) | ![20200619 065934](https://user-images.githubusercontent.com/66636084/85095898-766d3e80-b1fb-11ea-83d9-b42ef6cf793d.png) |

## Почему и что этот ПР улучшит
fixes #1204
fixes #3415
fixes #5129
## Авторство
Корректировка направления иконки взята с тг, остальное я

https://github.com/tgstation/tgstation/blob/add74bee56cfde91602eb8ee28e3cae5959bc4f6/code/__HELPERS/icons.dm
## Чеинжлог
:cl:
 - bugfix: на фото не попадали некоторые объекты и плитки
 - bugfix: на фото, сделанных camera obscura, были белые артефакты и трубы