### PR TITLE
Таяры не получают уничтожение глаз при надевании очков с цветофильтром

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1576,14 +1576,12 @@
 			sightglassesmod = "greyscale"
 
 	if(species.nighteyes)
-		if(sightglassesmod)
-			sightglassesmod = "nightsight_glasses"
-		else
-			var/light_amount = 0
-			var/turf/T = get_turf(src)
-			light_amount = round(T.get_lumcount()*10)
-			if(light_amount > 1)
-				sightglassesmod = null
+		var/light_amount = 0
+		var/turf/T = get_turf(src)
+		light_amount = round(T.get_lumcount()*10)
+		if(light_amount < 1)
+			if(sightglassesmod)
+				sightglassesmod = "nightsight_glasses"
 			else
 				sightglassesmod = "nightsight"
 	set_EyesVision(sightglassesmod)
@@ -1739,7 +1737,7 @@
 
 	if(HAS_TRAIT(src, TRAIT_CPB))
 		return PULSE_NORM
-		
+
 	var/obj/item/organ/internal/heart/IO = organs_by_name[O_HEART]
 	if(IO.heart_status == HEART_FAILURE)
 		return PULSE_NONE


### PR DESCRIPTION
## Описание изменений
Таяры при надевании очков с цветофильтром получали постоянный эффект ночного зрения, даже при полном свете, что вызывает неимоверную боль и агонию.
теперь-же данный эффект происходит только при очках с цветофильтром внутри темноты, что менее болезненно для глаз.
## Почему и что этот ПР улучшит
От очков на таяре не будут болеть глаза у игроков на таяре
## Авторство
Felix Ruin - Winter Schock
## Чеинжлог
:cl: Winter Schock
- bugfix: постоянный эффект ночного зрения у таяр в очках с цветокоррекцией 