### PR TITLE
Слепые "видят" в темноте и имеют максимальную дальность ночного "зрения" 

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1409,6 +1409,10 @@
 			see_in_dark = 8
 			see_invisible = SEE_INVISIBLE_MINIMUM
 
+		if(blinded)
+			see_in_dark = 8
+			see_invisible = SEE_INVISIBLE_MINIMUM
+
 		if(healths)
 			if (analgesic)
 				healths.icon_state = "health_health_numb"
@@ -1561,6 +1565,9 @@
 	sightglassesmod = null
 	if(stat == DEAD)
 		set_EyesVision(transition_time = 0)
+		return
+	if(blinded)
+		set_EyesVision("greyscale")
 		return
 	var/obj/item/clothing/glasses/G = glasses
 	if(istype(G) && G.active)
@@ -1739,7 +1746,7 @@
 
 	if(HAS_TRAIT(src, TRAIT_CPB))
 		return PULSE_NORM
-		
+
 	var/obj/item/organ/internal/heart/IO = organs_by_name[O_HEART]
 	if(IO.heart_status == HEART_FAILURE)
 		return PULSE_NONE


### PR DESCRIPTION
## Описание изменений
Теперь слепые видят в темноте и максимально далеко видят в темноте
Слепые получили серый (детективский) фильтр на глаза
В итоге это выглядит так
![image](https://user-images.githubusercontent.com/31424899/85106357-c0165300-b214-11ea-8aab-f9674b3b3041.png)
Так-что слепые в дополнение к этому потеряли ощущение цвета объектов (и вообще могут забыть что такое свет, им более им не нужен)
## Почему и что этот ПР улучшит
Слепые не смогут заметить нюкеров по зелёному свету
Слепым не нужен свет чтобы видеть в темноте
Слепые не смогут в понимание света и цвета объектов
## Авторство
Felix Ruin - Winter Schock
## Чеинжлог
:cl: Winter Schock
- tweak: слепые не нуждаются в свете для ощущения объектов вокруг себя