### PR TITLE
премодерация флафа в fun и выдача пойнтов в пермишены

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -26,8 +26,6 @@ var/list/admin_verbs_admin = list(
 	/client/proc/get_whitelist, 			//Whitelist,
 	/client/proc/add_to_whitelist,
 	/datum/admins/proc/whitelist_panel,
-	/datum/admins/proc/customitems_panel,
-	/datum/admins/proc/customitemspremoderation_panel,
 	/datum/admins/proc/library_recycle_bin,
 	/client/proc/jumptocoord,			//we ghost and jump to a coordinate,
 	/client/proc/Getmob,				//teleports a mob to our location,
@@ -110,6 +108,7 @@ var/list/admin_verbs_fun = list(
 	/client/proc/one_click_antag,
 	/datum/admins/proc/toggle_aliens,
 	/datum/admins/proc/toggle_space_ninja,
+	/datum/admins/proc/customitemspremoderation_panel,
 	/client/proc/send_space_ninja,
 	/client/proc/cmd_admin_add_freeform_ai_law,
 	/client/proc/cmd_admin_add_random_ai_law,
@@ -195,6 +194,7 @@ var/list/admin_verbs_permissions = list(
 	/client/proc/library_debug_read,
 	/client/proc/regisration_panic_bunker,
 	/client/proc/host_announcements,
+	/datum/admins/proc/customitems_panel,
 	)
 var/list/admin_verbs_rejuv = list(
 	/client/proc/cmd_admin_rejuvenate,

--- a/code/modules/fluff/premoderation.dm
+++ b/code/modules/fluff/premoderation.dm
@@ -76,7 +76,7 @@
 
 /datum/admins/proc/customitemsview_panel(player_ckey = null)
 	src = usr.client.holder
-	if(!check_rights(R_PERMISSIONS))
+	if(!check_rights(R_FUN))
 		return
 
 	var/output = {"<!DOCTYPE html>


### PR DESCRIPTION
## Описание изменений
Перетаскивание админских кнопок для флафа под нужные права
Смена прав на подтверждение флафа под права фана
## Почему и что этот ПР улучшит
Более быстрое рассмотрение флафа
Уменьшение количества надоедливых кнопок у недостойных
## Авторство
Felix Ruin - Winter Schock
## Чеинжлог
:cl: Winter Schock
- tweak: админы с кнопками fun способны подтверждать флаф