### PR TITLE
matches igniting attackby

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -429,7 +429,7 @@
 /obj/item/weapon/storage/box/matches/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/weapon/match))
 		var/obj/item/weapon/match/M = I
-		if(!M.lit && !M.burnt)
+		if(M.lit || M.burnt)
 			return
 
 		if(prob(20))


### PR DESCRIPTION
## Описание изменений

Из-за того что я перепутал при переносе порядок проверок, спички нельзя было зажечь об коробку. Теперь можно.

## Почему и что этот ПР улучшит

Исправляет баг.

## Чеинжлог
:cl: Luduk
- bugfix: Спички зажигаются об спичечный коробок.