### PR TITLE
Хим диспенсер в химии принимает только beaker

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -194,7 +194,7 @@
 		to_chat(user, "Something is already loaded into the machine.")
 		return
 	if(istype(B, /obj/item/weapon/reagent_containers/glass) || istype(B, /obj/item/weapon/reagent_containers/food))
-		if(!accept_glass && istype(B,/obj/item/weapon/reagent_containers/food))
+		if(!accept_glass && (!istype(B,/obj/item/weapon/reagent_containers/glass/beaker) || istype(B,/obj/item/weapon/reagent_containers/glass/beaker/fluff/eleanor_stone)))
 			to_chat(user, "<span class='notice'>This machine only accepts beakers</span>")
 			return
 		if(istype(B, /obj/item/weapon/reagent_containers/food/drinks/cans))
@@ -1145,7 +1145,7 @@
 		to_chat(user, "Cannot refine into a reagent.")
 		return 1
 
-	user.drop_from_inventory(O, src) 
+	user.drop_from_inventory(O, src)
 	holdingitems += O
 	src.updateUsrDialog()
 	return 0


### PR DESCRIPTION
## Описание изменений
Хим диспенсер в химии принимает только beaker (чайник тоже не принимается)
![image](https://user-images.githubusercontent.com/31424899/85360399-bdbc3d80-b521-11ea-9265-8deb25107cf9.png)
вот это всё короче принимает только
## Почему и что этот ПР улучшит
Чайник перестанут воровать из приёмной мед-бея
Механопрелюбодеятели не смогут пихать что попало в хим раздатчик
## Авторство
Felix Ruin - Winter Schock
## Чеинжлог
:cl: Winter Schock
- balance: хим диспенсер в химии принимает только beaker