### PR TITLE
Заказ 4 каталки за 1000 пойнтов в карго

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -995,6 +995,15 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	crate_name = "Medical crate"
 	group = "Medical / Science"
 
+/datum/supply_pack/roller_beds
+	name = "Roller beds crate"
+	cost = 1000
+	contains = list(/obj/item/roller, /obj/item/roller,
+					/obj/item/roller, /obj/item/roller)
+	crate_type = /obj/structure/closet/crate
+	crate_name = "Roller beds crate"
+	group = "Medical / Science"
+
 /datum/supply_pack/virus
 	name = "Virus sample crate"
 	contains = list(/obj/item/weapon/virusdish/random,


### PR DESCRIPTION
## Описание изменений
Возможность заказать в карго 4 каталки
resolve https://github.com/TauCetiStation/TauCetiClassic/issues/5458
## Почему и что этот ПР улучшит
Больше возобновляемых ресурсов на станции - более шансов всё восстановить
Медикам не придётся бегать за клоунами которые воруют каталки
## Авторство
Felix Ruin - Winter Schock
## Чеинжлог
:cl: Winter Schock
- tweak: возможность заказать 4 каталки в карго за 1000 пойнтов