### PR TITLE
Comemmorative plaque fix

### DIFF
--- a/code/game/turfs/simulated/floor_types.dm
+++ b/code/game/turfs/simulated/floor_types.dm
@@ -45,6 +45,11 @@
 	heat_capacity = 325000
 	footstep = FOOTSTEP_PLATING
 
+/turf/simulated/floor/goonplaque
+	name = "Comemmorative Plaque";
+	desc = "\"This is a plaque in honour of our comrades on the G4407 Stations. Hopefully TG4407 model can live up to your fame and fortune.\" Scratched in beneath that is a crude image of a meteor and a spaceman. The spaceman is laughing. The meteor is exploding.";
+	icon_state = "plaque";
+
 /turf/simulated/floor/engine/attackby(obj/item/weapon/C, mob/user)
 	if(iswrench(C))
 		if(user.is_busy(src))

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -20322,15 +20322,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor{
-	desc = "“This is a plaque in honour of our comrades on the G4407 Stations. Hopefully TG4407 model can live up to your fame and fortune.” Scratched in beneath that is a crude image of a meteor and a spaceman. The spaceman is laughing. The meteor is exploding.";
-	dir = 4;
-	icon_state = "plaque";
-	name = "Comemmorative Plaque";
-	nitrogen = 30;
-	oxygen = 70;
-	temperature = 80
-	},
+/turf/simulated/floor/goonplaque,
 /area/station/hallway/secondary/entry)
 "aKc" = (
 /obj/structure/toilet{

--- a/maps/gamma/gamma.dmm
+++ b/maps/gamma/gamma.dmm
@@ -59759,15 +59759,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "srk" = (
-/turf/simulated/floor{
-	desc = "“This is a plaque in honour of our comrades on the G4407 Stations. Hopefully TG4407 model can live up to your fame and fortune.” Scratched in beneath that is a crude image of a meteor and a spaceman. The spaceman is laughing. The meteor is exploding.";
-	dir = 4;
-	icon_state = "plaque";
-	name = "Comemmorative Plaque";
-	nitrogen = 30;
-	oxygen = 70;
-	temperature = 80
-	},
+/turf/simulated/floor/goonplaque,
 /area/station/hallway/secondary/entry)
 "srx" = (
 /obj/structure/grille,


### PR DESCRIPTION
## Описание изменений
Добавляет памятную плитку как объект /turf/simulated/floor/goonplaque и заменяет на картах 
## Почему и что этот ПР улучшит
В ПРах, в которых редактируется карта больше не будет всплывать изменение памятной плитки из-за кавычек
## Авторство
так сделано на тг и на парадайз стэйшн