### PR TITLE
Фикс абуза фавора

### DIFF
--- a/code/game/gamemodes/heist/heist_prices.dm
+++ b/code/game/gamemodes/heist/heist_prices.dm
@@ -221,6 +221,7 @@
 /obj/item/weapon/stock_parts/cell/super/price = 3800
 /obj/item/weapon/circular_saw/price = 1250
 /obj/item/weapon/claymore/price = 5000
+/obj/item/weapon/claymore/religion/price = 2000
 /obj/item/weapon/coin/price = 15
 /obj/item/weapon/coin/bananium/price = 3000
 /obj/item/weapon/coin/diamond/price = 20000


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Можно было сделать меч за 100 фавора, а потом его пожертвовать и получить 250 фавора

## Почему и что этот ПР улучшит
Баланс

## Авторство
Я

## Чеинжлог
:cl:
 - bugfix: Капеллан мог пожертвовать призванный клеймор и получить больше фавора, чем затратил.