### PR TITLE
фиксит ракетницу голиаф

### DIFF
--- a/code/modules/projectiles/guns/projectile/rocket.dm
+++ b/code/modules/projectiles/guns/projectile/rocket.dm
@@ -21,6 +21,27 @@
 	wielded = 1
 	update_icon()
 
+/obj/item/weapon/gun/projectile/revolver/rocketlauncher/MouseDrop(obj/over_object)
+	if (ishuman(usr) || ismonkey(usr))
+		var/mob/M = usr
+		//makes sure that the clothing is equipped so that we can't drag it into our hand from miles away.
+		if (loc != usr)
+			return
+		if (!over_object)
+			return
+
+		if (!usr.incapacitated())
+			switch(over_object.name)
+				if("r_hand")
+					if(!M.unEquip(src))
+						return
+					M.put_in_r_hand(src)
+				if("l_hand")
+					if(!M.unEquip(src))
+						return
+					M.put_in_l_hand(src)
+			add_fingerprint(usr)
+
 /obj/item/weapon/gun/projectile/revolver/rocketlauncher/mob_can_equip(M, slot)
 	//Cannot equip wielded items.
 	if(wielded)

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -177,7 +177,7 @@
 	edge = 0
 
 /obj/item/projectile/missile/on_hit(atom/target, def_zone = BP_CHEST, blocked = 0)
-	explosion(target.loc, 1,2,4,5)
+	explosion(target, 1,2,4,5)
 	return 1
 
 /obj/item/projectile/missile/emp

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -177,11 +177,8 @@
 	edge = 0
 
 /obj/item/projectile/missile/on_hit(atom/target, def_zone = BP_CHEST, blocked = 0)
-	target.ex_act(1)
-	explosion(target, 1,2,4,5)
+	explosion(target.loc, 1,2,4,5)
 	return 1
-
-
 
 /obj/item/projectile/missile/emp
 	damage = 10


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
теперь голиаф можно перетащить из слотов себе в руку и взрыв будет нормально взрываться при контакте со шлюзами и прочим.
## Почему и что этот ПР улучшит
багфикс
## Авторство

## Чеинжлог
:cl:
- bugfix: Ракетницу можно перетащить из слотов в руки.
- bugfix: Ракеты теперь нормально взрываются при контакте со шлюзами и прочим.
