### PR TITLE
Добавление lofi плэйлиста для жукбокса в баре

### DIFF
--- a/code/modules/media/jukebox.dm
+++ b/code/modules/media/jukebox.dm
@@ -301,6 +301,7 @@ var/global/loopModeNames=list(
 		"hiphop" = "Hip-Hop for Space Gangstas",
 		"vaporfunk" = "Qerrbalak VaporFunkFM",
 		"thematic" = "Side-Bursting Tunes",
+		"lofi" = "Sadness/Longing/Loneliness",
 	)
 
 // Relaxing elevator music~
@@ -330,6 +331,7 @@ var/global/loopModeNames=list(
 		"hiphop" = "Hip-Hop for Space Gangstas",
 		"vaporfunk" = "Qerrbalak VaporFunkFM",
 		"thematic" = "Side-Bursting Tunes",
+		"lofi" = "Sadness/Longing/Loneliness",
 	)
 
 /obj/machinery/media/jukebox/techno


### PR DESCRIPTION
## Описание изменений
Добавлен новый плэйлист
## Почему и что этот ПР улучшит
Добавление новых песен в жукбокс, что явно разнообразит бар
## Чеинжлог
🆑
- sound: В музыкальном проигрывателе появился новый плейлист для настоящих dead inside и sadboys