### PR TITLE
Zombie fix

### DIFF
--- a/code/modules/mob/living/carbon/human/zombie.dm
+++ b/code/modules/mob/living/carbon/human/zombie.dm
@@ -247,7 +247,7 @@
 
 	for(var/i = rand(maxchanges / 2, maxchanges), i > 0, i--)
 		var/insertpos = rand(1, message_list.len)
-		message_list.Insert(insertpos, "[pick("�����", "�����", "��������", "����������", "������", "����", "������", "�����", "����", "����", "��������", "������")]...")
+		message_list.Insert(insertpos, "[pick("ÌÎÇÃÈ", "Ìîçãè", "Ìîîçãèèè", "ÌÎÎÎÇÃÈÈÈÈ", "ÁÎËÜÍÎ", "ÁÎËÜ", "ÏÎÌÎÃÈ", "ÐÀÀÀÀ", "ÀÀÀÀ", "ÀÐÐÕ", "ÎÒÊÐÎÉÒÅ", "ÎÒÊÐÎÉ")]...")
 
 	for(var/i = 1, i <= message_list.len, i++)
 		if(prob(50) && !(copytext(message_list[i], length(message_list[i]) - 2) == "..."))

--- a/code/modules/mob/living/carbon/human/zombie.dm
+++ b/code/modules/mob/living/carbon/human/zombie.dm
@@ -172,13 +172,6 @@
 	H.nutrition = 400
 	H.SetSleeping(0)
 	H.radiation = 0
-
-	var/obj/item/organ/internal/eyes/IO = H.organs_by_name[O_EYES]
-	if(istype(IO))
-		IO.damage = 0
-		H.eye_blurry = 0
-		H.eye_blind = 0
-
 	H.heal_overall_damage(H.getBruteLoss(), H.getFireLoss())
 	H.restore_blood()
 
@@ -254,7 +247,7 @@
 
 	for(var/i = rand(maxchanges / 2, maxchanges), i > 0, i--)
 		var/insertpos = rand(1, message_list.len)
-		message_list.Insert(insertpos, "[pick("лнгцх", "лНГЦХ", "лННГЦХХХ", "лнннгцхххх", "анкэмн", "анкэ", "онлнцх", "пюююю", "юююю", "юппу", "нрйпнире", "нрйпни")]...")
+		message_list.Insert(insertpos, "[pick("О©╫О©╫О©╫О©╫О©╫", "О©╫О©╫О©╫О©╫О©╫", "О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫", "О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫", "О©╫О©╫О©╫О©╫О©╫О©╫", "О©╫О©╫О©╫О©╫", "О©╫О©╫О©╫О©╫О©╫О©╫", "О©╫О©╫О©╫О©╫О©╫", "О©╫О©╫О©╫О©╫", "О©╫О©╫О©╫О©╫", "О©╫О©╫О©╫О©╫О©╫О©╫О©╫О©╫", "О©╫О©╫О©╫О©╫О©╫О©╫")]...")
 
 	for(var/i = 1, i <= message_list.len, i++)
 		if(prob(50) && !(copytext(message_list[i], length(message_list[i]) - 2) == "..."))

--- a/code/modules/mob/living/carbon/human/zombie.dm
+++ b/code/modules/mob/living/carbon/human/zombie.dm
@@ -124,6 +124,15 @@
 		return
 	var/obj/item/organ/external/LArm = H.bodyparts_by_name[BP_L_ARM]
 	var/obj/item/organ/external/RArm = H.bodyparts_by_name[BP_R_ARM]
+	var/obj/item/organ/internal/eyes = H.bodyparts_by_name[O_EYES]
+	var/obj/item/organ/internal/brain = H.bodyparts_by_name[O_BRAIN]
+	if(eyes)
+		eyes.damage = 0
+	if(brain)
+		brain.damage = 0
+	H.setBrainLoss(0)
+	H.eye_blurry = 0
+	H.eye_blind = 0
 
 	if(LArm && !(LArm.is_stump) && !istype(H.l_hand, /obj/item/weapon/melee/zombie_hand))
 		H.drop_l_hand()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1047,7 +1047,8 @@ note dizziness decrements automatically in the mob's Life() proc.
 
 /mob/proc/AddSpell(obj/effect/proc_holder/spell/spell)
 	spell_list += spell
-	mind.spell_list += spell	//Connect spell to the mind for transfering action buttons between mobs
+	if(mind)
+		mind.spell_list += spell	//Connect spell to the mind for transfering action buttons between mobs
 	if(!spell.action)
 		spell.action = new/datum/action/spell_action
 		spell.action.target = spell

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -403,6 +403,8 @@
 /obj/item/organ/internal/eyes/process() //Eye damage replaces the old eye_stat var.
 	if(iszombie(owner))
 		damage = 0
+		owner.eye_blurry = 0
+		owner.eye_blind = 0
 		return
 	..()
 	if(is_bruised())

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -387,6 +387,7 @@
 
 /obj/item/organ/internal/brain/process()
 	if(iszombie(owner))
+		damage = 0
 		return
 	..()
 
@@ -401,6 +402,7 @@
 
 /obj/item/organ/internal/eyes/process() //Eye damage replaces the old eye_stat var.
 	if(iszombie(owner))
+		damage = 0
 		return
 	..()
 	if(is_bruised())

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -385,12 +385,6 @@
 	name = "positronic brain"
 	parent_bodypart = BP_CHEST
 
-/obj/item/organ/internal/brain/process()
-	if(iszombie(owner))
-		damage = 0
-		return
-	..()
-
 /obj/item/organ/internal/eyes
 	name = "eyes"
 	organ_tag = O_EYES
@@ -401,11 +395,6 @@
 	robotic = 2
 
 /obj/item/organ/internal/eyes/process() //Eye damage replaces the old eye_stat var.
-	if(iszombie(owner))
-		damage = 0
-		owner.eye_blurry = 0
-		owner.eye_blind = 0
-		return
 	..()
 	if(is_bruised())
 		owner.eye_blurry = 20

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -385,6 +385,11 @@
 	name = "positronic brain"
 	parent_bodypart = BP_CHEST
 
+/obj/item/organ/internal/brain/process()
+	if(iszombie(owner))
+		return
+	..()
+
 /obj/item/organ/internal/eyes
 	name = "eyes"
 	organ_tag = O_EYES
@@ -395,6 +400,8 @@
 	robotic = 2
 
 /obj/item/organ/internal/eyes/process() //Eye damage replaces the old eye_stat var.
+	if(iszombie(owner))
+		return
 	..()
 	if(is_bruised())
 		owner.eye_blurry = 20


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Теперь зомби не впадают в перманентный брейнрот от полученных на мозг повреждений
## Почему и что этот ПР улучшит
Улучшит жизнь зомбарям, которые постоянно бегают со слепотой, блюром, а каждые полсекунды падают на пол
(Я думал еще артериалки убрать или хотя бы лечить при воскрешении, но не знаю)
## Авторство
Cool20141
## Чеинжлог
:cl:
- bugfix: Брейндамаг и слепота теперь не затронут зомби