### PR TITLE
doesn't fix anything specifically as of yet but makes the thing a bit smarter about butcher results

### DIFF
--- a/code/modules/organs/external/flesh.dm
+++ b/code/modules/organs/external/flesh.dm
@@ -9,7 +9,7 @@
 	BP = B
 
 	if(BP.species && BP.species.bodypart_butcher_results)
-		BP.butcher_results = BP.species.bodypart_butcher_results
+		BP.butcher_results = BP.species.bodypart_butcher_results.Copy()
 	else if(bodypart_type == BODYPART_ORGANIC)
 		BP.butcher_results = list(/obj/item/weapon/reagent_containers/food/snacks/meat/human = 1)
 	else if(bodypart_type == BODYPART_ROBOTIC)


### PR DESCRIPTION
## Описание изменений

Копирует список результатов разделки у расы вместо того чтобы отсылаться на него

## Почему и что этот ПР улучшит

Никто не сможет создать баги убирая из этого списка элементы как это уже кое-где делалось и даже фиксилось #5660

