### PR TITLE
color mixer requires only one circuitboard

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -414,7 +414,6 @@ to destroy them and players will be able to make replacements.
 	origin_tech = "programming=2;materials=2"
 	board_type = "machine"
 	req_components = list(
-							/obj/item/weapon/circuitboard/color_mixer = 1,
 							/obj/item/weapon/stock_parts/manipulator = 2,
 							/obj/item/stack/cable_coil = 1)
 


### PR DESCRIPTION
## Описание изменений

Само наличие платы в руке уже показывает что она есть для этой машины, и её не нужно прописывать в список нужных компонентов

## Почему и что этот ПР улучшит

fixes #5723 

## Чеинжлог
:cl: Luduk
- bugfix: Color Mixer требует одну плату для сборки. 