### PR TITLE
Моб при притягивании-отталкивании смотрит в сторону действия

### DIFF
--- a/code/datums/components/swiping.dm
+++ b/code/datums/components/swiping.dm
@@ -305,6 +305,7 @@
 
 	sweep_push(target, T, user)
 
+	user.face_atom(T)
 	user.do_attack_animation(T)
 
 	if(istype(get_turf(W), /turf/simulated) && istype(user.buckled, /obj/structure/stool/bed/chair) && !user.buckled.anchored && user.buckled != target)
@@ -396,6 +397,7 @@
 
 	sweep_pull(target, T, user)
 
+	user.face_atom(T)
 	user.do_attack_animation(T)
 
 	if(WS.Adjacent(target))
@@ -434,10 +436,11 @@
 
 // A proc called each new tile we're swiping across, before all the possible checks.
 /datum/component/swiping/proc/sweep_move(turf/current_turf, obj/effect/effect/weapon_sweep/sweep_image, mob/user)
+	user.face_atom(current_turf)
+
 	if(on_sweep_move)
 		on_sweep_move.Invoke(current_turf, sweep_image, user)
 		return
-	user.face_atom(current_turf)
 
 // A proc that checks whether the sweep will hit target.
 /datum/component/swiping/proc/can_sweep_hit(atom/target, mob/user)

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -414,7 +414,6 @@ to destroy them and players will be able to make replacements.
 	origin_tech = "programming=2;materials=2"
 	board_type = "machine"
 	req_components = list(
-							/obj/item/weapon/circuitboard/color_mixer = 1,
 							/obj/item/weapon/stock_parts/manipulator = 2,
 							/obj/item/stack/cable_coil = 1)
 


### PR DESCRIPTION
## Описание изменений

См. шапку поста

## Почему и что этот ПР улучшит

Игроки не пихают-притягиваю жопой
(Постоянство, реакция на клик игрока по вещам именно такая - он к ней поворачивается, пуш-пулл-верчение делают клик - значит должны вертеться)