### PR TITLE
evidence bag doesn't bug wabbajack hat out

### DIFF
--- a/code/modules/clothing/head/wiz_tophat.dm
+++ b/code/modules/clothing/head/wiz_tophat.dm
@@ -158,6 +158,7 @@ var/global/list/tophats_list = list()
 
 /obj/effect/overlay/tophat_portal/attackby(obj/item/I, mob/user)
 	tp_to_tophat(I)
+	return TRUE
 
 /obj/effect/overlay/tophat_portal/Crossed(atom/movable/AM)
 	. = ..()
@@ -459,10 +460,10 @@ var/global/list/tophats_list = list()
 			to_chat(user, "<span class='warning'>Are you crazy? This hat could never fit [I] in...</span>")
 			return
 		drop_into(I, user)
-		return
+		return TRUE
 	if(user.mind && user.mind.special_role == "Wizard")
 		drop_into(I, user)
-		return
+		return TRUE
 	return ..()
 
 /obj/item/clothing/head/wizard/tophat/attack_hand(mob/living/user)


### PR DESCRIPTION
## Описание изменений

Не выполняется afterattack при клике пакетом для вещ. док-в по шляпе. Теперь шляпа не кладется в пакетик который кладётся в шляпу.

## Почему и что этот ПР улучшит

Исправляет баг

fixes #5770

## Чеинжлог
:cl: Luduk
- bugfix: Тык пакетиком для вещ. док-в по шляпе мага не телепортирует шляпу в пакетик а пакетик в шляпу уничтожая его, а просто телепортирует пакетик в шляпу.