### PR TITLE
кнопку [Guard pass] в "Server"

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1200,6 +1200,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		to_chat(src, "This player already has more minutes than [value]!")
 
 /client/proc/grand_guard_pass()
+	set category = "Server"
 	set name = "Guard pass"
 	set desc = "Allow a new player to skip the guard checks"
 


### PR DESCRIPTION
## Описание изменений
добавляет кнопку [Guard pass] в категорию "Server", тем самым убирая вкладку Commands с единственной кнопкой
<details>
  <summary> Было: </summary>

![20200706 180555](https://user-images.githubusercontent.com/66636084/86609156-32788880-bfb4-11ea-8f3f-658d39d8a65b.png)
</details>

## Почему и что этот ПР улучшит
Меньше вкладок, легче ориентироваться глазам