### PR TITLE
AI preview and eyeobj.loc fixes

### DIFF
--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -205,7 +205,7 @@
 
 	if(previewJob)
 		if(istype(previewJob, /datum/job/ai))
-			parent.show_character_previews(image('icons/mob/AI.dmi', "AI", dir = SOUTH))
+			parent.show_character_previews(image('icons/mob/AI.dmi', "ai", dir = SOUTH))
 			return
 		if(istype(previewJob, /datum/job/cyborg))
 			parent.show_character_previews(image('icons/mob/robots.dmi', "robot", dir = SOUTH))

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -77,6 +77,12 @@ var/list/ai_verbs_default = list(
 	var/last_announcement = ""
 	var/wipe_timer_id = 0
 
+	var/mob/camera/Eye/ai/eyeobj
+	var/sprint = 10
+	var/cooldown = 0
+	var/acceleration = 1
+	var/obj/machinery/hologram/holopad/holo = null
+
 /mob/living/silicon/ai/proc/add_ai_verbs()
 	verbs |= ai_verbs_default
 
@@ -165,6 +171,8 @@ var/list/ai_verbs_default = list(
 
 			job = "AI"
 
+	create_eye()
+	
 	new /obj/machinery/ai_powersupply(src)
 
 	hud_list[HEALTH_HUD]      = image('icons/mob/hud.dmi', src, "hudblank")

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -160,14 +160,7 @@ var/list/ai_verbs_default = list(
 			if (B.brainmob.mind)
 				B.brainmob.mind.transfer_to(src)
 
-			to_chat(src, "<B>You are playing the station's AI. The AI cannot move, but can interact with many objects while viewing them (through cameras).</B>")
-			to_chat(src, "<B>To look at other parts of the station, click on yourself to get a camera menu.</B>")
-			to_chat(src, "<B>While observing through a camera, you can use most (networked) devices which you can see, such as computers, APCs, intercoms, doors, etc.</B>")
-			to_chat(src, "To use something, simply click on it.")
-			to_chat(src, "Use say :b to speak to your cyborgs through binary.")
-			if (!(ticker && ticker.mode && (mind in ticker.mode.malf_ai)))
-				show_laws()
-				to_chat(src, "<b>These laws may be changed by other players, or by you being the traitor.</b>")
+			on_mob_init()
 
 			job = "AI"
 
@@ -185,6 +178,16 @@ var/list/ai_verbs_default = list(
 	hud_list[SPECIALROLE_HUD] = image('icons/mob/hud.dmi', src, "hudblank")
 
 	ai_list += src
+
+/mob/living/silicon/ai/proc/on_mob_init()
+	to_chat(src, "<B>You are playing the station's AI. The AI cannot move, but can interact with many objects while viewing them (through cameras).</B>")
+	to_chat(src, "<B>To look at other parts of the station, click on yourself to get a camera menu.</B>")
+	to_chat(src, "<B>While observing through a camera, you can use most (networked) devices which you can see, such as computers, APCs, intercoms, doors, etc.</B>")
+	to_chat(src, "To use something, simply click on it.")
+	to_chat(src, "Use say \":b to speak to your cyborgs through binary.")
+	if (!(ticker && ticker.mode && (src.mind in ticker.mode.malf_ai)))
+		src.show_laws()
+		to_chat(src, "<b>These laws may be changed by other players, or by you being the traitor.</b>")
 
 /mob/living/silicon/ai/Destroy()
 	connected_robots.Cut()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -160,7 +160,7 @@ var/list/ai_verbs_default = list(
 			if (B.brainmob.mind)
 				B.brainmob.mind.transfer_to(src)
 
-			on_mob_init()
+			announce_role()
 
 			job = "AI"
 
@@ -179,7 +179,7 @@ var/list/ai_verbs_default = list(
 
 	ai_list += src
 
-/mob/living/silicon/ai/proc/on_mob_init()
+/mob/living/silicon/ai/proc/announce_role()
 	to_chat(src, "<B>You are playing the station's AI. The AI cannot move, but can interact with many objects while viewing them (through cameras).</B>")
 	to_chat(src, "<B>To look at other parts of the station, click on yourself to get a camera menu.</B>")
 	to_chat(src, "<B>While observing through a camera, you can use most (networked) devices which you can see, such as computers, APCs, intercoms, doors, etc.</B>")

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -79,23 +79,15 @@
 		return loc
 
 // AI MOVEMENT
-
-// The AI's "eye". Described on the top of the page.
-
-/mob/living/silicon/ai
-	var/mob/camera/Eye/ai/eyeobj = new()
-	var/sprint = 10
-	var/cooldown = 0
-	var/acceleration = 1
-	var/obj/machinery/hologram/holopad/holo = null
-
 // Intiliaze the eye by assigning it's "ai" variable to us. Then set it's loc to us.
-/mob/living/silicon/ai/atom_init()
-	. = ..()
+/mob/living/silicon/ai/proc/create_eye()
+	if(eyeobj)
+		return
+	eyeobj = new()
 	eyeobj.master = src
 	eyeobj.ai = src
+	eyeobj.setLoc(loc)
 	eyeobj.name = "[src.name] (AI Eye)" // Give it a name
-	eyeobj.loc = loc
 
 /mob/living/silicon/ai/Destroy()
 	if(eyeobj)

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -142,11 +142,6 @@
 
 // Return to the Core.
 
-/mob/living/silicon/ai/proc/core()
-
-	view_core()
-
-
 /mob/living/silicon/ai/proc/view_core()
 	camera = null
 	cameraFollow = null

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -344,7 +344,7 @@
 	else
 		O.key = key
 
-	O.on_mob_init()
+	O.announce_role()
 
 	O.add_ai_verbs()
 	O.job = "AI"

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -305,16 +305,8 @@
 /mob/proc/AIize(move=1)
 	if(client)
 		playsound_stop(CHANNEL_MUSIC) // stop the jams for AIs
-	var/mob/living/silicon/ai/O = new (loc, base_law_type,,1)//No MMI but safety is in effect.
-	O.invisibility = 0
-	O.aiRestorePowerRoutine = 0
 
-	if(mind)
-		mind.transfer_to(O)
-		O.mind.original = O
-	else
-		O.key = key
-
+	var/newloc = loc
 	if(move)
 		var/obj/loc_landmark
 		for(var/obj/effect/landmark/start/sloc in landmarks_list)
@@ -330,13 +322,17 @@
 						continue
 					loc_landmark = tripai
 		if (!loc_landmark)
-			to_chat(O, "Oh god sorry we can't find an unoccupied AI spawn location, so we're spawning you on top of someone.")
+			to_chat(src, "Oh god sorry we can't find an unoccupied AI spawn location, so we're spawning you on top of someone.")
 			for(var/obj/effect/landmark/start/sloc in landmarks_list)
 				if (sloc.name == "AI")
 					loc_landmark = sloc
 
-		O.loc = loc_landmark.loc
-		for (var/obj/item/device/radio/intercom/comm in O.loc)
+		newloc = loc_landmark.loc
+
+	var/mob/living/silicon/ai/O = new (newloc, base_law_type,,1)//No MMI but safety is in effect.
+
+	if(move)
+		for(var/obj/item/device/radio/intercom/comm in O.loc)
 			comm.ai += O
 
 	to_chat(O, "<B>You are playing the station's AI. The AI cannot move, but can interact with many objects while viewing them (through cameras).</B>")
@@ -347,6 +343,14 @@
 	if (!(ticker && ticker.mode && (O.mind in ticker.mode.malf_ai)))
 		O.show_laws()
 		to_chat(O, "<b>These laws may be changed by other players, or by you being the traitor.</b>")
+	O.invisibility = 0
+	O.aiRestorePowerRoutine = 0
+
+	if(mind)
+		mind.transfer_to(O)
+		O.mind.original = O
+	else
+		O.key = key
 
 	O.add_ai_verbs()
 	O.job = "AI"

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -335,14 +335,6 @@
 		for(var/obj/item/device/radio/intercom/comm in O.loc)
 			comm.ai += O
 
-	to_chat(O, "<B>You are playing the station's AI. The AI cannot move, but can interact with many objects while viewing them (through cameras).</B>")
-	to_chat(O, "<B>To look at other parts of the station, click on yourself to get a camera menu.</B>")
-	to_chat(O, "<B>While observing through a camera, you can use most (networked) devices which you can see, such as computers, APCs, intercoms, doors, etc.</B>")
-	to_chat(O, "To use something, simply click on it.")
-	to_chat(O, "Use say \":b to speak to your cyborgs through binary.")
-	if (!(ticker && ticker.mode && (O.mind in ticker.mode.malf_ai)))
-		O.show_laws()
-		to_chat(O, "<b>These laws may be changed by other players, or by you being the traitor.</b>")
 	O.invisibility = 0
 	O.aiRestorePowerRoutine = 0
 
@@ -351,6 +343,8 @@
 		O.mind.original = O
 	else
 		O.key = key
+
+	O.on_mob_init()
 
 	O.add_ai_verbs()
 	O.job = "AI"


### PR DESCRIPTION
## Описание изменений
исправил баг, что глаз ИИ после спавна при попытке движения телепортировался на первый слой
исправил, что в превью не отображался ИИ
немножко рефактора

|Было|Стало|
|-|-|
| <img src="https://user-images.githubusercontent.com/66636084/86950017-3b09c400-c158-11ea-9ebf-85ac40b98c3b.png"/> |<img src="https://user-images.githubusercontent.com/66636084/86950071-51178480-c158-11ea-9f26-d468a4d318e9.png"/> |

|Было|Стало|
|-|-|
|![20200708 153505](https://user-images.githubusercontent.com/66636084/86949432-4c9e9c00-c157-11ea-9c7a-4f6a7055b740.png)|![20200708 153447](https://user-images.githubusercontent.com/66636084/86949450-51635000-c157-11ea-9367-03c713d408d4.png)|

## Почему и что этот ПР улучшит
ИИ больше не придется делать клик на кнопку телепорта к ядру после спавна
## Авторство
смотрел как сделано на paradise и polaris
## Чеинжлог
:cl:
 - bugfix: в преференсах в превью не отображался ИИ
 - bugfix: глаз ИИ больше не телепортируется на первый слой при попытке сдвинуться после спавна
