### PR TITLE
Закрывает преференс окно при спавне

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -547,6 +547,10 @@ commented cause polls are kinda broken now, needs refactoring */
 /mob/dead/new_player/proc/close_spawn_windows()
 	src << browse(null, "window=latechoices") //closes late choices window
 	src << browse(null, "window=playersetup") //closes the player setup window
+	src << browse(null, "window=preferences_window")
+	var/client/C = src.client
+	if(C)
+		C.clear_character_previews()
 
 /mob/dead/new_player/proc/has_admin_rights()
 	return (client && client.holder && (client.holder.rights & R_ADMIN))

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -548,9 +548,8 @@ commented cause polls are kinda broken now, needs refactoring */
 	src << browse(null, "window=latechoices") //closes late choices window
 	src << browse(null, "window=playersetup") //closes the player setup window
 	src << browse(null, "window=preferences_window")
-	var/client/C = src.client
-	if(C)
-		C.clear_character_previews()
+	if(client)
+		client.clear_character_previews()
 
 /mob/dead/new_player/proc/has_admin_rights()
 	return (client && client.holder && (client.holder.rights & R_ADMIN))


### PR DESCRIPTION
## Описание изменений
Закрывает преференс окно при спавне.

Описание проблемы:
Если открыть в лобби преференс окно ("Setup Character") и заспавниться, то оно не пропадет. При этом закрыть его нельзя, т.к. кнопки, включая "close" не работают, из-за чего приходится перезаходить или прятать окошко внизу, чтобы избавиться от него

<details>
 <summary> вот собственно как выглядит проблема: </summary>

Ты заспавнился, а преференс окно осталось и его нельзя закрыть:
![image](https://user-images.githubusercontent.com/66636084/87174755-51db2280-c2e0-11ea-851b-6cec76e7805f.png)

</details>

## Почему и что этот ПР улучшит
Больше не придется прятать окошко преференсов вниз или перезаходить, чтобы убрать его
## Чеинжлог
:cl:
 - bugfix: преференс окно не исчезало после спавна, при этом кнопки в нем не работали и закрыть его не получалось