### PR TITLE
latejoin eyeobj.loc fix

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -323,13 +323,13 @@ commented cause polls are kinda broken now, needs refactoring */
 	// AIs don't need a spawnpoint, they must spawn at an empty core
 	if(character.mind.assigned_role == "AI")
 
-		character = character.AIize(move=0) // AIize the character, but don't move them yet
-
 		// IsJobAvailable for AI checks that there is an empty core available in this list
 		var/obj/structure/AIcore/deactivated/C = empty_playable_ai_cores[1]
 		empty_playable_ai_cores -= C
 
 		character.loc = C.loc
+
+		character = character.AIize(move=0) // AIize the character, but don't move them yet
 
 		//AnnounceCyborg(character, rank, "has been downloaded to the empty core in \the [character.loc.loc]")
 		ticker.mode.latespawn(character)


### PR DESCRIPTION
## Описание изменений
Выяснилось, что #5789 решает проблему с глазом лишь у ИИ, заспавненных с начала раунда, но у ИИ, присоединившихся после начала раунда проблема осталась.
Теперь если ИИ присоединится после начала раунда, то его глаз будет на месте ядра
## Почему и что этот ПР улучшит
fix #5789