### PR TITLE
structures that break down break down only on harm and have cooldown

### DIFF
--- a/code/game/gamemodes/events/cellular_biomass/cellular_structures.dm
+++ b/code/game/gamemodes/events/cellular_biomass/cellular_structures.dm
@@ -68,9 +68,10 @@
 
 /obj/structure/cellular_biomass/attackby(obj/item/weapon/W, mob/user)
 	. = ..()
-	health -= W.force
-	playsound(src, 'sound/effects/attackblob.ogg', VOL_EFFECTS_MASTER)
-	healthcheck()
+	if(user.a_intent == INTENT_HARM)
+		health -= W.force
+		playsound(src, 'sound/effects/attackblob.ogg', VOL_EFFECTS_MASTER)
+		healthcheck()
 
 ////////////////////////////
 // WALLS GRASS AND CORES////

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -66,9 +66,9 @@ for reference:
 	var/maxhealth = 100.0
 
 /obj/structure/barricade/wooden/attackby(obj/item/W, mob/user)
-	if (istype(W, /obj/item/stack/sheet/wood))
+	if(istype(W, /obj/item/stack/sheet/wood))
 		user.SetNextMove(CLICK_CD_INTERACT)
-		if (src.health < src.maxhealth)
+		if(src.health < src.maxhealth)
 			if(user.is_busy()) return
 			visible_message("<span class='warning'>[user] begins to repair \the [src]!</span>")
 			if(W.use_tool(src, user, 20, volume = 50))
@@ -76,24 +76,21 @@ for reference:
 				W:use(1)
 				visible_message("<span class='warning'>[user] repairs \the [src]!</span>")
 				return
-		else
-			return
-		return
-	else
-		user.SetNextMove(CLICK_CD_MELEE)
+
+	else if(user.a_intent == INTENT_HARM)
 		switch(W.damtype)
 			if("fire")
 				src.health -= W.force * 1
 			if("brute")
 				src.health -= W.force * 0.75
 			else
-		if (src.health <= 0)
+		if(src.health <= 0)
 			visible_message("<span class='warning'><B>The barricade is smashed apart!</B></span>")
 			new /obj/item/stack/sheet/wood(get_turf(src))
 			new /obj/item/stack/sheet/wood(get_turf(src))
 			new /obj/item/stack/sheet/wood(get_turf(src))
 			qdel(src)
-		..()
+		return ..()
 
 /obj/structure/barricade/wooden/ex_act(severity)
 	switch(severity)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1201,9 +1201,6 @@ var/list/airlock_overlays = list()
 			if(prob(10))
 				to_chat(user,"<span=userdanger>You accidentally drop your wrench in the flame</span>")
 				qdel(O)
-	else
-		return
-
 
 /obj/structure/door_scrap/atom_init()
 	. = ..()

--- a/code/game/machinery/doors/firedoor_assembly.dm
+++ b/code/game/machinery/doors/firedoor_assembly.dm
@@ -65,4 +65,4 @@
 		else
 			to_chat(user, "<span class='notice'>You need more welding fuel.</span>")
 	else
-		..(C, user)
+		return ..()

--- a/code/game/machinery/droppod.dm
+++ b/code/game/machinery/droppod.dm
@@ -723,7 +723,7 @@
 	droped = TRUE
 
 /obj/structure/droppod/Syndi/attackby(obj/item/O, mob/living/carbon/user)
-	..()
+	. = ..()
 	if(flags & ADVANCED_AIMING_INSTALLED)
 		if(uses == 1 && !droped)
 			uses++ // this allow only to return to the base.

--- a/code/game/objects/effects/decals/contraband.dm
+++ b/code/game/objects/effects/decals/contraband.dm
@@ -83,7 +83,6 @@
 	poster_item_icon_state = initial(selected.poster_item_icon_state)
 	ruined = initial(selected.ruined)
 
-
 /obj/structure/sign/poster/attackby(obj/item/weapon/W, mob/user)
 	if(iswirecutter(W))
 		playsound(src, 'sound/items/Wirecutter.ogg', VOL_EFFECTS_MASTER)
@@ -93,8 +92,6 @@
 		else
 			to_chat(user, "<span class='notice'>You carefully remove the poster from the wall.</span>")
 			roll_and_drop(user.loc)
-		return
-
 
 /obj/structure/sign/poster/attack_hand(mob/user)
 	if(ruined)

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -660,8 +660,7 @@ steam.start() -- spawns the effect
 
 
 /obj/structure/foamedmetal/attackby(obj/item/I, mob/user)
-
-	if (istype(I, /obj/item/weapon/grab))
+	if(istype(I, /obj/item/weapon/grab))
 		var/obj/item/weapon/grab/G = I
 		G.affecting.forceMove(loc)
 		for(var/mob/O in viewers(src))

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -24,7 +24,7 @@
 
 
 /obj/structure/closet/body_bag/attackby(W, mob/user)
-	if (istype(W, /obj/item/weapon/pen))
+	if(istype(W, /obj/item/weapon/pen))
 		var/t = sanitize(input(user, "What would you like the label to be?", input_default(src.name), null)  as text, MAX_NAME_LEN)
 		if (user.get_active_hand() != W)
 			return
@@ -38,6 +38,7 @@
 			src.name = "body bag"
 	//..() //Doesn't need to run the parent. Since when can fucking bodybags be welded shut? -Agouri
 		return
+
 	else if(iswirecutter(W))
 		to_chat(user, "You cut the tag off the bodybag")
 		src.name = "body bag"

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -196,9 +196,9 @@ LINEN BINS
 		sheets.Add(I)
 		amount++
 		to_chat(user, "<span class='notice'>You put [I] in [src].</span>")
+
 	else if(amount && !hidden && I.w_class < ITEM_SIZE_LARGE)	//make sure there's sheets to hide it among, make sure nothing else is hidden in there.
-		user.drop_item()
-		I.loc = src
+		user.drop_from_inventory(I, src)
 		hidden = I
 		to_chat(user, "<span class='notice'>You hide [I] among the sheets.</span>")
 

--- a/code/game/objects/structures/coathanger.dm
+++ b/code/game/objects/structures/coathanger.dm
@@ -22,7 +22,7 @@
 		hat = null
 		update_icon()
 		return
-	
+
 
 /obj/structure/coatrack/attackby(obj/item/weapon/W, mob/user)
 	var/can_hang = 0
@@ -39,8 +39,7 @@
 		if (can_hang && !hat && istype(W, /obj/item/clothing/head/det_hat))
 			user.visible_message("[user] hangs [W] on \the [src].", "You hang [W] on the \the [src]")
 			hat = W
-			user.drop_item(src)
-			hat.loc = src
+			user.drop_from_inventory(hat, src)
 			update_icon()
 		else
 			to_chat(user, "<span class='notice'>You cannot hang [W] on [src]</span>")
@@ -70,10 +69,10 @@
 
 /obj/structure/coatrack/update_icon()
 	cut_overlays()
-	
+
 	if (hat) icon_state = "coatrack1"
 	else icon_state = "coatrack0"
-	
+
 	if (istype(coat, /obj/item/clothing/suit/storage/labcoat))
 		add_overlay(image(icon, icon_state = "coat_lab"))
 	if (istype(coat, /obj/item/clothing/suit/storage/labcoat/cmo))

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -71,11 +71,12 @@
 
 
 /obj/structure/displaycase/attackby(obj/item/weapon/W, mob/user)
-	user.SetNextMove(CLICK_CD_MELEE)
-	src.health -= W.force
-	src.healthcheck()
-	..()
-	return
+	if(user.a_intent != INTENT_HARM)
+		return
+
+	. = ..()
+	health -= W.force
+	healthcheck()
 
 /obj/structure/displaycase/attack_paw(mob/user)
 	return src.attack_hand(user)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -289,7 +289,7 @@
 			playsound(src, pick('sound/effects/explosion1.ogg', 'sound/effects/explosion2.ogg'), VOL_EFFECTS_MASTER)
 			shatter()
 
-	else
+	else if(user.a_intent == INTENT_HARM)
 		if(W.damtype == BRUTE || W.damtype == BURN)
 			take_damage(W.force, W.damtype)
 			if(health <= 7)
@@ -299,7 +299,7 @@
 				step(src, get_dir(user, src))
 		else
 			playsound(src, 'sound/effects/Glasshit.ogg', VOL_EFFECTS_MASTER)
-		..()
+		return ..()
 
 /obj/structure/window/proc/fastened_change()
 	return
@@ -582,4 +582,4 @@
 		src.id = t
 		to_chat(user, "<span class='notice'>The new ID of \the [src] is [id]</span>")
 		return TRUE
-	. = ..()
+	return ..()

--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -117,7 +117,7 @@
 		to_chat(user, ("<span class='notice'>It's a holowindow, you can't pry it!</span>"))
 	else if(iswrench(W) && !anchored && (!state || !reinf))
 		to_chat(user, ("<span class='notice'>It's a holowindow, you can't dismantle it!</span>"))
-	else
+	else if(user.a_intent == INTENT_HARM)
 		if(W.damtype == BRUTE || W.damtype == BURN)
 			take_damage(W.force)
 			if(health <= 7)
@@ -126,8 +126,7 @@
 				step(src, get_dir(user, src))
 		else
 			playsound(src, 'sound/effects/Glasshit.ogg', VOL_EFFECTS_MASTER)
-		..()
-	return
+		return ..()
 
 /obj/structure/window/reinforced/holowindow/shatter(display_message = 1)
 	playsound(src, pick(SOUNDIN_SHATTER), VOL_EFFECTS_MASTER)

--- a/code/modules/locations/shuttles/shuttle_window.dm
+++ b/code/modules/locations/shuttles/shuttle_window.dm
@@ -33,7 +33,7 @@
 					take_damage(12)
 					visible_message("<span class='warning'><big><b>[user] crushes [M] against \the [src]!</b></big></span>")
 			return
-	else
+	else if(user.a_intent == INTENT_HARM)
 		if(W.damtype == BRUTE || W.damtype == BURN)
 			take_damage(W.force)
 			if(health <= 7)
@@ -42,7 +42,7 @@
 				step(src, get_dir(user, src))
 		else
 			playsound(src, 'sound/effects/Glasshit.ogg', VOL_EFFECTS_MASTER)
-		..()
+		return ..()
 
 /obj/structure/window/reinforced/shuttle/mining
 	icon = 'code/modules/locations/shuttles/shuttle_mining.dmi'

--- a/code/modules/scrap/scrap_light.dm
+++ b/code/modules/scrap/scrap_light.dm
@@ -119,8 +119,10 @@
 			//	add_overlay(image('icons/obj/structures/scrap/bonfire.dmi', "bonfire_grill"))
 			//else
 			//	return ..()
+		return
 	if(W.get_current_temperature())
 		StartBurning()
+		return
 /*	if(grill)
 		if(user.a_intent != INTENT_HARM && !(W.flags_1 & ABSTRACT_1))
 			if(user.temporarilyRemoveItemFromInventory(W))


### PR DESCRIPTION
## Описание изменений

Добавляет проверки на харм так как задержка при атаке предметов по предметам происходит только на него

(возможно нам стоит когда-нибудь объединить систему получения урона вещами чтобы такого не было)

## Почему и что этот ПР улучшит

исправляет баги

## Чеинжлог
:cl: Luduk
- tweak: Нельзя ломать стекло не на харме.
- bugfix: Нельзя без задержки заламывать стекло предметами на хелпе.