### PR TITLE
Добавил священнику новую секту на аспект Mortem

### DIFF
--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -43,6 +43,16 @@
 		/datum/aspect/mystic = 1,
 	)
 
+/datum/religion_sect/preset/bloodgods
+    name = "The Slaves of "
+	desc = "Anything you need, little demon."
+	convert_opener = "Let the Great Harvest begin! Bring more blood!"
+	aspect_present = list(
+	    /datum/aspect/death = 2,
+		/datum/aspect/darkness = 2,
+		/datum/aspect/chaos = 2
+    )
+		
 /datum/religion_sect/preset/technophile
 	name = "The Technomancers of "
 	desc = "A sect oriented around technology."

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -48,9 +48,9 @@
 	desc = "Anything you need, little demon."
 	convert_opener = "Let the Great Harvest begin! Bring more blood!"
 	aspect_present = list(
-	    /datum/aspect/death = 2,
-		/datum/aspect/darkness = 2,
-		/datum/aspect/chaos = 2
+	    /datum/aspect/death = 1,
+		/datum/aspect/darkness = 1,
+		/datum/aspect/chaos = 1,
     )
 		
 /datum/religion_sect/preset/technophile

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -44,7 +44,7 @@
 	)
 
 /datum/religion_sect/preset/bloodgods
-    name = "The Slaves of "
+	name = "The Slaves of "
 	desc = "Anything you need, little demon."
 	convert_opener = "Let the Great Harvest begin! Bring more blood!"
 	aspect_preset = list(

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -49,7 +49,7 @@
 	convert_opener = "Let the Great Harvest begin! Bring more blood!"
 	aspect_preset = list(
 	    /datum/aspect/death = 1,
-		/datum/aspect/darkness = 1,
+		/datum/aspect/lightbending/darkness = 1,
 		/datum/aspect/chaos = 1,
     )
 		

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -47,7 +47,7 @@
     name = "The Slaves of "
 	desc = "Anything you need, little demon."
 	convert_opener = "Let the Great Harvest begin! Bring more blood!"
-	aspect_present = list(
+	aspect_preset = list(
 	    /datum/aspect/death = 1,
 		/datum/aspect/darkness = 1,
 		/datum/aspect/chaos = 1,


### PR DESCRIPTION
## Описание изменений
Права мамкиных сектантов больше не ущемляются. Теперь, наравне с технофилами, можно сразу выбрать готовую секту с уклоном на жертвоприношения. Так как сам путь кровавого священника довольно слаб, продублировал ему аспекты.
## Почему и что этот ПР улучшит
Новичкам, которые хотят уйти в жертвоприношения, больше не надо будет ломать себе голову над тем, какой же винегрет из аспектов себе собрать.
## Авторство
Da_kiselev
## Чеинжлог
🆑
- tweak: Добавил кровавый культ в список сект.