### PR TITLE
Убирание возможности конверта при рп реве через вёрб у глав ревера

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -707,7 +707,6 @@
 					to_chat(current, "<span class='warning'><FONT size = 3><B>You have been brainwashed! You are no longer a head revolutionary!</B></FONT></span>")
 					ticker.mode.update_rev_icons_removed(src)
 					special_role = null
-					current.verbs -= /mob/living/carbon/human/proc/RevConvert
 				log_admin("[key_name(usr)] has de-rev'ed [current].")
 
 			if("rev")
@@ -746,7 +745,6 @@
 							rev_obj.explanation_text = "Assassinate [O.target.name], the [O.target.assigned_role]."
 							objectives += rev_obj
 						ticker.mode.greet_revolutionary(src,0)
-				current.verbs += /mob/living/carbon/human/proc/RevConvert
 				ticker.mode.head_revolutionaries += src
 				ticker.mode.update_all_rev_icons()
 				special_role = "Head Revolutionary"


### PR DESCRIPTION
## Описание изменений
https://forum.taucetistation.org/t/ubrat-mehan-konverta-v-revu/19657
![image](https://user-images.githubusercontent.com/31424899/87306686-111e1c00-c521-11ea-9d5a-34508f51b618.png)
Убран прок - верб у глав реверов для конверта в революцию.
Убрано появление новых глав реверов из рядов реверов в рп революции из-за отсутсвия обычных реверов в революции.
## Почему и что этот ПР улучшит
Повышение рп составляющей в режиме революции из-за убирания чудо значка R над головами и, конечно, заставления игроков самим решать за кого они
## Авторство
Felix Ruin - Winter Schock
## Чеинжлог
:cl: Winter Schock
- experiment: убрана возможность конвертить в революции при рп революции
- experiment: убрана возможность появление новых глав реверов из обычных реверов при отсутствии глав реверов