### PR TITLE
remove /obj/machinery/mecha_part_fabricator/check_access() 

### DIFF
--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -86,17 +86,6 @@
 	efficiency_coeff = max(round(T * 0.3), 1)
 	time_coeff = round(initial(time_coeff) - (initial(time_coeff)*(T))/5,0.01)
 
-/obj/machinery/mecha_part_fabricator/check_access(obj/item/weapon/card/id/I)
-	if(istype(I, /obj/item/device/pda))
-		var/obj/item/device/pda/pda = I
-		I = pda.id
-	if(!istype(I) || !I.access) //not ID or no access
-		return 0
-	for(var/req in req_access)
-		if(!(req in I.access)) //doesn't have this access
-			return 0
-	return 1
-
 /obj/machinery/mecha_part_fabricator/emag_act(mob/user)
 	switch(emagged)
 		if(0)


### PR DESCRIPTION
## Описание изменений
удалил check_access() в фабрикаторе. Теперь используется check_access() из access.dm

https://github.com/TauCetiStation/TauCetiClassic/blob/fb818ae07da8fb2327725b07761cdce6440adb6c/code/game/jobs/access.dm#L137
## Почему и что этот ПР улучшит
fix #5815
fix #543

## Чеинжлог
:cl:
 - bugfix: борги теперь могут использовать exosuit fabricator