### PR TITLE
sweep cooldown no matter the disruption

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -20,6 +20,12 @@
 /mob/proc/SetNextMove(num)
 	next_move = world.time + ((num + next_move_adjust) * next_move_modifier)
 
+// Delays the mob's next click/action either by num deciseconds, or maximum that was already there.
+/mob/proc/AdjustNextMove(num)
+	var/new_next_move = world.time + ((num + next_move_adjust) * next_move_modifier)
+	if(new_next_move > next_move)
+		next_move = new_next_move
+
 /*
 	Before anything else, defer these calls to a per-mobtype handler.  This allows us to
 	remove istype() spaghetti code, but requires the addition of other handler procs to simplify it.

--- a/code/datums/components/swiping.dm
+++ b/code/datums/components/swiping.dm
@@ -529,7 +529,8 @@
 			return SWEEP_INTERUPT
 
 		sweep_to_check(current_turf, next_turf, sweep_image, A, user)
-		user.SetNextMove(sweep_image.sweep_delay + 1)
+		// Just in case of some delaying/async bull.
+		user.AdjustNextMove(sweep_image.sweep_delay + 1)
 
 	if(sweep_image.next_dir == sweep_image.dirs_to_move.len)
 		return SWEEP_END
@@ -551,6 +552,8 @@
 		for(var/obj/effect/effect/weapon_sweep/sweep_image in sweep_objects)
 			var/dir_ = sweep_image.dirs_to_move[sweep_image.next_dir]
 			var/turf/current_turf = get_step(W, dir_)
+
+			user.SetNextMove(sweep_image.sweep_delay * directions.len + 1)
 
 			INVOKE_ASYNC(src, .proc/move_sweep_image, current_turf, sweep_image)
 

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -212,12 +212,13 @@
 	SCB.can_sweep = TRUE
 	SCB.can_spin = TRUE
 
-	SCB.can_spin_call = CALLBACK(src, /obj/item/weapon/twohanded/dualsaber.proc/can_spin)
+	SCB.can_sweep_call = CALLBACK(src, /obj/item/weapon/twohanded/dualsaber.proc/can_swipe)
+	SCB.can_spin_call = CALLBACK(src, /obj/item/weapon/twohanded/dualsaber.proc/can_swipe)
 	SCB.on_get_sweep_objects = CALLBACK(src, /obj/item/weapon/twohanded/dualsaber.proc/get_sweep_objs)
 
 	AddComponent(/datum/component/swiping, SCB)
 
-/obj/item/weapon/twohanded/dualsaber/proc/can_spin(mob/user)
+/obj/item/weapon/twohanded/dualsaber/proc/can_swipe(mob/user)
 	return wielded
 
 /obj/item/weapon/twohanded/dualsaber/proc/get_sweep_objs(turf/start, obj/item/I, mob/user, list/directions, sweep_delay)


### PR DESCRIPTION
## Описание изменений

Не позволяет крутить выключенным дуалесвордом.

Так же прерывание свайпа(к примеру сменой рук) больше не сбрасывает КД от свайпа.

## Почему и что этот ПР улучшит

Фиксит баги.

## Чеинжлог
:cl: Luduk
- bugfix: Нельзя крутить на альт выключенным дуалсвордом.
- balance: КД от свайпа применяется сразу, и нельзя обходить кд на свайпы прерывая их при исполнении.