### PR TITLE
фикс "Спавнится два соулстона, вместо одного"

### DIFF
--- a/code/datums/spells/conjure.dm
+++ b/code/datums/spells/conjure.dm
@@ -30,7 +30,7 @@
 			for(var/atom/A in previous_objects)
 				qdel(A)
 				previous_objects -= A
-		for(var/i in 0 to summon_amt)
+		for(var/i in 1 to summon_amt)
 			if(!targets.len)
 				break
 			var/summoned_object_type = pick(summon_type)


### PR DESCRIPTION
## Описание изменений
for(var/i in **1** to summon_amt)
## Почему и что этот ПР улучшит
fix #5136

## Чеинжлог
:cl:
 - bugfix: констракты больше не спавнят два соулстоуна вместо одного