### PR TITLE
Больше нельзя емагнуть створку на базе нюки

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -174,6 +174,8 @@
 	try_open(user, I)
 
 /obj/machinery/door/emag_act(mob/user)
+	if(istype(src, /obj/machinery/door/poddoor/shutters/syndi))
+		return FALSE
 	if(src.density && hasPower())
 		update_icon(AIRLOCK_EMAG)
 		sleep(6)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -174,8 +174,6 @@
 	try_open(user, I)
 
 /obj/machinery/door/emag_act(mob/user)
-	if(istype(src, /obj/machinery/door/poddoor/shutters/syndi))
-		return FALSE
 	if(src.density && hasPower())
 		update_icon(AIRLOCK_EMAG)
 		sleep(6)

--- a/code/game/machinery/doors/shutters.dm
+++ b/code/game/machinery/doors/shutters.dm
@@ -21,5 +21,8 @@
 
 /obj/machinery/door/poddoor/shutters/syndi
 
+/obj/machinery/door/poddoor/shutters/syndi/emag_act(mob/user)
+	return FALSE
+
 /obj/machinery/door/poddoor/shutters/syndi/ex_act()
 	return


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Ещё одна проверка
## Почему и что этот ПР улучшит
Хаха нюка сосать
## Авторство
Remindme
## Чеинжлог
:cl: Remindme
 - bugfix: Емагом можно было взломать створку на базе синдиката