### PR TITLE
Борги больше не получают стан во время полета на шаттле

### DIFF
--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -374,7 +374,7 @@ var/datum/subsystem/shuttle/SSshuttle
 /datum/subsystem/shuttle/proc/shake_mobs_in_area(area/A, fall_direction)
 	for(var/mob/M in A)
 		if(M.client)
-			if(M.buckled)
+			if(M.buckled || issilicon(M))
 				shake_camera(M, 2, 1) // buckled, not a lot of shaking
 			else
 				shake_camera(M, 4, 2)// unbuckled, HOLY SHIT SHAKE THE ROOM


### PR DESCRIPTION
## Описание изменений
Борги больше не получают стан во время отлёта и прибытия шаттла
## Почему и что этот ПР улучшит
fix  #4710

## Чеинжлог
:cl:
 - tweak: борги больше не получают стан во время полета на шаттле