### PR TITLE
Service borg icons fixes

### DIFF
--- a/code/game/objects/items/weapons/RSF.dm
+++ b/code/game/objects/items/weapons/RSF.dm
@@ -6,7 +6,7 @@ RSF
 /obj/item/weapon/rsf
 	name = "Rapid-Service-Fabricator"
 	desc = "A device used to rapidly deploy service items."
-	icon = 'icons/obj/items.dmi'
+	icon = 'icons/obj/tools.dmi'
 	icon_state = "rcd"
 	opacity = 0
 	density = 0

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -276,6 +276,8 @@
 
 	var/obj/item/weapon/lighter/zippo/L = new /obj/item/weapon/lighter/zippo(src)
 	L.lit = 1
+	L.icon_state = L.icon_on
+	L.item_state = L.icon_on
 	modules += L
 
 	modules += new /obj/item/weapon/tray/robotray(src)


### PR DESCRIPTION
## Описание изменений
Rapid-Service-Fabricator теперь имеет иконку. Иконка зажигалки сервис борга теперь соответствует её включенному состоянию
|||
|-|-|
|![20200717 121750](https://user-images.githubusercontent.com/66636084/87770488-c1449b00-c827-11ea-8bba-39f297ae9772.png)|![20200717 121753](https://user-images.githubusercontent.com/66636084/87770492-c275c800-c827-11ea-8c4f-0d986d24d9ec.png)|

## Почему и что этот ПР улучшит
fix #5840
#822 (иконка зажигалки теперь соответствует ее включенному состоянию)