### PR TITLE
Автоподбор руды

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -138,21 +138,16 @@
 	w_class = ITEM_SIZE_NORMAL
 	max_storage_space = 100
 	can_hold = list(/obj/item/weapon/ore, /obj/item/bluespace_crystal)
-	var/mob/listeningTo	= null
 	var/spam_protection = FALSE
 
-/obj/item/weapon/storage/bag/ore/equipped(mob/user)
-	if(listeningTo == user)
-		return
-	if(listeningTo)
-		UnregisterSignal(listeningTo, list(COMSIG_MOVABLE_MOVED))
-	RegisterSignal(user, list(COMSIG_MOVABLE_MOVED), .proc/Pickup_ores)
-	listeningTo = user
 
-/obj/item/weapon/storage/bag/ore/dropped()
-	if(listeningTo)
-		UnregisterSignal(listeningTo, list(COMSIG_MOVABLE_MOVED))
-		listeningTo = null
+/obj/item/weapon/storage/bag/ore/equipped(mob/user)
+	RegisterSignal(user, list(COMSIG_MOVABLE_MOVED), .proc/Pickup_ores)
+
+
+/obj/item/weapon/storage/bag/ore/dropped(mob/user)
+	UnregisterSignal(user, list(COMSIG_MOVABLE_MOVED))
+
 
 /obj/item/weapon/storage/bag/ore/proc/Pickup_ores(mob/living/user)
 	var/show_message = TRUE

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -727,11 +727,14 @@
 	if(isrobot(M))
 		var/mob/living/silicon/robot/R = M
 		if(istype(R.module, /obj/item/weapon/robot_module/miner))
-			if(istype(R.module_state_1,/obj/item/weapon/storage/bag/ore))
-				attackby(R.module_state_1,R)
-			else if(istype(R.module_state_2,/obj/item/weapon/storage/bag/ore))
-				attackby(R.module_state_2,R)
-			else if(istype(R.module_state_3,/obj/item/weapon/storage/bag/ore))
-				attackby(R.module_state_3,R)
+			var/obj/item/weapon/storage/bag/ore/module = null
+			if(istype(R.module_state_1, /obj/item/weapon/storage/bag/ore))
+				module = R.module_state_1
+			else if(istype(R.module_state_2, /obj/item/weapon/storage/bag/ore))
+				module = R.module_state_2
+			else if(istype(R.module_state_3, /obj/item/weapon/storage/bag/ore))
+				module = R.module_state_3
+			if(module)
+				module.Pickup_ores(R)
 			else
 				return


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Шахтерская сумка при экипировке подбирает руду под ногами в себя или, если персонаж тащит за собой ore_box, перемещает в ящик.

## Почему и что этот ПР улучшит
Меньше рутины.

## Авторство
Порт с tg.

## Чеинжлог
:cl: Bledoslav
- tweak: Шахтерская сумка подбирает руду под ногами в себя или ящик.
- tweak: При выборе модуля Mining Satchel у шахтерского борга, подбирает руду теперь и в ящик