### PR TITLE
barsigns update!

### DIFF
--- a/code/game/objects/effects/barsign.dm
+++ b/code/game/objects/effects/barsign.dm
@@ -1,9 +1,0 @@
-/obj/effect/sign/double/barsign
-	icon = 'icons/obj/barsigns.dmi'
-	icon_state = "empty"
-	anchored = 1
-
-/obj/effect/sign/double/barsign/atom_init()
-	. = ..()
-	var/list/valid_states = list("pinkflamingo", "magmasea", "limbo", "rustyaxe", "armokbar", "brokendrum", "meadbay", "thedamnwall", "thecavern", "cindikate", "theorchard", "thesaucyclown", "theclownshead", "whiskeyimplant", "carpecarp", "robustroadhouse", "greytide", "theredshirt")
-	src.icon_state = "[pick(valid_states)]"

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -1,19 +1,27 @@
-// Should be global var, because all bar signs should have the same icon.
-var/bar_sing_global = pick("lv426", "zocalo", "4theemprah", "ishimura",\
-                           "tardis", "thecavern", "quarks", "tenforward",\
-                           "thepranicngpony", "vault13", "solaris", "thehive",\
-                           "cantina", "theouterspess", "milliways42", "thetimeofeve",\
-                           "spaceasshole", "dwarffortress", "maltesefalcon")
-
 /obj/structure/sign/double/barsign
 	icon = 'icons/obj/barsigns.dmi'
 	icon_state = "empty"
 	anchored = 1
 
+/obj/structure/sign/double/barsign/proc/get_valid_states()
+	. = icon_states(icon)
+	. -= "empty"
+
 /obj/structure/sign/double/barsign/atom_init()
 	. = ..()
-	ChangeSign(bar_sing_global)
+	icon_state = pick(get_valid_states())
 
-/obj/structure/sign/double/barsign/proc/ChangeSign(Text)
-	src.icon_state = "[Text]"
-	return
+/obj/structure/sign/double/barsign/attackby(obj/item/I, mob/user)
+	if(istype(I, /obj/item/weapon/card/id))
+		var/obj/item/weapon/card/id/card = I
+		if(access_bar in card.GetAccess())
+			var/sign_type = input(user, "What would you like to change the barsign to?") as null|anything in get_valid_states()
+			if(!sign_type)
+				return
+			icon_state = sign_type
+			to_chat(user, "<span class='notice'>You change the barsign.</span>")
+		else
+			to_chat(user, "<span class='warning'>Access denied.</span>")
+		return
+
+	return ..()


### PR DESCRIPTION
## Описание изменений
- удален не включенный в сборку code/game/objects/effects/barsign.dm
- теперь используются все спрайты из barsigns.dmi и добавление/удаление лого бара сводится лишь к изменению barsigns.dmi
- добавлена возможность изменить лого бара, проведя по нему айди картой с доступом бармена
## Почему и что этот ПР улучшит
Бармен сможет изменить лого своего бара, если он хочет другое
Нет неиспользуемых спрайтов в barsigns.dmi
Чтобы добавить/удалить лого бара не придется лезть в код
## Авторство
https://github.com/Baystation12/Baystation12/blob/e6487df28140a92215528c41c67eb04730cb74d7/code/game/objects/structures/barsign.dm
## Чеинжлог
:cl:
 - rscadd: айди картой с доступом бармена можно изменить лого бара (barsign)