### PR TITLE
Выпил заданий на воровство для генокрадов

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -96,12 +96,12 @@ var/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","Epsilon"
 	kill_objective.owner = changeling
 	kill_objective.find_target()
 	changeling.objectives += kill_objective
-
+/*
 	var/datum/objective/steal/steal_objective = new
 	steal_objective.owner = changeling
 	steal_objective.find_target()
 	changeling.objectives += steal_objective
-
+*/
 
 	switch(rand(1,100))
 		if(1 to 80)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Генокрады будучи непонятной нех, имеют задания на трусы ГП, это имхо не круто
## Почему и что этот ПР улучшит
У генокрадов не будет смешных заданий на капитанские трусы.

Возможно, генокрадам будет немного скучно.
## Авторство

## Чеинжлог
:cl:
- rscdel: Генокрады больше не получают задания на кражу.