### PR TITLE
Removes ghost verb from AI and pAI

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -85,6 +85,7 @@ var/list/ai_verbs_default = list(
 
 /mob/living/silicon/ai/proc/add_ai_verbs()
 	verbs |= ai_verbs_default
+	verbs -= /mob/living/verb/ghost
 
 /mob/living/silicon/ai/proc/hcattack_ai(atom/A)
 	if(!holo || !isliving(A) || !in_range(eyeobj, A))
@@ -101,6 +102,7 @@ var/list/ai_verbs_default = list(
 
 /mob/living/silicon/ai/proc/remove_ai_verbs()
 	verbs -= ai_verbs_default
+	verbs += /mob/living/verb/ghost
 
 /mob/living/silicon/ai/atom_init(mapload, datum/ai_laws/L, obj/item/device/mmi/B, safety = 0)
 	. = ..()

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -77,6 +77,8 @@
 	add_language("Tradeband", 1)
 	add_language("Gutter", 1)
 
+	verbs -= /mob/living/verb/ghost
+
 	//PDA
 	pda = new(src)
 	spawn(5)


### PR DESCRIPTION
## Описание изменений
Удаляет верб "Ghost" у ИИ и пИИ, т.к. у них для этого должны использоваться "Wipe Core" и "pAI Suicide" соответственно 
## Почему и что этот ПР улучшит
не будет неправильно гостнувшихся ИИ и пИИ
## Авторство
https://github.com/Baystation12/Baystation12/pull/16073
## Чеинжлог
:cl:
 - tweak: у ИИ и пИИ удален верб "Ghost". Вместо них должен использоваться "Wipe Core"/"pAI Suicide"