### PR TITLE
Borgs can modify airlock electronics access

### DIFF
--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -15,7 +15,7 @@
 	var/broken = FALSE
 
 /obj/item/weapon/airlock_electronics/attack_self(mob/user)
-	if (!ishuman(user) && !istype(user,/mob/living/silicon/robot/drone))
+	if (!ishuman(user) && !istype(user,/mob/living/silicon/robot))
 		return ..(user)
 
 	var/mob/living/carbon/human/H = user


### PR DESCRIPTION
## Описание изменений
Борги смогут изменять доступ плате шлюза, а не только дроны.
## Почему и что этот ПР улучшит
fix #5903

## Чеинжлог
:cl:
 - bugfix: Борги не могли изменять доступ платы шлюза (airlock electronics)