### PR TITLE
Fix513

### DIFF
--- a/code/game/gamemodes/changeling/powers/essences.dm
+++ b/code/game/gamemodes/changeling/powers/essences.dm
@@ -87,7 +87,7 @@
 		if(!(flags_allowed & ESSENCE_SPEAK_TO_HOST))
 			to_chat(src, "<span class='userdanger'>Your host forbade you speaking to him</span>")
 			return
-		message = copytext_char(message, 3) // deleting prefix
+		message = copytext_char(message, 2 + length(message[2])) // deleting prefix
 		var/n_message = sanitize(message)
 		for(var/M in changeling.essences)
 			to_chat(M, "<span class='shadowling'><b>[name]:</b> [n_message]</span>")

--- a/code/modules/mob/living/carbon/brain/say.dm
+++ b/code/modules/mob/living/carbon/brain/say.dm
@@ -5,8 +5,8 @@
 	if(container)
 		if(istype(container, /obj/item/device/mmi) || istype(container, /obj/item/device/mmi/posibrain))
 			message = sanitize(message)
-			if ((department_radio_keys[copytext(message, 1, 3)] == "binary") && (container && istype(container, /obj/item/device/mmi/posibrain)))
-				message = copytext(message, 3)
+			if ((department_radio_keys[copytext(message, 1, 2 + length(message[2]))] == "binary") && (container && istype(container, /obj/item/device/mmi/posibrain)))
+				message = copytext(message, 2 + length(message[2]))
 				message = trim(message)
 				robot_talk(message)
 				return

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -46,7 +46,7 @@
 		if (message_mode == "headset")
 			message = copytext(message,2)	//it would be really nice if the parse procs could do this for us.
 		else
-			message = copytext(message,3)
+			message = copytext(message,2 + length(message[2]))
 
 	//parse the language code and consume it or use default racial language if forced.
 	var/datum/language/speaking = parse_language(message)

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -76,12 +76,12 @@
 	else
 		switch(species.name)
 			if(TAJARAN)
-				message = replacetext(message, "р", pick(list("ррр" , "рр")))
-				message = replacetext(message, "Р", pick(list("Ррр" , "Рр")))
+				message = replacetextEx_char(message, "р", pick(list("ррр" , "рр")))
+				message = replacetextEx_char(message, "Р", pick(list("Ррр" , "Рр")))
 			if(UNATHI)
-				message = replacetext(message, "с", pick(list("ссс" , "сс")))
+				message = replacetextEx_char(message, "с", pick(list("ссс" , "сс")))
 				//И для заглавной... Фигова копипаста. Кто знает решение без второй обработки для заглавной буквы, обязательно переделайте.
-				message = replacetext(message, "С", pick(list("Ссс" , "Сс")))
+				message = replacetextEx_char(message, "С", pick(list("Ссс" , "Сс")))
 			if(ABDUCTOR)
 				var/mob/living/carbon/human/user = usr
 				var/sm = sanitize(message)

--- a/code/modules/mob/living/carbon/xenomorph/say.dm
+++ b/code/modules/mob/living/carbon/xenomorph/say.dm
@@ -12,8 +12,8 @@
 		return emote(copytext(message, 2))
 
 	if (length(message) >= 1)
-		if (department_radio_keys[copytext(message, 1, 3)] == "alientalk")
-			message = copytext(message, 3)
+		if (department_radio_keys[copytext(message, 1, 2 + length(message[2]))] == "alientalk")
+			message = copytext(message, 2 + length(message[2]))
 			message = trim(message)
 			if (stat == DEAD)
 				return say_dead(message)
@@ -32,8 +32,8 @@
 	message = sanitize(message)
 
 	if (length(message) >= 1)
-		if (department_radio_keys[copytext(message, 1, 3)] == "alientalk")
-			message = copytext(message, 3)
+		if (department_radio_keys[copytext(message, 1, 2 + length(message[2]))] == "alientalk")
+			message = copytext(message, 2 + length(message[2]))
 			message = trim(message)
 			if (stat == DEAD)
 				return say_dead(message)

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -128,11 +128,11 @@
 
 			for (var/mob/living/S in drone_list)
 				if(S.stat != DEAD)
-					to_chat(S, "<i><span class='game say'>Drone Talk, <span class='name'>[name]</span><span class='message'> transmits, \"[trim(copytext(message,3))]\"</span></span></i>")
+					to_chat(S, "<i><span class='game say'>Drone Talk, <span class='name'>[name]</span><span class='message'> transmits, \"[trim(copytext(message,2 + length(message[2])))]\"</span></span></i>")
 
 			for (var/mob/M in observer_list)
 				if(M.client && M.client.prefs.chat_toggles & CHAT_GHOSTEARS)
-					to_chat(M, "<i><span class='game say'>Drone Talk, <span class='name'>[name]</span><span class='message'> transmits, \"[trim(copytext(message,3))]\"</span></span></i>")
+					to_chat(M, "<i><span class='game say'>Drone Talk, <span class='name'>[name]</span><span class='message'> transmits, \"[trim(copytext(message,2 + length(message[2])))]\"</span></span></i>")
 
 		else
 

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -68,7 +68,7 @@
 		if (message_mode == "general")
 			message = trim(copytext(message,2))
 		else
-			message = trim(copytext(message,3))
+			message = trim(copytext(message,2 + length(message[2])))
 
 	if(message_mode && bot_type == IS_ROBOT && message_mode != "binary" && !R.is_component_functioning("radio"))
 		to_chat(src, "<span class='warning'>Your radio isn't functional at this time.</span>")

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -155,8 +155,8 @@
 						ears.loc = src.loc
 						ears = null
 						for(var/possible_phrase in speak)
-							if(copytext(possible_phrase,1,3) in department_radio_keys)
-								possible_phrase = copytext(possible_phrase,3,-1)
+							if(copytext(possible_phrase,1,2 + length(possible_phrase[2])) in department_radio_keys)
+								possible_phrase = copytext(possible_phrase, 2 + length(possible_phrase[2]),-1)
 					else
 						to_chat(usr, "<span class='warning'>There is nothing to remove from its [remove_from].</span>")
 						return
@@ -327,8 +327,8 @@
 						if(prob(50))
 							useradio = 1
 
-						if(copytext(possible_phrase,1,3) in department_radio_keys)
-							possible_phrase = "[useradio?pick(available_channels):""] [copytext(possible_phrase,3)]" //crop out the channel prefix
+						if(copytext(possible_phrase,1, 2 + length(possible_phrase[2])) in department_radio_keys)
+							possible_phrase = "[useradio?pick(available_channels):""] [copytext(possible_phrase,2 + length(possible_phrase[2]))]" //crop out the channel prefix
 						else
 							possible_phrase = "[useradio?pick(available_channels):""] [possible_phrase]"
 
@@ -336,8 +336,8 @@
 
 				else //If we have no headset or channels to use, dont try to use any!
 					for(var/possible_phrase in speak)
-						if(copytext(possible_phrase,1,3) in department_radio_keys)
-							possible_phrase = "[copytext(possible_phrase,3)]" //crop out the channel prefix
+						if(copytext(possible_phrase,1, 2 + length(possible_phrase[2])) in department_radio_keys)
+							possible_phrase = "[copytext(possible_phrase,2 + length(possible_phrase[2]))]" //crop out the channel prefix
 						newspeak.Add(possible_phrase)
 				speak = newspeak
 
@@ -783,11 +783,11 @@
 		message = copytext(message,2)
 
 	if(length(message) >= 2)
-		var/channel_prefix = copytext(message, 1 ,3)
+		var/channel_prefix = copytext(message, 1 ,2 + length(message[2]))
 		message_mode = department_radio_keys[channel_prefix]
 
 	if(message[1] == ":")
-		var/positioncut = 3
+		var/positioncut = 2 + length(message[2])
 		message = trim(copytext(message,positioncut))
 
 	message = capitalize(trim_left(message))

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -151,7 +151,7 @@
 		return standard_mode
 
 	if(length(message) >= 2)
-		var/channel_prefix = copytext(message, 1 ,3)
+		var/channel_prefix = copytext(message, 1, 2 + length(message[2]))
 		return department_radio_keys[channel_prefix]
 
 	return null
@@ -160,7 +160,7 @@
 //returns the language object only if the code corresponds to a language that src can speak, otherwise null.
 /mob/proc/parse_language(message)
 	if(length_char(message) >= 2)
-		var/language_prefix = lowertext(copytext_char(message, 1 ,3))
+		var/language_prefix = lowertext(copytext(message, 1, 2 + length(message[2])))
 		var/datum/language/L = language_keys[language_prefix]
 		if (can_speak(L))
 			return L

--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -208,6 +208,8 @@ nanoui is used to open and update nano browser uis
 
 	if (!isnull(data))
 		send_data["data"] = data
+	else
+		send_data["data"] = list() // in case if it's null and we're sending cached_data(I guess it can't happen but it's better to be sure anyway)
 
 	return send_data
 
@@ -357,7 +359,7 @@ nanoui is used to open and update nano browser uis
 	var/initial_data_json = json_encode(send_data)
 
 	if(cached_data)
-		initial_data_json = copytext(initial_data_json, 1, -1) + ",\"cached\":[cached_data]}"
+		initial_data_json = copytext(initial_data_json, 1, -2) + ",\"cached\":[cached_data]}}"
 
 	initial_data_json = replacetext(initial_data_json, "'", "`")
 
@@ -471,7 +473,7 @@ nanoui is used to open and update nano browser uis
 
 	var/send_json = json_encode(send_data)
 	if(cached_data)
-		send_json = copytext(send_json, 1, -1) + ",\"cached\":[cached_data]}"
+		send_json = copytext(send_json, 1, -2) + ",\"cached\":[cached_data]}}"
 
 	user << output(list2params(list(replacetext(send_json, "'", "`"))),"[window_id].browser:receiveUpdateData")
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Фикс некоторых проблем из-за перехода на 513, а именно:
Русские буквы при вводе языка/канала отдела.
Манифест у ПИИ и в ПДА, сесурити камеры(все это приколы с cached_data в наноуи)
Повторрр ссогласссных у таяррран и унатхов
closes #5918 
closes #5917 
closes #5912
closes #5909
## Почему и что этот ПР улучшит
Бульонд 513 и ебля с юникодом вперед! Продвинем киту к светлому будущему на новой версии бульонда!
## Авторство
AirBlack
## Чеинжлог
:cl:
 - bugfix: Русские алиасы на радио каналы и языки не работали
 - bugfix: Повторяющиеся согласные у унатхов и таяран повторялись по 2-3 раза
 - bugfix: Камеры и манифест в ПДА вызывали ошибки и не работали