### PR TITLE
Емаг байкхорна

### DIFF
--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -203,7 +203,7 @@
 	if(emagged)
 		return FALSE
 	to_chat(user, "<span class='warning'>You overload \the [src]'s bluespace air valve.</span>")
-	emagged = 1
+	emagged = TRUE
 	attack_verb = list("BWOINKED")
 	return TRUE
 

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -197,9 +197,22 @@
 	throw_range = 15
 	attack_verb = list("HONKED")
 	var/cooldown = FALSE
+	var/emagged = 0
+
+/obj/item/weapon/bikehorn/emag_act(mob/user)
+	if(emagged)
+		return FALSE
+	to_chat(user, "<span class='warning'>You overload \the [src]'s air valve.</span>")
+	emagged = 1
+	attack_verb = list("BWOINKED")
+	return TRUE
+
 
 /obj/item/weapon/bikehorn/proc/honk(mob/user)
-	playsound(src, 'sound/items/bikehorn.ogg', VOL_EFFECTS_MISC)
+	if(emagged)
+		playsound(src, 'sound/effects/adminhelp.ogg', VOL_EFFECTS_MISC)
+	else
+		playsound(src, 'sound/items/bikehorn.ogg', VOL_EFFECTS_MISC)
 	if(user.can_waddle())
 		user.waddle(pick(-14, 0, 14), 4)
 

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -197,7 +197,7 @@
 	throw_range = 15
 	attack_verb = list("HONKED")
 	var/cooldown = FALSE
-	var/emagged = 0
+	var/emagged = FALSE
 
 /obj/item/weapon/bikehorn/emag_act(mob/user)
 	if(emagged)

--- a/code/game/objects/items/weapons/clown_items.dm
+++ b/code/game/objects/items/weapons/clown_items.dm
@@ -202,7 +202,7 @@
 /obj/item/weapon/bikehorn/emag_act(mob/user)
 	if(emagged)
 		return FALSE
-	to_chat(user, "<span class='warning'>You overload \the [src]'s air valve.</span>")
+	to_chat(user, "<span class='warning'>You overload \the [src]'s bluespace air valve.</span>")
 	emagged = 1
 	attack_verb = list("BWOINKED")
 	return TRUE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Клоунский гудок можно взломать емагом. Вместо хонка будет бвоньк.

## Почему и что этот ПР улучшит
Гениальная фича, которая буквально позволит клоуну пугать\доводить до истерик,
также см. #5936 
## Авторство
#5936 
## Чеинжлог
:cl:
 - tweak: Клоунский гудок можно емагнуть и сделать бвоньк.