### PR TITLE
Возможность выбрать объект, который будет вытащен из человека при операции

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -51,8 +51,6 @@
 	var/stage = 0
 	var/cavity = 0
 	var/atom/movable/applied_pressure
-	var/atom/movable/implant_to_remove
-
 	// Misc
 	var/list/butcher_results
 

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -51,6 +51,7 @@
 	var/stage = 0
 	var/cavity = 0
 	var/atom/movable/applied_pressure
+	var/atom/movable/implant_to_remove
 
 	// Misc
 	var/list/butcher_results

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -163,7 +163,6 @@
 
 	min_duration = 80
 	max_duration = 100
-	var/atom/movable/implant_to_remove = null
 
 /datum/surgery_step/cavity/implant_removal/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(..())
@@ -175,8 +174,8 @@
 	var/list/implants = BP.implants.Copy()
 	if(BP.hidden)
 		implants += BP.hidden
-	implant_to_remove = input(user, "Select the item you want to pull out", "Implant removal")  as null|anything in implants
-	return implant_to_remove && checks_for_surgery(target, user, clothless)
+	BP.implant_to_remove = input(user, "Select the item you want to pull out", "Implant removal")  as null|anything in implants
+	return BP.implant_to_remove && checks_for_surgery(target, user, clothless)
 
 /datum/surgery_step/cavity/implant_removal/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
@@ -187,18 +186,18 @@
 
 /datum/surgery_step/cavity/implant_removal/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/chest/BP = target.get_bodypart(target_zone)
-	if(!implant_to_remove)
+	if(!BP.implant_to_remove)
 		return
 
 	var/remove_prob = 50
-	if(istype(implant_to_remove, /obj/item/weapon/implant))
-		var/obj/item/weapon/implant/imp = implant_to_remove
+	if(istype(BP.implant_to_remove, /obj/item/weapon/implant))
+		var/obj/item/weapon/implant/imp = BP.implant_to_remove
 		if(imp.islegal())
 			remove_prob = 60
 		else
 			remove_prob = 40
 
-	if(BP.hidden == implant_to_remove)
+	if(BP.hidden == BP.implant_to_remove)
 		user.visible_message("<span class='notice'>[user] takes something out of incision on [target]'s [BP.name] with \the [tool].</span>", \
 		"<span class='notice'>You take something out of incision on [target]'s [BP.name]s with \the [tool].</span>" )
 		BP.hidden.loc = get_turf(target)
@@ -210,25 +209,25 @@
 
 	else if(prob(remove_prob))
 		user.visible_message("<span class='notice'>[user] takes something out of incision on [target]'s [BP.name] with \the [tool].</span>", \
-		"<span class='notice'>You take [implant_to_remove] out of incision on [target]'s [BP.name]s with \the [tool].</span>" )
-		BP.implants -= implant_to_remove
+		"<span class='notice'>You take [BP.implant_to_remove] out of incision on [target]'s [BP.name]s with \the [tool].</span>" )
+		BP.implants -= BP.implant_to_remove
 		for(var/datum/wound/W in BP.wounds)
-			if(implant_to_remove in W.embedded_objects)
-				W.embedded_objects -= implant_to_remove
+			if(BP.implant_to_remove in W.embedded_objects)
+				W.embedded_objects -= BP.implant_to_remove
 				break
 
 		target.hud_updateflag |= 1 << IMPLOYAL_HUD
 
 		//Handle possessive brain borers.
-		if(istype(implant_to_remove, /mob/living/simple_animal/borer))
-			var/mob/living/simple_animal/borer/worm = implant_to_remove
+		if(istype(BP.implant_to_remove, /mob/living/simple_animal/borer))
+			var/mob/living/simple_animal/borer/worm = BP.implant_to_remove
 			if(worm.controlling)
 				target.release_control()
 			worm.detatch()
 
-		implant_to_remove.loc = get_turf(target)
-		if(istype(implant_to_remove,/obj/item/weapon/implant))
-			var/obj/item/weapon/implant/imp = implant_to_remove
+		BP.implant_to_remove.loc = get_turf(target)
+		if(istype(BP.implant_to_remove,/obj/item/weapon/implant))
+			var/obj/item/weapon/implant/imp = BP.implant_to_remove
 			imp.imp_in = null
 			imp.implanted = 0
 			if(istype(imp,/obj/item/weapon/implant/storage))
@@ -237,8 +236,8 @@
 		playsound(target, 'sound/effects/squelch1.ogg', VOL_EFFECTS_MASTER)
 	else
 		user.visible_message("<span class='notice'>[user] removes \the [tool] from [target]'s [BP.name].</span>", \
-		"<span class='notice'>You tried to pull [implant_to_remove] inside [target]'s [BP.name], but you just missed it this time.</span>" )
-	implant_to_remove = null
+		"<span class='notice'>You tried to pull [BP.implant_to_remove] inside [target]'s [BP.name], but you just missed it this time.</span>" )
+	BP.implant_to_remove = null
 
 /datum/surgery_step/cavity/implant_removal/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/chest/BP = target.get_bodypart(target_zone)
@@ -254,4 +253,4 @@
 			playsound(imp, 'sound/items/countdown.ogg', VOL_EFFECTS_MASTER, null, null, -3)
 			spawn(25)
 				imp.activate()
-	implant_to_remove = null
+	BP.implant_to_remove = null

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -220,7 +220,7 @@
 		target.hud_updateflag |= 1 << IMPLOYAL_HUD
 
 		//Handle possessive brain borers.
-		if(istype(implant_to_remove,/mob/living/simple_animal/borer))
+		if(istype(implant_to_remove, /mob/living/simple_animal/borer))
 			var/mob/living/simple_animal/borer/worm = implant_to_remove
 			if(worm.controlling)
 				target.release_control()

--- a/code/modules/surgery/plastic_surgery.dm
+++ b/code/modules/surgery/plastic_surgery.dm
@@ -100,23 +100,23 @@
 /datum/surgery_step/plastic_surgery/reshape_face/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return ..() && target.op_stage.plasticsur == 2 && target.op_stage.face == 1
 
-/datum/surgery_step/plastic_surgery/reshape_face/prepare_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	target.op_stage.plastic_new_name = sanitize_name(input(user, "Choose your character's name:", "Changing")  as text|null)
-	return target.op_stage.plastic_new_name && checks_for_surgery(target, user, clothless)
+/datum/surgery_step/plastic_surgery/reshape_face/prepare_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, prepare_selection)
+	. = sanitize_name(input(user, "Choose your character's name:", "Changing")  as text|null)
+	if(!checks_for_surgery(target, user, clothless))
+		return FALSE
 
 /datum/surgery_step/plastic_surgery/reshape_face/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message("[user] begins to alter [target]'s appearance with \the [tool].", \
 	"You begin to alter [target]'s appearance with \the [tool].")
 	..()
 
-/datum/surgery_step/plastic_surgery/reshape_face/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/plastic_surgery/reshape_face/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, prepare_selection)
 	user.visible_message("<span class='notice'>[user] alters [target]'s appearance with \the [tool].</span>",		\
 	"<span class='notice'>You alter [target]'s appearance with \the [tool].</span>")
-	if(target.op_stage.plastic_new_name)
-		target.real_name = target.op_stage.plastic_new_name
-		target.op_stage.plastic_new_name = null
+	if(prepare_selection)
+		target.real_name = prepare_selection
 
-/datum/surgery_step/plastic_surgery/reshape_face/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/plastic_surgery/reshape_face/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, prepare_selection)
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	user.visible_message("<span class='warning'>[user]'s hand slips, tearing skin on [target]'s face with \the [tool]!</span>", \
 	"<span class='warning'>Your hand slips, tearing skin on [target]'s face with \the [tool]!</span>")

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -41,7 +41,7 @@
 	return TRUE
 
 // does stuff to begin the step, usually just printing messages. Moved germs transfering and bloodying here too
-/datum/surgery_step/proc/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/proc/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, prepare_selection)
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
 	if(can_infect && BP)
 		spread_germs_to_organ(BP, user, tool)
@@ -54,7 +54,7 @@
 	return
 
 // does stuff to end the step, which is normally print a message + do whatever this step changes
-/datum/surgery_step/proc/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+/datum/surgery_step/proc/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool, prepare_selection)
 	return
 
 // stuff that happens when the step fails
@@ -149,15 +149,16 @@
 
 		//check if tool is right or close enough and if this step is possible
 		if(S.tool_quality(tool) && S.can_use(user, M, target_zone, tool) && S.is_valid_mutantrace(M))
-			if(!S.prepare_step(user, M, target_zone, tool))	//for some kind of checks
+			var/PS = S.prepare_step(user, M, target_zone, tool)
+			if(!PS)	//for some kind of checks
 				return TRUE
 
-			S.begin_step(user, M, target_zone, tool)		//...start on it
+			S.begin_step(user, M, target_zone, tool, PS)		//...start on it
 			//We had proper tools! (or RNG smiled.) and User did not move or change hands.
 			if(prob(S.tool_quality(tool)) && tool.use_tool(M,user, rand(S.min_duration, S.max_duration), volume=100) && user.zone_sel.selecting && target_zone == user.zone_sel.selecting)
-				S.end_step(user, M, target_zone, tool)		//finish successfully
+				S.end_step(user, M, target_zone, tool, PS)		//finish successfully
 			else if((tool in user.contents) && user.Adjacent(M))		//or (also check for tool in hands and being near the target)
-				S.fail_step(user, M, target_zone, tool)		//malpractice~
+				S.fail_step(user, M, target_zone, tool, PS)		//malpractice~
 			else	// this failing silently was a pain.
 				to_chat(user, "<span class='warning'>You must remain close to your patient to conduct surgery.</span>")
 


### PR DESCRIPTION
## Описание изменений
Добавлена возможность выбирать объект внутри человека, который будет вытащен из него после окончания операции
Обновлена функция prepare_step у операций для поддержки пересылания значений из него внутри прока операций с целью исключить перебивание одной операции другой и тому подобного 
## Почему и что этот ПР улучшит
Пытался вытащить шрапнель из капитана человека - случайно вытащил имплант лояльности - расстреляли за подрыв репутации станции и саботаж
## Авторство
Felix Ruin - Winter Schock
## Чеинжлог
:cl: Winter Schock
- tweak: возможность выбрать объект, который будет вытащен из человека во время операции