### PR TITLE
1 реагент нутриент = 10 переменная нутриента в мобе

### DIFF
--- a/code/modules/reagents/reagent_types/Chemistry-Foods.dm
+++ b/code/modules/reagents/reagent_types/Chemistry-Foods.dm
@@ -44,11 +44,11 @@
 		if(iscarbon(M))
 			var/mob/living/carbon/C = M
 			if(C.can_eat(diet_flags))
-				C.nutrition += nutriment_factor
+				C.nutrition += min(volume * 10, nutriment_factor)
 				if(prob(50))
 					C.adjustBruteLoss(-1)
 		else
-			M.nutrition += nutriment_factor
+			M.nutrition += min(volume * 10, nutriment_factor)
 	return TRUE
 
 /datum/reagent/nutriment/protein // Meat-based protein, digestable by carnivores and omnivores, worthless to herbivores


### PR DESCRIPTION
## Описание изменений
Было: каждый тик -0.8 реагента +8 нутриента => проблема реагентов от 0 до 1, которые так-же дают 8 нутриентов, из-за чего нутриенты считались так: 1 = 16, 2 = 24, 3 = 32, 4 = 40
Стало: каждый тик -0.8 реагента меньшее из 8 или количества реагента * 10 => проблемы нет, так-как счёт будет идти ровно: 1 = 10, 2 = 20, 3 = 30
## Почему и что этот ПР улучшит
Облегчение и так сложной математики реагентов
## Авторство
Felix Ruin - Winter Schock
## Чеинжлог
:cl: Winter Schock
- bugfix: 1 нутриент давал больше энергии чем 4 (если считать штучную эффективность каждого нутриента)