### PR TITLE
Makes new player panel update on round start.

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -268,6 +268,9 @@ var/datum/subsystem/ticker/ticker
 
 	spawn(0)//Forking here so we dont have to wait for this to finish
 		mode.post_setup()
+		for(var/mob/dead/new_player/N in new_player_list)
+			if(N.client)
+				N.new_player_panel_proc()
 		//Cleanup some stuff
 		for(var/obj/effect/landmark/start/S in landmarks_list)
 			//Deleting Startpoints but we need the ai point to AI-ize people later


### PR DESCRIPTION
## Описание изменений
Людям, которые остались в лобби, не придется прожимать ready, чтобы обновить панельку до актуального состояния и получить кнопку join
|Было [Раунд начался]|Стало [Раунд начался]|
|-|-|
|![20200807 104940](https://user-images.githubusercontent.com/66636084/89623179-d51a7480-d89c-11ea-8d24-1fdf805a6382.png)|![20200807 104948](https://user-images.githubusercontent.com/66636084/89623195-dba8ec00-d89c-11ea-845e-e2b2637124ea.png)|


## Почему и что этот ПР улучшит
Quality of Life
## Авторство
на CEV-Eris, Paradise, vgstation тоже есть автообновление
## Чеинжлог
:cl:
 - tweak: после старта раунда у оставшихся в лобби игроков панель автоматически обновится до состояния join/crew manifest