### PR TITLE
Возможность посмотреть возраст игрока пока его нет на сервере

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -235,7 +235,10 @@ proc/message_admins(msg, reg_flag = R_ADMIN)
 		if(C.ckey == key)
 			p_age = C.player_age
 			p_ingame_age = C.player_ingame_age
-
+		else
+			var/age_and_ingame_age = load_info_player_db_age_and_ingame_age(key)
+			p_age = age_and_ingame_age[1]
+			p_ingame_age = age_and_ingame_age[2]
 	// Gather data
 	var/list/db_messages = load_info_player_db_messages(key)
 	var/list/db_bans = load_info_player_db_bans(key)
@@ -268,6 +271,19 @@ proc/message_admins(msg, reg_flag = R_ADMIN)
 
 /proc/cmp_days_timestamp(datum/player_info/a, datum/player_info/b)
 	return a.get_days_timestamp() - b.get_days_timestamp()
+
+/datum/admins/proc/load_info_player_db_age_and_ingame_age(player_ckey)
+	var/list/age_and_ingame_age
+	var/DBQuery/query = dbcon.NewQuery("SELECT datediff(Now(),firstseen) as age, ingameage FROM erro_player WHERE ckey = '[sanitize_sql(player_ckey)]'")
+
+	if(!query.Execute()) // for some reason IsConnected() sometimes ignores disconnections
+		return           // dbcore revision needed
+
+	while(query.NextRow())
+		age_and_ingame_age[1] = text2num(query.item[1])
+		age_and_ingame_age[2] = text2num(query.item[2])
+		break
+	return age_and_ingame_age
 
 /datum/admins/proc/load_info_player_db_messages(player_ckey)
 	// Get player ckey and generate list of players_notes

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -237,8 +237,9 @@ proc/message_admins(msg, reg_flag = R_ADMIN)
 			p_ingame_age = C.player_ingame_age
 		else
 			var/age_and_ingame_age = load_info_player_db_age_and_ingame_age(key)
-			p_age = age_and_ingame_age[1]
-			p_ingame_age = age_and_ingame_age[2]
+			if(age_and_ingame_age)
+				p_age = age_and_ingame_age[1]
+				p_ingame_age = age_and_ingame_age[2]
 	// Gather data
 	var/list/db_messages = load_info_player_db_messages(key)
 	var/list/db_bans = load_info_player_db_bans(key)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -275,7 +275,7 @@ proc/message_admins(msg, reg_flag = R_ADMIN)
 
 /datum/admins/proc/load_info_player_db_age_and_ingame_age(player_ckey)
 	var/list/age_and_ingame_age
-	var/DBQuery/query = dbcon.NewQuery("SELECT datediff(Now(),firstseen) as age, ingameage FROM erro_player WHERE ckey = '[sanitize_sql(player_ckey)]'")
+	var/DBQuery/query = dbcon.NewQuery("SELECT datediff(Now(),firstseen) as age, ingameage FROM erro_player WHERE ckey = '[sanitize_sql(ckey(player_ckey))]'")
 
 	if(!query.Execute()) // for some reason IsConnected() sometimes ignores disconnections
 		return           // dbcore revision needed

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -276,9 +276,7 @@ proc/message_admins(msg, reg_flag = R_ADMIN)
 /datum/admins/proc/load_info_player_db_age_and_ingame_age(player_ckey)
 	var/list/age_and_ingame_age
 	var/DBQuery/query = dbcon.NewQuery("SELECT datediff(Now(),firstseen) as age, ingameage FROM erro_player WHERE ckey = '[sanitize_sql(ckey(player_ckey))]'")
-
-	if(!query.Execute()) // for some reason IsConnected() sometimes ignores disconnections
-		return           // dbcore revision needed
+	query.Execute()
 
 	while(query.NextRow())
 		age_and_ingame_age[1] = text2num(query.item[1])


### PR DESCRIPTION
## Описание изменений
Добавлена возможность админам посмотреть игровой и общее время игры на сервере у игрока при отсуствии игрока на сервер... или нет, пожалуйста, научите в бд, ну или проверьте там... (〃￣ω￣〃)
## Почему и что этот ПР улучшит
Админам не придётся гадать, сколько-же играет игрок на сервере
## Авторство
Felix Ruin - Winter Schock
## Чеинжлог
:cl: Winter Schock
- tweak: админы могут узнать время игры у отсутствующего на сервере игрока