### PR TITLE
 IPC Posibrain, возвращаем жизнь в пустое позитронное тело

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1873,7 +1873,7 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 	to_chat(src,"<span class='warning'>Well... I need my mask back.</span>")
 
 /mob/living/carbon/human/proc/IPC_change_screen()
-	set category = "IC"
+	set category = "IPC"
 	set name = "Change IPC Screen"
 	set desc = "Allow change monitor type"
 	if(stat)
@@ -1909,7 +1909,7 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 	update_hair()
 
 /mob/living/carbon/human/proc/IPC_toggle_screen()
-	set category = "IC"
+	set category = "IPC"
 	set name = "Toggle IPC Screen"
 	set desc = "Allow toggle monitor"
 
@@ -1932,6 +1932,24 @@ INITIALIZE_IMMEDIATE(/mob/living/carbon/human/dummy)
 		if(BP.ipc_head == "Default")
 			h_style = "IPC off screen"
 		update_hair()
+
+/mob/living/carbon/human/proc/IPC_System_Start()
+	set category = "IPC"
+	set name = "IPC Systems Start"
+	set desc = "Turn on chassis systems"
+	if(stat == CONSCIOUS)
+		return
+	if(nutrition < 251)
+		to_chat(usr, "<span class='warning bold'>%ACCUMULATOR% CHARGE IS TOO LOW.</span>")
+		return
+	if(organs_by_name[O_BRAIN].damage > 30)
+		to_chat(usr, "<span class='warning bold'>%%P05IBR*IH@% $Ys7EMm ER00xr// .</span>")
+		return
+	if(stat == DEAD)
+		to_chat(usr, "<span class='warning bold'>POWERING UP THE SYSTEMS.</span>")
+		stat = CONSCIOUS
+		nutrition -= 250
+
 
 /mob/living/carbon/human/has_brain()
 	if(organs_by_name[O_BRAIN])

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -816,6 +816,7 @@
 /datum/species/machine/on_gain(mob/living/carbon/human/H)
 	H.verbs += /mob/living/carbon/human/proc/IPC_change_screen
 	H.verbs += /mob/living/carbon/human/proc/IPC_toggle_screen
+	H.verbs += /mob/living/carbon/human/proc/IPC_System_Start
 	var/obj/item/organ/external/head/robot/ipc/BP = H.bodyparts_by_name[BP_HEAD]
 	if(BP)
 		H.set_light(BP.screen_brightness)
@@ -823,6 +824,7 @@
 /datum/species/machine/on_loose(mob/living/carbon/human/H)
 	H.verbs -= /mob/living/carbon/human/proc/IPC_change_screen
 	H.verbs -= /mob/living/carbon/human/proc/IPC_toggle_screen
+	H.verbs -= /mob/living/carbon/human/proc/IPC_System_Start
 	var/obj/item/organ/external/head/robot/ipc/BP = H.bodyparts_by_name[BP_HEAD]
 	if(BP && BP.screen_toggle)
 		H.set_light(0)

--- a/code/modules/surgery/ribcage.dm
+++ b/code/modules/surgery/ribcage.dm
@@ -472,7 +472,7 @@
 	P.transfer_identity(target)
 
 	target.chest_brain_op_stage = 2
-	target.death()
+	target.stat = DEAD
 
 /datum/surgery_step/ipc_ribcage/extract_posibrain/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)
@@ -504,6 +504,11 @@
 	if(PB.brainmob && PB.brainmob.mind)
 		PB.brainmob.mind.transfer_to(target)
 		target.dna = PB.brainmob.dna
+	dead_mob_list -= user
+	alive_mob_list += user
+	target.stat = CONSCIOUS
+	target.tod = null
+	target.timeofdeath = 0
 
 	qdel(tool)
 //////////////////////////////////////////////////////////////////

--- a/code/modules/surgery/ribcage.dm
+++ b/code/modules/surgery/ribcage.dm
@@ -472,7 +472,7 @@
 	P.transfer_identity(target)
 
 	target.chest_brain_op_stage = 2
-	target.stat = DEAD
+	target.death()
 
 /datum/surgery_step/ipc_ribcage/extract_posibrain/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/BP = target.get_bodypart(target_zone)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Если вернуть позитронку в тело СПУ, после того как она была изъята, тело СПУ вновь оживет. 
Если корпус функционален(тоесть его починили), СПУ сможет вернутся к функциональности сам, потратив 250 энергии.
Перенес кнопки управления монитором во вкладку IPC, туда же добавил кнопку что старует установку
## Почему и что этот ПР улучшит
СПУ можно вернуть в игру
## Авторство
Lexanx
## Чеинжлог
:cl: Lexanx
 - bugfix: СПУ можно вернуть к жизни, после операции
 - rscadd: СПУ может вернутся к жизни, если его корпус цел, функционален