### PR TITLE
suit_storage_unit CSS_THEME_LIGHT

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -112,7 +112,6 @@
 		//user << browse(dat, "window=ssu_m_panel;size=400x500")
 		//onclose(user, "ssu_m_panel")
 	else if(src.isUV) //The thing is running its cauterisation cycle. You have to wait.
-		dat += "<HEAD><meta http-equiv='Content-Type' content='text/html; charset=utf-8'><TITLE>Suit storage unit</TITLE></HEAD>"
 		dat+= "<font color ='red'><B>Unit is cauterising contents with selected UV ray intensity. Please wait.</font></B><BR>"
 		//dat+= "<font colr='black'><B>Cycle end in: [src.cycletimeleft()] seconds. </font></B>"
 		//user << browse(dat, "window=ssu_cycling_panel;size=400x500")
@@ -145,7 +144,6 @@
 			//user << browse(dat, "window=Suit Storage Unit;size=400x500")
 			//onclose(user, "Suit Storage Unit")
 		else //Ohhhh shit it's dirty or broken! Let's inform the guy.
-			dat+= "<HEAD><meta http-equiv='Content-Type' content='text/html; charset=utf-8'><TITLE>Suit storage unit</TITLE></HEAD>"
 			dat+= "<font color='maroon'><B>Unit chamber is too contaminated to continue usage. Please call for a qualified individual to perform maintenance.</font></B><BR><BR>"
 			dat+= text("<HR><A href='?src=\ref[];mach_close=suit_storage_unit'>Close control panel</A>", user)
 			//user << browse(dat, "window=suit_storage_unit;size=400x500")

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -151,7 +151,7 @@
 			//user << browse(dat, "window=suit_storage_unit;size=400x500")
 			//onclose(user, "suit_storage_unit")
 
-	var/datum/browser/popup = new(user, "window=suit_storage_unit", src.name, 400, 500)
+	var/datum/browser/popup = new(user, "window=suit_storage_unit", src.name, 400, 500, ntheme = CSS_THEME_LIGHT)
 	popup.set_content(dat)
 	popup.open()
 


### PR DESCRIPTION
## Описание изменений
Изменяет тему окна на светлую. заодно убрал тег \<head\>
|ууф|стало|
|-|-|
|![20200812 100318](https://user-images.githubusercontent.com/66636084/89985281-7fbada80-dc83-11ea-83e2-ddf16b5107dc.png)|![20200812 100507](https://user-images.githubusercontent.com/66636084/89985289-834e6180-dc83-11ea-8a95-7b9692686c13.png)|

## Почему и что этот ПР улучшит
UI

## Чеинжлог
:cl:
 - tweak: тема интерфейса "Suit Storage Unit" изменена на светлую тему. Пожалуйста, сообщайте о всех "вырвиглазных" интерфейсах