### PR TITLE
Self Surgery

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1143,6 +1143,10 @@ var/global/list/common_tools = list(
 		return 75
 	if(locate(/obj/structure/table) in location)
 		return 66
+	if(locate(/obj/structure/stool/bed/chair/comfy))
+		return 55
+	if(locate(/obj/structure/stool/bed/chair))
+		return 50
 	return 0
 
 //check if mob is lying down on something we can operate him on.


### PR DESCRIPTION

<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Люди в реальности способны на ампутацию собственных конечностей, недавно довелось читать как один хирург себе аппендикс удалял. Поэтому почему этого нет на Тау?
Можно будет проводить операции на себе, для этого потребуется быть в удобном кресле (55%) или в обычном (50%)
## Почему и что этот ПР улучшит
Больше возможностей, все еще кажущихся достаточно реальными. 
## Авторство
Lexanx
## Чеинжлог
:cl: Lexanx
 - tweak: Теперь можно оперировать себя, находясь на кресле