### PR TITLE
Починил say-hear в объектах

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -188,7 +188,9 @@
 	return level == 1
 
 /atom/movable/proc/get_listeners()
-	return list()
+	. = list()
+	for(var/mob/M in contents)
+		. |= M.get_listeners()
 
 /mob/get_listeners()
 	. = list(src)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Добавил в hear-say проверку на содержимое живых в объектах. Теперь в объектах люди смогут общаться [объект(существо)], но не решает проблему [объект(объект(существо))]. Со второй не разобрался т.к. 1) не очень нужно, 2) слишком затратно по ресурсам
Fixes #6041, fixes #5934
## Почему и что этот ПР улучшит
Фикс багов.
## Чеинжлог
:cl:
 - bugfix: починен разговор в объектах.