### PR TITLE
Anomaly fixes

### DIFF
--- a/code/modules/events/anomaly.dm
+++ b/code/modules/events/anomaly.dm
@@ -12,13 +12,13 @@
 		CRASH("Anomaly : No valid turfs found for [impact_area] - [impact_area.type]")
 
 /datum/event/anomaly/tick()
-	if(!newAnomaly)
+	if(QDELETED(newAnomaly))
 		kill()
 		return
 	newAnomaly.anomalyEffect()
 
 /datum/event/anomaly/end()
-	if(newAnomaly)//If it hasn't been neutralized, it's time to blow up.
+	if(!QDELETED(newAnomaly))//If it hasn't been neutralized, it's time to blow up.
 		qdel(newAnomaly)
 
 

--- a/code/modules/events/anomaly_bluespace.dm
+++ b/code/modules/events/anomaly_bluespace.dm
@@ -13,7 +13,7 @@
 
 /datum/event/anomaly/anomaly_bluespace/end()
 	if(!QDELETED(newAnomaly))//If it hasn't been neutralized, it's time to warp half the station away jeez
-		var/turf/T = pick(get_area_turfs(impact_area))
+		var/turf/T = get_turf(newAnomaly)
 		if(T)
 				// Calculate new position (searches through beacons in world)
 			var/obj/item/device/radio/beacon/chosen

--- a/code/modules/events/anomaly_bluespace.dm
+++ b/code/modules/events/anomaly_bluespace.dm
@@ -12,7 +12,7 @@
 		newAnomaly = new /obj/effect/anomaly/bluespace(T)
 
 /datum/event/anomaly/anomaly_bluespace/end()
-	if(newAnomaly)//If it hasn't been neutralized, it's time to warp half the station away jeez
+	if(!QDELETED(newAnomaly))//If it hasn't been neutralized, it's time to warp half the station away jeez
 		var/turf/T = pick(get_area_turfs(impact_area))
 		if(T)
 				// Calculate new position (searches through beacons in world)

--- a/code/modules/events/anomaly_flux.dm
+++ b/code/modules/events/anomaly_flux.dm
@@ -12,6 +12,6 @@
 		newAnomaly = new /obj/effect/anomaly/flux(T)
 
 /datum/event/anomaly/anomaly_flux/end()
-		explosion(newAnomaly, 3, 5, 5)
 	if(!QDELETED(newAnomaly))//If it hasn't been neutralized, it's time to blow up.
+		explosion(get_turf(newAnomaly), 3, 5, 5)
 		qdel(newAnomaly)

--- a/code/modules/events/anomaly_flux.dm
+++ b/code/modules/events/anomaly_flux.dm
@@ -12,6 +12,6 @@
 		newAnomaly = new /obj/effect/anomaly/flux(T)
 
 /datum/event/anomaly/anomaly_flux/end()
-	if(newAnomaly)//If it hasn't been neutralized, it's time to blow up.
 		explosion(newAnomaly, 3, 5, 5)
+	if(!QDELETED(newAnomaly))//If it hasn't been neutralized, it's time to blow up.
 		qdel(newAnomaly)

--- a/code/modules/events/anomaly_pyro.dm
+++ b/code/modules/events/anomaly_pyro.dm
@@ -12,14 +12,14 @@
 		newAnomaly = new /obj/effect/anomaly/pyro(T)
 
 /datum/event/anomaly/anomaly_pyro/tick()
-	if(!newAnomaly)
+	if(QDELETED(newAnomaly))
 		kill()
 		return
 	if(IS_MULTIPLE(activeFor, 5))
 		newAnomaly.anomalyEffect()
 
 /datum/event/anomaly/anomaly_pyro/end()
-	if(newAnomaly)//Kill the anomaly if it still exists at the end.
+	if(!QDELETED(newAnomaly))//Kill the anomaly if it still exists at the end.
 		var/turf/simulated/T = get_turf(newAnomaly)
 		if(istype(T))
 			T.assume_gas("phoron", 200)


### PR DESCRIPTION
## Описание изменений
Исправляет и корректирует работу аномалий
## Почему и что этот ПР улучшит
fix #6049

## Чеинжлог
:cl:
 - bugfix: аномалии больше не срабатывают после обезвреживания
 - bugfix: флюкс аномалия не взрывалась, если не была обезврежена
 - tweak: блюспейс аномалия телепортирует вещи вокруг себя, а не из зоны, в которой появилась