### PR TITLE
Добавил ящик в котором есть сканер для аутопсии

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -356,6 +356,22 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	access = access_teleporter
 	group = "Security"
 
+/datum/supply_pack/investigation
+	name = "Investigation Crate"
+	cost = 1500
+	contains =  list(/obj/item/weapon/autopsy_scanner,
+	                /obj/item/weapon/scalpel,
+					/obj/item/device/detective_scanner,
+					/obj/item/device/taperecorder,
+					/obj/item/clothing/gloves/latex,
+					/obj/item/clothing/suit/storage/labcoat,
+					/obj/item/clothing/mask/surgical,
+					/obj/item/weapon/storage/box/evidence
+					 )
+	crate_type = /obj/structure/closet/crate/secure
+	crate_name = "Investigation Crate"
+	group = "Security"
+
 //----------------------------------------------
 //-----------------HOSPITALITY------------------
 //----------------------------------------------

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -359,8 +359,8 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 /datum/supply_pack/investigation
 	name = "Investigation Crate"
 	cost = 1500
-	contains =  list(/obj/item/weapon/autopsy_scanner,
-	                /obj/item/weapon/scalpel,
+	contains = list(/obj/item/weapon/autopsy_scanner,
+					/obj/item/weapon/scalpel,
 					/obj/item/device/detective_scanner,
 					/obj/item/device/taperecorder,
 					/obj/item/clothing/gloves/latex,


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Добавил ящик со сканером детектива и сканером для аутопсии в список вещей что может заказать карго. Стоимость ящика 1500, находится во вкладке "Security" и называется "Investigation Crate"

<details> 
  <summary>Подробное содержание ящика:</summary>

- Сканнер аутопсии

- Скальпель

- Сканнер детектива

- Диктофон

- Стерильные перчатки

- Лабораторный халат

- Лицевая повязка 

- Коробка с пакетами для вещдоков

</details>

## Почему и что этот ПР улучшит
Теперь на станции может быть больше чем два сканнера для аутопсии, ученым не надо будет воровать сканнер из морга.
fix https://github.com/TauCetiStation/TauCetiClassic/issues/5695
## Авторство
Dushess0
## Чеинжлог
🆑  
- tweak:  В карго во вкладке "Security" появился ящик с набором для расследований "Investigation Crate", который содержит сканнер для аутопсии, сканнер детектива, и другие небходимые для расследования вещи.