### PR TITLE
Runtime fixes

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1195,7 +1195,7 @@ var/list/airlock_overlays = list()
 
 /obj/structure/door_scrap/attackby(obj/item/O, mob/user)
 	if(iswrench(O))
-		if(SSticker >= 300)
+		if(ticker >= 300)
 			user.visible_message("[user] has disassemble these scrap...")
 			new /obj/item/stack/sheet/metal(loc)
 			new /obj/item/stack/sheet/metal(loc)
@@ -1214,7 +1214,7 @@ var/list/airlock_overlays = list()
 	START_PROCESSING(SSobj, src)
 
 /obj/structure/door_scrap/process()
-	if(SSticker >= 300)
+	if(ticker >= 300)
 		cut_overlays()
 		STOP_PROCESSING(SSobj, src)
 		return

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -74,7 +74,7 @@ var/emojiJson = file2text("code/modules/goonchat/browserassets/js/emojiList.json
 		ehjax_send(data = data)
 
 /datum/chatOutput/proc/doneLoading()
-	if(loaded)
+	if(!owner || loaded)
 		return
 
 	loaded = TRUE

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -589,7 +589,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		return 0 //something is terribly wrong
 
 	var/ghosts_can_write
-	if(SSticker.mode.name == "cult")
+	if(SSticker.mode && SSticker.mode.name == "cult")
 		var/datum/game_mode/cult/C = SSticker.mode
 		if(C.cult.len > config.cult_ghostwriter_req_cultists)
 			ghosts_can_write = 1


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Исправляет некоторые рантаймы:
Госты могли спавнить рантаймы до начала раунда
```
Runtime in observer.dm, line 592: Cannot read null.name
proc name: Write in blood (/mob/dead/observer/verb/bloody_doodle)
usr: Allie Lafortune (t6751) (/mob/dead/observer)
usr.loc: The floor (139,118,2) (/turf/simulated/floor)
src: Allie Lafortune (/mob/dead/observer)
src.loc: the floor (139,118,2) (/turf/simulated/floor)
call stack:
Allie Lafortune (/mob/dead/observer): Write in blood()
```
---
А здесь имелась ввиду переменная ticker, а не подсистема, когда я заменял на SSticker. да.
```
Runtime in airlock.dm, line 1217: type mismatch: cannot compare Ticker (/datum/controller/subsystem/ticker) to 300
proc name: process (/obj/structure/door_scrap/process)
src: Engine Room remains (/obj/structure/door_scrap)
src.loc: the floor (151,160,2) (/turf/simulated/floor)
call stack:
Engine Room remains (/obj/structure/door_scrap): process()
Objects (/datum/controller/subsystem/obj): fire(0)
Objects (/datum/controller/subsystem/obj): ignite(0)
Master (/datum/controller/master): RunQueue()
Master (/datum/controller/master): Loop()
Master (/datum/controller/master): StartProcessing(0)
```
---
Добавил проверку на owner (как у ![гунов](https://github.com/goonstation/goonstation/blob/5a72ffb06e189fdfa6dfc0c7f3f4c56a568ce1a6/code/datums/browserOutput.dm#L108)). как понимаю, на случай, если дисконект.
```
Runtime in browserOutput.dm, line 96: bad client
proc name: showChat (/datum/chatOutput/proc/showChat)
src: /datum/chatOutput (/datum/chatOutput)
call stack:
/datum/chatOutput (/datum/chatOutput): showChat()
/datum/chatOutput (/datum/chatOutput): doneLoading()
/datum/chatOutput (/datum/chatOutput): start()
New(null)
```
```
Runtime in browserOutput.dm, line 117: Cannot read null.ckey
proc name: sendClientData (/datum/chatOutput/proc/sendClientData)
src: /datum/chatOutput (/datum/chatOutput)
call stack:
/datum/chatOutput (/datum/chatOutput): sendClientData()
/datum/chatOutput (/datum/chatOutput): doneLoading()
/datum/chatOutput (/datum/chatOutput): start()
New(null)
```


## Почему и что этот ПР улучшит
меньше рантаймов
## Авторство

## Чеинжлог
