### PR TITLE
Boxstation fixes

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -14730,7 +14730,7 @@
 	},
 /area/station/rnd/tox_launch)
 "azS" = (
-/obj/machinery/constructable_frame,
+/obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "vault"
@@ -25417,7 +25417,7 @@
 /turf/simulated/floor/plating,
 /area/station/medical/medbreak)
 "aTu" = (
-/obj/machinery/constructable_frame,
+/obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -46779,7 +46779,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bJA" = (
-/obj/machinery/constructable_frame,
+/obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -78296,9 +78296,6 @@
 	icon_state = "dark"
 	},
 /area/station/medical/morgue)
-"tpb" = (
-/turf/simulated/wall/r_wall,
-/area/station/medical/patients_rooms)
 "tpw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -121882,7 +121879,7 @@ bGR
 bIq
 bKa
 bMm
-tpb
+bDV
 lTb
 qUb
 bSi


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Теперь в церкви стоят правильные machine_frame
А также стена здесь теперь обычная:
|было|стало|
|-|-|
|![unknown](https://user-images.githubusercontent.com/66636084/93021896-49f47300-f5ee-11ea-882d-2f8f4959ddea.png)|![image](https://user-images.githubusercontent.com/66636084/93022012-149c5500-f5ef-11ea-9dea-431147431609.png)|

## Почему и что этот ПР улучшит
fix #6067

## Чеинжлог
:cl:
 - bugfix: machine frame в церкви нельзя было разобрать