### PR TITLE
Фикс атмоса на гамме

### DIFF
--- a/maps/gamma/gamma.dmm
+++ b/maps/gamma/gamma.dmm
@@ -15771,7 +15771,7 @@
 "efE" = (
 /obj/machinery/atmospherics/components/trinary/filter/m_filter/on{
 	dir = 8;
-	filter_type = 3;
+	filter_type = "carbon_dioxide";
 	name = "Gas filter (CO2 tank)"
 	},
 /turf/simulated/floor,
@@ -18884,7 +18884,7 @@
 /area/station/engineering/engine)
 "fdb" = (
 /obj/machinery/atmospherics/components/trinary/filter/m_filter/on{
-	filter_type = 2;
+	filter_type = "nitrogen";
 	name = "Gas filter (N2 tank)"
 	},
 /turf/simulated/floor,
@@ -29281,7 +29281,7 @@
 "ixJ" = (
 /obj/machinery/atmospherics/components/trinary/filter/m_filter/on{
 	dir = 8;
-	filter_type = 4;
+	filter_type = "sleeping_agent";
 	name = "Gas filter (N2O tank)"
 	},
 /turf/simulated/floor,
@@ -31110,7 +31110,7 @@
 /area/station/maintenance/science)
 "jfB" = (
 /obj/machinery/atmospherics/components/trinary/filter/m_filter/on{
-	filter_type = 0;
+	filter_type = "phoron";
 	name = "Gas filter (Toxins tank)"
 	},
 /turf/simulated/floor,
@@ -59242,7 +59242,7 @@
 /area/station/rnd/mixing)
 "sgg" = (
 /obj/machinery/atmospherics/components/trinary/filter/m_filter/on{
-	filter_type = 1;
+	filter_type = "oxygen";
 	name = "Gas filter (O2 tank)"
 	},
 /turf/simulated/floor,


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Поменял какие-то цифорки на названия газов
## Почему и что этот ПР улучшит
QoL
## Авторство
Remindme
## Чеинжлог
:cl: Remindme
 - bugfix: Фильтры в атмосе на гамме теперь работают как надо