### PR TITLE
Ящик для руды фикс

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -261,20 +261,19 @@ var/global/regex/code_response_highlight_rule
 		. += i != codewords.len ? ", " : "."
 	return
 
-/proc/highlight_traitor_codewords(t, datum/mind/traitor_mind)
+/proc/highlight_traitor_codewords(message, datum/mind/traitor_mind)
 	if(!traitor_mind || !traitor_mind.syndicate_awareness)
-		return
+		return message
 
-	var/message = ""
 	switch(traitor_mind.syndicate_awareness)
 		if(SYNDICATE_AWARE)
-			message = highlight_codewords(t, global.code_phrase_highlight_rule) // Same can be done with code_response or any other list of words, using regex created by generate_code_regex(). You can also add the name of CSS class as argument to change highlight style.
+			message = highlight_codewords(message, global.code_phrase_highlight_rule) // Same can be done with code_response or any other list of words, using regex created by generate_code_regex(). You can also add the name of CSS class as argument to change highlight style.
 			message = highlight_codewords(message, global.code_response_highlight_rule, "deptradio")
 
 		if(SYNDICATE_PHRASES)
-			message = highlight_codewords(t, global.code_phrase_highlight_rule)
+			message = highlight_codewords(message, global.code_phrase_highlight_rule)
 
 		if(SYNDICATE_RESPONSE)
-			message = highlight_codewords(t, global.code_response_highlight_rule, "deptradio")
+			message = highlight_codewords(message, global.code_response_highlight_rule, "deptradio")
 
 	return message

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -282,9 +282,9 @@
 		else
 			W.layer = initial(W.layer)
 			W.plane = initial(W.plane)
-		W.loc = new_location
+		W.Move(new_location)
 	else
-		W.loc = get_turf(src)
+		W.Move(get_turf(src))
 
 	if(usr && !NoUpdate)
 		update_ui_after_item_removal()

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -416,7 +416,7 @@
 	var/obj/structure/ore_box/B = locate() in orange(1)
 	if(B)
 		for(var/obj/item/weapon/ore/O in contents)
-			O.loc = B
+			O.Move(B)
 		to_chat(usr, "<span class='notice'>You unload the drill's storage cache into the ore box.</span>")
 	else
 		to_chat(usr, "<span class='notice'>You must move an ore box up to the drill before you can unload it.</span>")

--- a/code/modules/mining/machine_unloading.dm
+++ b/code/modules/mining/machine_unloading.dm
@@ -32,8 +32,7 @@
 			var/obj/structure/ore_box/BOX = locate(/obj/structure/ore_box, input.loc)
 			var/i = 0
 			for (var/obj/item/weapon/ore/O in BOX.contents)
-				BOX.contents -= O
-				O.loc = output.loc
+				O.Move(output.loc)
 				i++
 				if (i>=10)
 					return
@@ -43,7 +42,7 @@
 			for (i = 0; i<10; i++)
 				O = locate(/obj/item, input.loc)
 				if (O)
-					O.loc = src.output.loc
+					O.Move(output.loc)
 				else
 					return
 	return

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -9,16 +9,16 @@
 	density = 1
 	var/last_update = 0
 	var/list/stored_ore = list(
-		hematite = 0,
-		carbonaceous rock = 0,
-		impure silicates = 0,
-		pitchblende = 0,
-		diamonds = 0,
-		native gold ore = 0,
-		native silver ore = 0,
-		phoron crystals = 0,
-		raw platinum = 0,
-		raw hydrogen = 0
+		"hematite" = 0,
+		"carbonaceous rock" = 0,
+		"impure silicates" = 0,
+		"pitchblende" = 0,
+		"diamonds" = 0,
+		"native gold ore" = 0,
+		"native silver ore" = 0,
+		"phoron crystals" = 0,
+		"raw platinum" = 0,
+		"raw hydrogen" = 0,
 	)
 
 /obj/structure/ore_box/attackby(obj/item/weapon/W, mob/user)

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -28,7 +28,7 @@
 /obj/structure/ore_box/Exited(atom/movable/ORE)
 	if(istype(ORE, /obj/item/weapon/ore))
 		stored_ore[ORE.name]--
-	if(!contents)
+	if(!contents.len)
 		stored_ore = list()
 
 /obj/structure/ore_box/attack_hand(mob/user)

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -8,18 +8,7 @@
 	desc = "A heavy box used for storing ore."
 	density = 1
 	var/last_update = 0
-	var/list/stored_ore = list(
-		"hematite" = 0,
-		"carbonaceous rock" = 0,
-		"impure silicates" = 0,
-		"pitchblende" = 0,
-		"diamonds" = 0,
-		"native gold ore" = 0,
-		"native silver ore" = 0,
-		"phoron crystals" = 0,
-		"raw platinum" = 0,
-		"raw hydrogen" = 0,
-	)
+	var/list/stored_ore = list()
 
 /obj/structure/ore_box/attackby(obj/item/weapon/W, mob/user)
 	if(istype(W, /obj/item/weapon/ore))
@@ -39,6 +28,8 @@
 /obj/structure/ore_box/Exited(atom/movable/ORE)
   if(istype(ORE, /obj/item/weapon/ore))
     stored_ore[ORE.name]--
+if(!contents)
+	stored_ore = list()
 
 /obj/structure/ore_box/attack_hand(mob/user)
 	var/dat = ""

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -22,14 +22,14 @@
 	return
 
 /obj/structure/ore_box/Entered(atom/movable/ORE)
-  if(istype(ORE, /obj/item/weapon/ore))
-    stored_ore[ORE.name]++
+	if(istype(ORE, /obj/item/weapon/ore))
+		stored_ore[ORE.name]++
 
 /obj/structure/ore_box/Exited(atom/movable/ORE)
-  if(istype(ORE, /obj/item/weapon/ore))
-    stored_ore[ORE.name]--
-if(!contents)
-	stored_ore = list()
+	if(istype(ORE, /obj/item/weapon/ore))
+		stored_ore[ORE.name]--
+	if(!contents)
+		stored_ore = list()
 
 /obj/structure/ore_box/attack_hand(mob/user)
 	var/dat = ""

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -8,20 +8,37 @@
 	desc = "A heavy box used for storing ore."
 	density = 1
 	var/last_update = 0
-	var/list/stored_ore = list()
+	var/list/stored_ore = list(
+		hematite = 0,
+		carbonaceous rock = 0,
+		impure silicates = 0,
+		pitchblende = 0,
+		diamonds = 0,
+		native gold ore = 0,
+		native silver ore = 0,
+		phoron crystals = 0,
+		raw platinum = 0,
+		raw hydrogen = 0
+	)
 
 /obj/structure/ore_box/attackby(obj/item/weapon/W, mob/user)
 	if(istype(W, /obj/item/weapon/ore))
 		user.drop_from_inventory(W, src)
-		stored_ore[W.name]++
 	else if(istype(W, /obj/item/weapon/storage))
 		var/obj/item/weapon/storage/S = W
 		user.SetNextMove(CLICK_CD_INTERACT)
 		for(var/obj/item/weapon/ore/O in S.contents)
 			S.remove_from_storage(O, src) //This will move the item to this item's contents
-			stored_ore[O.name]++
 		to_chat(user, "<span class='notice'>You empty the satchel into the box.</span>")
 	return
+
+/obj/structure/ore_box/Entered(atom/movable/ORE)
+  if(istype(ORE, /obj/item/weapon/ore))
+    stored_ore[ORE.name]++
+
+/obj/structure/ore_box/Exited(atom/movable/ORE)
+  if(istype(ORE, /obj/item/weapon/ore))
+    stored_ore[ORE.name]--
 
 /obj/structure/ore_box/attack_hand(mob/user)
 	var/dat = ""
@@ -64,9 +81,7 @@
 	src.add_fingerprint(usr)
 	if(href_list["removeall"])
 		for (var/obj/item/weapon/ore/O in contents)
-			contents -= O
-			O.loc = src.loc
-		stored_ore = list()
+			O.Move(src.loc)
 		to_chat(usr, "<span class='notice'>You empty the box</span>")
 	src.updateUsrDialog()
 	return
@@ -80,7 +95,7 @@
 		to_chat(usr, "<span class='warning'>You are physically incapable of emptying the ore box.</span>")
 		return
 
-	if( usr.incapacitated() )
+	if(usr.incapacitated() )
 		return
 
 	if(!Adjacent(usr)) //You can only empty the box if you can physically reach it
@@ -94,8 +109,8 @@
 		return
 
 	for (var/obj/item/weapon/ore/O in contents)
-		contents -= O
-		O.loc = src.loc
+		O.Move(src.loc)
+	
 	to_chat(usr, "<span class='notice'>You empty the ore box</span>")
 
 	return


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Все перемещения руды переведены на Move(), следовательно изменение кол-ва руды в ящике обрабатывается проками Entered() и Exited()
## Почему и что этот ПР улучшит
Fixes #6077 
Fixes #6120 
## Авторство
Remindme
## Чеинжлог
:cl: Remindme
 - bugfix: В ящике для руды в определённых случаях не обновлялось или некорректно отображалось кол-во руды.