### PR TITLE
Нарси больше не в лобби

### DIFF
--- a/code/game/gamemodes/cult/narsie.dm
+++ b/code/game/gamemodes/cult/narsie.dm
@@ -146,8 +146,10 @@
 
 /obj/singularity/narsie/large/atom_init()
 	. = ..()
-	to_chat(world, "<font size='15' color='red'><b>NAR-SIE HAS RISEN</b></font>")
-	world << pick(sound('sound/hallucinations/im_here1.ogg'), sound('sound/hallucinations/im_here2.ogg'))
+	for(var/mob/M in player_list)
+		if(!isnewplayer(M))
+			to_chat(M, "<font size='15' color='red'><b>NAR-SIE HAS RISEN</b></font>")
+			M.playsound_local(null, pick('sound/hallucinations/im_here1.ogg', 'sound/hallucinations/im_here2.ogg'), VOL_EFFECTS_VOICE_ANNOUNCEMENT, vary = FALSE, ignore_environment = TRUE)
 
 	var/area/A = get_area(src)
 	if(A)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Избавляемся от <<, NAR-SIE HAS RISEN теперь только у игроков НЕ в лобби
## Почему и что этот ПР улучшит

## Авторство
Remindme
## Чеинжлог
:cl: Remindme
 - bugfix: Надпись о появлении нарси теперь не появляется у игроков из лобби