### PR TITLE
encode = FALSE

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -75,7 +75,7 @@
 	var/datum/asset/assets = get_asset_datum(/datum/asset/simple/paper)
 	assets.send(user)
 
-	name = sanitize(name)
+	name = sanitize(name, encode = FALSE)
 	var/data
 
 	if((!(ishuman(user) || isobserver(user) || issilicon(user)) && !forceshow) || forcestars)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -75,7 +75,6 @@
 	var/datum/asset/assets = get_asset_datum(/datum/asset/simple/paper)
 	assets.send(user)
 
-	name = sanitize(name, encode = FALSE)
 	var/data
 
 	if((!(ishuman(user) || isobserver(user) || issilicon(user)) && !forceshow) || forcestars)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Из-за двойного кодирования ломались одинарные ковычки
![image](https://user-images.githubusercontent.com/66636084/94099292-4e612d00-fe33-11ea-8229-3f18f4c146aa.png)

## Почему и что этот ПР улучшит
Одинарные кавычки в названии бумаг отображаются как надо

## Чеинжлог
:cl:
 - bugfix: если в названии бумаги присутствовали одинарные кавычки, то они отображались некорректно
