### PR TITLE
Фикс мед. телепортер не анбаклил при телепортации

### DIFF
--- a/code/game/objects/items/devices/radio/beacon.dm
+++ b/code/game/objects/items/devices/radio/beacon.dm
@@ -140,13 +140,8 @@
 			s2.set_up(3, 1, beacon)
 			s.start()
 			s2.start()
-			H.loc = get_turf(beacon)
+			H.forceMove(get_turf(beacon))
 		if (src)
 			qdel(src)
 		H.cut_overlay(I)
 		qdel(I)
-
-
-
-
-


### PR DESCRIPTION
## Описание изменений
сабж
Не менять `loc` напрямую, использовать `forceMove`

## Почему и что этот ПР улучшит
fixes #6160 

## Авторство

## Чеинжлог
:cl:
 - fix: Медицинский телепортер отстегивает людей от стульев/кроватей/итд во время телепортации