### PR TITLE
removes reverse_direction

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1153,25 +1153,6 @@ var/global/list/common_tools = list(
 		return TRUE
 	return FALSE
 
-/proc/reverse_direction(dir)
-	switch(dir)
-		if(NORTH)
-			return SOUTH
-		if(NORTHEAST)
-			return SOUTHWEST
-		if(EAST)
-			return WEST
-		if(SOUTHEAST)
-			return NORTHWEST
-		if(SOUTH)
-			return NORTH
-		if(SOUTHWEST)
-			return NORTHEAST
-		if(WEST)
-			return EAST
-		if(NORTHWEST)
-			return SOUTHEAST
-
 /*
 Checks if that loc and dir has a item on the wall
 */

--- a/code/datums/components/swiping.dm
+++ b/code/datums/components/swiping.dm
@@ -689,7 +689,7 @@
 	var/turf/over_turf = get_turf(over)
 	var/turf/dropping_turf = get_turf(dropping)
 
-	if(get_dir(user, over_turf) == reverse_direction(get_dir(user, dropping_turf)))
+	if(get_dir(user, over_turf) == turn(get_dir(user, dropping_turf), 180))
 		if(can_spin && sweep_spin(parent, user) != NONE)
 			return COMPONENT_NO_MOUSEDROP
 

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -78,7 +78,7 @@
 
 		if (bloodDNA)
 			src.AddTracks(M,bloodDNA,M.dir,0,blooddatum) // Coming
-			var/turf/simulated/from = get_step(M,reverse_direction(M.dir))
+			var/turf/simulated/from = get_step(M, turn(M.dir, 180))
 			if(istype(from) && from)
 				from.AddTracks(M,bloodDNA,0,M.dir,blooddatum) // Going
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
После обсуждения в #5575 решил провести замеры и выяснить, что же лучше. Выяснил.

В общем, получил следующие результаты, из которых выясняется, что лучше всего использовать turn прямо как есть (3-ий тест):
```
Test 1 took: 0.00036
Test 2 took: 0.00033
Test 3 took: 0.00015
Test 4 took: 0.00033
Test 5 took: 0.00019
```
Итог: использовать turn(dir, 180) напрямую, а reverse_direction удалить

<details>
<summary>код замеров</summary>

```dm
var/global/list/rrdir = list(
	SOUTH,
	NORTH,
	null,
	WEST,
	SOUTHWEST,
	NORTHWEST,
	null,
	EAST,
	SOUTHEAST,
	NORTHEAST
	)

/proc/test1(dir)
	switch(dir)
		if(NORTH)
			return SOUTH
		if(NORTHEAST)
			return SOUTHWEST
		if(EAST)
			return WEST
		if(SOUTHEAST)
			return NORTHWEST
		if(SOUTH)
			return NORTH
		if(SOUTHWEST)
			return NORTHEAST
		if(WEST)
			return EAST
		if(NORTHWEST)
			return SOUTHEAST

/proc/test2(dir)
	return turn(dir, 180)

/proc/test4(dir)
	var/static/list/rdir = list(
	SOUTH,
	NORTH,
	null,
	WEST,
	SOUTHWEST,
	NORTHWEST,
	null,
	EAST,
	SOUTHEAST,
	NORTHEAST
	)
	return rdir[dir]

/proc/compare(cases)

	var/static/list/testdata = list()
	for(var/i in 1 to cases)
		testdata += pick(NORTH, NORTHEAST, EAST, SOUTHEAST, SOUTH, SOUTHWEST, WEST, NORTHWEST)

	var/start_time = world.tick_usage
	for(var/i in 1 to cases)
		test1(testdata[i])
	world.log << "Test 1 took: [(world.tick_usage - start_time) / cases]"

	start_time = world.tick_usage
	for(var/i in 1 to cases)
		test2(testdata[i])
	world.log << "Test 2 took: [(world.tick_usage - start_time) / cases]"

	start_time = world.tick_usage
	for(var/i in 1 to cases)
		turn(testdata[i], 180)
	world.log << "Test 3 took: [(world.tick_usage - start_time) / cases]"

	start_time = world.tick_usage
	for(var/i in 1 to cases)
		test4(testdata[i])
	world.log << "Test 4 took: [(world.tick_usage - start_time) / cases]"

	start_time = world.tick_usage
	for(var/i in 1 to cases)
		global.rrdir[testdata[i]]
	world.log << "Test 5 took: [(world.tick_usage - start_time) / cases]"

/proc/main()
	var/cases = 100000
	world.log << "cases: [cases]" 
	compare(cases)

```

</details>

## Почему и что этот ПР улучшит
performance

