### PR TITLE
close Disposal tgui

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -385,6 +385,9 @@ Class Procs:
 	interact(user)
 	return 0
 
+/obj/machinery/tgui_close(mob/user)
+	user.unset_machine(src)
+
 /obj/machinery/CheckParts(list/parts_list)
 	..()
 	RefreshParts()

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -380,8 +380,6 @@
 				INVOKE_ASYNC(src, .proc/flush)
 		flush_count = 0
 
-	src.updateDialog()
-
 	if(flush && air_contents.return_pressure() >= SEND_PRESSURE )	// flush can happen even without power
 		flush()
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -275,6 +275,9 @@
 		ui = new(user, src, "DisposalUnit", name)
 		ui.open()
 
+/obj/machinery/disposal/tgui_close(mob/user)
+	user.unset_machine(src)
+
 /obj/machinery/disposal/tgui_data(mob/user)
 	var/list/data = list()
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -275,9 +275,6 @@
 		ui = new(user, src, "DisposalUnit", name)
 		ui.open()
 
-/obj/machinery/disposal/tgui_close(mob/user)
-	user.unset_machine(src)
-
 /obj/machinery/disposal/tgui_data(mob/user)
 	var/list/data = list()
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
ТГУИ портирован верно, просто урна в процессинге вызывает ```updateDialog()```, который в свою очередь вызывает интеракт для стоящих рядом мобов, у которых считается, что открыто окно, поэтому для корректного закрытия нужно вызвать unset_machine, как раньше
## Почему и что этот ПР улучшит
fix #6110

## Чеинжлог
:cl:
 - bugfix: урну нельзя было закрыть на совсем, если стоять к ней на расстоянии 1 тайла