### PR TITLE
Фикс необновляемых худов при раскопке артефактов

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -228,6 +228,7 @@
 				excavate_find(5, finds[1])
 			else if(prob(50))
 				finds.Remove(finds[1])
+				set_mine_hud()
 				if(prob(50))
 					artifact_debris()
 
@@ -404,6 +405,7 @@
 				qdel(W)
 
 	finds.Remove(F)
+	set_mine_hud()
 
 
 /turf/simulated/mineral/proc/artifact_debris(severity = 0)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Фикс необновляемых худов при раскопке всех артефактов

## Почему и что этот ПР улучшит
Меньше багов

## Авторство

## Чеинжлог
:cl:
 - bugfix: Теперь майн-худ корректно обновляется, когда вытаскиваешь из стены астеройда артефакт 