### PR TITLE
PIXEL_SCALE

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1,6 +1,6 @@
 /atom/movable
 	layer = 3
-	appearance_flags = TILE_BOUND
+	appearance_flags = TILE_BOUND|PIXEL_SCALE
 	var/last_move = null
 	var/anchored = 0
 	var/move_speed = 10


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
PIXEL_SCALE
> Normally if an icon is transformed via atom.transform, it uses bilinear texture sampling which produces a nice smooth effect. If you want a granular pixel-art effect instead, PIXEL_SCALE will do that for you by using nearest-neighbor sampling. 

|OFF|ON|
|-|-|
|![20201005 015606](https://user-images.githubusercontent.com/66636084/95029099-7e6bc400-06ae-11eb-8824-a73da7d695bd.png)|![20201005 015556](https://user-images.githubusercontent.com/66636084/95029101-7f9cf100-06ae-11eb-9d97-da86a6cd70eb.png)|
## Почему и что этот ПР улучшит
Увеличенные/уменьшенные объекты не будут размыты
## Авторство
https://github.com/tgstation/tgstation/pull/26056