### PR TITLE
На камнем теперь может отображаться сразу два худ-обозначения

### DIFF
--- a/code/__DEFINES/atom_hud.dm
+++ b/code/__DEFINES/atom_hud.dm
@@ -32,10 +32,12 @@
 #define IMPMINDS_HUD		"14"
 // Broken glasses hud
 #define BROKEN_HUD			"15"
-// Mine huds
-#define MINE_HUD			"16"
+// Mineral hud
+#define MINE_MINERAL_HUD	"16"
 // Hud of the golem that shows its master
 #define GOLEM_MASTER_HUD	"17"
+// Artifact huds
+#define MINE_ARTIFACT_HUD	"18"
 
 //by default everything in the hud_list of an atom is an image
 //a value in hud_list with one of these will change that behavior

--- a/code/datums/atom_hud_data.dm
+++ b/code/datums/atom_hud_data.dm
@@ -257,7 +257,7 @@
 	var/image/holder = hud_list[MINE_HUD]
 	if(finds && finds.len || artifact_find)
 		holder.icon_state = "hudanomaly"
-	if(mineral)
+	else if(mineral)
 		holder.icon_state = "hud[mineral.ore_type]"
 
 /*~~~~~~~~~~~~~~~~~~~~

--- a/code/datums/atom_hud_data.dm
+++ b/code/datums/atom_hud_data.dm
@@ -53,7 +53,7 @@
 	hud_icons = list(DIAG_HUD, DIAG_STAT_HUD, DIAG_BATT_HUD, DIAG_MECH_HUD, DIAG_AIRLOCK_HUD)
 
 /datum/atom_hud/data/mine
-	hud_icons = list(MINE_HUD)
+	hud_icons = list(MINE_MINERAL_HUD, MINE_ARTIFACT_HUD)
 
 /datum/atom_hud/broken
 	hud_icons = list(BROKEN_HUD)
@@ -254,11 +254,18 @@
 	MINECRAFT HUDs
 ~~~~~~~~~~~~~~~~~~~~~*/
 /turf/simulated/mineral/proc/set_mine_hud()
-	var/image/holder = hud_list[MINE_HUD]
+	var/image/holder1 = hud_list[MINE_ARTIFACT_HUD]
+	var/image/holder2 = hud_list[MINE_MINERAL_HUD]
+	var/states = 0
 	if(finds && finds.len || artifact_find)
-		holder.icon_state = "hudanomaly"
-	else if(mineral)
-		holder.icon_state = "hud[mineral.ore_type]"
+		holder1.icon_state = "hudanomaly"
+		states += 1
+	if(mineral)
+		holder2.icon_state = "hud[mineral.ore_type]"
+		states += 1
+	if(states == 2)
+		holder1.pixel_x = 6
+		holder2.pixel_x = -6
 
 /*~~~~~~~~~~~~~~~~~~~~
 	BROKEN HUUDs

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -9,7 +9,7 @@
 	density = 1
 	blocks_air = 1
 	temperature = TCMB
-	hud_possible = list(MINE_HUD)
+	hud_possible = list(MINE_MINERAL_HUD, MINE_ARTIFACT_HUD)
 	var/mineral/mineral
 	var/mined_ore = 0
 	var/last_act = 0


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Теперь отображение одновременно и худ аномалий, и худ минералов, если это возможно

> Если я выкапываю первый артефакт в породе с другим минералом, спрайт на худах меняется с артефакта на 
шахтерскую руду
> Но скан показывает что артефакты еще есть

## Почему и что этот ПР улучшит
QoL

## Авторство

## Чеинжлог
не