### PR TITLE
Предупреждение о разрядке батарейки холодильника для IPC.

### DIFF
--- a/code/game/objects/items/devices/suit_cooling.dm
+++ b/code/game/objects/items/devices/suit_cooling.dm
@@ -21,7 +21,7 @@
 	var/max_cooling = 12				//in degrees per second - probably don't need to mess with heat capacity here
 	var/charge_consumption = 16.6		//charge per second at max_cooling
 	var/thermostat = T20C
-	var/warn = FALSE
+	var/warn = 0
 
 	//TODO: make it heat up the surroundings when not in space
 
@@ -60,10 +60,13 @@
 	if(cell.charge <= 0)
 		turn_off()
 		
-	if(cell.charge <= cell.maxcharge*0.1 && !warn)
-		warn = TRUE
+	if(cell.charge <= cell.maxcharge*0.1 && warn <= 0)
 		to_chat(H, "<span class='warning'>Cooling unit charge below 10%.</span>")
-		playsound(H, 'sound/rig/shortbeep.ogg', VOL_EFFECTS_MASTER)
+		playsound(H, 'sound/rig/shortbeep.wav', VOL_EFFECTS_MASTER)
+		warn = cell.charge
+		
+	if(cell.charge >= cell.maxcharge*0.1 && warn >= 0)
+		warn = 0
 	
 /obj/item/device/suit_cooling_unit/proc/get_environment_temperature()
 	if(ishuman(loc))
@@ -154,7 +157,6 @@
 			else
 				user.drop_from_inventory(I, src)
 				cell = I
-				warn = FALSE
 				to_chat(user, "You insert the [cell].")
 		updateicon()
 		return

--- a/code/game/objects/items/devices/suit_cooling.dm
+++ b/code/game/objects/items/devices/suit_cooling.dm
@@ -91,7 +91,7 @@
 	if(ishuman(loc))
 		var/mob/living/carbon/human/H = loc
 		to_chat(H, "<span class='warning'>Cooling unit charge below 10%.</span>")
-		playsound(H, 'sound/rig/shortbeep.wav', VOL_EFFECTS_MASTER)
+		playsound(H, 'sound/rig/shortbeep.ogg', VOL_EFFECTS_MASTER)
 	charge_warning = TRUE
 
 /obj/item/device/suit_cooling_unit/proc/attached_to_suit(mob/M)

--- a/code/game/objects/items/devices/suit_cooling.dm
+++ b/code/game/objects/items/devices/suit_cooling.dm
@@ -62,7 +62,7 @@
 		
 	if(cell.charge <= cell.maxcharge*0.1 && warn <= 0)
 		to_chat(H, "<span class='warning'>Cooling unit charge below 10%.</span>")
-		playsound(H, 'sound/rig/shortbeep.wav', VOL_EFFECTS_MASTER)
+		playsound(H, 'sound/rig/shortbeep.ogg', VOL_EFFECTS_MASTER)
 		warn = cell.charge
 		
 	if(cell.charge >= cell.maxcharge*0.1 && warn >= 0)

--- a/code/game/objects/items/devices/suit_cooling.dm
+++ b/code/game/objects/items/devices/suit_cooling.dm
@@ -63,7 +63,7 @@
 	if(cell.charge <= cell.maxcharge*0.1 && !warn)
 		warn = TRUE
 		to_chat(H, "<span class='warning'>Cooling unit charge below 10%.</span>")
-		playsound(H, 'sound/rig/shortbeep.wav', VOL_EFFECTS_MASTER)
+		playsound(H, 'sound/rig/shortbeep.ogg', VOL_EFFECTS_MASTER)
 	
 /obj/item/device/suit_cooling_unit/proc/get_environment_temperature()
 	if(ishuman(loc))

--- a/code/game/objects/items/devices/suit_cooling.dm
+++ b/code/game/objects/items/devices/suit_cooling.dm
@@ -21,7 +21,7 @@
 	var/max_cooling = 12				//in degrees per second - probably don't need to mess with heat capacity here
 	var/charge_consumption = 16.6		//charge per second at max_cooling
 	var/thermostat = T20C
-	var/charge_warning = 0
+	var/charge_warning = FALSE
 
 	//TODO: make it heat up the surroundings when not in space
 
@@ -57,15 +57,14 @@
 
 	cell.use(charge_usage)
 
+	//Sound warning.
+	if(cell.charge <= cell.maxcharge*0.1 && !charge_warning)
+		charge_warning()
+	if(cell.charge >= cell.maxcharge*0.1 && charge_warning)
+		charge_warning = FALSE
+
 	if(cell.charge <= 0)
 		turn_off()
-		
-	if(cell.charge <= cell.maxcharge*0.1 && charge_warning <= 0)
-		to_chat(H, "<span class='warning'>Cooling unit charge below 10%.</span>")
-		playsound(H, 'sound/rig/shortbeep.ogg', VOL_EFFECTS_MASTER)
-		charge_warning = cell.charge	
-	if(cell.charge >= cell.maxcharge*0.1 && charge_warning >= 0)
-		charge_warning = 0
 	
 /obj/item/device/suit_cooling_unit/proc/get_environment_temperature()
 	if(ishuman(loc))
@@ -87,6 +86,13 @@
 		return 0
 
 	return environment.temperature
+
+/obj/item/device/suit_cooling_unit/proc/charge_warning()
+	if(ishuman(loc))
+		var/mob/living/carbon/human/H = loc
+		to_chat(H, "<span class='warning'>Cooling unit charge below 10%.</span>")
+		playsound(H, 'sound/rig/shortbeep.wav', VOL_EFFECTS_MASTER)
+	charge_warning = TRUE
 
 /obj/item/device/suit_cooling_unit/proc/attached_to_suit(mob/M)
 	if (!ishuman(M))

--- a/code/game/objects/items/devices/suit_cooling.dm
+++ b/code/game/objects/items/devices/suit_cooling.dm
@@ -21,6 +21,7 @@
 	var/max_cooling = 12				//in degrees per second - probably don't need to mess with heat capacity here
 	var/charge_consumption = 16.6		//charge per second at max_cooling
 	var/thermostat = T20C
+	var/warn = FALSE
 
 	//TODO: make it heat up the surroundings when not in space
 
@@ -58,7 +59,12 @@
 
 	if(cell.charge <= 0)
 		turn_off()
-
+		
+	if(cell.charge <= cell.maxcharge*0.1 && !warn)
+		warn = TRUE
+		to_chat(H, "<span class='warning'>Cooling unit charge below 10%.</span>")
+		playsound(H, 'sound/rig/shortbeep.wav', VOL_EFFECTS_MASTER)
+	
 /obj/item/device/suit_cooling_unit/proc/get_environment_temperature()
 	if(ishuman(loc))
 		var/mob/living/carbon/human/H = loc
@@ -148,6 +154,7 @@
 			else
 				user.drop_from_inventory(I, src)
 				cell = I
+				warn = FALSE
 				to_chat(user, "You insert the [cell].")
 		updateicon()
 		return

--- a/code/game/objects/items/devices/suit_cooling.dm
+++ b/code/game/objects/items/devices/suit_cooling.dm
@@ -21,7 +21,7 @@
 	var/max_cooling = 12				//in degrees per second - probably don't need to mess with heat capacity here
 	var/charge_consumption = 16.6		//charge per second at max_cooling
 	var/thermostat = T20C
-	var/warn = 0
+	var/charge_warning = 0
 
 	//TODO: make it heat up the surroundings when not in space
 
@@ -60,13 +60,12 @@
 	if(cell.charge <= 0)
 		turn_off()
 		
-	if(cell.charge <= cell.maxcharge*0.1 && warn <= 0)
+	if(cell.charge <= cell.maxcharge*0.1 && charge_warning <= 0)
 		to_chat(H, "<span class='warning'>Cooling unit charge below 10%.</span>")
 		playsound(H, 'sound/rig/shortbeep.ogg', VOL_EFFECTS_MASTER)
-		warn = cell.charge
-		
-	if(cell.charge >= cell.maxcharge*0.1 && warn >= 0)
-		warn = 0
+		charge_warning = cell.charge	
+	if(cell.charge >= cell.maxcharge*0.1 && charge_warning >= 0)
+		charge_warning = 0
 	
 /obj/item/device/suit_cooling_unit/proc/get_environment_temperature()
 	if(ishuman(loc))


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Посылает в чат сообщение и звук, когда заряд батарейки ниже 10%.
## Почему и что этот ПР улучшит
Исправляет бесшумное выключение холодильника.
## Авторство

## Чеинжлог
:cl: Kortez90
 - tweak: Предупреждение о разрядке cooling_unit.