### PR TITLE
Верб "rotate" для инъекторов топлива.

### DIFF
--- a/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
@@ -47,7 +47,10 @@ var/list/fuel_injectors = list()
 	if (src.anchored || usr:stat)
 		to_chat(usr, "It is fastened to the floor!")
 		return 0
-	src.dir = turn(src.dir, 90)
+	if (usr.incapacitated())
+		to_chat(usr, "You are incapacitated.")
+		return 0
+	dir = turn(dir, 90)
 	return 1
 
 /obj/machinery/fusion_fuel_injector/attackby(obj/item/W, mob/user)

--- a/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
@@ -46,12 +46,12 @@ var/list/fuel_injectors = list()
 
 	if (src.anchored || usr:stat)
 		to_chat(usr, "It is fastened to the floor!")
-		return 0
+		return
 	if (usr.incapacitated())
 		to_chat(usr, "You are incapacitated.")
-		return 0
+		return
 	dir = turn(dir, 90)
-	return 1
+	return
 
 /obj/machinery/fusion_fuel_injector/attackby(obj/item/W, mob/user)
 

--- a/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
@@ -39,6 +39,17 @@ var/list/fuel_injectors = list()
 		else
 			Inject()
 
+/obj/machinery/fusion_fuel_injector/verb/rotate()
+	set name = "Rotate"
+	set category = "Object"
+	set src in oview(1)
+
+	if (src.anchored || usr:stat)
+		to_chat(usr, "It is fastened to the floor!")
+		return 0
+	src.dir = turn(src.dir, 90)
+	return 1
+
 /obj/machinery/fusion_fuel_injector/attackby(obj/item/W, mob/user)
 
 	if(ismultitool(W))

--- a/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
@@ -51,7 +51,6 @@ var/list/fuel_injectors = list()
 		to_chat(usr, "You are incapacitated.")
 		return
 	dir = turn(dir, 90)
-	return
 
 /obj/machinery/fusion_fuel_injector/attackby(obj/item/W, mob/user)
 

--- a/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
@@ -44,11 +44,10 @@ var/list/fuel_injectors = list()
 	set category = "Object"
 	set src in oview(1)
 
-	if (anchored)
-		to_chat(usr, "It is fastened to the floor!")
-		return
 	if (usr.incapacitated())
-		to_chat(usr, "You are incapacitated.")
+		return
+	if (anchored)
+		to_chat(usr,"<span class='notice'>It is fastened to the floor!</span>")
 		return
 	dir = turn(dir, 90)
 

--- a/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
@@ -44,7 +44,7 @@ var/list/fuel_injectors = list()
 	set category = "Object"
 	set src in oview(1)
 
-	if (src.anchored)
+	if (anchored)
 		to_chat(usr, "It is fastened to the floor!")
 		return
 	if (usr.incapacitated())

--- a/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
@@ -44,7 +44,7 @@ var/list/fuel_injectors = list()
 	set category = "Object"
 	set src in oview(1)
 
-	if (src.anchored || usr:stat)
+	if (src.anchored)
 		to_chat(usr, "It is fastened to the floor!")
 		return
 	if (usr.incapacitated())


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Добавляет верб кручения инъекторов.
## Почему и что этот ПР улучшит
Чиним отсутствие кручения инъекторов, так как они не наследуют код эмиттеров.
## Авторство

## Чеинжлог
:cl: Kortez90
 - tweak: Топливные инъекторы раста можно крутить через пкм.