### PR TITLE
Убран ручной запуск процессинга для loyalty импланта

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -678,7 +678,6 @@
 			else
 				L = new /obj/item/weapon/implant/mindshield/loyalty(H)
 				L.inject(H)
-				START_PROCESSING(SSobj, L)
 
 			H.sec_hud_set_implants()
 			to_chat(H, "<span class='warning'><Font size =3><B>You somehow have become the recepient of a [is_mind_shield ? "mind shield" : "loyalty"] transplant,\

--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -268,5 +268,4 @@ var/can_call_ert
 
 	var/obj/item/weapon/implant/mindshield/loyalty/L = new(src)
 	L.inject(src)
-	START_PROCESSING(SSobj, L)
 	return 1

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -1176,7 +1176,6 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 			M.equip_to_slot_or_del(W, SLOT_WEAR_ID)
 
 			var/obj/item/weapon/implant/mindshield/loyalty/L = new(M)
-			START_PROCESSING(SSobj, L)
 			L.inject(M)
 		if("hop")
 			M.equip_to_slot_or_del(new /obj/item/clothing/under/rank/head_of_personnel(M), SLOT_W_UNIFORM)
@@ -1226,7 +1225,6 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 
 			var/obj/item/weapon/implant/mindshield/loyalty/L = new(M)
 			L.inject(M)
-			START_PROCESSING(SSobj, L)
 		if("cmo")
 			M.equip_to_slot_or_del(new /obj/item/clothing/under/rank/chief_medical_officer(M), SLOT_W_UNIFORM)
 			M.equip_to_slot_or_del(new /obj/item/clothing/shoes/brown(M), SLOT_SHOES)
@@ -1750,7 +1748,6 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 
 			var/obj/item/weapon/implant/mindshield/loyalty/L = new(M)
 			L.inject(M)
-			START_PROCESSING(SSobj, L)
 		if("assistant")
 			M.equip_to_slot_or_del(new /obj/item/clothing/under/color/grey(M), SLOT_W_UNIFORM)
 			M.equip_to_slot_or_del(new /obj/item/clothing/shoes/black(M), SLOT_SHOES)

--- a/code/modules/admin/verbs/striketeam.dm
+++ b/code/modules/admin/verbs/striketeam.dm
@@ -164,7 +164,6 @@ var/global/sent_strike_team = 0
 
 	var/obj/item/weapon/implant/mindshield/loyalty/L = new(src)
 	L.inject(src)
-	START_PROCESSING(SSobj, L)
 
 
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Имплант сам запускает процессинг при инжекте

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
