### PR TITLE
Открывание боргов ломом через use_tool().

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -638,12 +638,12 @@
 			else
 				if(user.is_busy())
 					return
-				user.SetNextMove(CLICK_CD_INTERACT)
 				if(do_after(user,12,target = src))
 					to_chat(user, "You open the cover.")
 					playsound(src, 'sound/misc/robot_open.ogg', VOL_EFFECTS_MASTER)
 					opened = 1
 					updateicon()
+				user.SetNextMove(CLICK_CD_INTERACT)
 
 	else if (istype(W, /obj/item/weapon/stock_parts/cell) && opened)	// trying to put a cell inside
 		var/datum/robot_component/C = components["power cell"]

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -636,10 +636,11 @@
 			if(locked)
 				to_chat(user, "The cover is locked and cannot be opened.")
 			else
-				to_chat(user, "You open the cover.")
-				playsound(src, 'sound/misc/robot_open.ogg', VOL_EFFECTS_MASTER)
-				opened = 1
-				updateicon()
+				if(do_after(user,12,target = src))
+					to_chat(user, "You open the cover.")
+					playsound(src, 'sound/misc/robot_open.ogg', VOL_EFFECTS_MASTER)
+					opened = 1
+					updateicon()
 
 	else if (istype(W, /obj/item/weapon/stock_parts/cell) && opened)	// trying to put a cell inside
 		var/datum/robot_component/C = components["power cell"]

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -636,6 +636,8 @@
 			if(locked)
 				to_chat(user, "The cover is locked and cannot be opened.")
 			else
+				if(user.is_busy())
+					return
 				user.SetNextMove(CLICK_CD_INTERACT)
 				if(do_after(user,12,target = src))
 					to_chat(user, "You open the cover.")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -638,7 +638,7 @@
 			else
 				if(user.is_busy())
 					return
-				if(do_after(user,12,target = src))
+				if(W.use_tool(src, user, 12, volume = 50))
 					to_chat(user, "You open the cover.")
 					playsound(src, 'sound/misc/robot_open.ogg', VOL_EFFECTS_MASTER)
 					opened = 1

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -636,6 +636,7 @@
 			if(locked)
 				to_chat(user, "The cover is locked and cannot be opened.")
 			else
+				user.SetNextMove(CLICK_CD_INTERACT)
 				if(do_after(user,12,target = src))
 					to_chat(user, "You open the cover.")
 					playsound(src, 'sound/misc/robot_open.ogg', VOL_EFFECTS_MASTER)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Добавил `use_tool` на 12, как защиту от всяких ролей, которые мгновенно вскрывают боргов капитанской картой и на ходу вытаскивают батарейку. Возможно, нужно даже больше, чем 12...
## Почему и что этот ПР улучшит
Боргов будет чуть более проблематично вскрыть для ролей.
## Авторство

## Чеинжлог
:cl: Kortez90
 - tweak: Крышка доступа к батарее боргов вскрывается дольше.