### PR TITLE
Фикс спама ослепления

### DIFF
--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -27,17 +27,21 @@
 		screen.add_screen_part(client)
 	return screen
 
-/mob/proc/clear_fullscreen(category, animate = 10)
-	set waitfor = 0
+/mob/proc/clear_fullscreen(category, animated = 10)
 	var/obj/screen/fullscreen/screen = screens[category]
 	if(!screen)
 		return
-
-	if(animate)
-		animate(screen, alpha = 0, time = animate)
-		sleep(animate)
-
 	screens -= category
+	if(animated)
+		animate(screen, alpha = 0, time = animated)
+		addtimer(CALLBACK(src, .proc/clear_fullscreen_after_animate, screen), animated, TIMER_CLIENT_TIME)
+	else
+		if(client)
+			client.screen -= screen
+			screen.remove_screen_part(client)
+		qdel(screen)
+
+/mob/proc/clear_fullscreen_after_animate(obj/screen/fullscreen/screen)
 	if(client)
 		client.screen -= screen
 		screen.remove_screen_part(client)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1006,11 +1006,9 @@
 /mob/living/proc/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0, type = /obj/screen/fullscreen/flash)
 	if(override_blindness_check || !(disabilities & BLIND))
 		overlay_fullscreen("flash", type)
-		spawn(0)
-			sleep(25)
-			if(src)
-				clear_fullscreen("flash", 25)
-		return 1
+		addtimer(CALLBACK(src, .proc/clear_fullscreen, "flash", 25), 25)
+		return TRUE
+	return FALSE
 
 /mob/living/proc/has_brain()
 	return TRUE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Спам фонариком/флешкой в глаза не будет делать вечно белый экран
animate() не может спать.

## Почему и что этот ПР улучшит
fix https://github.com/TauCetiStation/TauCetiClassic/issues/2547
fix https://github.com/TauCetiStation/TauCetiClassic/issues/3721
## Авторство

## Чеинжлог
🆑 Morair

* bugfix: Спам светом в глаза не ломает экран