### PR TITLE
исправлено отображение двух одинаковых блобов в титрах

### DIFF
--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -44,7 +44,7 @@ var/global/blobwincount = 500
 		if (!antag_candidates.len)
 			break
 		var/datum/mind/blob = pick(antag_candidates)
-		infected_crew += blob
+		infected_crew |= blob
 		blob.special_role = "Blob"
 		log_game("[key_name(blob)] has been selected as a Blob")
 		antag_candidates -= blob
@@ -94,7 +94,7 @@ var/global/blobwincount = 500
 			if(core.overmind && core.overmind.mind)
 				core.overmind.mind.name = blob.name
 				infected_crew -= blob
-				infected_crew += core.overmind.mind
+				infected_crew |= core.overmind.mind
 
 
 /datum/game_mode/blob/post_setup()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Исправляет показ одного блоба два раза
## Почему и что этот ПР улучшит
fix #6040

## Чеинжлог
:cl:
 - bugfix: в титрах один блоб мог показываться дважды