### PR TITLE
Фикс дюпа синдиборгов 

### DIFF
--- a/code/game/objects/items/weapons/antagspawner.dm
+++ b/code/game/objects/items/weapons/antagspawner.dm
@@ -23,9 +23,9 @@
 		to_chat(user, "The teleporter is out of power.")
 		return
 	to_chat(user, "<span class='notice'>Searching for available borg personality. Please wait 30 seconds...</span>")
+	used = TRUE
 	var/list/borg_candicates = pollGhostCandidates("Syndicate requesting a personality for a syndicate borg. Would you like to play as one?", ROLE_OPERATIVE)
 	if(borg_candicates.len)
-		used = TRUE
 		var/mob/M = pick(borg_candicates)
 		spawn_antag(M.client, get_turf(src.loc), "syndieborg")
 	else


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Во время поиска активировать спавнер синдиборгов нельзя
## Почему и что этот ПР улучшит
fix #6298

## Чеинжлог
:cl:
 - bugfix: можно было заспавнить нескольких синдиборгов вместо одного