### PR TITLE
Отображение ням-батона в руке

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -3166,6 +3166,7 @@
 	name = "Yum-baton Bar"
 	desc = "Chocolate and toffee in the shape of a baton. Security sure knows how to pound these down!"
 	icon_state = "yumbaton"
+	item_state = "baton"
 	filling_color = "#7d5f46"
 
 /obj/item/weapon/reagent_containers/food/snacks/candy/malper


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Теперь, при взятии кондитерского изделия, известный как ням-батон (Yum-baton), в руке персонажа для окружающих будет отображаться стан-батон. Все лучше, чем просто пустая рука.
<details> 
  <summary>Пример</summary>

![Скриншот 01-11-2020 142722](https://user-images.githubusercontent.com/62613651/97810519-80ad4800-1c85-11eb-84fc-55a38221f09d.jpg)
</details>

## Почему и что этот ПР улучшит
Теперь ням-батон не только красиво и подозрительно выглядит на столе, но и в руке
## Авторство
Rolt
## Чеинжлог
:cl:
 - image: Ням батон получил инхенды дубинки