### PR TITLE
steal objective finding

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -568,16 +568,22 @@ Turf and target are seperate in case you want to teleport some distance from a t
 	sleep(max(sleeptime, 15))
 	qdel(animation)
 
-//Will return the contents of an atom recursivly to a depth of 'searchDepth'
-/atom/proc/GetAllContents(searchDepth = 5)
-	var/list/toReturn = list()
+/*
+	Gets all contents of contents and returns them all in a list.
+*/
+/atom/proc/GetAllContents()
+	var/list/processing_list = list(src)
+	var/list/assembled = list()
 
-	for(var/atom/part in contents)
-		toReturn += part
-		if(part.contents.len && searchDepth)
-			toReturn += part.GetAllContents(searchDepth - 1)
+	while(processing_list.len)
+		var/atom/A = processing_list[1]
+		processing_list -= A
 
-	return toReturn
+		processing_list |= (A.contents - assembled)
+
+		assembled |= A
+
+	return assembled
 
 //Step-towards method of determining whether one atom can see another. Similar to viewers()
 /proc/can_see(atom/source, atom/target, length=5) // I couldnt be arsed to do actual raycasting :I This is horribly inaccurate.

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -202,7 +202,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 					break
 
 		//update our pda and id if we have them on our person
-		var/list/searching = GetAllContents(searchDepth = 3)
+		var/list/searching = GetAllContents()
 		var/search_id = 1
 		var/search_pda = 1
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -277,7 +277,7 @@ var/global/list/all_objectives = list()
 		return OBJECTIVE_WIN
 	if( !owner.current || owner.current.stat==DEAD )//If you're otherwise dead.
 		return OBJECTIVE_LOSS
-	var/list/all_items = owner.current.get_contents()
+	var/list/all_items = owner.current.GetAllContents()
 	for(var/obj/item/device/biocan/B in all_items)
 		if(B.brainmob && B.brainmob == target.current)
 			return OBJECTIVE_WIN
@@ -583,7 +583,7 @@ var/global/list/all_objectives = list()
 /datum/objective/steal/check_completion()
 	if(!steal_target || !owner.current)	return OBJECTIVE_LOSS
 	if(!isliving(owner.current))	return OBJECTIVE_LOSS
-	var/list/all_items = owner.current.get_contents()
+	var/list/all_items = owner.current.GetAllContents()
 	switch (target_name)
 		if("28 moles of phoron (full tank)","10 diamonds","50 gold bars","25 refined uranium bars")
 			var/target_amount = text2num(target_name)//Non-numbers are ignored.
@@ -895,7 +895,7 @@ var/global/list/all_objectives = list()
 	var/datum/game_mode/heist/H = SSticker.mode
 	for(var/datum/mind/raider in H.raiders)
 		if(raider.current)
-			for(var/obj/O in raider.current.get_contents())
+			for(var/obj/O in raider.current.GetAllContents())
 				if(istype(O,target))
 					total_amount++
 				if(total_amount >= target_amount)
@@ -936,7 +936,7 @@ var/global/list/all_objectives = list()
 	var/datum/game_mode/heist/H = SSticker.mode
 	for(var/datum/mind/raider in H.raiders)
 		if(raider.current)
-			for(var/obj/item/O in raider.current.get_contents())
+			for(var/obj/item/O in raider.current.GetAllContents())
 				if(istype(O,/obj/item/stack/sheet))
 					if(O.name == target)
 						var/obj/item/stack/sheet/S = O

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -906,7 +906,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	set category = "Special Verbs"
 	set name = "Check Contents"
 
-	var/list/L = M.get_contents()
+	var/list/L = M.GetAllContents()
 	for(var/t in L)
 		to_chat(usr, "[t]")
 	feedback_add_details("admin_verb","CC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Используется ```GetAllContents``` заместо ```get_contents``` там где нужно. 
```GetAllContents``` немного переписан
## Почему и что этот ПР улучшит
fix #1249
fix #4730
fix #6356

## Авторство

## Чеинжлог
🆑 Morair
* bugfix: admin verb Check Contents показывает вещи в имплантах/карманах
* bugfix: вещи в имплантах/карманах засчитываются за кражу