### PR TITLE
Сингулярные мобы теперь не тянут после смерти

### DIFF
--- a/code/modules/roguelike/mob_modifiers/positive.dm
+++ b/code/modules/roguelike/mob_modifiers/positive.dm
@@ -375,8 +375,8 @@
 	H.add_overlay(singularity_overlay)
 
 	START_PROCESSING(SSmob_modifier, src)
-	RegisterSignal(H, list(COMSIG_MOB_DIED), .proc/stop_processing)
-	RegisterSignal(H, list(COMSIG_LIVING_REJUVENATE), .proc/start_processing)
+	RegisterSignal(H, list(COMSIG_MOB_DIED), .proc/stop_pulling)
+	RegisterSignal(H, list(COMSIG_LIVING_REJUVENATE), .proc/start_pulling)
 
 /datum/component/mob_modifier/singular/revert(update = FALSE)
 	if(!update)
@@ -424,10 +424,10 @@
 		consume(X)
 		CHECK_TICK
 
-/datum/component/mob_modifier/singular/proc/start_processing()
+/datum/component/mob_modifier/singular/proc/start_pulling()
 	START_PROCESSING(SSmob_modifier, src)
 
-/datum/component/mob_modifier/singular/proc/stop_processing()
+/datum/component/mob_modifier/singular/proc/stop_pulling()
 	STOP_PROCESSING(SSmob_modifier, src)
 
 

--- a/code/modules/roguelike/mob_modifiers/positive.dm
+++ b/code/modules/roguelike/mob_modifiers/positive.dm
@@ -375,6 +375,8 @@
 	H.add_overlay(singularity_overlay)
 
 	START_PROCESSING(SSmob_modifier, src)
+	RegisterSignal(H, list(COMSIG_MOB_DIED), .proc/stop_processing)
+	RegisterSignal(H, list(COMSIG_LIVING_REJUVENATE), .proc/start_processing)
 
 /datum/component/mob_modifier/singular/revert(update = FALSE)
 	if(!update)
@@ -421,6 +423,12 @@
 			continue
 		consume(X)
 		CHECK_TICK
+
+/datum/component/mob_modifier/singular/proc/start_processing()
+	START_PROCESSING(SSmob_modifier, src)
+
+/datum/component/mob_modifier/singular/proc/stop_processing()
+	STOP_PROCESSING(SSmob_modifier, src)
 
 
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Теперь сингулярные мобы не тянут после смерти, так же предусмотрел восстановление притягивания при реджуве.
## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
🆑 
 - tweak: Теперь мобы на шахте с сингулярным модификатором перестают притягивать после своей смерти.