### PR TITLE
User_unbuckle_mob для труб.

### DIFF
--- a/code/modules/atmospheric/machinery/pipes/pipes.dm
+++ b/code/modules/atmospheric/machinery/pipes/pipes.dm
@@ -110,3 +110,8 @@
 		return node.pipe_color
 	else
 		return pipe_color
+
+/obj/machinery/atmospherics/pipe/attack_hand(mob/living/carbon/human/H)
+	if(can_buckle && buckled_mob && istype(H))
+		user_unbuckle_mob(H)
+	..()

--- a/code/modules/atmospheric/machinery/pipes/pipes.dm
+++ b/code/modules/atmospheric/machinery/pipes/pipes.dm
@@ -114,4 +114,4 @@
 /obj/machinery/atmospherics/pipe/attack_hand(mob/living/carbon/human/H)
 	if(can_buckle && buckled_mob && istype(H))
 		user_unbuckle_mob(H)
-	..()
+		..()

--- a/code/modules/atmospheric/machinery/pipes/pipes.dm
+++ b/code/modules/atmospheric/machinery/pipes/pipes.dm
@@ -114,4 +114,3 @@
 /obj/machinery/atmospherics/pipe/attack_hand(mob/living/carbon/human/H)
 	if(can_buckle && buckled_mob && istype(H))
 		user_unbuckle_mob(H)
-		..()

--- a/code/modules/atmospheric/machinery/pipes/pipes.dm
+++ b/code/modules/atmospheric/machinery/pipes/pipes.dm
@@ -114,3 +114,5 @@
 /obj/machinery/atmospherics/pipe/attack_hand(mob/living/carbon/human/H)
 	if(can_buckle && buckled_mob && istype(H))
 		user_unbuckle_mob(H)
+	else
+		..()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Мобов нельзя было снять с трубы, если они к ней были пристегнуты. Теперь можно.

## Почему и что этот ПР улучшит
Fix #6388.
## Авторство

## Чеинжлог
:cl: Kortez90
 - bugfix: Можно отстегивать людей от трубы.