### PR TITLE
Фикс рантайма при взрыве меха.

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1749,7 +1749,7 @@
 	delay = 15
 
 /datum/global_iterator/mecha_tank_give_air/process(var/obj/mecha/mecha)
-	if(mecha.internal_tank)
+	if(mecha.internal_tank && !mecha.wreckage)
 		var/datum/gas_mixture/tank_air = mecha.internal_tank.return_air()
 		var/datum/gas_mixture/cabin_air = mecha.cabin_air
 
@@ -1775,7 +1775,7 @@
 				else //just delete the cabin gas, we're in space or some shit
 					qdel(removed)
 	else
-		return stop()
+		return STOP_PROCESSING(SSobj, src)
 	return
 
 /datum/global_iterator/mecha_internal_damage/process(var/obj/mecha/mecha) // processing internal damage


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Добавил проверку `wreckage` в процессинг внутренних баков меха и заменил `stop()` на `STOP_PROCESSING`.
На тестах рантаймы не проскакивали.
## Почему и что этот ПР улучшит
Fix #6401 
## Авторство

## Чеинжлог
