### PR TITLE
solution to all hand-breaking combo bugs.

### DIFF
--- a/code/modules/unarmed_combat/combo_handler.dm
+++ b/code/modules/unarmed_combat/combo_handler.dm
@@ -191,6 +191,8 @@
 		CC.before_animation(victim, attacker)
 
 	if(!CC.do_combo(victim, attacker, ANIM_DELAY_WINDUP + ANIM_DELAY_RETURN))
+		if(CC.heavy_animation)
+			CC.after_animation(victim, attacker)
 		return
 	CC.animate_combo(victim, attacker)
 


### PR DESCRIPTION
## Описание изменений

Решает все проблемы о которых на данный момент известно с комбами, и багом "занятости" рук.

Суть в том, что был период в два тика, перед любой анимированной комбой, в который если прервать комбу - то не применялись эффекты "после комбо анимации" - аля кукла не переставала быть занятой, внутри анимации, и т.д.

Этот ПР исправляет это, вызывая эффекты конца анимации при этом прерывании

## Почему и что этот ПР улучшит

fixes #6456 
fixes #6346 
fixes #6188 
fixes #5923 

## Авторство

Спасибо @Motzord-у, и вообще всем кто пытался найти источник.

## Чеинжлог
:cl: Luduk
- bugfix: Прерывании комбы во время начала исполнения не предовтращает последующее взаимодействие с предметами которые требуют полоски действий.