### PR TITLE
Фикс casingtype у синдиката.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -114,7 +114,7 @@
 	rapid = 1
 	icon_state = "syndicateranged"
 	icon_living = "syndicateranged"
-	casingtype = /obj/item/ammo_casing/a12mm
+	casingtype = /obj/item/ammo_casing/c45
 	projectilesound = 'sound/weapons/guns/gunshot_light.ogg'
 	projectiletype = /obj/item/projectile/bullet/midbullet2
 	retreat_distance = 5


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Мобы-синдикатовцы плевались после выстрела `a12mm`, который, вроде бы, нигде не используется. Поменял на `45c`.
## Почему и что этот ПР улучшит
Fix #6517.
## Авторство

## Чеинжлог
:cl: Kortez90
 - bugfix: Мобы-синдикатовцы плюются после выстрела гильзами .45.