### PR TITLE
ghost follow hotfix

### DIFF
--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -58,9 +58,9 @@
 		name += " ([key])"
 
 	var/rendered = "<span class='game deadsay linkify emojify'><span class='prefix'>DEAD:</span> <span class='name'>[name]</span>[alt_name] [pick("complains","moans","whines","laments","blubbers")], <span class='message'>\"[message]\"</span></span>"
-	var/tracker = "<a href='byond://?src=\ref[src];track=\ref[src]'>(F)</a> "
 
 	for(var/mob/M in player_list)
+		var/tracker = "<a href='byond://?src=\ref[M];track=\ref[src]'>(F)</a> "
 		if(isnewplayer(M))
 			continue
 		if(M.client && M.stat == DEAD && (M.client.prefs.chat_toggles & CHAT_DEAD))


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Follow телепортирует на говорящего призрака, а не на себя
## Почему и что этот ПР улучшит
fix #6382
## Авторство

## Чеинжлог
:cl:
 - bugfix: кнопка (F) на говорящих призраках работает корректно