### PR TITLE
Suicide теперь "лечится" rejuv'ом

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -507,7 +507,7 @@
 	disabilities = 0
 	ExtinguishMob()
 	fire_stacks = 0
-	suiciding = 0
+	suiciding = FALSE
 
 	if(pinned.len)
 		for(var/obj/O in pinned)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -507,6 +507,7 @@
 	disabilities = 0
 	ExtinguishMob()
 	fire_stacks = 0
+	suiciding = 0
 
 	if(pinned.len)
 		for(var/obj/O in pinned)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Теперь прок rejuvenate лечит последствия суицида. Раньше, в некоторых случаях, если тело суицидника оживлялось, то оно продолжало получать урон, вплоть до своей смерти
## Почему и что этот ПР улучшит
Как минимум два момента. Генка мог прожать suicide, стазис и после стазиса испытывать проблемы. Культист мог оживить собрата, который прожал suicide и тот тоже впоследствии умирал
## Авторство
Я
## Чеинжлог
:cl:
- bugfix: Теперь суицид "лечится" после регена генокрада или руны воскрешения культа