### PR TITLE
Фикс рантайма в уи проводов

### DIFF
--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -168,7 +168,6 @@ var/global/list/wire_daltonism_colors = list()
 			var/new_b = CM.matrix[3] * r + CM.matrix[6] * g + CM.matrix[9] * b + CM.matrix[12] * 255
 
 			wire_daltonism_colors[sight_mod][i] = rgb(new_r, new_g, new_b)
-			qdel(CM)
 
 /datum/wires/tgui_host()
 	return holder

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -138,41 +138,37 @@ var/global/list/wire_daltonism_colors = list()
 	if(additional_checks_and_effects(user))
 		return FALSE
 
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(H.sightglassesmod)
-
-			if(!wire_daltonism_colors)
-				wire_daltonism_colors = list()
-
-			// Creates a list of color for people with daltonism and save his
-			if(!wire_daltonism_colors[H.sightglassesmod])
-				wire_daltonism_colors[H.sightglassesmod] = list()
-				for(var/i in wire_colors)
-					var/color_hex = color_by_hex[i]
-
-					if(!color_hex)
-						var/color = pick(wire_colors)
-						wire_daltonism_colors[H.sightglassesmod][i] = color
-						continue
-
-					var/r = hex2num(copytext(color_hex, 2, 4))
-					var/g = hex2num(copytext(color_hex, 4, 6))
-					var/b = hex2num(copytext(color_hex, 6, 8))
-
-					var/datum/ColorMatrix/CM = new(H.sightglassesmod)
-					var/new_r = CM.matrix[1] * r + CM.matrix[4] * g + CM.matrix[7] * b + CM.matrix[10] * 255
-					var/new_g = CM.matrix[2] * r + CM.matrix[5] * g + CM.matrix[8] * b + CM.matrix[11] * 255
-					var/new_b = CM.matrix[3] * r + CM.matrix[6] * g + CM.matrix[9] * b + CM.matrix[12] * 255
-
-					wire_daltonism_colors[H.sightglassesmod][i] = rgb(new_r, new_g, new_b)
-					qdel(CM)
-
 	user.set_machine(holder)
 
 	tgui_interact(user, null)
 
 	return TRUE
+
+/datum/wires/proc/calculate_daltonism_colors(sight_mod)
+	if (!wire_daltonism_colors)
+		wire_daltonism_colors = list()
+	if(sight_mod && !wire_daltonism_colors[sight_mod])
+		// Creates a list of color for people with daltonism and save his
+		wire_daltonism_colors[sight_mod] = list()
+		for(var/i in wire_colors)
+			var/color_hex = color_by_hex[i]
+
+			if(!color_hex)
+				var/color = pick(wire_colors)
+				wire_daltonism_colors[sight_mod][i] = color
+				continue
+
+			var/r = hex2num(copytext(color_hex, 2, 4))
+			var/g = hex2num(copytext(color_hex, 4, 6))
+			var/b = hex2num(copytext(color_hex, 6, 8))
+
+			var/datum/ColorMatrix/CM = new(sight_mod)
+			var/new_r = CM.matrix[1] * r + CM.matrix[4] * g + CM.matrix[7] * b + CM.matrix[10] * 255
+			var/new_g = CM.matrix[2] * r + CM.matrix[5] * g + CM.matrix[8] * b + CM.matrix[11] * 255
+			var/new_b = CM.matrix[3] * r + CM.matrix[6] * g + CM.matrix[9] * b + CM.matrix[12] * 255
+
+			wire_daltonism_colors[sight_mod][i] = rgb(new_r, new_g, new_b)
+			qdel(CM)
 
 /datum/wires/tgui_host()
 	return holder
@@ -225,6 +221,7 @@ var/global/list/wire_daltonism_colors = list()
 				shownColorLbl = capitalize(shownColor)
 			else
 				var/mcolor
+				calculate_daltonism_colors(see_effect)
 				if(hex2color(wire_daltonism_colors[see_effect][color])) // Color in color_by_hex list
 					mcolor = hex2color(wire_daltonism_colors[see_effect][color])
 				else // Closest color name from list


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Пофиксил рантайм ошибку свою.
Раньше наноуи(предположительно) обновлял уи при интеракте, расчет всех цветов был в самом интеракте.
ТГУИ обновляет уи раз в секунду примерно, то есть можно было подойти к дверям без очков, посмотреть на провода, надеть очки и вызвать рантайм ошибку из-за того, что при интеракте цвета для матрицы очков не просчитались но попытались отправиться в уи.
Подвинул всю эту проверку и расчет в отдельный прок, убрал его из интеракта вообще и вставил его в tgui_data, т.е. именно там, где цвета эти и используются.
## Почему и что этот ПР улучшит
Нет рантайм ошибки. Обмануть код смены цветов не получится.
## Авторство
AirBlack - Фикс
## Чеинжлог
:cl:
 - bugfix: Цвета проводов конкретно и точно обновляются зависимо от матрицы зрения.