### PR TITLE
Фикс рантайма при клике по меч_компу, когда в мехе нету батарейки

### DIFF
--- a/code/game/mecha/mech_bay.dm
+++ b/code/game/mecha/mech_bay.dm
@@ -116,7 +116,7 @@
 		else
 			data += "<div class='Section'>Integrity: [recharge_port.recharging_mech.health]<BR>"
 			if(!recharge_port.recharging_mech.cell)
-				data += "<div class='Section'>No cell detected in the mech.<BR>"
+				data += "<span class='bad'>No cell detected in the mech.</span><BR>"
 			else
 				if(recharge_port.recharging_mech.cell.crit_fail)
 					data += "<span class='bad'>WARNING : the mech cell seems faulty!</span></div>"

--- a/code/game/mecha/mech_bay.dm
+++ b/code/game/mecha/mech_bay.dm
@@ -115,10 +115,13 @@
 			data += "<div class='Section'>No mech detected.</div>"
 		else
 			data += "<div class='Section'>Integrity: [recharge_port.recharging_mech.health]<BR>"
-			if(recharge_port.recharging_mech.cell.crit_fail)
-				data += "<span class='bad'>WARNING : the mech cell seems faulty!</span></div>"
+			if(!recharge_port.recharging_mech.cell)
+				data += "<div class='Section'>No cell detected in the mech.<BR>"
 			else
-				data += "Power: [recharge_port.recharging_mech.cell.charge]/[recharge_port.recharging_mech.cell.maxcharge]</div>"
+				if(recharge_port.recharging_mech.cell.crit_fail)
+					data += "<span class='bad'>WARNING : the mech cell seems faulty!</span></div>"
+				else
+					data += "Power: [recharge_port.recharging_mech.cell.charge]/[recharge_port.recharging_mech.cell.maxcharge]</div>"
 
 	var/datum/browser/popup = new(user, "mech recharger", name, 300, 300)
 	popup.set_content(data)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
![fawaaaaa](https://user-images.githubusercontent.com/26389417/103951752-529a2780-5150-11eb-8b81-4affa113b94d.PNG)

скрин до спана
![image](https://user-images.githubusercontent.com/26389417/103952048-c0deea00-5150-11eb-83a6-014ee30a7fd9.png)


## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
:cl:
 - fix: Теперь мех-компьютер показывает, что в мехе нету батарейки