### PR TITLE
Фикс сонных животных

### DIFF
--- a/code/modules/mob/living/carbon/brain/login.dm
+++ b/code/modules/mob/living/carbon/brain/login.dm
@@ -1,4 +1,5 @@
 /mob/living/carbon/brain/Login()
 	..()
 	update_hud()
-	return
+	blinded = FALSE
+	stat = CONSCIOUS

--- a/code/modules/mob/living/simple_animal/shade.dm
+++ b/code/modules/mob/living/simple_animal/shade.dm
@@ -107,11 +107,6 @@
 
 	return ..()
 
-/mob/living/simple_animal/shade/god/Login()
-	..()
-	stat = CONSCIOUS
-	blinded = FALSE
-
 /mob/living/simple_animal/shade/god/Life()
 	..()
 	if(global.chaplain_religion)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -79,6 +79,12 @@
 	if(footstep_type)
 		AddComponent(/datum/component/footstep, footstep_type)
 
+/mob/living/simple_animal/Login()
+	..()
+	blinded = FALSE
+	stat = CONSCIOUS
+	update_canmove()
+
 /mob/living/simple_animal/Grab(atom/movable/target, force_state, show_warnings = TRUE)
 	return
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Из-за того, что у симплов_энималов нету в лайфе обновления статуса(как у хуманов) они "спали", если перезайти в игру

Возможно, мейнтейнерам фикс покажется костыльным, но решать баг тем же способом, что и у хуманов, выглядит еще хуже, ведь у хуманов в /Лайфе есть хендлер статуса, который делает почти тоже самое

Мб какие-то ишуи не нашел

fixes #6485, fixes #5874, fixes #615, fixes #3361

## Почему и что этот ПР улучшит
Минус баг

## Авторство

## Чеинжлог
:cl:
 - fix: Теперь при перезаходе в игру, играя не за людей и яна, Вы сможете продолжить нормально играть
