### PR TITLE
Дрель больше нельзя носить за ухом

### DIFF
--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -111,6 +111,7 @@
 	materials = list(MAT_METAL=150, MAT_SILVER=50)
 	origin_tech = "materials=2;engineering=2" //done for balance reasons, making them high value for research, but harder to get
 	force = 8 //might or might not be too high, subject to change
+	w_class = ITEM_SIZE_SMALL
 	throwforce = 8
 	throw_speed = 2
 	throw_range = 3//it's heavier than a screw driver/wrench, so it does more damage, but can't be thrown as far


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
fixes #6653
Увеличен размер для дрели в режиме отвертки с TINY до SMALL, то есть в любом режиме в ухо не поместится
## Почему и что этот ПР улучшит
Странно, что дрель можно положить в ухо, в режиме отвертки. Добавляет... логичность?
## Авторство

## Чеинжлог
:cl:
- bugfix: Дрель в режиме отвертки больше не положить в ухо.