### PR TITLE
Только ревер может стать хедревером, если стартовые ливнут

### DIFF
--- a/code/game/gamemodes/revolution/rp_revolution.dm
+++ b/code/game/gamemodes/revolution/rp_revolution.dm
@@ -273,12 +273,12 @@
 						rev_obj.explanation_text = "Capture, convert or exile from station [head_mind.name], the [head_mind.assigned_role]. Assassinate if you have no choice."
 						H.mind.objectives += rev_obj
 
-				H.verbs += /mob/living/carbon/human/proc/RevConvert
-				add_antag_hud(antag_hud_type, antag_hud_name, H)
+					H.verbs += /mob/living/carbon/human/proc/RevConvert
+					add_antag_hud(antag_hud_type, antag_hud_name, H)
 
-				to_chat(H, "<span class='warning'>Congratulations, yer heads of revolution are all gone now, so yer earned yourself a promotion.</span>")
-				added_heads = 1
-				break
+					to_chat(H, "<span class='warning'>Congratulations, yer heads of revolution are all gone now, so yer earned yourself a promotion.</span>")
+					added_heads = 1
+					break
 
 			if(added_heads)
 				log_admin("Managed to add new heads of revolution.")


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
До фикса хедревером при отсутствие других ревером мог стать абсолютно любой хуман, даже кукла из генетики, даже ливнувший хедревер, они получит кнопку конверта и все, целей ей не дадут и цикл опять будет искать нового хедревера, потому что они не попадают в лист к хедреверам. 

Вроде объяснил суть бага.

fix #6681

## Почему и что этот ПР улучшит
Минус баг

## Авторство


## Чеинжлог
:cl:
 - fix: Теперь хед-ревером может стать только ревер