### PR TITLE
[Alien] fix runtime

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/say.dm
+++ b/code/modules/mob/living/carbon/xenomorph/say.dm
@@ -23,9 +23,9 @@
 			alien_talk(message)
 			return
 
-	if(!stat)
+	if(stat == CONSCIOUS)
 		playsound(src, pick(SOUNDIN_XENOMORPH_TALK), VOL_EFFECTS_MASTER, 45) // So aliens can hiss while they hiss yo/N
-	return ..(message, xeno_language, sanitize = 0)
+		return ..(message, xeno_language, sanitize = 0)
 
 /mob/living/carbon/xenomorph/facehugger/say(message)
 

--- a/code/modules/mob/living/carbon/xenomorph/say.dm
+++ b/code/modules/mob/living/carbon/xenomorph/say.dm
@@ -16,15 +16,16 @@
 	if(message[1] == "*")
 		return emote(copytext(message, 2))
 
-	if(length(message) >= 1)
+	if(length(message) >= 2)
 		if(department_radio_keys[copytext(message, 1, 2 + length(message[2]))] == "alientalk")
 			message = copytext(message, 2 + length(message[2]))
 			message = trim(message)
 			alien_talk(message)
-		else
-			if(!stat)
-				playsound(src, pick(SOUNDIN_XENOMORPH_TALK), VOL_EFFECTS_MASTER, 45) // So aliens can hiss while they hiss yo/N
-			return ..(message, xeno_language, sanitize = 0)
+			return
+
+	if(!stat)
+		playsound(src, pick(SOUNDIN_XENOMORPH_TALK), VOL_EFFECTS_MASTER, 45) // So aliens can hiss while they hiss yo/N
+	return ..(message, xeno_language, sanitize = 0)
 
 /mob/living/carbon/xenomorph/facehugger/say(message)
 

--- a/code/modules/mob/living/carbon/xenomorph/say.dm
+++ b/code/modules/mob/living/carbon/xenomorph/say.dm
@@ -23,7 +23,7 @@
 			alien_talk(message)
 			return
 
-	if(stat == CONSCIOUS)
+	if(stat != CONSCIOUS)
 		playsound(src, pick(SOUNDIN_XENOMORPH_TALK), VOL_EFFECTS_MASTER, 45) // So aliens can hiss while they hiss yo/N
 		return ..(message, xeno_language, sanitize = 0)
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Рантаймило в сей-коде алиенов при наборе одного символа в сообщении. Так как для разговора в улей надо набрать минимум два символа (:A) ,а не один,  я сделал `if(length(message) >= 2)`
<details> 
  <summary>Runtime</summary>

```
  Runtime in say.dm:17 : list index out of bounds<br>
  proc name: say (/mob/living/carbon/xenomorph/say)<br>
  usr: The alien larva (384) (/mob/living/carbon/xenomorph/larva)<br>
  usr.loc: The alien embryo (154,109,2) (/obj/item/alien_embryo)<br>
  src: the alien larva (384) (/mob/living/carbon/xenomorph/larva)<br>
  src.loc: the alien embryo (/obj/item/alien_embryo)<br>
  call stack:<br>
  the alien larva (384) (/mob/living/carbon/xenomorph/larva): say("?")<br>
  the alien larva (384) (/mob/living/carbon/xenomorph/larva): Say("?")<br>
```

</details>

## Почему и что этот ПР улучшит
Меньше ошибок

## Авторство
Я

## Чеинжлог
не нужен