### PR TITLE
Фикс урона удара головой.

### DIFF
--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -517,11 +517,11 @@
 							var/mob/living/carbon/assailant_C = assailant
 							var/obj/item/clothing/hat = assailant_C.head
 							if(istype(hat))
-								damage += hat.force * 10
+								damage += hat.force * 4
 						var/armor = affecting.run_armor_check(BP_HEAD, "melee")
 						var/armor_assailant = assailant.run_armor_check(BP_HEAD, "melee")
 						affecting.apply_damage(damage*rand(90, 110)/100, BRUTE, BP_HEAD, blocked = armor)
-						assailant.apply_damage((10*rand(90, 110))/100, BRUTE, BP_HEAD, blocked = armor_assailant)
+						assailant.apply_damage(10*rand(90, 110)/100, BRUTE, BP_HEAD, blocked = armor_assailant)
 						if(!armor && prob(damage))
 							affecting.apply_effect(20, PARALYZE)
 							affecting.visible_message("<span class='danger'>[affecting] has been knocked unconscious!</span>")

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -520,7 +520,7 @@
 								damage += hat.force * 4
 						var/armor = affecting.run_armor_check(BP_HEAD, "melee")
 						var/armor_assailant = assailant.run_armor_check(BP_HEAD, "melee")
-						affecting.apply_damage(damage*rand(90, 110)/100, BRUTE, BP_HEAD, blocked = armor)
+						affecting.apply_damage(damage*rand(60, 82)/100, BRUTE, BP_HEAD, blocked = armor)
 						assailant.apply_damage(10*rand(90, 110)/100, BRUTE, BP_HEAD, blocked = armor_assailant)
 						if(!armor && prob(damage))
 							affecting.apply_effect(20, PARALYZE)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -521,7 +521,7 @@
 						var/armor = affecting.run_armor_check(BP_HEAD, "melee")
 						var/armor_assailant = assailant.run_armor_check(BP_HEAD, "melee")
 						affecting.apply_damage(damage*rand(90, 110)/100, BRUTE, BP_HEAD, blocked = armor)
-						assailant.apply_damage(10*rand(90, 110)/100, BRUTE, BP_HEAD, blocked = armor_assailant)
+						assailant.apply_damage((10*rand(90, 110))/100, BRUTE, BP_HEAD, blocked = armor_assailant)
 						if(!armor && prob(damage))
 							affecting.apply_effect(20, PARALYZE)
 							affecting.visible_message("<span class='danger'>[affecting] has been knocked unconscious!</span>")


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
По каким-то странным причинам урон от удара головой составил ~68, а не ~10-20, как должно было быть.

Похоже, что какие-то шлемы или игрушки, которые можно носить на голове, имели переменную `force` равной 5 или выше, что приводило к такому: "(20+5*10) * rand(90, 110) /100". Максимум такого примера - 77. Обрезал до ~16.
## Почему и что этот ПР улучшит
Fix #6707.
## Авторство

## Чеинжлог
