### PR TITLE
Sandstorm Announce fix

### DIFF
--- a/code/modules/events/dust.dm
+++ b/code/modules/events/dust.dm
@@ -1,6 +1,4 @@
 /datum/event/space_dust
-	announcement = new /datum/announcement/centcomm/dust
-	announcement_end = new /datum/announcement/centcomm/dust_passed
 
 /datum/event/space_dust/start()
 	spawn_meteors(1, meteors_dust)
@@ -9,6 +7,8 @@
 	startWhen = 1
 	endWhen = 90
 	announceWhen = 0
+	announcement = new /datum/announcement/centcomm/dust
+	announcement_end = new /datum/announcement/centcomm/dust_passed
 
 /datum/event/sandstorm/tick()
 	spawn_meteors(10, meteors_dust)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Анонс песочного шторма был ошибочно перенесен в ивент с одинокой космопылью. Соответственно возвращаю как было
## Почему и что этот ПР улучшит
fix #6738
## Авторство

## Чеинжлог
:cl:
 - fix: Анонс песочного шторма анонсировал не то событие