### PR TITLE
[PORT] Remove meaningless "Type too long" message from VV

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -202,14 +202,7 @@
 
 	body += "</tr></td></table>"
 
-	var/formatted_type = text("[D.type]")
-	if(length(formatted_type) > 25)
-		var/middle_point = length(formatted_type) / 2
-		var/splitpoint = findtext(formatted_type,"/",middle_point)
-		if(splitpoint)
-			formatted_type = "[copytext(formatted_type,1,splitpoint)]<br>[copytext(formatted_type,splitpoint)]"
-		else
-			formatted_type = "Type too long" //No suitable splitpoint (/) found.
+	var/formatted_type = replacetext("[D.type]", "/", "<wbr>/")
 
 	body += "<div align='center'><b><font size='1'>[formatted_type]</font></b>"
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений

|Было|Стало|
|-|-|
|![20210126 014447](https://user-images.githubusercontent.com/66636084/105775969-c9208d00-5f78-11eb-8e40-545b78b22d9e.png)|![20210126 014619](https://user-images.githubusercontent.com/66636084/105775940-ba39da80-5f78-11eb-9ce3-60f024da6c98.png)|

А также, если скопировать путь теперь, то он скопируется как 
```/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/banana_mortar/mousetrap_mortar```, а не 
```
/obj/item/mecha_parts/mecha_equipment/weapon/ballistic
/missile_rack/banana_mortar/mousetrap_mortar
```

## Почему и что этот ПР улучшит
VV чуть более удобнее
## Авторство
SpaceManiac https://github.com/tgstation/tgstation/pull/33386
## Чеинжлог
