### PR TITLE
"View Del()/Initialize Log" в "Logs"

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -2019,51 +2019,6 @@ But you can call procs that are of type /mob/living/carbon/human/proc/ for that 
 		if("Joined Clients")
 			to_chat(usr, jointext(joined_player_list,","))
 
-/client/proc/cmd_display_del_log()
-	set category = "Debug"
-	set name = "Display del() Log"
-	set desc = "Display del's log of everything that's passed through it."
-
-	var/list/dellog = list("<B>List of things that have gone through qdel this round</B><BR><BR><ol>")
-	sortTim(SSgarbage.items, cmp=/proc/cmp_qdel_item_time, associative = TRUE)
-	for(var/path in SSgarbage.items)
-		var/datum/qdel_item/I = SSgarbage.items[path]
-		dellog += "<li><u>[path]</u><ul>"
-		if (I.failures)
-			dellog += "<li>Failures: [I.failures]</li>"
-		dellog += "<li>qdel() Count: [I.qdels]</li>"
-		dellog += "<li>Destroy() Cost: [I.destroy_time]ms</li>"
-		if (I.hard_deletes)
-			dellog += "<li>Total Hard Deletes [I.hard_deletes]</li>"
-			dellog += "<li>Time Spent Hard Deleting: [I.hard_delete_time]ms</li>"
-		if (I.slept_destroy)
-			dellog += "<li>Sleeps: [I.slept_destroy]</li>"
-		if (I.no_respect_force)
-			dellog += "<li>Ignored force: [I.no_respect_force]</li>"
-		if (I.no_hint)
-			dellog += "<li>No hint: [I.no_hint]</li>"
-		dellog += "</ul></li>"
-
-	dellog += "</ol>"
-
-	var/datum/browser/popup = new(usr, "dellog")
-	popup.set_content(dellog.Join())
-	popup.open()
-
-/client/proc/cmd_display_init_log()
-	set category = "Debug"
-	set name = "Display Initialize() Log"
-	set desc = "Displays a list of things that didn't handle Initialize() properly"
-
-	if(!length(SSatoms.BadInitializeCalls))
-		to_chat(usr, "<span class='notice'>There is no bad initializations found in log.</span>")
-	else
-		var/dat = replacetext(SSatoms.InitLog(), "\n", "<br>")
-
-		var/datum/browser/popup = new(usr, "initlog")
-		popup.set_content(dat)
-		popup.open()
-
 // DNA2 - Admin Hax
 /client/proc/cmd_admin_toggle_block(mob/M,block)
 	if(!SSticker)

--- a/code/modules/admin/verbs/getlogs.dm
+++ b/code/modules/admin/verbs/getlogs.dm
@@ -105,3 +105,48 @@
 			return
 
 		browseserverlogs("data/logs/[round_date]/round-[id]/[subpath]")
+
+/client/proc/cmd_display_del_log()
+	set category = "Logs"
+	set name = "View del() Log"
+	set desc = "Display del's log of everything that's passed through it."
+
+	var/list/dellog = list("<B>List of things that have gone through qdel this round</B><BR><BR><ol>")
+	sortTim(SSgarbage.items, cmp=/proc/cmp_qdel_item_time, associative = TRUE)
+	for(var/path in SSgarbage.items)
+		var/datum/qdel_item/I = SSgarbage.items[path]
+		dellog += "<li><u>[path]</u><ul>"
+		if (I.failures)
+			dellog += "<li>Failures: [I.failures]</li>"
+		dellog += "<li>qdel() Count: [I.qdels]</li>"
+		dellog += "<li>Destroy() Cost: [I.destroy_time]ms</li>"
+		if (I.hard_deletes)
+			dellog += "<li>Total Hard Deletes [I.hard_deletes]</li>"
+			dellog += "<li>Time Spent Hard Deleting: [I.hard_delete_time]ms</li>"
+		if (I.slept_destroy)
+			dellog += "<li>Sleeps: [I.slept_destroy]</li>"
+		if (I.no_respect_force)
+			dellog += "<li>Ignored force: [I.no_respect_force]</li>"
+		if (I.no_hint)
+			dellog += "<li>No hint: [I.no_hint]</li>"
+		dellog += "</ul></li>"
+
+	dellog += "</ol>"
+
+	var/datum/browser/popup = new(usr, "dellog")
+	popup.set_content(dellog.Join())
+	popup.open()
+
+/client/proc/cmd_display_init_log()
+	set category = "Logs"
+	set name = "View Initialize() Log"
+	set desc = "Displays a list of things that didn't handle Initialize() properly"
+
+	if(!length(SSatoms.BadInitializeCalls))
+		to_chat(usr, "<span class='notice'>There is no bad initializations found in log.</span>")
+	else
+		var/dat = replacetext(SSatoms.InitLog(), "\n", "<br>")
+
+		var/datum/browser/popup = new(usr, "initlog")
+		popup.set_content(dat)
+		popup.open()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Переместил вербы для просмотра del() и Initialize логов во вкладку "Logs", где им самое место быть, и переименовал соответственно, чтобы находились рядом с "View Runtimes"
![20210128 152957](https://user-images.githubusercontent.com/66636084/106139361-64cf1a80-617e-11eb-8cf0-46abaa489549.png)

Своего рода дополнение к https://github.com/TauCetiStation/TauCetiClassic/pull/4600

## Почему и что этот ПР улучшит
Логично ожидать, что все вербы для просмотра логов должны быть в "Logs"
Удобнее просматривать логи, не переключаясь между вкладками
## Авторство

## Чеинжлог
