### PR TITLE
[Alien] Быстрофикс рантайма

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/effects/aliens.dm
+++ b/code/modules/mob/living/carbon/xenomorph/effects/aliens.dm
@@ -129,8 +129,8 @@
 	healthcheck()
 	return
 
-/obj/structure/alien/resin/attack_paw()
-	return attack_hand()
+/obj/structure/alien/resin/attack_paw(mob/user)
+	return attack_hand(user)
 
 /obj/structure/alien/resin/attack_alien(mob/user)
 	user.do_attack_animation(src)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Вообще весь файл `aliens.dm` нуждается в рефакторинге, чем я сейчас и занимаюсь. Но, перед предстоящим тестом, решил отдельно пофиксить этот рантайм. Возникал из-за того, что `/obj/structure/alien/resin/attack_paw()` был без аргумента.

```
 Runtime in aliens.dm, line 121: Cannot execute null.do attack animation().
proc name: attack hand (/obj/structure/alien/resin/attack_hand)
usr: The alien facehugger (843) (foxlate) (/mob/living/carbon/xenomorph/facehugger)
usr.loc: The plating (177,96,2) (/turf/simulated/floor/plating)
src: the resin wall (/obj/structure/alien/resin/wall)
src.loc: the plating (177,97,2) (/turf/simulated/floor/plating)
call stack:
the resin wall (/obj/structure/alien/resin/wall): attack hand(null)
the resin wall (/obj/structure/alien/resin/wall): attack paw(the alien facehugger (843) (/mob/living/carbon/xenomorph/facehugger))
the resin wall (/obj/structure/alien/resin/wall): attack facehugger(the alien facehugger (843) (/mob/living/carbon/xenomorph/facehugger))
the alien facehugger (843) (/mob/living/carbon/xenomorph/facehugger): UnarmedAttack(the resin wall (/obj/structure/alien/resin/wall))
the alien facehugger (843) (/mob/living/carbon/xenomorph/facehugger): ClickOn(the resin wall (/obj/structure/alien/resin/wall), "icon-x=19;icon-y=10;left=1;scr...")
the resin wall (/obj/structure/alien/resin/wall): Click(the plating (177,97,2) (/turf/simulated/floor/plating), "mapwindow.map", "icon-x=19;icon-y=10;left=1;scr...")
Foxlate (/client): Click(the resin wall (/obj/structure/alien/resin/wall), the plating (177,97,2) (/turf/simulated/floor/plating), "mapwindow.map", "icon-x=19;icon-y=10;left=1;scr...")
```

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
