### PR TITLE
Add icon state manifest checking to the build process

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,5 +4,12 @@ indent_style = tab
 indent_size = 4
 trim_trailing_whitespace = true
 
-[*.dm]
+[*.{dm, sh}]
 end_of_line = lf
+
+[*.coffee]
+indent_style = space
+
+[*.json]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/check_icon_state_manifest.yml
+++ b/.github/workflows/check_icon_state_manifest.yml
@@ -18,3 +18,5 @@ jobs:
 
     - name: Verify Manifest
       run: bash tools/check_icon_state_manifest/action.sh
+    - with:
+        conclusion: neutral

--- a/.github/workflows/check_icon_state_manifest.yml
+++ b/.github/workflows/check_icon_state_manifest.yml
@@ -19,4 +19,4 @@ jobs:
     - name: Verify Manifest
       run: bash tools/check_icon_state_manifest/action.sh
     - with:
-        conclusion: neutral
+        status: neutral

--- a/.github/workflows/check_icon_state_manifest.yml
+++ b/.github/workflows/check_icon_state_manifest.yml
@@ -1,0 +1,20 @@
+name: 'Check Icon State Manifest'
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  verify_manifest:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Project
+      uses: actions/checkout@v2
+
+    - name: Setup Node
+      uses: actions/setup-node@v2-beta
+
+    - name: Verify Manifest
+      run: bash tools/check_icon_state_manifest/action.sh

--- a/tools/check_icon_state_manifest/.gitignore
+++ b/tools/check_icon_state_manifest/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/tools/check_icon_state_manifest/action.sh
+++ b/tools/check_icon_state_manifest/action.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# check_icon_state_manifest.sh
+# Verify the project contains icon_state listed in a manifest file
+
+PROJECT_ROOT="$PWD"
+cd tools/check_icon_state_manifest
+npm ci
+node_modules/.bin/coffee index.coffee "$PROJECT_ROOT"

--- a/tools/check_icon_state_manifest/icon_state.manifest
+++ b/tools/check_icon_state_manifest/icon_state.manifest
@@ -9,5 +9,58 @@
 # the project, or if that icon file exists but does not contain the
 # icon_state that has been specified.
 
-icons/mob/species/vox/helmet.dmi : hardhat_yellow0
-icons/mob/species/vox/helmet.dmi : icons/obj/clothing/hats.dmi
+# Base types for convenience
+
+# Clothing
+# icons/mob/belt.dmi :
+# icons/mob/ears.dmi :
+# icons/mob/eyes.dmi :
+# icons/mob/feet.dmi :
+# icons/mob/hands.dmi :
+# icons/mob/head.dmi :
+# icons/mob/mask.dmi :
+# icons/mob/suit.dmi :
+# icons/mob/suit_fat.dmi :
+# icons/mob/uniform.dmi :
+# icons/mob/uniform_fat.dmi :
+
+# Inhands
+# icons/mob/inhands/clothing_lefthand.dmi :
+# icons/mob/inhands/clothing_righthand.dmi :
+# icons/mob/inhands/guns_lefthand.dmi :
+# icons/mob/inhands/guns_righthand.dmi :
+# icons/mob/inhands/items_lefthand.dmi :
+# icons/mob/inhands/items_righthand.dmi :
+
+
+# Species-specific sprites. All sprites from spritesheets must be in human files too! Check #6806
+
+# Vox Armalis
+icons/mob/feet.dmi : icons/mob/species/armalis/feet.dmi
+icons/mob/hands.dmi : icons/mob/species/armalis/gloves.dmi
+icons/mob/head.dmi : icons/mob/species/armalis/head.dmi
+icons/mob/mask.dmi : icons/mob/species/armalis/mask.dmi
+icons/mob/suit.dmi : icons/mob/species/armalis/suit.dmi
+
+# Skrell
+icons/mob/head.dmi : icons/mob/species/skrell/helmet.dmi
+icons/mob/suit.dmi : icons/mob/species/skrell/suit.dmi
+
+# Tajaran (our lovely cats)
+icons/mob/head.dmi : icons/mob/species/tajaran/helmet.dmi
+icons/mob/suit.dmi : icons/mob/species/tajaran/suit.dmi
+icons/mob/suit_fat.dmi : icons/mob/species/tajaran/suit_fat.dmi
+
+# Unathi
+icons/mob/head.dmi : icons/mob/species/unathi/helmet.dmi
+icons/mob/suit.dmi : icons/mob/species/unathi/suit.dmi
+icons/mob/suit_fat.dmi : icons/mob/species/unathi/suit_fat.dmi
+
+# Vox
+icons/mob/eyes.dmi : icons/mob/species/vox/eyes.dmi
+icons/mob/feet.dmi : icons/mob/species/vox/shoes.dmi
+icons/mob/hands.dmi : icons/mob/species/vox/gloves.dmi
+icons/mob/head.dmi : icons/mob/species/vox/helmet.dmi
+icons/mob/mask.dmi : icons/mob/species/vox/masks.dmi
+icons/mob/suit.dmi : icons/mob/species/vox/suit.dmi
+icons/mob/uniform.dmi : icons/mob/species/vox/uniform.dmi

--- a/tools/check_icon_state_manifest/icon_state.manifest
+++ b/tools/check_icon_state_manifest/icon_state.manifest
@@ -9,3 +9,5 @@
 # the project, or if that icon file exists but does not contain the
 # icon_state that has been specified.
 
+icons/mob/species/vox/helmet.dmi : hardhat_yellow0
+icons/mob/species/vox/helmet.dmi : icons/obj/clothing/hats.dmi

--- a/tools/check_icon_state_manifest/icon_state.manifest
+++ b/tools/check_icon_state_manifest/icon_state.manifest
@@ -1,0 +1,11 @@
+# icon_state.manifest
+#
+# This is a manifest of all the icon_state that we want to verify are in
+# the project at build time. Each line has the following format:
+#
+# path/to/icon.dmi:icon_state
+#
+# The process will exit with an error if the icon file does not exist in
+# the project, or if that icon file exists but does not contain the
+# icon_state that has been specified.
+

--- a/tools/check_icon_state_manifest/index.coffee
+++ b/tools/check_icon_state_manifest/index.coffee
@@ -1,0 +1,126 @@
+# index.coffee
+# Verify the project contains icon_state listed in a manifest file
+
+extract = require "png-chunks-extract"
+fs = require "fs"
+{inflateSync} = require "zlib"
+path = require "path"
+
+DEQUOTE_RE = /^"(.*)"$/
+EQUAL_RE = /^(\t*)([^=]+)=(.*)$/
+
+checkManifest = ->
+    # figure out where we're starting from
+    projectRoot = process.argv[2]
+    process.stdout.write "Checking icon manifest against #{projectRoot}\n"
+
+    # read the icon manifest
+    manifest = fs.readFileSync "icon_state.manifest", {encoding: "utf8"}
+
+    # filter the lines of the icon manifest
+    lines = manifest.split "\n"
+    lines = (line.trim() for line in lines)
+    lines = (line for line in lines when line.length > 0)
+    lines = lines.filter (x) -> not x.startsWith "#"
+    process.stdout.write "There are #{lines.length} manifest entries\n"
+
+    # parse the lines of the icon manifest
+    maniStates = []
+    for line in lines
+        cols = line.split ":"
+        cols = (x.trim() for x in cols)
+        maniStates.push
+            path: cols[0]
+            iconState: cols[1]
+            hash: cols[2]
+
+    # process each of the manifest entries
+    icons = {}
+    for maniState in maniStates
+        iconPath = path.join projectRoot, maniState.path
+        exists = fs.existsSync iconPath
+        if exists
+            if not icons[maniState.path]?
+                icons[maniState.path] = loadIconStates iconPath
+        else
+            process.stdout.write "ERROR: Missing icon file: #{maniState.path}\n"
+            process.exitCode = 1
+
+    # bail if we identified any errors
+    return if process.exitCode is 1
+
+    # check to see that the icon states exist
+    for maniState in maniStates
+        if maniState.iconState not in icons[maniState.path]
+            process.stdout.write "ERROR: Missing icon_state: '#{maniState.iconState}' in #{maniState.path}\n"
+            process.exitCode = 1
+
+    # bail if we identified any errors
+    return if process.exitCode is 1
+
+    # otherwise send a nice message
+    process.stdout.write "All manifest entries are verified as present\n"
+    process.exitCode = 0
+
+deQuote = (text) ->
+    # remove double-quotes if present, otherwise no-op
+    quotedText = DEQUOTE_RE.exec text
+    return quotedText[1] if quotedText?
+    return text
+
+extractDescription = (buffer) ->
+    # extract the compressed text (zTXt) chunk of a PNG file
+    chunks = extract buffer
+    for chunk in chunks
+        if chunk.name is "zTXt"
+            pngZippedText = chunk.data
+            metaText = inflateSync getDeflate pngZippedText
+            return metaText.toString "utf8"
+    return ""
+
+findKeywordEndIndex = (data) ->
+    # basically strlen(), but don't tell anybody
+    index = 0
+    while data[index] isnt 0
+        index++
+    return index
+
+getDeflate = (data) ->
+    # slice off the uncompressed header of the chunk data
+    index = findKeywordEndIndex data
+    return data.slice index+2
+
+loadIconStates = (iconPath) ->
+    # extract and parse the metadata from the icon file
+    buffer = fs.readFileSync iconPath
+    metadata = extractDescription buffer
+    lines = metadata.split "\n"
+    lines = (x for x in lines when x.startsWith "state")
+    # return an array of icon_state names
+    states = (parseEqualLine x for x in lines)
+    stateNames = (x.rhs for x in states)
+    return stateNames
+
+parseEqualLine = (line) ->
+    # parse a metadata line like:
+    #     state = "soapark"
+    #
+    # into an object like:
+    #     {
+    #         level: 0,
+    #         lhs: "state",
+    #         rhs: "soapark"
+    #     }
+    #
+    # note the input data contains double-quotes, but the output data does NOT
+    parsed = EQUAL_RE.exec line
+    return null if not parsed?
+    return
+        level: parsed[1].length
+        lhs: parsed[2].trim()
+        rhs: deQuote parsed[3].trim()
+
+do ->
+    # where the rubber meets the road; check the codebase icons against
+    # the manifest file for icon states
+    checkManifest()

--- a/tools/check_icon_state_manifest/index.coffee
+++ b/tools/check_icon_state_manifest/index.coffee
@@ -29,10 +29,22 @@ checkManifest = ->
     for line in lines
         cols = line.split ":"
         cols = (x.trim() for x in cols)
-        maniStates.push
-            path: cols[0]
-            iconState: cols[1]
-            hash: cols[2]
+        if cols[1][-4..] == ".dmi"
+            iconPath = path.join projectRoot, cols[1]
+            exists = fs.existsSync iconPath
+            if exists
+                icons = loadIconStates iconPath
+                for icon in icons
+                    maniStates.push
+                        path: cols[0]
+                        iconState: icon
+            else
+                process.stdout.write "ERROR: Missing icon file: #{cols[1]}\n"
+                process.exitCode = 1
+        else
+            maniStates.push
+                path: cols[0]
+                iconState: cols[1]
 
     # process each of the manifest entries
     icons = {}

--- a/tools/check_icon_state_manifest/package-lock.json
+++ b/tools/check_icon_state_manifest/package-lock.json
@@ -1,0 +1,26 @@
+{
+  "name": "check_icon_state_manifest",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "coffeescript": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.5.1.tgz",
+      "integrity": "sha512-J2jRPX0eeFh5VKyVnoLrfVFgLZtnnmp96WQSLAS8OrLm2wtQLcnikYKe1gViJKDH7vucjuhHvBKKBP3rKcD1tQ=="
+    },
+    "crc-32": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-0.3.0.tgz",
+      "integrity": "sha1-aj02h/W67EH36bmf4ZU6Ll0Zd14="
+    },
+    "png-chunks-extract": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/png-chunks-extract/-/png-chunks-extract-1.0.0.tgz",
+      "integrity": "sha1-+tSpBeZmUhlzUcZeNbksZDEeRy0=",
+      "requires": {
+        "crc-32": "^0.3.0"
+      }
+    }
+  }
+}

--- a/tools/check_icon_state_manifest/package.json
+++ b/tools/check_icon_state_manifest/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "check_icon_state_manifest",
+  "version": "1.0.0",
+  "description": "Verify the project contains icon_state listed in a manifest file",
+  "author": "blinkdog@protonmail.com",
+  "license": "SEE LICENSE IN LICENSE-AGPL3.txt",
+  "dependencies": {
+    "coffeescript": "2.5.1",
+    "png-chunks-extract": "1.0.0"
+  }
+}


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
~~После мержа, когда мерж случится, нужно будет добавить действие в список обязательных тестов volas~~

Добавляет в Github Actions действие "Check Icon State Manifest", проверящие наличие спрайтов по названию в .dmi
Например, такая запись в манифесте (конфиге):

```
# Проверяет наличие icon_state hardhat_yellow0 в helmet.dmi 
icons/mob/species/vox/helmet.dmi : hardhat_yellow0
# Проверяет наличие всех icon_state из icons/obj/clothing/hats.dmi в helmet.dmi
icons/mob/species/vox/helmet.dmi : icons/obj/clothing/hats.dmi
```

Например, просмотреть вывод отстутвующих спрайтов для ```icons/mob/species/vox/helmet.dmi : icons/obj/clothing/hats.dmi```: https://github.com/TauCetiStation/TauCetiClassic/runs/1798769712
<details>
<summary> Пример как будет выглядеть список с ненайденными спрайтами</summary>

![image](https://user-images.githubusercontent.com/66636084/106368224-1cb81f80-6359-11eb-8264-6ad0e01a2733.png)
</details>

---

Сейчас остаётся лишь три не решенных мной вопроса, поэтому желательно чтобы кто-то помог их решить:
 - [x] ~Требуется помощь в создании списка обязательных связей dmi-dmi или dmi-icon_state~ Спасибо @4310V343k 
 - [x] ~Вероятно понадобятся спрайты для выявленных отсутствующих спрайтов~ Так как это будет информационная, а не блокирующая проверка, то исправлять спрайты здесь не нужно
 - [ ] Проверка не должна запрещать мерж, а быть информационной

## Почему и что этот ПР улучшит
Позволит избежать ситуаций, как, например, в https://github.com/TauCetiStation/TauCetiClassic/pull/6806, https://github.com/TauCetiStation/TauCetiClassic/pull/6799, когда добавить спрайты или обновить их названия в определенных .dmi просто забыли.
Ревьювить такие моменты в ручную сложно, поэтому лучше автоматизировать
(Обновлён .editorconfig, чтобы редактировать .coffee и связанные с данным линтером файлы было несколько удобнее)
## Авторство
blinkdog https://github.com/ScorpioStation/ScorpioStation/pull/169, от себя добавил возможность записи ```file1.dmi : file2.dmi```
## Чеинжлог
