### PR TITLE
Фикс забакленных куриц.

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -190,7 +190,9 @@
 	if(!stat)
 		amount_grown += rand(1,2)
 		if(amount_grown >= 100)
-			new /mob/living/simple_animal/chicken(src.loc)
+			if(buckled)
+				buckled.unbuckle_mob(src)
+			new /mob/living/simple_animal/chicken(get_turf(src))
 			qdel(src)
 
 var/const/MAX_CHICKENS = 50

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -192,7 +192,7 @@
 		if(amount_grown >= 100)
 			if(buckled)
 				buckled.unbuckle_mob(src)
-			new /mob/living/simple_animal/chicken(get_turf(src))
+			new /mob/living/simple_animal/chicken(src.loc)
 			qdel(src)
 
 var/const/MAX_CHICKENS = 50


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Теперь цыплята когда выростают - анбаклятся, если забаклены к чему-либо.
## Почему и что этот ПР улучшит
Fix #6841.
## Авторство

## Чеинжлог
