### PR TITLE
Фикс, когда пытается создаться фоллов-кнопка, если у цель в нулле

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -180,8 +180,14 @@
 		if(isAI(speaker))
 			var/mob/living/silicon/ai/S = speaker
 			speaker = S.eyeobj
+
+		var/track_button
 		var/turf/T = get_turf(speaker)
-		track = "[FOLLOW_OR_TURF_LINK(src, speaker, T)] [speaker_name]"
+		if(T)
+			track_button = FOLLOW_OR_TURF_LINK(src, speaker, T)
+		else
+			track_button = FOLLOW_LINK(src, speaker)
+		track = "[track_button] [speaker_name]"
 
 	if(isliving(src))
 		message = highlight_traitor_codewords(message, src.mind)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Как я понял, если глаз иишки где-то в нуллспейсе, то происходил такой рантайм и кнопка с сообщением вообще не появлялись.

```
[20:54:36] Cannot read null.x in hear_say.dm:184 :
proc name: hear radio (/mob/proc/hear_radio)
  source file: hear_say.dm,184
  usr: Natos (/mob/living/carbon/human)
  src: Janis Firsovs (/mob/dead/observer)
  usr.loc: the floor (129,147,2) (/turf/simulated/floor)
  src.loc: the floor (129,147,2) (/turf/simulated/floor)
  call stack:
Janis Firsovs (/mob/dead/observer): hear radio("Marck Licenko has died in Cent...", "says", null, "<span class=\'radio\'><span cl...", "</span><b> \[145.9]</b> <span ...", "</span></span>", Solo (AI Eye) (/mob/camera/Eye/ai), 0, "Marck Licenko\'s Death Alarm")
Broadcast Message(/datum/radio_frequency (/datum/radio_frequency), Solo (/mob/living/silicon/ai), 0, "*garbled automated announcemen...", the radio headset (/obj/item/device/radio/headset), "Marck Licenko has died in Cent...", "Marck Licenko\'s Death Alarm", "Automated Announcement", "Marck Licenko\'s Death Alarm", "synthesized voice", 4, 0, /list (/list), 1459, "says", null)
the radio headset (/obj/item/device/radio/headset): autosay("Marck Licenko has died in Cent...", "Marck Licenko\'s Death Alarm", null, 1459)
the death alarm implant (/obj/item/weapon/implant/death_alarm): activate("emp")
the death alarm implant (/obj/item/weapon/implant/death_alarm): emp act(2)
the death alarm implant (/obj/item/weapon/implant/death_alarm): emplode(2)
Marck Licenko (/mob/living/carbon/human): emp act(2)
Marck Licenko (/mob/living/carbon/human): emplode(2)
empulse(the floor (129,147,2) (/turf/simulated/floor), 3, 5, 0)
the emp implant (/obj/item/weapon/implant/emp): ui action click()
EMP pulse (/datum/action/item_action/hands_free): Trigger()
EMP pulse (/obj/screen/movable/action_button): Click(null, "mapwindow.map", "icon-x=20;icon-y=15;left=1;scr...")
```


## Почему и что этот ПР улучшит
fix #6839

## Авторство

## Чеинжлог
