### PR TITLE
Исправление логической ошибки в моем старом коде

### DIFF
--- a/code/modules/detectivework/autopsy.dm
+++ b/code/modules/detectivework/autopsy.dm
@@ -199,7 +199,7 @@
 		usr.update_inv_r_hand()
 
 /obj/item/weapon/autopsy_scanner/attack(mob/living/carbon/human/M, mob/living/carbon/user, def_zone)
-	if(!istype(M) && !can_operate(M))
+	if(!istype(M) || !can_operate(M))
 		return
 
 	if(do_after(user,15,target = M))

--- a/code/modules/detectivework/autopsy.dm
+++ b/code/modules/detectivework/autopsy.dm
@@ -199,7 +199,7 @@
 		usr.update_inv_r_hand()
 
 /obj/item/weapon/autopsy_scanner/attack(mob/living/carbon/human/M, mob/living/carbon/user, def_zone)
-	if(!istype(M) &!can_operate(M))
+	if(!istype(M) && !can_operate(M))
 		return
 
 	if(do_after(user,15,target = M))


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Я недосмотрел, мейнтейнеры и мержеры недосмотрели. Вообщем, там сто процентов должен был стоять `||`

Пруф
![image](https://user-images.githubusercontent.com/26389417/107787819-a9eb7300-6d60-11eb-8d83-a4dfd941daef.png)


## Почему и что этот ПР улучшит
Исправление ошибки, которую никто не заметил.

## Авторство

## Чеинжлог
