### PR TITLE
Нинжу в инвизе НЕвидно через худы

### DIFF
--- a/code/game/gamemodes/ninja/suit/n_suit_verbs/ninja_stealth.dm
+++ b/code/game/gamemodes/ninja/suit/n_suit_verbs/ninja_stealth.dm
@@ -21,6 +21,7 @@
 		U.regenerate_icons()	//update their icons
 		U.visible_message("[U.name] vanishes into thin air!", "<span class='notice'>You are now invisible to normal detection.</span>")
 		U.invisibility = INVISIBILITY_LEVEL_TWO
+		HideHuds(U)
 		if(istype(U.get_active_hand(), /obj/item/weapon/melee/energy/blade))
 			U.drop_item()
 		if(istype(U.get_inactive_hand(), /obj/item/weapon/melee/energy/blade))
@@ -34,6 +35,7 @@
 		anim(U.loc,U,'icons/mob/mob.dmi',,"uncloak",,U.dir)
 		s_active=FALSE
 		U.invisibility = 0
+		UnhideHuds(U)
 		U.visible_message("[U.name] appears from thin air!", "<span class='notice'>You are now visible.</span>")
 		if(U.mind.protector_role)
 			icon_state = U.gender==FEMALE ? "s-ninjakf" : "s-ninjak"
@@ -42,6 +44,18 @@
 		U.regenerate_icons()	//update their icons
 		return 1
 	return 0
+
+/obj/item/clothing/suit/space/space_ninja/proc/HideHuds(mob/living/target)
+	var/datum/atom_hud/M = global.huds[DATA_HUD_MEDICAL]
+	M.remove_from_hud(target)
+	var/datum/atom_hud/S = global.huds[DATA_HUD_SECURITY]
+	S.remove_from_hud(target)
+
+/obj/item/clothing/suit/space/space_ninja/proc/UnhideHuds(mob/living/target)
+	var/datum/atom_hud/M = global.huds[DATA_HUD_MEDICAL]
+	M.add_to_hud(target)
+	var/datum/atom_hud/S = global.huds[DATA_HUD_SECURITY]
+	S.add_to_hud(target)
 
 /obj/item/clothing/suit/space/space_ninja/proc/pop_stealth()
 	var/mob/living/carbon/human/U = affecting

--- a/code/game/gamemodes/ninja/suit/n_suit_verbs/ninja_stealth.dm
+++ b/code/game/gamemodes/ninja/suit/n_suit_verbs/ninja_stealth.dm
@@ -69,6 +69,7 @@
 
 		s_active=FALSE
 		U.invisibility = 0
+		HideHuds(U)
 		U.visible_message("[U.name] appears from thin air!", "<span class='notice'>You are now visible.</span>")
 		if(U.mind.protector_role)
 			icon_state = U.gender==FEMALE ? "s-ninjakf" : "s-ninjak"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Нинжу в инвизе НЕвидно через худы

https://user-images.githubusercontent.com/26389417/107813860-07dc8280-6d82-11eb-893d-2ffe225ace68.mp4


По факту, когда он нажимает кнопку, то кукла впринципе исчезает с худа

fix #6859

## Почему и что этот ПР улучшит
Минус баг

## Авторство

## Чеинжлог
:cl:
 - fix: Теперь у нинзи в стелсе не видны худы.