### PR TITLE
admin staffwho update

### DIFF
--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -132,7 +132,7 @@
 	var/msg
 	for(var/staff in staffwho)
 		if(!staff[SW_COUNT])
-			msg += "<tr><th colspan='3' class='[staff[SW_NAME]]'><span style='color:black' class='fas fa-times'></span> <b>No [staff[SW_NAME]] online</b></td></tr>"
+			msg += "<tr><th colspan='3' class='[staff[SW_NAME]]'><span style='color:black' class='fas fa-close'></span> <b>No [staff[SW_NAME]] online</b></td></tr>"
 			continue
 		msg += "<tr><th colspan='3' class='[staff[SW_NAME]]'><b>Current [staff[SW_NAME]] ([staff[SW_COUNT]])</b></td></tr>"
 		msg += "[staff[SW_WHOTEXT]]"

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -85,7 +85,7 @@
 #define SW_ALL_PARAMS 3 //update this, if add more params
 
 #define SW_TR(CKEY, RANK, EXTRA) "<tr><td>&emsp;[CKEY]</td><td><b>[RANK]</b></td><td>[EXTRA]</td></tr>"
-#define SW_INCREMENT(GROUP, CKEY, RANK, EXTRA) staffwho[GROUP][SW_WHOTEXT] = SW_TR(CKEY, RANK, EXTRA);staffwho[GROUP][SW_COUNT]++
+#define SW_INCREMENT(GROUP, CKEY, RANK, EXTRA) staffwho[GROUP][SW_WHOTEXT] += SW_TR(CKEY, RANK, EXTRA);staffwho[GROUP][SW_COUNT]++
 /client/verb/staffwho()
 	set category = "Admin"
 	set name = "Staffwho"

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -127,7 +127,7 @@
 
 	var/msg
 	for(var/staff in staffwho)
-		msg += "<tr><th class='[staff[SW_NAME]]' colspan='3'>[staff[SW_NAME]]—[staff[SW_COUNT] || 0]</td></tr>"
+		msg += "<tr><th class='[staff[SW_NAME]]' colspan='3'>[staff[SW_NAME]] — [staff[SW_COUNT] || 0]</td></tr>"
 		if(!staff[SW_COUNT])
 			continue
 		msg += "[staff[SW_WHOTEXT]]"

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -133,7 +133,6 @@
 		msg += "[staff[SW_WHOTEXT]]"
 	msg = "<table class='staffwho'>[msg]</table>"
 	to_chat(src, msg)
-	return // https://secure.byond.com/forum/post/2072419
 
 #undef SW_ADMINS
 #undef SW_MENTORS

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -80,6 +80,8 @@
 #define SW_NAME    1
 #define SW_WHOTEXT 2
 #define SW_COUNT   3
+
+#define SW_TR(CKEY, RANK, EXTRA) "<tr><td>[CKEY]</td><td><b>[RANK]</b></td><td>[EXTRA]</td></tr>"
 /client/verb/staffwho()
 	set category = "Admin"
 	set name = "Staffwho"
@@ -98,38 +100,41 @@
 		var/extra = ""
 		if(holder)
 			if(C.holder?.fakekey)
-				extra += " <i>(as [C.holder.fakekey])</i>"
+				extra += "<i>(as [C.holder.fakekey])</i> "
 			if(isobserver(C.mob))
-				extra += " - Observing"
+				extra += "Observing"
 			else if(isnewplayer(C.mob))
-				extra += " - Lobby"
+				extra += "Lobby"
 			else
-				extra += " - Playing"
+				extra += "Playing"
 			if(C.is_afk())
 				extra += " (AFK - [C.inactivity2text()])"
 		if(C.ckey in mentor_ckeys)
-			staffwho[SW_MENTORS][SW_WHOTEXT] = "&emsp;[C] is a <b>Mentor</b>[extra]<br>"
+			staffwho[SW_MENTORS][SW_WHOTEXT] = SW_TR(C, "Mentor", extra)
 			staffwho[SW_MENTORS][SW_COUNT]++
 		if(C.holder)
 			if(R_BAN & C.holder.rights)
-				staffwho[SW_ADMINS][SW_WHOTEXT] = "&emsp;[C] is a <b>[C.holder.rank]</b>[extra]<br>"
+				staffwho[SW_ADMINS][SW_WHOTEXT] = SW_TR(C, C.holder.rank, extra)
 				staffwho[SW_ADMINS][SW_COUNT]++
 			else if(R_DEBUG & C.holder.rights)
-				staffwho[SW_DEVELOPERS][SW_WHOTEXT] = "&emsp;[C] is a <b>[C.holder.rank]</b>[extra]<br>"
+				staffwho[SW_DEVELOPERS][SW_WHOTEXT] = SW_TR(C, C.holder.rank, extra)
 				staffwho[SW_DEVELOPERS][SW_COUNT]++
 			else if(R_WHITELIST & C.holder.rights)
-				staffwho[SW_XENOVISORS][SW_WHOTEXT] = "&emsp;[C] is a <b>[C.holder.rank]</b>[extra]<br>"
+				staffwho[SW_XENOVISORS][SW_WHOTEXT] = SW_TR(C, C.holder.rank, extra)
 				staffwho[SW_XENOVISORS][SW_COUNT]++
 			else
-				staffwho[SW_ADMINS][SW_WHOTEXT] = "&emsp;[C] is a <b>[C.holder.rank]</b>[extra]<br>"
+				staffwho[SW_ADMINS][SW_WHOTEXT] = SW_TR(C, C.holder.rank, extra)
 				staffwho[SW_ADMINS][SW_COUNT]++
 
-
+	var/msg
 	for(var/staff in staffwho)
 		if(!staff[SW_COUNT])
-			to_chat(src, "<b>No [staff[SW_NAME]] online</b><br>")
+			msg += "<tr><th colspan='3' class='[staff[SW_NAME]]'><b>No [staff[SW_NAME]] online</b></td></tr>"
 			continue
-		to_chat(src, "<b>Current [staff[SW_NAME]] ([staff[SW_COUNT]]):</b><br>[staff[SW_WHOTEXT]]")
+		msg += "<tr><th colspan='3' class='[staff[SW_NAME]]'><b>Current [staff[SW_NAME]] ([staff[SW_COUNT]]):</b></td></tr>"
+		msg += "[staff[SW_WHOTEXT]]"
+	msg = "<table class='staffwho'>[msg]</table>"
+	to_chat(src, msg)
 	return // https://secure.byond.com/forum/post/2072419
 
 #undef SW_ADMINS
@@ -139,3 +144,4 @@
 #undef SW_NAME
 #undef SW_WHOTEXT
 #undef SW_COUNT
+#undef SW_TR

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -84,13 +84,14 @@
 #define SW_COUNT      3
 #define SW_ALL_PARAMS 3 //update this, if add more params
 
-#define SW_TR(CKEY, RANK, EXTRA) "<tr><td>[CKEY]</td><td><b>[RANK]</b></td><td>[EXTRA]</td></tr>"
+#define SW_TR(CKEY, RANK, EXTRA) "<tr><td>&emsp;[CKEY]</td><td><b>[RANK]</b></td><td>[EXTRA]</td></tr>"
+#define SW_INCREMENT(GROUP, CKEY, RANK, EXTRA) staffwho[GROUP][SW_WHOTEXT] = SW_TR(CKEY, RANK, EXTRA);staffwho[GROUP][SW_COUNT]++
 /client/verb/staffwho()
 	set category = "Admin"
 	set name = "Staffwho"
 
 	var/list/staffwho[SW_ALL_GROUPS][SW_ALL_PARAMS]
-	staffwho[SW_ADMINS][SW_NAME] = "Admins"
+	staffwho[SW_ADMINS][SW_NAME] = "Admins" // update browserOutput.css, if change this
 	staffwho[SW_MENTORS][SW_NAME] = "Mentors"
 	staffwho[SW_XENOVISORS][SW_NAME] = "Xenovisors"
 	staffwho[SW_DEVELOPERS][SW_NAME] = "Developers"
@@ -113,28 +114,22 @@
 			if(C.is_afk())
 				extra += " (AFK - [C.inactivity2text()])"
 		if(C.ckey in mentor_ckeys)
-			staffwho[SW_MENTORS][SW_WHOTEXT] = SW_TR(C, "Mentor", extra)
-			staffwho[SW_MENTORS][SW_COUNT]++
+			SW_INCREMENT(SW_MENTORS, C, "Mentor", extra)
 		if(C.holder)
 			if(R_BAN & C.holder.rights)
-				staffwho[SW_ADMINS][SW_WHOTEXT] = SW_TR(C, C.holder.rank, extra)
-				staffwho[SW_ADMINS][SW_COUNT]++
+				SW_INCREMENT(SW_ADMINS, C, C.holder.rank, extra)
 			else if(R_DEBUG & C.holder.rights)
-				staffwho[SW_DEVELOPERS][SW_WHOTEXT] = SW_TR(C, C.holder.rank, extra)
-				staffwho[SW_DEVELOPERS][SW_COUNT]++
+				SW_INCREMENT(SW_DEVELOPERS, C, C.holder.rank, extra)
 			else if(R_WHITELIST & C.holder.rights)
-				staffwho[SW_XENOVISORS][SW_WHOTEXT] = SW_TR(C, C.holder.rank, extra)
-				staffwho[SW_XENOVISORS][SW_COUNT]++
+				SW_INCREMENT(SW_XENOVISORS, C, C.holder.rank, extra)
 			else
-				staffwho[SW_ADMINS][SW_WHOTEXT] = SW_TR(C, C.holder.rank, extra)
-				staffwho[SW_ADMINS][SW_COUNT]++
+				SW_INCREMENT(SW_ADMINS, C, C.holder.rank, extra)
 
 	var/msg
 	for(var/staff in staffwho)
+		msg += "<tr><th class='[staff[SW_NAME]]' colspan='3'>[staff[SW_NAME]]—[staff[SW_COUNT] || 0]</td></tr>"
 		if(!staff[SW_COUNT])
-			msg += "<tr><th colspan='3' class='[staff[SW_NAME]]'><span style='color:black' class='fas fa-times'></span> <b>No [staff[SW_NAME]] online</b></td></tr>"
 			continue
-		msg += "<tr><th colspan='3' class='[staff[SW_NAME]]'><b>Current [staff[SW_NAME]] ([staff[SW_COUNT]])</b></td></tr>"
 		msg += "[staff[SW_WHOTEXT]]"
 	msg = "<table class='staffwho'>[msg]</table>"
 	to_chat(src, msg)
@@ -148,5 +143,6 @@
 #undef SW_WHOTEXT
 #undef SW_COUNT
 #undef SW_TR
+#undef SW_INCREMENT
 #undef SW_ALL_GROUPS
 #undef SW_ALL_PARAMS

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -77,16 +77,19 @@
 #define SW_MENTORS    2
 #define SW_XENOVISORS 3
 #define SW_DEVELOPERS 4
-#define SW_NAME    1
-#define SW_WHOTEXT 2
-#define SW_COUNT   3
+#define SW_ALL_GROUPS 4 //update this, if add more staff groups
+
+#define SW_NAME       1
+#define SW_WHOTEXT    2
+#define SW_COUNT      3
+#define SW_ALL_PARAMS 3 //update this, if add more params
 
 #define SW_TR(CKEY, RANK, EXTRA) "<tr><td>[CKEY]</td><td><b>[RANK]</b></td><td>[EXTRA]</td></tr>"
 /client/verb/staffwho()
 	set category = "Admin"
 	set name = "Staffwho"
 
-	var/list/staffwho[4][3]
+	var/list/staffwho[SW_ALL_GROUPS][SW_ALL_PARAMS]
 	staffwho[SW_ADMINS][SW_NAME] = "Admins"
 	staffwho[SW_MENTORS][SW_NAME] = "Mentors"
 	staffwho[SW_XENOVISORS][SW_NAME] = "Xenovisors"
@@ -129,7 +132,7 @@
 	var/msg
 	for(var/staff in staffwho)
 		if(!staff[SW_COUNT])
-			msg += "<tr><th colspan='3' class='[staff[SW_NAME]]'><span style='color:black' class='fas fa-times'></span> <b>No [staff[SW_NAME]] online</b></td></tr>"
+			msg += "<tr><th colspan='3' class='[staff[SW_NAME]]'><span style='color:black' class='fas fa-times'></span	> <b>No [staff[SW_NAME]] online</b></td></tr>"
 			continue
 		msg += "<tr><th colspan='3' class='[staff[SW_NAME]]'><b>Current [staff[SW_NAME]] ([staff[SW_COUNT]])</b></td></tr>"
 		msg += "[staff[SW_WHOTEXT]]"
@@ -145,3 +148,5 @@
 #undef SW_WHOTEXT
 #undef SW_COUNT
 #undef SW_TR
+#undef SW_ALL_GROUPS
+#undef SW_ALL_PARAMS

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -126,14 +126,12 @@
 				SW_INCREMENT(SW_ADMINS, C, C.holder.rank, extra)
 
 	var/msg
-	var/staff_online = FALSE
 	for(var/staff in staffwho)
 		if(!staff[SW_COUNT])
 			continue
-		staff_online = TRUE
 		msg += "<tr><th class='[staff[SW_NAME]]' colspan='3'>[staff[SW_NAME]] — [staff[SW_COUNT] || 0]</td></tr>"
 		msg += "[staff[SW_WHOTEXT]]"
-	if(!staff_online)
+	if(!msg)
 		msg = "<b>No Staff Online</b>"
 	else
 		msg = "<table class='staffwho'>[msg]</table>"

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -129,7 +129,7 @@
 	var/msg
 	for(var/staff in staffwho)
 		if(!staff[SW_COUNT])
-			msg += "<tr><th colspan='3' class='[staff[SW_NAME]]'><i style='color:black' class='fas fa-times'> </i> <b>No [staff[SW_NAME]] online</b></td></tr>"
+			msg += "<tr><th colspan='3' class='[staff[SW_NAME]]'><span style='color:black' class='fas fa-times'></span> <b>No [staff[SW_NAME]] online</b></td></tr>"
 			continue
 		msg += "<tr><th colspan='3' class='[staff[SW_NAME]]'><b>Current [staff[SW_NAME]] ([staff[SW_COUNT]])</b></td></tr>"
 		msg += "[staff[SW_WHOTEXT]]"

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -55,6 +55,8 @@
 
 			if(is_special_character(C.mob))
 				entry += " - <b><font color='red'>Antagonist</font></b>"
+			if(C.is_afk())
+				entry += " (AFK - [C.inactivity2text()])"
 			entry += " (<A HREF='?_src_=holder;adminmoreinfo=\ref[C.mob]'>?</A>)"
 			Lines += entry
 	else
@@ -104,7 +106,7 @@
 			else
 				extra += " - Playing"
 			if(C.is_afk())
-				extra += " (AFK)"
+				extra += " (AFK - [C.inactivity2text()])"
 		if(C.ckey in mentor_ckeys)
 			staffwho[SW_MENTORS][SW_WHOTEXT] = "&emsp;[C] is a <b>Mentor</b>[extra]<br>"
 			staffwho[SW_MENTORS][SW_COUNT]++

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -129,9 +129,9 @@
 	var/msg
 	for(var/staff in staffwho)
 		if(!staff[SW_COUNT])
-			msg += "<tr><th colspan='3' class='[staff[SW_NAME]]'><b>No [staff[SW_NAME]] online</b></td></tr>"
+			msg += "<tr><th colspan='3' class='[staff[SW_NAME]]'><i style='color:black' class='fas fa-times'></i> <b>No [staff[SW_NAME]] online</b></td></tr>"
 			continue
-		msg += "<tr><th colspan='3' class='[staff[SW_NAME]]'><b>Current [staff[SW_NAME]] ([staff[SW_COUNT]]):</b></td></tr>"
+		msg += "<tr><th colspan='3' class='[staff[SW_NAME]]'><b>Current [staff[SW_NAME]] ([staff[SW_COUNT]])</b></td></tr>"
 		msg += "[staff[SW_WHOTEXT]]"
 	msg = "<table class='staffwho'>[msg]</table>"
 	to_chat(src, msg)

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -91,11 +91,11 @@
 	for(var/client/C in admins|mentors)
 		if(C.ckey in stealth_keys)
 			continue
-		if(C.holder.fakekey && !(R_ADMIN & holder.rights))
+		if(C.holder?.fakekey && !(R_ADMIN & holder.rights))
 			continue
 		var/extra = ""
 		if(holder)
-			if(C.holder.fakekey)
+			if(C.holder?.fakekey)
 				extra += " <i>(as [C.holder.fakekey])</i>"
 			if(isobserver(C.mob))
 				extra += " - Observing"
@@ -105,21 +105,22 @@
 				extra += " - Playing"
 			if(C.is_afk())
 				extra += " (AFK)"
-		if(mentors[C.ckey])
-			staffwho[SW_MENTORS][SW_WHOTEXT] = "&emsp;[C] is a Mentor[extra]<br>"
+		if(C.ckey in mentor_ckeys)
+			staffwho[SW_MENTORS][SW_WHOTEXT] = "&emsp;[C] is a <b>Mentor</b>[extra]<br>"
 			staffwho[SW_MENTORS][SW_COUNT]++
-		if(R_BAN & C.holder.rights)
-			staffwho[SW_ADMINS][SW_WHOTEXT] = "&emsp;[C] is a <b>[C.holder.rank]</b>[extra]<br>"
-			staffwho[SW_ADMINS][SW_COUNT]++
-		else if(R_DEBUG & C.holder.rights)
-			staffwho[SW_DEVELOPERS][SW_WHOTEXT] = "&emsp;[C] is a [C.holder.rank][extra]<br>"
-			staffwho[SW_DEVELOPERS][SW_COUNT]++
-		else if(R_WHITELIST & C.holder.rights)
-			staffwho[SW_XENOVISORS][SW_WHOTEXT] = "&emsp;[C] is a <b>[C.holder.rank]</b>[extra]<br>"
-			staffwho[SW_XENOVISORS][SW_COUNT]++
-		else
-			staffwho[SW_ADMINS][SW_WHOTEXT] = "&emsp;[C] is a <b>[C.holder.rank]</b>[extra]<br>"
-			staffwho[SW_ADMINS][SW_COUNT]++
+		if(C.holder)
+			if(R_BAN & C.holder.rights)
+				staffwho[SW_ADMINS][SW_WHOTEXT] = "&emsp;[C] is a <b>[C.holder.rank]</b>[extra]<br>"
+				staffwho[SW_ADMINS][SW_COUNT]++
+			else if(R_DEBUG & C.holder.rights)
+				staffwho[SW_DEVELOPERS][SW_WHOTEXT] = "&emsp;[C] is a <b>[C.holder.rank]</b>[extra]<br>"
+				staffwho[SW_DEVELOPERS][SW_COUNT]++
+			else if(R_WHITELIST & C.holder.rights)
+				staffwho[SW_XENOVISORS][SW_WHOTEXT] = "&emsp;[C] is a <b>[C.holder.rank]</b>[extra]<br>"
+				staffwho[SW_XENOVISORS][SW_COUNT]++
+			else
+				staffwho[SW_ADMINS][SW_WHOTEXT] = "&emsp;[C] is a <b>[C.holder.rank]</b>[extra]<br>"
+				staffwho[SW_ADMINS][SW_COUNT]++
 
 
 	for(var/staff in staffwho)

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -126,12 +126,17 @@
 				SW_INCREMENT(SW_ADMINS, C, C.holder.rank, extra)
 
 	var/msg
+	var/staff_online = FALSE
 	for(var/staff in staffwho)
-		msg += "<tr><th class='[staff[SW_NAME]]' colspan='3'>[staff[SW_NAME]] — [staff[SW_COUNT] || 0]</td></tr>"
 		if(!staff[SW_COUNT])
 			continue
+		staff_online = TRUE
+		msg += "<tr><th class='[staff[SW_NAME]]' colspan='3'>[staff[SW_NAME]] — [staff[SW_COUNT] || 0]</td></tr>"
 		msg += "[staff[SW_WHOTEXT]]"
-	msg = "<table class='staffwho'>[msg]</table>"
+	if(!staff_online)
+		msg = "<b>No Staff Online</b>"
+	else
+		msg = "<table class='staffwho'>[msg]</table>"
 	to_chat(src, msg)
 
 #undef SW_ADMINS

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -132,7 +132,7 @@
 	var/msg
 	for(var/staff in staffwho)
 		if(!staff[SW_COUNT])
-			msg += "<tr><th colspan='3' class='[staff[SW_NAME]]'><span style='color:black' class='fas fa-close'></span> <b>No [staff[SW_NAME]] online</b></td></tr>"
+			msg += "<tr><th colspan='3' class='[staff[SW_NAME]]'><span style='color:black' class='fas fa-times'></span> <b>No [staff[SW_NAME]] online</b></td></tr>"
 			continue
 		msg += "<tr><th colspan='3' class='[staff[SW_NAME]]'><b>Current [staff[SW_NAME]] ([staff[SW_COUNT]])</b></td></tr>"
 		msg += "[staff[SW_WHOTEXT]]"

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -132,7 +132,7 @@
 	var/msg
 	for(var/staff in staffwho)
 		if(!staff[SW_COUNT])
-			msg += "<tr><th colspan='3' class='[staff[SW_NAME]]'><span style='color:black' class='fas fa-times'></span	> <b>No [staff[SW_NAME]] online</b></td></tr>"
+			msg += "<tr><th colspan='3' class='[staff[SW_NAME]]'><span style='color:black' class='fas fa-times'></span> <b>No [staff[SW_NAME]] online</b></td></tr>"
 			continue
 		msg += "<tr><th colspan='3' class='[staff[SW_NAME]]'><b>Current [staff[SW_NAME]] ([staff[SW_COUNT]])</b></td></tr>"
 		msg += "[staff[SW_WHOTEXT]]"

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -73,7 +73,8 @@
 
 #define SW_ADMINS     1
 #define SW_MENTORS    2
-#define SW_DEVELOPERS 3
+#define SW_XENOVISORS 3
+#define SW_DEVELOPERS 4
 #define SW_NAME    1
 #define SW_WHOTEXT 2
 #define SW_COUNT   3
@@ -81,9 +82,10 @@
 	set category = "Admin"
 	set name = "Staffwho"
 
-	var/list/staffwho[3][3]
+	var/list/staffwho[4][3]
 	staffwho[SW_ADMINS][SW_NAME] = "Admins"
 	staffwho[SW_MENTORS][SW_NAME] = "Mentors"
+	staffwho[SW_XENOVISORS][SW_NAME] = "Xenovisors"
 	staffwho[SW_DEVELOPERS][SW_NAME] = "Developers"
 
 	for(var/client/C in admins|mentors)
@@ -106,15 +108,19 @@
 		if(mentors[C.ckey])
 			staffwho[SW_MENTORS][SW_WHOTEXT] = "&emsp;[C] is a Mentor[extra]<br>"
 			staffwho[SW_MENTORS][SW_COUNT]++
-		if(R_ADMIN & C.holder.rights)
+		if(R_BAN & C.holder.rights)
 			staffwho[SW_ADMINS][SW_WHOTEXT] = "&emsp;[C] is a <b>[C.holder.rank]</b>[extra]<br>"
 			staffwho[SW_ADMINS][SW_COUNT]++
 		else if(R_DEBUG & C.holder.rights)
 			staffwho[SW_DEVELOPERS][SW_WHOTEXT] = "&emsp;[C] is a [C.holder.rank][extra]<br>"
 			staffwho[SW_DEVELOPERS][SW_COUNT]++
+		else if(R_WHITELIST & C.holder.rights)
+			staffwho[SW_XENOVISORS][SW_WHOTEXT] = "&emsp;[C] is a <b>[C.holder.rank]</b>[extra]<br>"
+			staffwho[SW_XENOVISORS][SW_COUNT]++
 		else
 			staffwho[SW_ADMINS][SW_WHOTEXT] = "&emsp;[C] is a <b>[C.holder.rank]</b>[extra]<br>"
 			staffwho[SW_ADMINS][SW_COUNT]++
+
 
 	for(var/staff in staffwho)
 		if(!staff[SW_COUNT])
@@ -125,6 +131,7 @@
 
 #undef SW_ADMINS
 #undef SW_MENTORS
+#undef SW_XENOVISORS
 #undef SW_DEVELOPERS
 #undef SW_NAME
 #undef SW_WHOTEXT

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -129,7 +129,7 @@
 	var/msg
 	for(var/staff in staffwho)
 		if(!staff[SW_COUNT])
-			msg += "<tr><th colspan='3' class='[staff[SW_NAME]]'><i style='color:black' class='fas fa-times'></i> <b>No [staff[SW_NAME]] online</b></td></tr>"
+			msg += "<tr><th colspan='3' class='[staff[SW_NAME]]'><i style='color:black' class='fas fa-times'> </i> <b>No [staff[SW_NAME]] online</b></td></tr>"
 			continue
 		msg += "<tr><th colspan='3' class='[staff[SW_NAME]]'><b>Current [staff[SW_NAME]] ([staff[SW_COUNT]])</b></td></tr>"
 		msg += "[staff[SW_WHOTEXT]]"

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -581,6 +581,10 @@ var/list/blacklisted_builds = list(
 /client/proc/is_afk(duration = config.afk_time_bracket)
 	return inactivity > duration
 
+/client/proc/inactivity2text()
+	var/seconds = inactivity / 10
+	return "[round(seconds / 60)] minute\s, [seconds % 60] second\s"
+
 // Send resources to the client.
 /client/proc/send_resources()
 	// Most assets are now handled through asset_cache.dm

--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -418,3 +418,20 @@ h1.alert, h2.alert	{color: #000000;}
 }
 .embedded_tip:hover .embedded_tip-text{display: block;}
 .embedded_tip-mark{font-style: italic;}
+
+
+table.staffwho {
+	border-spacing: 0;
+	border-collapse:collapse;
+	color: #333;
+}
+table.staffwho td, table.staffwho th {
+	padding: 6px 13px;
+	border: 1px solid #dfe2e5;
+}
+table.staffwho th {color:white}
+table.staffwho .Admins    {background:#E67E22;}
+table.staffwho .Mentors   {background:#E91E63;}
+table.staffwho .Developers{background:#5E5ED1;}
+table.staffwho .Xenovisors{background:#2ECC71;}
+

--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -419,19 +419,29 @@ h1.alert, h2.alert	{color: #000000;}
 .embedded_tip:hover .embedded_tip-text{display: block;}
 .embedded_tip-mark{font-style: italic;}
 
-
 table.staffwho {
 	border-spacing: 0;
 	border-collapse:collapse;
 	color: #333;
+	line-height: 1;
 }
 table.staffwho td, table.staffwho th {
-	padding: 6px 13px;
-	border: 1px solid #dfe2e5;
+	margin:0;
+	padding: 2px 4px;
+	font-size: 14px;
 }
-table.staffwho th {color:white}
-table.staffwho .Admins    {background:#E67E22;}
-table.staffwho .Mentors   {background:#E91E63;}
-table.staffwho .Developers{background:#5E5ED1;}
-table.staffwho .Xenovisors{background:#2ECC71;}
+table.staffwho td:first-child{
+	font-weight: bold;
+}
 
+table.staffwho th {
+	text-transform: uppercase;
+	text-align: left;
+	color: #807473;
+	font-size: 12px;
+	font-weight: bold;
+}
+table.staffwho .Admins    {color:#E67E22;}
+table.staffwho .Mentors   {color:#E91E63;}
+table.staffwho .Developers{color:#5E5ED1;}
+table.staffwho .Xenovisors{color:#2ECC71;}

--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -428,10 +428,7 @@ table.staffwho {
 table.staffwho td, table.staffwho th {
 	margin:0;
 	padding: 2px 4px;
-	font-size: 14px;
-}
-table.staffwho td:first-child{
-	font-weight: bold;
+	font-size: 13px;
 }
 
 table.staffwho th {


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Добавляет в admin staffwho категорию developers и xenovisors, чтобы собственно отделить их от админов
И в целом рефактор прока

|Было|Стало|
|-|-|
|![Screen Shot 2021-02-21 at 14 51 04](https://user-images.githubusercontent.com/66636084/108624223-a3da4e00-7454-11eb-8d7f-7f7a92f1b04c.png)|![20210225 001523](https://user-images.githubusercontent.com/66636084/109066778-9c3dd200-76fe-11eb-8e7c-6ca4b0cde284.png)|



## Почему и что этот ПР улучшит
Игроки думали, что я админ, но я не админ
Админы смогут видеть как долго игроки и другие админы афк 
## Авторство
T6751
За основу рефактора staffwho взят https://github.com/DS-13-Dev-Team/DS13/pull/546
https://github.com/Baystation12/Baystation12/pull/12308 - Время как долго АФК (staffwho)
https://github.com/Baystation12/Baystation12/pull/12429 - Время как долго АФК (who)
## Чеинжлог
:cl:
 - tweak: в staffwho добавлены категории Developers и Xenovisors. Стиль вывода staffwho изменён и стал немного компактнее
