### PR TITLE
Fix shock damage for NO_PAIN

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -392,7 +392,7 @@
 
 		// Suturing yourself brings much more pain.
 		var/pain_factor = H == user ? 40 : 20
-		if(H.stat == CONSCIOUS)
+		if(H.stat == CONSCIOUS && !H.species.flags[NO_PAIN])
 			H.shock_stage += pain_factor
 		BP.status &= ~ORGAN_ARTERY_CUT
 		BP.strap()

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -80,7 +80,7 @@
 			if(I && !(I.flags & ABSTRACT) && I.w_class >= ITEM_SIZE_NORMAL)
 				tally += 0.5 * (I.w_class - 2) // (3 = 0.5) || (4 = 1) || (5 = 1.5)
 
-	if(shock_stage >= 10)
+	if(shock_stage >= 10 && !species.flags[NO_PAIN])
 		tally += round(log(3.5, shock_stage), 0.1) // (40 = ~3.0) and (starts at ~1.83)
 
 	if(pull_debuff)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1008,8 +1008,8 @@ note dizziness decrements automatically in the mob's Life() proc.
 		H.sec_hud_set_implants()
 		for(var/datum/wound/wound in BP.wounds)
 			wound.embedded_objects -= selection
-
-		H.shock_stage += 20
+		if(!H.species.flags[NO_PAIN])
+			H.shock_stage += 20
 		BP.take_damage((selection.w_class * 3), null, DAM_EDGE, "Embedded object extraction")
 
 		if(prob(selection.w_class * 5) && BP.sever_artery()) // I'M SO ANEMIC I COULD JUST -DIE-.


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Фикс СПУ, и существ с NO PAIN Что не могли бегать после извлечения шрапнели из за накидывания на них шокового урона.

## Почему и что этот ПР улучшит
СПУ и NO_PAIN существа не должны ощущать последствия шока в виде замедления.

fix https://github.com/TauCetiStation/TauCetiClassic/issues/5949
fix https://github.com/TauCetiStation/TauCetiClassic/issues/5825 

## Авторство
Lexanx
## Чеинжлог
:cl: Lexanx
 - bugfix: Существа не чувствующие боли, больше не будут получать замедления от шокового урона