### PR TITLE
Удалена неиспользуемая переменная w_amt у класса obj

### DIFF
--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -11,7 +11,6 @@
 	throw_speed = 1
 	throw_range = 2
 	m_amt = 750
-	w_amt = 750
 	origin_tech = "powerstorage=3;syndicate=5"
 	var/drain_rate = 600000		// amount of power to drain per tick
 	var/power_drained = 0 		// has drained this much power

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -2,7 +2,6 @@
 	//var/datum/module/mod		//not used
 	var/m_amt = 0	// metal
 	var/g_amt = 0	// glass
-	var/w_amt = 0	// waster amounts
 	var/origin_tech = null	//Used by R&D to determine what research bonuses it grants.
 	var/reliability = 100	//Used by SOME devices to determine how reliable they are.
 	var/crit_fail = 0

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -7,7 +7,6 @@
 	w_class = ITEM_SIZE_SMALL
 	m_amt = 100
 	g_amt = 0
-	w_amt = 0
 	throwforce = 2
 	throw_speed = 3
 	throw_range = 10

--- a/code/modules/assembly/igniter.dm
+++ b/code/modules/assembly/igniter.dm
@@ -4,7 +4,6 @@
 	icon_state = "igniter"
 	m_amt = 500
 	g_amt = 50
-	w_amt = 10
 	origin_tech = "magnets=1"
 
 	secured = 1

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -4,7 +4,6 @@
 	icon_state = "infrared"
 	m_amt = 1000
 	g_amt = 500
-	w_amt = 100
 	origin_tech = "magnets=2"
 
 	wires = WIRE_PULSE

--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -3,7 +3,6 @@
 	desc = "A handy little spring-loaded trap for catching pesty rodents."
 	icon_state = "mousetrap"
 	m_amt = 100
-	w_amt = 10
 	origin_tech = "combat=1"
 	var/armed = 0
 

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -4,7 +4,6 @@
 	icon_state = "prox"
 	m_amt = 800
 	g_amt = 200
-	w_amt = 50
 	origin_tech = "magnets=1"
 
 	wires = WIRE_PULSE

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -5,7 +5,6 @@
 	item_state = "signaler"
 	m_amt = 1000
 	g_amt = 200
-	w_amt = 100
 	origin_tech = "magnets=1"
 	wires = WIRE_RECEIVE | WIRE_PULSE | WIRE_RADIO_PULSE | WIRE_RADIO_RECEIVE
 

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -4,7 +4,6 @@
 	icon_state = "timer"
 	m_amt = 500
 	g_amt = 50
-	w_amt = 10
 	origin_tech = "magnets=1"
 
 	wires = WIRE_PULSE

--- a/code/modules/power/antimatter/shielding.dm
+++ b/code/modules/power/antimatter/shielding.dm
@@ -211,7 +211,6 @@
 	throw_speed = 1
 	throw_range = 2
 	m_amt = 100
-	w_amt = 2000
 
 /obj/item/device/am_shielding_container/attackby(obj/item/I, mob/user, params)
 	if(ismultitool(I) && istype(loc, /turf))


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Удалена неиспользуемая переменная w_amt у класса obj
## Почему и что этот ПР улучшит
Не будет неиспользуемой переменной
## Авторство

## Чеинжлог
