### PR TITLE
Stun projectiles rebalance

### DIFF
--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -73,12 +73,12 @@
 	projectile_type = /obj/item/projectile/energy/electrode
 	select_name = "stun - electrode"
 	fire_sound = 'sound/weapons/guns/gunpulse_taser.ogg'
+	e_cost = 50
 
 /obj/item/ammo_casing/energy/stun
 	projectile_type = /obj/item/projectile/beam/stun
 	select_name = "stun"
 	fire_sound = 'sound/weapons/guns/gunpulse_taser.ogg'
-	e_cost = 50
 
 /obj/item/ammo_casing/energy/electrode/gun
 	fire_sound = 'sound/weapons/guns/gunpulse_stunrevolver.ogg'

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -3,7 +3,7 @@
 	desc = "A small, low capacity gun used for non-lethal takedowns."
 	icon_state = "taser"
 	item_state = null	//so the human update icon uses the icon_state instead.
-	ammo_type = list(/obj/item/ammo_casing/energy/stun, /obj/item/ammo_casing/energy/electrode)
+	ammo_type = list(/obj/item/ammo_casing/energy/electrode)
 	can_be_holstered = TRUE
 	cell_type = /obj/item/weapon/stock_parts/cell/crap
 

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -15,10 +15,19 @@
 
 	stun = 0
 	weaken = 0
-	stutter = 10
-	agony = 120
+	stutter = 5
+	agony = 40
 	damage_type = HALLOSS
 	//Damage will be handled on the MOB side, to prevent window shattering.
+
+/obj/item/projectile/energy/electrode/on_hit(atom/target, def_zone = BP_CHEST, blocked = 0)
+	var/datum/effect/effect/system/spark_spread/s = new /datum/effect/effect/system/spark_spread
+	if(ismob(target))
+		s.set_up(1, 0, target)
+	else
+		s.set_up(2, 0, src)
+	s.start()
+	return ..()
 
 /obj/item/projectile/energy/declone
 	name = "declone"


### PR DESCRIPTION
## Описание изменений
До:
- Тазер ложил каждого без брони с одного электрода
- Станревольвер стрелял 20! выстрелов без перезарядки

После:
- Тазер стреляет только электродами, которые по силе и затратам как старый луч. (10 выстрелов) Таким образом охрана не сможет стрелять в стекла через всю карту, придется выходить из спасительных стекл
- Луч ест больше энергии, станревольвер и еган стреляет 10 раз
- Электроды получили искры при попадании, показывающие успешное попадание или промах

Если кто забыл - Нужно 3 попадания для падения

*Заметка: Эти изменения касаются именно электрода и луча, возможны не очевидные изменения, где они используются, например риг хоса, который теперь стреляет 5 лучей и перезаряжается*
## Почему и что этот ПР улучшит
Курс на отказ от инста-стан механик
## Авторство

## Чеинжлог
:cl: UDaV73rus
 - balance: У тазера удалён луч, сила электрода снижена до силы луча
 - balance: Повышено энергопотребление стан луча, станревольверы меньше стреляют
 - rscadd: Электроды создают искры