### PR TITLE
Possible fix for cyborgs late spawn

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -202,7 +202,7 @@
 	SSjob.EquipRank(character, rank, 1)					//equips the human
 
 	// AIs don't need a spawnpoint, they must spawn at an empty core
-	if(character.mind.assigned_role == "AI")
+	if(rank == "AI")
 
 		// IsJobAvailable for AI checks that there is an empty core available in this list
 		var/obj/structure/AIcore/deactivated/C = empty_playable_ai_cores[1]
@@ -230,7 +230,7 @@
 
 	//SSticker.mode.latespawn(character)
 
-	if(character.mind.assigned_role != "Cyborg")
+	if(rank != "Cyborg")
 		data_core.manifest_inject(character)
 		SSticker.minds += character.mind//Cyborgs and AIs handle this in the transform proc.	//TODO!!!!! ~Carn
 	//	AnnounceArrival(character, rank)


### PR DESCRIPTION

## Описание изменений

Возможный фикс спавна киборгов в лейтджойн. Почему-то на этом моменте у них не оказывается mind-а, возможно гонки или из-за того что их спавн происходит по особому. 

```
Cannot read null.assigned_role in new_player.dm:205 :
proc name: AttemptLateSpawn (/mob/dead/new_player/proc/AttemptLateSpawn)
  source file: new_player.dm,205
  usr: (src)
  src: User (/mob/dead/new_player)
  src.loc: the floor (8,174,1) (/turf/unsimulated/floor)
  call stack:
User (/mob/dead/new_player): AttemptLateSpawn("Cyborg")
```

У нас в этот момент есть переданный в функцию ``rank`` с тем же самым нужным нам значением, и он точно никуда не девается. Так что киборги могут дальше творить там что угодно, мы можем с этим справиться... хотя, возможно, тут какая-то большая проблема, но если есть что-то во время тм-а увидим.
