### PR TITLE
[Alien] Фикс худа заражения

### DIFF
--- a/code/__DEFINES/atom_hud.dm
+++ b/code/__DEFINES/atom_hud.dm
@@ -54,6 +54,7 @@
 #define DATA_HUD_BROKEN					20
 #define DATA_HUD_MINER					21
 #define DATA_HUD_GOLEM					14
+#define DATA_HUD_EMBRYO					23
 
 //antag HUD defines
 #define ANTAG_HUD_CULT          4
@@ -71,7 +72,6 @@
 #define ANTAG_HUD_ERT           17
 #define ANTAG_HUD_MALF          18
 #define ANTAG_HUD_ZOMB          19
-#define ANTAG_HUD_ALIEN_EMBRYO	23
 
 /// cooldown for being shown the images for any particular data hud
 #define ADD_HUD_TO_COOLDOWN 20

--- a/code/datums/atom_huds/atom_hud.dm
+++ b/code/datums/atom_huds/atom_hud.dm
@@ -16,6 +16,7 @@ var/global/list/huds[23]
 	huds[DATA_HUD_BROKEN] = new/datum/atom_hud/data/broken
 	huds[DATA_HUD_MINER] = new/datum/atom_hud/mine
 	huds[DATA_HUD_GOLEM] = new/datum/atom_hud/golem
+	huds[DATA_HUD_EMBRYO] = new/datum/atom_hud/embryo
 	huds[ANTAG_HUD_CULT] = new/datum/atom_hud/antag
 	huds[ANTAG_HUD_REV] = new/datum/atom_hud/antag
 	huds[ANTAG_HUD_OPS] = new/datum/atom_hud/antag
@@ -31,7 +32,6 @@ var/global/list/huds[23]
 	huds[ANTAG_HUD_ERT] = new/datum/atom_hud/antag
 	huds[ANTAG_HUD_MALF] = new/datum/atom_hud/antag/hidden
 	huds[ANTAG_HUD_ZOMB] = new/datum/atom_hud/antag
-	huds[ANTAG_HUD_ALIEN_EMBRYO] = new/datum/atom_hud/antag/embryo
 
 /datum/atom_hud
 	var/list/atom/hudatoms = list() //list of all atoms which display this hud

--- a/code/datums/atom_huds/atom_hud_antag.dm
+++ b/code/datums/atom_huds/atom_hud_antag.dm
@@ -6,10 +6,6 @@
 /datum/atom_hud/antag/hidden
 	self_visible = FALSE
 
-
-/datum/atom_hud/antag/embryo
-	hud_icons = list(ALIEN_EMBRYO_HUD)
-
 /datum/atom_hud/antag/proc/join_hud(mob/M)
 	if(!istype(M))
 		CRASH("join_hud(): [M] ([M.type]) is not a mob!")

--- a/code/datums/atom_huds/atom_hud_data.dm
+++ b/code/datums/atom_huds/atom_hud_data.dm
@@ -60,6 +60,9 @@
 /datum/atom_hud/golem
 	hud_icons = list(GOLEM_MASTER_HUD)
 
+/datum/atom_hud/embryo
+	hud_icons = list(ALIEN_EMBRYO_HUD)
+
 /* MED/SEC/DIAG HUD HOOKS */
 
 /*

--- a/code/modules/mob/living/carbon/xenomorph/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/xenomorph/special/alien_embryo.dm
@@ -195,13 +195,13 @@ This is emryo growth procs
 
 //only aliens will see this HUD
 /obj/item/alien_embryo/proc/add_infected_hud()
-	var/datum/atom_hud/antag/hud = global.huds[ANTAG_HUD_ALIEN_EMBRYO]
+	var/datum/atom_hud/hud = global.huds[DATA_HUD_EMBRYO]
 	hud.add_to_hud(affected_mob)
 	var/image/holder = affected_mob.hud_list[ALIEN_EMBRYO_HUD]
 	holder.icon_state = "infected[stage]"
 
 /obj/item/alien_embryo/proc/remove_infected_hud()
-	var/datum/atom_hud/antag/hud = global.huds[ANTAG_HUD_ALIEN_EMBRYO]
-	hud.leave_hud(affected_mob)
+	var/datum/atom_hud/hud = global.huds[DATA_HUD_EMBRYO]
+	hud.remove_hud_from(affected_mob)
 	var/image/holder = affected_mob.hud_list[ALIEN_EMBRYO_HUD]
 	holder.icon_state = null

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -29,11 +29,12 @@
 /mob/living/carbon/xenomorph/atom_init()
 	. = ..()
 	add_language("Xenomorph language")
-	var/datum/atom_hud/antag/hud = global.huds[ANTAG_HUD_ALIEN_EMBRYO]
+	var/datum/atom_hud/hud = global.huds[DATA_HUD_EMBRYO]
 	hud.add_hud_to(src)	//add xenomorph to the hudusers list to see who is infected
 
 /mob/living/carbon/xenomorph/Destroy()
-	remove_antag_hud(ANTAG_HUD_ALIEN_EMBRYO, src)
+	var/datum/atom_hud/hud = global.huds[DATA_HUD_EMBRYO]
+	hud.remove_hud_from(src)
 	return ..()
 
 /mob/living/carbon/xenomorph/adjustToxLoss(amount)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Алиены иногда не видели худ заражения. Происходило это из-за того, что использовался антаг худ, а не обычный. Если сказать коротко, то при вызове прока `mind.transfer_to` происходило удаление старого антаг худа и из-за этого происходил этот баг.

## Почему и что этот ПР улучшит
минус баг
## Авторство
я
## Чеинжлог
:cl: Ahio
 - bugfix: Алиены иногда не видели худ заражения.