### PR TITLE
Эмбиент окклюжен для стен цк

### DIFF
--- a/code/game/turfs/unsimulated/walls.dm
+++ b/code/game/turfs/unsimulated/walls.dm
@@ -2,6 +2,7 @@
 	name = "wall"
 	icon = 'icons/turf/walls/riveted.dmi'
 	icon_state = "box"
+	plane = GAME_PLANE
 	opacity = 1
 	density = 1
 	smooth = SMOOTH_TRUE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Оказывается, раньше стены ЦК были на одном плейне с ЦК-полом и поэтому от них не было тени, как на станции.

| Стены на станции     | Стены на ЦК до этого ПРа | Стены на ЦК после этого ПРа |
| ------------- |:-------------:|:-------------:|
| ![image](https://user-images.githubusercontent.com/26389417/111347504-54bcbd00-8690-11eb-8ef4-a325110b8770.png) | ![image](https://user-images.githubusercontent.com/26389417/111347576-656d3300-8690-11eb-877e-3bc3ae823f3e.png) | ![image](https://user-images.githubusercontent.com/26389417/111348074-e4626b80-8690-11eb-8b2c-2f559d0c28bf.png)|


Го быстро-мерж.

## Почему и что этот ПР улучшит
Красивее

## Авторство

## Чеинжлог
