### PR TITLE
Сохранение всех настроек у всех персонажей

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -327,6 +327,19 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	snd_admin_vol = sanitize_integer(snd_admin_vol, 0, 100, initial(snd_admin_vol))
 	snd_jukebox_vol = sanitize_integer(snd_jukebox_vol, 0, 100, initial(snd_jukebox_vol))
 
+	if(needs_update >= 0) //save the updated version
+		var/old_default_slot = default_slot
+		for (var/slot in S.dir) //but first, update all current character slots.
+			if (copytext(slot, 1, 10) != "character")
+				continue
+			var/slotnum = text2num(copytext(slot, 10))
+			if (!slotnum)
+				continue
+			default_slot = slotnum
+			if (load_character())
+				save_character()
+		default_slot = old_default_slot
+
 	return 1
 
 /datum/preferences/proc/save_preferences()

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -339,6 +339,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 			if (load_character())
 				save_character()
 		default_slot = old_default_slot
+		save_preferences()
 
 	return 1
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений

>Savefiles now update all character slots when the version is bumped (instead of just the current one), and saves the updated savefile to disk afterwards

Порт https://github.com/tgstation/tgstation/pull/52549/files
close #6894


## Почему и что этот ПР улучшит
Игроку не будут прилетать окошки при смене персонажа или при несохранении слота.

## Авторство

## Чеинжлог
