### PR TITLE
Ням-батон (он же yum-baton) можно поместить в кабуру для стан батона

### DIFF
--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -231,7 +231,8 @@
 
 	can_hold = list(
 		/obj/item/weapon/melee,
-		/obj/item/weapon/crowbar
+		/obj/item/weapon/crowbar,
+		/obj/item/weapon/reagent_containers/food/snacks/candy/yumbaton
 		)
 
 	sliding_behavior = TRUE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Ням-батон можно поместить в чехол для стан-батона
## Почему и что этот ПР улучшит
Вкусную шоколадку, которая выглядит как стан-батон, теперь можно положить в чехол для батонов, и разыграть офицера
## Авторство
Rolt146
## Чеинжлог
:cl:
 - rscadd: Теперь ням-батон можно положить в чехол для стан-батонов