### PR TITLE
канал ерт снова работает на станции

### DIFF
--- a/code/game/machinery/telecomms/presets.dm
+++ b/code/game/machinery/telecomms/presets.dm
@@ -26,6 +26,7 @@
 
 /obj/machinery/telecomms/relay/preset/centcom
 	id = "Centcom Relay"
+	listening_level = 2
 	hide = 1
 	toggled = 1
 	//anchored = 1


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
поменял listening_level в презете центкомовского телеком-релея на 2. не знаю, что это делает, но я потыкал и вроде работает.
## Почему и что этот ПР улучшит
фиксит "баг".
## Авторство

## Чеинжлог
:cl:
- bugfix: Канал ОБР снова работает на станции.