### PR TITLE
[Aliens] Увеличил кол-во игроков для старта режима. Алиены в ротацию!

### DIFF
--- a/code/game/gamemodes/infestation/infestation.dm
+++ b/code/game/gamemodes/infestation/infestation.dm
@@ -10,9 +10,9 @@
 	name = "infestation"
 	config_tag = "infestation"
 	role_type = ROLE_ALIEN
-	required_players = 20
-	required_players_bundles = 15
-	required_enemies = 2
+	required_players = 25
+	required_players_bundles = 35
+	required_enemies = 3
 	recommended_enemies = 4
 	votable = 0
 	var/last_check = 0


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Для сикрета нужно 35 игроков, для обычного запуска - 25. Также увеличил минимальное количество ксеноморфов для старта режима с 2 до 3. 

Для добавления infestation в ротацию в конфиге нужно будет прописать `PROBABILITY INFESTATION 1` , ну **volas** знает))
## Почему и что этот ПР улучшит
Можно добавлять режим в **secret**
## Авторство
Ahio
## Чеинжлог
:cl: Ahio
 - tweak: Увеличено количество игроков для старта режима infestation в secret до 35, для обычного запуска - 25. Увеличено минимальное количество ксеноморфов с 2 до 3.