### PR TITLE
ребаланс тазеров

### DIFF
--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -71,6 +71,7 @@
 
 /obj/item/ammo_casing/energy/electrode
 	projectile_type = /obj/item/projectile/energy/electrode
+	e_cost = 200
 	select_name = "stun - electrode"
 	fire_sound = 'sound/weapons/guns/gunpulse_taser.ogg'
 

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -11,7 +11,7 @@
 	var/select = 1 //The state of the select fire switch. Determines from the ammo_type list what kind of shot is fired next.
 
 /obj/item/weapon/gun/energy/emp_act(severity)
-	power_supply.use(round(power_supply.maxcharge / severity))
+	power_supply.use(round(power_supply.charge / severity))
 	update_icon()
 	..()
 

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -2198,24 +2198,12 @@
 	},
 /area/station/security/main)
 "adG" = (
-/obj/machinery/power/apc{
-	name = "Armory APC";
-	pixel_y = -28
-	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	name = "Weapons locker";
-	req_access = list(3)
-	},
-/obj/structure/closet/wardrobe/tactical,
+/obj/machinery/light/small/emergency,
 /turf/simulated/floor{
 	icon_state = "warndark"
 	},
@@ -62046,17 +62034,6 @@
 	},
 /area/station/security/main)
 "ctH" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	req_access = list(72)
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	name = "Weapons locker";
-	req_access = list(3)
-	},
-/obj/structure/closet/wardrobe/tactical,
 /turf/simulated/floor{
 	icon_state = "warndark"
 	},
@@ -69807,14 +69784,14 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/mine_sci_shuttle)
 "erb" = (
-/obj/structure/window/reinforced,
-/obj/machinery/light/small/emergency,
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	name = "Weapons locker";
-	req_access = list(3)
+/obj/machinery/power/apc{
+	name = "Armory APC";
+	pixel_y = -28
 	},
-/obj/structure/closet/wardrobe/tactical,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor{
 	icon_state = "warndark"
 	},


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
в одном тазере теперь только два электрода, количество лучей осталось тем же.
пофиксил баг с использованием заряда при эми.
выпилил маринармор из оружейки, это была плохая идея.
станревольверы не трогал, так как у них всего лишь в два раза больше лучей, но нет электродов, так что они достаточно балансед.
## Почему и что этот ПР улучшит
баланс, офицеры подумают, перед тем как стрелять из тазера электродом.
маринармор же ничего не привносил в раунд. задумывался он, должно быть, как особая броня для особых случаев, но в реальности каждый малогей только и делает, что ноет по поводу закрытия этой брони в любой ситуации и затаривается гиперцином, который нивелирует её главный недостаток. поэтому так.
## Авторство

## Чеинжлог
:cl:
- balance: количество электродов в тазере уменьшено до двух штук.
- balance: броня морпехов удалена из оружейной.