### PR TITLE
убирает сокращение урона в два раза

### DIFF
--- a/code/modules/organs/external/flesh.dm
+++ b/code/modules/organs/external/flesh.dm
@@ -55,14 +55,6 @@
 		damage_amt += burn
 		cur_damage += BP.burn_dam
 
-	if(BP.bodypart_organs.len && (cur_damage + damage_amt >= BP.max_damage || (((sharp && damage_amt >= 5) || damage_amt >= 10) && prob(5))))
-		// Damage an internal organ
-		var/obj/item/organ/internal/IO = pick(BP.bodypart_organs)
-		IO.take_damage(damage_amt / 2)
-		brute /= 2
-		if(laser)
-			burn /= 2
-
 	if(used_weapon)
 		if(brute > 0 && burn == 0)
 			BP.add_autopsy_data("[used_weapon]", brute, type_damage = BRUTE)

--- a/code/modules/organs/external/flesh.dm
+++ b/code/modules/organs/external/flesh.dm
@@ -55,6 +55,11 @@
 		damage_amt += burn
 		cur_damage += BP.burn_dam
 
+	if(BP.bodypart_organs.len && (cur_damage + damage_amt >= BP.max_damage || (((sharp && damage_amt >= 5) || damage_amt >= 10) && prob(5))))
+	// Damage an internal organ
+		var/obj/item/organ/internal/IO = pick(BP.bodypart_organs)
+		IO.take_damage(damage_amt / 2)
+
 	if(used_weapon)
 		if(brute > 0 && burn == 0)
 			BP.add_autopsy_data("[used_weapon]", brute, type_damage = BRUTE)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
удалено сокращение урона в два раза при переходе порога урона. конечности не затронуты, а голова гроин и сундук - затронуты.
## Почему и что этот ПР улучшит
куклы теперь будут умирать быстрее, не будут выдерживать миллион пуль из калаша в упор и прочее и прочее
## Авторство

## Чеинжлог
:cl:
- experiment: при преодолении порога урона на голове, груди, и пахе урон больше не будет резаться в два раза, значит, куклы будут умирать быстрее.