### PR TITLE
[Alien] Нельзя ломать компьютеры, можно плавить APC, кислота быстрее и дешевле.

### DIFF
--- a/code/game/gamemodes/infestation/infestation.dm
+++ b/code/game/gamemodes/infestation/infestation.dm
@@ -69,7 +69,7 @@
 			apc.overload_lighting()
 
 		var/mob/living/carbon/xenomorph/larva/L = new /mob/living/carbon/xenomorph/larva(get_turf(start_point))
-		xeno.transfer_to(L)
+		L.key = xeno.key
 		QDEL_NULL(xeno.original)
 		add_antag_hud(ANTAG_HUD_ALIEN, "hudalien", L)
 		greet_xeno(xeno)

--- a/code/game/gamemodes/infestation/infestation.dm
+++ b/code/game/gamemodes/infestation/infestation.dm
@@ -69,7 +69,8 @@
 			apc.overload_lighting()
 
 		var/mob/living/carbon/xenomorph/larva/L = new /mob/living/carbon/xenomorph/larva(get_turf(start_point))
-		L.key = xeno.key
+		xeno.transfer_to(L)
+		xeno.name = L.real_name
 		QDEL_NULL(xeno.original)
 		add_antag_hud(ANTAG_HUD_ALIEN, "hudalien", L)
 		greet_xeno(xeno)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -37,7 +37,6 @@
 	req_one_access = list(access_atmospherics, access_engine_equip)
 	frequency = 1439
 	allowed_checks = ALLOWED_CHECK_NONE
-	unacidable = TRUE
 
 	var/breach_detection = TRUE // Whether to use automatic breach detection or not
 	//var/skipprocess = 0 //Experimenting

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -225,18 +225,8 @@
 	if(istype(user, /mob/living/carbon/xenomorph/humanoid/queen))
 		attack_hand(user)
 		return
-	if(circuit)
-		user.do_attack_animation(src)
-		user.SetNextMove(CLICK_CD_MELEE)
-		if(prob(80))
-			user.visible_message("<span class='danger'>[user.name] smashes the [src.name] with \his claws.</span>",
-			"<span class='danger'>You smash the [src.name] with your claws.</span>",
-			"<span class='danger'>You hear a smashing sound.</span>")
-			set_broken()
-			return
-	user.visible_message("<span class='danger'>[user.name] smashes against the [src.name] with \his claws.</span>",
-	"<span class='danger'>You smash against the [src.name] with your claws.</span>",
-	"<span class='danger'>You hear a clicking sound.</span>")
+	else
+		to_chat(user, "You don't want to break these thing")
 
 /obj/machinery/computer/attack_animal(mob/living/simple_animal/M)
 	if(istype(M, /mob/living/simple_animal/hulk))

--- a/code/modules/mob/living/carbon/xenomorph/effects/aliens.dm
+++ b/code/modules/mob/living/carbon/xenomorph/effects/aliens.dm
@@ -431,7 +431,7 @@
 			var/mob/living/carbon/xenomorph/facehugger/FH = new /mob/living/carbon/xenomorph/facehugger(get_turf(src))
 			FH.key = user.key
 			FH.mind.add_antag_hud(ANTAG_HUD_ALIEN, "hudalien", FH)
-			to_chat(FH, "<span class='notice'>You are now a facehugger, go hug some human faces <3</span>")
+			to_chat(FH, "<span class='notice'>You are now a facehugger, go hug some human faces!</span>")
 			icon_state = "egg_hatched"
 			flick("egg_opening", src)
 			status = BURSTING

--- a/code/modules/mob/living/carbon/xenomorph/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/humanoid/alien_powers.dm
@@ -209,11 +209,11 @@ Doesn't work on other aliens/AI.*/
 			adjustToxLoss(-50)
 			neurotoxin_next_shot = world.time  + neurotoxin_delay
 		if(ALIEN_ACID)
-			if(!powerc(100))
+			if(!powerc(75))
 				return
 			BB = new /obj/item/projectile/acid_special(usr.loc)
-			neurotoxin_next_shot = world.time  + (neurotoxin_delay * 3)
-			adjustToxLoss(-100)
+			neurotoxin_next_shot = world.time  + (neurotoxin_delay * 2)
+			adjustToxLoss(-75)
 
 	visible_message("<span class='danger'>[src] spits [BB.name] at [target]!</span>")
 	playsound(src, pick(SOUNDIN_XENOMORPH_SPLITACID), VOL_EFFECTS_MASTER, vary = FALSE, ignore_environment = TRUE)

--- a/code/modules/mob/living/carbon/xenomorph/humanoid/caste/drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/humanoid/caste/drone.dm
@@ -50,8 +50,8 @@
 				return
 			adjustToxLoss(-500)
 			var/mob/living/carbon/xenomorph/humanoid/queen/new_xeno = new (loc)
-			new_xeno.key = key
-			new_xeno.mind.add_antag_hud(ANTAG_HUD_ALIEN, "hudalien", new_xeno)
+			mind.transfer_to(new_xeno)
+			new_xeno.mind.name = new_xeno.real_name
 			qdel(src)
 		else
 			to_chat(src, "<span class='notice'>We already have an alive queen.</span>")

--- a/code/modules/mob/living/carbon/xenomorph/humanoid/caste/drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/humanoid/caste/drone.dm
@@ -50,7 +50,8 @@
 				return
 			adjustToxLoss(-500)
 			var/mob/living/carbon/xenomorph/humanoid/queen/new_xeno = new (loc)
-			mind.transfer_to(new_xeno)
+			new_xeno.key = key
+			new_xeno.mind.add_antag_hud(ANTAG_HUD_ALIEN, "hudalien", new_xeno)
 			qdel(src)
 		else
 			to_chat(src, "<span class='notice'>We already have an alive queen.</span>")

--- a/code/modules/mob/living/carbon/xenomorph/larva/powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/larva/powers.dm
@@ -59,8 +59,8 @@
 		if(!new_xeno)
 			CRASH("new_xeno = null. Chosen caste: [alien_caste].")
 		if(mind)
-			new_xeno.key = key
-			new_xeno.mind.add_antag_hud(ANTAG_HUD_ALIEN, "hudalien", new_xeno)
+			mind.transfer_to(new_xeno)
+			new_xeno.mind.name = new_xeno.real_name
 			qdel(src)
 		return
 	else

--- a/code/modules/mob/living/carbon/xenomorph/larva/powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/larva/powers.dm
@@ -59,7 +59,7 @@
 		if(!new_xeno)
 			CRASH("new_xeno = null. Chosen caste: [alien_caste].")
 		if(mind)
-			mind.transfer_to(new_xeno)
+			new_xeno.key = key
 			new_xeno.mind.add_antag_hud(ANTAG_HUD_ALIEN, "hudalien", new_xeno)
 			qdel(src)
 		return

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -47,7 +47,6 @@
 	use_power = NO_POWER_USE
 	req_access = list(access_engine_equip)
 	allowed_checks = ALLOWED_CHECK_NONE
-	unacidable = TRUE
 	var/area/area
 	var/areastring = null
 	var/obj/item/weapon/stock_parts/cell/cell

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -218,7 +218,7 @@
 	name = "neurotoxin"
 	icon_state = "energy2"
 	damage = 5
-	paralyze = 10
+	weaken = 10
 	damage_type = TOX
 	flag = "bio"
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений

1. Так как компьютеры иногда нужны королеве, запретил ломать их другим алиенам, чтоб не сломали, случайно кликнув. Если очень нужно уничтожить консоль, то её, по прежнему, можно расплавить.
2. Дал возможность алиенам **расплавить** APC и Air Alarm. Сейчас алиены бояться разгерм больше чем экипаж, поэтому не вижу смысла запрещать алиенам уничтожать APC и Air Alarm. Так они могут защититься от ИИ. 
3. Была проблема в том что у `mind` алиенов не изменялся `name`. Это приводило к тому, что в гостчате игрок **не** назывался именем алиена за которого умер. Прок `mind.transfer_to()` почему-то не изменяет имя у `mind`'a , а вот если просто присваивать `key` игрока к новому мобу, то имя меняется везде как надо. Поэтому отказался от использования прока `mind.transfer_to()`.
4. Плевок кислотой теперь стоит 75 плазмы, а не 100, также уменьшил время перезарядки. Откатил нерф короче.
5. Алиены теперь не будут падать в стан от нейротоксина. Происходило это из-за того, что нейротоксин применял эффект `paralyze`, которому подвержены алиены. Изменил на `weaken`

## Почему и что этот ПР улучшит
игру за ксеноморфов
## Авторство
я
## Чеинжлог
:cl: Ahio
 - bugfix: Ксеноморфов станил свой же нейротоксин.
 - tweak: Ксеноморфы больше не могут ломать консоли, но могут их расплавить.
 - tweak: Ксеноморфы могут расплавить APC и Air Alarm.
 - balance: Плевок кислотой теперь стоит 75 плазмы, а не 100, уменьшено время перезарядки.