### PR TITLE
[Alien] В ксенобиологию добавлены 5 мартышек

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -76209,6 +76209,10 @@
 /obj/machinery/atmospherics/components/unary/portables_connector,
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
+"nXs" = (
+/mob/living/carbon/monkey,
+/turf/simulated/floor/engine,
+/area/station/rnd/xenobiology)
 "nYb" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -127149,7 +127153,7 @@ aaa
 cbD
 cxT
 ckC
-ckC
+nXs
 cjv
 cjr
 ckC
@@ -127404,9 +127408,9 @@ aaa
 aaa
 aaa
 cbD
-ckC
-ckC
-ckC
+nXs
+nXs
+nXs
 cjv
 cjr
 ckC
@@ -127663,7 +127667,7 @@ aaa
 cbD
 ckC
 iNb
-ckC
+nXs
 cjv
 avx
 aYM

--- a/maps/gamma/gamma.dmm
+++ b/maps/gamma/gamma.dmm
@@ -74464,6 +74464,10 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/dormitories)
+"wov" = (
+/mob/living/carbon/monkey,
+/turf/simulated/floor/engine,
+/area/station/rnd/xenobiology)
 "woF" = (
 /obj/structure/object_wall/pod{
 	dir = 1;
@@ -123927,7 +123931,7 @@ afi
 vNi
 pkz
 pkz
-pkz
+wov
 vNi
 kHU
 plf
@@ -124182,9 +124186,9 @@ nKo
 afz
 xzl
 eTL
-pkz
-pkz
-pkz
+wov
+wov
+wov
 vNi
 kHU
 plf
@@ -124441,7 +124445,7 @@ jdG
 vNi
 ujB
 pkz
-pkz
+wov
 vNi
 kHU
 plf


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Для того чтобы вирусология была не единственным привлекательным местом для гнезда алиенов, предлагаю добавить в ксенобиологию 5 мартышек. Если дать возможность квине брать в руки манкикубы и соответственно загружать их в консоль, то она сделает около 15 мартышек (лежит 3 коробки по 5 манкикубов), что слишком много, как по мне.
**Коробка**
![monkey](https://user-images.githubusercontent.com/58528255/114167167-eb4a6a00-992e-11eb-8646-1f7e9c8ef4c3.jpg)
**Гамма**
![monkey_gamma](https://user-images.githubusercontent.com/58528255/114167203-f30a0e80-992e-11eb-8264-17afeada29f9.jpg)

## Почему и что этот ПР улучшит
Больше мест для гнёзд ксеноморфов.
## Авторство
я
## Чеинжлог
:cl: Ahio
 - map: В ксенобиологию добавлены 5 мартышек (boxstation, gamma). Ещё одно возможное место для гнезда алиенов.