### PR TITLE
Не будет рево-боргов

### DIFF
--- a/code/game/machinery/podmen.dm
+++ b/code/game/machinery/podmen.dm
@@ -106,10 +106,7 @@ Growing it to term with nothing injected will grab a ghost from the observers. *
 	found_player = TRUE
 
 	var/mob/living/carbon/monkey/diona/podman = new(parent.loc)
-	podman.ckey = candidate.ckey
-
-	if(candidate.mob && candidate.mob.mind)
-		candidate.mob.mind.transfer_to(podman)
+	podman.key = candidate.key
 
 	if(realName)
 		podman.real_name = realName

--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -56,9 +56,7 @@
 /obj/item/device/mmi/posibrain/proc/transfer_personality(mob/candidate)
 
 	src.searching = FALSE
-	src.brainmob.mind = candidate.mind
-	//src.brainmob.key = candidate.key
-	src.brainmob.ckey = candidate.ckey
+	src.brainmob.key = candidate.key
 	src.name = "positronic brain ([src.brainmob.name])"
 
 	to_chat(src.brainmob, "<b>You are a positronic brain, brought into existence on [station_name()].</b>")
@@ -110,12 +108,13 @@
 	..()
 
 /obj/item/device/mmi/posibrain/attack_ghost(mob/dead/observer/O)
-	if(!ping_cd)
-		ping_cd = 1
-		spawn(50)
-			ping_cd = 0
-		audible_message("<span class='notice'>\The [src] pings softly.</span>", deaf_message = "\The [src] indicator blinks.")
-		playsound(src, 'sound/machines/ping.ogg', VOL_EFFECTS_MASTER, 10, FALSE)
+	if(brainmob && !brainmob.key && searching == 0)
+		//Start the process of searching for a new user.
+		to_chat(O, "<span class='notice'>You carefully locate the manual activation switch and start the positronic brain's boot process.</span>")
+		icon_state = "posibrain-searching"
+		searching = TRUE
+		request_player()
+		addtimer(CALLBACK(src, .proc/reset_search), 300)
 
 /obj/item/device/mmi/posibrain/atom_init()
 

--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -108,13 +108,12 @@
 	..()
 
 /obj/item/device/mmi/posibrain/attack_ghost(mob/dead/observer/O)
-	if(brainmob && !brainmob.key && searching == 0)
-		//Start the process of searching for a new user.
-		to_chat(O, "<span class='notice'>You carefully locate the manual activation switch and start the positronic brain's boot process.</span>")
-		icon_state = "posibrain-searching"
-		searching = TRUE
-		request_player()
-		addtimer(CALLBACK(src, .proc/reset_search), 300)
+	if(!ping_cd)
+		ping_cd = 1
+		spawn(50)
+			ping_cd = 0
+		audible_message("<span class='notice'>\The [src] pings softly.</span>", deaf_message = "\The [src] indicator blinks.")
+		playsound(src, 'sound/machines/ping.ogg', VOL_EFFECTS_MASTER, 10, FALSE)
 
 /obj/item/device/mmi/posibrain/atom_init()
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Теперь худ и некоторые обжекты будут работать корректно. Вся проблема в том, что когда ты гостаешься, то майнд хумана переезжает в призрака. Когда ты вызываешь позитронку, то уже майнд из призрака переселяется в позитронку. В итоге у нас и получается, что борги являются целькой триторов и бегают с разными худами.

А так же гост->диона пофиксил, а не только гост->позитронка->борг

Когда я добавил божка, то я скопировал код боргов. У меня вылезла та же проблема, но позже я это просто пофиксил. Так сказать, прошло время, собрались результаты и я пришел к выводу, что и боргам это нужно фиксить.

fix #7028
fix #2564

## Почему и что этот ПР улучшит
Баг или не баг столетней давности пофишкен

## Авторство


## Чеинжлог
:cl:
 - fix: Киборг, в которого вселился игрок имевший антаг-худ, больше не получит антаг-худ куклы игрока.