### PR TITLE
Возможность залезать в вентиляцию через трубы

### DIFF
--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -69,6 +69,9 @@ var/list/ventcrawl_machinery = list(
 	return TRUE
 
 /obj/machinery/atmospherics/AltClick(mob/living/L)
+	if(!istype(L))
+		return
+
 	if(!L.can_ventcrawl())
 		return
 

--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -69,79 +69,80 @@ var/list/ventcrawl_machinery = list(
 	return TRUE
 
 /obj/machinery/atmospherics/AltClick(mob/living/L)
-	if(is_type_in_list(src, ventcrawl_machinery))
-		L.handle_ventcrawl(src)
+	if(!L.can_ventcrawl())
 		return
+
+	if(!L.Adjacent(src))
+		to_chat(L, "You must be standing on or beside an air vent to enter it.")
+		return
+
+	if(is_type_in_list(src, ventcrawl_machinery))
+		var/obj/machinery/atmospherics/components/unary/vent_found = src
+		if(!vent_found.can_crawl_through())
+			to_chat(L, "You can't crawl through [src].")
+			return
+		var/datum/pipeline/vent_found_parent = vent_found.PARENT1
+		if(!vent_found_parent && !(vent_found_parent.members.len || vent_found_parent.other_atmosmch))
+			to_chat(L, "This vent is not connected to anything.")
+			return
+		L.handle_ventcrawl(src, vent_found_parent)
+		return
+
+	else if(istype(src, /obj/machinery/atmospherics/pipe))
+		var/obj/machinery/atmospherics/pipe/vent_found = src
+		var/connections = 0	//count the number of pipes connected
+		for(var/node in vent_found.nodes)
+			if(!node)
+				continue
+			connections++
+		if(connections == vent_found.device_type)
+			return	//This means that there are no free holes and we cannot get into the pipe.
+		var/datum/pipeline/vent_found_parent = vent_found.parent
+		L.handle_ventcrawl(src, vent_found_parent)
+		return
+
 	..()
 
-/mob/living/proc/handle_ventcrawl(atom/clicked_on)
+/mob/living/proc/handle_ventcrawl(obj/machinery/atmospherics/vent_found, datum/pipeline/vent_found_parent)
+	to_chat(src, "You begin climbing into the ventilation system...")
+	var/time = 40
+	if(small)
+		time = 5
+	if(is_busy() || !do_after(src, time, null, vent_found))
+		return
+
 	if(!can_ventcrawl())
 		return
 
-	var/obj/machinery/atmospherics/components/unary/vent_found
-	if(clicked_on && Adjacent(clicked_on))
-		vent_found = clicked_on
-		if(!istype(vent_found) || !vent_found.can_crawl_through())
-			vent_found = null
+	if(vent_found_parent)
+		var/datum/gas_mixture/air_contents = vent_found_parent.air
 
-	if(!vent_found)
-		for(var/obj/machinery/atmospherics/machine in range(1, src))
-			if(is_type_in_list(machine, ventcrawl_machinery))
-				vent_found = machine
+		if(air_contents && !issilicon(src))
 
-			if(!vent_found || !vent_found.can_crawl_through())
-				vent_found = null
+			switch(air_contents.temperature)
+				if(0 to BODYTEMP_COLD_DAMAGE_LIMIT)
+					to_chat(src, "<span class='danger'>You feel a painful freeze coming from the vent!</span>")
+				if(BODYTEMP_COLD_DAMAGE_LIMIT to T0C)
+					to_chat(src, "<span class='warning'>You feel an icy chill coming from the vent.</span>")
+				if(T0C + 40 to BODYTEMP_HEAT_DAMAGE_LIMIT)
+					to_chat(src, "<span class='warning'>You feel a hot wash coming from the vent.</span>")
+				if(BODYTEMP_HEAT_DAMAGE_LIMIT to INFINITY)
+					to_chat(src, "<span class='danger'>You feel a searing heat coming from the vent!</span>")
 
-			if(vent_found)
-				break
+			switch(air_contents.return_pressure())
+				if(0 to HAZARD_LOW_PRESSURE)
+					to_chat(src, "<span class='danger'>You feel a rushing draw pulling you into the vent!</span>")
+				if(HAZARD_LOW_PRESSURE to WARNING_LOW_PRESSURE)
+					to_chat(src, "<span class='warning'>You feel a strong drag pulling you into the vent.</span>")
+				if(WARNING_HIGH_PRESSURE to HAZARD_HIGH_PRESSURE)
+					to_chat(src, "<span class='warning'>You feel a strong current pushing you away from the vent.</span>")
+				if(HAZARD_HIGH_PRESSURE to INFINITY)
+					to_chat(src, "<span class='danger'>You feel a roaring wind pushing you away from the vent!</span>")
 
-	if(vent_found)
-		var/datum/pipeline/vent_found_parent = vent_found.PARENT1
-		if(vent_found_parent && (vent_found_parent.members.len || vent_found_parent.other_atmosmch))
+	visible_message("<B>[src] scrambles into the ventilation ducts!</B>", "You climb into the ventilation system.")
 
-			to_chat(src, "You begin climbing into the ventilation system...")
-			var/time = 40
-			if(small)
-				time = 5
-			if(is_busy() || !do_after(src, time, null, vent_found))
-				return
-
-			if(!can_ventcrawl())
-				return
-
-			var/datum/gas_mixture/air_contents = vent_found.AIR1
-
-			if(air_contents && !issilicon(src))
-
-				switch(air_contents.temperature)
-					if(0 to BODYTEMP_COLD_DAMAGE_LIMIT)
-						to_chat(src, "<span class='danger'>You feel a painful freeze coming from the vent!</span>")
-					if(BODYTEMP_COLD_DAMAGE_LIMIT to T0C)
-						to_chat(src, "<span class='warning'>You feel an icy chill coming from the vent.</span>")
-					if(T0C + 40 to BODYTEMP_HEAT_DAMAGE_LIMIT)
-						to_chat(src, "<span class='warning'>You feel a hot wash coming from the vent.</span>")
-					if(BODYTEMP_HEAT_DAMAGE_LIMIT to INFINITY)
-						to_chat(src, "<span class='danger'>You feel a searing heat coming from the vent!</span>")
-
-				switch(air_contents.return_pressure())
-					if(0 to HAZARD_LOW_PRESSURE)
-						to_chat(src, "<span class='danger'>You feel a rushing draw pulling you into the vent!</span>")
-					if(HAZARD_LOW_PRESSURE to WARNING_LOW_PRESSURE)
-						to_chat(src, "<span class='warning'>You feel a strong drag pulling you into the vent.</span>")
-					if(WARNING_HIGH_PRESSURE to HAZARD_HIGH_PRESSURE)
-						to_chat(src, "<span class='warning'>You feel a strong current pushing you away from the vent.</span>")
-					if(HAZARD_HIGH_PRESSURE to INFINITY)
-						to_chat(src, "<span class='danger'>You feel a roaring wind pushing you away from the vent!</span>")
-
-			visible_message("<B>[src] scrambles into the ventilation ducts!</B>", "You climb into the ventilation system.")
-
-			forceMove(vent_found)
-			add_ventcrawl(vent_found)
-
-		else
-			to_chat(src, "This vent is not connected to anything.")
-	else
-		to_chat(src, "You must be standing on or beside an air vent to enter it.")
+	forceMove(vent_found)
+	add_ventcrawl(vent_found)
 
 /mob/living/proc/add_ventcrawl(obj/machinery/atmospherics/starting_machine)
 

--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -75,43 +75,29 @@ var/list/ventcrawl_machinery = list(
 	if(!L.can_ventcrawl())
 		return
 
-	if(!L.Adjacent(src))
-		to_chat(L, "You must be standing on or beside an air vent to enter it.")
-		return
-
-	if(is_type_in_list(src, ventcrawl_machinery))
-		var/obj/machinery/atmospherics/components/unary/vent_found = src
-		if(!vent_found.can_crawl_through())
-			to_chat(L, "You can't crawl through [src].")
+	if(is_type_in_list(src, ventcrawl_machinery) || istype(src, /obj/machinery/atmospherics/pipe))
+		if(!L.Adjacent(src))
+			to_chat(L, "You must be standing on or beside an air vent to enter it.")
 			return
-		var/datum/pipeline/vent_found_parent = vent_found.PARENT1
-		if(!vent_found_parent && !(vent_found_parent.members.len || vent_found_parent.other_atmosmch))
-			to_chat(L, "This vent is not connected to anything.")
-			return
-		L.handle_ventcrawl(src, vent_found_parent)
-		return
 
-	else if(istype(src, /obj/machinery/atmospherics/pipe))
-		var/obj/machinery/atmospherics/pipe/vent_found = src
-		var/connections = 0	//count the number of pipes connected
-		for(var/node in vent_found.nodes)
-			if(!node)
-				continue
-			connections++
-		if(connections == vent_found.device_type)
-			return	//This means that there are no free holes and we cannot get into the pipe.
-		var/datum/pipeline/vent_found_parent = vent_found.parent
+		if(!can_enter_to())
+			to_chat(L, "You can't enter to [src].")
+			return
+
+		var/datum/pipeline/vent_found_parent = returnPipenet()
 		L.handle_ventcrawl(src, vent_found_parent)
 		return
 
 	..()
 
 /mob/living/proc/handle_ventcrawl(obj/machinery/atmospherics/vent_found, datum/pipeline/vent_found_parent)
+	if(is_busy())
+		return
 	to_chat(src, "You begin climbing into the ventilation system...")
 	var/time = 40
 	if(small)
 		time = 5
-	if(is_busy() || !do_after(src, time, null, vent_found))
+	if(!do_after(src, time, null, vent_found))
 		return
 
 	if(!can_ventcrawl())

--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -75,20 +75,15 @@ var/list/ventcrawl_machinery = list(
 	if(!L.can_ventcrawl())
 		return
 
-	if(is_type_in_list(src, ventcrawl_machinery) || istype(src, /obj/machinery/atmospherics/pipe))
-		if(!L.Adjacent(src))
-			to_chat(L, "You must be standing on or beside an air vent to enter it.")
-			return
-
-		if(!can_enter_to())
-			to_chat(L, "You can't enter to [src].")
-			return
-
-		var/datum/pipeline/vent_found_parent = returnPipenet()
-		L.handle_ventcrawl(src, vent_found_parent)
+	if(!suitable_for_ventcrawl())
+		to_chat(L, "You can't enter to [src].")
 		return
 
-	..()
+	if(!L.Adjacent(src))
+		to_chat(L, "You must be standing on or beside an air vent to enter it.")
+		return
+
+	L.handle_ventcrawl(src, returnPipenet())
 
 /mob/living/proc/handle_ventcrawl(obj/machinery/atmospherics/vent_found, datum/pipeline/vent_found_parent)
 	if(is_busy())

--- a/code/modules/ventcrawl/ventcrawl_atmospherics.dm
+++ b/code/modules/ventcrawl/ventcrawl_atmospherics.dm
@@ -85,10 +85,10 @@
 /obj/machinery/atmospherics/components/binary/valve/can_crawl_through()
 	return open
 
-/obj/machinery/atmospherics/proc/can_enter_to()
-	return TRUE
+/obj/machinery/atmospherics/proc/suitable_for_ventcrawl()
+	return FALSE
 
-/obj/machinery/atmospherics/pipe/can_enter_to()
+/obj/machinery/atmospherics/pipe/suitable_for_ventcrawl()
 	var/connections = 0	//count the number of pipes connected
 	for(var/node in nodes)
 		if(!node)
@@ -98,7 +98,7 @@
 		return	FALSE//This means that there are no free holes and we cannot get into the pipe.
 	return TRUE
 
-/obj/machinery/atmospherics/components/can_enter_to()
+/obj/machinery/atmospherics/components/suitable_for_ventcrawl()
 	return can_crawl_through()
 
 /obj/machinery/atmospherics/proc/findConnecting(direction)

--- a/code/modules/ventcrawl/ventcrawl_atmospherics.dm
+++ b/code/modules/ventcrawl/ventcrawl_atmospherics.dm
@@ -85,6 +85,22 @@
 /obj/machinery/atmospherics/components/binary/valve/can_crawl_through()
 	return open
 
+/obj/machinery/atmospherics/proc/can_enter_to()
+	return TRUE
+
+/obj/machinery/atmospherics/pipe/can_enter_to()
+	var/connections = 0	//count the number of pipes connected
+	for(var/node in nodes)
+		if(!node)
+			continue
+		connections++
+	if(connections == device_type)
+		return	FALSE//This means that there are no free holes and we cannot get into the pipe.
+	return TRUE
+
+/obj/machinery/atmospherics/components/can_enter_to()
+	return can_crawl_through()
+
 /obj/machinery/atmospherics/proc/findConnecting(direction)
 	for(var/obj/machinery/atmospherics/target in get_step(src, direction))
 		if(target.initialize_directions & get_dir(target, src))


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Снова лезу в код венткравла ))
Пришлось значительно переписать код входа в вентиляцию для того чтобы дать возможность залезать в неё через трубы. Потестил, всё работает, вроде ничего не сломал.
<details> 
  <summary>Гифка</summary>
  <img src="https://user-images.githubusercontent.com/58528255/115615059-bc4cd480-a2ee-11eb-9d2a-f60311b8352d.gif">
</details>

## Почему и что этот ПР улучшит
Хитрожопые космонавты откручивают трубы, чтобы ксеноморфы не могли по ним ползать. Теперь это будет не так выгодно. Да и вообще, через вент памп и скраббер залезть можно, а через трубу нельзя - странно...
## Авторство
я
## Чеинжлог
:cl: Ahio
 - tweak: В вентиляцию можно залезать через трубы.