### PR TITLE
Админы на раунд (one day admins)

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -56,6 +56,10 @@
 
 #define R_HOST			65535
 
+#define ADMIN_RANK_ROUND   "Temporary Round Admin"
+#define ADMIN_RANK_SANDBOX "Sandbox Admin"
+#define ADMIN_RANK_REMOVED "Removed"
+
 #define ADMIN_QUE(user) "(<a href='?_src_=holder;adminmoreinfo=\ref[user]'>?</a>)"
 #define ADMIN_FLW(target) "(<a href='?_src_=holder;adminplayerobservefollow=\ref[target]'>FLW</a>)"
 #define ADMIN_JMP(target) "(<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[target.x];Y=[target.y];Z=[target.z]'>JMP</a>)"

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -24,7 +24,7 @@ var/list/admin_ranks = list()								//list of all ranks with associated rights
 		switch(rank)
 			if(null,"")
 				continue
-			if("Removed")
+			if(ADMIN_RANK_REMOVED)
 				continue				//Reserved
 
 		var/rights = 0
@@ -114,7 +114,7 @@ var/list/admin_ranks = list()								//list of all ranks with associated rights
 		while(query.NextRow())
 			var/ckey = query.item[1]
 			var/rank = query.item[2]
-			if(rank == "Removed")
+			if(rank == ADMIN_RANK_REMOVED)
 				continue	//This person was de-adminned. They are only in the admin list for archive purposes.
 
 			var/rights = query.item[4]

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -195,6 +195,7 @@ var/list/admin_verbs_permissions = list(
 	/client/proc/library_debug_read,
 	/client/proc/regisration_panic_bunker,
 	/client/proc/host_announcements,
+	/client/proc/add_round_admin,
 	)
 var/list/admin_verbs_rejuv = list(
 	/client/proc/cmd_admin_rejuvenate,

--- a/code/modules/admin/permissionverbs/permissionedit.dm
+++ b/code/modules/admin/permissionverbs/permissionedit.dm
@@ -344,7 +344,7 @@ var elements = document.getElementsByName('rights');
 		return
 
 	if(!target.holder)
-		var/confirm = alert("You want to grant permissions for [target.ckey], are you sure?", "Confirmation", "Yes", "No")
+		var/confirm = tgui_alert(usr, "You want to grant permissions for [target.ckey], are you sure?", "Confirmation", list("Yes", "No"))
 		if (confirm != "Yes")
 			return
 

--- a/code/modules/admin/permissionverbs/permissionedit.dm
+++ b/code/modules/admin/permissionverbs/permissionedit.dm
@@ -87,6 +87,7 @@
 			return
 		admin_datums -= adm_ckey
 		D.disassociate()
+		change_permissions(adm_ckey, 0)
 		db_admin_rank_modification(adm_ckey, ADMIN_RANK_REMOVED)
 		message_admins("[key_name_admin(usr)] removed [adm_ckey] from the admins list")
 		log_admin("[key_name(usr)] removed [adm_ckey] from the admins list")
@@ -113,7 +114,7 @@
 			return
 		if("*New Rank*")
 			new_rank = sanitize(input("Please input a new rank", "New custom rank", null, null) as null|text)
-			if(!new_rank)
+			if(!new_rank || (new_rank in list(ADMIN_RANK_ROUND, ADMIN_RANK_SANDBOX, ADMIN_RANK_REMOVED)))
 				to_chat(usr, "<span class='alert'>Error: Topic 'editrights': Invalid rank</span>")
 				return
 	if(D)
@@ -215,7 +216,7 @@ var elements = document.getElementsByName('rights');
 	var/admin_id
 	while(select_query.NextRow())
 		admin_id = text2num(select_query.item[1])
-	if(!admin_id)
+	if(!admin_id) // also prevents changes to sandbox and round admins
 		return
 	var/DBQuery/insert_query = dbcon.NewQuery("UPDATE `erro_admin` SET flags = [new_rights] WHERE id = [admin_id]")
 	insert_query.Execute()
@@ -302,8 +303,10 @@ var elements = document.getElementsByName('rights');
 		return
 	if(!istext(adm_ckey) || !istext(new_rank))
 		return
-	if(new_rank in list(ADMIN_RANK_ROUND, ADMIN_RANK_SANDBOX, ADMIN_RANK_REMOVED))
-		to_chat(usr, "<span class='alert'>You can not edit special admin rank [new_rank]!</span>")
+
+	var/datum/admins/D = admin_datums[adm_ckey]
+	if(D.rank in list(ADMIN_RANK_ROUND, ADMIN_RANK_SANDBOX))
+		to_chat(usr, "<span class='alert'>You can not edit special rank [D.rank]!</span>")
 		return
 
 	var/DBQuery/select_query = dbcon.NewQuery("SELECT id FROM erro_admin WHERE ckey = '[adm_ckey]'")

--- a/code/modules/admin/permissionverbs/permissionedit.dm
+++ b/code/modules/admin/permissionverbs/permissionedit.dm
@@ -356,7 +356,7 @@ var elements = document.getElementsByName('rights');
 		log_admin("[key_name(usr)] added [key_name(target)] to the admins list as [ADMIN_RANK_ROUND]")
 
 	else if(target.holder && target.holder.rank == ADMIN_RANK_ROUND)
-		var/confirm = alert("You want to remove [ADMIN_RANK_ROUND] permissions from [target.ckey], are you sure?", "Confirmation", "Yes", "No")
+		var/confirm = tgui_alert(usr, "You want to remove [ADMIN_RANK_ROUND] permissions from [target.ckey], are you sure?", "Confirmation", list("Yes", "No"))
 		if (confirm != "Yes")
 			return
 

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -230,7 +230,7 @@ var/list/blacklisted_builds = list(
 	if(config.sandbox)
 		var/sandbox_permissions = (R_HOST & ~(R_PERMISSIONS | R_DEBUG | R_BAN | R_LOG))
 		if(!holder)
-			new /datum/admins("Sandbox Admin", sandbox_permissions, ckey)
+			new /datum/admins(ADMIN_RANK_SANDBOX, sandbox_permissions, ckey)
 			holder = admin_datums[ckey]
 		else
 			holder.rights = (holder.rights | sandbox_permissions)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений

Возможность назначить админа на раунд, без записи в базу. Необходимо для "Админ на день", и может в целом будет полезно.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
