### PR TITLE
Bunker pass for mentors

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -70,6 +70,7 @@ var/list/net_announcer_secret = list()
 	var/allowed_by_bunker_player_age = 60
 	var/client_limit_panic_bunker_count = null
 	var/client_limit_panic_bunker_link = null
+	var/client_limit_panic_bunker_mentor_pass_cap = 3
 
 	var/cult_ghostwriter = 1               //Allows ghosts to write in blood in cult rounds...
 	var/cult_ghostwriter_req_cultists = 9  //...so long as this many cultists are active.
@@ -636,6 +637,9 @@ var/list/net_announcer_secret = list()
 
 				if("client_limit_panic_bunker_count")
 					config.client_limit_panic_bunker_count = text2num(value)
+				
+				if("client_limit_panic_bunker_mentor_pass_cap")
+					config.client_limit_panic_bunker_mentor_pass_cap = text2num(value)
 
 				if("client_limit_panic_bunker_link")
 					config.client_limit_panic_bunker_link = value

--- a/code/modules/admin/permissionverbs/permissionedit.dm
+++ b/code/modules/admin/permissionverbs/permissionedit.dm
@@ -244,7 +244,8 @@ var elements = document.getElementsByName('rights');
 	if(ment_ckey in admin_datums)
 		remove_admin(ment_ckey)
 	mentor_ckeys += ment_ckey
-	mentors += directory[ment_ckey]
+	if(directory[ment_ckey])
+		mentors += directory[ment_ckey]
 	message_admins("[key_name_admin(usr)] added [ment_ckey] to the mentors list")
 	log_admin("[key_name(usr)] added [ment_ckey] to the mentors list")
 

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -344,7 +344,9 @@ var/list/blacklisted_builds = list(
 
 /client/proc/handle_autokick_reasons()
 	if(config.client_limit_panic_bunker_count != null)
-		if(!(ckey in admin_datums) && !supporter && (clients.len > config.client_limit_panic_bunker_count) && !(ckey in joined_player_list))
+		if(!(ckey in admin_datums) && !supporter && (clients.len > config.client_limit_panic_bunker_count) && !(ckey in joined_player_list) && \
+			!((ckey in mentor_ckeys) && length(mentors) <= config.client_limit_panic_bunker_mentor_pass_cap))
+
 			if (config.client_limit_panic_bunker_link)
 				to_chat(src, "<span class='notice'>Player limit is enabled. You are redirected to [config.client_limit_panic_bunker_link].</span>")
 				SEND_LINK(src, config.client_limit_panic_bunker_link)

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -344,18 +344,32 @@ var/list/blacklisted_builds = list(
 
 /client/proc/handle_autokick_reasons()
 	if(config.client_limit_panic_bunker_count != null)
-		if(!(ckey in admin_datums) && !supporter && (clients.len > config.client_limit_panic_bunker_count) && !(ckey in joined_player_list) && \
-			!((ckey in mentor_ckeys) && length(mentors) <= config.client_limit_panic_bunker_mentor_pass_cap))
 
-			if (config.client_limit_panic_bunker_link)
-				to_chat(src, "<span class='notice'>Player limit is enabled. You are redirected to [config.client_limit_panic_bunker_link].</span>")
-				SEND_LINK(src, config.client_limit_panic_bunker_link)
-				log_access("Failed Login: [key] [computer_id] [address] - redirected by limit bunker to [config.client_limit_panic_bunker_link]")
-			else
-				to_chat(src, "<span class='danger'>Sorry, player limit is enabled. Try to connect later.</span>")
-				log_access("Failed Login: [key] [computer_id] [address] - blocked by panic bunker")
-				QDEL_IN(src, 2 SECONDS)
-			return
+		if(clients.len > config.client_limit_panic_bunker_count)
+			var/blocked_by_bunker = TRUE
+
+			if(ckey in admin_datums) // admins immune to bunker
+				blocked_by_bunker = FALSE
+
+			if(supporter) // and patrons
+				blocked_by_bunker = FALSE
+
+			if(ckey in joined_player_list) // player already joined the game and just reconnects, so we pass him
+				blocked_by_bunker = FALSE
+
+			if((ckey in mentor_ckeys) && length(mentors) <= config.client_limit_panic_bunker_mentor_pass_cap) // mentors immune too, but only before own cap 
+				blocked_by_bunker = FALSE
+
+			if(blocked_by_bunker)
+				if (config.client_limit_panic_bunker_link)
+					to_chat(src, "<span class='notice'>Player limit is enabled. You are redirected to [config.client_limit_panic_bunker_link].</span>")
+					SEND_LINK(src, config.client_limit_panic_bunker_link)
+					log_access("Failed Login: [key] [computer_id] [address] - redirected by limit bunker to [config.client_limit_panic_bunker_link]")
+				else
+					to_chat(src, "<span class='danger'>Sorry, player limit is enabled. Try to connect later.</span>")
+					log_access("Failed Login: [key] [computer_id] [address] - blocked by panic bunker")
+					QDEL_IN(src, 2 SECONDS)
+				return
 
 	if(config.registration_panic_bunker_age)
 		if(!(ckey in admin_datums) && !(src in mentors) && is_blocked_by_regisration_panic_bunker())

--- a/code/modules/mentor/mentor.dm
+++ b/code/modules/mentor/mentor.dm
@@ -17,7 +17,8 @@
 					continue
 				var/ckey = copytext(line, 1)
 				mentor_ckeys += ckey
-				mentors += directory[ckey]
+				if(directory[ckey])
+					mentors += directory[ckey]
 	else
 		establish_db_connection()
 		if(!dbcon.IsConnected())
@@ -31,7 +32,8 @@
 		while(query.NextRow())
 			var/ckey = query.item[1]
 			mentor_ckeys += ckey
-			mentors += directory[ckey]
+			if(directory[ckey])
+				mentors += directory[ckey]
 
 /proc/message_mentors(msg, observer_only = 0)
 	msg = "<span class=\"admin\"><span class=\"prefix\">MENTOR LOG:</span> <span class=\"message\">[msg]</span></span>"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений

Пропуск менторам на бункер.
Исправлена ошибка со счетом "активных" менторов - из-за ошибки в инициализации сервер считал активными всех возможных менторов из базы данных.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог

:cl:
 - tweak: Менторам добавлен пропуск мимо бункера, но только если на сервере меньше 3 менторов.