### PR TITLE
Индивидуальные проверки на наличие таблиц в бд

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -28,6 +28,11 @@
 #define BANTYPE_ANY_FULLBAN_STR	"ANY"
 #define BANTYPE_ANY_JOB_STR		"ANYJOB"
 
+#define STICKYBAN_TABLENAME "erro_stickyban"
+#define STICKYBAN_CKEY_MATCHED_TABLENAME "erro_stickyban_matched_ckey"
+#define STICKYBAN_CID_MATCHED_TABLENAME "erro_stickyban_matched_cid"
+#define STICKYBAN_IP_MATCHED_TABLENAME "erro_stickyban_matched_ip"
+
 //Please don't edit these values without speaking to Errorage first	~Carn
 //Admin Permissions
 #define R_BUILDMODE		1

--- a/code/controllers/subsystem/stickyban.dm
+++ b/code/controllers/subsystem/stickyban.dm
@@ -1,8 +1,3 @@
-#define STICKYBAN_TABLENAME "erro_stickyban"
-#define STICKYBAN_CKEY_MATCHED_TABLENAME "erro_stickyban_matched_ckey"
-#define STICKYBAN_CID_MATCHED_TABLENAME "erro_stickyban_matched_cid"
-#define STICKYBAN_IP_MATCHED_TABLENAME "erro_stickyban_matched_ip"
-
 SUBSYSTEM_DEF(stickyban)
 	name = "PRISM"
 
@@ -35,7 +30,7 @@ SUBSYSTEM_DEF(stickyban)
 	// Delete bans that no longer exist in the database
 	// and add new bans to the database
 	// Config => DB && remove expired DB stickyban from Config
-	if (establish_db_connection() || length(dbcache))
+	if (establish_db_connection(STICKYBAN_TABLENAME, STICKYBAN_CKEY_MATCHED_TABLENAME, STICKYBAN_CID_MATCHED_TABLENAME, STICKYBAN_IP_MATCHED_TABLENAME) || length(dbcache))
 		if (length(global.stickyban_admin_exemptions))
 			restore_stickybans()
 		// Checking new bans from Config
@@ -76,7 +71,7 @@ SUBSYSTEM_DEF(stickyban)
 
 /datum/controller/subsystem/stickyban/proc/get_cached_sticky_banned_ckeys()
 	// Return list of stickybaned ckeys form DBcache or null. Update dbcache on timer
-	if (establish_db_connection() || length(dbcache))
+	if (establish_db_connection(STICKYBAN_TABLENAME, STICKYBAN_CKEY_MATCHED_TABLENAME, STICKYBAN_CID_MATCHED_TABLENAME, STICKYBAN_IP_MATCHED_TABLENAME) || length(dbcache))
 		populate_expired_dbcache()
 		// Is dbcache initilized?
 		if (dbcache_expire)
@@ -85,7 +80,7 @@ SUBSYSTEM_DEF(stickyban)
 /datum/controller/subsystem/stickyban/proc/get_dbcached_stickyban(ckey)
 	// Return stickyban, if have it in DB or DBcache. Update dbcache on timer
 	var/list/stickyban_record = list()
-	if ((establish_db_connection()) || length(dbcache))
+	if ((establish_db_connection(STICKYBAN_TABLENAME, STICKYBAN_CKEY_MATCHED_TABLENAME, STICKYBAN_CID_MATCHED_TABLENAME, STICKYBAN_IP_MATCHED_TABLENAME)) || length(dbcache))
 		populate_expired_dbcache()
 		// Is dbcache initilized?
 		if (dbcache_expire)
@@ -112,7 +107,7 @@ SUBSYSTEM_DEF(stickyban)
 	// Load DBcache from DB
 
 	var/list/new_dbcache = list() //so if we runtime or the db connection dies we don't kill the existing cache
-	if (!establish_db_connection())
+	if (!establish_db_connection(STICKYBAN_TABLENAME, STICKYBAN_CKEY_MATCHED_TABLENAME, STICKYBAN_CID_MATCHED_TABLENAME, STICKYBAN_IP_MATCHED_TABLENAME))
 		return
 
 	var/DBQuery/query_stickybans = dbcon.NewQuery("SELECT ckey, reason, banning_admin, datetime FROM [STICKYBAN_TABLENAME] ORDER BY ckey")
@@ -220,7 +215,7 @@ SUBSYSTEM_DEF(stickyban)
 	if (!ban[BANKEY_MSG])
 		ban[BANKEY_MSG] = "Evasion"
 
-	if (!establish_db_connection())
+	if (!establish_db_connection(STICKYBAN_TABLENAME, STICKYBAN_CKEY_MATCHED_TABLENAME, STICKYBAN_CID_MATCHED_TABLENAME, STICKYBAN_IP_MATCHED_TABLENAME))
 		return
 	var/DBQuery/query_create_stickyban = dbcon.NewQuery({"INSERT IGNORE INTO [STICKYBAN_TABLENAME]
 		(ckey, reason, banning_admin)
@@ -268,17 +263,17 @@ SUBSYSTEM_DEF(stickyban)
 			sqlips[++sqlips.len] = sqlip
 
 	// Execute prepared mass insert
-	if (length(sqlckeys) && establish_db_connection())
+	if (length(sqlckeys) && establish_db_connection(STICKYBAN_TABLENAME, STICKYBAN_CKEY_MATCHED_TABLENAME, STICKYBAN_CID_MATCHED_TABLENAME, STICKYBAN_IP_MATCHED_TABLENAME))
 		var/DBQuery/matched_ckey_query = dbcon.NewMassInsertQuery(STICKYBAN_CKEY_MATCHED_TABLENAME, sqlckeys, FALSE, TRUE)
 		if (matched_ckey_query)
 			matched_ckey_query.Execute()
 
-	if (length(sqlcids) && establish_db_connection())
+	if (length(sqlcids) && establish_db_connection(STICKYBAN_TABLENAME, STICKYBAN_CKEY_MATCHED_TABLENAME, STICKYBAN_CID_MATCHED_TABLENAME, STICKYBAN_IP_MATCHED_TABLENAME))
 		var/DBQuery/matched_cid_query = dbcon.NewMassInsertQuery(STICKYBAN_CID_MATCHED_TABLENAME, sqlcids, FALSE, TRUE)
 		if (matched_cid_query)
 			matched_cid_query.Execute()
 
-	if (length(sqlips) && establish_db_connection())
+	if (length(sqlips) && establish_db_connection(STICKYBAN_TABLENAME, STICKYBAN_CKEY_MATCHED_TABLENAME, STICKYBAN_CID_MATCHED_TABLENAME, STICKYBAN_IP_MATCHED_TABLENAME))
 		var/DBQuery/matched_ip_query = dbcon.NewMassInsertQuery(STICKYBAN_IP_MATCHED_TABLENAME, sqlips, FALSE, TRUE)
 		if (matched_ip_query)
 			matched_ip_query.Execute()
@@ -288,7 +283,7 @@ SUBSYSTEM_DEF(stickyban)
 /datum/controller/subsystem/stickyban/proc/remove(ckey)
 	// Drop stickyban record from all
 	if (ckey)
-		if (establish_db_connection())
+		if (establish_db_connection(STICKYBAN_TABLENAME, STICKYBAN_CKEY_MATCHED_TABLENAME, STICKYBAN_CID_MATCHED_TABLENAME, STICKYBAN_IP_MATCHED_TABLENAME))
 			var/sanitized_ckey = ckey(ckey)
 			if (length(sanitized_ckey))
 				var/list/sql_q = list(
@@ -316,7 +311,7 @@ SUBSYSTEM_DEF(stickyban)
 			cache[ckey] = ban
 			var/sanitized_ckey = sanitize_sql(ckey)
 			var/sanitized_alt_ckey = sanitize_sql(altckey)
-			if (length(sanitized_ckey) && length(sanitized_alt_ckey) && establish_db_connection())
+			if (length(sanitized_ckey) && length(sanitized_alt_ckey) && establish_db_connection(STICKYBAN_TABLENAME, STICKYBAN_CKEY_MATCHED_TABLENAME, STICKYBAN_CID_MATCHED_TABLENAME, STICKYBAN_IP_MATCHED_TABLENAME))
 				var/DBQuery/query = dbcon.NewQuery("DELETE FROM [STICKYBAN_CKEY_MATCHED_TABLENAME] WHERE stickyban = '[sanitized_ckey]' AND matched_ckey = '[sanitized_alt_ckey]'")
 				if (query)
 					query.Execute()
@@ -330,7 +325,7 @@ SUBSYSTEM_DEF(stickyban)
 		if (length(ban))
 			ban[BANKEY_MSG] = "[reason]"
 			var/santinized_ckey = sanitize_sql(ckey)
-			if (santinized_ckey && establish_db_connection())
+			if (santinized_ckey && establish_db_connection(STICKYBAN_TABLENAME, STICKYBAN_CKEY_MATCHED_TABLENAME, STICKYBAN_CID_MATCHED_TABLENAME, STICKYBAN_IP_MATCHED_TABLENAME))
 				var/DBQuery/query_update = dbcon.NewQuery("UPDATE [STICKYBAN_TABLENAME] SET reason = '[sanitize_sql(reason)]' WHERE ckey = '[santinized_ckey]'")
 				if (query_update)
 					query_update.Execute()
@@ -352,7 +347,7 @@ SUBSYSTEM_DEF(stickyban)
 			world.SetConfig("ban", ckey, list2stickyban(ban))
 			cache[ckey] = ban
 			// Update DB if can
-			if (establish_db_connection())
+			if (establish_db_connection(STICKYBAN_TABLENAME, STICKYBAN_CKEY_MATCHED_TABLENAME, STICKYBAN_CID_MATCHED_TABLENAME, STICKYBAN_IP_MATCHED_TABLENAME))
 				var/sanitized_ckey = sanitize_sql(ckey)
 				var/sanitized_alt_ckey = sanitize_sql(altckey)
 				if (sanitized_ckey && sanitized_alt_ckey)
@@ -375,7 +370,7 @@ SUBSYSTEM_DEF(stickyban)
 			world.SetConfig("ban", ckey, list2stickyban(ban))
 			cache[ckey] = ban
 			// Update DB if can
-			if (establish_db_connection())
+			if (establish_db_connection(STICKYBAN_TABLENAME, STICKYBAN_CKEY_MATCHED_TABLENAME, STICKYBAN_CID_MATCHED_TABLENAME, STICKYBAN_IP_MATCHED_TABLENAME))
 				var/sanitized_ckey = sanitize_sql(ckey)
 				var/sanitized_alt_ckey = sanitize_sql(altckey)
 				if (sanitized_ckey && sanitized_alt_ckey)
@@ -424,7 +419,7 @@ SUBSYSTEM_DEF(stickyban)
 	// Updates matches tables
 	// If matched address, ckey or cid found, update last_matched column in DB
 
-	if(establish_db_connection())
+	if(establish_db_connection(STICKYBAN_TABLENAME, STICKYBAN_CKEY_MATCHED_TABLENAME, STICKYBAN_CID_MATCHED_TABLENAME, STICKYBAN_IP_MATCHED_TABLENAME))
 		var/list/ckey_match_row = list(
 			"stickyban" = "'[sanitize_sql(ckey)]'",
 			"matched_ckey" = "'[sanitize_sql(matched_ckey)]'")
@@ -532,8 +527,3 @@ SUBSYSTEM_DEF(stickyban)
 	buffer -= BANKEY_ADMIN_MATCHES_THIS_ROUND
 	buffer -= BANKEY_PENDING_MATCHES
 	return list2params(buffer)
-
-#undef STICKYBAN_TABLENAME
-#undef STICKYBAN_CKEY_MATCHED_TABLENAME
-#undef STICKYBAN_CID_MATCHED_TABLENAME
-#undef STICKYBAN_IP_MATCHED_TABLENAME

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -114,7 +114,7 @@ SUBSYSTEM_DEF(ticker)
 					if(blackbox)
 						blackbox.save_all_data_to_sql()
 
-					if(dbcon.IsConnected())
+					if(establish_db_connection("erro_round"))
 						var/DBQuery/query_round_game_mode = dbcon.NewQuery("UPDATE erro_round SET end_datetime = Now(), game_mode_result = '[sanitize_sql(mode.mode_result)]' WHERE id = [global.round_id]")
 						query_round_game_mode.Execute()
 
@@ -230,7 +230,7 @@ SUBSYSTEM_DEF(ticker)
 	round_start_time = world.time
 	round_start_realtime = world.realtime
 
-	if(dbcon.IsConnected())
+	if(establish_db_connection("erro_round"))
 		var/DBQuery/query_round_game_mode = dbcon.NewQuery("UPDATE erro_round SET start_datetime = Now(), map_name = '[sanitize_sql(SSmapping.config.map_name)]' WHERE id = [global.round_id]")
 		query_round_game_mode.Execute()
 

--- a/code/defines/procs/dbcore.dm
+++ b/code/defines/procs/dbcore.dm
@@ -150,8 +150,8 @@
 
 	table_name = sanitize_sql(table_name)
 
-	if(table_exists["table_name"] == 1)
-		return 1
+	if(table_name in table_exists)
+		return table_exists[table_name]
 
 	var/DBQuery/check_table = NewQuery("SHOW TABLES LIKE '[table_name]'")
 	check_table.Execute()

--- a/code/defines/procs/statistics.dm
+++ b/code/defines/procs/statistics.dm
@@ -30,10 +30,8 @@
 	var/sqlbrain = text2num(H.brainloss)
 	var/sqloxy = text2num(H.getOxyLoss())
 
-	establish_db_connection()
-	if(!dbcon.IsConnected())
-		log_game("SQL ERROR during death reporting. Failed to connect.")
-	else
+	
+	if(establish_db_connection("erro_death"))
 		var/DBQuery/query = dbcon.NewQuery("INSERT INTO erro_death (name, byondkey, job, special, pod, tod, laname, lakey, gender, bruteloss, fireloss, brainloss, oxyloss, coord) VALUES ('[sqlname]', '[sqlkey]', '[sqljob]', '[sqlspecial]', '[sqlpod]', '[sqltime]', '[laname]', '[lakey]', '[sqlgender]', [sqlbrute], [sqlfire], [sqlbrain], [sqloxy], '[sqlcoord]')")
 		query.Execute()
 
@@ -69,10 +67,7 @@
 	var/sqlbrain = text2num(H.brainloss)
 	var/sqloxy = text2num(H.getOxyLoss())
 
-	establish_db_connection()
-	if(!dbcon.IsConnected())
-		log_game("SQL ERROR during death reporting. Failed to connect.")
-	else
+	if(establish_db_connection("erro_death"))
 		var/DBQuery/query = dbcon.NewQuery("INSERT INTO erro_death (name, byondkey, job, special, pod, tod, laname, lakey, gender, bruteloss, fireloss, brainloss, oxyloss, coord) VALUES ('[sqlname]', '[sqlkey]', '[sqljob]', '[sqlspecial]', '[sqlpod]', '[sqltime]', '[laname]', '[lakey]', '[sqlgender]', [sqlbrute], [sqlfire], [sqlbrain], [sqloxy], '[sqlcoord]')")
 		query.Execute()
 
@@ -89,10 +84,7 @@
 		log_game("Round ended without any feedback being generated. No feedback was sent to the database.")
 		return
 
-	establish_db_connection()
-	if(!dbcon.IsConnected())
-		log_game("SQL ERROR during feedback reporting. Failed to connect.")
-	else
+	if(establish_db_connection("erro_feedback"))
 		for(var/datum/feedback_variable/item in content)
 			var/variable = item.get_variable()
 			var/value = item.get_value()

--- a/code/defines/procs/statistics.dm
+++ b/code/defines/procs/statistics.dm
@@ -30,7 +30,6 @@
 	var/sqlbrain = text2num(H.brainloss)
 	var/sqloxy = text2num(H.getOxyLoss())
 
-	
 	if(establish_db_connection("erro_death"))
 		var/DBQuery/query = dbcon.NewQuery("INSERT INTO erro_death (name, byondkey, job, special, pod, tod, laname, lakey, gender, bruteloss, fireloss, brainloss, oxyloss, coord) VALUES ('[sqlname]', '[sqlkey]', '[sqljob]', '[sqlspecial]', '[sqlpod]', '[sqltime]', '[laname]', '[lakey]', '[sqlgender]', [sqlbrute], [sqlfire], [sqlbrain], [sqloxy], '[sqlcoord]')")
 		query.Execute()

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -148,7 +148,7 @@ Implants;
 	start_state = new /datum/station_state()
 	start_state.count(1)
 
-	if(dbcon.IsConnected())
+	if(establish_db_connection("erro_round"))
 		var/DBQuery/query_round_game_mode = dbcon.NewQuery("UPDATE erro_round SET game_mode = '[sanitize_sql(SSticker.mode)]' WHERE id = [global.round_id]")
 		query_round_game_mode.Execute()
 	return 1

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -464,7 +464,7 @@ var/failed_db_connections = 0
 
 //This proc ensures that the connection to the database (global variable dbcon) is established
 //optionally you can pass table names as args to check that they exist
-/proc/establish_db_connection()
+/proc/establish_db_connection(...)
 	if(failed_db_connections > FAILED_DB_CONNECTION_CUTOFF)
 		return 0
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -14,6 +14,12 @@ var/base_commit_sha = 0
 	timezoneOffset = text2num(time2text(0, "hh")) HOURS
 
 	load_configuration()
+
+	if(!setup_database_connection())
+		log_sql("Your server failed to establish a connection with the SQL database.")
+	else
+		log_sql("SQL database connection established.")
+
 	load_regisration_panic_bunker()
 	load_stealth_keys()
 	load_mode()
@@ -49,11 +55,6 @@ var/base_commit_sha = 0
 	data_core = new /obj/effect/datacore()
 	paiController = new /datum/paiController()
 	ahelp_tickets = new
-
-	if(!setup_database_connection())
-		log_sql("Your server failed to establish a connection with the SQL database.")
-	else
-		log_sql("SQL database connection established.")
 
 	SetRoundID()
 	base_commit_sha = GetGitMasterCommit(1)

--- a/code/modules/admin/DB ban/functions.dm
+++ b/code/modules/admin/DB ban/functions.dm
@@ -5,8 +5,7 @@
 	if(!check_rights(R_BAN))
 		return
 
-	establish_db_connection()
-	if(!dbcon.IsConnected())
+	if(!establish_db_connection("erro_ban", "erro_player"))
 		return
 
 	var/serverip = sanitize_sql("[world.internet_address]:[world.port]")
@@ -143,8 +142,7 @@
 	if(job)
 		sql += " AND job = '[sanitize_sql(job)]'"
 
-	establish_db_connection()
-	if(!dbcon.IsConnected())
+	if(!establish_db_connection("erro_ban"))
 		return
 
 	var/ban_id
@@ -256,8 +254,7 @@
 
 	var/sql = "SELECT ckey FROM erro_ban WHERE id = [id]"
 
-	establish_db_connection()
-	if(!dbcon.IsConnected())
+	if(!establish_db_connection("erro_ban"))
 		return
 
 	var/ban_number = 0 //failsafe
@@ -315,8 +312,7 @@
 
 	if(!check_rights(R_BAN))	return
 
-	establish_db_connection()
-	if(!dbcon.IsConnected())
+	if(!establish_db_connection("erro_ban"))
 		to_chat(usr, "<span class='warning'>Failed to establish database connection</span>")
 		return
 
@@ -513,8 +509,7 @@
 
 //Version of DB_ban_record that can be used without holder.
 /proc/DB_ban_record_2(bantype, mob/banned_mob, duration = -1, reason, job = "", banckey = null, banip = null, bancid = null)
-	establish_db_connection()
-	if(!dbcon.IsConnected())
+	if(!establish_db_connection("erro_player"))
 		return
 
 	var/serverip = sanitize_sql("[world.internet_address]:[world.port]")

--- a/code/modules/admin/IsBanned.dm
+++ b/code/modules/admin/IsBanned.dm
@@ -52,7 +52,7 @@
 
 	// Database ban system
 	else
-		if(!establish_db_connection())
+		if(!establish_db_connection("erro_ban"))
 			error("Ban database connection failure. Key [ckey] not checked")
 			log_misc("Ban database connection failure. Key [ckey] not checked")
 			return

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -224,7 +224,7 @@ var/global/BSACooldown = 0
 	if(!key || !config.sql_enabled)
 		return
 
-	if(!establish_db_connection())
+	if(!establish_db_connection("erro_messages", "erro_ban"))
 		usr.show_message("Notes [key] from DB don't available.")
 		return
 

--- a/code/modules/admin/admin_ranks.dm
+++ b/code/modules/admin/admin_ranks.dm
@@ -102,8 +102,7 @@ var/list/admin_ranks = list()								//list of all ranks with associated rights
 	else
 		//The current admin system uses SQL
 
-		establish_db_connection()
-		if(!dbcon.IsConnected())
+		if(!establish_db_connection("erro_admin"))
 			error("Failed to connect to database in load_admins(). Reverting to legacy system.")
 			log_misc("Failed to connect to database in load_admins(). Reverting to legacy system.")
 			config.admin_legacy_system = 1

--- a/code/modules/admin/permissionverbs/permissionedit.dm
+++ b/code/modules/admin/permissionverbs/permissionedit.dm
@@ -204,8 +204,7 @@ var elements = document.getElementsByName('rights');
 		message_admins("[key_name_admin(usr)] removed[removed_rights] permissions of [adm_ckey]")
 		log_admin("[key_name(usr)] removed[removed_rights] permission of [adm_ckey]")
 
-	establish_db_connection()
-	if(!dbcon.IsConnected())
+	if(!establish_db_connection("erro_admin", "erro_admin_log"))
 		to_chat(usr, "<span class='alert'>Failed to establish database connection</span>")
 		return
 	adm_ckey = ckey(adm_ckey)
@@ -249,8 +248,7 @@ var elements = document.getElementsByName('rights');
 	message_admins("[key_name_admin(usr)] added [ment_ckey] to the mentors list")
 	log_admin("[key_name(usr)] added [ment_ckey] to the mentors list")
 
-	establish_db_connection()
-	if(!dbcon.IsConnected())
+	if(!establish_db_connection("erro_mentor", "erro_admin_log"))
 		to_chat(usr, "<span class='alert'>Failed to establish database connection</span>")
 		return
 	ment_ckey = ckey(ment_ckey)
@@ -275,8 +273,7 @@ var elements = document.getElementsByName('rights');
 		message_admins("[key_name_admin(usr)] removed [ment_ckey] from the mentors list")
 		log_admin("[key_name(usr)] removed [ment_ckey] from the mentors list")
 
-		establish_db_connection()
-		if(!dbcon.IsConnected())
+		if(!establish_db_connection("erro_mentor", "erro_admin_log"))
 			to_chat(usr, "<span class='alert'>Failed to establish database connection</span>")
 			return
 		ment_ckey = ckey(ment_ckey)
@@ -295,8 +292,7 @@ var elements = document.getElementsByName('rights');
 	if(!usr.client.holder || !(usr.client.holder.rights & R_PERMISSIONS))
 		to_chat(usr, "<span class='alert'>You do not have permission to do this!</span>")
 		return
-	establish_db_connection()
-	if(!dbcon.IsConnected())
+	if(!establish_db_connection("erro_admin", "erro_admin_log"))
 		to_chat(usr, "<span class='alert'>Failed to establish database connection</span>")
 		return
 	if(!adm_ckey || !new_rank)

--- a/code/modules/admin/player_notes.dm
+++ b/code/modules/admin/player_notes.dm
@@ -8,8 +8,8 @@
 	if(!(check_rights(R_LOG) && check_rights(R_BAN)))
 		return
 
-	establish_db_connection()
-	if(!dbcon.IsConnected())
+	
+	if(!establish_db_connection("erro_messages"))
 		return
 
 	var/admin_key = admin ? ckey(admin.ckey) : "Adminbot"

--- a/code/modules/admin/server_whitelist.dm
+++ b/code/modules/admin/server_whitelist.dm
@@ -2,7 +2,7 @@
 
 //return 1, if player in server db, or 0
 /proc/check_if_a_new_player(key)
-	if(!establish_db_connection())
+	if(!establish_db_connection("erro_player"))
 		world.log << "Ban database connection failure. Key [key] not checked"
 		log_debug("Ban database connection failure. Key [key] not checked")
 		return 1
@@ -28,8 +28,7 @@
 	if(!config.serverwhitelist)
 		return
 
-	establish_db_connection()
-	if(!dbcon.IsConnected())
+	if(!establish_db_connection("erro_player"))
 		to_chat(usr, "<span class='warning'>Failed to establish database connection</span>")
 		return
 

--- a/code/modules/admin/stickyban.dm
+++ b/code/modules/admin/stickyban.dm
@@ -179,7 +179,7 @@
 /datum/admins/proc/stickyban_timeout(ckey)
 	if (!ckey)
 		return
-	if (!establish_db_connection())
+	if (!establish_db_connection(STICKYBAN_TABLENAME, STICKYBAN_CKEY_MATCHED_TABLENAME, STICKYBAN_CID_MATCHED_TABLENAME, STICKYBAN_IP_MATCHED_TABLENAME))
 		to_chat(usr, "<span class='adminnotice'>No database connection!</span>")
 		return
 	if (alert("Are you sure you want to put [ckey]'s stickyban on timeout until next round (or removed)?","Are you sure","Yes","No") == "No")
@@ -195,7 +195,7 @@
 /datum/admins/proc/stickyban_untimeout(ckey)
 	if (!ckey)
 		return
-	if (!establish_db_connection())
+	if (!establish_db_connection(STICKYBAN_TABLENAME, STICKYBAN_CKEY_MATCHED_TABLENAME, STICKYBAN_CID_MATCHED_TABLENAME, STICKYBAN_IP_MATCHED_TABLENAME))
 		to_chat(usr, "<span class='adminnotice'>No database connection!</span>")
 		return
 	if (alert("Are you sure you want to lift the timeout on [ckey]'s stickyban?","Are you sure","Yes","No") == "No")
@@ -228,8 +228,8 @@
 		return
 	var/src_href = "_src_=holder"
 	var/disable_link = "<a href='?[src_href];stickyban=revert&ckey=[ckey]'>Revert</a>"
-	establish_db_connection()
-	if(dbcon && dbcon.IsConnected())
+	
+	if(establish_db_connection(STICKYBAN_TABLENAME, STICKYBAN_CKEY_MATCHED_TABLENAME, STICKYBAN_CID_MATCHED_TABLENAME, STICKYBAN_IP_MATCHED_TABLENAME))
 		disable_link = "<a href='?[src_href];stickyban=[(ban[BANKEY_TIMEOUT] ? "untimeout" : "timeout")]&ckey=[ckey]'>[ban[BANKEY_TIMEOUT] ? "Untimeout" : "Timeout"]</a>"
 	var/remove_link = "<a href='?[src_href];stickyban=remove&ckey=[ckey]'>-</a>"
 	var/edit_link = "<b><a href='?[src_href];stickyban=edit&ckey=[ckey]'>Edit</a></b>"

--- a/code/modules/admin/verbs/getlogs.dm
+++ b/code/modules/admin/verbs/getlogs.dm
@@ -85,7 +85,7 @@
 
 /client/proc/browseserverlogs_id(subpath = "")
 
-	if(!dbcon.IsConnected())
+	if(!establish_db_connection("erro_round"))
 		to_chat(usr, "<span class='alert'>Database connection required</span>")
 		return
 

--- a/code/modules/admin/verbs/library.dm
+++ b/code/modules/admin/verbs/library.dm
@@ -3,8 +3,7 @@
 	set name = "Library: Remove by id"
 	if(!check_rights(R_DEBUG))	return
 
-	establish_db_connection()
-	if(!dbcon.IsConnected())
+	if(!establish_db_connection("erro_library"))
 		to_chat(usr, "BD POTRACHENO")
 		return
 
@@ -37,8 +36,7 @@
 	set name = "Library: Read by id"
 	if(!check_rights(R_DEBUG))	return
 
-	establish_db_connection()
-	if(!dbcon.IsConnected())
+	if(!establish_db_connection("erro_library"))
 		to_chat(usr, "BD POTRACHENO")
 		return
 
@@ -67,8 +65,7 @@
 	set category = "Admin"
 	set name = "Library: Recycle bin"
 
-	establish_db_connection()
-	if(!dbcon.IsConnected())
+	if(!establish_db_connection("erro_library"))
 		to_chat(usr, "Database is not connected.")
 		return
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1160,7 +1160,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	if(!check_rights(R_VAREDIT))
 		return
 
-	if(!dbcon.IsConnected())
+	if(!establish_db_connection("erro_player"))
 		return
 
 	var/ckey = ckey(input("Enter player ckey") as null|text)

--- a/code/modules/admin/whitelist.dm
+++ b/code/modules/admin/whitelist.dm
@@ -172,8 +172,7 @@
 			to_chat(usr, "<span class='warning'>[role] for [target_ckey] already exists in whitelist.</span>")
 		return FALSE
 
-	establish_db_connection()
-	if(!dbcon.IsConnected())
+	if(!establish_db_connection("erro_whitelist"))
 		if(!added_by_bot)
 			to_chat(usr, "<span class='warning'>Failed to establish database connection.</span>")
 		return FALSE
@@ -238,8 +237,7 @@
 		to_chat(usr, "<span class='warning'>[role] for [target_ckey] does not exist in whitelist.</span>")
 		return
 
-	establish_db_connection()
-	if(!dbcon.IsConnected())
+	if(!establish_db_connection("whitelist"))
 		to_chat(usr, "<span class='warning'>Failed to establish database connection.</span>")
 		return
 
@@ -279,8 +277,7 @@
 
 	role_whitelist = list()
 
-	establish_db_connection()
-	if(!dbcon.IsConnected())
+	if(!establish_db_connection("whitelist"))
 		world.log << "SQL ERROR (L): whitelist: connection failed to SQL database."
 		return
 

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -404,8 +404,7 @@ var/list/blacklisted_builds = list(
 	if ( IsGuestKey(src.key) )
 		return
 
-	establish_db_connection()
-	if(!dbcon.IsConnected())
+	if(!establish_db_connection("erro_player"))
 		return
 
 	var/sql_ckey = ckey(src.ckey)
@@ -572,8 +571,7 @@ var/list/blacklisted_builds = list(
 	if ( IsGuestKey(src.key) )
 		return
 
-	establish_db_connection()
-	if(!dbcon.IsConnected())
+	if(!establish_db_connection("erro_player"))
 		return
 
 	if(!isnum(player_ingame_age))

--- a/code/modules/client/guard.dm
+++ b/code/modules/client/guard.dm
@@ -273,7 +273,7 @@
 
 /datum/guard/proc/process_autoban()
 
-	if(!dbcon.IsConnected())
+	if(!establish_db_connection("erro_ban"))
 		message_admins("GUARD: autoban for [holder.ckey] not processed due to database connection problem.")
 		return
 

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -56,8 +56,7 @@
 			if(!isnum(page))
 				return
 
-			establish_db_connection()
-			if(!dbcon.IsConnected())
+			if(!establish_db_connection("erro_library"))
 				dat += "<font color=red><b>ERROR</b>: Unable to contact External Archive. Please contact your system administrator for assistance.</font><BR>"
 			else
 				var/SQLquery = "SELECT author, title, category, id FROM erro_library WHERE "
@@ -229,8 +228,8 @@
 				return
 
 			dat += "<h3>External Archive</h3>"
-			establish_db_connection()
-			if(!dbcon.IsConnected())
+
+			if(!establish_db_connection("erro_library"))
 				dat += "<font color=red><b>ERROR</b>: Unable to contact External Archive. Please contact your system administrator for assistance.</font>"
 			else
 				var/DBQuery/query = dbcon.NewQuery("SELECT id, author, title, category, deletereason FROM erro_library LIMIT [page], [LIBRETURNLIMIT]")
@@ -379,8 +378,7 @@
 					if(scanner.cache.unique)
 						alert("This book has been rejected from the database. Aborting!")
 					else
-						establish_db_connection()
-						if(!dbcon.IsConnected())
+						if(!establish_db_connection("erro_library"))
 							alert("Connection to Archive has been severed. Aborting.")
 						else
 							/*
@@ -406,8 +404,7 @@
 		if(!sqlid)
 			return
 
-		establish_db_connection()
-		if(!dbcon.IsConnected())
+		if(!establish_db_connection("erro_library"))
 			alert("Connection to Archive has been severed. Aborting.")
 		if(next_print > world.time)
 			visible_message("<b>[src]</b>'s monitor flashes, \"Printer unavailable. Please allow a short time before attempting to print.\"")
@@ -434,8 +431,7 @@
 		if(!sqlid)
 			return
 
-		establish_db_connection()
-		if(!dbcon.IsConnected())
+		if(!establish_db_connection("erro_library"))
 			alert("Connection to Archive has been severed. Aborting.")
 			return
 

--- a/code/modules/mentor/mentor.dm
+++ b/code/modules/mentor/mentor.dm
@@ -4,7 +4,11 @@
 /world/proc/load_mentors()
 	mentor_ckeys.Cut()
 	mentors.Cut()
-	if(config.admin_legacy_system)
+
+	if(!establish_db_connection("erro_mentor"))
+		error("Failed to connect to database in load_mentors(). Reverting to legacy system.")
+		log_misc("Failed to connect to database in load_mentors(). Reverting to legacy system.")
+
 		var/text = file2text("config/mentors.txt")
 		if (!text)
 			error("Failed to load config/mentors.txt")
@@ -20,13 +24,6 @@
 				if(directory[ckey])
 					mentors += directory[ckey]
 	else
-		establish_db_connection()
-		if(!dbcon.IsConnected())
-			error("Failed to connect to database in load_mentors(). Reverting to legacy system.")
-			log_misc("Failed to connect to database in load_mentors(). Reverting to legacy system.")
-			config.admin_legacy_system = 1
-			load_mentors()
-			return
 		var/DBQuery/query = dbcon.NewQuery("SELECT ckey FROM erro_mentor")
 		query.Execute()
 		while(query.NextRow())

--- a/code/modules/mentor/mentor.dm
+++ b/code/modules/mentor/mentor.dm
@@ -5,10 +5,16 @@
 	mentor_ckeys.Cut()
 	mentors.Cut()
 
-	if(!establish_db_connection("erro_mentor"))
+	var/legacy_system = FALSE
+
+	if(config.admin_legacy_system)
+		legacy_system = TRUE
+	else if(!establish_db_connection("erro_mentor"))
+		legacy_system = TRUE
 		error("Failed to connect to database in load_mentors(). Reverting to legacy system.")
 		log_misc("Failed to connect to database in load_mentors(). Reverting to legacy system.")
 
+	if(legacy_system)
 		var/text = file2text("config/mentors.txt")
 		if (!text)
 			error("Failed to load config/mentors.txt")

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -300,8 +300,9 @@ var/obj/machinery/blackbox_recorder/blackbox
 	if(!feedback) return
 
 	round_end_data_gathering() //round_end time logging and some other data processing
-	establish_db_connection()
-	if(!dbcon.IsConnected()) return
+
+	if(!establish_db_connection("erro_feedback"))
+		return
 
 	for(var/datum/feedback_variable/FV in feedback)
 		var/sql = "INSERT INTO erro_feedback VALUES (null, Now(), [global.round_id], \"[sanitize_sql(FV.get_variable())]\", [sanitize_sql(FV.get_value())], \"[sanitize_sql(FV.get_details())]\")"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений

``dbcon.IsConnected`` почти везде заменено в пользу ``establish_db_connection`` - второй делает то же, что и первый, и чуть больше.
``establish_db_connection`` в качестве доп параметров может проверять наличие таблиц в базе данных, потому что у нас с песочницей вдруг может возникнуть проблема с отсутствием каких-то таблиц. Альтернативный вариант решения был бы делать свой конфиг для каждой таблицы, но этих конфигов и так слишком много, так что такой вариант мне показался проще.
Везде к ``establish_db_connection`` проставлены зависимые для функций таблицы в качестве аргументов.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
