### PR TITLE
Админправа в песочнице

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -220,9 +220,13 @@ var/list/blacklisted_builds = list(
 	//Admin Authorisation
 	holder = admin_datums[ckey]
 
-	if(config.sandbox && !holder)
-		new /datum/admins("Sandbox Admin", (R_HOST & ~(R_PERMISSIONS | R_BAN | R_LOG)), ckey)
-		holder = admin_datums[ckey]
+	if(config.sandbox)
+		var/sandbox_permissions = (R_HOST & ~(R_PERMISSIONS | R_DEBUG | R_BAN | R_LOG))
+		if(!holder)
+			new /datum/admins("Sandbox Admin", sandbox_permissions, ckey)
+			holder = admin_datums[ckey]
+		else
+			holder.rights = (holder.rights | sandbox_permissions)
 
 	if(holder)
 		holder.owner = src


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений

Убрал дебаг у сандбокс админов - на него завязаны некоторые логи, так что лучше отдельно как нибудь посмотреть о необходимости.
Админы при подключении к сандбокс серверу сохраняют свои права, если есть в базе.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
