### PR TITLE
Фикс ошибок при снятии шлема

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -388,7 +388,9 @@
 		if(istype(H))
 			if(helmet && H.head == helmet)
 				helmet.canremove = 1
+				var/dropped_helmet = helmet
 				H.drop_from_inventory(helmet)
+				helmet = dropped_helmet		//attach the helmet back to the suit
 				helmet.loc = src
 
 	if(boots)
@@ -427,7 +429,9 @@
 
 	if(H.head == helmet)
 		helmet.canremove = 1
+		var/dropped_helmet = helmet
 		H.drop_from_inventory(helmet)
+		helmet = dropped_helmet		//attach the helmet back to the suit
 		helmet.loc = src
 		to_chat(H, "<span class='notice'>You retract your hardsuit helmet.</span>")
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
fix #7047 
fix #7056
Видимо плохо я тестит ПР, раз не заметил очевидную вещь. Прошу прошения)
При переключении шлема он дропается из инвентаря и вызывается прок `dropped` у шлема, который обнуляет переменную `helmet` у рига. А потом, при попытке прикрепить шлем обратно к ригу, код обращается к `helmet.loc` , а  `helmet` рига уже равен `null`. Это вызывало рантайм и баги.

Добавил `var/dropped_helmet` в которой храню ссылку на снимаемый шлем
## Почему и что этот ПР улучшит
баги
## Авторство
я
## Чеинжлог
:cl: Ahio
 - bugfix: При нажимание toggle helmet с шлемом на голове, шлем от РИГа отцеплялся и падал на пол.
 - bugfix: Оставался интерфейс скафандра после его снятия.