### PR TITLE
Теперь за пирокластических слаймов можно играть

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -647,7 +647,7 @@
 	if(key || mind || stat != CONSCIOUS)
 		return
 
-	if(Ignore_Role && M.client.prefs.ignore_question.Find(IGNORE_BORER))
+	if(Ignore_Role && M.client.prefs.ignore_question.Find(Ignore_Role))
 		return
 
 	if(isobserver(M))
@@ -675,10 +675,11 @@
 		ans = alert(M, Question, "[be_special_type] Request", "No", "Yes", "Not This Round")
 	else
 		ans = alert(M, Question, "[be_special_type] Request", "No", "Yes")
+
 	if(ans == "No")
 		return
 	if(ans == "Not This Round")
-		M.client.prefs.ignore_question += IGNORE_BORER
+		M.client.prefs.ignore_question += Ignore_Role
 		return
 
 	if(key || mind || stat != CONSCIOUS)

--- a/code/modules/events/anomaly_pyro.dm
+++ b/code/modules/events/anomaly_pyro.dm
@@ -24,6 +24,10 @@
 			S = new/mob/living/carbon/slime/red(T)
 		else
 			S = new/mob/living/carbon/slime/orange(T)
-		S.rabid = 1
+		S.rabid = TRUE
+		S.name = "pyroclastic [S.name]"
+
+		for(var/mob/dead/observer/O in observer_list)
+			S.try_request_n_transfer(O, "A new Pyroclastic Slime was born. Do you want to be him?", ROLE_GHOSTLY)
 
 		qdel(newAnomaly)

--- a/code/modules/mob/living/carbon/metroid/metroid.dm
+++ b/code/modules/mob/living/carbon/metroid/metroid.dm
@@ -268,6 +268,14 @@
 /mob/living/carbon/slime/attack_ui(slot)
 	return
 
+/mob/living/carbon/slime/transfer_personality(client/candidate)
+	if(!candidate)
+		return
+
+	ckey = candidate.ckey
+
+	to_chat(src, "Вы - [name].")
+	to_chat(src, "Ваша цель - размножение.")
 
 /mob/living/carbon/slime/hurtReaction(mob/living/attacker, show_message = TRUE)
 	if(Victim)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Когда пирокластическая аномалия разрушается, то спавнится слайм. Теперь гостам кидается рассылка и кто первый нажмет на Yes будет за слизня играть.

Так же пофиксил одну опечатку, где проверялась один дефайн.

fixes #6963

## Почему и что этот ПР улучшит
Гостам чуточку веселее будет

## Авторство

## Чеинжлог
:cl:
 - tweak: Госты смогут поиграть за слизня после саморазрушения пирокластической аномалии. 