### PR TITLE
Замена дебаггера extools на auxtools

### DIFF
--- a/SpacemanDMM.toml
+++ b/SpacemanDMM.toml
@@ -4,3 +4,6 @@ dreamchecker = true
 [code_standards]
 disallow_relative_type_definitions = true
 disallow_relative_proc_definitions = true
+
+[debugger]
+engine = "auxtools"

--- a/code/__DEFINES/spaceman_dmm.dm
+++ b/code/__DEFINES/spaceman_dmm.dm
@@ -32,8 +32,20 @@
 #endif
 
 #ifdef DEBUG
+/proc/auxtools_stack_trace(msg)
+	CRASH(msg)
+
+/proc/enable_debugging(mode, port)
+	CRASH("auxtools not loaded")
+
 /world/proc/enable_debugger()
-	var/dll = world.GetConfig("env", "EXTOOLS_DLL")
-	if (dll)
-		call(dll, "debug_initialize")()
+	var/debug_server = world.GetConfig("env", "AUXTOOLS_DEBUG_DLL")
+	if (debug_server)
+		call(debug_server, "auxtools_init")()
+		enable_debugging()
+
+/world/proc/disable_debugger()
+	var/debug_server = world.GetConfig("env", "AUXTOOLS_DEBUG_DLL")
+	if (debug_server)
+		call(debug_server, "auxtools_shutdown")()
 #endif

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -240,6 +240,10 @@ var/shutdown_processed = FALSE
 	..()
 
 /world/Del()
+#ifdef DEBUG
+	disable_debugger()
+#endif
+
 	if(!shutdown_processed) //if SIGTERM signal, not restart/reboot
 		PreShutdown("Graceful shutdown")
 		round_log("Graceful shutdown")


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Раньше у меня не работало, когда я попробовал подключить аухстулс, то все заработало. К тому же, ехтуллс вроде уже помер и закрылся, поэтому актуальненькую штуку подключаем. 

> Extools will no longer be receiving updates. I recommend switching to Rust-based Auxtools, which I contribute to as well. (https://github.com/MCHSL/extools)

Запускается дебаггин только из ВСКода через F5, поэтому локалочки не должны откисать от неподключенных хуков.

https://github.com/SpaceManiac/SpacemanDMM/wiki/Setting-up-Debugging



<details> 
  <summary>Я думал это миф</summary>
  
![image](https://user-images.githubusercontent.com/26389417/117280621-743fbd00-ae6b-11eb-86be-84c9f8ed775e.png)


</details>

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
