### PR TITLE
Множество фиксов и рефакторов у бореров

### DIFF
--- a/code/modules/events/borers.dm
+++ b/code/modules/events/borers.dm
@@ -29,7 +29,7 @@
 		if(spawncount <= 0 || !vents.len)
 			break
 		var/obj/vent = pick_n_take(vents)
-		var/mob/living/simple_animal/borer/B = new(vent.loc)
+		var/mob/living/simple_animal/borer/B = new(vent.loc, FALSE, 1)
 		B.transfer_personality(M.client)
 		message_admins("[B] has spawned at [B.x],[B.y],[B.z] [ADMIN_JMP(B)] [ADMIN_FLW(B)].")
 		successSpawn = TRUE

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -569,6 +569,8 @@
 	verbs -= /mob/living/carbon/proc/punish_host
 	verbs -= /mob/living/carbon/proc/spawn_larvae
 
+	med_hud_set_status()
+
 //Brain slug proc for tormenting the host.
 /mob/living/carbon/proc/punish_host()
 	set category = "Borer"

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -537,15 +537,19 @@
 	if(alert(src, "You sure you want to sleep for a while?","Sleep","Yes","No") == "Yes")
 		SetSleeping(40 SECONDS) //Short nap
 
+//Check for brain worms in head.
+/mob/proc/has_brain_worms()
+	for(var/mob/living/simple_animal/borer/B in contents)
+		return B
+	return null
+
 //Brain slug proc for voluntary removal of control.
 /mob/living/carbon/proc/release_control()
-
 	set category = "Borer"
 	set name = "Release Control"
 	set desc = "Release control of your host's body."
 
 	var/mob/living/simple_animal/borer/B = has_brain_worms()
-
 	if(!B)
 		return
 
@@ -553,7 +557,8 @@
 		to_chat(src, "<span class='danger'>You withdraw your probosci, releasing control of [B.host_brain].</span>")
 		to_chat(B.host_brain, "<span class='danger'>Your vision swims as the alien parasite releases control of your body.</span>")
 		B.ckey = ckey
-		B.controlling = 0
+		B.controlling = FALSE
+
 	if(B.host_brain.ckey)
 		ckey = B.host_brain.ckey
 		B.host_brain.ckey = null
@@ -571,7 +576,6 @@
 	set desc = "Punish your host with agony."
 
 	var/mob/living/simple_animal/borer/B = has_brain_worms()
-
 	if(!B)
 		return
 
@@ -579,35 +583,25 @@
 		to_chat(src, "<span class='danger'>You send a punishing spike of psychic agony lancing into your host's brain.</span>")
 		to_chat(B.host_brain, "<span class='danger'><FONT size=3>Horrific, burning agony lances through you, ripping a soundless scream from your trapped mind!</FONT></span>")
 
-//Check for brain worms in head.
-/mob/proc/has_brain_worms()
-
-	for(var/I in contents)
-		if(istype(I,/mob/living/simple_animal/borer))
-			return I
-
-	return 0
-
 /mob/living/carbon/proc/spawn_larvae()
 	set category = "Borer"
-	set name = "Reproduce"
+	set name = "Reproduce(100)"
 	set desc = "Spawn several young."
 
 	var/mob/living/simple_animal/borer/B = has_brain_worms()
-
 	if(!B)
 		return
 
-	if(B.chemicals >= 100)
-		to_chat(src, "<span class='danger'>Your host twitches and quivers as you rapdly excrete several larvae from your sluglike body.</span>")
-		B.chemicals -= 100
-		B.has_reproduced = 1
-
-		vomit()
-		new/mob/living/simple_animal/borer(get_turf(src), TRUE)
-	else
+	if(B.chemicals < 100)
 		to_chat(src, "<span class='info'>You do not have enough chemicals stored to reproduce.</span>")
 		return
+
+	to_chat(src, "<span class='danger'>Your host twitches and quivers as you rapdly excrete several larvae from your sluglike body.</span>")
+	B.chemicals -= 100
+	B.has_reproduced = TRUE
+
+	vomit()
+	new /mob/living/simple_animal/borer(loc, TRUE, B.generation + 1)
 
 /mob/living/carbon/proc/uncuff()
 	if(handcuffed)

--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -363,6 +363,13 @@
 	reset_view(null)
 	machine = null
 
+	host.reset_view(null)
+	host.machine = null
+
+	host.verbs -= /mob/living/carbon/proc/release_control
+	host.verbs -= /mob/living/carbon/proc/punish_host
+	host.verbs -= /mob/living/carbon/proc/spawn_larvae
+
 	if(host_brain.ckey)
 		ckey = host.ckey
 		host.ckey = host_brain.ckey

--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -195,8 +195,7 @@
 		to_chat(src, "You cannot use that ability again so soon.")
 		return
 
-	var/mob/living/carbon/M = input(src,"Who do you wish to dominate?") in null|choices
-
+	var/mob/living/carbon/M = input(src,"Who do you wish to dominate?") as null|anything in choices
 	if(!M || !src)
 		return
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Здесь я пофиксил несколько рантаймов, багов, а так же привел код в более читаемое состояние, расставив тру/фолсы, ранние возвраты и тд. Раньше переменная `host` была типом хуманов, но ниже по коду он садился в карбонов. В итоге, сидя в карбоне, происходило обращение на прямую к хумано-переменным, от того и были рантаймы, невозможности вылезти из янов и тд.
При взятие контроля, не всегда мог обновится мед_худ, это я тоже пофиксил.
Запретил борерам влиять на големов, дион, спу и слаймов.

fix #7050
fix #6615
(я хз как я починил эти два ишуя, но у меня не воспроизвелись баги после ффиксов)
fix #6349
fix #6335
fix #6460

## Почему и что этот ПР улучшит
Бореры стали немного играбельнее.

## Авторство

## Чеинжлог
:cl:
 - fix: Бореры теперь могут корректно сидеть в Яне и обезьяноподобных.
 - fix: Каждая новая популяция борера получает корректное имя.
 - balance: Теперь бореры не могу залезть в СПУ, големов, дион и слаймов.