### PR TITLE
Нерф DXM

### DIFF
--- a/code/modules/reagents/reagent_types/Chemistry-Medicine.dm
+++ b/code/modules/reagents/reagent_types/Chemistry-Medicine.dm
@@ -221,7 +221,7 @@
 	reagent_state = LIQUID
 	color = "#ffc0cb" // rgb: 255, 192, 203
 	overdose = 10
-	custom_metabolism = REAGENTS_METABOLISM * 0.5
+	custom_metabolism = REAGENTS_METABOLISM * 0.25
 	taste_message = "sickening bitterness"
 	restrict_species = list(IPC, DIONA)
 
@@ -240,15 +240,15 @@
 		var/obj/item/organ/internal/lungs/IO = H.organs_by_name[O_LUNGS]
 		if(istype(IO))
 			if(IO.damage > 0 && IO.robotic < 2)
-				IO.damage = max(IO.damage - 0.7, 0)
+				IO.damage -= min(3 * custom_metabolism, IO.damage)
 		switch(data["ticks"])
-			if(50 to 100)
+			if(100 to 200)
 				H.disabilities &= ~COUGHING
-			if(100 to INFINITY)
+			if(200 to INFINITY)
 				H.hallucination = max(H.hallucination, 7)
 	data["ticks"]++
 
-/datum/reagent/dexalinp/on_vox_digest(mob/living/M)
+/datum/reagent/dextromethorphan/on_vox_digest(mob/living/M)
 	..()
 	M.adjustToxLoss(7 * REM)
 	return FALSE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
DXM был одним из сильнейших препаратов в игре в связи с тем что будучи сравнительно дешёвым лечил довольно значительные повреждения, а именно 7 у/ю по лёгким (при этом залечивая разрыв лёгких) при скорости метаболизма 0.1 ю/т, что давало скорость лечения 0.7 у/т что примерно равняется 1.4 у/с.

Теперь DXM метаболизируется в два раза медленнее (что поощряет его использование как средства от кашля), а именно 0.05 ю/т и лечит меньше в чуть больше чем четыре с половиной раза, то есть 0.15 у/т (~0.3 у/с), что эквивалентно 3 у/ю.

Также DXM из-за опечатки не дамажил воксов, но это исправлено.

## Почему и что этот ПР улучшит
Баланс

## Авторство

## Чеинжлог
:cl: Getup1
- balance: Изменения декстрометорфана: скорость метаболизма - 0.1 ю/т -> 0.05 ю/т; лечение - 7 у/ю -> 3 у/ю.
- bugfix: Исправлена ошибка в связи с которой декстрометорфан не был токсичен для воксов.