### PR TITLE
Щит больше не станет и не кладет людей

### DIFF
--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -34,8 +34,6 @@
 		if(M.buckled)
 			M.buckled.user_unbuckle_mob(M)
 
-		M.apply_effect(2, STUN, 0)
-		M.apply_effect(2, WEAKEN, 0)
 		M.apply_effect(4, STUTTER, 0)
 		shake_camera(M, 1, 1)
 
@@ -65,8 +63,6 @@
 				if(M.buckled)
 					M.buckled.user_unbuckle_mob(M)
 
-				M.apply_effect(2, STUN, 0)
-				M.apply_effect(2, WEAKEN, 0)
 				M.apply_effect(6, STUTTER, 0)
 				shake_camera(M, 1, 1)
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Мы вроде уходили от стан2вин механик, но данный щит возвращает этот механ, так еще и с расстояния тайл, так еще и бесконечный. В итоге, достаточно приловчившемуся игроку напасть с нужного угла, как любая ролька соснет от одного лишь отталкивания в стену щитом.
Убрал еще и процентный шанс при АЛЬТ+клике, ибо ну зачем? Это тогда нужно добавлять на обычную атаку щитом, а не только в этот свип.

Мне кажется, шатающаяся камера уже хороший способ дезориентировать цель.

## Почему и что этот ПР улучшит
Уход от пермастана и стан2вин.

## Авторство


## Чеинжлог
:cl:
 - balance: Щитом больше невозможно положить и застанить человека.