### PR TITLE
В карманный патронаж теперь можно засунуть клипсы для игрушечного револьвера

### DIFF
--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -164,7 +164,8 @@
 
 	can_hold = list(
 		/obj/item/ammo_box,
-		/obj/item/ammo_casing
+		/obj/item/ammo_casing,
+		/obj/item/toy/ammo/gun
 		)
 
 /obj/item/weapon/storage/pouch/flare


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Теперь в карманный чехол для патронов и магазинов можно положить клипсы под игрушечный револьвер
## Почему и что этот ПР улучшит
Можно разыграть нюкера или персонал, оставив им чехлы с игрушечным револьвером и игрушечными боеприпасами
## Авторство
Rolt146
## Чеинжлог
:cl:
 - tweak: добавляет возможность класть игрушечные клипсы в чехол под патроны