### PR TITLE
Выбор цвета костюма для хирурга

### DIFF
--- a/code/datums/outfits/jobs/medical.dm
+++ b/code/datums/outfits/jobs/medical.dm
@@ -33,14 +33,31 @@
 	back_style = BACKPACK_STYLE_MEDICAL
 
 
-// SURGEON OUTFIT
-/datum/outfit/job/surgeon
-	name = OUTFIT_JOB_NAME("Surgeon")
+// SURGEON_BLUE OUTFIT
+/datum/outfit/job/surgeon_blue
+	name = OUTFIT_JOB_NAME("Surgeon blue")
 
 	uniform = /obj/item/clothing/under/rank/medical/blue
 	shoes = /obj/item/clothing/shoes/white
 	suit = /obj/item/clothing/suit/storage/labcoat
 	head = /obj/item/clothing/head/surgery/blue
+
+	belt = /obj/item/device/pda/medical
+	l_ear = /obj/item/device/radio/headset/headset_med
+
+	l_hand = /obj/item/weapon/storage/firstaid/adv
+	suit_store = /obj/item/device/flashlight/pen
+
+	back_style = BACKPACK_STYLE_MEDICAL
+
+// SURGEON_GREEN OUTFIT
+/datum/outfit/job/surgeon_green
+	name = OUTFIT_JOB_NAME("Surgeon green")
+
+	uniform = /obj/item/clothing/under/rank/medical/green
+	shoes = /obj/item/clothing/shoes/white
+	suit = /obj/item/clothing/suit/storage/labcoat
+	head = /obj/item/clothing/head/surgery/green
 
 	belt = /obj/item/device/pda/medical
 	l_ear = /obj/item/device/radio/headset/headset_med

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -42,7 +42,8 @@
 	access = list(access_medical, access_morgue, access_surgery, access_maint_tunnels, access_medbay_storage)
 	salary = 160
 	alt_titles = list(
-		"Surgeon" = /datum/outfit/job/surgeon,
+		"Surgeon blue" = /datum/outfit/job/surgeon_blue,
+		"Surgeon green" = /datum/outfit/job/surgeon_green,
 		"Nurse" = /datum/outfit/job/nurse
 		)
 	minimal_player_ingame_minutes = 960


### PR DESCRIPTION

<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Добавление возможности выбрать между зеленым и синим костюмом при выборе хирурга.
![image](https://user-images.githubusercontent.com/46276761/118026562-96ed3c80-b369-11eb-8fb1-c93241955f09.png)

## Почему и что этот ПР улучшит
Отсутствие необходимости переодеваться в начале каждой смены при желании сменить цвет костюма.
## Авторство
--
## Чеинжлог
:cl: Invent0_r
- tweak: Возможность выбора цвета костюма хирурга