### PR TITLE
toggling the kinetic energy scanner messaging module off

### DIFF
--- a/code/modules/research/experiment.dm
+++ b/code/modules/research/experiment.dm
@@ -206,6 +206,8 @@
 
 	channels = list("Science" = 1)
 
+	var/message_scientists = TRUE
+
 	// This thing should be really hard to destroy by any means.
 	// Some destruction methods(Lord Singuloo) are expected, and not considered anomalous.
 	var/anomalous_destruction = TRUE
@@ -223,6 +225,15 @@
 /obj/item/device/radio/beacon/interaction_watcher/atom_init()
 	. = ..()
 	global.interaction_watcher_list += src
+
+/obj/item/device/radio/beacon/interaction_watcher/attack_self(mob/living/carbon/human/user)
+	message_scientists = !message_scientists
+	to_chat(user, "<span class='notice'>You toggle [src]'s messaging module [message_scientists ? "on" : "off"]</span>")
+
+/obj/item/device/radio/beacon/interaction_watcher/autosay(message, from, channel, freq = 1459)
+	if(!message_scientists)
+		return
+	return ..()
 
 /obj/item/device/radio/beacon/interaction_watcher/Destroy()
 	global.interaction_watcher_list -= src


### PR DESCRIPTION
## Описание изменений

Позволяет при активации датчика в руке деактировать сообщения в чатик. (Датчик взрывов/ЕМП).

## Почему и что этот ПР улучшит

Ученые при желании могут не захламлять канал.

## Авторство

UDaV73rus - придумал.

## Чеинжлог
:cl: Luduk
- rscadd: Активация датчика взрывов и ЭМИ в руке отключит сообщения о взрывах/ЭМИ в РнД канал.