### PR TITLE
фикс пакетика для улик

### DIFF
--- a/code/modules/detectivework/evidence.dm
+++ b/code/modules/detectivework/evidence.dm
@@ -18,7 +18,7 @@
 	if(I.anchored)
 		return ..()
 
-	if(I.flags & (ABSTRACT|DROPDEL) || !I.canremove)
+	if((I.flags & (ABSTRACT|DROPDEL)) || !I.canremove)
 		return
 
 	if(istype(I, /obj/item/weapon/evidencebag))

--- a/code/modules/detectivework/evidence.dm
+++ b/code/modules/detectivework/evidence.dm
@@ -18,6 +18,9 @@
 	if(I.anchored)
 		return ..()
 
+	if(I.flags & (ABSTRACT|DROPDEL) || !I.canremove)
+		return
+
 	if(istype(I, /obj/item/weapon/evidencebag))
 		to_chat(user, "<span class='notice'>You find putting an evidence bag in another evidence bag to be slightly absurd.</span>")
 		return


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
теперь в него нельзя положить заклинания мага и руку-меч генокрада

fix #7142

## Почему и что этот ПР улучшит
минус баг

## Авторство

## Чеинжлог
:cl:
 - fix: В пакет для улик нельзя положить заклинания мага, руки генокрада и тд.