### PR TITLE
fixes #7173

### DIFF
--- a/code/modules/roguelike/mob_modifiers/positive.dm
+++ b/code/modules/roguelike/mob_modifiers/positive.dm
@@ -152,10 +152,12 @@
 	H.color = saved_color
 
 	if(!update && rejuve_timer)
-		SEND_SIGNAL(possessed, COMSIG_NAME_MOD_REMOVE, /datum/name_modifier/prefix/cursed, 1)
 		deltimer(rejuve_timer)
 		rejuve_timer = null
-		H.forceMove(get_turf(possessed))
+
+		if(possessed)
+			SEND_SIGNAL(possessed, COMSIG_NAME_MOD_REMOVE, /datum/name_modifier/prefix/cursed, 1)
+			H.forceMove(get_turf(possessed))
 
 	return ..()
 


### PR DESCRIPTION
## Описание изменений

если что-то удаляет игрушку, удалялся родитель компоненты, в котором ревертался эффект, в реверте которого мы пытались у игрушки удалить текст. очевидно игрушки уже к этому моменту не было, и возникал рантайм

## Почему и что этот ПР улучшит

fixes #7173
