### PR TITLE
Удаление абуза со стрельбой без КД

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -89,16 +89,13 @@
 	var/obj/item/I = get_active_hand()
 	if(istype(I, /obj/item/weapon/gun))
 		var/obj/item/weapon/gun/G = I
-		if(src.client.gun_mode)
-			G.Fire(A, src)
-		else
-			if(isliving(A))
-				var/mob/living/M = A
-				if(M in G.target)
-					M.NotTargeted(G)
-				else
-					G.PreFire(M, src)
-				return
+		if(isliving(A))
+			var/mob/living/M = A
+			if(M in G.target)
+				M.NotTargeted(G)
+			else
+				G.PreFire(M, src)
+			return
 	..()
 
 /obj/item/weapon/gun/proc/Fire(atom/target, mob/living/user, params, reflex = 0, point_blank = FALSE)//TODO: go over this

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -80,22 +80,28 @@
 /obj/item/weapon/gun/afterattack(atom/target, mob/user, proximity, params)
 	if(proximity)	return //It's adjacent, is the user, or is on the user's person
 	if(istype(target, /obj/machinery/recharger) && istype(src, /obj/item/weapon/gun/energy))	return//Shouldnt flag take care of this?
-	if(user && user.client && user.client.gun_mode && !(target in target))
+	if(user && user.client && user.client.gun_mode && !(target in src.target))
 		PreFire(target,user,params) //They're using the new gun system, locate what they're aiming at.
 	else
 		Fire(target,user,params) //Otherwise, fire normally.
 
 /mob/living/carbon/AltClickOn(atom/A)
+	if(next_move > world.time) // CD for clicks is checked before clicks with modifiers(shift, alt)
+		return
 	var/obj/item/I = get_active_hand()
 	if(istype(I, /obj/item/weapon/gun))
 		var/obj/item/weapon/gun/G = I
-		if(isliving(A))
-			var/mob/living/M = A
-			if(M in G.target)
-				M.NotTargeted(G)
-			else
-				G.PreFire(M, src)
-			return
+		if(client.gun_mode)
+			if(G.can_fire())
+				G.Fire(A, src)
+		else
+			if(isliving(A))
+				var/mob/living/M = A
+				if(M in G.target)
+					M.NotTargeted(G)
+				else
+					G.PreFire(M, src)
+				return
 	..()
 
 /obj/item/weapon/gun/proc/Fire(atom/target, mob/living/user, params, reflex = 0, point_blank = FALSE)//TODO: go over this

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -91,8 +91,9 @@
 	var/obj/item/I = get_active_hand()
 	if(istype(I, /obj/item/weapon/gun))
 		var/obj/item/weapon/gun/G = I
-		if(client.gun_mode && G.can_fire())
-			G.Fire(A, src)
+		if(client.gun_mode)
+			if(G.can_fire())
+				G.Fire(A, src)
 		else
 			if(isliving(A))
 				var/mob/living/M = A

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -91,9 +91,8 @@
 	var/obj/item/I = get_active_hand()
 	if(istype(I, /obj/item/weapon/gun))
 		var/obj/item/weapon/gun/G = I
-		if(client.gun_mode)
-			if(G.can_fire())
-				G.Fire(A, src)
+		if(client.gun_mode && G.can_fire())
+			G.Fire(A, src)
 		else
 			if(isliving(A))
 				var/mob/living/M = A


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Теперь зажав альт клик и нажимая на куклу не будет стрельбы без кд. Я упустил важный элемент повторения бага, ну чтоб особо умные не начали абузить щас. Если хотите узнать, то пишите в ЛС в дисе

Вообщем была ошибка с тем, что проверка на Кд клика идет после клика с модификатором.


Так же, пофиксил баг с тем, что нельзя было стрелять по цели под прицелом, потому что аргумент и название переменной класса были одинаковыми и автор кода это не учел

## Почему и что этот ПР улучшит
Минус баг

## Авторство

## Чеинжлог
