### PR TITLE
Фикс ширины окна PDA в соответствии с новой кнопкой "DM" в Crew Manifest

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -577,7 +577,7 @@
 	if (!ui)
 		// the ui does not exist, so we'll create a new() one
 	        // for a list of parameters and their descriptions see the code docs in \code\modules\nano\nanoui.dm
-		ui = new(user, src, ui_key, "pda.tmpl", title, 520, 400)
+		ui = new(user, src, ui_key, "pda.tmpl", title, 590, 430)
 		// when the ui is first opened this is the data it will use
 
 		ui.load_cached_data(ManifestJSON)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Фикс ширины окна ПДА в соответствиии с этим ишью: fixes #7233

## Почему и что этот ПР улучшит
Улучшение внешнего вида ПДА в соответствии с новой кнопкой DM в крю манифесте из этого ПРа: [#7225](https://github.com/TauCetiStation/TauCetiClassic/pull/7225) 

## Авторство

## Чеинжлог
:cl: 
 - bugfix: Поправлены размеры строк в Crew Manifest в ПДА
