### PR TITLE
fixing the #7090 ramen issue

### DIFF
--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -290,7 +290,7 @@
 /obj/item/weapon/reagent_containers/food/drinks/dry_ramen/attack_self(mob/user)
 	if (!is_open_container())
 		flags |= OPENCONTAINER
-		flags += /obj/item/weapon/reagent_containers/food/drinks/proc/gulp_whole
+		verbs += /obj/item/weapon/reagent_containers/food/drinks/proc/gulp_whole
 		playsound(src, 'sound/items/crumple.ogg', VOL_EFFECTS_MASTER, rand(10, 50))
 		to_chat(user, "<span class='notice'>You open the [src].</span>")
 		update_icon()


### PR DESCRIPTION
## Описание изменений

Раменам при открытии корректно обновляет спрайт в связи с тем что не появляется рантайм попытки добавить верб в список не-вербов

## Почему и что этот ПР улучшит

у раменов при открытии будет корректный спрайт

## Чеинжлог
:cl: Luduk
- bugfix: У раменов при открытии не обновлялся спрайт, пока в них не зальёшь воду.