### PR TITLE
Выключение анимаций радиального меню

### DIFF
--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -313,6 +313,7 @@ var/global/list/radial_menus = list()
 		menu.radius = radius
 	if(istype(custom_check))
 		menu.custom_check_callback = custom_check
+	menu.entry_animation = user.client.prefs.radial_anim
 	menu.anchor = anchor
 	menu.check_screen_border(user) //Do what's needed to make it look good near borders or on hud
 	menu.set_choices(choices, tooltips)

--- a/code/modules/client/character menu/global.dm
+++ b/code/modules/client/character menu/global.dm
@@ -78,6 +78,10 @@
 	. += 					"<td><a href='?_src_=prefs;preference=ambientocclusion'><b>[ambientocclusion ? "Enabled" : "Disabled"]</b></a></td>"
 	. += 				"</tr>"
 	. += 				"<tr>"
+	. += 					"<td width='45%'>Radial animations:</td>"
+	. += 					"<td><a href='?_src_=prefs;preference=radial_anim'><b>[radial_anim ? "Enabled" : "Disabled"]</b></a></td>"
+	. += 				"</tr>"
+	. += 				"<tr>"
 	. += 					"<td width='45%'>Melee Animations:</td>"
 	. += 					"<td><a href='?_src_=prefs;preference=see_animations'><b>[(toggles & SHOW_ANIMATIONS) ? "Yes" : "No"]</b></a></td>"
 	. += 				"</tr>"
@@ -175,6 +179,9 @@
 			if(parent && parent.screen && parent.screen.len)
 				var/obj/screen/plane_master/game_world/PM = locate(/obj/screen/plane_master/game_world) in parent.screen
 				PM.backdrop(parent.mob)
+
+		if("radial_anim")
+			radial_anim = !radial_anim
 
 		if("parallax_theme")
 			switch(parallax_theme)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -34,14 +34,16 @@ var/const/MAX_SAVE_SLOTS = 10
 	var/chat_toggles = TOGGLES_DEFAULT_CHAT
 	var/chat_ghostsight = CHAT_GHOSTSIGHT_ALL
 	var/ghost_orbit = GHOST_ORBIT_CIRCLE
-	var/lastchangelog = ""              //Saved changlog filesize to detect if there was a change
+	var/lastchangelog = ""              //Saved changelog filesize to detect if there was a change
 
 	var/tooltip = TRUE
 	var/tooltip_font = "Small Fonts"
 	var/tooltip_size = 8
 
+	//outline
 	var/outline_enabled = TRUE
 	var/outline_color = COLOR_BLUE_LIGHT
+
 	var/eorg_enabled = TRUE
 
 	//TGUI
@@ -140,6 +142,7 @@ var/const/MAX_SAVE_SLOTS = 10
 	var/volume = 100
 	var/parallax = PARALLAX_HIGH
 	var/ambientocclusion = TRUE
+	var/radial_anim = TRUE
 	var/parallax_theme = PARALLAX_THEME_CLASSIC
 
   //custom loadout

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -265,6 +265,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["parallax"]			>> parallax
 	S["parallax_theme"]		>> parallax_theme
 	S["ambientocclusion"]	>> ambientocclusion
+	S["radial_anim"]		>> radial_anim
 	S["tooltip"]			>> tooltip
 	S["tooltip_size"]		>> tooltip_size
 	S["tooltip_font"]		>> tooltip_font
@@ -292,28 +293,29 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 		update_preferences(needs_update, S) // needs_update = savefile_version if we need an update (positive integer)
 
 	//Sanitize
-	ooccolor		= normalize_color(sanitize_hexcolor(ooccolor, initial(ooccolor)))
-	aooccolor		= normalize_color(sanitize_hexcolor(aooccolor, initial(aooccolor)))
-	lastchangelog	= sanitize_text(lastchangelog, initial(lastchangelog))
-	UI_style		= sanitize_inlist(UI_style, global.available_ui_styles, global.available_ui_styles[1])
-	default_slot	= sanitize_integer(default_slot, 1, MAX_SAVE_SLOTS, initial(default_slot))
-	toggles		= sanitize_integer(toggles, 0, 65535, initial(toggles))
-	chat_toggles	= sanitize_integer(chat_toggles, 0, 65535, initial(chat_toggles))
-	ghost_orbit 	= sanitize_inlist(ghost_orbit, ghost_orbits, initial(ghost_orbit))
-	chat_ghostsight	= sanitize_integer(chat_ghostsight, CHAT_GHOSTSIGHT_ALL, CHAT_GHOSTSIGHT_NEARBYMOBS, CHAT_GHOSTSIGHT_ALL)
-	randomslot		= sanitize_integer(randomslot, 0, 1, initial(randomslot))
-	UI_style_color	= sanitize_hexcolor(UI_style_color, initial(UI_style_color))
-	UI_style_alpha	= sanitize_integer(UI_style_alpha, 0, 255, initial(UI_style_alpha))
-	tgui_fancy		= sanitize_integer(tgui_fancy, 0, 1, initial(tgui_fancy))
-	tgui_lock		= sanitize_integer(tgui_lock, 0, 1, initial(tgui_lock))
-	parallax		= sanitize_integer(parallax, PARALLAX_INSANE, PARALLAX_DISABLE, PARALLAX_HIGH)
-	parallax_theme	= sanitize_text(parallax_theme, initial(parallax_theme))
-	ambientocclusion = sanitize_integer(ambientocclusion, 0, 1, initial(ambientocclusion))
-	tooltip = sanitize_integer(tooltip, 0, 1, initial(tooltip))
-	tooltip_size = sanitize_integer(tooltip_size, 1, 15, initial(tooltip_size))
-	outline_enabled = sanitize_integer(outline_enabled, 0, 1, initial(outline_enabled))
-	outline_color = normalize_color(sanitize_hexcolor(outline_color, initial(outline_color)))
-	eorg_enabled = sanitize_integer(eorg_enabled, 0, 1, initial(eorg_enabled))
+	ooccolor			= normalize_color(sanitize_hexcolor(ooccolor, initial(ooccolor)))
+	aooccolor			= normalize_color(sanitize_hexcolor(aooccolor, initial(aooccolor)))
+	lastchangelog		= sanitize_text(lastchangelog, initial(lastchangelog))
+	UI_style			= sanitize_inlist(UI_style, global.available_ui_styles, global.available_ui_styles[1])
+	default_slot		= sanitize_integer(default_slot, 1, MAX_SAVE_SLOTS, initial(default_slot))
+	toggles				= sanitize_integer(toggles, 0, 65535, initial(toggles))
+	chat_toggles		= sanitize_integer(chat_toggles, 0, 65535, initial(chat_toggles))
+	ghost_orbit 		= sanitize_inlist(ghost_orbit, ghost_orbits, initial(ghost_orbit))
+	chat_ghostsight		= sanitize_integer(chat_ghostsight, CHAT_GHOSTSIGHT_ALL, CHAT_GHOSTSIGHT_NEARBYMOBS, CHAT_GHOSTSIGHT_ALL)
+	randomslot			= sanitize_integer(randomslot, 0, 1, initial(randomslot))
+	UI_style_color		= sanitize_hexcolor(UI_style_color, initial(UI_style_color))
+	UI_style_alpha		= sanitize_integer(UI_style_alpha, 0, 255, initial(UI_style_alpha))
+	tgui_fancy			= sanitize_integer(tgui_fancy, 0, 1, initial(tgui_fancy))
+	tgui_lock			= sanitize_integer(tgui_lock, 0, 1, initial(tgui_lock))
+	parallax			= sanitize_integer(parallax, PARALLAX_INSANE, PARALLAX_DISABLE, PARALLAX_HIGH)
+	parallax_theme		= sanitize_text(parallax_theme, initial(parallax_theme))
+	ambientocclusion	= sanitize_integer(ambientocclusion, 0, 1, initial(ambientocclusion))
+	radial_anim 		= sanitize_integer(radial_anim, 0, 1, initial(radial_anim))
+	tooltip 			= sanitize_integer(tooltip, 0, 1, initial(tooltip))
+	tooltip_size 		= sanitize_integer(tooltip_size, 1, 15, initial(tooltip_size))
+	outline_enabled 	= sanitize_integer(outline_enabled, 0, 1, initial(outline_enabled))
+	outline_color 		= normalize_color(sanitize_hexcolor(outline_color, initial(outline_color)))
+	eorg_enabled 		= sanitize_integer(eorg_enabled, 0, 1, initial(eorg_enabled))
 	if(!cid_list)
 		cid_list = list()
 	ignore_cid_warning = sanitize_integer(ignore_cid_warning, 0, 1, initial(ignore_cid_warning))
@@ -375,10 +377,10 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["parallax"]			<< parallax
 	S["parallax_theme"]		<< parallax_theme
 	S["ambientocclusion"]	<< ambientocclusion
+	S["radial_anim"]		<< radial_anim
 	S["tooltip"]			<< tooltip
 	S["tooltip_size"]		<< tooltip_size
 	S["tooltip_font"]		<< tooltip_font
-
 	S["outline_enabled"]	<< outline_enabled
 	S["outline_color"]		<< outline_color
 	S["eorg_enabled"]		<< eorg_enabled

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -201,6 +201,16 @@ var/global/list/ghost_orbits = list(GHOST_ORBIT_CIRCLE,GHOST_ORBIT_TRIANGLE,GHOS
 		PM.backdrop(mob)
 	feedback_add_details("admin_verb","TAC")
 
+/client/verb/toggle_radial_animation()
+	set name = "Toggle Radial Animation"
+	set category = "Preferences"
+	set desc = "Toggles animation when a new radial menu appears"
+
+	prefs.radial_anim = !prefs.radial_anim
+	prefs.save_preferences()
+	to_chat(src, "Now you [prefs.radial_anim ? "will" : "won't"] see the animation of radial menu appearing")
+	feedback_add_details("admin_verb", "TRA") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
 /client/verb/set_parallax_quality()
 	set name = "Set Parallax Quality"
 	set category = "Preferences"
@@ -277,7 +287,7 @@ var/global/list/ghost_orbits = list(GHOST_ORBIT_CIRCLE,GHOST_ORBIT_TRIANGLE,GHOS
 
 	prefs.tgui_fancy = !prefs.tgui_fancy
 	prefs.save_preferences()
-	feedback_add_details("admin_verb", "TFTGUI")
+	feedback_add_details("admin_verb", "TFTGUI") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/verb/toggle_tooltip()
 	set name = "Tooltip: Show/Hide"
@@ -293,7 +303,7 @@ var/global/list/ghost_orbits = list(GHOST_ORBIT_CIRCLE,GHOST_ORBIT_TRIANGLE,GHOS
 
 	prefs.save_preferences()
 	to_chat(src, "Name of items [prefs.tooltip ? "enabled" : "disabled"].")
-	feedback_add_details("admin_verb", "TTIP")
+	feedback_add_details("admin_verb", "TTIP") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/verb/change_font_tooltip()
 	set name = "Tooltip: Change Font"
@@ -313,7 +323,7 @@ var/global/list/ghost_orbits = list(GHOST_ORBIT_CIRCLE,GHOST_ORBIT_TRIANGLE,GHOS
 	prefs.tooltip_font = font
 
 	prefs.save_preferences()
-	feedback_add_details("admin_verb", "FTIP")
+	feedback_add_details("admin_verb", "FTIP") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/verb/change_size_tooltip()
 	set name = "Tooltip: Change Size"
@@ -324,7 +334,7 @@ var/global/list/ghost_orbits = list(GHOST_ORBIT_CIRCLE,GHOST_ORBIT_TRIANGLE,GHOS
 
 	tooltip.font_size = prefs.tooltip_size
 	prefs.save_preferences()
-	feedback_add_details("admin_verb", "LTIP")
+	feedback_add_details("admin_verb", "LTIP") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/verb/toggle_outline()
 	set name = "Toggle Outline"
@@ -334,7 +344,7 @@ var/global/list/ghost_orbits = list(GHOST_ORBIT_CIRCLE,GHOST_ORBIT_TRIANGLE,GHOS
 	prefs.outline_enabled = !prefs.outline_enabled
 	prefs.save_preferences()
 	to_chat(src, "Outline is [prefs.outline_enabled ? "enabled" : "disabled"].")
-	feedback_add_details("admin_verb", "TO")
+	feedback_add_details("admin_verb", "TO") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/verb/change_outline_color()
 	set name = "Change Outline Color"
@@ -347,7 +357,7 @@ var/global/list/ghost_orbits = list(GHOST_ORBIT_CIRCLE,GHOST_ORBIT_TRIANGLE,GHOS
 	prefs.outline_color = pickedOutlineColor
 	prefs.save_preferences()
 	to_chat(src, "Outline color changed.")
-	feedback_add_details("admin_verb", "COC")
+	feedback_add_details("admin_verb", "COC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/verb/toggle_eorg()
 	set name = "Toggle End of Round Deathmatch"
@@ -357,4 +367,4 @@ var/global/list/ghost_orbits = list(GHOST_ORBIT_CIRCLE,GHOST_ORBIT_TRIANGLE,GHOS
 	prefs.eorg_enabled = !prefs.eorg_enabled
 	prefs.save_preferences()
 	to_chat(src, "You [prefs.eorg_enabled ? "will be" : "won't be"] teleported to Thunderdome at round end.")
-	feedback_add_details("admin_verb", "ED")
+	feedback_add_details("admin_verb", "ED") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
thank god
Теперь не надо ждать долгие полсекунды пока радиалка не появится
Или надо, если вы не умеете в механ и работку
## Почему и что этот ПР улучшит
Моё удовлетворение игрой на ИИ
## Авторство
remindme
## Чеинжлог
:cl:
 - tweak: Анимацию появления радиального меню теперь можно выключить в настройках персонажа или из вкладки Preferences