### PR TITLE
Фикс рантайма с пиканьем из пустого листа

### DIFF
--- a/code/modules/events/roundstart_events/area/maintenance.dm
+++ b/code/modules/events/roundstart_events/area/maintenance.dm
@@ -20,7 +20,8 @@
 			if(!T.CanPass(null, T))
 				all_turfs -= T
 
-		spawn_atom(pick(possible_types), pick(all_turfs))
+		if(all_turfs.len)
+			spawn_atom(pick(possible_types), pick(all_turfs))
 
 /datum/event/roundstart/area/maintenance_spawn/invasion
 	possible_types = list(


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
К сожалению, скриншоты я не храню. Но суть рантайма в том, что не было проверки на количество элементов в листе и происходил pick() из пустого листа

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
