### PR TITLE
Фикс ассоциативных списков в тгуи_алертах

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -790,6 +790,10 @@
 			return TRUE
 
 	return FALSE
+/proc/copy_keys(list/L)
+	. = list()
+	for(var/E in L)
+		. += E
 
 #define LAZYINITLIST(L) if (!L) L = list()
 #define UNSETEMPTY(L) if (L && !L.len) L = null

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -63,7 +63,7 @@
 /datum/tgui_modal/New(mob/user, message, title, list/buttons, timeout)
 	src.title = title
 	src.message = message
-	src.buttons = buttons
+	src.buttons = buttons.Copy()
 	if (timeout)
 		src.timeout = timeout
 		start_time = world.time

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -144,10 +144,7 @@
 	. = ..()
 	if (!. || choice == null)
 		return
-	if(is_associative_list(buttons))
-		callback.InvokeAsync(buttons[choice])
-	else
-		callback.InvokeAsync(choice)
+	callback.InvokeAsync(choice)
 	qdel(src)
 
 /datum/tgui_modal/async/wait()

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -63,7 +63,9 @@
 /datum/tgui_modal/New(mob/user, message, title, list/buttons, timeout)
 	src.title = title
 	src.message = message
-	src.buttons = buttons.Copy()
+	src.buttons = list()
+	for(var/btn in buttons)
+		src.buttons.Add(btn)
 	if (timeout)
 		src.timeout = timeout
 		start_time = world.time

--- a/code/_onclick/hud/alert.dm
+++ b/code/_onclick/hud/alert.dm
@@ -63,9 +63,7 @@
 /datum/tgui_modal/New(mob/user, message, title, list/buttons, timeout)
 	src.title = title
 	src.message = message
-	src.buttons = list()
-	for(var/btn in buttons)
-		src.buttons.Add(btn)
+	src.buttons = buttons
 	if (timeout)
 		src.timeout = timeout
 		start_time = world.time
@@ -101,7 +99,7 @@
 	. = list(
 		"title" = title,
 		"message" = message,
-		"buttons" = buttons
+		"buttons" = copy_keys(buttons)
 	)
 	if(timeout)
 		.["timeout"] = CLAMP01((timeout - (world.time - start_time) - 1 SECONDS) / (timeout - 1 SECONDS))
@@ -114,7 +112,10 @@
 		if("choose")
 			if (!(params["choice"] in buttons))
 				return
-			choice = params["choice"]
+			if(is_associative_list(buttons))
+				choice = buttons[params["choice"]]
+			else
+				choice = params["choice"]
 			SStgui.close_uis(src)
 			return TRUE
 
@@ -143,7 +144,10 @@
 	. = ..()
 	if (!. || choice == null)
 		return
-	callback.InvokeAsync(choice)
+	if(is_associative_list(buttons))
+		callback.InvokeAsync(buttons[choice])
+	else
+		callback.InvokeAsync(choice)
 	qdel(src)
 
 /datum/tgui_modal/async/wait()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Честно, я не сильно разбираюсь в тгуи, поэтому это просто решение наугад.
Раньше если передавать ассоциативный список в тгуи_алерт там выбивался синий экран, поэтому я теперь возвращаю ассоциацию из этого списка.

## Почему и что этот ПР улучшит
Можно передавать ассоциативный список в тгуи_алерт.

## Авторство

## Чеинжлог
