### PR TITLE
Фикс рантаймов новой системы хоткеев

### DIFF
--- a/code/modules/client/character menu/customkeybindings.dm
+++ b/code/modules/client/character menu/customkeybindings.dm
@@ -1,4 +1,10 @@
 /datum/preferences/proc/ShowCustomKeybindings(mob/user)
+	if(!key_bindings.len)
+		. += "Этот текст вы можете видеть только при ошибке со стороны кода.<br>"
+		. += "Попробуйте нажать сверху кнопку Reload Slot. Если это не помогло, то подождите рестрат."
+		. += "Можете так же сообщить о проблеме в гитхаб репозитория."
+		return
+
 	// Create an inverted list of keybindings -> key
 	var/list/user_binds = list()
 	for (var/key in key_bindings)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -228,6 +228,12 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 /datum/preferences/proc/check_keybindings()
 	if(!parent)
 		return
+
+	// When loading from savefile key_binding can be null
+	// This happens when player had savefile created before new kb system, but hotkeys was not saved
+	if(!key_bindings || !key_bindings.len)
+		key_bindings = deepCopyList(global.hotkey_keybinding_list_by_key) // give them default keybinds too
+
 	var/list/user_binds = list()
 	for (var/key in key_bindings)
 		for(var/kb_name in key_bindings[key])

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -231,7 +231,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	// When loading from savefile key_binding can be null
 	// This happens when player had savefile created before new kb system, but hotkeys was not saved
-	if(!key_bindings || !key_bindings.len)
+	if(!length(key_bindings))
 		key_bindings = deepCopyList(global.hotkey_keybinding_list_by_key) // give them default keybinds too
 
 	var/list/user_binds = list()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений

https://github.com/TauCetiStation/TauCetiClassic/pull/7287

Это фикс этих двух рантаймов.

`bad index in preferences_savefile.dm:242 :` происходил по причине того, что если у человека был файл сохранений до обновления системы, то код пытался из этого файла загрузить лист со всеми хоткеями, но так как он еще не был сохранен, то из файла загружался `null`. Именно он приводил к этой проблеме. (нельзя делать null["smth"]).

`bad text or out of bounds in customkeybindings.dm:27 ` поидее, этот рантайм вытекает из первого, когда у клиента не были загружены хоткеи и на основе их что-то пыталось загрузиться


## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
