### PR TITLE
В тринарный можно говорить через ":x" (англ)

### DIFF
--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -12,7 +12,7 @@
 	var/exclaim_verb = "exclaims" // Used when sentence ends in a !
 	var/signlang_verb = list()       // list of emotes that might be displayed if this language has NONVERBAL or SIGNLANG flags
 	var/colour = "body"         // CSS style to use for strings in this language.
-	var/list/key = list("x")                    // Character used to speak in language eg. :o for Unathi.
+	var/list/key = list()                    // Character used to speak in language eg. :o for Unathi.
 	var/flags = 0                    // Various language flags.
 	var/native                       // If set, non-native speakers will have trouble speaking.
 	var/list/syllables               // Used when scrambling text for a non-speaker.

--- a/code/modules/mob/living/carbon/xenomorph/say.dm
+++ b/code/modules/mob/living/carbon/xenomorph/say.dm
@@ -17,7 +17,7 @@
 		return emote(copytext(message, 2))
 
 	if(length(message) >= 2)
-		if(department_radio_keys[copytext(message, 1, 2 + length(message[2]))] == "alientalk")
+		if(parse_message_mode(message) == "alientalk")
 			message = copytext(message, 2 + length(message[2]))
 			message = trim(message)
 			alien_talk(message)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Title
## Почему и что этот ПР улучшит
fixes #7292
## Авторство
remindme
## Чеинжлог
:cl: Remind me
 - fix: На тринарном языке нельзя было говорить на английской раскладке (":x")