### PR TITLE
Исправление невозможности отвечать на ahelp с мутом.

### DIFF
--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -33,7 +33,7 @@
 	feedback_add_details("admin_verb","APM") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/proc/cmd_ahelp_reply(whom, reply_type)
-	if(prefs.muted & (MUTE_ADMINHELP|MUTE_MENTORHELP))
+	if(prefs.muted & MUTE_ADMINHELP)
 		to_chat(src, "<font color='red'>Error: Admin-PM: You are unable to use admin PM-s (muted).</font>")
 		return
 	var/client/C
@@ -64,7 +64,7 @@
 //Fetching a message if needed. src is the sender and C is the target client
 
 /client/proc/cmd_admin_pm(whom, msg)
-	if(prefs.muted & (MUTE_ADMINHELP|MUTE_MENTORHELP))
+	if(prefs.muted & MUTE_ADMINHELP)
 		to_chat(src, "<font color='red'>Error: Private-Message: You are unable to use PM-s (muted).</font>")
 		return
 
@@ -94,7 +94,7 @@
 		if(!msg)
 			return
 
-		if(prefs.muted & (MUTE_ADMINHELP|MUTE_MENTORHELP)) // maybe client were muted while typing input.
+		if(prefs.muted & MUTE_ADMINHELP) // maybe client were muted while typing input.
 			to_chat(src, "<font color='red'>Error: Admin-PM: You are unable to use admin PM-s (muted).</font>")
 			return
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -34,7 +34,7 @@ var/const/MAX_SAVE_SLOTS = 10
 	var/chat_toggles = TOGGLES_DEFAULT_CHAT
 	var/chat_ghostsight = CHAT_GHOSTSIGHT_ALL
 	var/ghost_orbit = GHOST_ORBIT_CIRCLE
-	var/lastchangelog = ""              //Saved changlog filesize to detect if there was a change
+	var/lastchangelog = ""				//Saved changlog filesize to detect if there was a change
 
 	// Custom Keybindings
 	var/list/key_bindings = list()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
fix #6712 теперь можно отвечать с мутом на mentorhelp в ahelp. И писать тоже.
## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
