### PR TITLE
запрет на ожирение големам

### DIFF
--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -937,6 +937,7 @@
 	,NO_EMOTION = TRUE
 	,NO_VOMIT = TRUE
 	,NO_MUTATION = TRUE
+	,NO_FAT = TRUE
 	)
 
 	has_bodypart = list(

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -1107,7 +1107,8 @@
 		NO_FINGERPRINT = TRUE,
 		NO_MINORCUTS = TRUE,
 		NO_EMOTION = TRUE,
-		NO_MUTATION = TRUE
+		NO_MUTATION = TRUE,
+		NO_FAT = TRUE,
 		)
 
 	has_organ = list(


### PR DESCRIPTION
потому что оно снимало им броню

<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Убирает ожирение големам.

Вообще, это частичное решение, по идее надо броне голема прописать чтобы при ожирении она не спадала или что-то еще. В любом случае, но фэт флаг у големов это логично как по мне.

## Почему и что этот ПР улучшит
Голем больше не может скинуть с себя броню и надеть другую

## Авторство

## Чеинжлог
:cl: Getup1
- bugfix: Исправлена ошибка, позволявшая големам снимать с себя броню.