### PR TITLE
Исправление хождения через стену

### DIFF
--- a/maps/templates/space_structures/robostation.dmm
+++ b/maps/templates/space_structures/robostation.dmm
@@ -885,7 +885,6 @@
 /turf/simulated/shuttle/wall{
 	icon_state = "swall3"
 	},
-/turf/space,
 /area/space_structures/robostatoin)
 "dm" = (
 /turf/simulated/floor/plating,

--- a/maps/templates/space_structures/robostation.dmm
+++ b/maps/templates/space_structures/robostation.dmm
@@ -594,11 +594,6 @@
 	icon_state = "swall_s6"
 	},
 /area/space_structures/robostatoin)
-"cm" = (
-/turf/simulated/shuttle/wall{
-	icon_state = "swall3"
-	},
-/area/space_structures/robostatoin)
 "cn" = (
 /obj/structure/closet/critter/pig,
 /turf/simulated/floor{
@@ -2040,10 +2035,10 @@ aa
 aa
 at
 cC
-cm
+dk
 au
-cm
-cm
+dk
+dk
 ci
 aa
 aa
@@ -2352,10 +2347,10 @@ aa
 aa
 bf
 cf
-cm
+dk
 au
 dk
-cm
+dk
 cs
 aa
 aa


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Удалил поверхность космоса, наслоенную на поверхность стены шаттла
![image](https://user-images.githubusercontent.com/47633880/121984636-fe990c00-cd9b-11eb-92e2-73be0e1e30c5.png)
![image](https://user-images.githubusercontent.com/47633880/121984676-0eb0eb80-cd9c-11eb-9ff6-77e10503fe3e.png)

## Почему и что этот ПР улучшит
Нельзя будет ходить через стену

## Авторство

## Чеинжлог
:cl:
- map:  исправление хождения через стену на карте robostation