### PR TITLE
Добавлен ученым доступ к АПЦ в своих соответствующих отделах

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -20010,7 +20010,9 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Toxins Lab APC";
-	pixel_y = 25
+	pixel_y = 25;
+	req_access = list();
+	req_one_access = list(11,8)
 	},
 /obj/structure/cable{
 	d2 = 2;
@@ -37483,7 +37485,9 @@
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Telescience Research APC";
-	pixel_x = -25
+	pixel_x = -25;
+	req_access = list();
+	req_one_access = list(11,7)
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -38338,7 +38342,9 @@
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "Research Lab APC";
-	pixel_y = 24
+	pixel_y = 24;
+	req_access = list();
+	req_one_access = list(11,7)
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -48063,7 +48069,9 @@
 /obj/structure/closet/wardrobe/robotics_black,
 /obj/machinery/power/apc{
 	name = "Robotics Lab APC";
-	pixel_y = -26
+	pixel_y = -26;
+	req_access = list();
+	req_one_access = list(11,29)
 	},
 /obj/structure/cable,
 /turf/simulated/floor{


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Для АПЦ добавлено требование доступа аналогичное тому, что **есть на дверях**, в следующие отсеки:
* РнД, основная лаба
* РнД, комната смешивания токсинов
* РнД, робототехника
* РнД, телесаенс

## Почему и что этот ПР улучшит
QoL для ученых, особенно ночных, которые так или иначе при потере питания взламывали АПЦ, что просто сжирало время и откровенно бесило. Логически объясняется просто: раз ученые работают с лазерным оружием и прочим экипом, работающем на батарейках, то сложности с заменой батареи в АПЦ у них возникнуть не должно, а так как это отсек, по эффективности работы которого считается эффективность работы станции, то и ученым с соответствующими знаниями дали лазить в их АПЦ.

## Авторство
я

## Чеинжлог
:cl: Logimy
 - map: Ученым добавлен доступ к АПЦ в своих лабораториях