### PR TITLE
Возвращает тазер в постройку ED-209

### DIFF
--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -245,7 +245,7 @@
 	new /obj/item/device/assembly/prox_sensor(Tsec)
 
 	if(!lasertag_color)
-		var/obj/item/weapon/gun/energy/taser/stunrevolver/G = new /obj/item/weapon/gun/energy/taser/stunrevolver(Tsec)
+		var/obj/item/weapon/gun/energy/taser/G = new /obj/item/weapon/gun/energy/taser/(Tsec)
 		G.power_supply.charge = 0
 	else if(lasertag_color == "blue")
 		var/obj/item/weapon/gun/energy/laser/lasertag/bluetag/G = new /obj/item/weapon/gun/energy/laser/lasertag/bluetag(Tsec)
@@ -450,7 +450,7 @@
 						return
 					name = "redtag ED-209 assembly"
 				if("")
-					if(!istype(I, /obj/item/weapon/gun/energy/taser/stunrevolver))
+					if(!istype(I, /obj/item/weapon/gun/energy/taser/))
 						return
 					name = "taser ED-209 assembly"
 				else

--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -245,7 +245,7 @@
 	new /obj/item/device/assembly/prox_sensor(Tsec)
 
 	if(!lasertag_color)
-		var/obj/item/weapon/gun/energy/taser/G = new /obj/item/weapon/gun/energy/taser/(Tsec)
+		var/obj/item/weapon/gun/energy/taser/G = new /obj/item/weapon/gun/energy/taser(Tsec)
 		G.power_supply.charge = 0
 	else if(lasertag_color == "blue")
 		var/obj/item/weapon/gun/energy/laser/lasertag/bluetag/G = new /obj/item/weapon/gun/energy/laser/lasertag/bluetag(Tsec)

--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -450,7 +450,7 @@
 						return
 					name = "redtag ED-209 assembly"
 				if("")
-					if(!istype(I, /obj/item/weapon/gun/energy/taser/))
+					if(!istype(I, /obj/item/weapon/gun/energy/taser))
 						return
 					name = "taser ED-209 assembly"
 				else


### PR DESCRIPTION
## Описание изменений
Вернул тазер (И его подтипы) в постройку ED-209
## Почему и что этот ПР улучшит
Снова можно использовать тазер и стан-револьвер, а не только последний, для постройки ED-209
## Авторство
Haggerd
## Чеинжлог
:cl: Haggerd
 - tweak: Тазер можно использовать для постройки ED-209