### PR TITLE
Фикс разговорных биндов.

### DIFF
--- a/code/datums/keybinding/communication.dm
+++ b/code/datums/keybinding/communication.dm
@@ -6,12 +6,29 @@
 	name = "Say"
 	full_name = "IC Say"
 
+/datum/keybinding/client/communication/say/down(client/user)
+	user.mob?.say_wrapper()
+	return TRUE
+
 /datum/keybinding/client/communication/ooc
 	hotkey_keys = list("F2", "O")
 	name = "OOC"
 	full_name = "Out Of Character Say (OOC)"
 
+/datum/keybinding/client/communication/ooc/down(client/user)
+	var/message = input(user, "", "OOC \"text\"") as text|null //verb_like input
+	if(message)
+		user.ooc(message)
+	return TRUE
+
 /datum/keybinding/client/communication/me
 	hotkey_keys = list("F4", "M")
 	name = "Me"
 	full_name = "Custom Emote (/Me)"
+
+/datum/keybinding/client/communication/me/down(client/user)
+	if(user.mob)
+		var/message = input(user, "", "Me \"text\"") as text|null //verb_like input
+		if(message)
+			user.mob.me_verb(message)
+	return TRUE

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -718,9 +718,3 @@ var/list/blacklisted_builds = list(
 					movement_keys[key] = WEST
 				if("South")
 					movement_keys[key] = SOUTH
-				if("Say")
-					winset(src, "default-\ref[key]", "parent=default;name=[key];command=.say") // ".say" is wrapper over say, see in code\modules\mob\typing_indicator.dm
-				if("OOC")
-					winset(src, "default-\ref[key]", "parent=default;name=[key];command=ooc")
-				if("Me")
-					winset(src, "default-\ref[key]", "parent=default;name=[key];command=me")

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -18,7 +18,7 @@
 	set hidden = TRUE
 
 	set_typing_indicator(TRUE)
-	var/message = input("","say (text)") as text|null
+	var/message = input(src, "", "Say \"text\"") as text|null //verb_like input
 	if(message)
 		say_verb(message)
 	set_typing_indicator(FALSE)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Теперь say, me, ooc бинды работают как остальные.

## Почему и что этот ПР улучшит
Не нужно перезаходить или перебиндить на английской раскладке. 

## Авторство

## Чеинжлог
:cl: Kalazus
- bugfix: Нужно было перезаходить на английской раскладке чтобы работали me, ooc, say бинды.