### PR TITLE
mecha: brain interface fix

### DIFF
--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -17,11 +17,11 @@
 
 	var/datum/action/innate/mecha/mech_defence_mode/defence_action = new
 
-/obj/mecha/combat/durand/GrantActions(mob/living/user, human_occupant = 0)
+/obj/mecha/combat/durand/GrantActions(mob/living/user, human_occupant = FALSE)
 	..()
 	defence_action.Grant(user, src)
 
-/obj/mecha/combat/durand/RemoveActions(mob/living/user, human_occupant = 0)
+/obj/mecha/combat/durand/RemoveActions(mob/living/user, human_occupant = FALSE)
 	..()
 	defence_action.Remove(user)
 

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -18,11 +18,11 @@
 
 	var/datum/action/innate/mecha/mech_overload_mode/overload_action = new
 
-/obj/mecha/combat/gygax/GrantActions(mob/living/user, human_occupant = 0)
+/obj/mecha/combat/gygax/GrantActions(mob/living/user, human_occupant = FALSE)
 	..()
 	overload_action.Grant(user, src)
 
-/obj/mecha/combat/gygax/RemoveActions(mob/living/user, human_occupant = 0)
+/obj/mecha/combat/gygax/RemoveActions(mob/living/user, human_occupant = FALSE)
 	..()
 	overload_action.Remove(user)
 

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -34,13 +34,13 @@
 	if(thrusters_active && movement_dir && use_power(ENERGY_USE_WITH_THRUSTERS))
 		return 1
 
-/obj/mecha/combat/marauder/GrantActions(mob/living/user, human_occupant = 0)
+/obj/mecha/combat/marauder/GrantActions(mob/living/user, human_occupant = FALSE)
 	..()
 	smoke_action.Grant(user, src)
 	zoom_action.Grant(user, src)
 	thrusters_action.Grant(user, src)
 
-/obj/mecha/combat/marauder/RemoveActions(mob/living/user, human_occupant = 0)
+/obj/mecha/combat/marauder/RemoveActions(mob/living/user, human_occupant = FALSE)
 	..()
 	smoke_action.Remove(user)
 	zoom_action.Remove(user)

--- a/code/game/mecha/combat/phazon.dm
+++ b/code/game/mecha/combat/phazon.dm
@@ -22,12 +22,12 @@
 	var/datum/action/innate/mecha/mech_toggle_phasing/phasing_action = new
 	max_equip = 4
 
-/obj/mecha/combat/phazon/GrantActions(mob/living/user, human_occupant = 0)
+/obj/mecha/combat/phazon/GrantActions(mob/living/user, human_occupant = FALSE)
 	..()
 	switch_damtype_action.Grant(user, src)
 	phasing_action.Grant(user, src)
 
-/obj/mecha/combat/phazon/RemoveActions(mob/living/user, human_occupant = 0)
+/obj/mecha/combat/phazon/RemoveActions(mob/living/user, human_occupant = FALSE)
 	..()
 	switch_damtype_action.Remove(user)
 	phasing_action.Remove(user)

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -1035,7 +1035,7 @@
 		src.icon_state = reset_icon()
 		set_dir(dir_in)
 		playsound(src, 'sound/machines/windowdoor.ogg', VOL_EFFECTS_MASTER)
-		GrantActions(H, human_occupant = 1)
+		GrantActions(H, human_occupant = TRUE)
 		if(!hasInternalDamage())
 			occupant.playsound_local(null, 'sound/mecha/nominal.ogg', VOL_EFFECTS_MASTER, null, FALSE)
 		return 1
@@ -1093,6 +1093,7 @@
 		Move(src.loc)
 		src.icon_state = reset_icon()
 		set_dir(dir_in)
+		GrantActions(mmi_as_oc.brainmob, human_occupant = FALSE)
 		log_message("[mmi_as_oc] moved in as pilot.")
 		log_admin("[key_name(mmi_as_oc)] has moved in [src.type] with name [src.name] as MMI brain by [key_name(user)]")
 		if(!hasInternalDamage())
@@ -1133,7 +1134,7 @@
 	var/atom/movable/mob_container
 	if(ishuman(occupant))
 		mob_container = src.occupant
-		RemoveActions(occupant, human_occupant = 1)
+		RemoveActions(occupant, human_occupant = TRUE)
 	else if(istype(occupant, /mob/living/carbon/brain))
 		var/mob/living/carbon/brain/brain = occupant
 		RemoveActions(brain)

--- a/code/game/mecha/mecha_actions.dm
+++ b/code/game/mecha/mecha_actions.dm
@@ -1,6 +1,6 @@
 //////////////////////////////////////// Action Buttons ///////////////////////////////////////////////
 
-/obj/mecha/proc/GrantActions(mob/living/user, human_occupant = 0)
+/obj/mecha/proc/GrantActions(mob/living/user, human_occupant = FALSE)
 	if(human_occupant)
 		eject_action.Grant(user, src)
 	internals_action.Grant(user, src)
@@ -10,7 +10,7 @@
 	strafing_action.Grant(user, src)
 
 
-/obj/mecha/proc/RemoveActions(mob/living/user, human_occupant = 0)
+/obj/mecha/proc/RemoveActions(mob/living/user, human_occupant = FALSE)
 	if(human_occupant)
 		eject_action.Remove(user)
 	internals_action.Remove(user)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
 Теперь у позитронок и обычных мозгов есть интерфейс, когда их запихивают в мех
## Почему и что этот ПР улучшит
Fixes #5763
Fixes #6600
Fixes #6934
Fixes #7255
Fixes #7323
## Авторство

## Дополнительная информация
 Есть проблема, связанная с тем, что при перезаходе,будучи мозгом/позитронкой, интерфейс пропадает, у хуманов есть такая же проблема, но она фиксится нажатием кнопочки F12, а мозги/позитронки не могут её нажимать, потому что сделано так, что её могут нажимать только хуманы. Не знаю, как фиксить данную ситуацию, но пусть хотя бы так.

## Чеинжлог
🆑 
 - bugfix: Позитронки получают интерфейс в мехе.
