### PR TITLE
Med belt can hold AB scaner

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -81,7 +81,7 @@
 	    /obj/item/weapon/reagent_containers/hypospray,
 	    /obj/item/device/sensor_device,
 	    /obj/item/device/mass_spectrometer,
-	    /obj/item/device/reagent_scanner
+	    /obj/item/device/reagent_scanner,
 		/obj/item/device/antibody_scanner
 	    )
 /obj/item/weapon/storage/belt/medical/surg

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -82,7 +82,7 @@
 	    /obj/item/device/sensor_device,
 	    /obj/item/device/mass_spectrometer,
 	    /obj/item/device/reagent_scanner,
-		/obj/item/device/antibody_scanner
+		/obj/item/device/antibody_scanner,
 	    )
 /obj/item/weapon/storage/belt/medical/surg
 	name = "Surgery belt"

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -82,6 +82,7 @@
 	    /obj/item/device/sensor_device,
 	    /obj/item/device/mass_spectrometer,
 	    /obj/item/device/reagent_scanner
+		/obj/item/device/antibody_scanner
 	    )
 /obj/item/weapon/storage/belt/medical/surg
 	name = "Surgery belt"


### PR DESCRIPTION
## Описание изменений
AB сканер можно положить в мед пояс
## Почему и что этот ПР улучшит
Добавит комфорта вирусологам с поясами
## Авторство
Haggerd
## Чеинжлог
:cl:  Hagger
- tweak: Сканер антител можно положить в медицинский пояс