### PR TITLE
Ксеноморфы теперь не могут начать кравл на хоткей

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -273,6 +273,9 @@ Hit Procs
 /mob/living/carbon/xenomorph/getTrail()
 	return "xltrails"
 
+/mob/living/carbon/xenomorph/crawl()
+	return
+
 /mob/living/carbon/xenomorph/swap_hand()
 	var/obj/item/item_in_hand = get_active_hand()
 	if(item_in_hand) //this segment checks if the item in your hand is twohanded.


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
Ксеноморфы теперь не могут начать кравл на хоткей

Им верб не выдавался. Анимация выглядит убого. Некоторые штуки работают, хотя не должны

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
:cl:
 - fix: Ксеноморфы больше не могут кравлить через хоткей