### PR TITLE
Awaiting Review метки

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,7 +22,7 @@ jobs:
           close-pr-message: >
             ПР закрыт из-за длительного отсуствия активности. Для переоткрытия ПРа, пожалуйста, обратитесь к
             кому-либо из мейнтейнеров. Вы можете призвать их в комментарии слапнув ``@TauCetiStation/maintainers``.
-          exempt-pr-labels: 'Pinned'
+          exempt-pr-labels: 'Pinned, Awaiting Review [Translation Dep], Awaiting Review [Sprite Dep]'
           stale-pr-label: 'Stalled PR'
           days-before-pr-stale: 7
           days-before-pr-close: 7


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
"Awaiting Review" метки работают как "pinned", не позволяя боту отметить ПР устаревшим и закрыть его.
## Почему и что этот ПР улучшит
Организационный момент
"Готовые" ПРы не закроются и их не придется переоткрывать, просто потому что долго нет ревью
## Авторство

## Чеинжлог
