### PR TITLE
Религия при перемещение mind'a тоже перемещается корректно

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -40,7 +40,7 @@
 
 // /datum/religion signals
 /// from base of religion/add_membern(): (/mob, holy_role)
-#define COMSIG_REL_ADD_MEMBER "rite_on_chosen"
+#define COMSIG_REL_ADD_MEMBER "rel_add_member"
 
 // /datum/role signals
 /// from base of role/GetScoreboard(): ()

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -75,8 +75,6 @@
 	if(current)					//remove ourself from our old body's mind variable
 		SStgui.on_transfer(current, new_character)
 		current.mind = null
-		if(current.my_religion)
-			current.my_religion.add_member(new_character, holy_role)
 
 	if(new_character.mind)		//remove any mind currently in our new body's mind variable
 		new_character.mind.current = null
@@ -86,6 +84,9 @@
 	var/mob/old_character = current
 	current = new_character		//link ourself to our new body
 	new_character.mind = src	//and link our new body to ourself
+
+	if(current?.my_religion)
+		current.my_religion.add_member(new_character, holy_role)
 
 	transfer_actions(new_character)
 	var/datum/atom_hud/antag/hud_to_transfer = antag_hud


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
-->
## Описание изменений
К сожалению или к счастью вся религия содержится в мобе, а не в маенде. Перемещение религии тоже зависит от прошлого тела.
Ну в общем, здесь была ошибка, что при перемещение религии в новое тело нельзя было обратится к маенду нового тела по причине того, что он еще не успел переехать в это самое новое тело. Из-за этого могут возникать рантаймы при добавление во фракцию культа. Это происходит из-за того, что в религию можно приглашать по мобу (что и юзается), а во фракцию по маенду. В итоге происходит: добавить_в_религию(новый_моб) -> добавить_во_фракцию_культа(новый_моб.маенд). 

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
