### PR TITLE
Повышение фпсов клиенту

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -51,3 +51,6 @@
 #define JP_LEVELS list(JP_HIGH, JP_MEDIUM, JP_LOW)
 
 #define TOOLTIP_NORTH "TOP+0.1, CENTER-3"
+
+//recommened client FPS
+#define RECOMMENDED_FPS 40

--- a/code/modules/client/character menu/global.dm
+++ b/code/modules/client/character menu/global.dm
@@ -12,6 +12,7 @@
 	. += 				"<tr><td>TGUI Window Placement:</b> <a href='?_src_=prefs;preference=tgui_lock'><b>[tgui_lock ? "Primary Monitor" : "Free (default)"]</a></td></tr>"
 	. += 				"<tr><td>Outline: <a href='?_src_=prefs;preference=outline_enabled'>[outline_enabled ? "Enabled" : "Disabled"]</a><br>"
 	. += 				"<tr><td>Outline Color: <span style='border:1px solid #161616; background-color: [outline_color];'>&nbsp;&nbsp;&nbsp;</span> <a href='?_src_=prefs;preference=outline_color'>Change</a><BR>"
+	. += 				"<tr><td>FPS: <a href='?_src_=prefs;preference=change_fps'>[clientfps]</a></td></tr>"
 	. +=			"<tr><td><br><b>OOC Notes: </b><a href='?_src_=prefs;preference=metadata;task=input'>[length(metadata)>0?"[copytext_char(metadata, 1, 3)]...":"\[...\]"]</a></td></tr>"
 	//if(user.client) TG
 	//	if(user.client.holder)
@@ -163,6 +164,12 @@
 			var/pickedOutlineColor = input(user, "Choose your outline color.", "General Preference", outline_color) as color|null
 			if(pickedOutlineColor)
 				outline_color = pickedOutlineColor
+
+		if("change_fps")
+			var/desiredfps = input(user, "Choose your desired fps.\n-1 means recommended value (currently:[RECOMMENDED_FPS])\n0 means world fps (currently:[world.fps])", "Character Preference", clientfps)  as null|num
+			if (!isnull(desiredfps))
+				clientfps = sanitize_integer(desiredfps, -1, 1000, clientfps)
+				parent.fps = (clientfps < 0) ? RECOMMENDED_FPS : clientfps
 
 		if("parallaxup")
 			parallax = WRAP(parallax + 1, PARALLAX_INSANE, PARALLAX_DISABLE + 1)

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -264,6 +264,7 @@ var/list/blacklisted_builds = list(
 		preferences_datums[ckey] = prefs
 	prefs.last_ip = address				//these are gonna be used for banning
 	prefs.last_id = computer_id			//these are gonna be used for banning
+	fps = (prefs.clientfps < 0) ? RECOMMENDED_FPS : prefs.clientfps
 
 	var/cur_date = time2text(world.realtime, "YYYY/MM/DD hh:mm:ss")
 	if("[computer_id]" in prefs.cid_list)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -35,6 +35,7 @@ var/const/MAX_SAVE_SLOTS = 10
 	var/chat_ghostsight = CHAT_GHOSTSIGHT_ALL
 	var/ghost_orbit = GHOST_ORBIT_CIRCLE
 	var/lastchangelog = ""				//Saved changlog filesize to detect if there was a change
+	var/clientfps = -1
 
 	// Custom Keybindings
 	var/list/key_bindings = list()

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -292,6 +292,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["UI_style"]			>> UI_style
 	S["UI_style_color"]		>> UI_style_color
 	S["UI_style_alpha"]		>> UI_style_alpha
+	S["clientfps"]			>> clientfps
 	S["default_slot"]		>> default_slot
 	S["chat_toggles"]		>> chat_toggles
 	S["toggles"]			>> toggles
@@ -340,6 +341,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	aooccolor		= normalize_color(sanitize_hexcolor(aooccolor, initial(aooccolor)))
 	lastchangelog	= sanitize_text(lastchangelog, initial(lastchangelog))
 	UI_style		= sanitize_inlist(UI_style, global.available_ui_styles, global.available_ui_styles[1])
+	clientfps		= sanitize_integer(clientfps, -1, 1000, -1)
 	default_slot	= sanitize_integer(default_slot, 1, MAX_SAVE_SLOTS, initial(default_slot))
 	toggles			= sanitize_integer(toggles, 0, 65535, initial(toggles))
 	chat_toggles	= sanitize_integer(chat_toggles, 0, 65535, initial(chat_toggles))
@@ -411,6 +413,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["UI_style"]			<< UI_style
 	S["UI_style_color"]		<< UI_style_color
 	S["UI_style_alpha"]		<< UI_style_alpha
+	S["clientfps"]			<< clientfps
 	S["default_slot"]		<< default_slot
 	S["toggles"]			<< toggles
 	S["chat_toggles"]		<< chat_toggles


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Клиент сможет выбирать фпс себе на вкус. На сервер это не скажется, ибо это уже будет на стороне игрока. По дефолту стоит 40, но можно поставить хоть 144. Раньше фпс клиента был равен фпсу сервера, а это около 20-25 или меньше.

Дальше для плавности остается сделать только: https://github.com/TauCetiStation/TauCetiClassic/issues/6864

## Почему и что этот ПР улучшит
Плавность картинки

## Авторство
ТГ

## Чеинжлог
:cl:
 - add: Можно изменить фпс. По умолчанию стоит 40.