### PR TITLE
Fix pipe in toxin room [gamma]

### DIFF
--- a/maps/gamma/gamma.dmm
+++ b/maps/gamma/gamma.dmm
@@ -8455,10 +8455,10 @@
 /area/station/maintenance/bridge)
 "bHn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+	dir = 10
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -33901,18 +33901,19 @@
 /area/station/rnd/sppodconstr)
 "jJi" = (
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 5;
+	icon_state = "warning"
 	},
 /area/station/rnd/mixing)
 "jJo" = (
@@ -71408,12 +71409,6 @@
 	},
 /area/station/hallway/primary/bridgehall)
 "vyZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -72864,13 +72859,15 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/meeting_room)
 "vRj" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/simulated/floor{
-	dir = 5;
+	dir = 1;
 	icon_state = "warning"
 	},
 /area/station/rnd/mixing)
@@ -128706,9 +128703,9 @@ xtd
 uFD
 uFD
 uFD
-jJi
+lLH
 bHn
-gjh
+vRj
 sVE
 wNV
 vqj
@@ -128965,7 +128962,7 @@ tGM
 kZV
 vyZ
 vJp
-vRj
+jJi
 lPN
 ucd
 ucd


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Короче искал один баг, нашел другой. Первый так и не нашел, но второй решил не оставлять, хоть он и супер мелкий и находится на ненужной никому карте.
![image](https://user-images.githubusercontent.com/67091522/123958788-256b5b00-d9b6-11eb-81c6-e6e095667eec.png)

## Почему и что этот ПР улучшит
fix
## Авторство

## Чеинжлог
:cl:
- bugfix: Фикс расположения труб в токсинной на карте g*mma, теперь они не идут в стену.