### PR TITLE
Абдукторские наручники удаляются при дропе только после того, как были надеты

### DIFF
--- a/code/game/gamemodes/modes_gameplays/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/modes_gameplays/abduction/abduction_gear.dm
@@ -548,10 +548,14 @@
 	name = "hard-light energy field"
 	desc = "A hard-light field restraining the hands."
 	icon_state = "handcuffAlien"
-	flags = DROPDEL // no CONDUCT
 	origin_tech = "materials=5;combat=4;powerstorage=5"
 	breakouttime = 450
 
+/obj/item/weapon/handcuffs/alien/place_handcuffs()
+	. = ..()
+	if(!.)
+		return FALSE
+	flags = DROPDEL // no CONDUCT
 
 // SURGICAL INSTRUMENTS
 /obj/item/weapon/scalpel/alien

--- a/code/game/gamemodes/modes_gameplays/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/modes_gameplays/abduction/abduction_gear.dm
@@ -553,9 +553,8 @@
 
 /obj/item/weapon/handcuffs/alien/place_handcuffs()
 	. = ..()
-	if(!.)
-		return FALSE
-	flags = DROPDEL // no CONDUCT
+	if(.)
+		flags = DROPDEL // no CONDUCT
 
 // SURGICAL INSTRUMENTS
 /obj/item/weapon/scalpel/alien

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -40,7 +40,7 @@
 
 /obj/item/weapon/handcuffs/proc/place_handcuffs(mob/living/carbon/target, mob/user)
 	if(user.is_busy(target))
-		return
+		return FALSE
 
 	playsound(src, cuff_sound, VOL_EFFECTS_MASTER, 30, null, -2)
 
@@ -58,7 +58,7 @@
 						break
 				if (!grabbing)
 					to_chat(user, "<span class='warning'>Your grasp was broken before you could restrain [target]!</span>")
-					return
+					return FALSE
 
 			var/obj/item/weapon/handcuffs/cuffs = src
 			if(!dispenser)
@@ -69,6 +69,7 @@
 			target.equip_to_slot(cuffs, SLOT_HANDCUFFED, TRUE)
 			target.attack_log += "\[[time_stamp()]\] <font color='orange'>[user.name] ([user.ckey]) placed on our [target.slot_id_to_name(SLOT_HANDCUFFED)] ([cuffs])</font>"
 			user.attack_log += "\[[time_stamp()]\] <font color='red'>Placed on [target.name]'s ([target.ckey]) [target.slot_id_to_name(SLOT_HANDCUFFED)] ([cuffs])</font>"
+			return TRUE
 
 /obj/item/weapon/handcuffs/cable
 	name = "cable restraints"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Наручники будут удаляться при дропе, только если были надеты на кого-либо.
А до тех пор их можно перекладывать между руками и бросать на стол, на пол
## Почему и что этот ПР улучшит
fix https://github.com/TauCetiStation/TauCetiClassic/issues/7392

## Чеинжлог
:cl:
 - fix: наручники абдукторов исчезали, если они перекладывались между руками 