### PR TITLE
Можно менять руки у боргов при помощи хоткея X

### DIFF
--- a/code/datums/keybinding/carbon.dm
+++ b/code/datums/keybinding/carbon.dm
@@ -60,17 +60,6 @@
 	user.mob?.a_intent_change(INTENT_HARM)
 	return TRUE
 
-/datum/keybinding/carbon/swap_hands
-	hotkey_keys = list("X", "Northeast") // PAGEUP
-	name = "swap_hands"
-	full_name = "Swap hands"
-	description = ""
-
-/datum/keybinding/carbon/swap_hands/down(client/user)
-	var/mob/living/carbon/C = user.mob
-	C.swap_hand()
-	return TRUE
-
 /datum/keybinding/carbon/give
 	hotkey_keys = list("None")
 	name = "Give_Item"

--- a/code/datums/keybinding/living.dm
+++ b/code/datums/keybinding/living.dm
@@ -54,3 +54,14 @@
 	var/mob/living/L = user.mob
 	L.lay_down()
 	return TRUE
+
+/datum/keybinding/living/swap_hands
+	hotkey_keys = list("X", "Northeast") // PAGEUP
+	name = "swap_hands"
+	full_name = "Swap hands"
+	description = ""
+
+/datum/keybinding/living/swap_hands/down(client/user)
+	var/mob/living/L = user.mob
+	L.swap_hand()
+	return TRUE

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -147,7 +147,7 @@
 	return shock_damage
 
 
-/mob/living/carbon/proc/swap_hand()
+/mob/living/carbon/swap_hand()
 	var/obj/item/item_in_hand = get_active_hand()
 	if(item_in_hand) //this segment checks if the item in your hand is twohanded.
 		if(istype(item_in_hand, /obj/item/weapon/twohanded) || istype(item_in_hand, /obj/item/weapon/gun/projectile/automatic/l6_saw))	//OOP? Generics? Hue hue hue hue ...

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1338,3 +1338,6 @@
 			hud_used.move_intent.icon_state = intent == MOVE_INTENT_WALK ? "walking" : "running"
 
 	return TRUE
+
+/mob/living/proc/swap_hand()
+	return

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1121,3 +1121,6 @@
 		var/datum/robot_component/C = components[V]
 		if(C.installed)
 			C.toggled = !C.toggled
+
+/mob/living/silicon/robot/swap_hand()
+	cycle_modules()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Можно менять руки (модули) у боргов при помощи хоткея X, как раньше
## Почему и что этот ПР улучшит
fix #7415
## Авторство

## Чеинжлог
:cl:
 - fix: с помощью хоткея X (по умолчанию) модули борга не переключались