### PR TITLE
Емагнутый pile ripper даёт правильное мясо

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1168,16 +1168,17 @@
 			harvest(user)
 		return TRUE
 
-/mob/living/proc/harvest(mob/user)
+/mob/living/proc/harvest(mob/user, turf/newloc = loc)
 	if(QDELETED(src))
 		return
 	if(length(butcher_results))
 		for(var/path in butcher_results)
 			for(var/i = 1 to butcher_results[path])
-				new path(src.loc)
+				new path(newloc)
 			//In case you want to have things like simple_animals drop their butcher results on gib, so it won't double up below.
 			butcher_results.Remove(path)
-		visible_message("<span class='notice'>[user] butchers [src].</span>")
+		if(user)
+			visible_message("<span class='notice'>[user] butchers [src].</span>")
 		gib()
 
 /mob/living/proc/get_taste_sensitivity()

--- a/code/modules/scrap/scrap_pileripper.dm
+++ b/code/modules/scrap/scrap_pileripper.dm
@@ -158,4 +158,4 @@
 		L.adjustBruteLoss(45)
 		return
 
-	L.harvest(null, get_turf(get_step(src, EAST)))
+	L.harvest(null, get_step(src, EAST))

--- a/code/modules/scrap/scrap_pileripper.dm
+++ b/code/modules/scrap/scrap_pileripper.dm
@@ -153,22 +153,15 @@
 				return
 
 	// Start shredding meat
-
-	var/slab_name = L.name
-	var/slab_type = /obj/item/weapon/reagent_containers/food/snacks/meat
-
-	if(istype(L,/mob/living/carbon/human))
-		slab_name = L.real_name
-		slab_type = /obj/item/weapon/reagent_containers/food/snacks/meat/human
-	else if(istype(L, /mob/living/carbon/monkey))
-		slab_type = /obj/item/weapon/reagent_containers/food/snacks/meat/monkey
-	var/obj/item/weapon/reagent_containers/food/snacks/meat/new_meat = new slab_type(get_turf(get_step(src, 4)))
-	new_meat.name = "[slab_name] [new_meat.name]"
-
-	new_meat.reagents.add_reagent("nutriment", 10)
 	L.nutrition -= 100
 	if(L.nutrition > 0)
 		L.adjustBruteLoss(45)
-	else
-		L.gib()
+		return
+
+	if(length(L.butcher_results))
+		for(var/path in L.butcher_results)
+			for(var/i = 1 to L.butcher_results[path])
+				new path(get_turf(get_step(src, EAST)))
+
+	L.gib()
 

--- a/code/modules/scrap/scrap_pileripper.dm
+++ b/code/modules/scrap/scrap_pileripper.dm
@@ -158,10 +158,4 @@
 		L.adjustBruteLoss(45)
 		return
 
-	if(length(L.butcher_results))
-		for(var/path in L.butcher_results)
-			for(var/i = 1 to L.butcher_results[path])
-				new path(get_turf(get_step(src, EAST)))
-
-	L.gib()
-
+	L.harvest(null, get_turf(get_step(src, EAST)))


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
pile_ripper давал неправильное мясо. Теперь он даёт правильное мясо
## Почему и что этот ПР улучшит
`А ведь он реально убил весь экипаж и всё сб ради одного мясо... Еще и получил редтекст...`
fix #6865
## Авторство

## Чеинжлог
:cl:
 - fix: мясо корги, полученное с помощью pile ripper, не давало гринтекст