### PR TITLE
Возвращен верб "Ghost" для ИИ/ПИИ

### DIFF
--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -180,7 +180,7 @@
 	set category = "pAI Commands"
 	set desc = "Kill yourself and become a ghost (You will receive a confirmation prompt)."
 	set name = "pAI Suicide"
-	var/answer = input("REALLY kill yourself? This action can't be undone.", "Suicide", "No") in list ("Yes", "No")
+	var/answer = tgui_alert(usr, "REALLY kill yourself? This action can't be undone.", "Confirm Suicide", list("Yes", "No"))
 	if(answer == "Yes")
 		var/obj/item/device/paicard/card = loc
 		card.removePersonality()

--- a/code/game/verbs/suicide.dm
+++ b/code/game/verbs/suicide.dm
@@ -176,10 +176,8 @@
 		adjustOxyLoss(max(maxHealth * 2 - getToxLoss() - getFireLoss() - getBruteLoss() - getOxyLoss(), 0))
 		updatehealth()
 
-/mob/living/silicon/pai/verb/suicide()
-	set category = "pAI Commands"
-	set desc = "Kill yourself and become a ghost (You will receive a confirmation prompt)."
-	set name = "pAI Suicide"
+// Kill yourself and become a ghost (You will receive a confirmation prompt).
+/mob/living/silicon/pai/proc/suicide()
 	var/answer = tgui_alert(usr, "REALLY kill yourself? This action can't be undone.", "Confirm Suicide", list("Yes", "No"))
 	if(answer == "Yes")
 		var/obj/item/device/paicard/card = loc

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -885,3 +885,8 @@ var/list/ai_verbs_default = list(
 #undef AI_CHECK_WIRELESS
 #undef AI_CHECK_RADIO
 #undef EMERGENCY_MESSAGE_COOLDOWN
+
+/mob/living/silicon/ai/ghost()
+	if(istype(loc, /obj/item/device/aicard) || istype(loc, /obj/item/clothing/suit/space/space_ninja))
+		return ..()
+	wipe_core_verb()

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -136,7 +136,6 @@ var/list/ai_verbs_default = list(
 
 /mob/living/silicon/ai/proc/add_ai_verbs()
 	verbs |= ai_verbs_default
-	verbs -= /mob/living/verb/ghost
 
 /mob/living/silicon/ai/proc/hcattack_ai(atom/A)
 	if(!holo || !isliving(A) || !in_range(eyeobj, A))
@@ -153,7 +152,6 @@ var/list/ai_verbs_default = list(
 
 /mob/living/silicon/ai/proc/remove_ai_verbs()
 	verbs -= ai_verbs_default
-	verbs += /mob/living/verb/ghost
 
 /mob/living/silicon/ai/atom_init(mapload, datum/ai_laws/L, obj/item/device/mmi/B, safety = 0)
 	. = ..()

--- a/code/modules/mob/living/silicon/ai/latejoin.dm
+++ b/code/modules/mob/living/silicon/ai/latejoin.dm
@@ -10,11 +10,8 @@ var/global/list/empty_playable_ai_cores = list()
 
 	return 1
 
-/mob/living/silicon/ai/verb/wipe_core_verb()
-	set name = "Wipe Core"
-	set category = "OOC"
-	set desc = "Wipe your core. This is functionally equivalent to cryo or robotic storage, freeing up your job slot."
-
+// Wipe your core. This is functionally equivalent to cryo or robotic storage, freeing up your job slot.
+/mob/living/silicon/ai/proc/wipe_core_verb()
 	if(ismalf(usr))
 		to_chat(usr, "<span class='danger'>You cannot use this verb in malfunction. If you need to leave, please adminhelp.</span>")
 		return

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -196,6 +196,9 @@
 	unset_machine()
 	src.cameraFollow = null
 
+/mob/living/silicon/pai/ghost()
+	suicide()
+
 //Addition by Mord_Sith to define AI's network change ability
 /*
 /mob/living/silicon/pai/proc/pai_network_change()

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -77,8 +77,6 @@
 	add_language("Tradeband", 1)
 	add_language("Gutter", 1)
 
-	verbs -= /mob/living/verb/ghost
-
 	//PDA
 	pda = new(src)
 	spawn(5)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Вернул ИИ/ПИИ верб ghost, однако изменил поведение вербов. Если ИИ не на интелкарте, то ему будет предложено вайпнуться, иначе гост. ПИИ же будет предложен Suicide.

(Дополнительно изменил в вербе ПИИ input на более современный tgui_alert)
## Почему и что этот ПР улучшит
close #7014
close #6196
## Авторство

## Чеинжлог
:cl:
 - tweak: Вербы "Wipe Core" у ИИ и "pAI Suicide" заменены на "Ghost"
 - fix: в определенных ситуациях ИИ совсем не мог стать наблюдателем