### PR TITLE
Invisible AI hologram fix

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -735,7 +735,6 @@ var/list/ai_verbs_default = list(
 				if(!state)
 					return
 				if(chooses_ai_staff[state])
-					qdel(holo_icon) //Clear old icon so we're not storing it in memory.
 					holo_icon = chooses_ai_staff[state]
 			else
 				tgui_alert(usr, "No suitable records found. Aborting.")
@@ -745,7 +744,6 @@ var/list/ai_verbs_default = list(
 			var/state = show_radial_menu(usr, eyeobj, chooses_ai_holo, radius = 38, tooltips = TRUE)
 			if(!state)
 				return
-			qdel(holo_icon)
 			holo_icon = chooses_ai_holo[state]
 
 //I am the icon meister. Bow fefore me.	//>fefore


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
qdel удалял изображение из-за чего оно пропадало из радиального меню

![image](https://user-images.githubusercontent.com/66636084/124384788-9626b600-dcdb-11eb-9f00-ec3b18f39555.png)

## Почему и что этот ПР улучшит
fix #7334
## Авторство
T6751
## Чеинжлог
:cl: 
 - fix: в определенных случаях голограмма ИИ могла стать невидимой