### PR TITLE
fixes the qdeleted signal

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -18,8 +18,8 @@
 #define COMSIG_COMPONENT_REMOVING "component_removing"
 /// before a datum's Destroy() is called: (force), returning a nonzero value will cancel the qdel operation
 #define COMSIG_PARENT_PREQDELETED "parent_preqdeleted"
-/// after a datum's Destroy() is called: (force, qdel_hint), at this point none of the other components chose to interrupt qdel and Destroy has been called
-#define COMSIG_PARENT_QDELETED "parent_qdeleted"
+/// just before a datum's Destroy() is called: (force), at this point none of the other components chose to interrupt qdel and Destroy will be called
+#define COMSIG_PARENT_QDELETING "parent_qdeleting"
 
 // /datum/religion_rites signals
 /// from base of religion_rites/on_chosen(): (/mob, /obj)

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -256,8 +256,8 @@ SUBSYSTEM_DEF(garbage)
 		D.gc_destroyed = GC_CURRENTLY_BEING_QDELETED
 		var/start_time = world.time
 		var/start_tick = world.tick_usage
+		SEND_SIGNAL(D, COMSIG_PARENT_QDELETING, force) // Let the (remaining) components know about the result of Destroy
 		var/hint = D.Destroy(arglist(args.Copy(2))) // Let our friend know they're about to get fucked up.
-		SEND_SIGNAL(D, COMSIG_PARENT_QDELETED, force, hint) // Let the (remaining) components know about the result of Destroy
 		if(world.time != start_time)
 			I.slept_destroy++
 		else

--- a/code/datums/atom_huds/atom_hud.dm
+++ b/code/datums/atom_huds/atom_hud.dm
@@ -57,7 +57,7 @@ var/global/list/huds[23]
 	if(!M || !hudusers[M])
 		return
 	if (absolute || !--hudusers[M])
-		UnregisterSignal(M, COMSIG_PARENT_QDELETED)
+		UnregisterSignal(M, COMSIG_PARENT_QDELETING)
 		hudusers -= M
 		if(next_time_allowed[M])
 			next_time_allowed -= M
@@ -86,7 +86,7 @@ var/global/list/huds[23]
 		return
 	if(!hudusers[M])
 		hudusers[M] = 1
-		RegisterSignal(M, COMSIG_PARENT_QDELETED, .proc/unregister_mob)
+		RegisterSignal(M, COMSIG_PARENT_QDELETING, .proc/unregister_mob)
 		if(next_time_allowed[M] > world.time)
 			if(!queued_to_see[M])
 				addtimer(CALLBACK(src, .proc/show_hud_images_after_cooldown, M), next_time_allowed[M] - world.time)

--- a/code/datums/components/attack_self_effect.dm
+++ b/code/datums/components/attack_self_effect.dm
@@ -38,7 +38,7 @@
 	RegisterSignal(parent, list(COMSIG_ITEM_ATTACK_SELF), .proc/do_effect)
 	RegisterSignal(parent, list(COMSIG_ITEM_EQUIPPED), .proc/equipped_effect)
 	RegisterSignal(parent, list(COMSIG_ITEM_DROPPED), .proc/dropped_effect)
-	RegisterSignal(parent, list(COMSIG_PARENT_QDELETED), .proc/del_effect)
+	RegisterSignal(parent, list(COMSIG_PARENT_QDELETING), .proc/del_effect)
 
 	var/datum/mechanic_tip/self_effect/effect_tip = new(src, effect_type)
 

--- a/code/datums/components/bound.dm
+++ b/code/datums/components/bound.dm
@@ -41,8 +41,8 @@
 	resolve_callback = _resolve_callback
 
 	RegisterSignal(bound_to, list(COMSIG_MOVABLE_MOVED, COMSIG_MOVABLE_LOC_MOVED), .proc/check_bounds)
-	RegisterSignal(bound_to, list(COMSIG_PARENT_PREQDELETED), .proc/on_bound_destroyed)
-	RegisterSignal(parent, list(COMSIG_PARENT_QDELETED), .proc/on_bound_destroyed)
+	RegisterSignal(bound_to, list(COMSIG_PARENT_QDELETING), .proc/on_bound_destroyed)
+	RegisterSignal(parent, list(COMSIG_PARENT_QDELETING), .proc/on_bound_destroyed)
 	RegisterSignal(parent, list(COMSIG_MOVABLE_MOVED), .proc/check_bounds)
 	RegisterSignal(parent, list(COMSIG_MOVABLE_PRE_MOVE), .proc/on_try_move)
 
@@ -177,7 +177,7 @@
 /datum/component/bounded/proc/hide_radius()
 	SEND_SIGNAL(bound_to, COMSIG_HIDE_RADIUS)
 
-/datum/component/bounded/proc/on_bound_destroyed(force, qdel_hint)
+/datum/component/bounded/proc/on_bound_destroyed(force)
 	// Perhaps add an abilities to resolve this situation with a callback? ~Luduk
 	qdel(src)
 

--- a/code/datums/components/forcefield.dm
+++ b/code/datums/components/forcefield.dm
@@ -365,7 +365,7 @@
 /// A wrapper function to add A to protected list from a signal.
 /datum/component/forcefield/proc/add_protected(datum/source, atom/A)
 	LAZYADD(protected, A)
-	RegisterSignal(A, list(COMSIG_PARENT_QDELETED), CALLBACK(src, .proc/stop_protecting, A))
+	RegisterSignal(A, list(COMSIG_PARENT_QDELETING), CALLBACK(src, .proc/stop_protecting, A))
 
 	if(active)
 		start_protecting(A)
@@ -375,7 +375,7 @@
 	if(active)
 		stop_protecting(A)
 
-	UnregisterSignal(A, list(COMSIG_PARENT_QDELETED))
+	UnregisterSignal(A, list(COMSIG_PARENT_QDELETING))
 	LAZYREMOVE(protected, A)
 
 #undef FORCEFIELDING_TIP

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -71,7 +71,7 @@
 	if(loc != NewLoc)
 		if (!is_diagonal) //Cardinal move
 			. = ..()
-		else //Diagonal move, split it into cardinal 
+		else //Diagonal move, split it into cardinal
 			var/v = Dir & NORTH_SOUTH
 			var/h = Dir & EAST_WEST
 
@@ -94,7 +94,7 @@
 	if(!loc || (loc == oldloc && oldloc != NewLoc))
 		last_move = 0
 		return FALSE
-	
+
 	if(!is_diagonal && moving_diagonally != SECOND_DIAG_STEP)
 		move_speed = world.time - l_move_time
 		l_move_time = world.time
@@ -243,7 +243,7 @@
 
 	var/datum/thrownthing/TT = new()
 	TT.thrownthing = src
-	RegisterSignal(TT, COMSIG_PARENT_QDELETED, /datum/thrownthing.proc/on_thrownthing_qdel)
+	RegisterSignal(TT, COMSIG_PARENT_QDELETING, /datum/thrownthing.proc/on_thrownthing_qdel)
 	TT.target = target
 	TT.target_turf = get_turf(target)
 	TT.init_dir = get_dir(src, target)

--- a/code/game/gamemodes/modes_gameplays/cult/cult_items.dm
+++ b/code/game/gamemodes/modes_gameplays/cult/cult_items.dm
@@ -172,7 +172,7 @@
 
 /obj/item/device/cult_camera/proc/off()
 	if(toggle)
-		UnregisterSignal(camera, list(COMSIG_PARENT_QDELETED))
+		UnregisterSignal(camera, list(COMSIG_PARENT_QDELETING))
 		current_user.reset_view()
 		current_user.force_remote_viewing = FALSE
 		camera.icon_state = initial(camera.icon_state)
@@ -209,7 +209,7 @@
 	current_user.reset_view(camera)
 	toggle = !toggle
 
-	RegisterSignal(camera, list(COMSIG_PARENT_QDELETED), .proc/feel_pain)
+	RegisterSignal(camera, list(COMSIG_PARENT_QDELETING), .proc/feel_pain)
 
 /obj/item/device/cult_camera/dropped(mob/living/carbon/human/user)
 	. = ..()

--- a/code/game/objects/effects/decals/crayon.dm
+++ b/code/game/objects/effects/decals/crayon.dm
@@ -10,7 +10,7 @@
 	RegisterSignal(src, list(COMSIG_MOVABLE_MOVED), .proc/update_plane)
 	if(istype(loc, /atom/movable))
 		RegisterSignal(loc, list(COMSIG_MOVABLE_MOVED), .proc/update_plane)
-	RegisterSignal(loc, list(COMSIG_PARENT_QDELETED), .proc/destroy_rune)
+	RegisterSignal(loc, list(COMSIG_PARENT_QDELETING), .proc/destroy_rune)
 	update_plane()
 
 	name = e_name

--- a/code/modules/clothing/shoes/boots.dm
+++ b/code/modules/clothing/shoes/boots.dm
@@ -37,10 +37,10 @@
 
 /obj/item/clothing/shoes/boots/proc/add_knife(obj/item/K)
 	knife = K
-	RegisterSignal(knife, list(COMSIG_PARENT_QDELETED), .proc/remove_knife)
+	RegisterSignal(knife, list(COMSIG_PARENT_QDELETING), .proc/remove_knife)
 
 /obj/item/clothing/shoes/boots/proc/remove_knife()
-	UnregisterSignal(knife, list(COMSIG_PARENT_QDELETED))
+	UnregisterSignal(knife, list(COMSIG_PARENT_QDELETING))
 	knife = null
 
 /obj/item/clothing/shoes/boots/galoshes

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -56,7 +56,7 @@
 /obj/item/weapon/gripper/proc/wrap(obj/item/I)
 	wrapped = I
 	I.forceMove(src)
-	RegisterSignal(I, list(COMSIG_PARENT_PREQDELETED), .proc/clear_wrapped)
+	RegisterSignal(I, list(COMSIG_PARENT_QDELETING), .proc/clear_wrapped)
 
 /obj/item/weapon/gripper/proc/attack_as_hand(datum/source, atom/T, mob/user, params)
 	if(wrapped)
@@ -98,7 +98,7 @@
 		I.forceMove(T)
 	else
 		I.forceMove(get_turf(user))
-	UnregisterSignal(wrapped, list(COMSIG_PARENT_PREQDELETED))
+	UnregisterSignal(wrapped, list(COMSIG_PARENT_QDELETING))
 	wrapped = null
 	return TRUE
 

--- a/code/modules/roguelike/mob_modifiers/positive.dm
+++ b/code/modules/roguelike/mob_modifiers/positive.dm
@@ -74,7 +74,7 @@
 	var/mob/living/simple_animal/hostile/H = parent
 
 	qdel(possessed.GetComponent(/datum/component/bounded))
-	UnregisterSignal(possessed, list(COMSIG_PARENT_QDELETED))
+	UnregisterSignal(possessed, list(COMSIG_PARENT_QDELETING))
 
 	if(rejuve_timer)
 		SEND_SIGNAL(possessed, COMSIG_NAME_MOD_REMOVE, /datum/name_modifier/prefix/cursed, 1)
@@ -116,7 +116,7 @@
 
 	// ghostly_filter = filter(type="color", color=ghostly_matrix)
 
-	RegisterSignal(possessed, list(COMSIG_PARENT_QDELETED), .proc/on_phylactery_destroyed)
+	RegisterSignal(possessed, list(COMSIG_PARENT_QDELETING), .proc/on_phylactery_destroyed)
 	possessed.forceMove(H.loc)
 
 	if(QDELING(possessed) || !get_turf(possessed))


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Сигнал COMSIG_PARENT_QDELETED никогда не срабатывал, т.к., внезапно, вызывался после дестроя, который анрегистрировал все сигналы

Теперь всё будет работать как должно.

## Почему и что этот ПР улучшит
Мне это для рунчата нужно, чтобы работало ок

closes https://github.com/TauCetiStation/TauCetiClassic/issues/6946
Также вероятно закрывает https://github.com/TauCetiStation/TauCetiClassic/issues/6562, т.к. соответственно не вызывались COMSIG_PARENT_QDELETED, но не проверял, поэтому не могу сказать точно

## Авторство
Фикс на тг принадлежит автору этого ПРа https://github.com/tgstation/tgstation/pull/44817
## Чеинжлог
