### PR TITLE
Цель на убийство не ищется на ЦК

### DIFF
--- a/code/game/gamemodes/objectives/target/target.dm
+++ b/code/game/gamemodes/objectives/target/target.dm
@@ -19,6 +19,8 @@ var/global/list/target_objectives = list()
 		return FALSE
 	if(possible_target.current.stat == DEAD)
 		return FALSE
+	if(is_centcom_level(possible_target.current.z))
+		return FALSE
 	if(possible_target.assigned_role in protected_jobs)
 		return FALSE
 	return TRUE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Все таргет обжекты, которые подразумевают что-то деланье с каким-то человеком, будут выбирать цель на всех слоях, кроме ЦКшного

fix https://github.com/TauCetiStation/TauCetiClassic/issues/7529


## Почему и что этот ПР улучшит
Не будет цели убить админа

## Авторство

## Чеинжлог
:cl:
 - fix: Цель задачи антагониста могла находится на слое ЦК.