### PR TITLE
Фикс рантайма с неизвестным проком при удаление кидающего какую-то штуку

### DIFF
--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -65,7 +65,7 @@ SUBSYSTEM_DEF(throwing)
 	var/datum/callback/early_callback // used when you want to call something before throw_impact().
 
 /datum/thrownthing/New(thrownthing, target, target_turf, init_dir, maxrange, speed, thrower, diagonals_first, datum/callback/callback, datum/callback/early_callback)
-	src.thrownthing = src
+	src.thrownthing = thrownthing
 	RegisterSignal(thrownthing, COMSIG_PARENT_QDELETING, .proc/on_thrownthing_qdel)
 	src.target = target
 	src.target_turf = get_turf(target)

--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -64,6 +64,19 @@ SUBSYSTEM_DEF(throwing)
 	var/datum/callback/callback
 	var/datum/callback/early_callback // used when you want to call something before throw_impact().
 
+/datum/thrownthing/New(thrownthing, target, target_turf, init_dir, maxrange, speed, thrower, diagonals_first, datum/callback/callback, datum/callback/early_callback)
+	src.thrownthing = src
+	RegisterSignal(thrownthing, COMSIG_PARENT_QDELETING, .proc/on_thrownthing_qdel)
+	src.target = target
+	src.target_turf = get_turf(target)
+	src.init_dir = get_dir(src, target)
+	src.maxrange = maxrange
+	src.speed = speed
+	src.thrower = thrower
+	src.diagonals_first = diagonals_first
+	src.callback = callback
+	src.early_callback = early_callback
+
 /datum/thrownthing/Destroy()
 	SSthrowing.processing -= thrownthing
 	SSthrowing.currentrun -= thrownthing

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -241,18 +241,7 @@
 			if (speed <= 0)
 				return //no throw speed, the user was moving too fast.
 
-	var/datum/thrownthing/TT = new()
-	TT.thrownthing = src
-	RegisterSignal(TT, COMSIG_PARENT_QDELETING, /datum/thrownthing.proc/on_thrownthing_qdel)
-	TT.target = target
-	TT.target_turf = get_turf(target)
-	TT.init_dir = get_dir(src, target)
-	TT.maxrange = range
-	TT.speed = speed
-	TT.thrower = thrower
-	TT.diagonals_first = diagonals_first
-	TT.callback = callback
-	TT.early_callback = early_callback
+	var/datum/thrownthing/TT = new(src, target, get_turf(target), get_dir(src, target), range, speed, thrower, diagonals_first, callback, early_callback)
 
 	var/dist_x = abs(target.x - src.x)
 	var/dist_y = abs(target.y - src.y)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Фикс этого поидее. Смысл в том, что раньше сигнал регестрировался на тровинг-датум, а теперь на предмет, который кидает
![image](https://user-images.githubusercontent.com/26389417/124656904-77c2e500-deaa-11eb-8de0-2d8a05138cbf.png)



## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
