### PR TITLE
Небольшие изменения культа и скелетов

### DIFF
--- a/code/game/objects/items/weapons/storage/bible/tome.dm
+++ b/code/game/objects/items/weapons/storage/bible/tome.dm
@@ -144,7 +144,7 @@
 	if(religion.runes_by_mob[H])
 		var/list/L = religion.runes_by_mob[H]
 		if(L.len > religion.max_runes_on_mob)
-			to_chat(H, "<span class='warning'>Вуаль пространтсва не сможет сдержать больше рун!</span>")
+			to_chat(H, "<span class='warning'>Ваше тело слишком слабо, чтобы выдержать ещё больше рун!</span>")
 			return
 
 	if(!religion.check_costs(choice.favor_cost * cost_coef, choice.piety_cost * cost_coef, H))
@@ -156,7 +156,7 @@
 		return
 	scribing = FALSE
 
-	H.take_certain_bodypart_damage(list(BP_L_ARM, BP_R_ARM), ((rand(9) + 1) / 10))
+	H.take_certain_bodypart_damage(list(BP_L_ARM, BP_R_ARM), (rand(9) + 1) / 10)
 
 	var/obj/effect/rune/R = new choice.building_type(get_turf(H), religion, H)
 	R.icon = rune_choices_image[choice]

--- a/code/modules/organs/external/skeleton.dm
+++ b/code/modules/organs/external/skeleton.dm
@@ -20,10 +20,10 @@
 	playsound(BP.owner, pick(SOUNDIN_BONEBREAK), VOL_EFFECTS_MASTER, null, null, -2)
 
 	var/lose_bone_chance = 100
-	if(brute < BP.min_broken_damage * 2)
-		lose_bone_chance = 20
-	else if(brute < BP.min_broken_damage)
+	if(brute < BP.min_broken_damage)
 		lose_bone_chance = 5
+	else if(brute < BP.min_broken_damage * 2)
+		lose_bone_chance = 20
 
 	if(prob(lose_bone_chance))
 		if(!BP.cannot_amputate)

--- a/code/modules/religion/religion_types/cult.dm
+++ b/code/modules/religion/religion_types/cult.dm
@@ -216,12 +216,13 @@
 /datum/religion/cult/can_convert(mob/M)
 	if(M.my_religion)
 		return FALSE
-	if(M.stat == DEAD || M.species.flags[NO_BLOOD])
+	if(M.stat == DEAD)
 		return FALSE
 	if(jobban_isbanned(M, ROLE_CULTIST) || jobban_isbanned(M, "Syndicate")) // Nar-sie will punish people with a jobban, it's funny
 		return FALSE
 	if(ishuman(M))
-		if(M.mind.assigned_role == "Captain")
+		var/mob/living/carbon/human/H = M
+		if(H.mind.assigned_role == "Captain" || H.species.flags[NO_BLOOD])
 			return FALSE
 	if(ismindshielded(M) || isloyal(M))
 		return FALSE

--- a/code/modules/religion/religion_types/cult.dm
+++ b/code/modules/religion/religion_types/cult.dm
@@ -216,6 +216,10 @@
 /datum/religion/cult/can_convert(mob/M)
 	if(M.my_religion)
 		return FALSE
+	if(M.stat == DEAD || M.species.flags[NO_BLOOD])
+		return FALSE
+	if(jobban_isbanned(M, ROLE_CULTIST) || jobban_isbanned(M, "Syndicate")) // Nar-sie will punish people with a jobban, it's funny
+		return FALSE
 	if(ishuman(M))
 		if(M.mind.assigned_role == "Captain")
 			return FALSE

--- a/code/modules/religion/religion_types/cult.dm
+++ b/code/modules/religion/religion_types/cult.dm
@@ -223,8 +223,6 @@
 	if(ishuman(M))
 		if(M.mind.assigned_role == "Captain")
 			return FALSE
-		if(M.get_species() == GOLEM)
-			return FALSE
 	if(ismindshielded(M) || isloyal(M))
 		return FALSE
 	return TRUE

--- a/code/modules/religion/rites/instant/instant.dm
+++ b/code/modules/religion/rites/instant/instant.dm
@@ -76,36 +76,19 @@
 	favor_cost = 100
 	can_talismaned = FALSE
 
-/datum/religion_rites/instant/cult/convert/proc/can_convert(mob/living/user, obj/AOG)
-	if(!ishuman(AOG.buckled_mob))
-		to_chat(user, "<span class='warning'>Только человек может пройти через ритуал.</span>")
-		return FALSE
-
-	var/mob/living/carbon/human/H = AOG.buckled_mob
-	if(religion.is_member(H) || H.stat == DEAD || H.species.flags[NO_BLOOD])
-		to_chat(user, "<span class='warning'>Неподходящее тело.</span>")
-		return FALSE
-	if(!global.cult_religion.can_convert(H))
-		to_chat(user, "<span class='warning'>Разум тела сопротивляется.</span>")
-		return FALSE
-	if(jobban_isbanned(H, ROLE_CULTIST) || jobban_isbanned(H, "Syndicate"))
-		to_chat(user, "<span class='warning'>Нар-Си не нужно такое тело.</span>")
-		return FALSE
-
-	return TRUE
-
 /datum/religion_rites/instant/cult/convert/can_start(mob/living/user, obj/AOG)
 	if(!..())
 		return FALSE
 
-	if(!can_convert(user, AOG))
+	if(!religion.can_convert(AOG.buckled_mob))
+		to_chat(user, "<span class='warning'>Вы не можете обратить это существо.</span>")
 		return FALSE
 
 	return TRUE
 
 /datum/religion_rites/instant/cult/convert/invoke_effect(mob/living/user, obj/AOG)
 	..()
-	if(!can_convert(user, AOG))
+	if(!religion.can_convert(AOG.buckled_mob))
 		return FALSE
 
 	religion.add_member(AOG.buckled_mob, CULT_ROLE_HIGHPRIEST)

--- a/code/modules/religion/rites/pedestals/pedestals.dm
+++ b/code/modules/religion/rites/pedestals/pedestals.dm
@@ -129,6 +129,11 @@
 			to_chat(user, "<span class='warning'>На алтаре должен быть человек.</span>")
 		return FALSE
 
+	if(!religion.can_convert(AOG.buckled_mob))
+		if(user)
+			to_chat(user, "<span class='warning'>Неподходящее существо.</span>")
+		return FALSE
+
 	return TRUE
 
 /datum/religion_rites/pedestals/cult/make_skeleton/invoke_effect(mob/living/user, obj/structure/altar_of_gods/AOG)

--- a/code/modules/religion/rites/pedestals/pedestals.dm
+++ b/code/modules/religion/rites/pedestals/pedestals.dm
@@ -152,11 +152,12 @@
 	S.color = "#db0101"
 	S.start()
 
+	religion.add_member(H, CULT_ROLE_HIGHPRIEST)
+
 	H.set_species(SKELETON)
 	H.revive()
 	H.visible_message("<span class='warning'>После того, как дым развеялся, на алтаре виден скелет человека.</span>",
 					"<span class='cult'>Вы чувствуете, как с вас буквально содрали всю кожу, хотя у тебя теперь нет и нервов.</span>")
-	religion.add_member(H, CULT_ROLE_HIGHPRIEST)
 	H.regenerate_icons()
 
 	return TRUE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Если продамажить конечность скелета на демедж меньший min_broken_damage, и при этом меньший min_broken_damage * 2, то шанс на отлетаниние руки был 20 процентов, а не 5.

Немного перенес код конверта из ритуала в религию, а это значит, что конвертировать случайного человека в культ будет сложнее И нарси будет предлагать большее количество людей жертвопринести. Раньше жертвой могли стать только СБшники, капитан и капеллан. А сейчас же, могут быть ксеносы без крови и с джобкой на культ или всех антагов. Так сказать, нар-си взломал реальность

## Почему и что этот ПР улучшит
Скелеты смогут с большим шансом нарисовать руну и не сломать кости. Возможность конвертировать чела более централизованнее

## Авторство
я

## Чеинжлог
:cl:
 - fix: У скелетов шанс на отлетание руки был больше, если наносить маленький урон
 - add: Нар-си выбрался из матрицы и теперь сможет предлагать приносить в жертву людей с джобкой на культ