### PR TITLE
blurb runtime hotfix

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -692,11 +692,12 @@ SUBSYSTEM_DEF(job)
 
 	lines[4] = "[current_date_string], [worldtime2text()]"
 
+	C.screen += B
+
 	var/newline_flag = TRUE
 	for(var/j in 1 to lines.len)
 		var/new_line = uppertext(lines[j])
 		var/old_line = j > 1 ? "<span style=\"[style_for_line[j - 1]]\">[uppertext(lines[j - 1])]</span>" : null
-		C.screen += B
 		animate(B, alpha = 255, time = 10)
 		newline_flag = !newline_flag
 		for(var/i = 2 to length_char(new_line) + 1)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Игрок вышел во время показа текста
И в целом это не нужно в цикле
## Почему и что этот ПР улучшит
фикс рантайма после #7574
## Авторство

## Чеинжлог
