### PR TITLE
GC fixes

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -16,7 +16,7 @@
 	for(var/alert in alerts)
 		clear_alert(alert, TRUE)
 	remote_control = null
-	qdel(hud_used)
+	QDEL_NULL(hud_used)
 	ghostize(bancheck = TRUE)
 	my_religion?.remove_member(src)
 

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -23,6 +23,10 @@
 	transform = turn(transform,rand(0,360))
 	update_icon()
 
+/obj/item/ammo_casing/Destroy()
+	QDEL_NULL(BB)
+	return ..()
+
 /obj/item/ammo_casing/update_icon()
 	..()
 	icon_state = "[initial(icon_state)][BB ? "-live" : ""]"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
```
GC: -- [0x21000068] | /obj/item/projectile/kinetic was unable to be GC'd --
Found /obj/item/projectile/kinetic [0x2007811] in /obj/item/ammo_casing/energy/kinetic's [0x2007810] BB var. World -> /obj/item/ammo_casing/energy/kinetic

Found /datum/hud [0x210007aa] in /mob/dead/new_player's [0x300000b] hud_used var. World -> /mob/dead/new_player
GC: -- [0x21000068] | /datum/hud was unable to be GC'd --

```

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
