### PR TITLE
Исправление укладки кабеля на catwalk

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1267,11 +1267,6 @@ var/list/WALLITEMS = typecacheof(list(
 	tY = clamp(origin.y + 7 - tY, 1, world.maxy)
 	return locate(tX, tY, tZ)
 
-/proc/iscatwalk(atom/A)
-	if(istype(A, /turf/simulated/floor/plating/airless/catwalk))
-		return 1
-	return 0
-
 /proc/getOPressureDifferential(turf/loc)
 	var/minp=16777216;
 	var/maxp=0;

--- a/code/game/turfs/simulated/floor_types.dm
+++ b/code/game/turfs/simulated/floor_types.dm
@@ -409,11 +409,7 @@
 	temperature = TCMB
 	thermal_conductivity = OPEN_HEAT_TRANSFER_COEFFICIENT
 	heat_capacity = 700000
-
-//	accepts_lighting=0 			// Don't apply overlays
-
 	intact = 0
-
 	footstep = FOOTSTEP_CATWALK
 
 /turf/simulated/floor/plating/airless/catwalk/atom_init()
@@ -436,18 +432,6 @@
 			if(propogate)
 				C.update_icon(0)
 	icon_state="catwalk[dirs]"
-
-
-/turf/simulated/floor/plating/airless/catwalk/attackby(obj/item/C, mob/user)
-	if(isscrewdriver(C))
-		user.SetNextMove(CLICK_CD_INTERACT)
-		ReplaceWithLattice()
-		playsound(src, 'sound/items/Screwdriver.ogg', VOL_EFFECTS_MASTER)
-		return
-
-	if(iscoil(C))
-		var/obj/item/stack/cable_coil/coil = C
-		coil.turf_place(src, user)
 
 /turf/simulated/floor/plating/airless/catwalk/is_catwalk()
 	return TRUE


### PR DESCRIPTION
## Описание изменений
Для `catwalk` была своя переопределенная `attackby`. Хотя всё, что в ней, уже есть в `/turf/simulated/floor/attackby`. Плюс еще и делалось неправильно для кабелей.

## Почему и что этот ПР улучшит
При укладке кабеля на catwalk больше не нужно кликать по уже уложенному кабелю. А можно кликать по самому catwalk-полу, как при укладке на обычный пол.

## Чеинжлог
:cl:
 - bugfix: При укладке кабеля на catwalk (решетчатые полы в космосе) теперь не нужно целиться в уже уложенный кабель.