### PR TITLE
parent_qdeleting overridden fix

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -216,26 +216,11 @@
 			wrapped = null
 
 /obj/item/weapon/gripper/verb/drop_item_verb()
-
 	set name = "Drop Item"
 	set desc = "Release an item from your magnetic gripper."
 	set category = "Drone"
 
-	if(!wrapped)
-		//There's some weirdness with items being lost inside the arm. Trying to fix all cases. ~Z
-		for(var/obj/item/thing in src.contents)
-			thing.loc = get_turf(src)
-		return
-
-	if(wrapped.loc != src)
-		wrapped = null
-		return
-
-	to_chat(src.loc, "<span class='warning'>You drop \the [wrapped].</span>")
-	var/obj/item/I = wrapped
-	I.forceMove(get_turf(src))
-	wrapped = null
-	//update_icon()
+	drop_item(null, get_turf(src))
 
 /obj/item/weapon/gripper/attack(mob/living/carbon/M, mob/living/carbon/user)
 	return


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Если борг использовал верб для дропа предмета, то происходил рантайм, да
## Почему и что этот ПР улучшит
fix #7538
## Авторство

## Чеинжлог
