### PR TITLE
Лоббискрин скрывается после логина, а не перед логаутом

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -661,6 +661,7 @@ SUBSYSTEM_DEF(job)
 /proc/show_location_blurb(client/C)
 	set waitfor = FALSE
 
+	stoplag(1.5 SECOND)
 	if(!C)
 		return
 

--- a/code/modules/mob/dead/new_player/login.dm
+++ b/code/modules/mob/dead/new_player/login.dm
@@ -4,7 +4,6 @@
 		mind.active = TRUE
 		mind.current = src
 
-	my_client = client
 	..()
 
 	if(join_motd)

--- a/code/modules/mob/dead/new_player/logout.dm
+++ b/code/modules/mob/dead/new_player/logout.dm
@@ -1,9 +1,6 @@
 /mob/dead/new_player/Logout()
 	ready = 0
 	client << output(ready, "lobbybrowser:imgsrc")
-	if(my_client)
-		hide_titlescreen()
-		my_client = null
 	..()
 	if(!spawning)//Here so that if they are spawning and log out, the other procs can play out and they will have a mob to come back to.
 		key = null//We null their key before deleting the mob, so they are properly kicked out.

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -42,6 +42,9 @@
 	return
 
 /mob/proc/hide_titlescreen()
+	set waitfor = FALSE
+
+	stoplag()
 	if(client)
 		winset(client, "lobbybrowser", "is-disabled=true;is-visible=false")
 

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -44,7 +44,7 @@
 /mob/proc/hide_titlescreen()
 	set waitfor = FALSE
 
-	stoplag(5)
+	stoplag(1 SECOND)
 	if(client)
 		winset(client, "lobbybrowser", "is-disabled=true;is-visible=false")
 

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -11,7 +11,6 @@
 	var/spawning          = FALSE // Referenced when you want to delete the new_player later on in the code.
 	var/totalPlayers      = FALSE // Player counts for the Lobby tab
 	var/totalPlayersReady = FALSE
-	var/client/my_client
 
 /mob/dead/new_player/atom_init()
 	if(length(newplayer_start))
@@ -39,10 +38,11 @@
 	client << browse(global.current_lobby_screen, "file=titlescreen.gif;display=0")
 	client << browse(get_lobby_html(), "window=lobbybrowser")
 
-/mob/dead/new_player/proc/hide_titlescreen()
-	if(my_client.mob) // Check if the client is still connected to something
-		// Hide title screen, allowing player to see the map
-		winset(my_client, "lobbybrowser", "is-disabled=true;is-visible=false")
+/mob/dead/new_player/hide_titlescreen()
+	return
+
+/mob/proc/hide_titlescreen()
+	winset(client, "lobbybrowser", "is-disabled=true;is-visible=false")
 
 /mob/dead/new_player/prepare_huds()
 	return

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -44,7 +44,7 @@
 /mob/proc/hide_titlescreen()
 	set waitfor = FALSE
 
-	stoplag(1 SECOND)
+	stoplag(5)
 	if(client)
 		winset(client, "lobbybrowser", "is-disabled=true;is-visible=false")
 

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -105,8 +105,6 @@
 			var/obj/O = locate("landmark*Observer-Start")
 			to_chat(src, "<span class='notice'>Now teleporting.</span>")
 			observer.loc = O.loc
-			client.eye = observer.loc
-			client.perspective = EYE_PERSPECTIVE
 			observer.timeofdeath = world.time // Set the time of death so that the respawn timer works correctly.
 
 			// client.prefs.update_preview_icon()

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -105,6 +105,8 @@
 			var/obj/O = locate("landmark*Observer-Start")
 			to_chat(src, "<span class='notice'>Now teleporting.</span>")
 			observer.loc = O.loc
+			client.eye = observer.loc
+			client.perspective = EYE_PERSPECTIVE
 			observer.timeofdeath = world.time // Set the time of death so that the respawn timer works correctly.
 
 			// client.prefs.update_preview_icon()

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -44,7 +44,7 @@
 /mob/proc/hide_titlescreen()
 	set waitfor = FALSE
 
-	stoplag()
+	stoplag(1 SECOND)
 	if(client)
 		winset(client, "lobbybrowser", "is-disabled=true;is-visible=false")
 

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -42,7 +42,8 @@
 	return
 
 /mob/proc/hide_titlescreen()
-	winset(client, "lobbybrowser", "is-disabled=true;is-visible=false")
+	if(client)
+		winset(client, "lobbybrowser", "is-disabled=true;is-visible=false")
 
 /mob/dead/new_player/prepare_huds()
 	return

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -81,4 +81,5 @@
 		if(H.species && H.species.abilities)
 			client.verbs |= H.species.abilities
 
-	hide_titlescreen()
+	spawn(10)
+		hide_titlescreen()

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -80,3 +80,5 @@
 		var/mob/living/carbon/human/H = src
 		if(H.species && H.species.abilities)
 			client.verbs |= H.species.abilities
+
+	hide_titlescreen()

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -81,4 +81,5 @@
 		if(H.species && H.species.abilities)
 			client.verbs |= H.species.abilities
 
-	hide_titlescreen()
+	spawn(5)
+		hide_titlescreen()

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -81,5 +81,4 @@
 		if(H.species && H.species.abilities)
 			client.verbs |= H.species.abilities
 
-	spawn(10)
-		hide_titlescreen()
+	hide_titlescreen()

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -81,5 +81,5 @@
 		if(H.species && H.species.abilities)
 			client.verbs |= H.species.abilities
 
-	spawn(5)
+	spawn(10)
 		hide_titlescreen()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Сейчас при заходе на сервер иногда (часто) на мгновение показываются некрасивые стены с ЦК слоя, что несколько раздражает.

Добавил, чтобы лобби скрывалось через ~1 секунду после логина, а не до логаута, чтобы некрасивые стены не показывались игрокам
Также вступительные текст теперь начинает показываться не сразу.


Анимированная фотокарточка проблемы:
![problem](https://user-images.githubusercontent.com/66636084/126302745-cea08017-9dae-48d5-a579-376aaf21f7b0.gif)

## Почему и что этот ПР улучшит
Не будут показываться некрасивые стены при заходе на сервер
А ещё как бонус убирается "бесполезная" переменная ```my_client```
## Авторство

## Чеинжлог
