### PR TITLE
При кидание вещи не запоминалось первоначальное направление

### DIFF
--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -66,16 +66,17 @@ SUBSYSTEM_DEF(throwing)
 
 /datum/thrownthing/New(thrownthing, target, target_turf, init_dir, maxrange, speed, thrower, diagonals_first, datum/callback/callback, datum/callback/early_callback)
 	src.thrownthing = thrownthing
-	RegisterSignal(thrownthing, COMSIG_PARENT_QDELETING, .proc/on_thrownthing_qdel)
 	src.target = target
-	src.target_turf = get_turf(target)
-	src.init_dir = get_dir(src, target)
+	src.target_turf = target_turf
+	src.init_dir = init_dir
 	src.maxrange = maxrange
 	src.speed = speed
 	src.thrower = thrower
 	src.diagonals_first = diagonals_first
 	src.callback = callback
 	src.early_callback = early_callback
+
+	RegisterSignal(thrownthing, COMSIG_PARENT_QDELETING, .proc/on_thrownthing_qdel)
 
 /datum/thrownthing/Destroy()
 	SSthrowing.processing -= thrownthing


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Короче был баг, что когда вокс прыгает в космос со станции, то он останавливался в космосе, а не продолжал лететь по инерции. Оно почему-то не работало с предметами и они продолжали лететь

## Почему и что этот ПР улучшит
Минус бан

## Авторство

## Чеинжлог
