### PR TITLE
Фикс проверки у рейдеров на живость экипажа

### DIFF
--- a/code/game/gamemodes/factions/heist.dm
+++ b/code/game/gamemodes/factions/heist.dm
@@ -97,7 +97,7 @@
 
 /datum/faction/heist/proc/is_raider_crew_alive()
 	for(var/datum/role/vox_raider/V in members)
-		if(ishuman(V.antag.current) && V.antag.current.stat == DEAD)
+		if(ishuman(V.antag.current) && V.antag.current.stat != DEAD)
 			return TRUE
 
 	return FALSE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Если кто-то помер, то возвращалось тру, что значило, что экипаж жив

## Почему и что этот ПР улучшит
минус баг

## Авторство

## Чеинжлог
