### PR TITLE
Исправляет комментарий у переменной фултона людук тиран

### DIFF
--- a/code/game/objects/items/weapons/fulton.dm
+++ b/code/game/objects/items/weapons/fulton.dm
@@ -62,7 +62,7 @@
 	BPs.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 	var/obj/effect/BPe
-	if(!del_target)
+	if(extraction_point)
 		BPe = new /obj/effect(extraction_point)
 		BPe.icon = 'icons/effects/anomalies.dmi'
 		BPe.icon_state = "bluespace"
@@ -85,7 +85,7 @@
 		H.say(pick(extraction_appends))
 		H.emote("scream")
 
-	if(del_target)
+	if(del_target && !extraction_point)
 		qdel(target)
 		qdel(holder_obj)
 		qdel(BPs)

--- a/code/game/objects/items/weapons/fulton.dm
+++ b/code/game/objects/items/weapons/fulton.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/fulton.dmi'
 	icon_state = "extraction_pack"
 	var/turf/extraction_point
-	var/del_target = TRUE // if extraction_point = null, then the thing flies away, but does not arrive
+	var/del_target = FALSE // the thing flies away, but does not arrive
 	var/list/extraction_appends = list("AAAAAAAAAAAAAAAAAUGH", "AAAAAAAAAAAHHHHHHHHHH")
 
 /obj/item/weapon/extraction_pack/afterattack(atom/target, mob/user, proximity, params)

--- a/code/game/objects/items/weapons/fulton.dm
+++ b/code/game/objects/items/weapons/fulton.dm
@@ -62,7 +62,7 @@
 	BPs.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
 	var/obj/effect/BPe
-	if(extraction_point)
+	if(!del_target)
 		BPe = new /obj/effect(extraction_point)
 		BPe.icon = 'icons/effects/anomalies.dmi'
 		BPe.icon_state = "bluespace"
@@ -85,7 +85,7 @@
 		H.say(pick(extraction_appends))
 		H.emote("scream")
 
-	if(del_target && !extraction_point)
+	if(del_target)
 		qdel(target)
 		qdel(holder_obj)
 		qdel(BPs)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
> var/del_target = TRUE // if extraction_point = null, then the thing flies away, but does not arrive

Комментарий не соответствовал действительности. Предмет удалялся всегда. Я мог либо его изменить, либо все же пойти на поводу у прошлого меня.

~~Теперь, если екстратион поинт != нулл, то цель гарантированно долетит, не смотря на состояние del_target~~

del_target = FALSE и изменен коммент

## Почему и что этот ПР улучшит
Минус баг?

## Авторство

## Чеинжлог
