### PR TITLE
officer armour shelves are not gated behind warden access

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -980,7 +980,7 @@
 	},
 /obj/machinery/door/window/brigdoor{
 	name = "Weapons locker";
-	req_access = list(3)
+	req_access = list(2)
 	},
 /obj/item/ammo_box/magazine/m9mm_2/rubber,
 /obj/item/ammo_box/magazine/m9mm_2/rubber,
@@ -1022,7 +1022,7 @@
 	},
 /obj/machinery/door/window/brigdoor{
 	name = "Weapons locker";
-	req_access = list(3)
+	req_access = list(2)
 	},
 /obj/structure/rack,
 /obj/item/weapon/melee/baton,
@@ -1078,7 +1078,7 @@
 	},
 /obj/machinery/door/window/brigdoor{
 	name = "Weapons locker";
-	req_access = list(3)
+	req_access = list(2)
 	},
 /obj/structure/rack,
 /obj/item/weapon/melee/baton,
@@ -1100,7 +1100,7 @@
 	},
 /obj/machinery/door/window/brigdoor{
 	name = "Weapons locker";
-	req_access = list(3)
+	req_access = list(2)
 	},
 /obj/item/clothing/suit/storage/flak/bulletproof,
 /obj/item/clothing/suit/storage/flak/bulletproof,
@@ -1125,7 +1125,7 @@
 	},
 /obj/machinery/door/window/brigdoor{
 	name = "Weapons locker";
-	req_access = list(3)
+	req_access = list(2)
 	},
 /obj/structure/rack,
 /obj/item/weapon/melee/baton,
@@ -1178,7 +1178,7 @@
 	},
 /obj/machinery/door/window/brigdoor{
 	name = "Weapons locker";
-	req_access = list(3)
+	req_access = list(2)
 	},
 /obj/item/clothing/suit/armor/laserproof,
 /obj/item/clothing/suit/armor/laserproof,

--- a/maps/gamma/gamma.dmm
+++ b/maps/gamma/gamma.dmm
@@ -33512,7 +33512,7 @@
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
 	name = "Weapons locker";
-	req_access = list(3)
+	req_access = list(2)
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -34461,7 +34461,7 @@
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
 	name = "Weapons locker";
-	req_access = list(3)
+	req_access = list(2)
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -44515,7 +44515,7 @@
 	},
 /obj/machinery/door/window/brigdoor{
 	name = "Weapons locker";
-	req_access = list(3)
+	req_access = list(2)
 	},
 /obj/item/ammo_box/magazine/m9mm_2/rubber,
 /obj/item/ammo_box/magazine/m9mm_2/rubber,
@@ -67251,7 +67251,7 @@
 	},
 /obj/machinery/door/window/brigdoor{
 	name = "Weapons locker";
-	req_access = list(3)
+	req_access = list(2)
 	},
 /obj/item/clothing/suit/armor/laserproof,
 /obj/item/clothing/suit/armor/laserproof,
@@ -68430,7 +68430,7 @@
 	},
 /obj/machinery/door/window/brigdoor{
 	name = "Weapons locker";
-	req_access = list(3)
+	req_access = list(2)
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -69685,7 +69685,7 @@
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
 	name = "Weapons locker";
-	req_access = list(3)
+	req_access = list(2)
 	},
 /turf/simulated/floor{
 	dir = 8;


### PR DESCRIPTION
## Описание изменений

Альтернатива к #7768 

Фактически откатывает #3897

Офицеру могут открывать створки к броне сами.

## Почему и что этот ПР улучшит

#4878 Все аргументы о том почему броня эффективно вне оборота офицеров - тут.

## Авторство

Mintt, как автор и идеяголова.

## Чеинжлог
:cl: Mintt
- map: Стеклянные дверцы в верхней оружейной могут открывать офицеры.