### PR TITLE
Enforce Captain Presence

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -19,7 +19,6 @@ SUBSYSTEM_DEF(job)
 	var/static/list/critical_occupations = list(
 		"Captain" = 1,
 		"Head of Security" = 1,
-		"Internal Affairs Agent" = 1,
 	)
 	var/list/critical_unfulfilled = list()
 

--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -21,6 +21,7 @@ SUBSYSTEM_DEF(job)
 		"Head of Security" = 1,
 		"Internal Affairs Agent" = 1,
 	)
+	var/list/critical_unfulfilled = list()
 
 /datum/controller/subsystem/job/Initialize(timeofday)
 	SSmapping.LoadMapConfig() // Required before SSmapping initialization so we can modify the jobs
@@ -90,10 +91,10 @@ SUBSYSTEM_DEF(job)
 		player.mind.role_alt_title = GetPlayerAltTitle(player, rank)
 		unassigned -= player
 		job.current_positions++
-		if(critical_occupations[rank])
-			critical_occupations[rank] -= 1
-			if(critical_occupations[rank] <= 0)
-				critical_occupations -= rank
+		if(critical_unfulfilled[rank])
+			critical_unfulfilled[rank] -= 1
+			if(critical_unfulfilled[rank] <= 0)
+				critical_unfulfilled -= rank
 		return 1
 	Debug("AR has failed, Player: [player], Rank: [rank]")
 	return 0
@@ -171,6 +172,7 @@ SUBSYSTEM_DEF(job)
 			player.mind.assigned_job = null
 			player.mind.special_role = null
 	SetupOccupations()
+	critical_unfulfilled = list()
 	unassigned = list()
 	return
 
@@ -262,6 +264,7 @@ SUBSYSTEM_DEF(job)
 	var/total_critical_occupations = 0
 	for(var/occupation in critical_occupations)
 		total_critical_occupations += critical_occupations[occupation]
+		critical_unfulfilled[occupation] = critical_occupations[occupation]
 
 	//Holder for Triumvirate is stored in the ticker, this just processes it
 	if(SSticker)
@@ -384,7 +387,7 @@ SUBSYSTEM_DEF(job)
 
 	// If there wasn't some important role, and there are enough players to fulfill all roles -
 	// Round shouldn't start.
-	if(critical_occupations.len > 0 && player_list.len > total_critical_occupations)
+	if(critical_unfulfilled.len > 0 && player_list.len >= total_critical_occupations)
 		return FALSE
 
 	return 1

--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -1,3 +1,6 @@
+// If there are more than this much players, critical occupations must be fulfilled.
+#define MIN_CRITICAL_OCUPATIONS_PLAYER_AMOUNT 15
+
 SUBSYSTEM_DEF(job)
 	name = "Jobs"
 
@@ -384,12 +387,16 @@ SUBSYSTEM_DEF(job)
 			unassigned -= player
 			to_chat(player, "<span class='alert bold'>You were returned to the lobby because your job preferences unavailable.  You can change this behavior in preferences.</span>")
 
+	// If there is less than a certain amount of players, don't care about fulfilling all critical roles.
+	if(player_list.len < MIN_CRITICAL_OCUPATIONS_PLAYER_AMOUNT)
+		return TRUE
+
 	// If there wasn't some important role, and there are enough players to fulfill all roles -
 	// Round shouldn't start.
 	if(critical_unfulfilled.len > 0 && player_list.len >= total_critical_occupations)
 		return FALSE
 
-	return 1
+	return TRUE
 
 //Gives the player the stuff he should have with his rank
 /datum/controller/subsystem/job/proc/EquipRank(mob/living/carbon/human/H, rank, joined_late=0)
@@ -750,3 +757,5 @@ SUBSYSTEM_DEF(job)
 	appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	screen_loc = "LEFT+1,BOTTOM+2"
+
+#undef MIN_CRITICAL_OCUPATIONS_PLAYER_AMOUNT

--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -12,6 +12,10 @@ SUBSYSTEM_DEF(job)
 	var/list/job_debug = list()			//Debug info
 	var/obj/effect/landmark/start/fallback_landmark
 
+	// Amount of each job there needs to be for a round to start.
+	// If there isn't enough players to satisfy all of these, round starts anyway.
+	// TO-DO: make datum/occupation_requirement with more flexible requirements than just an amount of a job?
+	// (e.g.: you don't need a captain for a round of 3 people) ~Luduk
 	var/static/list/critical_occupations = list(
 		"Captain" = 1,
 		"Head of Security" = 1,

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -95,6 +95,10 @@ SUBSYSTEM_DEF(ticker)
 			if(!setup())
 				//setup failed
 				current_state = GAME_STATE_STARTUP
+				if(start_ASAP)
+					message_admins("<font color='blue'>Due to setup failure, the game will begin as normal.</font>")
+
+					start_ASAP = FALSE
 
 		if(GAME_STATE_PLAYING)
 			mode.process(wait * 0.1)
@@ -215,7 +219,7 @@ SUBSYSTEM_DEF(ticker)
 			else
 				unfulfilled += ", [position]([SSjob.critical_occupations[position]])"
 
-		to_chat(world, "<B>Error setting up the round. Some critical position has been unfulfilled: [unfulfilled].</B> Reverting to pre-game lobby.")
+		to_chat(world, "<B>Error setting up the round. Some critical positions have been unfulfilled: [unfulfilled].</B> Reverting to pre-game lobby.")
 		SSjob.ResetOccupations()
 		return FALSE
 

--- a/code/game/gamemodes/roles/abductor.dm
+++ b/code/game/gamemodes/roles/abductor.dm
@@ -2,6 +2,8 @@
 	disallow_job = TRUE
 	required_pref = ROLE_ABDUCTOR
 
+	restricted_jobs = list("Head of Security", "Captain")
+
 	antag_hud_type = ANTAG_HUD_ABDUCTOR
 	antag_hud_name = "abductor"
 

--- a/code/game/gamemodes/roles/alien.dm
+++ b/code/game/gamemodes/roles/alien.dm
@@ -4,6 +4,8 @@
 	required_pref = ROLE_ALIEN
 	disallow_job = TRUE
 
+	restricted_jobs = list("Head of Security", "Captain")
+
 	antag_hud_type = ANTAG_HUD_ALIEN
 	antag_hud_name = "hudalien"
 

--- a/code/game/gamemodes/roles/borer.dm
+++ b/code/game/gamemodes/roles/borer.dm
@@ -3,6 +3,8 @@
 	id = BORER
 	disallow_job = TRUE
 
+	restricted_jobs = list("Head of Security", "Captain")
+
 	logo_state = "borer-logo"
 
 /datum/role/borer/Greet(greeting, custom)

--- a/code/game/gamemodes/roles/heist.dm
+++ b/code/game/gamemodes/roles/heist.dm
@@ -4,6 +4,8 @@
 	required_pref = ROLE_RAIDER
 	disallow_job = TRUE
 
+	restricted_jobs = list("Head of Security", "Captain")
+
 	logo_state = "raider-logo"
 
 /datum/role/vox_raider/Greet(greeting, custom)

--- a/code/game/gamemodes/roles/ninja.dm
+++ b/code/game/gamemodes/roles/ninja.dm
@@ -7,7 +7,7 @@
 	antag_hud_type = ANTAG_HUD_NINJA
 	antag_hud_name = "hudninja"
 
-	restricted_jobs = list("Cyborg", "AI")
+	restricted_jobs = list("Cyborg", "AI", "Captain", "Head of Security")
 	logo_state = "ninja-logo"
 
 /datum/role/ninja/OnPostSetup(laterole)

--- a/code/game/gamemodes/roles/syndicate.dm
+++ b/code/game/gamemodes/roles/syndicate.dm
@@ -8,6 +8,8 @@
 	antag_hud_type = ANTAG_HUD_OPS
 	antag_hud_name = "hudsyndicate"
 
+	restricted_jobs = list("Head of Security", "Captain")
+
 	logo_state = "nuke-logo"
 
 	var/nuclear_outfit = /datum/outfit/nuclear

--- a/code/game/gamemodes/roles/wizard.dm
+++ b/code/game/gamemodes/roles/wizard.dm
@@ -5,6 +5,8 @@
 
 	required_pref = ROLE_WIZARD
 
+	restricted_jobs = list("Head of Security", "Captain")
+
 	antag_hud_type = ANTAG_HUD_WIZ
 	antag_hud_name = "hudwizard"
 


### PR DESCRIPTION
## Описание изменений

Добавляет систему "необходимых профессий" в раунды.

Если нету всех необходимых профессий - раунд не начнётся, и в чате появится сообщение о том каких профессий не хватило для старта:

![image](https://user-images.githubusercontent.com/17705613/129353023-876f9d2f-7a8c-495f-8b6e-1a953122537c.png)

Единственное исключение - если игроков меньше, чем требований - требования полностью игнорируются.

Небольшая забавная побочка - если насильно стартануть раунд, и не будет нужных ролей - то оно будет рестартиться и фейлится мгновенно постоянно, поэтому сделал сброс start_ASAP-а при фейле стартапа раунда.

## Почему и что этот ПР улучшит

Позволяет добавлять фичи которые требовали бы чтобы тот или иной член экипажа был бы в раунде. Теперь, если к примеру, капитану дадут что-то убер важное без чего жить нельзя (допустим только кэп может поднять код до синего) - можно спокойно знать что он всегда будет в раунде.

(сейчас это определенно не нужно, но если я умру а это понадобится то боюсь что не сделают...)

## Чеинжлог
:cl: Luduk
- rscadd: Система "необходимых профессий" - без некоторых профессий раунд попросту не начнётся, и уведомит всех игроков об этом.