### PR TITLE
Важные фиксы системы гейм мода

### DIFF
--- a/code/game/gamemodes/factions.dm
+++ b/code/game/gamemodes/factions.dm
@@ -47,12 +47,10 @@
 
 // Destroy fraction and her members
 /datum/faction/proc/Dismantle()
-	for(var/datum/role/R in members)
-		var/datum/game_mode/G = SSticker.mode
-		G.orphaned_roles += R
-		remove_role(R)
-	qdel(objective_holder)
 	var/datum/game_mode/G = SSticker.mode
+	for(var/datum/role/R in members)
+		HandleRemovedRole(R)
+	qdel(objective_holder)
 	G.factions -= src
 	qdel(src)
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -157,6 +157,7 @@
 			if(F.max_roles && F.members.len >= F.max_roles)
 				break
 			if(!F.can_join_faction(P))
+				log_mode("[P] failed [F] can_join_faction!")
 				continue
 			if(!F.HandleNewMind(P.mind))
 				log_mode("[P] failed [F] HandleNewMind!")

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -80,14 +80,20 @@
 	SetupFactions()
 	var/FactionSuccess = CreateFactions()
 	var/RolesSuccess = CreateRoles()
-	return FactionSuccess && RolesSuccess
+	var/GeneralSuccess = FactionSuccess && RolesSuccess
+	if(!GeneralSuccess)
+		DropAll()
+	return GeneralSuccess
 
-//1 = station, 2 = centcomm
-/datum/game_mode/proc/ShuttleDocked(state)
-	for(var/datum/faction/F in factions)
-		F.ShuttleDocked(state)
-	for(var/datum/role/R in orphaned_roles)
-		R.ShuttleDocked(state)
+// it is necessary in those rare cases when the gamemode did not start for those reasons
+// that cannot be detected BEFORE the creation of a human
+/datum/game_mode/proc/DropAll()
+	for(var/f in factions)
+		var/datum/faction/faction = f
+		faction.Dismantle()
+	for(var/r in orphaned_roles)
+		var/datum/role/role = r
+		role.Drop()
 
 /*===FACTION RELATED STUFF===*/
 
@@ -343,3 +349,10 @@
 					return "lose"
 
 	return "win"
+
+//1 = station, 2 = centcomm
+/datum/game_mode/proc/ShuttleDocked(state)
+	for(var/datum/faction/F in factions)
+		F.ShuttleDocked(state)
+	for(var/datum/role/R in orphaned_roles)
+		R.ShuttleDocked(state)

--- a/code/game/gamemodes/role.dm
+++ b/code/game/gamemodes/role.dm
@@ -56,7 +56,7 @@
 		log_mode("M is [M.type]!")
 		return FALSE
 	if(!CanBeAssigned(M) && !override)
-		log_mode("[M.name] was to be assigned to [name] but failed CanBeAssigned!")
+		log_mode("[key_name(M)] was to be assigned to [name] but failed CanBeAssigned!")
 		return FALSE
 
 	antag = M

--- a/code/game/gamemodes/role.dm
+++ b/code/game/gamemodes/role.dm
@@ -122,6 +122,11 @@
 			return FALSE
 
 	if(M?.current?.client)
+
+		if(jobban_isbanned(M.current, required_pref) || jobban_isbanned(M.current, "Syndicate"))
+			log_mode("[ckey_of_antag] have jobban.")
+			return FALSE
+
 		var/datum/preferences/prefs = M.current.client.prefs
 		var/datum/species/S = all_species[prefs.species]
 

--- a/code/game/gamemodes/role.dm
+++ b/code/game/gamemodes/role.dm
@@ -106,15 +106,19 @@
 
 // General sanity checks before assigning the person to the role, such as checking if they're part of the protected jobs or antags.
 /datum/role/proc/CanBeAssigned(datum/mind/M)
+	var/ckey_of_antag = key_name(M)
 	if(M.assigned_role in list("Velocity Officer", "Velocity Chief", "Velocity Medical Doctor"))
+		log_mode("[ckey_of_antag] has a protected job, his job - [M.assigned_role]")
 		return FALSE
 
 	if(restricted_jobs.len > 0)
 		if(M.assigned_role in restricted_jobs)
+			log_mode("[ckey_of_antag] has a restricted job, his job - [M.assigned_role]")
 			return FALSE
 
 	if(required_jobs.len > 0)
 		if(!(M.assigned_role in required_jobs))
+			log_mode("[ckey_of_antag] doesn't have a required job, his job - [M.assigned_role]")
 			return FALSE
 
 	if(M?.current?.client)
@@ -122,13 +126,16 @@
 		var/datum/species/S = all_species[prefs.species]
 
 		if(!S.can_be_role(required_pref))
+			log_mode("[ckey_of_antag] his species \"[S.name]\" can't be a role")
 			return FALSE
 
 		for(var/specie_flag in restricted_species_flags)
 			if(S.flags[specie_flag])
+				log_mode("[ckey_of_antag] his species \"[S.name]\" has restricted flag")
 				return FALSE
 
 	if(is_type_in_list(src, M.antag_roles)) //No double double agent agent
+		log_mode("[ckey_of_antag] already has this role.")
 		return FALSE
 
 	return TRUE

--- a/code/game/gamemodes/roles/revolution.dm
+++ b/code/game/gamemodes/roles/revolution.dm
@@ -12,8 +12,6 @@
 		return FALSE
 	if(M.current.ismindprotect())
 		return FALSE
-	if(jobban_isbanned(M.current, ROLE_REV) || jobban_isbanned(M.current, "Syndicate"))
-		return FALSE
 	return TRUE
 
 /datum/role/rev/Greet(greeting, custom)

--- a/code/modules/mob/living/carbon/xenomorph/effects/aliens.dm
+++ b/code/modules/mob/living/carbon/xenomorph/effects/aliens.dm
@@ -417,7 +417,7 @@
 			if(kill_fh)
 				FH.Die()
 
-/obj/structure/alien/egg/attack_ghost(mob/living/user)
+/obj/structure/alien/egg/attack_ghost(mob/dead/observer/user)
 	if(facehuggers_control_type != FACEHUGGERS_PLAYABLE)
 		to_chat(user, "<span class='notice'>You can't control the facehugger! This feature is disabled by the administrator, you can ask him to enable this feature.</span>")
 		return
@@ -432,6 +432,8 @@
 			to_chat(user, "<span class='warning'>The facehugger hasn't grown yet.</span>")
 			return
 		if(GROWN)
+			if(jobban_isbanned(user, ROLE_ALIEN) || jobban_isbanned(user, "Syndicate"))
+				return
 			var/mob/living/carbon/xenomorph/facehugger/FH = new /mob/living/carbon/xenomorph/facehugger(get_turf(src))
 			FH.key = user.key
 			to_chat(FH, "<span class='notice'>You are now a facehugger, go hug some human faces <3</span>")

--- a/code/modules/religion/religion_types/cult.dm
+++ b/code/modules/religion/religion_types/cult.dm
@@ -218,7 +218,7 @@
 		return FALSE
 	if(M.stat == DEAD)
 		return FALSE
-	if(jobban_isbanned(M, ROLE_CULTIST) || jobban_isbanned(M, "Syndicate")) // Nar-sie will punish people with a jobban, it's funny
+	if(jobban_isbanned(M, ROLE_CULTIST) || jobban_isbanned(M, "Syndicate")) // Nar-sie will punish people with a jobban, it's funny (used for objective)
 		return FALSE
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
1. Пофикшена проблема, когда режим потенициально может быть запущен, но в итоге не находятся пара последних игроков, ибо у них какие-то неподходящие профессии или расы. Это довольно проблематично проверить до спавна куклы. Раньше такие роли сохранялись в маенде у куклы и переходили в следующий режим. Сейчас все подобные фракции и роли будут удаляться.
2. Можно было конвертить людей с джобками в свою фракцию, если в этом конверте не было своих лишних проверок на джобку. 
3. Добавил больше мест для логов, чтобы были они более подробными.
4. Люди с джобкой на аленей не смогут за них играть, зайдя через яйца в хаггера
5. fix #7784

## Почему и что этот ПР улучшит
Минус баги.

## Авторство

## Чеинжлог
:cl:
 - fix: Люди с джобкой на роль действительно не смогут играть за неё.