### PR TITLE
take_overall_damage, electrocute_act fix

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -120,7 +120,11 @@
 	shock_damage *= siemens_coeff
 	if(shock_damage<1)
 		return 0
-	apply_damage(shock_damage, BURN, def_zone, used_weapon="Electrocution")
+	if(def_zone)
+		apply_damage(shock_damage, BURN, def_zone, used_weapon = "Electrocution")
+	else
+		take_overall_damage(burn = shock_damage, used_weapon = "Electrocution")
+
 	if(shock_damage > 10)
 		playsound(src, 'sound/effects/electric_shock.ogg', VOL_EFFECTS_MASTER, tesla_shock ? 10 : 50, FALSE) //because Tesla proc causes a lot of sounds
 		visible_message(

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -626,11 +626,6 @@
 		to_chat(src, "<span class='notice'>You feel pain, but you like it!</span>")
 		try_mutate_to_hulk()
 
-	if(!def_zone)
-		def_zone = pick(BP_L_ARM , BP_R_ARM)
-
-	var/obj/item/organ/external/BP = get_bodypart(check_zone(def_zone))
-
 	if(tesla_shock)
 		var/total_coeff = 1
 		if(gloves)
@@ -642,7 +637,8 @@
 			if(S.siemens_coefficient <= 0)
 				total_coeff -= 0.95
 		siemens_coeff = total_coeff
-	else
+	else if(def_zone)
+		var/obj/item/organ/external/BP = get_bodypart(check_zone(def_zone))
 		siemens_coeff *= get_siemens_coefficient_organ(BP)
 
 	if(species)

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -287,10 +287,13 @@
 	while(parts.len && (brute > 0 || burn > 0) )
 		var/obj/item/organ/external/BP = pick(parts)
 
+		var/brute_per_part = round(brute / parts.len)
+		var/burn_per_part = round(burn / parts.len)
+
 		var/brute_was = BP.brute_dam
 		var/burn_was = BP.burn_dam
 
-		BP.take_damage(brute, burn, damage_flags, used_weapon)
+		BP.take_damage(brute_per_part, burn_per_part, damage_flags, used_weapon)
 		brute -= (BP.brute_dam - brute_was)
 		burn -= (BP.burn_dam - burn_was)
 

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -311,8 +311,10 @@
 
 	//This is for performance optimization only.
 	//DO NOT modify siemens_coeff here. That is checked in human/electrocute_act()
+	var/def_zone
 	if(istype(M,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
+		def_zone = H.bodyparts_by_name[H.hand ? BP_L_ARM : BP_R_ARM] //strikes only active hand
 		if(H.gloves)
 			var/obj/item/clothing/gloves/G = H.gloves
 			if(G.siemens_coefficient == 0)	return 0		//to avoid spamming with insulated glvoes on
@@ -357,7 +359,7 @@
 	else
 		power_source = cell
 		shock_damage = cell_damage
-	var/drained_hp = M.electrocute_act(shock_damage, source, siemens_coeff) //zzzzzzap!
+	var/drained_hp = M.electrocute_act(shock_damage, source, siemens_coeff, def_zone) //zzzzzzap!
 	var/drained_energy = drained_hp*20
 
 	if (source_area)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
take_overall_damage наносил урон по 1 части тела, должен был по многим сразу.
electrocute_act на human-е без def_zone всегда выбирал руки. electrocute_act наносит урон через take_overall_damage, если не выбрана def_zone.
## Почему и что этот ПР улучшит
Наверно фиксит баги
## Авторство

## Чеинжлог
🆑
* fix: Урон, который должен был распределяться по всему телу, распределяется корректно, а не на одну конечность.