### PR TITLE
Бафф эксты

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -780,7 +780,7 @@ var/list/net_announcer_secret = list()
 		if (probabilities[M.config_name] <= 0)
 			qdel(M)
 			continue
-		if (global.master_last_mode == M.name)
+		if (global.master_last_mode == M.name && !istype(M, /datum/game_mode/extended))
 			qdel(M)
 			continue
 		var/mod_prob = probabilities[M.name]

--- a/code/game/gamemodes/modes_declares/extended.dm
+++ b/code/game/gamemodes/modes_declares/extended.dm
@@ -1,7 +1,7 @@
 /datum/game_mode/extended
 	name = "Extended"
 	config_name = "extended"
-	probability = 40
+	probability = 30
 	minimum_player_count = 0
 
 /datum/game_mode/extended/announce()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Теперь можно словить стрик из экстендедов. Игра будет игнорировать, что экста была в прошлом раунде.
Это сделано для третьего сервера, чтобы там могла быть экста хоть 24 на 7.
В связи с этим, был понижен шанс на эксту примерно на 1% (вроде 1)

## Почему и что этот ПР улучшит
На третьем не будет ситуаций, когда уже была экста, но люди выбирают сикрет. В итоге им на выбор выпадают только триторы (ибо почти все уже должны на них играть), но получается, что правильная триторская профессия или раса не присутствует у всех игроков. И выходит ситуация, что триторы бесконечно не могут запуститься.

## Авторство

## Чеинжлог
:cl:
 - tweak: Экстендед теперь может выпадать бесконечное количество раз подряд.