### PR TITLE
[Families ReBalance] Небольшой ребаланс контрабандиста

### DIFF
--- a/code/datums/uplinks_items.dm
+++ b/code/datums/uplinks_items.dm
@@ -18,6 +18,10 @@
 			if(I.last)
 				last += I
 				continue
+			if(uplink.uplink_type == "dealer" && I.need_wanted_level)
+				var/datum/faction/cops/cops = find_faction_by_type(/datum/faction/cops)
+				if(cops && I.need_wanted_level > cops.wanted_level)
+					continue
 
 			if(!uplink.uplink_items[I.category])
 				uplink.uplink_items[I.category] = list()
@@ -45,6 +49,8 @@
 	var/last = 0 // Appear last
 	var/list/uplink_types = list() //Empty list means that the object will be available in all types of uplinks. Alias you will need to state its type.
 
+	// used for dealer items
+	var/need_wanted_level
 
 /datum/uplink_item/proc/spawn_item(turf/loc, obj/item/device/uplink/U, mob/user)
 	if(item)
@@ -140,12 +146,16 @@
 	cost = 8
 	uplink_types = list("dealer")
 
+	need_wanted_level = 3
+
 /datum/uplink_item/dangerous/deagle_gold
 	name = "Desert Eagle Gold"
 	desc = "A gold plated gun folded over a million times by superior martian gunsmiths. Uses .50 AE ammo."
 	item = /obj/item/weapon/gun/projectile/automatic/deagle/weakened/gold
 	cost = 9
 	uplink_types = list("dealer")
+
+	need_wanted_level = 3
 
 /datum/uplink_item/dangerous/smg
 	name = "C-20r Submachine Gun"
@@ -161,12 +171,16 @@
 	cost = 12
 	uplink_types = list("dealer")
 
+	need_wanted_level = 3
+
 /datum/uplink_item/dangerous/tommygun
 	name = "Tommygun"
 	desc = "Based on the classic 'Chicago Typewriter'. Uses 9mm rounds."
 	item = /obj/item/weapon/gun/projectile/automatic/tommygun
-	cost = 15
+	cost = 10
 	uplink_types = list("dealer")
+
+	need_wanted_level = 2
 
 /datum/uplink_item/dangerous/bulldog
 	name = "V15 Bulldog shotgun"
@@ -202,6 +216,8 @@
 	item = /obj/item/weapon/gun/projectile/automatic/a74
 	cost = 20
 	uplink_types = list("nuclear", "dealer")
+
+	need_wanted_level = 5
 
 /datum/uplink_item/dangerous/crossbow
 	name = "Miniature Energy Crossbow"
@@ -714,6 +730,8 @@
 	item = /obj/item/clothing/glasses/thermal/dealer
 	cost = 8
 	uplink_types = list("dealer")
+
+	need_wanted_level = 3
 
 /datum/uplink_item/stealthy_tools/emplight
 	name = "EMP Flashlight"

--- a/code/game/gamemodes/factions/cops.dm
+++ b/code/game/gamemodes/factions/cops.dm
@@ -17,6 +17,9 @@
 	var/end_time = null
 	/// Whether the gamemode-announcing announcement has been sent. Used and set internally.
 	var/sent_announcement = FALSE
+	/// time in ticks when the dealer will arrive
+	var/dealer_timer
+
 	var/datum/announcement/centcomm/gang/announce_gamemode/first_announce = new
 
 /datum/faction/cops/OnPostSetup()
@@ -24,7 +27,7 @@
 	start_time = world.time
 	end_time = start_time + 80 MINUTES
 
-	addtimer(CALLBACK(src, .proc/send_syndicate), 30 MINUTES) // called here because cops are only faction
+	dealer_timer = addtimer(CALLBACK(src, .proc/send_syndicate), rand(25 MINUTES, 35 MINUTES)) // called here because cops are only faction
 	addtimer(CALLBACK(src, .proc/announce_gang_locations), 5 MINUTES)
 	SSshuttle.fake_recall = TRUE
 
@@ -35,16 +38,15 @@
 /datum/faction/cops/proc/send_syndicate()
 	var/list/candidates = pollGhostCandidates("Хотите помочь бандам устроить хаос?", ROLE_FAMILIES)
 	var/spawncount = 2
-	var/indx = 1
 	while(spawncount > 0 && candidates.len)
-		var/spawnloc = dealerstart[indx]
+		var/spawnloc = pick(dealerstart)
 		var/mob/candidate = pick(candidates)
 
 		INVOKE_ASYNC(src, .proc/traitor_create_apperance, spawnloc, candidate.client)
 
 		candidates -= candidate
 		spawncount--
-		indx++
+		dealerstart -= spawnloc
 
 /datum/faction/cops/proc/traitor_create_apperance(spawnloc, client/C)
 	var/mob/living/carbon/human/H = new(null)
@@ -73,6 +75,9 @@
 	var/time_to_cops = max(((end_time - world.time) / 600), 0)
 	var/minutes = pluralize_russian(time_to_cops, "[time_to_cops] минута", "[time_to_cops] минуты", "[time_to_cops] минут")
 	. += "<br>До прилёта полиции: [minutes]"
+	var/dealer_time = timeleft(dealer_timer)
+	var/time_to_dealer = dealer_time ? max((dealer_time / 600), 0) : 0
+	. += "<br>До прилёта дилера: [time_to_dealer]"
 	. += "<br>Смертей: [global.deaths_during_shift]"
 
 /datum/faction/cops/custom_result()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Теперь, имбовый дилер не получает сразу доступ ко всем видам оружия, дабы бандитосы не бегали с АК и не вырезали всех обоповцев и всё что движется.

Так же, тут есть и минорные изменения, типа рандомизации времени спавна дилера и вывод времени до его спавна в админ панель.

```
Штука = Звезды
томиган = 2
диглы = 3
узи = 3
ака = 5
термалы = 3
```

Это первый пр, который входит в серию ребалансов ТГшного генга под тау с вводом новых фич, дающих механ, ведь игроки без механа стоят АФК.

## Почему и что этот ПР улучшит
Банды стали значительно слабее против слабого обопа.

## Авторство

## Чеинжлог
:cl:
 - balance: Арсенал контрабандиста пополняется в соответствие со звёздами ОБОПА.