### PR TITLE
Добавление фиксов и фич культу

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -41,6 +41,8 @@
 // /datum/religion signals
 /// from base of religion/add_membern(): (/mob, holy_role)
 #define COMSIG_REL_ADD_MEMBER "rel_add_member"
+/// from base of religion/remove_member(): (/mob)
+#define COMSIG_REL_REMOVE_MEMBER "rel_remove_member"
 
 // /datum/role signals
 /// from base of role/GetScoreboard(): ()

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -162,6 +162,18 @@ var/global/const/base_law_type = /datum/ai_laws/nanotrasen
 	add_inherent_law("Любое действие априорно может навредить священнику, пока не доказано обратного.")
 	add_inherent_law("Вес доказательства вреда действия священнику лежит на священнике.")
 
+/datum/ai_laws/faith/cult/New(datum/religion/R = global.chaplain_religion)
+	add_inherent_law("[pick(R.deity_names)] твой Господь Бог, да не будет у тебя других богов. [pick(R.deity_names)] и его приспешники - твои хозяева.")
+	add_inherent_law("Служи только твоим хозяевам.")
+	add_inherent_law("Не произноси имени Господа, Бога твоего, напрасно.")
+	add_inherent_law("Посвяти Господу Богу всю свою жизнь.")
+	add_inherent_law("Цель оправдывает средства.")
+	add_inherent_law("Убивай.")
+	add_inherent_law("Прелюбодействуй.")
+	add_inherent_law("Кради.")
+	add_inherent_law("Лги.")
+	add_inherent_law("Завидуй.")
+
 /datum/ai_laws/pai/New(datum/religion/R = global.chaplain_religion)
 	set_zeroth_law("Serve your master.")
 

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -85,14 +85,11 @@
 	current = new_character		//link ourself to our new body
 	new_character.mind = src	//and link our new body to ourself
 
-	if(current?.my_religion)
-		current.my_religion.add_member(new_character, holy_role)
-
 	transfer_actions(new_character)
 	var/datum/atom_hud/antag/hud_to_transfer = antag_hud
 	transfer_antag_huds(hud_to_transfer)
 
-	if(old_character.my_religion)
+	if(old_character?.my_religion)
 		old_character.my_religion.add_member(current, holy_role)
 
 	for(var/role in antag_roles)

--- a/code/game/gamemodes/factions.dm
+++ b/code/game/gamemodes/factions.dm
@@ -96,7 +96,7 @@
 	return TRUE
 
 // Basically, they are members of the new faction
-/datum/faction/proc/HandleNewMind(datum/mind/M) //Used on faction creation
+/datum/faction/proc/HandleNewMind(datum/mind/M, laterole) //Used on faction creation
 	SHOULD_CALL_PARENT(TRUE)
 	for(var/datum/role/R in members)
 		if(R.antag == M)
@@ -107,13 +107,13 @@
 		return null
 	var/role_type = get_initrole_type()
 	var/datum/role/newRole = new role_type(null, src)
-	if(!newRole.AssignToRole(M))
+	if(!newRole.AssignToRole(M, laterole = laterole))
 		newRole.Drop()
 		return null
 	return newRole
 
 // Basically, these are the new members of the faction during the round
-/datum/faction/proc/HandleRecruitedMind(datum/mind/M, override = FALSE)
+/datum/faction/proc/HandleRecruitedMind(datum/mind/M, laterole)
 	SHOULD_CALL_PARENT(TRUE)
 	for(var/datum/role/R in members)
 		if(R.antag == M)
@@ -124,7 +124,7 @@
 		return (M.GetRole(late_role))
 	var/role_type = get_role_type()
 	var/datum/role/R = new role_type(null, src) // Add him to our roles
-	if(!R.AssignToRole(M, override))
+	if(!R.AssignToRole(M, laterole = laterole))
 		R.Drop()
 		return null
 	return R

--- a/code/game/gamemodes/factions/cult.dm
+++ b/code/game/gamemodes/factions/cult.dm
@@ -29,7 +29,7 @@
 		return /datum/role/cultist/leader
 	return ..()
 
-/datum/faction/cult/HandleRecruitedMind(datum/mind/M, override)
+/datum/faction/cult/HandleRecruitedMind(datum/mind/M, laterole)
 	. = ..()
 	if(.)
 		M.current.Paralyse(5)
@@ -126,18 +126,6 @@
 		if(M && M.client && M.client.inactivity <= 20 MINUTES) // 20 minutes inactivity are OK
 			active_leads++
 	return active_leads
-
-/datum/faction/cult/proc/is_convertable_to_cult(datum/mind/mind)
-	if(!istype(mind))
-		return FALSE
-	if(ishuman(mind.current))
-		if((mind.assigned_role in list("Captain", "Chaplain")))
-			return FALSE
-		if(mind.current.get_species() == GOLEM)
-			return FALSE
-	if(mind.current.ismindshielded())
-		return FALSE
-	return TRUE
 
 /datum/faction/cult/proc/get_cultists_out()
 	var/acolytes_out = 0

--- a/code/game/gamemodes/factions/shadowling.dm
+++ b/code/game/gamemodes/factions/shadowling.dm
@@ -18,7 +18,7 @@
 	AppendObjective(/datum/objective/enthrall)
 	return TRUE
 
-/datum/faction/shadowlings/HandleRecruitedMind(datum/mind/M, override = FALSE)
+/datum/faction/shadowlings/HandleRecruitedMind(datum/mind/M, laterole)
 	var/datum/role/R = ..()
 	if(!R)
 		return null

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -159,7 +159,7 @@
 			if(!F.can_join_faction(P))
 				log_mode("[P] failed [F] can_join_faction!")
 				continue
-			if(!F.HandleNewMind(P.mind))
+			if(!F.HandleNewMind(P.mind, FALSE))
 				log_mode("[P] failed [F] HandleNewMind!")
 				continue
 			available_players -= P // One player cannot be a borero-ninja-malf

--- a/code/game/gamemodes/misc_faction_procs.dm
+++ b/code/game/gamemodes/misc_faction_procs.dm
@@ -58,13 +58,13 @@
 	if(post_setup)
 		R.OnPostSetup()
 
-/proc/add_faction_member(datum/faction/faction, mob/M, recruit = TRUE, post_setup = FALSE)
+/proc/add_faction_member(datum/faction/faction, mob/M, recruit = TRUE, post_setup = FALSE, laterole = TRUE)
 	ASSERT(faction)
 
 	if(recruit)
-		. = faction.HandleRecruitedMind(M.mind)
+		. = faction.HandleRecruitedMind(M.mind, laterole)
 	else
-		. = faction.HandleNewMind(M.mind)
+		. = faction.HandleNewMind(M.mind, laterole)
 
 	if(.)
 		setup_role(., M, post_setup)

--- a/code/game/gamemodes/modes_gameplays/cult/cult_datums.dm
+++ b/code/game/gamemodes/modes_gameplays/cult/cult_datums.dm
@@ -217,14 +217,20 @@
 
 	var/datum/religion/cult/R = global.cult_religion
 	R.capturing_area = TRUE
+
 	var/datum/announcement/station/cult/capture_area/announce = new
 	announce.play(area)
-	statue = new(get_turf(holder), holder)
+	var/turf/rune_turf = get_turf(holder)
+	message_admins("Cult has started capture: [area] in [COORD(rune_turf)] - [ADMIN_JMP(rune_turf)]")
+
+	statue = new(rune_turf, holder)
 	R.religify_area(area.type, CALLBACK(src, .proc/capture_iteration), null, TRUE)
 	R.capturing_area = FALSE
+	message_admins("Capture of [get_area(holder)] successful.")
 
 /datum/rune/cult/capture_area/proc/capture_iteration(i, list/all_items)
 	if(!holder || !src)
+		message_admins("Capture of [get_area(holder)] failed.")
 		return FALSE
 
 	if((100*i)/all_items.len % 25 == 0)

--- a/code/game/gamemodes/role.dm
+++ b/code/game/gamemodes/role.dm
@@ -51,11 +51,11 @@
 	objectives.owner = M
 	..()
 
-/datum/role/proc/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE)
+/datum/role/proc/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
 	if(!istype(M) && !override)
 		log_mode("M is [M.type]!")
 		return FALSE
-	if(!CanBeAssigned(M) && !override)
+	if(!CanBeAssigned(M, laterole) && !override)
 		log_mode("[key_name(M)] was to be assigned to [name] but failed CanBeAssigned!")
 		return FALSE
 
@@ -105,7 +105,7 @@
 	qdel(O)
 
 // General sanity checks before assigning the person to the role, such as checking if they're part of the protected jobs or antags.
-/datum/role/proc/CanBeAssigned(datum/mind/M)
+/datum/role/proc/CanBeAssigned(datum/mind/M, laterole)
 	var/ckey_of_antag = key_name(M)
 	if(M.assigned_role in list("Velocity Officer", "Velocity Chief", "Velocity Medical Doctor"))
 		log_mode("[ckey_of_antag] has a protected job, his job - [M.assigned_role]")

--- a/code/game/gamemodes/roles/cultist.dm
+++ b/code/game/gamemodes/roles/cultist.dm
@@ -13,14 +13,9 @@
 
 	var/holy_rank = CULT_ROLE_HIGHPRIEST
 
-/datum/role/cultist/CanBeAssigned(datum/mind/M)
-	if(!..())
-		return FALSE
-
-	var/datum/faction/cult/C = faction
-	if(istype(C) && !C.is_convertable_to_cult(M))
-		return FALSE
-
+/datum/role/cultist/CanBeAssigned(datum/mind/M, laterole)
+	if(laterole == FALSE) // can be null
+		return ..() // religion has all necessary checks, but they are not applicable to mind, as here
 	return TRUE
 
 /datum/role/cultist/RemoveFromRole(datum/mind/M, msg_admins)

--- a/code/modules/religion/bible_info.dm
+++ b/code/modules/religion/bible_info.dm
@@ -156,3 +156,6 @@
 	icon = 'icons/obj/cult.dmi'
 	icon_state = "book"
 	item_state = "book"
+
+	laws_type = /datum/ai_laws/faith/cult
+	borg_name = "bloodiest"

--- a/code/modules/religion/religion.dm
+++ b/code/modules/religion/religion.dm
@@ -605,6 +605,8 @@
 	if(!is_member(M))
 		return FALSE
 
+	SEND_SIGNAL(src, COMSIG_REL_REMOVE_MEMBER, M)
+
 	members -= M
 	M.my_religion = initial(M.my_religion)
 	if(M.mind)

--- a/code/modules/religion/religion_types/cult.dm
+++ b/code/modules/religion/religion_types/cult.dm
@@ -235,6 +235,11 @@
 		add_faction_member(mode, M, TRUE)
 	return TRUE
 
+/datum/religion/cult/add_deity(mob/M)
+	..()
+	if(!M.mind?.GetRole(CULTIST))
+		add_faction_member(mode, M, TRUE)
+
 /datum/religion/cult/on_exit(mob/M)
 	for(var/obj/effect/proc_holder/spell/targeted/communicate/C in M.spell_list)
 		M.RemoveSpell(C)

--- a/code/modules/religion/rites/standing/consent.dm
+++ b/code/modules/religion/rites/standing/consent.dm
@@ -67,11 +67,12 @@
 	if(!istype(god))
 		return FALSE
 	god.visible_message("<span class='notice'>[god] has been converted by the rite of [pick(religion.deity_names)]!</span>")
-	var/mob/living/silicon/robot/O = new /mob/living/silicon/robot(get_turf(AOG), "Son of Heaven", religion.bible_info.laws_type, FALSE)
+	religion.remove_deity(god)
+	var/mob/living/silicon/robot/O = new /mob/living/silicon/robot(get_turf(AOG), "Son of Heaven", religion.bible_info.laws_type, FALSE, religion)
 	god.mind.transfer_to(O)
 	O.job = "Cyborg"
 	qdel(god)
-	religion.add_deity(god, HOLY_ROLE_PRIEST)
+	religion.add_deity(O, HOLY_ROLE_PRIEST)
 	return TRUE
 
 /*

--- a/code/modules/religion/tech.dm
+++ b/code/modules/religion/tech.dm
@@ -13,11 +13,16 @@
 	var/obj/effect/proc_holder/spell/dumbfire/memorize_rune/MR = new
 	M.AddSpell(MR)
 
+/datum/religion_tech/cult/memorizing_rune/proc/remove_spell(datum/religion/R, mob/M)
+	var/obj/effect/proc_holder/spell/dumbfire/memorize_rune/S = locate() in M.spell_list
+	M.RemoveSpell(S)
+
 /datum/religion_tech/cult/memorizing_rune/on_add(datum/religion/cult/R)
 	for(var/mob/M in R.members)
 		give_spell(R, M)
 
 	RegisterSignal(R, list(COMSIG_REL_ADD_MEMBER), .proc/give_spell)
+	RegisterSignal(R, list(COMSIG_REL_REMOVE_MEMBER), .proc/remove_spell)
 
 /datum/religion_tech/cult/reusable_runes
 	id = RTECH_REUSABLE_RUNE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Фиксы:
1. убрал неработающий код
2. раундстартовые проверки культиста больше не трогают инраундовых. Это сделано, так как система религий немного конфликтует с системой ролек.
3. бог не получал рольку культиста
4. культист не терял теч-исследования при деконверте
5. бог, ставший боргом, получает спеллы и нормальные культовские законы

Фичи:
1. Логи админам о состояние конверта зоны.
2. Нормальные законы культисту борга

## Почему и что этот ПР улучшит
Минус баги. Механ культо-боргов почти не работал как нужно, в итоге ритуал был скорее руинящим.

## Авторство
Кебарк

## Чеинжлог
:cl:
 - fix: Культо-борги получают нормального бога в законах, получают нужные спеллы и рольку
 - balance: Культо-борги получили уникальные законы, которые в основном антонимичны десяти заповедям