### PR TITLE
Запрещает рисовать граффити под аирлоком, сквозь стекло, под столом и тд

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -43,7 +43,8 @@
 
 
 /obj/item/toy/crayon/afterattack(atom/target, mob/user, proximity, params)
-	if(!proximity) return
+	if(!proximity || !target.CanPass(null, target))
+		return
 	if(!uses)
 		to_chat(user, "<span class='warning'>There is no more of [src.name] left!</span>")
 		if(!instant)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Запрещает рисовать граффити под аирлоком, сквозь стекло, под столом и тд

## Почему и что этот ПР улучшит
По факту, это нерф генга, чтобы челы не рисовали свои граффити под закрытыми аирлоками и тд

## Авторство

## Чеинжлог
:cl:
 - fix: Можно было нарисовать граффити под непроходимыми объектами(закрытая дверь, стекло)