### PR TITLE
Перезарядка пулемёта без всплывающего окна и попутный мелкофикс

### DIFF
--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -117,7 +117,7 @@
 	..()
 	//handles unwielding a twohanded weapon when dropped as well as clearing up the offhand
 	if(user)
-		var/obj/item/weapon/gun/projectile/automatic/l6_saw/O = user.get_inactive_hand()
+		var/obj/item/weapon/twohanded/offhand/O = user.get_inactive_hand()
 		if(istype(O))
 			O.unwield()
 	return	unwield()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Если держать пулемёт в обоих руках и уронить его на пол, во второй руке больше не остаётся айтем offhand. (привет Moggilazz'у)
Для перезарядки пулемёта теперь не нужно возиться со всплывающим окном. Управление для перезарядки теперь выглядит так:
- Use (по умолчанию Z), он же клик по пулемёту, держа его в активной руке: меняет хват, если крышка закрыта. Если крышка открыта, закрывает её.
- Клик по пулемёту пустой рукой: открыть крышку или достать магазин, если крышка открыта. Если крышка открыта и магазин отсутствует, клик пустой рукой опустошает затвор пулемёта.

## Почему и что этот ПР улучшит
Всплывающее окно не будет ломать динамику боя, закрывая половину экрана. Перезарядка всё ещё немного сложная, но все другие варианты, что пришли в голову, выглядят ещё хуже. Да и в тексте это всё выглядит сложнее, чем оно ощущается в игре.
## Авторство
я
## Чеинжлог
:cl: TEXHAPb
 - bugfix: item offhand работает корректно при вырасывании L6 Saw на пол
 - tweak[link]: при перезарядке L6 Saw больше не всплывает окно выбора действия