### PR TITLE
[Families ReBalance] Больше возможностей потерять очки бандам

### DIFF
--- a/code/game/gamemodes/factions/cops.dm
+++ b/code/game/gamemodes/factions/cops.dm
@@ -86,7 +86,7 @@
 
 	var/report
 	var/highest_point_value = 0
-	var/highest_gang = "Leet Like Jeff K"
+	var/datum/faction/gang/highest_gang
 	var/objective_failures = TRUE
 
 	for(var/G in all_gangs)
@@ -99,11 +99,11 @@
 		if(!objective_failures)
 			if(GG.points >= highest_point_value && GG.members.len && GG.IsSuccessful())
 				highest_point_value = GG.points
-				highest_gang = GG.name
+				highest_gang = GG
 		else
 			if(GG.points >= highest_point_value && GG.members.len)
 				highest_point_value = GG.points
-				highest_gang = GG.name
+				highest_gang = GG
 
 	var/alive_gangsters = 0
 	var/alive_cops = 0
@@ -130,11 +130,11 @@
 				continue
 			alive_cops++
 
-	if(alive_gangsters > alive_cops)
+	if(highest_gang.members > alive_cops)
 		if(!objective_failures)
-			report = "<span class='red'>[highest_gang] побеждает, выполнив свою свою задачу и набрав наибольшее количество очков!</span>"
+			report = "<span class='red'>[highest_gang.name] побеждает, выполнив свою свою задачу и набрав наибольшее количество очков!</span>"
 		else
-			report = "<span class='red'>[highest_gang] побеждает, набрав наибольшее количество очков!</span>"
+			report = "<span class='red'>[highest_gang.name] побеждает, набрав наибольшее количество очков!</span>"
 	else if(alive_gangsters == alive_cops)
 		report = "<span class='orange'>Легенды гласят, что у НаноТрейзен и семей до сих пор идет конфликт!</span>"
 	else

--- a/code/game/gamemodes/factions/cops.dm
+++ b/code/game/gamemodes/factions/cops.dm
@@ -79,10 +79,6 @@
 	var/list/all_gangs = find_factions_by_type(/datum/faction/gang)
 	if(!all_gangs.len)
 		return
-	var/list/all_gangsters = list()
-	for(var/G in all_gangs)
-		var/datum/faction/gang/GG = G
-		all_gangsters |= GG.members
 
 	var/report
 	var/highest_point_value = 0
@@ -107,7 +103,7 @@
 
 	var/alive_gangsters = 0
 	var/alive_cops = 0
-	for(var/M in all_gangsters)
+	for(var/M in highest_gang.members)
 		var/datum/role/gangster/gangbanger = M
 		if(!gangbanger.antag)
 			continue
@@ -130,13 +126,11 @@
 				continue
 			alive_cops++
 
-	if(highest_gang.members > alive_cops)
+	if(alive_gangsters > alive_cops)
 		if(!objective_failures)
 			report = "<span class='red'>[highest_gang.name] побеждает, выполнив свою свою задачу и набрав наибольшее количество очков!</span>"
 		else
 			report = "<span class='red'>[highest_gang.name] побеждает, набрав наибольшее количество очков!</span>"
-	else if(alive_gangsters == alive_cops)
-		report = "<span class='orange'>Легенды гласят, что у НаноТрейзен и семей до сих пор идет конфликт!</span>"
 	else
 		report = "<span class='green'>НаноТрейзен смогла остановить деятельность банд!</span>"
 

--- a/code/game/gamemodes/factions/families.dm
+++ b/code/game/gamemodes/factions/families.dm
@@ -58,6 +58,7 @@
 /datum/faction/gang/GetScoreboard()
 	. = ..()
 	. += "Очки: [round(points)]"
+	. += "<br>Граффити: [gang_tags.len]"
 
 /datum/faction/gang/AdminPanelEntry()
 	. = ..()
@@ -66,6 +67,9 @@
 
 /// Adds points to the points var.
 /datum/faction/gang/proc/adjust_points(points_to_adjust)
+	if(points + points_to_adjust < 0)
+		return
+
 	points += points_to_adjust
 
 /datum/faction/gang/red

--- a/code/game/gamemodes/modes_gameplays/families/gang_handler.dm
+++ b/code/game/gamemodes/modes_gameplays/families/gang_handler.dm
@@ -23,20 +23,28 @@ var/global/deaths_during_shift = 0
 
 /// Internal. Assigns points to families according to gang tags.
 /datum/faction/gang/proc/check_tagged_turfs()
-	adjust_points(5 * gang_tags.len)
+	if(gang_tags.len == 0)
+		adjust_points(-20)
+	else
+		adjust_points(5 * gang_tags.len)
 
 /// Internal. Assigns points to families according to clothing of all currently living humans.
 /datum/faction/gang/proc/check_gang_clothes() // TODO: make this grab the sprite itself, average out what the primary color would be, then compare how close it is to the gang color so I don't have to manually fill shit out for 5 years for every gang type
+	var/members_in_clothing = 0
+	var/valid_members = 0
 	for(var/role in members)
 		var/datum/role/gangster/G = role
 		if(!G.antag || !G.antag.current || !G.antag.current.client || !ishuman(G.antag.current))
 			continue
 		var/mob/living/carbon/human/H = G.antag.current
+		valid_members++
 		for(var/clothing in H.get_all_slots())
 			if(is_type_in_list(clothing, acceptable_clothes))
-				adjust_points(1)
-
+				members_in_clothing++
 		CHECK_TICK
+
+	var/points_to_add = members_in_clothing >= valid_members ? members_in_clothing : -valid_members
+	adjust_points(points_to_add)
 
 /// Internal. Assigns points to families according to groups of nearby family members.
 /datum/faction/gang/proc/check_rollin_with_crews()

--- a/code/game/gamemodes/modes_gameplays/families/gang_handler.dm
+++ b/code/game/gamemodes/modes_gameplays/families/gang_handler.dm
@@ -26,7 +26,7 @@ var/global/deaths_during_shift = 0
 	if(gang_tags.len == 0)
 		adjust_points(-20)
 	else
-		adjust_points(5 * gang_tags.len)
+		adjust_points(2 * gang_tags.len)
 
 /// Internal. Assigns points to families according to clothing of all currently living humans.
 /datum/faction/gang/proc/check_gang_clothes() // TODO: make this grab the sprite itself, average out what the primary color would be, then compare how close it is to the gang color so I don't have to manually fill shit out for 5 years for every gang type

--- a/code/game/gamemodes/modes_gameplays/families/induction_package.dm
+++ b/code/game/gamemodes/modes_gameplays/families/induction_package.dm
@@ -41,7 +41,7 @@
 	add_faction_member(team_to_use, user, TRUE, TRUE)
 	for(var/threads in team_to_use.free_clothes)
 		new threads(get_turf(user))
-	team_to_use.adjust_points(3)
+	team_to_use.adjust_points(15)
 
 /// Checks if the user is trying to use the package of the family they are in, and if not, adds them to the family, with some differing processing depending on whether the user is already a family member.
 /obj/item/gang_induction_package/proc/attempt_join_gang(mob/living/user)
@@ -51,7 +51,7 @@
 			if(is_gangster.faction == team_to_use || !istype(is_gangster.faction, /datum/faction/gang))
 				return
 			var/datum/faction/gang/gang = is_gangster.faction
-			gang.adjust_points(-3)
+			gang.adjust_points(-30)
 			is_gangster.Drop()
 		add_to_gang(user)
 		qdel(src)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -177,7 +177,7 @@
 	if(enemy_tag)
 		if(!do_after(user, 40, target = target))
 			return
-		gang.adjust_points(2)
+		gang.adjust_points(10)
 
 	for(var/obj/effect/decal/cleanable/crayon/old_marking in target)
 		qdel(old_marking)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
В пре вы увидите
1. Ребаланс очков
2. Фикс(или нет) гринтекста уничтоженной банды у обопа
3. В титрах написано о количестве граффити банд

<hr>


Ребаланс очков сделан с целью сильнее замотивировать людей на активные действия. Важная ремарка, очки капают примерно раз в 2 секунды.
1. Если нету граффити на станции у банды, то очки будут очень быстро утекать
2. Прибыль очков от граффити уменьшено более чем в 2 раза.
3. Если людей без любого элемента прикида банды больше, чем людей в этой самой одежде, то очки будут убывать в соответствие людей без прикида, ну и наоборот.
4. Очки не могут опуститься меньше 0
5. Конверт дает в 3 раз больше очков (но этот способ заработка останется все таким же бесполезным) (было 5, стало 15)
6. Переход в другую банду тоже забирает значительно больше, но думаю, все так же мало. (было -3, стало -30)
7. Перекраска вражеского граффити дают 10 очков, вместо двух

## Почему и что этот ПР улучшит
Дополнительная мотивация что-то делать, чтобы не получить банду с 0 очков в титрах (кринж)

## Авторство

## Чеинжлог
:cl:
 - fix: Банда больше не получит гринтекст, если была разрушена.
 - balance[link]: Ребаланс получения очков банд. Они теперь могут быстро уменьшиться.