### PR TITLE
Baton holster bug fix

### DIFF
--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -233,6 +233,10 @@
 	can_hold = list(
 		/obj/item/weapon/melee/baton,
 		/obj/item/weapon/melee/classic_baton,
+		/obj/item/weapon/melee/telebaton,
+		/obj/item/weapon/wirerod,
+		/obj/item/weapon/melee/cattleprod,
+		/obj/item/weapon/minihoe,
 		/obj/item/weapon/crowbar,
 		/obj/item/weapon/reagent_containers/food/snacks/candy/yumbaton
 		)

--- a/code/game/objects/items/weapons/storage/pouches.dm
+++ b/code/game/objects/items/weapons/storage/pouches.dm
@@ -231,7 +231,8 @@
 	max_w_class = SIZE_NORMAL
 
 	can_hold = list(
-		/obj/item/weapon/melee,
+		/obj/item/weapon/melee/baton,
+		/obj/item/weapon/melee/classic_baton,
 		/obj/item/weapon/crowbar,
 		/obj/item/weapon/reagent_containers/food/snacks/candy/yumbaton
 		)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
* Теперь в кобуру нельзя положить меч культистов и другие неуместные вещи.
## Почему и что этот ПР улучшит
fixes #7823
## Авторство
Rahmano
## Чеинжлог
:cl: Rahmano
- bugfix: В кобуру нельзя положить меч культистов и другие неуместные вещи.
- add: Теперь можно положить в кобуру маленькую тяпку(minihoe) и wirerod(необходим для крафта станрода).