### PR TITLE
фиксит баг с пепельницами

### DIFF
--- a/code/game/objects/items/ashtray.dm
+++ b/code/game/objects/items/ashtray.dm
@@ -65,7 +65,7 @@
 /obj/item/ashtray/proc/die()
 	visible_message("<span class='warning'>[src] shatters spilling its contents!</span>")
 	for (var/obj/item/I in contents)
-		I.loc = src.loc
+		I.forceMove(loc)
 	icon_state = icon_broken
 
 /obj/item/ashtray/plastic

--- a/code/game/objects/items/ashtray.dm
+++ b/code/game/objects/items/ashtray.dm
@@ -58,7 +58,7 @@
 		if (contents.len)
 			visible_message("<span class='warning'>[src] slams into [hit_atom] spilling its contents!</span>")
 		for (var/obj/item/I in contents)
-			I.loc = src.loc
+			I.forceMove(loc)
 		icon_state = icon_empty
 	return ..()
 

--- a/code/game/objects/items/ashtray.dm
+++ b/code/game/objects/items/ashtray.dm
@@ -57,15 +57,15 @@
 			return
 		if (contents.len)
 			visible_message("<span class='warning'>[src] slams into [hit_atom] spilling its contents!</span>")
-		for (var/obj/item/clothing/mask/cigarette/O in contents)
-			O.loc = src.loc
+		for (var/obj/item/I in contents)
+			I.loc = src.loc
 		icon_state = icon_empty
 	return ..()
 
 /obj/item/ashtray/proc/die()
 	visible_message("<span class='warning'>[src] shatters spilling its contents!</span>")
-	for (var/obj/item/clothing/mask/cigarette/O in contents)
-		O.loc = src.loc
+	for (var/obj/item/I in contents)
+		I.loc = src.loc
 	icon_state = icon_broken
 
 /obj/item/ashtray/plastic


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
пепельницы при броске выбрасывали только целые сигареты, а не вообще все свои внутренности, теперь это пофикшено.
## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
