### PR TITLE
checking whether old_loc.loc is not null

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -174,7 +174,7 @@ var/list/slot_equipment_priority = list(
 
 		W.forceMove(src)		//TODO: move to equipped?
 
-		if(old_loc && (src != old_loc) && (src != old_loc.loc))
+		if(old_loc && old_loc.loc && (src != old_loc) && (src != old_loc.loc))
 			INVOKE_ASYNC(W, /atom/movable.proc/do_pickup_animation, src, old_loc)
 
 		l_hand = W
@@ -203,7 +203,7 @@ var/list/slot_equipment_priority = list(
 
 		W.forceMove(src)
 
-		if(old_loc && (src != old_loc) && (src != old_loc.loc))
+		if(old_loc && old_loc.loc && (src != old_loc) && (src != old_loc.loc))
 			INVOKE_ASYNC(W, /atom/movable.proc/do_pickup_animation, src, old_loc)
 
 		r_hand = W


### PR DESCRIPTION
## Описание изменений

Анимация подбора проверяла была ли старая локация у предмета. Но юзалась не эта локация, а её турф. Если у старой локации локация - нуллспейс, то выходило что мы пытались брать у нулла координаты для анимации.

## Почему и что этот ПР улучшит

fixes #7833 
