### PR TITLE
fixes double ghostimage

### DIFF
--- a/code/game/gamemodes/modes_gameplays/blob/overmind.dm
+++ b/code/game/gamemodes/modes_gameplays/blob/overmind.dm
@@ -16,6 +16,7 @@
 	var/blob_points = 0
 	var/max_blob_points = 100
 	var/victory_in_progress = FALSE
+	var/image/ghostimage = null
 
 	var/datum/faction/blob_conglomerate/b_congl
 
@@ -23,6 +24,9 @@
 	var/new_name = "[initial(name)] ([rand(1, 999)])"
 	name = new_name
 	real_name = new_name
+	ghostimage = image(src.icon,src,src.icon_state)
+	ghost_sightless_images |= ghostimage //so ghosts can see the AI eye when they disable ghost sight
+	updateallghostimages()
 	. = ..()
 
 /mob/camera/blob/Login()
@@ -104,3 +108,11 @@
 	if(NewLoc && B)
 		loc = NewLoc
 		return TRUE
+
+/mob/camera/blob/Destroy()
+	if(ghostimage)
+		ghost_sightless_images -= ghostimage
+		qdel(ghostimage)
+		ghostimage = null
+		updateallghostimages()
+	return ..()

--- a/code/modules/mob/dead/observer/login.dm
+++ b/code/modules/mob/dead/observer/login.dm
@@ -4,8 +4,6 @@
 	if(check_rights(R_ADMIN, 0))
 		has_unlimited_silicon_privilege = 1
 
-	if(ghostimage)
-		ghostimage.icon_state = src.icon_state
 	ghost_orbit = client.prefs.ghost_orbit
 
 	updateghostimages()

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1,4 +1,3 @@
-var/global/list/image/ghost_darkness_images = list() //this is a list of images for things ghosts should still be able to see when they toggle darkness
 var/global/list/image/ghost_sightless_images = list() //this is a list of images for things ghosts should still be able to see even without ghost sight
 
 /mob/dead/observer
@@ -30,7 +29,6 @@ var/global/list/image/ghost_sightless_images = list() //this is a list of images
 	universal_speak = 1
 	var/golem_rune = null //Used to check, if we already queued as a golem.
 
-	var/image/ghostimage = null //this mobs ghost image, for deleting and stuff
 	var/ghostvision = 1 //is the ghost able to see things humans can't?
 	var/ghost_orbit = GHOST_ORBIT_CIRCLE
 	var/datum/orbit_menu/orbit_menu
@@ -42,8 +40,6 @@ var/global/list/image/ghost_sightless_images = list() //this is a list of images
 
 	verbs += /mob/dead/observer/proc/dead_tele
 
-	ghostimage = image(icon, src, "ghost")
-	ghost_darkness_images |= ghostimage
 	updateallghostimages()
 
 	var/turf/T
@@ -98,11 +94,6 @@ var/global/list/image/ghost_sightless_images = list() //this is a list of images
 	if(data_hud)
 		remove_data_huds()
 	observer_list -= src
-	if (ghostimage)
-		ghost_darkness_images -= ghostimage
-		qdel(ghostimage)
-		ghostimage = null
-		updateallghostimages()
 	if(orbit_menu)
 		SStgui.close_uis(orbit_menu)
 		QDEL_NULL(orbit_menu)
@@ -646,14 +637,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if (!client)
 		return
 	if (!ghostvision)
-		client.images -= ghost_darkness_images
 		client.images |= ghost_sightless_images
 	else
 		//add images for the 60inv things ghosts can normally see when darkness is enabled so they can see them now
 		client.images -= ghost_sightless_images
-		client.images |= ghost_darkness_images
-		if (ghostimage)
-			client.images -= ghostimage //remove ourself
 
 /mob/dead/observer/IsAdvancedToolUser()
 	return IsAdminGhost(src)

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -28,14 +28,12 @@
 
 /mob/camera/Eye/atom_init()
 	ghostimage = image(src.icon,src,src.icon_state)
-	ghost_darkness_images |= ghostimage //so ghosts can see the AI eye when they disable darkness
 	ghost_sightless_images |= ghostimage //so ghosts can see the AI eye when they disable ghost sight
 	updateallghostimages()
 	. = ..()
 
 /mob/camera/Eye/Destroy()
 	if (ghostimage)
-		ghost_darkness_images -= ghostimage
 		ghost_sightless_images -= ghostimage
 		qdel(ghostimage)
 		ghostimage = null


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
забыл почистить `var/ghostimage` у `/observer`. `var/global/list/image/ghost_darkness_images` не нужен, вижен у гостов делается через плейны. Камеру блоба видно без ghostvision ~копипаста с кода ии~
## Почему и что этот ПР улучшит
closes #7837
## Авторство

## Чеинжлог
🆑
* fix: У гостов не будут появляться два спрайта
* fix: Камеру блоба видно с выключенным ghostvision