### PR TITLE
фиксит показывание технических названий внутренних магазинов пушек

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -131,7 +131,6 @@
 			user.drop_from_inventory(AC, src)
 			num_loaded++
 	if(num_loaded)
-		to_chat(user, "<span class='notice'>You load [num_loaded] shell\s into \the [src]!</span>")
 		playsound(src, 'sound/weapons/guns/ammo_insert.ogg', VOL_EFFECTS_MASTER, 100, FALSE)
 		I.update_icon()
 		update_icon()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
удаляет строчку которую писал ammo_box при заряжании его в магазин, потому что тоже самое, но нормально, уже и так пишет нам пушка.
## Почему и что этот ПР улучшит
красоту
## Авторство

## Чеинжлог
