### PR TITLE
фиксит шлюзы в доке шаттла обр

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -68550,13 +68550,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
-"cKd" = (
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Arrival Airlock"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
 "cKe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
@@ -90912,7 +90905,7 @@ bgj
 bgj
 bgj
 bgj
-cKd
+evb
 boX
 aro
 fab
@@ -91169,7 +91162,7 @@ bgj
 bgj
 bgj
 bgj
-cKd
+evb
 aro
 aro
 fab


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
теперь должны разблокировываться все шлюзы у шаттла обр на станции
## Почему и что этот ПР улучшит
фикс??
## Авторство
я
## Чеинжлог
:cl:
- bugfix: Все шлюзы в доке шаттла ОБР на станции корректно разболтируются при стыковке.