### PR TITLE
Рецепт гиперцина перестал быть

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -290,7 +290,6 @@
 	charges["dermaline"]     = new /datum/rig_charge("dermaline",     "dermaline",     0)
 	charges["bicaridine"]    = new /datum/rig_charge("bicaridine",    "bicaridine",    0)
 	charges["oxycodone"]     = new /datum/rig_charge("oxycodone",     "oxycodone",     0)
-	charges["hyperzine"]     = new /datum/rig_charge("hyperzine",     "hyperzine",     0)
 
 /obj/item/rig_module/chem_dispenser/medical/ert // variant for the medical ert rigs
 	name = "hardsuit mounted chemical injector"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -294,12 +294,14 @@
 	required_reagents = list("lexorin" = 5, "peridaxon" = 5, "nanobots" = 1, "dexalinp" = 5, "sugar" = 5, "iron" = 5)
 	result_amount = 5
 
+/*
 /datum/chemical_reaction/hyperzine
 	name = "Hyperzine"
 	id = "hyperzine"
 	result = "hyperzine"
 	required_reagents = list("sugar" = 1, "phosphorus" = 1, "sulfur" = 1,)
 	result_amount = 3
+*/
 
 /datum/chemical_reaction/ryetalyn
 	name = "Ryetalyn"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Космонавты утеряли формулу божественной силы серых предков
![image](https://user-images.githubusercontent.com/33157992/131408847-a540d0dc-1a4b-40c0-88be-966c883ad37a.png)
Удалил из синтеза в модуле рига. Рецепт закомментил потому что его в будущем должны будут вернуть, но в более адекватном виде. Если не вернут, то смешно... сколько войны зря

## Почему и что этот ПР улучшит
Абсолютное большинство космонавтов пришло к выводу что с ним нужно что-то делать, но в соседних ПРах всё затянулось...
Теперь его чаще всего можно будет увидеть только у шахтеров и военных
<details> 
  <summary>[к открытию только хард рп игрокам] </summary>
   В игре всё ещё присутствуют методы производства гиперцина в промышленных масштабах, но на них нужно уделить побольше мозговых усилий и времени. Может быть потом и их придется выпилить
</details>

## Авторство

## Чеинжлог
:cl: 
 - rscdel: Гиперцин нельзя получить химической реакцией