### PR TITLE
Noticeboard code cleaning

### DIFF
--- a/code/datums/atom_huds/alternate_apperance.dm
+++ b/code/datums/atom_huds/alternate_apperance.dm
@@ -231,6 +231,8 @@ var/global/list/active_alternate_appearances = list()
 /datum/atom_hud/alternate_appearance/basic/group_exclude
 	var/list/blinds
 
+	add_ghost_version = FALSE
+
 /datum/atom_hud/alternate_appearance/basic/group_exclude/New(key, image/I, mob_or_mobs)
 	..(key, I, FALSE)
 	var/list/mobs = islist(mob_or_mobs) ? mob_or_mobs : list(mob_or_mobs)

--- a/code/game/objects/structures/noticeboard.dm
+++ b/code/game/objects/structures/noticeboard.dm
@@ -1,5 +1,5 @@
 
-#define MAX_NOTICES	30
+#define NOTICEBOARD_MAX_NOTICES	30
 
 /obj/item/noticeboard_frame
 	name = "noticeboard frame"
@@ -204,14 +204,14 @@
 
 	LAZYSET(hash_removal_timers, note_hash, addtimer(CALLBACK(src, .proc/remove_hash, note_hash), 2 MINUTES, TIMER_STOPPABLE))
 
-/obj/structure/noticeboard/proc/add_viewer(mob/living/viewer)
+/obj/structure/noticeboard/proc/add_viewer(mob/viewer)
 	if(!quest.mobShouldSee(viewer))
 		return
 
 	LAZYADD(quest.blinds, viewer)
 	quest.remove_hud_from(viewer)
 
-/obj/structure/noticeboard/proc/remove_viewer(mob/living/viewer)
+/obj/structure/noticeboard/proc/remove_viewer(mob/viewer)
 	LAZYREMOVE(quest.blinds, viewer)
 	quest.add_hud_to(viewer)
 
@@ -233,10 +233,10 @@
 	if(!is_type_in_list(I, note_types))
 		return ..()
 
-	if(length(notices) >= MAX_NOTICES)
+	if(length(notices) >= NOTICEBOARD_MAX_NOTICES)
 		to_chat(user, "<span class='warning'>You hesitate, certain [I] will not be seen among the many others already attached to \the [src].</span>")
 		return
-	if(length(hash_removal_timers) >= MAX_NOTICES)
+	if(length(hash_removal_timers) >= NOTICEBOARD_MAX_NOTICES)
 		to_chat(user, "<span class='warning'>You hesitate, certain [I] will not be noticed when so many papers were attached and remove from \the [src].</span>")
 		return
 	if(!user.drop_from_inventory(I, src))
@@ -249,7 +249,6 @@
 /obj/structure/noticeboard/examine(mob/user)
 	add_viewer(user)
 	tgui_interact(user)
-	return list()
 
 /obj/structure/noticeboard/tgui_interact(mob/user, datum/tgui/ui)
 	ui = SStgui.try_update_ui(user, src, ui)
@@ -277,8 +276,9 @@
 	return data
 
 /obj/structure/noticeboard/tgui_act(action, params)
-	if(..())
-		return TRUE
+	. = ..()
+	if(.)
+		return
 
 	if(!in_range(src, usr))
 		return FALSE
@@ -333,3 +333,5 @@
 /obj/structure/noticeboard/chaplain
 	icon_state = "notice_board_chapel"
 	frame_type = /obj/item/noticeboard_frame/wood
+
+#undef NOTICEBOARD_MAX_NOTICES

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -963,4 +963,3 @@
 	icon_state = "xeno_warning"
 
 #undef EQUIPMENT
-#undef MAX_NOTICES


### PR DESCRIPTION
## Описание изменений

по задумке госты должны мочь всё осматривать (но не могут) - решил это отразить в коде, по задумке у гостов тоже должен пропадать знак (но не пропадает), переименовал дефайн чтобы он никогда не совпал с чужими