### PR TITLE
Chemistry light fixture move

### DIFF
--- a/code/game/gamemodes/factions/wizards.dm
+++ b/code/game/gamemodes/factions/wizards.dm
@@ -10,7 +10,7 @@
 	max_roles = 2
 
 /datum/faction/wizards/can_setup(num_players)
-	max_roles = max(1, round(num_players/30))
+	max_roles = max(1, round(num_players/20))
 	return (..() && wizardstart.len != 0)
 
 /datum/faction/wizards/OnPostSetup()

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -54200,6 +54200,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -55078,15 +55081,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
-"cav" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "caA" = (
 /obj/machinery/vending/eva/engineering,
 /turf/simulated/floor,
@@ -117368,7 +117362,7 @@ jAb
 bWl
 aPE
 bXR
-cav
+aPE
 aPE
 aPE
 qMb

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -47855,6 +47855,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "warning"
@@ -69990,9 +69993,6 @@
 /area/station/storage/emergency)
 "dub" = (
 /obj/machinery/chem_dispenser,
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "warning"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
* Перемещена лампочка в химии на 1 тайл севернее:
* Перемещена лампочка рядом с химией на 1 тайл севернее:
![Screenshot_1284](https://user-images.githubusercontent.com/67812445/132330432-e5c8f415-471a-4d35-ac4d-dc1bec263eae.png)

## Почему и что этот ПР улучшит
Может показаться что это ничего не делает, но на самом деле это упрощает жизнь химикам. Ещё когда я в первый раз играл на химике, я разлил свои химикаты на эту лампочку. И вот с того момента я видел множество подобных случаев. 
Считаю расположение лампочки плохим и перемещаю её на 1 тайл выше. 
## Авторство
Rahmano
## Чеинжлог
:cl: Rahmano
* map: Перемещено две лампочки одна в химии, вторая снаружи химии.