### PR TITLE
chloralhydrate doesnt set your weaken to 30 on the second tick

### DIFF
--- a/code/modules/reagents/reagent_types/Chemistry-Toxic.dm
+++ b/code/modules/reagents/reagent_types/Chemistry-Toxic.dm
@@ -359,13 +359,18 @@
 		data["ticks"] = 1
 	data["ticks"]++
 	switch(data["ticks"])
-		if(1)
-			M.confused += 2
-			M.drowsyness += 2
-		if(2 to 199)
-			M.Weaken(30)
-		if(200 to INFINITY)
-			M.SetSleeping(20 SECONDS)
+		if(5 to 15)
+			M.drowsyness += 1
+			if(prob(30))
+				M.AdjustWeakened(2)
+				M.drowsyness += 1
+		if(15 to 30)
+			M.drowsyness += 2.5
+			if(prob(30))
+				M.AdjustWeakened(2)
+		if(30 to INFINITY)
+			M.SetSleeping(5 SECONDS)
+			
 
 /datum/reagent/toxin/potassium_chloride
 	name = "Potassium Chloride"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
закройте если #7920 не пройдет
| Было      |                                | Стало     |                                                                  |   |
|-----------|--------------------------------|-----------|------------------------------------------------------------------|---|
|   1 тик   | confused += 2; drowsyness += 2 |  0-4 тик  | ничего                                                           |   |
| 2-199 тик | Weaken(30)                     | 5-15 тик  | drowsyness += 1;  prob(30) M.AdjustWeakened(2) M.drowsyness += 1 |   |
| 200+ тик  | Сон 20 секунд                  | 15-30 тик | drowsyness += 2.5; prob(30) AdjustWeakened(2)                    |   |
|           |                                | 30+ тик   | Сон 5 секунд                                                     |   |
## Почему и что этот ПР улучшит
https://github.com/TauCetiStation/TauCetiClassic/pull/7920#issuecomment-913416314
## Авторство

## Чеинжлог
🆑
* balance[link]: chloralhydrate эффект изменен