### PR TITLE
Fix Ian interfase after relogin

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -270,6 +270,8 @@ var/list/blacklisted_builds = list(
 
 	prefs_ready = TRUE // if moved below parent call, Login feature with lobby music will be broken and maybe anything else.
 
+	update_supporter_status()
+
 	. = ..()	//calls mob.Login()
 
 	if(SSinput.initialized)
@@ -279,8 +281,6 @@ var/list/blacklisted_builds = list(
 		chatOutput.start()
 
 	connection_time = world.time
-
-	update_supporter_status()
 
 	if(custom_event_msg && custom_event_msg != "")
 		to_chat(src, "<h1 class='alert'>Custom Event</h1>")

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -513,7 +513,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	var/mob/living/carbon/ian/phoron_dog
 	for(var/mob/living/carbon/ian/IAN in alive_mob_list) // Incase there is multi_ians, what should NOT ever happen normally!
-		if(IAN.mind) // Mind means someone was or is in a body.
+		if(IAN.client)
 			continue
 		phoron_dog = IAN
 		break


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

ian/login вызывался до обновления статуса суппортера и терял юи

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог

:cl: 
- fix: Исправлена ошибка с пропаданием интерфейса Яна у суппортера при переподключении.