### PR TITLE
stats about which jobs are the ones who leave the most

### DIFF
--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -23,6 +23,10 @@
 	for(var/mob/living/carbon/human/E in human_list)
 		if(E.stat == DEAD)
 			continue
+
+		if(E.mind && E.mind.assigned_role && E.mind.assigned_job)
+			feedback_add_details("job_left_while_alive", "[E.mind.assigned_job.title]")
+
 		cashscore = 0
 		dmgscore = 0
 		var/turf/location = get_turf(E.loc)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -222,6 +222,9 @@ var/global/list/frozen_items = list()
 			if(occupant && occupant.mind)
 				var/job = occupant.mind.assigned_role
 
+				if(occupant.mind.assigned_job)
+					feedback_add_details("job_left_while_alive", "[occupant.mind.assigned_job.title]")
+
 				SSjob.FreeRole(job)
 
 			// Delete them from datacore.

--- a/code/modules/mob/living/silicon/ai/latejoin.dm
+++ b/code/modules/mob/living/silicon/ai/latejoin.dm
@@ -22,6 +22,8 @@ var/global/list/empty_playable_ai_cores = list()
 	//Handle job slot/tater cleanup.
 	if(mind)
 		var/job = mind.assigned_role
+		if(mind.assigned_job)
+			feedback_add_details("job_left_while_alive", "[mind.assigned_job.title]")
 		SSjob.FreeRole(job)
 		if(isanyantag(src))
 			mind.special_role = null


### PR DESCRIPTION
## Описание изменений

если зайти в крио, вайпнуть ядро, или на момент конца раунда быть не в кукле (и она жива) - в БД записывается что с той или иной профы ливнули во время раунда

ограничение на "кукла жива" нужна для всяких офицериков которые выходят потому-что их замочили - это бы портило статистику.

## Почему и что этот ПР улучшит

информация про то какие профы интересны игрокам
