### PR TITLE
escape objective restrained check not tied to a specific floor type

### DIFF
--- a/code/game/gamemodes/objectives/escape.dm
+++ b/code/game/gamemodes/objectives/escape.dm
@@ -14,12 +14,10 @@
 	if(!location)
 		return OBJECTIVE_LOSS
 
-	if(istype(location, /turf/simulated/shuttle/floor/evac/sec1) || istype(location, /turf/simulated/shuttle/floor/evac/sec2))
-		if(iscarbon(owner.current))
-			var/mob/living/carbon/C = owner.current
-			if(!C.restrained())
-				return OBJECTIVE_WIN
-		return OBJECTIVE_LOSS
+	if(iscarbon(owner.current))
+		var/mob/living/carbon/C = owner.current
+		if(C.restrained())
+			return OBJECTIVE_LOSS
 
 	var/area/check_area = location.loc
 	if(istype(check_area, /area/shuttle/escape/centcom))

--- a/code/game/gamemodes/objectives/escape.dm
+++ b/code/game/gamemodes/objectives/escape.dm
@@ -14,10 +14,12 @@
 	if(!location)
 		return OBJECTIVE_LOSS
 
-	if(iscarbon(owner.current))
-		var/mob/living/carbon/C = owner.current
-		if(C.restrained())
-			return OBJECTIVE_LOSS
+	if(istype(location, /turf/simulated/shuttle/floor/evac/sec1) || istype(location, /turf/simulated/shuttle/floor/evac/sec2))
+		if(iscarbon(owner.current))
+			var/mob/living/carbon/C = owner.current
+			if(!C.restrained())
+				return OBJECTIVE_WIN
+		return OBJECTIVE_LOSS
 
 	var/area/check_area = location.loc
 	if(istype(check_area, /area/shuttle/escape/centcom))

--- a/code/game/gamemodes/objectives/escape.dm
+++ b/code/game/gamemodes/objectives/escape.dm
@@ -14,12 +14,10 @@
 	if(!location)
 		return OBJECTIVE_LOSS
 
-	if(istype(location, /turf/simulated/shuttle/floor4)) // Fails traitors if they are in the shuttle brig -- Polymorph
-		if(istype(owner.current, /mob/living/carbon))
-			var/mob/living/carbon/C = owner.current
-			if (!C.restrained())
-				return OBJECTIVE_WIN
-		return OBJECTIVE_LOSS
+	if(iscarbon(owner.current))
+		var/mob/living/carbon/C = owner.current
+		if(C.restrained())
+			return OBJECTIVE_LOSS
 
 	var/area/check_area = location.loc
 	if(istype(check_area, /area/shuttle/escape/centcom))


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Логично что если человек в наручниках на шаттле то OBJECTIVE_LOSS независимо от зоны. сделайте шаттл отдельными зонами пожалуйста еще...
## Почему и что этот ПР улучшит
fixes #7988
## Авторство

## Чеинжлог
🆑
* fix: Escape задание засчитывалось если вы в наручниках