### PR TITLE
Повышение реди-игроков для старта семей

### DIFF
--- a/code/game/gamemodes/modes_declares/families.dm
+++ b/code/game/gamemodes/modes_declares/families.dm
@@ -5,8 +5,8 @@
 
 	factions_allowed = list(/datum/faction/cops)
 
-	minimum_player_count = 30
-	minimum_players_bundles = 30
+	minimum_player_count = 40
+	minimum_players_bundles = 40
 
 	var/gangs_to_generate = 3
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Как я много раз видел, часто тупо нехватает игроков для начала режима. У многих тупо нету префа или некорректная профессия. Дабы избежать `Error setting up Team Based. Reverting to pre-game lobby.` поднимаю эту цифру

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
