### PR TITLE
AltClick on /crayon to force drawing appear centered

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -12,11 +12,14 @@
 	var/colourName = "red" // for updateIcon purposes
 	var/list/validSurfaces = list(/turf/simulated/floor)
 	var/edible = 1
-	var/draw_at_center = FALSE // will painting be centered
 
 	var/list/actions
 	var/list/arrows
 	var/list/letters
+
+/obj/item/toy/crayon/atom_init()
+	. = ..()
+	RegisterSignal(src, list(COMSIG_ITEM_ALTCLICKWITH), .proc/afterattack_no_params)
 
 /obj/item/toy/crayon/suicide_act(mob/user)
 	to_chat(viewers(user), "<span class='danger'><b>[user] is jamming the [src.name] up \his nose and into \his brain. It looks like \he's trying to commit suicide.</b></span>")
@@ -126,9 +129,10 @@
 				if(!can_claim_for_gang(user, target, gang_mode))
 					return
 				tag_for_gang(user, target, gang_mode)
-			else if(draw_at_center)
+			else if(!params)
 				new /obj/effect/decal/cleanable/crayon(target,colour,shadeColour,drawtype)
 			else
+				draw_at_center = FALSE
 				var/list/click_params = params2list(params)
 				var/p_x
 				var/p_y
@@ -151,10 +155,8 @@
 				if(!instant)
 					qdel(src)
 
-/obj/item/toy/crayon/AltClick(mob/user)
-	if(!user.incapacitated() && Adjacent(user))
-		draw_at_center = !draw_at_center
-		to_chat(user, "<span class = 'notice'>Your painting will [draw_at_center ? "be centered" : "not be centered"].</span>")
+/obj/item/toy/crayon/proc/afterattack_no_params(obj/spraycan, atom/target, mob/user)
+	afterattack(target, user, TRUE)
 
 /obj/item/toy/crayon/proc/can_claim_for_gang(mob/user, atom/target, datum/faction/gang/gang)
 	var/area/A = get_area(target)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -152,8 +152,9 @@
 					qdel(src)
 
 /obj/item/toy/crayon/AltClick(mob/user)
-	draw_at_center = !draw_at_center
-	to_chat(user, "<span class = 'notice'>Your painting will [draw_at_center ? "be centered" : "not be centered"].</span>")
+	if(!user.incapacitated() && Adjacent(user))
+		draw_at_center = !draw_at_center
+		to_chat(user, "<span class = 'notice'>Your painting will [draw_at_center ? "be centered" : "not be centered"].</span>")
 
 /obj/item/toy/crayon/proc/can_claim_for_gang(mob/user, atom/target, datum/faction/gang/gang)
 	var/area/A = get_area(target)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -132,7 +132,6 @@
 			else if(!params)
 				new /obj/effect/decal/cleanable/crayon(target,colour,shadeColour,drawtype)
 			else
-				draw_at_center = FALSE
 				var/list/click_params = params2list(params)
 				var/p_x
 				var/p_y

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -12,6 +12,7 @@
 	var/colourName = "red" // for updateIcon purposes
 	var/list/validSurfaces = list(/turf/simulated/floor)
 	var/edible = 1
+	var/draw_at_center = FALSE // will painting be centered
 
 	var/list/actions
 	var/list/arrows
@@ -115,13 +116,6 @@
 		if(!Adjacent(target) || usr.get_active_hand() != i) // Some check to see if he's allowed to write
 			return
 		to_chat(user, "<span class = 'notice'>You start [instant ? "spraying" : "drawing"] [sub] [drawtype] on the [target.name].</span>")
-
-		var/list/click_params = params2list(params)
-		var/p_x
-		var/p_y
-		if(click_params && click_params[ICON_X] && click_params[ICON_Y])
-			p_x = clamp(text2num(click_params[ICON_X]) - 16, -(world.icon_size / 2), world.icon_size / 2)
-			p_y = clamp(text2num(click_params[ICON_Y]) - 16, -(world.icon_size / 2), world.icon_size / 2)
 		if(!user.Adjacent(target))
 			to_chat(user, "<span class = 'notice'>You must stay close to your drawing if you want to draw something.</span>")
 			return
@@ -132,7 +126,15 @@
 				if(!can_claim_for_gang(user, target, gang_mode))
 					return
 				tag_for_gang(user, target, gang_mode)
+			else if(draw_at_center)
+				new /obj/effect/decal/cleanable/crayon(target,colour,shadeColour,drawtype)
 			else
+				var/list/click_params = params2list(params)
+				var/p_x
+				var/p_y
+				if(click_params && click_params[ICON_X] && click_params[ICON_Y])
+					p_x = clamp(text2num(click_params[ICON_X]) - 16, -(world.icon_size / 2), world.icon_size / 2)
+					p_y = clamp(text2num(click_params[ICON_Y]) - 16, -(world.icon_size / 2), world.icon_size / 2)
 				var/obj/effect/decal/cleanable/crayon/Q = new /obj/effect/decal/cleanable/crayon(target,colour,shadeColour,drawtype)
 				Q.pixel_x = p_x
 				Q.pixel_y = p_y
@@ -148,6 +150,10 @@
 				to_chat(user, "<span class='warning'>There is no more of [src.name] left!</span>")
 				if(!instant)
 					qdel(src)
+
+/obj/item/toy/crayon/AltClick(mob/user)
+	draw_at_center = !draw_at_center
+	to_chat(user, "<span class = 'notice'>Your painting will [draw_at_center ? "be centered" : "not be centered"].</span>")
 
 /obj/item/toy/crayon/proc/can_claim_for_gang(mob/user, atom/target, datum/faction/gang/gang)
 	var/area/A = get_area(target)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Добавлен альт клик интеракция для мелка
## Почему и что этот ПР улучшит
Люди смогут центрировать рисунки если захотят
## Авторство

## Чеинжлог
🆑
* tweak: Рисование через альт+клик центрирует рисунок