### PR TITLE
Фикс настакивания выбора секты в алтаре

### DIFF
--- a/code/modules/religion/altar_types/altar_of_gods.dm
+++ b/code/modules/religion/altar_types/altar_of_gods.dm
@@ -287,12 +287,13 @@
 	tgui_interact(user)
 
 /obj/structure/altar_of_gods/proc/sect_select(mob/user, sect_type)
-	if(!sect_type)
+	if(!sect_type || chosen_aspect)
 		return
+
+	chosen_aspect = TRUE
 
 	religion.sect = new sect_type
 	religion.sect.on_select(user, religion)
-	chosen_aspect = TRUE
 
 /obj/structure/altar_of_gods/proc/interact_bible(obj/item/I, mob/user)
 	return


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Фикс настакивания выбора секты в алтаре.

## Почему и что этот ПР улучшит
минус баг
## Авторство

## Чеинжлог
:cl:
 - fix: За капеллана больше нельзя выбрать 10000 аспектов