### PR TITLE
delay on mousedrop for rigs

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -324,7 +324,7 @@
 					var/obj/item/clothing/suit/V = H.wear_suit
 					V.attack_reaction(H, REACTION_ITEM_TAKEOFF)
 				if(istype(src, /obj/item/clothing/suit/space)) // If the item to be unequipped is a rigid suit
-					if(user.get_item_by_slot(SLOT_L_HAND) != src && user.get_item_by_slot(SLOT_R_HAND) != src) //item hands have no delay
+					if(user.get_item_by_slot(SLOT_L_HAND) != src && user.get_item_by_slot(SLOT_R_HAND) != src) //swap item in hands have no delay
 						if(!user.delay_clothing_unequip(src))
 							return
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -324,8 +324,9 @@
 					var/obj/item/clothing/suit/V = H.wear_suit
 					V.attack_reaction(H, REACTION_ITEM_TAKEOFF)
 				if(istype(src, /obj/item/clothing/suit/space)) // If the item to be unequipped is a rigid suit
-					if(!user.delay_clothing_u_equip(src))
-						return 0
+					if(user.get_item_by_slot(SLOT_L_HAND) != src && user.get_item_by_slot(SLOT_R_HAND) != src) //item hands have no delay
+						if(!user.delay_clothing_unequip(src))
+							return
 
 	else
 		if(isliving(src.loc))

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -188,18 +188,27 @@ var/global/list/icon_state_allowed_cache = list()
 			return
 		if (!over_object)
 			return
-
-		if (!usr.incapacitated())
-			switch(over_object.name)
-				if("r_hand")
-					if(!M.unEquip(src))
+		if (usr.incapacitated())
+			return
+		switch(over_object.name)
+			if("r_hand")
+				if(slot_equipped == SLOT_L_HAND) //item swap
+					if(M.unEquip(src))
+						M.put_in_r_hand(src)
+						add_fingerprint(usr)
 						return
-					M.put_in_r_hand(src)
-				if("l_hand")
-					if(!M.unEquip(src))
+			if("l_hand")
+				if(slot_equipped == SLOT_R_HAND) //item swap
+					if(M.unEquip(src))
+						M.put_in_l_hand(src)
+						add_fingerprint(usr)
 						return
-					M.put_in_l_hand(src)
+		if(!equip_time) //taking item from other slots
+			usr.remove_from_mob(src)
 			add_fingerprint(usr)
+			return
+		usr.delay_clothing_unequip(src)
+		add_fingerprint(usr)
 
 //Ears: headsets, earmuffs and tiny objects
 /obj/item/clothing/ears

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -190,25 +190,29 @@ var/global/list/icon_state_allowed_cache = list()
 			return
 		if (usr.incapacitated())
 			return
-		switch(over_object.name)
-			if("r_hand")
-				if(slot_equipped == SLOT_L_HAND) //item swap
+		add_fingerprint(usr)
+		if(!equip_time)
+			switch(over_object.name)
+				if("r_hand")
 					if(M.unEquip(src))
 						M.put_in_r_hand(src)
-						add_fingerprint(usr)
-						return
-			if("l_hand")
-				if(slot_equipped == SLOT_R_HAND) //item swap
+				if("l_hand")
 					if(M.unEquip(src))
 						M.put_in_l_hand(src)
-						add_fingerprint(usr)
-						return
-		if(!equip_time) //taking item from other slots
-			usr.remove_from_mob(src)
-			add_fingerprint(usr)
-			return
-		usr.delay_clothing_unequip(src)
-		add_fingerprint(usr)
+		else
+			switch(over_object.name)
+				if("r_hand")
+					if(slot_equipped == SLOT_L_HAND) //item swap
+						if(M.unEquip(src))
+							M.put_in_r_hand(src)
+					else
+						usr.delay_clothing_unequip(src)
+				if("l_hand")
+					if(slot_equipped == SLOT_R_HAND) //item swap
+						if(M.unEquip(src))
+							M.put_in_l_hand(src)
+					else
+						usr.delay_clothing_unequip(src)
 
 //Ears: headsets, earmuffs and tiny objects
 /obj/item/clothing/ears

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -524,25 +524,22 @@ var/list/slot_equipment_priority = list(
 	if(ishuman(src) || isrobot(src) || ismonkey(src) || isIAN(src) || isxenoadult(src))
 		return TRUE
 
-//Create delay for equipping
+//Create delay for unequipping
 /mob/proc/delay_clothing_unequip(obj/item/clothing/C)
-
 	if(!istype(C))
 		return FALSE
-
 	if(usr.is_busy())
 		return FALSE
-
 	if(C.equipping) // Item is already being (un)equipped
 		return FALSE
 
 	to_chat(usr, "<span class='notice'>You start unequipping the [C].</span>")
-	C.equipping = 1
+	C.equipping = TRUE
 	if(!do_after(usr, C.equip_time, target = C))
-		C.equipping = 0
+		C.equipping = FALSE
 		to_chat(src, "<span class='red'>\The [C] is too fiddly to unequip whilst moving.</span>")
 		return FALSE
-	C.equipping = 0
+	C.equipping = FALSE
 	remove_from_mob(C)
 	to_chat(usr, "<span class='notice'>You have finished unequipping the [C].</span>")
 	return TRUE

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -525,25 +525,27 @@ var/list/slot_equipment_priority = list(
 		return TRUE
 
 //Create delay for equipping
-/mob/proc/delay_clothing_u_equip(obj/item/clothing/C) // Bone White - delays unequipping by parameter.  Requires W to be /obj/item/clothing
+/mob/proc/delay_clothing_unequip(obj/item/clothing/C)
 
 	if(!istype(C))
-		return 0
+		return FALSE
 
 	if(usr.is_busy())
-		return
+		return FALSE
 
 	if(C.equipping) // Item is already being (un)equipped
-		return 0
+		return FALSE
 
 	to_chat(usr, "<span class='notice'>You start unequipping the [C].</span>")
 	C.equipping = 1
-	if(do_after(usr, C.equip_time, target = C))
-		remove_from_mob(C)
-		to_chat(usr, "<span class='notice'>You have finished unequipping the [C].</span>")
-	else
+	if(!do_after(usr, C.equip_time, target = C))
+		C.equipping = 0
 		to_chat(src, "<span class='red'>\The [C] is too fiddly to unequip whilst moving.</span>")
+		return FALSE
 	C.equipping = 0
+	remove_from_mob(C)
+	to_chat(usr, "<span class='notice'>You have finished unequipping the [C].</span>")
+	return TRUE
 
 /mob/proc/delay_clothing_equip_to_slot_if_possible(obj/item/clothing/C, slot, del_on_fail = 0, disable_warning = 0, redraw_mob = 1, delay_time = 0)
 	if(!istype(C))


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Риги не снимаются моментально через mousedrop. Свап рига в руки без do_after
## Почему и что этот ПР улучшит
fixes #5722
closes #7675
## Авторство

## Чеинжлог
🆑
* fix: Снятие ригов через перенос не мгновенное