### PR TITLE
Поднимаю тайминг стейл бота

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,7 +24,7 @@ jobs:
             кому-либо из мейнтейнеров. Вы можете призвать их в комментарии слапнув ``@TauCetiStation/maintainers``.
           exempt-pr-labels: 'Pinned, Awaiting Review [Translation Dep], Awaiting Review [Sprite Dep], Test Merge Candidate'
           stale-pr-label: 'Stalled PR'
-          days-before-pr-stale: 7
+          days-before-pr-stale: 14
           days-before-pr-close: 7
           close-issue-message:  >
             Данное предложение пробыло без активности открытым более полугода. Если вы найдёте того, кто его реализует,


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Сейчас ревувинг немного затянулся из-за всяких мертвых мейнтейнеров. Чтобы люди меньше отвлекались на прогнание бота я повысил тайминг стейл-пра до 2х недель

## Почему и что этот ПР улучшит
Народ будет реже отвлекаться по пустякам, а мертвые ПРы все равно за 3 недели закроются

## Авторство

## Чеинжлог
