### PR TITLE
Возможность настроить хоткей для LOOC

### DIFF
--- a/code/datums/keybinding/communication.dm
+++ b/code/datums/keybinding/communication.dm
@@ -11,6 +11,11 @@
 	name = "OOC"
 	full_name = "Out Of Character Say (OOC)"
 
+/datum/keybinding/client/communication/ooc
+	hotkey_keys = list("L")
+	name = "LOOC"
+	full_name = "Local Out Of Character Say (LOOC)"
+
 /datum/keybinding/client/communication/me
 	hotkey_keys = list("F4", "M")
 	name = "Me"

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -728,6 +728,9 @@ var/list/blacklisted_builds = list(
 				if("OOC")
 					winset(src, "default-\ref[key]", "parent=default;name=[key];command=ooc")
 					communication_hotkeys += key
+				if("LOOC")
+					winset(src, "default-\ref[key]", "parent=default;name=[key];command=looc")
+					communication_hotkeys += key
 				if("Me")
 					winset(src, "default-\ref[key]", "parent=default;name=[key];command=me")
 					communication_hotkeys += key


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Возможность настроить хоткей для LOOC (по умолчанию L)
## Почему и что этот ПР улучшит
QoL
## Авторство
notkripton
## Чеинжлог
:cl:
- tweak: Возможность настроить хоткей на LOOC в меню хоткеев (по умолчанию кнопка L).