### PR TITLE
Пофиксил жукбокс, теперь он отключается от области при откручивании.

### DIFF
--- a/code/modules/media/jukebox.dm
+++ b/code/modules/media/jukebox.dm
@@ -159,6 +159,8 @@ var/global/loopModeNames=list(
 			playing = emagged
 			update_music()
 			update_icon()
+			if(!anchored)
+				disconnect_media_source()
 	else
 		..()
 

--- a/code/modules/media/jukebox.dm
+++ b/code/modules/media/jukebox.dm
@@ -159,7 +159,7 @@ var/global/loopModeNames=list(
 			playing = emagged
 			update_music()
 			update_icon()
-			if(!anchored)
+			if(!anchored && !emagged)
 				disconnect_media_source()
 	else
 		..()


### PR DESCRIPTION
## Описание изменений
Теперь жукбокс отключается от отсека при откручивании

## Почему и что этот ПР улучшит
Жукбокс не будет донимать всю станцию, когда малолетние дебилы заставляют его играть везде свою малолетнюю дебильную музыку.

## Авторство
AndreyGysev

## Чеинжлог
:cl:
- bugfix: Пофиксил жукбокс, играющий во множестве отсеков станции. Теперь он играет только в том отсеке, где прикручен в последний раз.