### PR TITLE
Gloves & shoes are now cut for some species when joining the game

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -335,6 +335,15 @@ BLIND     // can't see anything
 	species_restricted_locked = TRUE
 	sprite_sheet_slot = SPRITE_SHEET_GLOVES
 
+/obj/item/clothing/gloves/proc/clip()
+	clipped = TRUE
+	name = "mangled [name]"
+	desc = "[desc]<br>They have had the fingertips cut off of them."
+	if("exclude" in species_restricted)
+		species_restricted -= UNATHI
+		species_restricted -= TAJARAN
+		species_restricted -= VOX
+
 /obj/item/clothing/gloves/emp_act(severity)
 	if(cell)
 		//why is this not part of the powercell code?
@@ -387,28 +396,31 @@ BLIND     // can't see anything
 	sprite_sheet_slot = SPRITE_SHEET_FEET
 
 //Cutting shoes
-/obj/item/clothing/shoes/attackby(obj/item/I, mob/user, params)
+/obj/item/clothing/shoes/proc/clip()
+	name = "mangled [name]"
+	desc = "[desc]<br>They have the toe caps cut off of them."
+	if("exclude" in species_restricted)
+		species_restricted -= UNATHI
+		species_restricted -= TAJARAN
+		species_restricted -= VOX
+	src.icon_state += "_cut"
+	clipped_status = CLIPPED
+
+/obj/item/clothing/shoes/attackby(obj/item/clothing/shoes/I, mob/user, params)
 	if(iswirecutter(I))
 		switch(clipped_status)
 			if(CLIPPABLE)
 				playsound(src, 'sound/items/Wirecutter.ogg', VOL_EFFECTS_MASTER)
 				user.visible_message("<span class='red'>[user] cuts the toe caps off of [src].</span>","<span class='red'>You cut the toe caps off of [src].</span>")
-
-				name = "mangled [name]"
-				desc = "[desc]<br>They have the toe caps cut off of them."
-				if("exclude" in species_restricted)
-					species_restricted -= UNATHI
-					species_restricted -= TAJARAN
-					species_restricted -= VOX
-				src.icon_state += "_cut"
-				user.update_inv_shoes()
-				clipped_status = CLIPPED
+				clip()
 			if(NO_CLIPPING)
 				to_chat(user, "<span class='notice'>You have no idea of how to clip [src]!</span>")
 			if(CLIPPED)
 				to_chat(user, "<span class='notice'>[src] have already been clipped!</span>")
 	else
 		return ..()
+
+
 
 /obj/item/clothing/shoes/play_unique_footstep_sound()
 	..()

--- a/code/modules/clothing/gloves/stungloves.dm
+++ b/code/modules/clothing/gloves/stungloves.dm
@@ -55,16 +55,9 @@
 
 		//clipping fingertips
 		if(!clipped)
+			clip()
 			playsound(src, 'sound/items/Wirecutter.ogg', VOL_EFFECTS_MASTER)
 			user.visible_message("<span class='warning'>[user] cuts the fingertips off of the [src].</span>","<span class='warning'>You cut the fingertips off of the [src].</span>")
-
-			clipped = TRUE
-			name = "mangled [name]"
-			desc = "[desc]<br>They have had the fingertips cut off of them."
-			if("exclude" in species_restricted)
-				species_restricted -= UNATHI
-				species_restricted -= TAJARAN
-				species_restricted -= VOX
 		else
 			to_chat(user, "<span class='notice'>The [src] have already been clipped!</span>")
 		return

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -38,7 +38,23 @@
 /mob/proc/equip_to_slot_if_possible(obj/item/W, slot, del_on_fail = 0, disable_warning = 0, redraw_mob = 1)
 	if(!istype(W)) return 0
 
-	if(!W.mob_can_equip(src, slot, disable_warning))
+	if(!W.mob_can_equip(src, slot, disable_warning)) // Clipping shoes & gloves if that helps equipping the item
+		if(istype(W, /obj/item/clothing/shoes))
+			var/obj/item/clothing/shoes/S = W
+			if(S.clipped_status == CLIPPABLE)
+				S.clip()
+			if(S.mob_can_equip(src, slot, disable_warning))
+				equip_to_slot(S, slot, redraw_mob)
+				return 1
+
+		if(istype(W, /obj/item/clothing/gloves))
+			var/obj/item/clothing/gloves/S = W
+			if(!S.clipped)
+				S.clip()
+			if(S.mob_can_equip(src, slot, disable_warning))
+				equip_to_slot(S, slot, redraw_mob)
+				return 1
+
 		if(del_on_fail)
 			qdel(W)
 		else


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Теперь если персонаж спавнится и не может надеть ботинки или перчатки, то они обрезаются и ксеносам не придется каждый раз при старте раунда бегать искать кусачки и обрезать то, с чем они и так прилетели на станцию. То есть принцип такой: твоя личная одежда и форма сделана уже под тебя, в начале раунда не надо ничего делать, а если ты хочешь новую форму - тогда вручную обрезай ее запчасти.

У меня возникли небольшие проблемы, т.к. нормальной возможности чекнуть расу при эквипе одежды в слоты я так и не нашел. В текущих условиях оно работает, по крайней мере.

## Почему и что этот ПР улучшит

Избавит игроков на ксеносах бессмысленного и утомляющего ритуала обрезания и так твоей одежды в начале каждого раунда.

## Авторство

## Чеинжлог

:cl:
- tweak: Обувь и перчатки теперь обрезаются для ксеносов при старте раунда
