### PR TITLE
Roundstart logout report logging

### DIFF
--- a/code/game/gamemodes/misc_gamemode_procs.dm
+++ b/code/game/gamemodes/misc_gamemode_procs.dm
@@ -195,6 +195,7 @@
 	for(var/client/M in admins)
 		if(M.holder)
 			to_chat(M, msg)
+	log_game(msg)
 
 /proc/find_syndicate_uplink(mob/living/carbon/human/human)
 	var/list/L = human.get_all_contents_type(/obj/item)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Теперь инфа о ливнувших из раунда челов идет в логи. Можно будет воласа попросить отпарсить данные и забанить.

## Почему и что этот ПР улучшит
Это конечно не полноценная статистика, но хоть что-то.

## Авторство

## Чеинжлог
