### PR TITLE
Борер полностью понимает хозяина, а других нет

### DIFF
--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -3,10 +3,7 @@
 	real_name = "host brain"
 
 /mob/living/captive_brain/say_understands(mob/other, datum/language/speaking)
-	var/mob/living/simple_animal/borer/my_borer = loc
-	if(!istype(loc))
-		return FALSE
-	return my_borer?.host.say_understands(other, speaking)
+	return other == loc // loc should be borer
 
 /mob/living/captive_brain/say(message)
 
@@ -124,9 +121,7 @@
 			host.emote("[pick(list("blink", "choke", "aflap", "drool", "twitch", "gasp"))]")
 
 /mob/living/simple_animal/borer/say_understands(mob/other, datum/language/speaking)
-	if(!host)
-		return FALSE
-	return host.say_understands(other, speaking)
+	return host == other
 
 /mob/living/simple_animal/borer/say(message)
 

--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -2,6 +2,12 @@
 	name = "host brain"
 	real_name = "host brain"
 
+/mob/living/captive_brain/say_understands(mob/other, datum/language/speaking)
+	var/mob/living/simple_animal/borer/my_borer = loc
+	if(!istype(loc))
+		return FALSE
+	return my_borer?.host.say_understands(other, speaking)
+
 /mob/living/captive_brain/say(message)
 
 	if (client)
@@ -116,6 +122,11 @@
 			host.adjustBrainLoss(rand(1,2))
 		if(prob(host.getBrainLoss() * 0.05))
 			host.emote("[pick(list("blink", "choke", "aflap", "drool", "twitch", "gasp"))]")
+
+/mob/living/simple_animal/borer/say_understands(mob/other, datum/language/speaking)
+	if(!host)
+		return FALSE
+	return host.say_understands(other, speaking)
 
 /mob/living/simple_animal/borer/say(message)
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Раньше борер никого нормально не понимал. Весь текст был со звездочками вместо букв. Теперь будет так же, но борер будет всегда понимать хоязина.
![image](https://user-images.githubusercontent.com/26389417/135324516-a58096d5-4da8-461d-803d-dae4f86a8ae7.png)

Хоть хост и понимает все языки, если в нем борер, это все равно не делает борера понимающим все языки в теле. Я сделал 2 коммита, в первом борер понимает абсолютно всё и всегда, во втором только хоста. Ваши предложения?

## Почему и что этот ПР улучшит
Не будет ситуаций, когда червь в бошке существа не понимает реплик существа.

## Авторство

## Чеинжлог
:cl:
 - tweak: Борер научился полностью понимать фразы хоста.