### PR TITLE
Фикс отображения таймера до прилета дилера в админ панеле

### DIFF
--- a/code/game/gamemodes/factions/cops.dm
+++ b/code/game/gamemodes/factions/cops.dm
@@ -27,7 +27,7 @@
 	start_time = world.time
 	end_time = start_time + 80 MINUTES
 
-	dealer_timer = addtimer(CALLBACK(src, .proc/send_syndicate), rand(25 MINUTES, 35 MINUTES)) // called here because cops are only faction
+	dealer_timer = addtimer(CALLBACK(src, .proc/send_syndicate), rand(25 MINUTES, 35 MINUTES), TIMER_STOPPABLE) // called here because cops are only faction
 	addtimer(CALLBACK(src, .proc/announce_gang_locations), 5 MINUTES)
 	SSshuttle.fake_recall = TRUE
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Проблема была в том, что таймер не возвращает свой ид, если не установлен флаг таймер_стоппейбл. Теперь он есть и ИДшник возвращается. 

## Почему и что этот ПР улучшит
Минус баг

## Авторство

## Чеинжлог
