### PR TITLE
Хотфикс сломанного культа

### DIFF
--- a/code/modules/religion/altar_types/altar_of_gods.dm
+++ b/code/modules/religion/altar_types/altar_of_gods.dm
@@ -240,9 +240,6 @@
 	return FALSE
 
 /obj/structure/altar_of_gods/proc/perform_rite(mob/user, rite_name)
-	if(!istype(user.get_active_hand(), /obj/item/weapon/nullrod))
-		return
-
 	if(!rite_name)
 		return
 
@@ -292,9 +289,6 @@
 	tgui_interact(user)
 
 /obj/structure/altar_of_gods/proc/sect_select(mob/user, sect_type)
-	if(!istype(user.get_active_hand(), /obj/item/weapon/nullrod))
-		return
-
 	if(!sect_type || chosen_aspect)
 		return
 

--- a/code/modules/religion/altar_types/cult/altar_of_gods.dm
+++ b/code/modules/religion/altar_types/cult/altar_of_gods.dm
@@ -23,3 +23,8 @@
 			to_chat(user, "<span class='warning'>Только лидер культа может выбирать аспекты!</span>")
 			return
 	interact_nullrod(I, user)
+
+/obj/structure/altar_of_gods/cult/tgui_data(mob/user)
+	var/list/data = ..()
+	data["holds_nullrod"] = istype(user.get_active_hand(), /obj/item/weapon/storage/bible/tome)
+	return data


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Я все сломал. Я почему-то забыл, что культ юзает том, а не нуллрод. Ну я щас так временно пофиксил, поэтому ТМ. Потом выкачу нормальный фикс, с небольшим рефактором, но слишком большим щас.


## Почему и что этот ПР улучшит
Том у культа не работал

## Авторство

## Чеинжлог
