### PR TITLE
chameleon-projector doesnt use bad sprites

### DIFF
--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -66,15 +66,27 @@
 /obj/item/device/chameleon/afterattack(atom/target, mob/user, proximity, params)
 	if(!proximity)
 		return
+	if(!check_sprite(target))
+		return
+	if(target.alpha != 255)
+		return
+	if(target.invisibility != 0)
+		return
 	if(!active_dummy)
 		active_dummy = new
-	if(active_dummy.current_type != target.type)
-		if(istype(target,/obj/item) && !istype(target, /obj/item/weapon/disk/nuclear))
-			playsound(src, 'sound/weapons/flash.ogg', VOL_EFFECTS_MASTER, null, FALSE, null, -6)
-			to_chat(user, "<span class='notice'>\The [target] scanned.</span>")
-			copy_item(target)
+	if(active_dummy.current_type == target.type)
+		return
+	if(istype(target,/obj/item) && !istype(target, /obj/item/weapon/disk/nuclear))
+		playsound(src, 'sound/weapons/flash.ogg', VOL_EFFECTS_MASTER, null, FALSE, null, -6)
+		to_chat(user, "<span class='notice'>\The [target] scanned.</span>")
+		copy_item(target)
 	else
 		to_chat(user, "<span class='notice'>\The [target] already scanned.</span>")
+
+/obj/item/device/chameleon/proc/check_sprite(atom/target)
+	if(target.icon_state in icon_states(target.icon))
+		return TRUE
+	return FALSE
 
 /obj/item/device/chameleon/proc/copy_item(obj/O)
 	var/obj/effect/dummy/chameleon/C = active_dummy


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Предметы без спрайтов, с алфа не 255, с инвизом каким-нибудь еще, больше не сканируются
## Почему и что этот ПР улучшит
fixes #7910
## Авторство

## Чеинжлог
🆑
* fix: chameleon-projector сканировал невидимые предметы и предметы без спрайтов