### PR TITLE
Добавляет защиту от кислоты для костюмов хим защиты.

### DIFF
--- a/code/modules/clothing/spacesuits/globose.dm
+++ b/code/modules/clothing/spacesuits/globose.dm
@@ -25,6 +25,7 @@
 	icon_state = "glob_science"
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 100)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit)
+	unacidable = 1
 
 /obj/item/clothing/head/helmet/space/globose/science
 	name = "science space helmet"
@@ -32,6 +33,7 @@
 	icon_state = "glob0_science"
 	mode = "science"
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 100)
+	unacidable = 1
 
 /***********-Black-***********/
 /obj/item/clothing/suit/space/globose/black

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -10,6 +10,7 @@
 	body_parts_covered = HEAD|FACE|EYES
 	pierce_protection = HEAD
 	siemens_coefficient = 0.4
+	unacidable = 1
 
 /obj/item/clothing/suit/bio_suit
 	name = "bio suit"
@@ -27,6 +28,7 @@
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 20)
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL
 	siemens_coefficient = 0.4
+	unacidable = 1
 
 
 //Standard biosuit, orange stripe


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Добавляет защиту от кислоты и растворения для костюмов хим защиты, костюмов защиты от аномалий и скафандров ученых.
![image](https://user-images.githubusercontent.com/44201461/135761352-ff944e7b-cf00-483f-9440-a33f75abd181.png)

Было:
![image](https://user-images.githubusercontent.com/44201461/135761371-faa105e6-d717-4c63-8cfc-c77ef9134e7f.png)
Стало:
![image](https://user-images.githubusercontent.com/44201461/135761380-157dface-e3f2-4afe-8fc2-07132f3416fa.png)
![image](https://user-images.githubusercontent.com/44201461/135761390-ccfbd889-93e2-4f87-8411-77109e5b6a73.png)
![image](https://user-images.githubusercontent.com/44201461/135761399-4d8471cc-57ec-43be-9e3e-053d824e7cc1.png)

## Почему и что этот ПР улучшит
Очень не логично что костюмы сделаные для защиты от химических/биологических угроз не защищают от них.  Пшикалка с кислотой могла расплавить эту вещь на полу или если одета на кукле, кислота чужих могла расплавить эту вещь если она лежала на полу.

## Авторство
Dushess0
## Чеинжлог
:cl: Dushess
 - tweak: Костюмы химической защиты и скафандры ученых теперь защищают от кислоты.