### PR TITLE
Возможность ставить шину на голову и грудь

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -334,7 +334,7 @@
 	w_class = SIZE_TINY
 	full_w_class = SIZE_TINY
 
-	self_delay = 50
+	self_delay = 250
 	other_delay = 25
 
 	repeating = FALSE
@@ -350,9 +350,7 @@
 	var/mob/living/carbon/human/H = L
 	var/obj/item/organ/external/BP = H.get_bodypart(user.get_targetzone())
 
-	if(BP.body_zone == BP_HEAD || BP.body_zone == BP_CHEST || BP.body_zone == BP_GROIN)
-		to_chat(user, "<span class='danger'>You can't apply a splint there!</span>")
-		return FALSE
+
 	if(BP.status & ORGAN_SPLINTED)
 		to_chat(user, "<span class='danger'>[H]'s [BP.name] is already splinted!</span>")
 		return FALSE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Теперь можно установить шину на голову и туловище, а так-же увеличил время самогипсования в 10 раз. 
## Почему и что этот ПР улучшит
Отныне перелом головы/грудной клетки не приговор, если нету врачей или мета игроков, а сбшники перестанут таскать арестантов в медбей на операцию, если те 5 раз подряд упадут затылком на их дубинки, а просто позовут парамедика, что бы арестант не убился во время прогулки по общагу. Так-же роли смогут востановить свой сундук/тыковку, если против них будет вся станция, или же офицеры/экипаж себя, если всех хирургов/метаигроков сожрут ксеносы
## Авторство
Rolt146
## Чеинжлог
:cl: 
 - tweak: Шиной можно загипсовать грудную клетку и голову.
 - tweak: Гипсование себя - долгая задача.