### PR TITLE
Добавление нитриловых перчаточек в коробки с латексными перчатками

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -62,13 +62,15 @@
 //Latex gloves
 /obj/item/weapon/storage/box/gloves
 	name = "box of latex gloves"
-	desc = "Contains white gloves. Must-have of a doctor."
+	desc = "Contains latex and nitrile gloves. Must-have of a doctor."
 	icon_state = "latex_box"
 
 /obj/item/weapon/storage/box/gloves/atom_init()
 	. = ..()
-	for(var/i in 1 to 7)
+	for(var/i in 1 to 5)
 		new /obj/item/clothing/gloves/latex(src)
+	for(var/i in 1 to 2)
+		new /obj/item/clothing/gloves/latex/nitrile(src)
 
 //Masks
 /obj/item/weapon/storage/box/masks


### PR DESCRIPTION
## Описание изменений
В коробках с латексными перчатками теперь лежит по две пары нитриловых перчаток. Количество латексных, соответственно, уменьшилось до пяти.

## Почему и что этот ПР улучшит
Простое добавление возможности надеть нитриловые перчатки не только трём медикам, включая СМО, добавляя другим медработникам выбор, что носить на кистях. Сами нитриловые перчатки являются по игровой сути теми же латексными, но другого цвета и названия, от чего баланс на станции не страдает.

## Авторство
Unchi

## Чеинжлог

:cl: Unchi
 - add: В коробки с латексными перчатками вложены две пары нитриловых перчаток.

