### PR TITLE
Флафф итемы могут скрывать волосы

### DIFF
--- a/code/modules/fluff/customitems.dm
+++ b/code/modules/fluff/customitems.dm
@@ -1,5 +1,12 @@
 #define FLUFF_FILE_PATH "data/customItemsCache.sav"
 
+// not BLOCKHEADHAIR/BLOCKHAIR for savefile in case someone change them
+#define FLUFF_HAIR_HIDE_NONE 0
+#define FLUFF_HAIR_HIDE_HEAD 1 // BLOCKHEADHAIR
+#define FLUFF_HAIR_HIDE_ALL 2 // BLOCKHAIR
+
+#define FLUFF_HAIR_HIDE_FLAG_TO_TEXT(flag) (flag == 1 && "Head Hair" || flag == 2 && "Head & Face Hair" || "None")
+
 /obj/item/customitem
 	name = "Custom item"
 
@@ -49,6 +56,8 @@
 	var/desc
 	var/icon
 	var/icon_state
+
+	var/hair_flags
 
 	var/status // submitted accepted rejected
 	var/moderator_message
@@ -256,6 +265,13 @@
 		item.icon_state = custom_item_info.icon_state
 		item.item_state = custom_item_info.icon_state
 		item.item_color = custom_item_info.icon_state
+
+		switch(custom_item_info.hair_flags)
+			if(FLUFF_HAIR_HIDE_HEAD)
+				item.flags |= BLOCKHEADHAIR
+			if(FLUFF_HAIR_HIDE_ALL)
+				item.flags |= BLOCKHAIR
+
 		if(custom_item_info.item_type == "small")
 			item.w_class = SIZE_TINY
 

--- a/code/modules/fluff/customitems.dm
+++ b/code/modules/fluff/customitems.dm
@@ -1,6 +1,7 @@
 #define FLUFF_FILE_PATH "data/customItemsCache.sav"
 
 // not BLOCKHEADHAIR/BLOCKHAIR for savefile in case someone change them
+// feel free to rename if more flags needed
 #define FLUFF_HAIR_HIDE_NONE 0
 #define FLUFF_HAIR_HIDE_HEAD 1 // BLOCKHEADHAIR
 #define FLUFF_HAIR_HIDE_ALL 2 // BLOCKHAIR

--- a/code/modules/fluff/fluffmenu.dm
+++ b/code/modules/fluff/fluffmenu.dm
@@ -96,7 +96,7 @@ var/list/editing_item_oldname_list = list()
 	dat += "<td>[readonly?"<b>[editing_item.desc]</b>":"<a class='small' href='?_src_=prefs;preference=fluff;change_desc=1'>[editing_item.desc]</a>"]</td>"
 	dat += "</tr>"
 	dat += "<tr>"
-	dat += "<td>Hide hair (for mask, hat or uniform)</td>"
+	dat += "<td>Hide hair<br>(for mask, hat or uniform)</td>"
 	dat += "<td>[readonly?"<b>[FLUFF_HAIR_HIDE_FLAG_TO_TEXT(editing_item.hair_flags)]</b>":"<a class='small' href='?_src_=prefs;preference=fluff;change_hair_flags=1'>[FLUFF_HAIR_HIDE_FLAG_TO_TEXT(editing_item.hair_flags)]</a>"]</td>"
 	dat += "</tr>"
 	if(!readonly)

--- a/code/modules/fluff/fluffmenu.dm
+++ b/code/modules/fluff/fluffmenu.dm
@@ -95,6 +95,10 @@ var/list/editing_item_oldname_list = list()
 	dat += "<td>Description</td>"
 	dat += "<td>[readonly?"<b>[editing_item.desc]</b>":"<a class='small' href='?_src_=prefs;preference=fluff;change_desc=1'>[editing_item.desc]</a>"]</td>"
 	dat += "</tr>"
+	dat += "<tr>"
+	dat += "<td>Hide hair (for mask, hat or uniform)</td>"
+	dat += "<td>[readonly?"<b>[FLUFF_HAIR_HIDE_FLAG_TO_TEXT(editing_item.hair_flags)]</b>":"<a class='small' href='?_src_=prefs;preference=fluff;change_hair_flags=1'>[FLUFF_HAIR_HIDE_FLAG_TO_TEXT(editing_item.hair_flags)]</a>"]</td>"
+	dat += "</tr>"
 	if(!readonly)
 		dat += "<tr>"
 		dat += "<td>Icon</td>"
@@ -184,6 +188,22 @@ var/list/editing_item_oldname_list = list()
 		if(!editing_item || !new_item_desc || length(new_item_desc) <= 2 || length(new_item_desc) > 500)
 			return
 		editing_item.desc = new_item_desc
+		edit_custom_item_panel(src, user)
+		return
+
+	if(href_list["change_hair_flags"])
+		var/new_hair_flags = input("Select which hair item should hide", "Text") as null|anything in list("None", "Head Hair", "Head & Face Hair")
+		if(!editing_item || !new_hair_flags)
+			return
+
+		switch(editing_item.hair_flags)
+			if("Head Hair")
+				editing_item.hair_flags = FLUFF_HAIR_HIDE_HEAD
+			if("Head & Face Hair")
+				editing_item.hair_flags = FLUFF_HAIR_HIDE_ALL
+			else
+				editing_item.hair_flags = null
+
 		edit_custom_item_panel(src, user)
 		return
 

--- a/code/modules/fluff/fluffmenu.dm
+++ b/code/modules/fluff/fluffmenu.dm
@@ -196,7 +196,7 @@ var/list/editing_item_oldname_list = list()
 		if(!editing_item || !new_hair_flags)
 			return
 
-		switch(editing_item.hair_flags)
+		switch(new_hair_flags)
 			if("Head Hair")
 				editing_item.hair_flags = FLUFF_HAIR_HIDE_HEAD
 			if("Head & Face Hair")

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -284,7 +284,7 @@ Please contact me on #coderbus IRC. ~Carn x
 					head.recolor()
 			standing += facial_s
 
-	if(h_style && !(head && (head.flags & BLOCKHEADHAIR)) && !(wear_suit && (wear_suit.flags & BLOCKHEADHAIR)) && !(w_uniform && (w_uniform.flags & BLOCKHEADHAIR)))
+	if(h_style && !(head && (head.flags & BLOCKHEADHAIR)) && !(wear_mask && (wear_mask.flags & BLOCKHEADHAIR)) && !(wear_suit && (wear_suit.flags & BLOCKHEADHAIR)) && !(w_uniform && (w_uniform.flags & BLOCKHEADHAIR)))
 		var/datum/sprite_accessory/hair_style = hair_styles_list[h_style]
 		if(hair_style && hair_style.species_allowed && (BP.species.name in hair_style.species_allowed))
 			var/icon/hair_s = new/icon("icon" = hair_style.icon, "icon_state" = "[hair_style.icon_state]_s")

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -284,7 +284,7 @@ Please contact me on #coderbus IRC. ~Carn x
 					head.recolor()
 			standing += facial_s
 
-	if(h_style && !(head && (head.flags & BLOCKHEADHAIR)))
+	if(h_style && !(head && (head.flags & BLOCKHEADHAIR)) && !(wear_suit && (wear_suit.flags & BLOCKHEADHAIR)) && !(w_uniform && (w_uniform.flags & BLOCKHEADHAIR)))
 		var/datum/sprite_accessory/hair_style = hair_styles_list[h_style]
 		if(hair_style && hair_style.species_allowed && (BP.species.name in hair_style.species_allowed))
 			var/icon/hair_s = new/icon("icon" = hair_style.icon, "icon_state" = "[hair_style.icon_state]_s")


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

нужно еще потестить

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог

:cl:
 - tweak: Флафф итемы можно настроить на скрытие причесок и усов