### PR TITLE
В листе со статистикой не было поля, по которому уже велась статистика

### DIFF
--- a/code/_globalvars/misc.dm
+++ b/code/_globalvars/misc.dm
@@ -41,6 +41,7 @@ var/global/list/score=list(
 	"disc"           = 0, // is the disc safe and secure?
 	"nuked"          = 0, // was the station blown into little bits?
 	"destranomaly"   = 0, // anomaly of cult
+	"rec_antags"     = 0, // How many antags did we reconvert
 
 	//crew
 	"crew_escaped"   = 0,      // how many people got out alive?


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
В листе со статистикой не было поля, по которому уже велась статистика. Похоже, что налажал тут я при рефакторинге геймодов

## Почему и что этот ПР улучшит
Значение будет по умолчанию 0, а не null

## Авторство

## Чеинжлог
