### PR TITLE
клоны больше не могут быть клонированы

### DIFF
--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -382,6 +382,7 @@
 	for(var/V in subject.roundstart_quirks)
 		var/datum/quirk/T = V
 		R.quirks += T.type
+	R.quirks += /datum/quirk/genetic_degradation // clones cannot be cloned
 
 	//Add an implant if needed
 	var/obj/item/weapon/implant/health/imp = locate(/obj/item/weapon/implant/health, subject)


### PR DESCRIPTION
## Описание изменений
Теперь плеер может быть клонирован только один раз

## Почему и что этот ПР улучшит
Баланс (триторам теперь можно будет выполнять задания на фраг какими-нибудь крутыми методами а не тупым похищением головы которое никому не интересно)

## Авторство

## Чеинжлог
:cl: Getup1
- experiment: Клоны больше не могут быть клонированы.