### PR TITLE
Фикс рантайма в случаях когда передвигают подключаемых к ИВЛ

### DIFF
--- a/code/game/machinery/life_assist.dm
+++ b/code/game/machinery/life_assist.dm
@@ -32,15 +32,15 @@
 	update_icon()
 
 /obj/machinery/life_assist/proc/detach(rip = FALSE)
-	if(attached)
-		if(!rip)
-			visible_message("<span class='notice'>[attached] is detached from \the [src]</span>")
-		else
-			visible_message("<span class='warning'>The tubes are ripped out of [attached], doesn't that hurt?</span>")
-			attached.apply_damage(15, BRUTE, BP_CHEST)
-		deassist(attached)
-		attached = null
+	if(!rip)
+		visible_message("<span class='notice'>[attached] is detached from \the [src]</span>")
+	else
+		visible_message("<span class='warning'>The tubes are ripped out of [attached], doesn't that hurt?</span>")
+		attached.apply_damage(15, BRUTE, BP_CHEST)
+
 	qdel(GetComponent(/datum/component/bounded))
+	deassist(attached)
+	attached = null
 	update_icon()
 
 // Add the LIFE_ASSIST trait, etc.

--- a/code/game/machinery/life_assist.dm
+++ b/code/game/machinery/life_assist.dm
@@ -94,7 +94,7 @@
 	var/obj/item/weapon/tank/holding
 
 /obj/machinery/life_assist/artificial_ventilation/attackby(obj/item/weapon/W, mob/user)
-	if (!istype(W, /obj/item/weapon/tank) && istype(W, /obj/item/weapon/tank/jetpack) && (stat & BROKEN))
+	if (!istype(W, /obj/item/weapon/tank) || istype(W, /obj/item/weapon/tank/jetpack) || (stat & BROKEN))
 		return
 	if (holding || !user.drop_from_inventory(W, src))
 		return
@@ -107,6 +107,10 @@
 			update_internal(attached, TRUE)
 
 /obj/machinery/life_assist/artificial_ventilation/attack_hand(mob/user)
+	. = ..()
+	if(.)
+		return
+
 	if(user.is_busy())
 		return
 	if(holding && do_after(user, 20, target = src))

--- a/code/game/machinery/life_assist.dm
+++ b/code/game/machinery/life_assist.dm
@@ -110,7 +110,7 @@
 	if(.)
 		return
 
-	if(user.is_busy())
+	if(user.is_busy() || issilicon(user))
 		return
 	if(holding && do_after(user, 20, target = src))
 		user.put_in_hands(holding)

--- a/code/game/machinery/life_assist.dm
+++ b/code/game/machinery/life_assist.dm
@@ -96,11 +96,11 @@
 /obj/machinery/life_assist/artificial_ventilation/attackby(obj/item/weapon/W, mob/user)
 	if (!istype(W, /obj/item/weapon/tank) || istype(W, /obj/item/weapon/tank/jetpack) || (stat & BROKEN) || holding)
 		return
-
 	if(do_after(user, 10, target = src))
+		if(!user.drop_from_inventory(W, src))
+			return
 		holding = W
 		add_overlay(holding.icon_state)
-		user.drop_from_inventory(holding, src)
 		visible_message("<span class='notice'>[holding] is attached to \the [src]</span>")
 		if(attached)
 			update_internal(attached, TRUE)

--- a/code/game/machinery/life_assist.dm
+++ b/code/game/machinery/life_assist.dm
@@ -59,6 +59,8 @@
 		return
 
 	if(do_after(usr, 20, target = src))
+		if(!(Adjacent(usr) && Adjacent(over_object) && usr.Adjacent(over_object)))
+			return
 		if(attached)
 			detach()
 		else if(ishuman(over_object))

--- a/code/game/machinery/life_assist.dm
+++ b/code/game/machinery/life_assist.dm
@@ -94,10 +94,9 @@
 	var/obj/item/weapon/tank/holding
 
 /obj/machinery/life_assist/artificial_ventilation/attackby(obj/item/weapon/W, mob/user)
-	if (!istype(W, /obj/item/weapon/tank) || istype(W, /obj/item/weapon/tank/jetpack) || (stat & BROKEN))
+	if (!istype(W, /obj/item/weapon/tank) || istype(W, /obj/item/weapon/tank/jetpack) || (stat & BROKEN) || holding)
 		return
-	if (holding || !user.drop_from_inventory(W, src))
-		return
+
 	if(do_after(user, 10, target = src))
 		holding = W
 		add_overlay(holding.icon_state)

--- a/code/game/machinery/life_assist.dm
+++ b/code/game/machinery/life_assist.dm
@@ -32,15 +32,15 @@
 	update_icon()
 
 /obj/machinery/life_assist/proc/detach(rip = FALSE)
-	if(!rip)
-		visible_message("<span class='notice'>[attached] is detached from \the [src]</span>")
-	else
-		visible_message("<span class='warning'>The tubes are ripped out of [attached], doesn't that hurt?</span>")
-		attached.apply_damage(15, BRUTE, BP_CHEST)
-
+	if(attached)
+		if(!rip)
+			visible_message("<span class='notice'>[attached] is detached from \the [src]</span>")
+		else
+			visible_message("<span class='warning'>The tubes are ripped out of [attached], doesn't that hurt?</span>")
+			attached.apply_damage(15, BRUTE, BP_CHEST)
+		deassist(attached)
+		attached = null
 	qdel(GetComponent(/datum/component/bounded))
-	deassist(attached)
-	attached = null
 	update_icon()
 
 // Add the LIFE_ASSIST trait, etc.


### PR DESCRIPTION
## Описание изменений
Добавил проверку на то, всё ещё ли рядом все участники подключения ИВЛ.

## Почему и что этот ПР улучшит
Не будет рантаймов в случаях когда передвигают подключаемых к ИВЛ

## Авторство
Darth_Sidious

## Чеинжлог
:cl:
 - bugfix: Не будет рантаймов в случаях когда передвигают подключаемых к ИВЛ