### PR TITLE
Больше голопадов на спутнике ИИ

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -37719,6 +37719,7 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/bluegrid{
 	icon_state = "dark";
 	name = "Server Walkway";
@@ -60850,6 +60851,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/whitegreed,
 /area/station/aisat/ai_chamber)
 "cpD" = (
@@ -61045,6 +61047,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/whitegreed,
 /area/station/aisat/ai_chamber)
 "cpR" = (
@@ -61320,7 +61323,6 @@
 /turf/simulated/floor,
 /area/station/engineering/break_room)
 "cqx" = (
-/obj/machinery/hologram/holopad,
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -61685,15 +61687,14 @@
 /area/station/cargo/office)
 "crn" = (
 /obj/machinery/hologram/holopad,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/turf/simulated/floor/bluegrid{
+	icon_state = "dark";
+	name = "Server Walkway";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/aisat/antechamber)
+/area/station/tcommsat/chamber)
 "cro" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -62500,6 +62501,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -62652,6 +62654,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -66537,7 +66540,6 @@
 /turf/simulated/wall,
 /area/station/security/execution)
 "cDq" = (
-/obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
@@ -67678,6 +67680,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -123466,7 +123469,7 @@ cDI
 cFS
 bid
 cqN
-cqN
+crn
 csD
 cIe
 cIe
@@ -126026,7 +126029,7 @@ cFP
 cFP
 cpy
 crN
-crn
+csN
 cti
 oAb
 cEW


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Отыграв на малфе на новом спутнике я понял что автор не учел, что голопады на спутнике нужны не только для ~~бесполезных~~ голограмм ии, но и играют важную роль в обороне спутника при игре за малфа, так как у него есть (дорогая) способность на их взлом.
Так что я добавил 4 новых голопада
![image](https://user-images.githubusercontent.com/47355061/140643083-3bd37906-8e07-4d96-ad78-60b1932c032e.png)
![image](https://user-images.githubusercontent.com/47355061/140643097-47a4d53d-d35a-4b03-a6b8-835aa2de1976.png)
И чуть-чуть передвинул пару старых
![image](https://user-images.githubusercontent.com/47355061/140643102-ffe2f5a5-2638-41d0-a00f-bfa1791a6cde.png)
![image](https://user-images.githubusercontent.com/47355061/140643109-b73068c3-1657-43d5-8860-babe5a881dce.png)
![image](https://user-images.githubusercontent.com/47355061/140643121-a3d1ca59-0598-4214-a851-b0b7ff994913.png)

## Почему и что этот ПР улучшит
malf gaming
## Авторство
Akellazp
## Чеинжлог
:cl:
 - map: На спутнике ИИ теперь больше голопадов