### PR TITLE
Фикс заклинания телепортации мага

### DIFF
--- a/code/datums/spells/area_teleport.dm
+++ b/code/datums/spells/area_teleport.dm
@@ -5,7 +5,7 @@
 	var/randomise_selection = 0 //if it lets the usr choose the teleport loc or picks it from the list
 	var/invocation_area = 1 //if the invocation appends the selected area
 
-/obj/effect/proc_holder/spell/targeted/area_teleport/perform(list/targets, recharge = 1)
+/obj/effect/proc_holder/spell/targeted/area_teleport/perform(list/targets, recharge = 1, mob/user = usr)
 	var/thearea = before_cast(targets)
 	if(!thearea || !cast_check(1))
 		revert_cast()
@@ -15,13 +15,13 @@
 	cast(targets,thearea)
 	invocation()
 
-/obj/effect/proc_holder/spell/targeted/area_teleport/before_cast(list/targets)
+/obj/effect/proc_holder/spell/targeted/area_teleport/before_cast(list/targets, mob/user = usr)
 	for(var/mob/living/target in targets)
 		if(target.incapacitated() || target.lying)
 			return FALSE
 	var/A = null
 	if(!randomise_selection)
-		A = input("Area to teleport to", "Teleport", A) as null|anything  in teleportlocs
+		A = tgui_input_list(user, "Зона для телепортации", "Телепортация", teleportlocs)
 	else
 		A = pick(teleportlocs)
 
@@ -35,7 +35,7 @@
 	else
 		return FALSE
 
-/obj/effect/proc_holder/spell/targeted/area_teleport/cast(list/targets, area/thearea)
+/obj/effect/proc_holder/spell/targeted/area_teleport/cast(list/targets, area/thearea, mob/user = usr)
 	for(var/mob/living/target in targets)
 		var/list/L = list()
 		for(var/turf/T in get_area_turfs(thearea.type))


### PR DESCRIPTION
## Описание изменений
- Починил сломанное заклинание телепортации мага;
- Заменил выбор зоны для телепорта на TGUI. (потому что могу)

При активации был рантайм, сейчас все гуд.
Рантайм возникал из-за того, что в `/perform()` спелла передавался именнованный аругмент `user`, который не был объявлен в параметрах метода.
```
Runtime in : : bad arg name 'user'
  proc name: perform (/obj/effect/proc_holder/spell/targeted/area_teleport/perform)
  usr: Yoda the Deathless (spair) (/mob/living/carbon/human)
  usr.loc: The floor (62,140,2) (/turf/simulated/floor)
  src: Телепорт (/obj/effect/proc_holder/spell/targeted/area_teleport/teleport)
  src.loc: null
  call stack:
  Телепорт (/obj/effect/proc_holder/spell/targeted/area_teleport/teleport): perform(/list (/list), null)
  Телепорт (/obj/effect/proc_holder/spell/targeted/area_teleport/teleport): choose targets(Yoda the Deathless (/mob/living/carbon/human))
  Телепорт (/obj/effect/proc_holder/spell/targeted/area_teleport/teleport): Click()
  Телепорт (/datum/action/spell_action): Trigger()
  Телепорт (/atom/movable/screen/movable/action_button): Click(null, "mapwindow.map", "icon-x=20;icon-y=12;left=1;scr...")
  SpaiR (/client): Click(Телепорт (/atom/movable/screen/movable/action_button), null, "mapwindow.map", "icon-x=20;icon-y=12;left=1;scr...")
```
 Я не стал проверять, но по блейму выглядит, будто бы сломалось тут #7876, два года назад. Там как раз добавлена передача `user`. Починил добавив соотв. аргумент в методы спелла.

Вообще, спеллы выглядят как будто бы их нужно порефачить, но они примерно также выглядели и 5 лет назад...

## Почему и что этот ПР улучшит
fixes #8094

## Авторство

## Чеинжлог
🆑 
 - fix: Заклинание телепортации мага работает
 - tweak: Выбор зон для телепортации мага в TGUI
