### PR TITLE
Фикс метода ghostize и его не установки времени смерти

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -142,7 +142,7 @@ var/global/list/image/ghost_sightless_images = list() //this is a list of images
 /mob/dead/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	return 1
 
-/mob/proc/ghostize(can_reenter_corpse = TRUE, bancheck = FALSE)
+/mob/proc/ghostize(can_reenter_corpse = TRUE, bancheck = FALSE, timeofdeath = world.time)
 	if(key)
 		if(!(ckey in admin_datums) && bancheck == TRUE && jobban_isbanned(src, "Observer"))
 			var/mob/M = mousize()
@@ -156,7 +156,7 @@ var/global/list/image/ghost_sightless_images = list() //this is a list of images
 		set_EyesVision(transition_time = 0)
 		SStgui.on_transfer(src, ghost)
 		ghost.can_reenter_corpse = can_reenter_corpse
-		ghost.timeofdeath = src.timeofdeath //BS12 EDIT
+		ghost.timeofdeath = timeofdeath
 		ghost.key = key
 		ghost.playsound_stop(CHANNEL_AMBIENT)
 		ghost.playsound_stop(CHANNEL_AMBIENT_LOOP)
@@ -180,8 +180,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			var/response = tgui_alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost, you won't be able to play this round for another 30 minutes! You can't change your mind so choose wisely!)","Are you sure you want to ghost?", list("Stay in body","Ghost"))
 			if(response != "Ghost")
 				return	//didn't want to ghost after-all
-			var/mob/dead/observer/ghost = ghostize(can_reenter_corpse = FALSE)
-			ghost.timeofdeath = world.time // Because the living mob won't have a time of death and we want the respawn timer to work properly.
+			ghostize(can_reenter_corpse = FALSE)
 		else
 			ghostize(can_reenter_corpse = TRUE)
 	else
@@ -193,10 +192,9 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			var/mob/living/silicon/robot/robot = usr
 			robot.toggle_all_components()
 		else
-			resting = 1
+			resting = TRUE
 			Sleeping(2 SECONDS)
-		var/mob/dead/observer/ghost = ghostize(can_reenter_corpse = FALSE)						//0 parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
-		ghost.timeofdeath = world.time // Because the living mob won't have a time of death and we want the respawn timer to work properly.
+		ghostize(can_reenter_corpse = FALSE)
 	return
 
 

--- a/code/modules/sports/pbag.dm
+++ b/code/modules/sports/pbag.dm
@@ -55,11 +55,12 @@
 
 	ghostize(can_reenter_corpse = FALSE) // If there was a @ckey before or something.
 	ckey = attacker.ckey
+	timeofdeath = attacker.timeofdeath
 	ghosts_were_here[ckey] = world.time + 10 MINUTES
 	qdel(attacker)
 
 /mob/living/pbag/ghostize(can_reenter_corpse = TRUE, bancheck = FALSE)
-	return ..(can_reenter_corpse = FALSE, bancheck = FALSE)
+	return ..(can_reenter_corpse = FALSE, bancheck = FALSE, timeofdeath = src.timeofdeath)
 
 /mob/living/pbag/UnarmedAttack(atom/A)
 	INVOKE_ASYNC(src, /mob/living/pbag.proc/swing)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Метод `ghostize()` устанавливал госту время смерти груши, которое было `0`, поэтому зайдя в середине раунда это был прямой способ сразу же респавнится.

- Добавил в `ghostize()` соотв. аргумент для выставления времени смерти. Если аргумент не передан, то будет использоваться `world.time`, фактически сбрасывая время оставшееся до респавна в начальную точку (на момент ПРа - 30 минут).
- При посесинге груши для битья в неё запоминается время смерти. Это время передается в `ghostize()`, так его таймер респавна не изменяется.

В теории, из-за того, что теперь `ghostize()` по умолчанию сбрасывает таймер в начальное значение, где-то могут возникнуть проблемы, но это в теории и может быть и поделом. Бегло глянувши по коду выглядит так, будто бы этот метод изанчально задумывался, как то, что будет вызываться уже после смерти пользователя. Например, моб умер и после этого его клиента превратили в госта. Но, по факту, сейчас метод используется как альтернатива смерти. Много кейсов, где на мобе сначала вызывают `ghostize()`, а затем изначальное тело удаляется.

Поэтому, если и будут случаи, где нужно сохранять время смерти, то теперь это нужно делать явно.

## Почему и что этот ПР улучшит
fixes #7778 

## Авторство

## Чеинжлог
:cl:
 - fix: Закрыт абуз с заходом за бойцовскую грушу и сбросом таймера респавна.