### PR TITLE
fix xenomorph confusion

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/life.dm
+++ b/code/modules/mob/living/carbon/xenomorph/life.dm
@@ -104,6 +104,9 @@
 
 		if(druggy)
 			setDrugginess(0)
+
+		if(confused)
+			confused = 0
 	return 1
 
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Добавил зануление конфуза к занулениям других переменных у алиенов.

## Почему и что этот ПР улучшит
Алиены не станут недееспособными навечно от конфуза (к примеру от крика генки).

## Авторство

## Чеинжлог
:cl: Kalazus
- bugfix: Ксеноморфы больше не станут недееспособными от крика генокрада.
