### PR TITLE
Убрал обновление окна Коммуникаций с ЦК, Атмос Алерта.

### DIFF
--- a/code/game/machinery/computer/atmos_control.dm
+++ b/code/game/machinery/computer/atmos_control.dm
@@ -14,10 +14,6 @@
 	var/obj/machinery/alarm/current
 	var/overridden = FALSE //not set yet, can't think of a good way to do it
 
-/obj/machinery/computer/atmoscontrol/process()
-	if(..())
-		updateUsrDialog()
-
 /obj/machinery/computer/atmoscontrol/ui_interact(mob/user)
 	if(allowed(user)) // this is very strange when you know, that this var will be set everytime someone opens with and without access and interfere with each other... but maybe i don't understand smth.
 		overridden = TRUE

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -66,12 +66,6 @@
 
 	return ..()
 
-/obj/machinery/computer/communications/process()
-	if(..())
-		if(state != STATE_STATUSDISPLAY)
-			updateDialog()
-
-
 /obj/machinery/computer/communications/Topic(href, href_list)
 	. = ..()
 	if(!.)

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -504,8 +504,8 @@
 		new R.product_path(get_turf(src))
 		playsound(src, 'sound/items/vending.ogg', VOL_EFFECTS_MASTER)
 		src.vend_ready = 1
-
-	updateUsrDialog()
+		src.currently_vending = null
+		updateUsrDialog()
 
 /obj/machinery/vending/proc/stock(datum/data/vending_product/R, mob/user)
 	if(src.panel_open)


### PR DESCRIPTION
## Описание изменений
Убрал обновление интерфейса из консолей, в которых это ломало нормальную работу с ними.
Исправил исправление вендомата, теперь он выходит на главную страницу покупки сразу после покупки, удобно.

Решение с консолями временное, до того времени, как их переведут на православный ТГуи

fix #8195
closes #8196 

## Почему и что этот ПР улучшит
Удобство, польза.

## Авторство
Darth_Sidious

## Чеинжлог
:cl:
 - tweak: Консоль Коммуникаций с ЦК теперь не обновляется постоянно, что раньше мешало набору текста и работе.
 - tweak: Консоль Атмосферных тревог теперь не обновляется постоянно, что раньше мешало работе.
 - bugfix: Пофиксил фикс вендоматов, теперь они точно выходят на главную страницу после покупки.