### PR TITLE
Фикс рантайма ресурс блоба

### DIFF
--- a/code/game/gamemodes/modes_gameplays/blob/blobs/resource.dm
+++ b/code/game/gamemodes/modes_gameplays/blob/blobs/resource.dm
@@ -14,14 +14,13 @@
 	return
 
 /obj/effect/blob/resource/run_action()
-
+	if(QDELETED(overmind))
+		overmind = null
+		return
 	if(resource_delay > world.time)
-		return 0
+		return
 
 	resource_delay = world.time + 40 // 4 seconds
 	PulseAnimation()
 
-	if(overmind)
-		overmind.add_points(1)
-	return 0
-
+	overmind.add_points(1)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Ресурс блоба продолжала пытаться создавать ресурсы для овермайнда даже после смерти ядра. когда овермайнд удаляется, из-за чего вылазила рантайм ошибка.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
