### PR TITLE
Event Manager Panel for +DEBUG

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -185,6 +185,7 @@ var/list/admin_verbs_debug = list(
 	/client/proc/cmd_display_init_log,
 	/client/proc/debugNatureMapGenerator,
 	/datum/admins/proc/run_unit_test,
+	/client/proc/event_manager_panel,
 	)
 var/list/admin_verbs_possess = list(
 	/proc/possess,


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Ивент менеджер панель для +дебага

В топике ивентменеджер панели чек стоит только на +админ, я не знаю, должно ли так быть, может быть это тоже надо поправить.

## Почему и что этот ПР улучшит
Проще дебажить получается.

## Авторство

## Чеинжлог
