### PR TITLE
Форматирование noob_notify и метод trim_margin()

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -475,7 +475,7 @@
 		|Byond profile: <a href='[player_byond_profile]'>open</a>
 		|Guard report: <a href='?_src_=holder;guard=\ref[M]'>show</a>"})
 
-		message_admins(adminmsg)
+		message_admins(adminmsg, emphasize = TRUE)
 
 	if((isnum(M.client.player_age) && M.client.player_age < 5) || (isnum(M.client.player_ingame_age) && M.client.player_ingame_age < 600)) //less than 5 days on server OR less than 10 hours in game
 		var/mentormsg = trim_margin({"
@@ -484,7 +484,7 @@
 		|Days on server: [M.client.player_age]; Minutes played: [M.client.player_ingame_age < 120 ? "<span class='alert'>[M.client.player_ingame_age]</span>" : M.client.player_ingame_age]
 		|Byond profile: <a href='[player_byond_profile]'>open</a> (can be experienced player from another server)"})
 
-		message_mentors(mentormsg, 1)
+		message_mentors(mentormsg, TRUE, TRUE)
 
 // Better get_dir proc
 /proc/get_general_dir(atom/Loc1, atom/Loc2)

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -469,18 +469,20 @@
 	var/player_assigned_role = (M.mind.assigned_role ? " ([M.mind.assigned_role])" : "")
 	var/player_byond_profile = "http://www.byond.com/members/[M.ckey]"
 	if(M.client.player_age == 0)
-		var/adminmsg = {"New player notify
-					Player '[M.ckey]' joined to the game as [M.mind.name][player_assigned_role] [ADMIN_FLW(M)] [ADMIN_PP(M)] [ADMIN_VV(M)]
-					Byond profile: <a href='[player_byond_profile]'>open</a>
-					Guard report: <a href='?_src_=holder;guard=\ref[M]'>show</a>"}
+		var/adminmsg = trim_margin({"
+		|New player notify
+		|Player '[M.ckey]' joined to the game as [M.mind.name][player_assigned_role] [ADMIN_FLW(M)] [ADMIN_PP(M)] [ADMIN_VV(M)]
+		|Byond profile: <a href='[player_byond_profile]'>open</a>
+		|Guard report: <a href='?_src_=holder;guard=\ref[M]'>show</a>"})
 
 		message_admins(adminmsg)
 
 	if((isnum(M.client.player_age) && M.client.player_age < 5) || (isnum(M.client.player_ingame_age) && M.client.player_ingame_age < 600)) //less than 5 days on server OR less than 10 hours in game
-		var/mentormsg = {"New player notify
-					Player '[M.key]' joined to the game as [M.mind.name][player_assigned_role] (<a href='byond://?_src_=usr;track=\ref[M]'>FLW</a>)
-					Days on server: [M.client.player_age]; Minutes played: [M.client.player_ingame_age < 120 ? "<span class='alert'>[M.client.player_ingame_age]</span>" : M.client.player_ingame_age]
-					Byond profile: <a href='[player_byond_profile]'>open</a> (can be experienced player from another server)"}
+		var/mentormsg = trim_margin({"
+		|New player notify
+		|Player '[M.key]' joined to the game as [M.mind.name][player_assigned_role] (<a href='byond://?_src_=usr;track=\ref[M]'>FLW</a>)
+		|Days on server: [M.client.player_age]; Minutes played: [M.client.player_ingame_age < 120 ? "<span class='alert'>[M.client.player_ingame_age]</span>" : M.client.player_ingame_age]
+		|Byond profile: <a href='[player_byond_profile]'>open</a> (can be experienced player from another server)"})
 
 		message_mentors(mentormsg, 1)
 

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -68,7 +68,7 @@
 	return sanitize(replace_characters(input, list(">"=" ","<"=" ", "\""="'")), max_length, encode, trim, extra, ascii_only)
 
 /proc/paranoid_sanitize(t)
-	var/regex/alphanum_only = regex("\[^a-zA-Z0-9# ,.?!:;()]", "g")
+	var/static/regex/alphanum_only = regex("\[^a-zA-Z0-9# ,.?!:;()]", "g")
 	return alphanum_only.Replace(t, "#")
 
 //Filters out undesirable characters from character names
@@ -242,6 +242,20 @@
 // not work for unicode spaces - you should cleanup them first with sanitize()
 /proc/trim(text)
 	return trim_left(trim_right(text))
+
+// Returns a string without a margin before the provided margin prefix.
+// Useful to do a code formatting when multiline strings are used.
+/proc/trim_margin(text, margin_prefix = "|")
+	var/result = ""
+
+	for (var/line in splittext(text, "\n"))
+		var/margin_idx = findtext_char(line, margin_prefix) + 1
+		line = copytext_char(line, margin_idx)
+		if (line != margin_prefix) // If the line is made of only a margin prefix, then make it an empty line.
+			result += line
+		result += "\n"
+
+	return trim(result)
 
 //Returns a string with the first element of the string capitalized.
 /proc/capitalize(text)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -3,9 +3,12 @@ var/global/BSACooldown = 0
 
 
 ////////////////////////////////
-/proc/message_admins(msg, reg_flag = R_ADMIN)
+/proc/message_admins(msg, reg_flag = R_ADMIN, emphasize = FALSE)
 	log_adminwarn(msg) // todo: msg in html format, dublicates other logs; must be removed, use logs_*() where necessary (also, thanks you dear ZVE)
-	msg = "<span class=\"admin\"><span class=\"prefix\">ADMIN LOG:</span> <span class=\"message\">[msg]</span></span>"
+	var/style = "admin"
+	if (emphasize)
+		style += " emphasized"
+	msg = "<span class='[style]'><span class='prefix'>ADMIN LOG:</span> <span class='message'>[msg]</span></span>"
 	for(var/client/C in admins)
 		if(C.holder.rights & reg_flag)
 			to_chat(C, msg)

--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -287,6 +287,12 @@ a.popt {text-decoration: none;}
 	margin-bottom: 4px;
 }
 
+.emphasized {
+	display: block;
+	border-left: 3px solid #e9e000;
+	background-color: #FAFFAF;
+	padding-left: 8px;
+}
 
 /* ADD HERE FOR BOLD */
 .bold, .name, .prefix, .ooc, .adminooc, .adminlooc, .admin, .adminobserverooc, .adminooc, .adminobserver, .adminsay, .wet {font-weight: bold;}

--- a/code/modules/mentor/mentor.dm
+++ b/code/modules/mentor/mentor.dm
@@ -38,8 +38,11 @@
 			if(directory[ckey])
 				mentors += directory[ckey]
 
-/proc/message_mentors(msg, observer_only = 0)
-	msg = "<span class=\"admin\"><span class=\"prefix\">MENTOR LOG:</span> <span class=\"message\">[msg]</span></span>"
+/proc/message_mentors(msg, observer_only = FALSE, emphasize = FALSE)
+	var/style = "admin"
+	if (emphasize)
+		style += " emphasized"
+	msg = "<span class='[style]'><span class='prefix'>MENTOR LOG:</span> <span class='message'>[msg]</span></span>"
 	for(var/client/C in mentors)
 		if(!observer_only || (observer_only && isobserver(C.mob)))
 			to_chat(C, msg)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Мне прямо глаза режет форматирование текста `noob_notify()` и дошли руки его поправить. На скринах как было и как стало.
**UPD:** А чтобы сообщение было заметным (а не кривым) добавил цветовую подсветку. 

Также добавил новый метод `trim_margin()` с помощью которого можно удобно форматировать многострочные строки, не ломая глаза при чтении кода. Обычно такое делают на уровне языка, но мы же помним на каком языке мы кодим?

## Почему и что этот ПР улучшит
![before](https://user-images.githubusercontent.com/12721311/141700293-5a5ff892-3c03-419b-8815-8158c868bb0d.png)
![highlight](https://user-images.githubusercontent.com/12721311/141737288-d9eb4aaf-2963-49cc-b8ec-7e9ba35109a8.png)

## Авторство

## Чеинжлог
