### PR TITLE
Анимация дерганья чего-то всегда будет видна

### DIFF
--- a/code/game/animation_helpers.dm
+++ b/code/game/animation_helpers.dm
@@ -4,10 +4,10 @@
 	//For handling persistent filters
 	var/list/filter_data
 
-/atom/proc/before_shake_animation(intensity, time, intensity_dropoff)
+/atom/proc/before_shake_animation(intensity, time, intensity_dropoff, list/viewers)
 	return
 
-/atom/proc/after_shake_animation(intensity, time, intensity_dropoff)
+/atom/proc/after_shake_animation(intensity, time, intensity_dropoff, list/viewers)
 	return
 
 /atom/proc/do_shake_animation(intensity, time, intensity_dropoff = 0.9)
@@ -27,16 +27,11 @@
 	I.loc = src
 	I.appearance_flags |= KEEP_APART
 
-	var/list/viewers = list()
-	for(var/mob/M in viewers(src))
-		if(M.client)
-			viewers += M.client
-
-	before_shake_animation(intensity, time, intensity_dropoff, viewers)
+	before_shake_animation(intensity, time, intensity_dropoff, clients)
 
 	var/prev_invis = invisibility
 
-	flick_overlay(I, viewers, time + 1)
+	flick_overlay(I, clients, time + 1)
 
 	var/stop_shaking = world.time + time
 	while(stop_shaking > world.time)
@@ -58,7 +53,7 @@
 			return
 		invisibility = prev_invis
 
-	after_shake_animation(intensity, time, intensity_dropoff, viewers)
+	after_shake_animation(intensity, time, intensity_dropoff, clients)
 
 	qdel(I)
 	is_invis_anim = FALSE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Начну сразу с примеров. У культа есть статуя, которая подергивается, когда тайл превращается в культистский. Раньше, люди в камерах эту статую видели только в моменты, когда она не трясется. Похожее было и с людьми. Если они подбегали к статуе во время анимации, то они ничего не видели и им приходилось ждать, пока анимка кончится. Я сделал так, чтобы эту анимацию видели все всегда.

(ну и по мелочи добавил для родительского прока параметр, который был у дочерних проков)

## Почему и что этот ПР улучшит
Минус баг

## Авторство

## Чеинжлог
:cl:
 - fix: Люди в некоторые моменты могли не видеть статую культа во время дерганья.