### PR TITLE
Фикс сообщений при захвате зоны культом + фича

### DIFF
--- a/code/game/gamemodes/modes_gameplays/cult/cult_datums.dm
+++ b/code/game/gamemodes/modes_gameplays/cult/cult_datums.dm
@@ -229,22 +229,22 @@
 	var/announcement_type = pick(typesof(/datum/announcement/centcomm/anomaly) - blacklisted_announcements)
 	var/datum/announcement/announce = new announcement_type
 	announce.play(area)
+
 	var/turf/rune_turf = get_turf(holder)
 	message_admins("Cult has started capture: [area] in [COORD(rune_turf)] - [ADMIN_JMP(rune_turf)]")
 
 	statue = new(rune_turf, holder)
-	R.religify_area(area.type, CALLBACK(src, .proc/capture_iteration), null, TRUE)
+	var/religify_compelted = R.religify_area(area.type, CALLBACK(src, .proc/capture_iteration), null, TRUE)
+	religion.send_message_to_members("Захват [get_area(holder)] [religify_compelted ? "удался" : "провален"].", pick(religion.deity_names))
+	message_admins("Capture of [get_area(holder)] [religify_compelted ? "successful" : "failed"].")
 	R.capturing_area = FALSE
-	message_admins("Capture of [get_area(holder)] successful.")
 
 /datum/rune/cult/capture_area/proc/capture_iteration(i, list/all_items)
 	if(!holder || !src)
-		message_admins("Capture of [get_area(holder)] failed.")
 		return FALSE
 
 	if((100*i)/all_items.len % 25 == 0)
-		for(var/mob/M in religion.members)
-			to_chat(M, "<span class='[religion.style_text]'>Захват [get_area(holder)] завершен на [round((100*i)/all_items.len, 0.1)]%</span>")
+		religion.send_message_to_members("Захват [get_area(holder)] завершен на [round((100*i)/all_items.len, 0.1)]%", font_size = 2)
 
 	INVOKE_ASYNC(src, .proc/capture_effect, i, all_items)
 	sleep(per_obj_cd)

--- a/code/game/gamemodes/modes_gameplays/cult/cult_datums.dm
+++ b/code/game/gamemodes/modes_gameplays/cult/cult_datums.dm
@@ -235,8 +235,8 @@
 
 	statue = new(rune_turf, holder)
 	var/religify_compelted = R.religify_area(area.type, CALLBACK(src, .proc/capture_iteration), null, TRUE)
-	religion.send_message_to_members("Захват [get_area(holder)] [religify_compelted ? "удался" : "провален"].", pick(religion.deity_names))
-	message_admins("Capture of [get_area(holder)] [religify_compelted ? "successful" : "failed"].")
+	religion.send_message_to_members("Захват [area] [religify_compelted ? "удался" : "провален"].", pick(religion.deity_names))
+	message_admins("Capture of [area] [religify_compelted ? "successful" : "failed"].")
 	R.capturing_area = FALSE
 
 /datum/rune/cult/capture_area/proc/capture_iteration(i, list/all_items)

--- a/code/modules/religion/religion.dm
+++ b/code/modules/religion/religion.dm
@@ -668,10 +668,11 @@
 				C.say(message)
 	return acolytes
 
-/datum/religion/proc/send_message_to_members(message, name) // As a god
+/datum/religion/proc/send_message_to_members(message, name, font_size = 6)
+	var/format_name = name ? "[name]: " : ""
 	for(var/mob/M in global.mob_list)
 		if(is_member(M) || isobserver(M))
-			to_chat(M, "<span class='[style_text]'><font size='6'>[name]: [message]</font></span>")
+			to_chat(M, "<span class='[style_text]'><font size='[font_size]'>[format_name][message]</font></span>")
 
 /datum/religion/proc/add_tech(tech_type)
 	var/datum/religion_tech/T = new tech_type


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
При провале захвата зоны будет только 1 лог админу

Культисты видят удалось или нет захватить зону. Сам бог это в чате скажет.

fix https://github.com/TauCetiStation/TauCetiClassic/issues/8167

## Почему и что этот ПР улучшит
фикс бага + QoL фича

## Авторство

## Чеинжлог
:cl:
 - tweak: Культистам теперь пишет в чат о результате захвата зоны.