### PR TITLE
Проклятый кубик больше не работает на культистов

### DIFF
--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -50,7 +50,8 @@
 		time--
 		sleep(1)
 	for(var/mob/living/A in viewers(3,   loc))
-		A.confused += SLIGHTLY_CONFUSED
+		if(!iscultist(A))
+			A.confused += SLIGHTLY_CONFUSED
 	loc.visible_message("<span class='warning'>You hear a loud pop, as [src] poofs out of existence.</span>")
 	playsound(src, 'sound/effects/bubble_pop.ogg', VOL_EFFECTS_MASTER)
 	qdel(src)

--- a/code/game/objects/items/weapons/dice.dm
+++ b/code/game/objects/items/weapons/dice.dm
@@ -49,7 +49,7 @@
 		set_light(light_range, 1, "#a2fad1")
 		time--
 		sleep(1)
-	for(var/mob/living/A in viewers(3,   loc))
+	for(var/mob/living/A in viewers(3, loc))
 		if(!iscultist(A))
 			A.confused += SLIGHTLY_CONFUSED
 	loc.visible_message("<span class='warning'>You hear a loud pop, as [src] poofs out of existence.</span>")


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Этот кубик из разряда тех вещей, которые должны юзать культисты чуть ли не всегда. Это же и к свечам (которые и не работают на культистов), и должно было бы наверное к кубикам.

## Почему и что этот ПР улучшит
У культистов появится почти стабильный способ накидывать на людей типо стан.

## Авторство

## Чеинжлог
:cl:
 - balance: Проклятый кубик больше не работает на культистов