### PR TITLE
[Alien] Ребаланс помощи с ЦК

### DIFF
--- a/code/__DEFINES/xenomorph.dm
+++ b/code/__DEFINES/xenomorph.dm
@@ -2,7 +2,7 @@
 #define TOTAL_HUMAN         1
 #define TOTAL_ALIEN         2
 #define ALIEN_PERCENT       3
-#define FIRST_HELP_PERCENT  25
+#define FIRST_HELP_PERCENT  20
 #define SECOND_HELP_PERCENT 60
 #define WIN_PERCENT         190
 

--- a/code/__DEFINES/xenomorph.dm
+++ b/code/__DEFINES/xenomorph.dm
@@ -2,8 +2,8 @@
 #define TOTAL_HUMAN         1
 #define TOTAL_ALIEN         2
 #define ALIEN_PERCENT       3
-#define FIRST_HELP_PERCENT  30
-#define SECOND_HELP_PERCENT 80
+#define FIRST_HELP_PERCENT  25
+#define SECOND_HELP_PERCENT 60
 #define WIN_PERCENT         190
 
 //alien list

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1888,11 +1888,12 @@ var/global/list/all_supply_groups = list("Operations","Security","Hospitality","
 //----------------------------------------------
 /datum/supply_pack/xeno_laser
 	name = "Xeno liquidator"
-	contains = list(/obj/item/clothing/suit/bio_suit/old_hazmat/firered,
-					/obj/item/clothing/head/bio_hood/old_hazmat/firered,
+	contains = list(/obj/item/clothing/suit/space/globose/recycler,
+					/obj/item/clothing/head/helmet/space/globose/recycler,
 					/obj/item/weapon/gun/energy/laser,
 					/obj/item/weapon/shield/buckler,
-					/obj/item/clothing/mask/gas/coloured,
+					/obj/item/clothing/mask/breath,
+					/obj/item/weapon/tank/oxygen,
 					/obj/item/weapon/grenade/chem_grenade/antiweed,
 					/obj/item/weapon/storage/firstaid/small_firstaid_kit/space)
 	cost = 10000
@@ -1908,7 +1909,8 @@ var/global/list/all_supply_groups = list("Operations","Security","Hospitality","
 					/obj/item/ammo_box/eight_shells/incendiary,
 					/obj/item/weapon/shield/riot,
 					/obj/item/clothing/ears/earmuffs,
-					/obj/item/clothing/mask/gas/coloured,
+					/obj/item/clothing/mask/breath,
+					/obj/item/weapon/tank/oxygen,
 					/obj/item/weapon/grenade/chem_grenade/antiweed,
 					/obj/item/weapon/grenade/chem_grenade/antiweed,
 					/obj/item/weapon/storage/firstaid/small_firstaid_kit/combat)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Процент первой помощи понизил до 20%, второй до 60%. Заменил биокостюмы на скафандры мусорщиков - у них защита мили 40. В обе поставки добавил маску для дыхания, вместо газовой маски, и баллон с кислородом.
## Почему и что этот ПР улучшит
Вторая помощь приходит очень поздно, никто не успевает её использовать. Биокостюмы как правило игнорировались, поэтому добавил то, что защитит от разгерм и повреждений.
## Авторство
я
## Чеинжлог
:cl: Ahio
 - balance: Первая и вторая помощь с ЦК, во время режима infestation, будет приходить раньше.
 - balance: В первой поставке, биокостюмы заменены на скафандры мусорщиков. В обе поставки добавлены маска для дыхания и баллон с кислородом.