### PR TITLE
Фикс зрения кисок в очках

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1442,6 +1442,8 @@
 			lighting_alpha = min(lighting_alpha, G.lighting_alpha)
 		if(G.sightglassesmod && (G.active || !G.toggleable))
 			sightglassesmod = G.sightglassesmod
+		else
+			sightglassesmod = null
 	else
 		sightglassesmod = null
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Сетался нулл когда не было очков, но я забыл сетать нулл, когда у очков нет сигхтмода

fix https://github.com/TauCetiStation/TauCetiClassic/issues/8346

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
:cl:
 - fix: У таярочек оставалось виденье в темноте, когда они в очках выходили из темноты