### PR TITLE
xeno notes for xenovisors

### DIFF
--- a/SQL/ss13.sql
+++ b/SQL/ss13.sql
@@ -182,7 +182,7 @@ CREATE TABLE `erro_stickyban_matched_cid` (
 /*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `erro_messages` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
-  `type` enum('note') NOT NULL,
+  `type` enum('note', 'xenonote') NOT NULL,
   `targetckey` varchar(32) NOT NULL,
   `adminckey` varchar(32) NOT NULL,
   `text` varchar(2048) NOT NULL,

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -212,8 +212,8 @@ var/global/BSACooldown = 0
 #define PLAYER_INFO_TYPE_XENOS "xenonote"
 
 #define PLAYERINFOS(o) \
-	o(PLAYER_INFO_TYPE_ADMIN, list(R_LOG, R_BAN),       "Admin note"), \
-	o(PLAYER_INFO_TYPE_XENOS, list(R_LOG, R_WHITELIST), "Xeno note"), \
+	o(PLAYER_INFO_TYPE_ADMIN, list(R_LOG, R_BAN),               "Admin note"), \
+	o(PLAYER_INFO_TYPE_XENOS, list(R_LOG, R_WHITELIST | R_BAN), "Xeno note"), \
 
 #define RIGHTS(name, rights, _) name = rights
 var/global/list/player_info_type_rights = list(

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -211,29 +211,20 @@ var/global/BSACooldown = 0
 #define PLAYER_INFO_TYPE_ADMIN "note"
 #define PLAYER_INFO_TYPE_XENOS "xenonote"
 
-#define PLAYERINFOS(o) \
-	o(PLAYER_INFO_TYPE_ADMIN, list(R_LOG, R_BAN),               "Admin note"), \
-	o(PLAYER_INFO_TYPE_XENOS, list(R_LOG, R_WHITELIST | R_BAN), "Xeno note"), \
-
-#define RIGHTS(name, rights, _) name = rights
 var/global/list/player_info_type_rights = list(
-	PLAYERINFOS(RIGHTS)
+	PLAYER_INFO_TYPE_ADMIN = list(R_LOG, R_BAN),
+	PLAYER_INFO_TYPE_XENOS = list(R_LOG, R_WHITELIST | R_BAN),
 )
-#undef RIGHTS
 
-#define UITEXT(name, _, uitext) name = uitext
 var/global/list/player_info_type_uitext = list(
-	PLAYERINFOS(UITEXT)
+	PLAYER_INFO_TYPE_ADMIN = "Admin note",
+	PLAYER_INFO_TYPE_XENOS = "Xeno note"
 )
-#undef UITEXT
 
-#define UITEXTREV(name, _, uitext) uitext = name
 var/global/list/player_info_type_from_uitext = list(
-	PLAYERINFOS(UITEXTREV)
+	"Admin note" = PLAYER_INFO_TYPE_ADMIN,
+	"Xeno note"  = PLAYER_INFO_TYPE_XENOS,
 )
-#undef UITEXTREV
-
-#undef PLAYERINFOS
 
 /datum/player_info
 	var/author = PLAYER_INFO_MISSING_AUTHOR_TEXT        // admin who authored the information

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -208,18 +208,52 @@ var/global/BSACooldown = 0
 #define PLAYER_INFO_MISSING_JOB_TEXT        "N/A"
 #define PLAYER_INFO_MISSING_ROUND_ID_TEXT   "N/A"
 
+#define PLAYER_INFO_TYPE_ADMIN "note"
+#define PLAYER_INFO_TYPE_XENOS "xenonote"
+
+#define PLAYERINFOS(o) \
+	o(PLAYER_INFO_TYPE_ADMIN, list(R_LOG, R_BAN),       "Admin note"), \
+	o(PLAYER_INFO_TYPE_XENOS, list(R_LOG, R_WHITELIST), "Xeno note"), \
+
+#define RIGHTS(name, rights, _) name = rights
+var/global/list/player_info_type_rights = list(
+	PLAYERINFOS(RIGHTS)
+)
+#undef RIGHTS
+
+#define UITEXT(name, _, uitext) name = uitext
+var/global/list/player_info_type_uitext = list(
+	PLAYERINFOS(UITEXT)
+)
+#undef UITEXT
+
+#define UITEXTREV(name, _, uitext) uitext = name
+var/global/list/player_info_type_from_uitext = list(
+	PLAYERINFOS(UITEXTREV)
+)
+#undef UITEXTREV
+
+#undef PLAYERINFOS
+
 /datum/player_info
 	var/author = PLAYER_INFO_MISSING_AUTHOR_TEXT        // admin who authored the information
 	var/content = PLAYER_INFO_MISSING_CONTENT_TEXT      // text content of the information
 	var/timestamp = PLAYER_INFO_MISSING_TIMESTAMP_TEXT  // Because this is bloody annoying
 	var/days_timestamp = 0 // number of day after 1 Jan 2000
 	var/round_id = PLAYER_INFO_MISSING_ROUND_ID_TEXT
+	var/note_type = PLAYER_INFO_TYPE_ADMIN // type of note, determines the access flags for message
+
+/datum/player_info/proc/can_view(datum/admins/A)
+	for(var/flag in global.player_info_type_rights[note_type])
+		if(!(A.rights & flag))
+			return FALSE
+	return TRUE
 
 /datum/player_info/proc/get_days_timestamp()
 	return isnum(days_timestamp) ? days_timestamp : 0
 
 /datum/admins/proc/show_player_notes(key)
-	if(!(check_rights(R_LOG) && check_rights(R_BAN)))
+	if(!check_rights(R_LOG))
 		return
 
 	key = ckey(key)
@@ -251,6 +285,9 @@ var/global/BSACooldown = 0
 	else
 		var/list/infos = generalized_players_info(db_messages, db_bans)
 		for(var/datum/player_info/I in infos)
+			if(!I.can_view(src))
+				continue
+			dat += "[global.player_info_type_uitext[I.note_type]]: "
 			dat += "<font color=#008800>[I.content]</font> <i>by [I.author]</i> on <i><font color=blue>#[I.round_id], [I.timestamp]</i></font> "
 			dat += "<br><br>"
 	dat += "<br>"
@@ -283,7 +320,8 @@ var/global/BSACooldown = 0
 		"text",
 		"DATE_FORMAT(timestamp, '[timestamp_format]')",
 		"DATEDIFF(timestamp, '[days_ago_start_date]')",
-		"round_id"
+		"round_id",
+		"type"
 	 )
 	var/DBQuery/query = dbcon.NewQuery("SELECT " + sql_fields.Join(", ") + " FROM erro_messages WHERE (targetckey = '[ckey(player_ckey)]') AND (deleted = 0) ORDER BY id LIMIT 100")
 	if(!query.Execute())
@@ -296,6 +334,7 @@ var/global/BSACooldown = 0
 		var/timestamp = query.item[3]
 		var/days_ago = text2num(query.item[4])
 		var/rid = text2num(query.item[5])
+		var/note_type = query.item[6]
 
 		if(length(a_ckey))
 			notes_record.author = a_ckey
@@ -307,6 +346,8 @@ var/global/BSACooldown = 0
 			notes_record.days_timestamp = days_ago
 		if(rid)
 			notes_record.round_id = rid
+		if(note_type)
+			notes_record.note_type = note_type
 
 		db_player_notes += notes_record
 

--- a/code/modules/admin/player_notes.dm
+++ b/code/modules/admin/player_notes.dm
@@ -1,14 +1,13 @@
-/proc/notes_add(key, note, client/admin, secret = 1)
+/proc/notes_add(key, note, client/admin, secret = 1, note_type = PLAYER_INFO_TYPE_ADMIN)
 	key = ckey(key)
 	note = sanitize(note)
 
 	if (!key || !note)
 		return
 
-	if(!(check_rights(R_LOG) && check_rights(R_BAN)))
+	if(!check_rights(R_LOG))
 		return
 
-	
 	if(!establish_db_connection("erro_messages"))
 		return
 
@@ -16,7 +15,7 @@
 	secret = !!secret
 
 	var/sql = {"INSERT INTO erro_messages (type, targetckey, adminckey, text, timestamp, server_ip, server_port, round_id, secret)
-	VALUES ('note', '[key]', '[admin_key]', '[sanitize_sql(note)]', Now(), INET_ATON(IF('[world.internet_address]' LIKE '', '0', '[sanitize_sql(world.internet_address)]')), '[sanitize_sql(world.port)]', '[global.round_id]', '[secret]')"}
+	VALUES ('[note_type]', '[key]', '[admin_key]', '[sanitize_sql(note)]', Now(), INET_ATON(IF('[world.internet_address]' LIKE '', '0', '[sanitize_sql(world.internet_address)]')), '[sanitize_sql(world.port)]', '[global.round_id]', '[secret]')"}
 	var/DBQuery/new_notes = dbcon.NewQuery(sql)
 	new_notes.Execute()
 

--- a/code/modules/admin/player_notes.dm
+++ b/code/modules/admin/player_notes.dm
@@ -5,8 +5,15 @@
 	if (!key || !note)
 		return
 
+	if(!(note_type in global.player_info_type_rights))
+		return
+
 	if(!check_rights(R_LOG))
 		return
+
+	for(var/flag in global.player_info_type_rights[note_type])
+		if(!check_rights(flag))
+			return
 
 	if(!establish_db_connection("erro_messages"))
 		return

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2275,8 +2275,27 @@
 		var/key = ckey(href_list["add_player_info"])
 		var/add = input("Add Player Info") as null|text//sanitise below in notes_add
 		if(!add) return
+		var/list/note_types = list()
+		for(var/NT in global.player_info_type_rights)
+			var/addthis = TRUE
+			for(var/flag in global.player_info_type_rights[NT])
+				if(!(rights & flag))
+					addthis = FALSE
+					break
+			if(addthis)
+				note_types += global.player_info_type_uitext[NT]
+		var/chosen_type
+		if(note_types.len == 0)
+			return
+		if(note_types.len == 1)
+			chosen_type = global.player_info_type_from_uitext[note_types[1]]
+		else
+			chosen_type = global.player_info_type_from_uitext[tgui_alert(usr, "Choose note type", "Add Player Info", note_types)]
 
-		notes_add(key, add, usr.client)
+		if(!chosen_type)
+			return
+
+		notes_add(key, add, usr.client, secret = TRUE, note_type = chosen_type)
 		show_player_notes(key)
 
 	/* unimplemented


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Ксенонотесы для ксеновизоров. Туда могут писать как админы, так и ксеновизоры. Сделано это для того, чтобы ксеновизоры без доступа к админским нотесам (то есть любые ванильные ксеновизоры) могли оставлять какие-то пометки насчет ксеноповедения игрока.

## Почему и что этот ПР улучшит
Проще ксеновизорить.

## Авторство

## Чеинжлог
<!--
:cl: Getup1
- admin: Ксеновизоры имеют свои собственные нотесы.
-->