### PR TITLE
Gamemode trigger

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -576,3 +576,8 @@ SUBSYSTEM_DEF(ticker)
 
 /world/proc/is_round_preparing()
 	return (SSticker && SSticker.current_state == GAME_STATE_PREGAME)
+
+/datum/controller/subsystem/ticker/proc/gamemode_trigger(modename,faction,message,data=null)
+	if (modename != mode.name && modename != "anymode") // Ignore trigger if it's not for this gamemode and not waste time to compare messages
+		return
+	mode.mode_trigger(faction,message,data)

--- a/code/game/gamemodes/factions.dm
+++ b/code/game/gamemodes/factions.dm
@@ -383,3 +383,6 @@
 	for(var/datum/role/R in members)
 		if(R.antag == M)
 			return R
+
+/datum/faction/proc/mode_trigger(message,data)
+	return

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -21,6 +21,11 @@
 	// List of faction-less roles currently in the gamemode
 	var/list/orphaned_roles = list()
 
+/datum/game_mode/proc/mode_trigger(faction,message,data)
+	for(var/datum/faction/F in factions)
+		if (faction == F.name || faction == "allfactions")
+			F.mode_trigger(message,data)
+
 /datum/game_mode/proc/announce()
 	return
 


### PR DESCRIPTION
## Описание изменений

Вместо обращений напрямую к режиму (и проверок он ли сейчас на сервере) можно вызвать в тикере gamemode_trigger, передав ему название нужного режима (или "anymode" если режим не важен), название фракции ("allfactions" передаст сообщение всем фракциям режима), если сообщение нужно передать в нее, само название триггера и опционально данные которые требуются передать.
В датуме фракции или гейммода переопределяем прок mode_trigger и делаем нужный нам механ.

## Почему и что этот ПР улучшит

Позволит не плодить макаронный код, когда механ отдельных режимов без нужды пихается внутрь файлов машинерии и прочих объектов, хотя ему самое место в коде самого режима.

## Авторство

## Чеинжлог
