### PR TITLE
Адаптация медбея под высокий онлайн + мелкие изменения

### DIFF
--- a/code/game/machinery/holosign.dm
+++ b/code/game/machinery/holosign.dm
@@ -44,7 +44,7 @@
 /obj/machinery/holosign_switch
 	name = "holosign switch"
 	icon = 'icons/obj/power.dmi'
-	icon_state = "light1"
+	icon_state = "light0"
 	desc = "A remote control switch for holosign."
 	anchored = TRUE
 	use_power = IDLE_POWER_USE

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -48107,6 +48107,9 @@
 	},
 /obj/item/device/healthanalyzer,
 /obj/item/device/healthanalyzer,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -74693,9 +74696,6 @@
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/structure/table/glass,
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -379,6 +379,28 @@
 	icon_state = "floorgrime"
 	},
 /area/station/security/range)
+"aaM" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/station/medical/hallway)
 "aaN" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -433,6 +455,34 @@
 	icon_state = "bar"
 	},
 /area/station/security/main)
+"aaR" = (
+/obj/machinery/camera{
+	c_tag = "Surgery Operating 1";
+	dir = 4;
+	network = list("SS13","Medical")
+	},
+/obj/structure/table,
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Surgery Cleaner";
+	pixel_x = 4
+	},
+/obj/item/weapon/razor{
+	pixel_x = -4
+	},
+/turf/simulated/floor,
+/area/station/medical/surgery)
+"aaS" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/machinery/iv_drip,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "whitehall"
+	},
+/area/station/medical/surgery)
 "aaT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -612,6 +662,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig)
+"abp" = (
+/obj/machinery/life_assist/cardiopulmonary_bypass,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "whitehall"
+	},
+/area/station/medical/surgery)
 "abq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -818,6 +875,10 @@
 	icon_state = "vault"
 	},
 /area/station/security/armoury)
+"abI" = (
+/obj/structure/closet/crate/freezer,
+/turf/simulated/floor,
+/area/station/medical/surgery)
 "abJ" = (
 /obj/machinery/deployable/barrier,
 /turf/simulated/floor{
@@ -4559,12 +4620,26 @@
 	},
 /area/station/civilian/fitness)
 "aif" = (
-/obj/structure/closet/crate/freezer,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "whitehall"
+	icon_state = "whiteblue"
 	},
-/area/station/medical/surgery2)
+/area/station/medical/hallway)
 "aig" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -4796,13 +4871,21 @@
 	},
 /area/station/rnd/robotics)
 "aiD" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "warning"
 	},
-/area/station/medical/hallway)
+/area/station/medical/cryo)
 "aiE" = (
 /obj/structure/table,
 /obj/item/device/camera{
@@ -9702,15 +9785,15 @@
 	},
 /area/station/security/lobby)
 "aqU" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/structure/sign/warning/nosmoking{
+/obj/structure/table,
+/obj/machinery/vending/wallmed2{
 	pixel_y = 32
 	},
+/obj/item/weapon/storage/visuals/surgery/full,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "whiteblue"
+	icon_state = "white"
 	},
-/area/station/medical/reception)
+/area/station/medical/surgery2)
 "aqV" = (
 /obj/machinery/light_switch{
 	pixel_y = -25
@@ -15836,11 +15919,6 @@
 "aDe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -16599,18 +16677,15 @@
 	},
 /area/station/ai_monitored/eva)
 "aEF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/structure/grille,
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "white"
-	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
 /area/station/medical/hallway)
 "aEG" = (
 /turf/simulated/floor{
@@ -18365,12 +18440,21 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "aIa" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
-/turf/simulated/floor{
-	dir = 9;
-	icon_state = "warning"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
-/area/station/medical/cryo)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "whiteblue"
+	},
+/area/station/medical/genetics)
 "aIb" = (
 /obj/structure/table,
 /obj/item/device/radio/intercom{
@@ -18406,17 +18490,15 @@
 	},
 /area/station/storage/tools)
 "aId" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
 "aIe" = (
@@ -18553,25 +18635,19 @@
 	},
 /area/station/ai_monitored/eva)
 "aIq" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/machinery/status_display{
+	pixel_y = -32
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -22124,12 +22200,16 @@
 	},
 /area/station/civilian/chapel/office)
 "aOO" = (
-/obj/machinery/status_display{
-	pixel_x = 32
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/simulated/floor{
-	icon_state = "white"
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
 /area/station/medical/hallway)
 "aOP" = (
 /obj/effect/decal/cleanable/blood/oil,
@@ -24276,12 +24356,20 @@
 /turf/simulated/wall,
 /area/station/civilian/locker)
 "aSQ" = (
-/obj/machinery/vending/medical,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "whiteblue"
+/obj/machinery/door/firedoor,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Medbay Hallway APC";
+	pixel_x = 26
 	},
-/area/station/medical/sleeper)
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/station/medical/hallway)
 "aSR" = (
 /obj/machinery/door/airlock/research/glass{
 	name = "Brainstorm Center";
@@ -24500,25 +24588,15 @@
 	},
 /area/station/bridge)
 "aTh" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/obj/machinery/status_display{
+	pixel_y = 32
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/bodyscanner,
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whiteblue"
 	},
-/area/station/medical/hallway)
+/area/station/medical/sleeper)
 "aTi" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -25662,22 +25740,13 @@
 	},
 /area/station/civilian/hydroponics)
 "aVi" = (
-/obj/machinery/light{
+/obj/machinery/sleeper{
 	dir = 8
 	},
-/obj/structure/table/glass,
-/obj/item/weapon/reagent_containers/spray/cleaner,
-/obj/machinery/vending/wallmed2{
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "whiteblue"
+	icon_state = "whitebluefull"
 	},
-/area/station/medical/cryo)
+/area/station/medical/sleeper)
 "aVj" = (
 /obj/structure/bookcase{
 	name = "bookcase (Fiction)"
@@ -31401,12 +31470,14 @@
 	},
 /area/station/hallway/secondary/exit)
 "bfa" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer1";
+	id_tag = "MedbayFoyerIn";
 	name = "Medbay";
 	req_access = list(5)
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -31825,17 +31896,8 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "bfL" = (
-/obj/machinery/power/apc{
-	name = "Operating 2 APC";
-	pixel_y = -25
-	},
-/obj/structure/cable,
-/obj/machinery/body_scanconsole,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "whitehall"
-	},
-/area/station/medical/surgery2)
+/turf/simulated/floor,
+/area/station/medical/surgeryobs)
 "bfM" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plating,
@@ -31936,23 +31998,16 @@
 	},
 /area/station/medical/chemistry)
 "bfW" = (
-/obj/structure/table,
-/obj/item/weapon/retractor,
-/obj/item/weapon/FixOVein{
-	pixel_x = -5
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/door_control{
-	id = "Medical_Surgery1";
-	name = "Privacy Shutters";
-	pixel_x = -25
+/obj/structure/stool/bed/roller,
+/obj/machinery/iv_drip,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "blue"
 	},
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
-	name = "Surgery Cleaner";
-	pixel_x = 4
-	},
-/turf/simulated/floor,
-/area/station/medical/surgery)
+/area/station/medical/surgeryobs)
 "bfX" = (
 /obj/structure/morgue{
 	dir = 8
@@ -31967,23 +32022,16 @@
 	},
 /area/station/medical/morgue)
 "bfY" = (
-/obj/structure/closet/secure_closet/medical2,
-/obj/item/clothing/under/patient_gown,
-/obj/machinery/holosign_switch{
-	id = "op1";
-	pixel_x = 27;
-	pixel_y = 9
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23
 	},
-/obj/machinery/light_switch{
-	pixel_x = 27;
-	pixel_y = -9
+/obj/item/weapon/flora/random,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "whitebluecorner"
 	},
-/obj/machinery/windowtint{
-	id = "op1";
-	pixel_x = 27
-	},
-/turf/simulated/floor,
-/area/station/medical/surgery)
+/area/station/medical/hallway)
 "bfZ" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -31991,15 +32039,20 @@
 	},
 /area/station/hallway/secondary/entry)
 "bga" = (
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "whitehall"
+	icon_state = "white"
 	},
-/area/station/medical/surgery)
+/area/station/medical/hallway)
 "bgb" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -32150,11 +32203,23 @@
 	},
 /area/station/rnd/hallway)
 "bgn" = (
-/obj/machinery/bodyscanner,
-/turf/simulated/floor{
+/obj/structure/window/reinforced/polarized{
 	dir = 1;
-	icon_state = "whitehall"
+	id = "op1"
 	},
+/obj/structure/window/reinforced/polarized{
+	id = "op1"
+	},
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	icon_state = "shutter0";
+	id = "Medical_Surgery1";
+	name = "Surgery Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
 /area/station/medical/surgery)
 "bgo" = (
 /obj/structure/stool/bed/chair{
@@ -32242,9 +32307,16 @@
 	},
 /area/station/hallway/primary/central)
 "bgw" = (
-/obj/machinery/body_scanconsole,
-/turf/simulated/floor,
-/area/station/medical/surgery)
+/obj/machinery/power/apc{
+	name = "Operating 2 APC";
+	pixel_y = -25
+	},
+/obj/structure/cable,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "whitehall"
+	},
+/area/station/medical/surgery2)
 "bgx" = (
 /obj/machinery/status_display{
 	layer = 4;
@@ -33287,17 +33359,17 @@
 	name = "Surgery";
 	req_access = list(5)
 	},
+/obj/structure/curtain/medical,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
 /area/station/medical/surgeryobs)
 "bix" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/body_scanconsole,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "whitebluecorner"
+	icon_state = "whitehall"
 	},
-/area/station/medical/hallway)
+/area/station/medical/surgery)
 "biy" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -33329,6 +33401,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "blue"
@@ -33342,6 +33419,11 @@
 	dir = 6
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor,
 /area/station/medical/genetics)
 "biD" = (
@@ -33426,6 +33508,15 @@
 /area/station/security/iaa_office)
 "biM" = (
 /obj/structure/closet/wardrobe/genetics_white,
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Genetics APC";
+	pixel_x = 26
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -33992,21 +34083,12 @@
 /turf/simulated/floor/plating,
 /area/station/bridge/captain_quarters)
 "bkd" = (
-/obj/structure/table,
-/obj/item/weapon/retractor,
-/obj/item/weapon/FixOVein{
-	pixel_x = -5
-	},
 /obj/machinery/door_control{
 	id = "Medical_Surgery2";
 	name = "Privacy Shutters";
 	pixel_y = 25
 	},
-/obj/item/weapon/reagent_containers/spray/cleaner{
-	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
-	name = "Surgery Cleaner";
-	pixel_x = 4
-	},
+/obj/machinery/body_scanconsole,
 /turf/simulated/floor,
 /area/station/medical/surgery2)
 "bke" = (
@@ -34231,22 +34313,19 @@
 	},
 /area/station/hallway/secondary/entry)
 "bkC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "";
-	name = "Surgery";
-	req_access = list(5)
-	},
-/turf/simulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/plating,
 /area/station/medical/surgeryobs)
 "bkD" = (
 /obj/item/weapon/reagent_containers/dropper/precision,
@@ -34451,6 +34530,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	icon_state = "blue"
 	},
@@ -35254,7 +35338,6 @@
 	},
 /area/station/medical/chemistry)
 "bmh" = (
-/obj/structure/closet/secure_closet/personal/patient,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
@@ -35264,9 +35347,20 @@
 	dir = 8;
 	network = list("SS13","Medical")
 	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Operation Observation Room APC";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/stool/bed/roller,
+/obj/machinery/iv_drip,
 /turf/simulated/floor{
 	dir = 5;
-	icon_state = "vault"
+	icon_state = "blue"
 	},
 /area/station/medical/surgeryobs)
 "bmi" = (
@@ -35368,9 +35462,7 @@
 	},
 /area/station/civilian/kitchen)
 "bmt" = (
-/obj/structure/stool/bed/chair/metal/blue{
-	dir = 8
-	},
+/obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -35803,17 +35895,8 @@
 	},
 /area/station/hallway/primary/fore)
 "bnm" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Medbay Hallway APC";
-	pixel_x = 24
-	},
 /obj/item/weapon/flora/pottedplant{
 	icon_state = "plant-22"
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -35821,13 +35904,10 @@
 	},
 /area/station/medical/hallway)
 "bnn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "whiteblue"
+	icon_state = "whitehall"
 	},
-/area/station/medical/hallway)
+/area/station/medical/surgery)
 "bno" = (
 /obj/structure/closet/crate,
 /obj/item/weapon/storage/belt/utility,
@@ -36230,13 +36310,9 @@
 /area/station/maintenance/atmos)
 "bob" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+	dir = 1
 	},
-/obj/structure/stool/bed/roller,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "blue"
-	},
+/turf/simulated/floor,
 /area/station/medical/surgeryobs)
 "boc" = (
 /obj/machinery/door/firedoor,
@@ -36343,14 +36419,10 @@
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
 "bol" = (
-/obj/machinery/computer/scan_consolenew,
-/obj/machinery/requests_console/genetics{
-	pixel_y = 30
-	},
-/turf/simulated/floor{
-	icon_state = "whitebluefull"
-	},
-/area/station/medical/genetics)
+/obj/structure/closet/secure_closet/medical2,
+/obj/item/clothing/under/patient_gown,
+/turf/simulated/floor,
+/area/station/medical/surgery)
 "bom" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -36609,8 +36681,15 @@
 	},
 /area/station/rnd/robotics)
 "boJ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
 	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/cleaner{
+	pixel_y = 32
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -36919,7 +36998,6 @@
 	},
 /area/station/medical/cryo)
 "bpo" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -36931,12 +37009,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/reagent_dispensers/cleaner{
-	pixel_y = -32
-	},
-/obj/structure/curtain/medical,
 /turf/simulated/floor{
-	icon_state = "delivery"
+	dir = 6;
+	icon_state = "warning"
 	},
 /area/station/medical/cryo)
 "bpp" = (
@@ -36948,7 +37023,6 @@
 /obj/machinery/holosign/surgery{
 	id = "op2"
 	},
-/obj/structure/curtain/medical,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -37283,33 +37357,6 @@
 /turf/simulated/floor,
 /area/station/cargo/office)
 "bpW" = (
-/obj/structure/window/reinforced/polarized{
-	dir = 1;
-	id = "op1"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "op1"
-	},
-/obj/structure/window/reinforced/polarized{
-	id = "op1"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 8;
-	id = "op1"
-	},
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	icon_state = "shutter0";
-	id = "Medical_Surgery1";
-	name = "Surgery Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/station/medical/surgery)
-"bpX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
 	name = "Operating Theatre 1";
@@ -37318,9 +37365,25 @@
 /obj/machinery/holosign/surgery{
 	id = "op1"
 	},
-/obj/structure/curtain/medical,
+/turf/simulated/floor,
+/area/station/medical/surgery)
+"bpX" = (
+/obj/machinery/windowtint{
+	id = "op1";
+	pixel_x = -27
+	},
+/obj/machinery/light_switch{
+	pixel_x = -27;
+	pixel_y = -9
+	},
+/obj/machinery/holosign_switch{
+	id = "op1";
+	pixel_x = -27;
+	pixel_y = 9
+	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whitehall"
 	},
 /area/station/medical/surgery)
 "bpY" = (
@@ -38099,11 +38162,19 @@
 	},
 /area/station/hallway/secondary/exit)
 "bro" = (
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "blue"
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 12
 	},
-/area/station/medical/surgeryobs)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "whitehall"
+	},
+/area/station/medical/surgery)
 "brp" = (
 /obj/structure/object_wall/mining{
 	icon_state = "4-9"
@@ -39021,8 +39092,8 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
+	dir = 6;
+	icon_state = "blue"
 	},
 /area/station/medical/surgeryobs)
 "btb" = (
@@ -39037,10 +39108,7 @@
 	},
 /area/station/bridge)
 "btc" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
-	},
+/obj/machinery/life_assist/cardiopulmonary_bypass,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whitehall"
@@ -39115,12 +39183,16 @@
 	},
 /area/station/medical/hallway)
 "bth" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "whiteblue"
@@ -39138,6 +39210,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -39408,7 +39484,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "whitebluecorner"
 	},
 /area/station/medical/hallway)
 "btL" = (
@@ -39614,11 +39691,6 @@
 /obj/effect/landmark/start{
 	name = "Geneticist"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "whiteblue"
@@ -39754,18 +39826,9 @@
 /area/station/rnd/hallway)
 "bur" = (
 /obj/machinery/iv_drip,
-/obj/machinery/holosign_switch{
-	id = "op2";
-	pixel_x = 27;
-	pixel_y = 9
-	},
-/obj/machinery/light_switch{
-	pixel_x = 27;
-	pixel_y = -9
-	},
-/obj/machinery/windowtint{
-	id = "op2";
-	pixel_x = 27
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -39887,9 +39950,14 @@
 	},
 /area/station/cargo/recycleroffice)
 "buC" = (
-/obj/machinery/status_display,
-/turf/simulated/wall,
-/area/station/medical/sleeper)
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/stool/bed/chair/comfy/teal,
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/station/medical/hallway)
 "buD" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -40410,13 +40478,15 @@
 	},
 /area/station/cargo/recycleroffice)
 "bvx" = (
-/obj/structure/stool/bed/roller,
-/obj/machinery/iv_drip,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "whiteblue"
+/obj/structure/table,
+/obj/machinery/vending/wallmed2{
+	pixel_x = -32
 	},
-/area/station/medical/sleeper)
+/obj/item/weapon/storage/visuals/surgery/full,
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/station/medical/surgery)
 "bvy" = (
 /obj/machinery/telecomms/server/presets/engineering,
 /obj/machinery/light/small{
@@ -41316,7 +41386,7 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/bar)
 "bwR" = (
-/obj/machinery/bodyscanner,
+/obj/structure/closet/crate/freezer,
 /turf/simulated/floor,
 /area/station/medical/surgery2)
 "bwS" = (
@@ -41625,12 +41695,12 @@
 /turf/simulated/wall,
 /area/station/medical/patient_a)
 "bxu" = (
-/obj/item/weapon/flora/random,
 /obj/machinery/power/apc{
 	name = "Treatment Center APC";
 	pixel_y = -25
 	},
 /obj/structure/cable,
+/obj/machinery/vending/blood,
 /turf/simulated/floor{
 	icon_state = "whiteblue"
 	},
@@ -41648,9 +41718,7 @@
 	},
 /area/station/cargo/storage)
 "bxw" = (
-/obj/structure/table,
-/obj/item/weapon/phone,
-/obj/item/clothing/accessory/stethoscope,
+/obj/machinery/vending/medical,
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "whiteblue"
@@ -42128,22 +42196,15 @@
 	},
 /area/station/cargo/storage)
 "byp" = (
-/obj/machinery/hologram/holopad{
-	pixel_x = 16;
-	pixel_y = -16
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/structure/table,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/station/medical/sleeper)
+/area/station/medical/hallway)
 "byq" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -42151,12 +42212,16 @@
 	},
 /area/station/cargo/storage)
 "byr" = (
-/obj/machinery/vending/blood,
 /obj/item/device/radio/intercom{
 	frequency = 1485;
 	name = "Station Intercom (Medbay)";
 	pixel_y = 25
 	},
+/obj/machinery/camera{
+	c_tag = "Medbay Treatment Center";
+	network = list("SS13","Medical")
+	},
+/obj/machinery/body_scanconsole,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "whiteblue"
@@ -42388,8 +42453,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "whitebluecorner"
+	icon_state = "white"
 	},
 /area/station/medical/sleeper)
 "byN" = (
@@ -42548,21 +42612,23 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "whiteblue"
+	icon_state = "whitebluefull"
 	},
-/area/station/medical/hallway)
+/area/station/medical/sleeper)
 "bzb" = (
-/obj/machinery/hologram/holopad{
-	pixel_x = 16;
-	pixel_y = -16
+/obj/structure/table,
+/obj/item/device/radio/intercom{
+	frequency = 1485;
+	name = "Station Intercom (Medbay)";
+	pixel_x = -28
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "whitehall"
 	},
-/turf/simulated/floor,
-/area/station/medical/cryo)
+/area/station/medical/surgery)
 "bzc" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -43227,14 +43293,14 @@
 /turf/simulated/floor/plating,
 /area/station/medical/patient_b)
 "bAr" = (
+/obj/structure/stool/bed/roller,
+/obj/machinery/iv_drip,
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/machinery/sleeper{
-	dir = 8
-	},
 /turf/simulated/floor{
-	icon_state = "whitebluefull"
+	dir = 5;
+	icon_state = "whiteblue"
 	},
 /area/station/medical/sleeper)
 "bAs" = (
@@ -43242,18 +43308,22 @@
 /turf/simulated/floor/carpet/blue,
 /area/station/bridge/captain_quarters)
 "bAt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "whiteblue"
+	dir = 4;
+	icon_state = "whitebluecorner"
 	},
-/area/station/medical/cryo)
+/area/station/medical/sleeper)
 "bAu" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -43311,17 +43381,10 @@
 /turf/simulated/floor/plating,
 /area/station/medical/patients_rooms)
 "bAy" = (
-/obj/machinery/camera{
-	c_tag = "Medbay Cryogenics";
-	dir = 1;
-	network = list("SS13","Medical")
-	},
-/obj/structure/stool/bed/roller,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "whiteblue"
+	icon_state = "whitebluecorner"
 	},
-/area/station/medical/cryo)
+/area/station/medical/sleeper)
 "bAz" = (
 /obj/machinery/camera{
 	c_tag = "Bridge Center";
@@ -43513,11 +43576,19 @@
 	},
 /area/station/medical/hallway)
 "bAR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/hologram/holopad{
+	pixel_y = -16
 	},
 /turf/simulated/floor{
-	icon_state = "whitebluecorner"
+	icon_state = "white"
 	},
 /area/station/medical/sleeper)
 "bAS" = (
@@ -44077,16 +44148,11 @@
 	},
 /area/station/rnd/lab)
 "bBX" = (
-/obj/structure/stool/bed/roller,
-/obj/machinery/camera{
-	c_tag = "Medbay Treatment Center";
-	dir = 1;
-	network = list("SS13","Medical")
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/machinery/iv_drip,
 /turf/simulated/floor{
-	dir = 6;
-	icon_state = "whiteblue"
+	icon_state = "white"
 	},
 /area/station/medical/sleeper)
 "bBY" = (
@@ -44455,9 +44521,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "bCF" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
@@ -44466,14 +44530,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/junction,
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
 "bCG" = (
@@ -44659,22 +44718,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "bCV" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
+	dir = 8;
+	pixel_x = 24
 	},
-/obj/structure/stool/bed/roller,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/sleeper{
+	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "whiteblue"
+	icon_state = "whitebluefull"
 	},
-/area/station/medical/cryo)
+/area/station/medical/sleeper)
 "bCW" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -45862,19 +45916,9 @@
 	},
 /area/station/medical/cryo)
 "bFf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	icon_state = "warning"
+	icon_state = "delivery"
 	},
 /area/station/medical/cryo)
 "bFg" = (
@@ -45889,26 +45933,33 @@
 	},
 /area/station/medical/hallway)
 "bFi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/status_display{
+	pixel_x = -32
 	},
 /turf/simulated/floor{
-	icon_state = "warning"
+	icon_state = "white"
 	},
-/area/station/medical/cryo)
+/area/station/medical/hallway)
 "bFj" = (
 /obj/structure/stool/bed/chair/metal/blue,
 /obj/machinery/power/apc{
@@ -45942,19 +45993,12 @@
 	},
 /area/station/rnd/lab)
 "bFm" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/components/unary/cryo_cell,
+/obj/machinery/status_display{
+	pixel_x = -32
 	},
 /turf/simulated/floor{
-	dir = 6;
+	dir = 9;
 	icon_state = "warning"
 	},
 /area/station/medical/cryo)
@@ -46971,19 +47015,14 @@
 /turf/simulated/floor/plating,
 /area/station/cargo/recycler)
 "bHb" = (
-/obj/structure/table,
-/obj/item/weapon/circular_saw{
-	pixel_y = 10
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
 	},
-/obj/item/weapon/scalpel,
-/obj/machinery/vending/wallmed2{
-	pixel_y = 32
+/obj/machinery/hologram/holopad{
+	pixel_y = -16
 	},
-/obj/item/weapon/storage/visuals/surgery,
-/turf/simulated/floor{
-	icon_state = "white"
-	},
-/area/station/medical/surgery2)
+/turf/simulated/floor,
+/area/station/medical/cryo)
 "bHc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -47554,10 +47593,9 @@
 "bHX" = (
 /obj/machinery/door_control{
 	desc = "A remote control switch for the medbay foyer.";
-	id = "MedbayFoyer1";
+	id = "MedbayFoyerIn";
 	name = "Medbay Doors Control";
-	pixel_y = 28;
-	range = 8
+	pixel_y = 28
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -47889,32 +47927,37 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "bIC" = (
-/obj/structure/table,
-/obj/item/weapon/hemostat,
-/obj/item/weapon/cautery,
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	icon_state = "whitehall"
+	dir = 8;
+	icon_state = "whiteblue"
 	},
-/area/station/medical/surgery2)
+/area/station/medical/hallway)
 "bID" = (
-/obj/structure/table,
-/obj/item/weapon/bonegel{
-	pixel_x = 5;
-	pixel_y = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/item/weapon/bonesetter,
-/obj/item/device/radio/intercom{
-	frequency = 1485;
-	name = "Station Intercom (Medbay)";
-	pixel_y = 25
+/obj/structure/disposalpipe/segment,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 1
 	},
 /turf/simulated/floor{
-	icon_state = "whitehall"
+	dir = 8;
+	icon_state = "whitebluecorner"
 	},
-/area/station/medical/surgery2)
+/area/station/medical/hallway)
 "bIE" = (
 /obj/machinery/disposal,
 /obj/structure/sign/warning/morgue_disposal{
@@ -48103,24 +48146,42 @@
 	},
 /area/station/medical/storage)
 "bIV" = (
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "blue"
-	},
-/area/station/medical/surgeryobs)
-"bIW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "blue"
+	icon_state = "warning"
 	},
-/area/station/medical/surgeryobs)
+/area/station/medical/cryo)
+"bIW" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "warning"
+	},
+/area/station/medical/cryo)
 "bIX" = (
 /obj/machinery/photocopier,
 /obj/machinery/camera{
@@ -48185,16 +48246,23 @@
 	},
 /area/station/rnd/robotics)
 "bJg" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -24
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/life_assist/cardiopulmonary_bypass,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/curtain/medical,
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "whitehall"
+	icon_state = "delivery"
 	},
-/area/station/medical/surgery2)
+/area/station/medical/cryo)
 "bJh" = (
 /obj/structure/object_wall/pod{
 	icon_state = "0,0"
@@ -48333,7 +48401,8 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
 "bJv" = (
@@ -48658,24 +48727,26 @@
 	},
 /area/station/rnd/hallway)
 "bKe" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
 /obj/machinery/light,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
-	},
+/obj/structure/stool/bed/roller,
+/obj/machinery/iv_drip,
 /turf/simulated/floor{
-	icon_state = "whitebluefull"
+	dir = 6;
+	icon_state = "whiteblue"
 	},
 /area/station/medical/sleeper)
 "bKf" = (
 /turf/simulated/floor/mech_bay_recharge_floor,
 /area/station/medical/hallway)
 "bKg" = (
-/obj/structure/stool/bed/roller,
-/obj/machinery/iv_drip,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -48995,30 +49066,45 @@
 	},
 /area/station/medical/medbreak)
 "bKO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor,
-/area/station/medical/surgeryobs)
-"bKP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/medical/surgeryobs)
-"bKQ" = (
-/obj/structure/closet/secure_closet/personal/patient,
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
+	dir = 1;
+	icon_state = "whiteblue"
 	},
-/area/station/medical/surgeryobs)
+/area/station/medical/cryo)
+"bKP" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/table/glass,
+/obj/machinery/vending/wallmed2{
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/item/weapon/phone,
+/obj/item/weapon/reagent_containers/spray/cleaner,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "whiteblue"
+	},
+/area/station/medical/cryo)
+"bKQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "whiteblue"
+	},
+/area/station/medical/cryo)
 "bKR" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_x = -32
@@ -49248,6 +49334,7 @@
 	},
 /obj/item/weapon/storage/belt/medical,
 /obj/item/clothing/glasses/hud/health,
+/obj/structure/window/reinforced,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whiteblue"
@@ -49287,11 +49374,24 @@
 	},
 /area/station/security/hos)
 "bLv" = (
-/obj/structure/table,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "";
+	name = "Surgery";
+	req_access = list(5)
+	},
+/obj/structure/curtain/medical,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/station/medical/hallway)
+/area/station/medical/surgeryobs)
 "bLw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -49331,34 +49431,38 @@
 	},
 /area/station/hallway/primary/fore)
 "bLA" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
+/obj/structure/stool/bed/roller,
+/obj/machinery/iv_drip,
+/obj/machinery/camera{
+	c_tag = "Medbay Cryogenics";
+	dir = 1;
+	network = list("SS13","Medical")
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whiteblue"
 	},
-/area/station/medical/hallway)
+/area/station/medical/cryo)
 "bLB" = (
 /obj/structure/stool/bed,
 /obj/item/weapon/bedsheet/medical,
 /turf/simulated/floor/carpet/green,
 /area/station/medical/patients_rooms)
 "bLC" = (
-/obj/structure/sign/warning/electricshock{
-	pixel_x = 32
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/stool/bed/chair/comfy/teal,
+/obj/structure/stool/bed/roller,
+/obj/machinery/iv_drip,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whiteblue"
 	},
-/area/station/medical/hallway)
+/area/station/medical/cryo)
 "bLD" = (
 /obj/structure/stool/bed/chair/comfy/black{
 	dir = 8
@@ -50669,22 +50773,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/genetics)
 "bNW" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor{
 	icon_state = "whiteblue"
 	},
@@ -51357,6 +51451,9 @@
 	},
 /obj/item/weapon/storage/belt/medical,
 /obj/item/clothing/glasses/hud/health,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whiteblue"
@@ -51481,15 +51578,17 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/starboard)
 "bPx" = (
-/obj/structure/stool/bed/roller,
-/obj/machinery/iv_drip,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27;
-	pixel_y = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "whitebluecorner"
+	icon_state = "white"
 	},
 /area/station/medical/hallway)
 "bPy" = (
@@ -51997,11 +52096,24 @@
 	},
 /area/station/maintenance/engineering)
 "bQx" = (
-/obj/structure/closet/crate/freezer,
+/obj/machinery/bodyscanner,
+/obj/machinery/holosign_switch{
+	id = "op2";
+	pixel_x = -9;
+	pixel_y = 27
+	},
+/obj/machinery/windowtint{
+	id = "op2";
+	pixel_y = 27
+	},
+/obj/machinery/light_switch{
+	pixel_x = 9;
+	pixel_y = 27
+	},
 /turf/simulated/floor{
 	icon_state = "whitehall"
 	},
-/area/station/medical/surgery)
+/area/station/medical/surgery2)
 "bQy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -52586,9 +52698,16 @@
 	},
 /area/station/medical/medbreak)
 "bRO" = (
-/obj/machinery/status_display,
-/turf/simulated/wall,
-/area/station/medical/cryo)
+/obj/structure/table,
+/obj/item/device/radio/intercom{
+	frequency = 1485;
+	name = "Station Intercom (Medbay)";
+	pixel_y = 25
+	},
+/turf/simulated/floor{
+	icon_state = "whitehall"
+	},
+/area/station/medical/surgery2)
 "bRP" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -52716,18 +52835,14 @@
 	},
 /area/station/medical/surgery)
 "bSf" = (
-/obj/structure/table,
-/obj/item/weapon/hemostat,
-/obj/item/weapon/cautery,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "whitehall"
+	dir = 1;
+	icon_state = "blue"
 	},
-/area/station/medical/surgery)
+/area/station/medical/surgeryobs)
 "bSg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -52935,11 +53050,14 @@
 	},
 /area/station/hallway/primary/starboard)
 "bSD" = (
-/obj/machinery/iv_drip,
-/turf/simulated/floor{
-	icon_state = "whitehall"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/area/station/medical/surgery)
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "blue"
+	},
+/area/station/medical/surgeryobs)
 "bSE" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -52988,6 +53106,11 @@
 	req_access = list(9)
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -53321,22 +53444,19 @@
 	},
 /area/station/medical/surgery)
 "bTz" = (
-/obj/structure/table,
-/obj/item/weapon/bonegel{
-	pixel_x = 5;
-	pixel_y = 5
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -24
 	},
-/obj/item/weapon/bonesetter,
-/obj/item/device/radio/intercom{
-	frequency = 1485;
-	name = "Station Intercom (Medbay)";
-	pixel_x = -28
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
 	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whitehall"
 	},
-/area/station/medical/surgery)
+/area/station/medical/surgery2)
 "bTA" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor/plating,
@@ -53423,19 +53543,18 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "bTY" = (
-/obj/structure/table,
-/obj/item/weapon/circular_saw{
-	pixel_y = 10
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/item/weapon/scalpel,
-/obj/machinery/vending/wallmed2{
-	pixel_x = -32
-	},
-/obj/item/weapon/storage/visuals/surgery,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/junction,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/station/medical/surgery)
+/area/station/medical/hallway)
 "bUa" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -53649,9 +53768,8 @@
 /turf/space,
 /area/space)
 "bUB" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/structure/sign/warning/electricshock{
+	pixel_x = 32
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -55834,9 +55952,12 @@
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/incinerator)
 "caT" = (
+/obj/structure/sign/mark{
+	icon_state = "fup";
+	pixel_y = -20
+	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "whitebluecorner"
+	icon_state = "whiteblue"
 	},
 /area/station/medical/reception)
 "caU" = (
@@ -55864,12 +55985,11 @@
 /turf/simulated/floor,
 /area/station/engineering/break_room)
 "cbb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
 /obj/effect/landmark/start{
 	name = "Medical Intern"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -56261,8 +56381,8 @@
 	},
 /area/station/engineering/atmos)
 "ccu" = (
-/obj/machinery/hologram/holopad{
-	pixel_x = 16
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -64970,11 +65090,13 @@
 /area/space)
 "czz" = (
 /obj/structure/table/reinforced,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/pen,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/item/weapon/reagent_containers/food/drinks/britcup{
+	pixel_x = -4
+	},
+/obj/item/weapon/reagent_containers/glass/beaker/fluff/eleanor_stone,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "blue"
@@ -65247,12 +65369,18 @@
 /area/station/maintenance/medbay)
 "cAb" = (
 /obj/structure/table,
-/obj/item/weapon/razor,
 /obj/machinery/camera{
 	c_tag = "Surgery Operating 2";
 	network = list("SS13","Medical")
 	},
-/obj/item/weapon/surgicaldrill,
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
+	name = "Surgery Cleaner";
+	pixel_x = 4
+	},
+/obj/item/weapon/razor{
+	pixel_x = -4
+	},
 /turf/simulated/floor,
 /area/station/medical/surgery2)
 "cAc" = (
@@ -65285,16 +65413,11 @@
 /turf/space,
 /area/space)
 "cAf" = (
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
-/obj/machinery/life_assist/cardiopulmonary_bypass,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "whitehall"
-	},
-/area/station/medical/surgery)
+/turf/simulated/floor,
+/area/station/medical/surgeryobs)
 "cAg" = (
 /obj/effect/decal/remains/robot,
 /turf/simulated/floor{
@@ -67859,15 +67982,6 @@
 	pixel_y = 6
 	},
 /obj/item/weapon/storage/box/rxglasses,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Genetics APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -68985,12 +69099,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "cKF" = (
-/obj/structure/stool/bed/roller,
-/obj/machinery/iv_drip,
-/turf/simulated/floor{
-	icon_state = "white"
+/obj/machinery/door_control{
+	id = "Medical_Surgery1";
+	name = "Privacy Shutters";
+	pixel_x = -25
 	},
-/area/station/medical/hallway)
+/obj/machinery/bodyscanner,
+/turf/simulated/floor,
+/area/station/medical/surgery)
 "cKJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -69771,18 +69887,17 @@
 /turf/simulated/floor/carpet/red,
 /area/station/security/hos)
 "cNc" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Operation Observation Room APC";
-	pixel_y = 24
-	},
 /obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/structure/stool/bed/roller,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
 /turf/simulated/floor{
-	dir = 5;
+	dir = 1;
 	icon_state = "blue"
 	},
 /area/station/medical/surgeryobs)
@@ -69797,11 +69912,6 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -69823,6 +69933,7 @@
 	name = "Station Intercom (Medbay)";
 	pixel_x = 28
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -69835,6 +69946,11 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -70930,6 +71046,9 @@
 	c_tag = "Medbay Foyer North";
 	network = list("SS13","Medical")
 	},
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = 32
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "whiteblue"
@@ -71153,12 +71272,13 @@
 /area/station/ai_monitored/storage_secure)
 "eWb" = (
 /obj/structure/closet/wardrobe/chemistry_white,
-/obj/item/device/radio/headset/headset_med,
 /obj/machinery/camera{
 	c_tag = "Chemistry";
 	dir = 8;
 	network = list("SS13","Medical")
 	},
+/obj/item/weapon/storage/belt/medical,
+/obj/item/device/radio/headset/headset_med,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whiteyellow"
@@ -71760,6 +71880,22 @@
 /obj/effect/landmark/start{
 	name = "Paramedic"
 	},
+/obj/machinery/door_control{
+	desc = "A remote control switch for the medbay foyer.";
+	id = "MedbayFoyerOut";
+	name = "Medbay Doors Control";
+	pixel_x = 26;
+	pixel_y = -7;
+	req_access = list(5)
+	},
+/obj/machinery/door_control{
+	desc = "A remote control switch for the medbay foyer.";
+	id = "MedbayFoyerIn";
+	name = "Medbay Doors Control";
+	pixel_x = 26;
+	pixel_y = 7;
+	req_access = list(5)
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "blue"
@@ -71801,18 +71937,14 @@
 	},
 /area/station/medical/reception)
 "gbb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/sortjunction{
-	dir = 2;
-	name = "Genetics Lab";
-	sortType = "Genetics Lab"
-	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "whiteblue"
+	icon_state = "white"
 	},
-/area/station/medical/genetics)
+/area/station/medical/reception)
 "gcb" = (
 /obj/structure/stool/bed/roller,
 /obj/structure/window/reinforced{
@@ -72250,10 +72382,9 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/item/weapon/reagent_containers/food/drinks/britcup{
-	pixel_x = -4
+/obj/item/weapon/reagent_containers/spray/cleaner{
+	pixel_x = 3
 	},
-/obj/item/weapon/reagent_containers/spray/cleaner,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -72753,17 +72884,11 @@
 	},
 /area/station/rnd/xenobiology)
 "hBb" = (
-/obj/item/weapon/storage/box/bodybags{
-	pixel_x = -1;
-	pixel_y = -2
-	},
-/obj/item/weapon/pen,
-/obj/structure/table/glass,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
+	icon_state = "white"
 	},
-/area/station/medical/genetics)
+/area/station/medical/reception)
 "hBN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -73802,16 +73927,20 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "jdb" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/glass/beaker/fluff/eleanor_stone,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/item/weapon/storage/box/bodybags{
+	pixel_x = -1;
+	pixel_y = -2
+	},
+/obj/item/weapon/pen,
+/obj/structure/table/glass,
+/obj/machinery/requests_console/genetics{
+	pixel_y = 30
 	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
 	},
-/area/station/medical/reception)
+/area/station/medical/genetics)
 "jeb" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/directions/security{
@@ -74244,18 +74373,15 @@
 /obj/item/weapon/bell{
 	pixel_x = 4
 	},
-/obj/machinery/door_control{
-	desc = "A remote control switch for the medbay foyer.";
-	id = "MedbayFoyer1";
-	name = "Medbay Doors Control";
-	pixel_x = -6;
-	pixel_y = -2;
-	range = 8;
-	req_access = list(5)
-	},
 /obj/machinery/door/window/eastleft{
 	dir = 1;
 	name = "Medbay Reception"
+	},
+/obj/item/weapon/paper_bin{
+	pixel_x = -5
+	},
+/obj/item/weapon/pen{
+	pixel_x = -5
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -74368,16 +74494,13 @@
 	},
 /area/station/medical/morgue)
 "kcb" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/medical/glass{
-	id_tag = "MedbayFoyer1";
-	name = "Medbay";
-	req_access = list(5)
+/obj/structure/window/reinforced{
+	dir = 4
 	},
+/obj/machinery/libraryscanner,
 /turf/simulated/floor{
-	icon_state = "whitebluefull"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/medical/reception)
 "kda" = (
@@ -74531,17 +74654,20 @@
 /area/station/medical/reception)
 "knb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "whitered"
+	dir = 4;
+	icon_state = "whiteblue"
 	},
-/area/station/medical/hallway)
+/area/station/medical/genetics)
 "kob" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
@@ -74942,12 +75068,19 @@
 /area/station/cargo/storage)
 "kUb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/sortjunction{
+	dir = 2;
+	name = "Genetics Lab";
+	sortType = "Genetics Lab"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
-	dir = 4;
+	dir = 5;
 	icon_state = "whiteblue"
 	},
 /area/station/medical/genetics)
@@ -75113,21 +75246,17 @@
 	},
 /area/station/civilian/locker)
 "llb" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/structure/sign/mark{
+	icon_state = "fdn";
+	pixel_y = 20
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 4;
+	dir = 1;
 	icon_state = "whiteblue"
 	},
-/area/station/medical/genetics)
+/area/station/medical/hallway)
 "lmg" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -75416,13 +75545,16 @@
 	},
 /area/station/medical/hallway)
 "lJb" = (
-/obj/machinery/alarm{
-	pixel_y = 23
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/sign/mark{
+	icon_state = "fdn";
+	pixel_y = 4
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whiteblue"
 	},
-/area/station/medical/hallway)
+/area/station/medical/reception)
 "lJr" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -75605,14 +75737,19 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "lUb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "whiteblue"
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/area/station/medical/genetics)
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/medical/hallway)
 "lUd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -75770,12 +75907,13 @@
 	},
 /area/station/medical/storage)
 "mgb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor{
-	icon_state = "whiteblue"
+/obj/structure/noticeboard{
+	pixel_y = 32
 	},
-/area/station/medical/reception)
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/station/medical/hallway)
 "mhb" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'VACUUM'";
@@ -75945,22 +76083,13 @@
 	},
 /area/station/cargo/recycleroffice)
 "mub" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
-	icon_state = "whitebluefull"
+	dir = 1;
+	icon_state = "whitered"
 	},
-/area/station/medical/sleeper)
+/area/station/medical/hallway)
 "mvb" = (
 /obj/structure/sign/departments/engineering,
 /turf/simulated/wall/r_wall,
@@ -76115,22 +76244,19 @@
 	},
 /area/station/medical/hallway)
 "mGb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "whitebluecorner"
+	dir = 4;
+	icon_state = "whiteblue"
 	},
-/area/station/medical/hallway)
+/area/station/medical/genetics)
 "mHb" = (
 /obj/structure/closet/toolcloset,
 /turf/simulated/floor/plating,
@@ -76290,15 +76416,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "mVb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/sign/mark{
+	icon_state = "fup";
+	pixel_y = -4
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
 "mWb" = (
@@ -78383,11 +78507,15 @@
 	c_tag = "Medbay North";
 	network = list("SS13","Medical")
 	},
-/obj/structure/noticeboard{
-	pixel_y = 32
+/obj/machinery/door_control{
+	desc = "A remote control switch for the medbay foyer.";
+	id = "MedbayFoyerOut";
+	name = "Medbay Doors Control";
+	pixel_y = 28
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whitebluecorner"
 	},
 /area/station/medical/hallway)
 "qkb" = (
@@ -78874,8 +79002,15 @@
 /turf/simulated/wall,
 /area/station/cargo/storage)
 "qZb" = (
-/obj/structure/sign/departments/medbay,
-/turf/simulated/wall,
+/obj/machinery/door/airlock/medical/glass{
+	id_tag = "MedbayFoyerOut";
+	name = "Medbay";
+	req_access = list(5)
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	icon_state = "whitebluefull"
+	},
 /area/station/medical/reception)
 "rbb" = (
 /obj/structure/table/glass,
@@ -80005,9 +80140,12 @@
 	},
 /area/station/medical/virology)
 "sAb" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -23
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -80069,16 +80207,21 @@
 	},
 /area/station/medical/virology)
 "sGb" = (
-/obj/structure/table,
-/obj/item/weapon/razor,
-/obj/machinery/camera{
-	c_tag = "Surgery Operating 1";
-	dir = 4;
-	network = list("SS13","Medical")
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/item/weapon/surgicaldrill,
-/turf/simulated/floor,
-/area/station/medical/surgery)
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "whitebluecorner"
+	},
+/area/station/medical/hallway)
 "sHb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -80346,14 +80489,11 @@
 	},
 /area/station/cargo/recycleroffice)
 "sWb" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "whitehall"
 	},
-/area/station/medical/hallway)
+/area/station/medical/surgery2)
 "sWE" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -118554,7 +118694,7 @@ bTs
 bha
 bLF
 cAb
-bJg
+bTz
 bKt
 btc
 bwR
@@ -118810,11 +118950,11 @@ bIS
 bIS
 bIS
 bLF
-bID
+bRO
 bKH
 bKy
 bNZ
-bfL
+bgw
 bLF
 bSc
 cce
@@ -119067,7 +119207,7 @@ bRV
 bUi
 aVe
 bLF
-bHb
+aqU
 aHm
 ckl
 ckt
@@ -119324,7 +119464,7 @@ bzV
 bVN
 bAG
 bLF
-bIC
+bQx
 aHm
 bMB
 aHm
@@ -119582,7 +119722,7 @@ bTc
 bkV
 bLF
 bkd
-aif
+sWb
 aHm
 bur
 bfR
@@ -119828,15 +119968,15 @@ bjk
 aHu
 bte
 bjl
-aSQ
+aTh
 bzh
 bAS
 aip
 bkV
-aIa
+bFm
 aRI
 bEX
-aVi
+bKP
 bLF
 bpq
 bpu
@@ -120080,7 +120220,7 @@ bHP
 ejb
 gMb
 dxb
-jdb
+kcb
 bjk
 bHX
 ldb
@@ -120099,11 +120239,11 @@ bhM
 bnq
 bpP
 bpD
-bfW
-bSf
-bTY
-bTz
-sGb
+cKF
+bpX
+bvx
+bzb
+aaR
 bQR
 bLt
 cdA
@@ -120334,33 +120474,33 @@ cpX
 ctJ
 bkH
 bkH
-bkH
-ccu
-bkH
-bAT
+jQb
+bGO
+gbb
+lJb
 bfa
-lFb
-mFb
+llb
+aId
 mQb
 bAp
-byp
+bzh
 bAO
 bdJ
-bpn
+bFf
 bCW
-bzb
+qrb
 bFd
 bBA
 biw
-bIV
-bKP
+bSD
+cAf
 bPf
-bpQ
-bQx
+bgn
+bix
 qhb
 qhb
 bUh
-cAf
+aaS
 bQR
 bLt
 cdA
@@ -120591,28 +120731,28 @@ cpX
 ctJ
 bkH
 bHP
-jQb
-bGO
+ccu
+hBb
 cbb
-mgb
-kcb
-bnn
+bAT
+cry
+lFb
 bth
 mQb
 bAp
-bzh
+bAR
 bAS
 bdJ
-bpn
+bFf
 bCW
-qrb
-bFi
-bAt
-bkC
-bIW
+bHb
+bIV
 bKO
+bkC
+bSf
+bfL
 bPf
-bpX
+bpQ
 qhb
 bSe
 cgs
@@ -120845,36 +120985,36 @@ bjt
 bNd
 bcb
 cpX
-cwD
-aqU
+ctJ
+bkH
 bkH
 jRb
 bkH
 fMb
 caT
 qZb
-lIb
-mGb
-buC
-bvx
+mVb
+mFb
+mQb
+bAp
 byM
-bAR
 bBX
-bkV
-bDj
-qrb
+bdJ
 bFf
-bAy
-bJo
+bCW
+qrb
+bIW
+bKQ
+bLv
 cNc
 bob
-bro
+bPf
 bpW
-bSD
+bnn
 qhb
 ciT
 bUl
-bgn
+abp
 bQR
 bLt
 cdA
@@ -121102,7 +121242,7 @@ bjt
 bNe
 bcb
 cpX
-bjk
+cwD
 eGb
 bmt
 dab
@@ -121114,24 +121254,24 @@ qjb
 btK
 bjl
 bAr
-btj
-qPb
+bAt
+bAy
 bKe
 bkV
-aIg
-aRQ
-bFm
-bCV
+bDj
+qrb
+aiD
+bLA
 bJo
 bmh
-bKQ
+bfW
 bta
 bQR
-bfY
-bga
+bol
+bro
 bTx
 sKb
-bgw
+abI
 bQR
 bLw
 cKD
@@ -121367,18 +121507,18 @@ gab
 bjk
 bjk
 bjk
-lJb
+mgb
 bti
 bjl
-kBb
-mub
-mQb
-bjl
-bRO
+aVi
+btj
+qPb
+bCV
 bkV
-bpn
+aIg
+aRQ
 bpo
-bkV
+bLC
 bJo
 bJo
 bJo
@@ -121625,26 +121765,26 @@ gRb
 cry
 aCW
 lKb
-btU
-cNh
-bvt
+aIq
+bjl
+kBb
 bza
-bzo
-bKg
-cKF
-bPx
-bzo
-bza
-bix
-aiD
+mQb
+bjl
+bkV
+bkV
+bpn
+bJg
+bkV
+bxi
 boJ
-sAb
+bfY
 bzo
 lIb
 bSO
-aiD
-bUB
-sWb
+buC
+byp
+sJb
 cJS
 cHZ
 bxi
@@ -121881,27 +122021,27 @@ fUb
 ftb
 nNb
 aDe
-knb
+mub
 cNd
 cNg
-mVb
+sAb
 bJu
-aEF
-mVb
-aIq
-aFY
-aFY
-aTh
-aId
-aFY
-bLA
-aFY
+bCF
+sGb
+bFi
+bID
+bIC
+aif
+bKg
+bPx
+bTY
+bga
 aFY
 aFY
 bSQ
 aFY
 aFY
-bCF
+aaM
 cCh
 cGn
 cJT
@@ -122139,8 +122279,8 @@ kdb
 cry
 bnm
 cNe
-aOO
-cNh
+bFh
+aSQ
 bFh
 bFh
 bAZ
@@ -122149,11 +122289,11 @@ rAb
 bFh
 bRh
 bYG
-cNh
+bFh
 cNf
-bLC
-bLv
-sJb
+bUB
+bYG
+bFh
 aSW
 qub
 bTK
@@ -122394,9 +122534,9 @@ bjk
 bjk
 bjk
 bjk
-bxi
-bxi
-bxi
+lUb
+aEF
+aOO
 bxi
 bzp
 bAW
@@ -122649,7 +122789,7 @@ bvD
 cvx
 ucb
 bqm
-hBb
+jdb
 bIR
 kpb
 cGB
@@ -122905,8 +123045,8 @@ bjd
 bXr
 tyb
 eEb
-bqm
-bol
+bvD
+blb
 kHb
 kqb
 buc
@@ -123677,10 +123817,10 @@ bin
 biC
 bkU
 bSN
-gbb
 kUb
-lUb
-llb
+knb
+mGb
+aIa
 mYb
 mqb
 neb

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -1289,6 +1289,17 @@
 "acl" = (
 /turf/simulated/floor,
 /area/station/security/main)
+"acm" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/structure/table,
+/obj/item/weapon/phone,
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/station/medical/hallway)
 "acn" = (
 /obj/machinery/door/airlock/security{
 	name = "Execution Chamber";
@@ -1401,6 +1412,16 @@
 	icon_state = "red"
 	},
 /area/station/security/processing)
+"acw" = (
+/obj/structure/table,
+/obj/machinery/vending/wallmed2{
+	pixel_x = -32
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "whitehall"
+	},
+/area/station/medical/surgery)
 "acy" = (
 /obj/structure/table,
 /obj/item/ashtray/glass{
@@ -9789,9 +9810,8 @@
 /obj/machinery/vending/wallmed2{
 	pixel_y = 32
 	},
-/obj/item/weapon/storage/visuals/surgery/full,
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitehall"
 	},
 /area/station/medical/surgery2)
 "aqV" = (
@@ -25105,11 +25125,9 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/starboard)
 "aUa" = (
-/obj/machinery/computer/med_data{
-	dir = 4
-	},
+/obj/machinery/vending/blood,
 /turf/simulated/floor{
-	dir = 8;
+	dir = 1;
 	icon_state = "whiteblue"
 	},
 /area/station/medical/sleeper)
@@ -32001,8 +32019,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/stool/bed/roller,
-/obj/machinery/iv_drip,
+/obj/structure/closet/secure_closet/personal/patient,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "blue"
@@ -32944,42 +32961,10 @@
 /turf/simulated/floor/carpet/blue2,
 /area/station/bridge/captain_quarters)
 "bhM" = (
-/obj/item/weapon/reagent_containers/blood/AMinus{
-	pixel_x = -7;
-	pixel_y = -3
-	},
-/obj/item/weapon/reagent_containers/blood/APlus{
-	pixel_x = -5;
-	pixel_y = 4
-	},
-/obj/item/weapon/reagent_containers/blood/empty{
-	pixel_x = 1;
-	pixel_y = -4
-	},
-/obj/item/weapon/reagent_containers/blood/empty{
-	pixel_x = 1;
-	pixel_y = -4
-	},
-/obj/item/weapon/reagent_containers/blood/BMinus{
-	pixel_y = 4
-	},
-/obj/item/weapon/reagent_containers/blood/BPlus{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/item/weapon/reagent_containers/blood/OMinus{
-	pixel_x = -5;
-	pixel_y = -1
-	},
-/obj/item/weapon/reagent_containers/blood/OPlus{
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/obj/structure/table/glass,
 /obj/item/device/radio/intercom{
 	frequency = 1485;
 	name = "Station Intercom (Medbay)";
-	pixel_y = 25
+	pixel_y = 22
 	},
 /turf/simulated/floor{
 	dir = 9;
@@ -35338,26 +35323,56 @@
 	},
 /area/station/medical/chemistry)
 "bmh" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/item/weapon/reagent_containers/blood/AMinus{
+	pixel_x = -7;
+	pixel_y = -3
+	},
+/obj/item/weapon/reagent_containers/blood/APlus{
+	pixel_x = -5;
+	pixel_y = 4
+	},
+/obj/item/weapon/reagent_containers/blood/empty{
+	pixel_x = 1;
+	pixel_y = -4
+	},
+/obj/item/weapon/reagent_containers/blood/empty{
+	pixel_x = 1;
+	pixel_y = -4
+	},
+/obj/item/weapon/reagent_containers/blood/BMinus{
+	pixel_y = 4
+	},
+/obj/item/weapon/reagent_containers/blood/BPlus{
+	pixel_x = 5;
+	pixel_y = 3
+	},
+/obj/item/weapon/reagent_containers/blood/OMinus{
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/obj/item/weapon/reagent_containers/blood/OPlus{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/structure/table/glass,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Operation Observation Room APC";
+	pixel_y = 26
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /obj/machinery/camera{
 	c_tag = "Surgery Observation";
 	dir = 8;
 	network = list("SS13","Medical")
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Operation Observation Room APC";
-	pixel_y = 24
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/stool/bed/roller,
-/obj/machinery/iv_drip,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "blue"
@@ -36688,9 +36703,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/reagent_dispensers/cleaner{
-	pixel_y = 32
-	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -37049,6 +37061,9 @@
 	name = "Surgery Shutters";
 	opacity = 0
 	},
+/obj/structure/window/reinforced/polarized{
+	id = "op2"
+	},
 /turf/simulated/floor/plating,
 /area/station/medical/surgery2)
 "bpr" = (
@@ -37078,28 +37093,11 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "bpu" = (
-/obj/structure/window/reinforced/polarized{
-	dir = 8;
-	id = "op2"
+/obj/structure/stool/bed/roller,
+/turf/simulated/floor{
+	icon_state = "blue"
 	},
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "op2"
-	},
-/obj/structure/window/reinforced/polarized{
-	id = "op2"
-	},
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	icon_state = "shutter0";
-	id = "Medical_Surgery2";
-	name = "Surgery Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/plating,
-/area/station/medical/surgery2)
+/area/station/medical/surgeryobs)
 "bpv" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -37287,11 +37285,32 @@
 	},
 /area/station/civilian/chapel/mass_driver)
 "bpP" = (
-/turf/simulated/floor{
-	dir = 10;
-	icon_state = "blue"
+/obj/structure/window/reinforced/polarized{
+	dir = 8;
+	id = "op2"
 	},
-/area/station/medical/surgeryobs)
+/obj/structure/window/reinforced/polarized{
+	dir = 4;
+	id = "op2"
+	},
+/obj/structure/window/reinforced/polarized{
+	id = "op2"
+	},
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	icon_state = "shutter0";
+	id = "Medical_Surgery2";
+	name = "Surgery Shutters";
+	opacity = 0
+	},
+/obj/structure/window/reinforced/polarized{
+	dir = 1;
+	id = "op2"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/surgery2)
 "bpQ" = (
 /obj/structure/window/reinforced/polarized{
 	dir = 1;
@@ -37357,16 +37376,12 @@
 /turf/simulated/floor,
 /area/station/cargo/office)
 "bpW" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical{
-	name = "Operating Theatre 1";
-	req_access = list(45)
+/obj/structure/stool/bed/roller,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "blue"
 	},
-/obj/machinery/holosign/surgery{
-	id = "op1"
-	},
-/turf/simulated/floor,
-/area/station/medical/surgery)
+/area/station/medical/surgeryobs)
 "bpX" = (
 /obj/machinery/windowtint{
 	id = "op1";
@@ -39605,8 +39620,7 @@
 	},
 /area/station/medical/storage)
 "btT" = (
-/obj/structure/stool/bed,
-/obj/item/weapon/bedsheet/medical,
+/obj/machinery/vending/medical,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "whiteblue"
@@ -40478,11 +40492,14 @@
 	},
 /area/station/cargo/recycleroffice)
 "bvx" = (
-/obj/structure/table,
-/obj/machinery/vending/wallmed2{
-	pixel_x = -32
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical{
+	name = "Operating Theatre 1";
+	req_access = list(45)
 	},
-/obj/item/weapon/storage/visuals/surgery/full,
+/obj/machinery/holosign/surgery{
+	id = "op1"
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -41700,7 +41717,8 @@
 	pixel_y = -25
 	},
 /obj/structure/cable,
-/obj/machinery/vending/blood,
+/obj/structure/stool/bed,
+/obj/item/weapon/bedsheet/medical,
 /turf/simulated/floor{
 	icon_state = "whiteblue"
 	},
@@ -41718,7 +41736,9 @@
 	},
 /area/station/cargo/storage)
 "bxw" = (
-/obj/machinery/vending/medical,
+/obj/machinery/computer/med_data{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "whiteblue"
@@ -42196,11 +42216,18 @@
 	},
 /area/station/cargo/storage)
 "byp" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
 	},
-/obj/structure/table,
+/obj/machinery/camera{
+	c_tag = "Medbay South";
+	dir = 4;
+	network = list("SS13","Medical")
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 1
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -42619,14 +42646,14 @@
 /area/station/medical/sleeper)
 "bzb" = (
 /obj/structure/table,
+/obj/item/weapon/storage/visuals/surgery/full,
 /obj/item/device/radio/intercom{
 	frequency = 1485;
 	name = "Station Intercom (Medbay)";
 	pixel_x = -28
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "whitehall"
+	icon_state = "white"
 	},
 /area/station/medical/surgery)
 "bzc" = (
@@ -49008,9 +49035,9 @@
 	},
 /area/station/medical/surgery2)
 "bKI" = (
-/obj/machinery/light,
 /obj/machinery/life_assist/artificial_ventilation,
 /turf/simulated/floor{
+	dir = 8;
 	icon_state = "whiteblue"
 	},
 /area/station/medical/sleeper)
@@ -49078,23 +49105,13 @@
 	},
 /area/station/medical/cryo)
 "bKP" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/table/glass,
-/obj/machinery/vending/wallmed2{
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/item/weapon/phone,
-/obj/item/weapon/reagent_containers/spray/cleaner,
+/obj/machinery/light,
+/obj/structure/stool/bed,
+/obj/item/weapon/bedsheet/medical,
 /turf/simulated/floor{
-	dir = 1;
 	icon_state = "whiteblue"
 	},
-/area/station/medical/cryo)
+/area/station/medical/sleeper)
 "bKQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -49453,14 +49470,16 @@
 /area/station/medical/patients_rooms)
 "bLC" = (
 /obj/machinery/light{
-	dir = 4
+	dir = 8
 	},
-/obj/structure/stool/bed/roller,
-/obj/machinery/iv_drip,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
+/obj/structure/table/glass,
+/obj/machinery/vending/wallmed2{
+	pixel_y = -32
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/item/weapon/reagent_containers/spray/cleaner,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "whiteblue"
@@ -52701,16 +52720,23 @@
 	},
 /area/station/medical/medbreak)
 "bRO" = (
-/obj/structure/table,
-/obj/item/device/radio/intercom{
-	frequency = 1485;
-	name = "Station Intercom (Medbay)";
-	pixel_y = 25
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/stool/bed/roller,
+/obj/machinery/iv_drip,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/structure/reagent_dispensers/cleaner{
+	pixel_x = 32
 	},
 /turf/simulated/floor{
-	icon_state = "whitehall"
+	dir = 1;
+	icon_state = "whiteblue"
 	},
-/area/station/medical/surgery2)
+/area/station/medical/cryo)
 "bRP" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -53119,18 +53145,17 @@
 	},
 /area/station/medical/genetics)
 "bSO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Medbay South";
-	dir = 4;
-	network = list("SS13","Medical")
+/obj/structure/table,
+/obj/item/weapon/storage/visuals/surgery/full,
+/obj/item/device/radio/intercom{
+	frequency = 1485;
+	name = "Station Intercom (Medbay)";
+	pixel_y = 25
 	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
-/area/station/medical/hallway)
+/area/station/medical/surgery2)
 "bSP" = (
 /turf/simulated/wall/r_wall,
 /area/station/engineering/break_room)
@@ -71888,7 +71913,7 @@
 	id = "MedbayFoyerOut";
 	name = "Medbay Doors Control";
 	pixel_x = 26;
-	pixel_y = -7;
+	pixel_y = -1;
 	req_access = list(5)
 	},
 /obj/machinery/door_control{
@@ -71896,7 +71921,7 @@
 	id = "MedbayFoyerIn";
 	name = "Medbay Doors Control";
 	pixel_x = 26;
-	pixel_y = 7;
+	pixel_y = 12;
 	req_access = list(5)
 	},
 /turf/simulated/floor{
@@ -74314,6 +74339,9 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "whiteblue"
@@ -75250,7 +75278,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/sign/mark{
 	icon_state = "fdn";
-	pixel_y = 20
+	pixel_y = 22
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -75549,7 +75577,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/sign/mark{
 	icon_state = "fdn";
-	pixel_y = 4
+	pixel_y = 6
 	},
 /turf/simulated/floor{
 	icon_state = "whiteblue"
@@ -118950,7 +118978,7 @@ bIS
 bIS
 bIS
 bLF
-bRO
+aqU
 bKH
 bKy
 bNZ
@@ -119198,7 +119226,7 @@ cNh
 bAQ
 bjl
 aRc
-aUa
+bKI
 byn
 bxw
 bkV
@@ -119207,7 +119235,7 @@ bRV
 bUi
 aVe
 bLF
-aqU
+bSO
 aHm
 ckl
 ckt
@@ -119711,10 +119739,10 @@ itb
 aHi
 btg
 aRA
-btT
+aUa
 bAA
 bAP
-bKI
+bKP
 bkV
 bkV
 bkV
@@ -119722,8 +119750,8 @@ bTc
 bkV
 bLF
 bkd
-sWb
 aHm
+sWb
 bur
 bfR
 bLF
@@ -119976,11 +120004,11 @@ bkV
 bFm
 aRI
 bEX
-bKP
+bLC
 bLF
 bpq
-bpu
 bpp
+bpP
 bLF
 bLF
 bLF
@@ -120237,12 +120265,12 @@ bAX
 bJo
 bhM
 bnq
-bpP
+bpW
 bpD
 cKF
 bpX
-bvx
 bzb
+acw
 aaR
 bQR
 bLt
@@ -120494,7 +120522,7 @@ bBA
 biw
 bSD
 cAf
-bPf
+bpu
 bgn
 bix
 qhb
@@ -120753,7 +120781,7 @@ bSf
 bfL
 bPf
 bpQ
-qhb
+bnn
 bSe
 cgs
 bUg
@@ -121009,8 +121037,8 @@ bLv
 cNc
 bob
 bPf
-bpW
-bnn
+bvx
+qhb
 qhb
 ciT
 bUl
@@ -121518,7 +121546,7 @@ bkV
 aIg
 aRQ
 bpo
-bLC
+bRO
 bJo
 bJo
 bJo
@@ -121781,9 +121809,9 @@ boJ
 bfY
 bzo
 lIb
-bSO
-buC
 byp
+buC
+acm
 sJb
 cJS
 cHZ

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -32281,18 +32281,13 @@
 	},
 /area/station/medical/medbreak)
 "bgt" = (
-/obj/structure/table,
-/obj/item/weapon/storage/box/gloves{
-	pixel_x = 3;
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/box/masks,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/machinery/computer/med_data,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -64907,6 +64902,7 @@
 /obj/machinery/alarm{
 	pixel_y = 23
 	},
+/obj/item/weapon/storage/box/gloves,
 /obj/item/weapon/folder/white,
 /turf/simulated/floor{
 	icon_state = "dark"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Текущий мед маппил я во времена более низкого онлайна (да и геймплей немного другой был), сейчас в нем чуть тесно, а еще в него не вносились никакие правки. Это не ремап, изменения несущественные и только по делу:
- Вход в медбей теперь по двум раздельным шлюзам in/out
- Проходы между отсеками терапии в 3 тайла
- Отсек со слиперами и с крио чуть увеличен
- Добавлен второй сканер
- В операционных стало больше места для прохода/складирования тел на каталках
- Генетики теперь просматриваются из медбея и частично из коридора (сейчас они как в бункере, считаю это плохо)
- Мусорка в коридоре медбея теперь находится ближе к экшону
- В лобби появился ксерокс
- Шторки с аирлоков операционных переехали. С ними приходилось альткликать по полу, чтобы закрыть дверь в операционную + не было нормально видно голограмму "операция"
- Вешалки парамедов разделены стеклами, чтобы если вдруг один оставил дверцу открытой, второй за это не страдал возможной кражей своего оборудования

В checks наглядно

## Почему и что этот ПР улучшит
QoL игрока в медбее засчет расширения тесных проходов между отсеками терапии, увеличения места в операционных, разделения входа в медбей на in/out
## Авторство

## Чеинжлог
:cl:
 - map: Небольшие изменения медбея.