### PR TITLE
Removal of 2 space first aid kits at the scientific outpost

### DIFF
--- a/maps/asteroid/asteroid.dmm
+++ b/maps/asteroid/asteroid.dmm
@@ -3389,8 +3389,6 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/item/weapon/storage/firstaid/small_firstaid_kit/space,
-/obj/item/weapon/storage/firstaid/small_firstaid_kit/space,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
 	icon_state = "white"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Количество аптечек уменьшено до 3-х.
До:
![Screenshot_560](https://user-images.githubusercontent.com/67812445/145683196-b9283e30-48f9-4c30-9b0e-3c81c9e1a218.png)
После:
![Screenshot_561](https://user-images.githubusercontent.com/67812445/145683208-2396c502-f906-42bb-9581-4fe41dc1acf4.png)

## Почему и что этот ПР улучшит
К сожалению данный ПР улучшит только баланс, потому что учёные ксеноархеологи имеют 5 космических аптечек, ещё кучу других аптечек в запасе, возможность изготавливать полезные медикаменты, крутой риг. 3 ксеноархеолога - 3 космические аптечки, думаю справедливо. У шахтёров всего одна космическая аптечка на старте, а их 3.
## Авторство
Rahmano
## Чеинжлог
:cl: Rahmano
* map: Удаление 2-х космических аптечек с аванпоста учёных(есть ещё 3 штуки, помимо этих).