### PR TITLE
Убраны лишние тайлы в коде boxstation.dmm

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -17782,10 +17782,9 @@
 	name = "Cargo Office";
 	req_access = list(50)
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/station/cargo/office)
 "aGR" = (
@@ -49500,7 +49499,6 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/turf/space,
 /turf/simulated/floor/plating,
 /area/station/civilian/dormitories)
 "bLS" = (


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Убраны двойные пожарные створки в карго, но из-за чего-то при запуске игры было видно только одну.
Убран лишний тайл космоса, который присутствовал на станции, но его не было видно, только в коде. 
Изменения понятны только если посмотреть в коде на них, мап дифф не поможет.
## Почему и что этот ПР улучшит
Не будет лишних строк в коде и в редакторе карт всё будет отображаться корректно.