### PR TITLE
Нёрф отрезания бошки кусачками

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -94,9 +94,9 @@
 				if(!protected)
 					//TODO: better alternative for applying damage multiple times? Nice knifing sound?
 					var/damage_flags = damage_flags()
-					M.apply_damage(20, BRUTE, BP_HEAD, null, damage_flags)
-					M.apply_damage(20, BRUTE, BP_HEAD, null, damage_flags)
-					M.apply_damage(20, BRUTE, BP_HEAD, null, damage_flags)
+					M.apply_damage(force, BRUTE, BP_HEAD, null, damage_flags)
+					M.apply_damage(force, BRUTE, BP_HEAD, null, damage_flags)
+					M.apply_damage(force, BRUTE, BP_HEAD, null, damage_flags)
 					M.adjustOxyLoss(60) // Brain lacks oxygen immediately, pass out
 					playsound(M, 'sound/effects/throat_cutting.ogg', VOL_EFFECTS_MASTER)
 					flick(G.hud.icon_state, G.hud)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Нёрф отрезания бошки подручными средствами за пару кликов. Раньше был фиксированный урон по 20\*3, что гарантированно отрезало бошку при втором клике. Сейчас же само отрезание башки зависит от урона оружия. В итоге будет force*3. 

Сам способ убийства остался, так же кукла умирает от кусачек и осколка за третий граб и 2-3 клика осколком, но теперь башка не будет отлетать. Для отлёта бошки нужно будет использовать оружие серьезнее (по тестам, только force = 15 отрезал бошку), например пила хирурга.

## Почему и что этот ПР улучшит
С вводом запрета на клонирование и воскрешение безголовых этот способ грифа и убийства стал слишком сильным. 
Этот ПР сам способ скрытого и быстрого убийства не трогает, а влияет только на отвал бошки.

## Авторство

## Чеинжлог
:cl:
 - balance: Изменен урон, который наносится при клике на голову острым предметом в третьем грабе. Раньше был фиксированный `20*3`, сейчас будет `урон_оружия*3`