### PR TITLE
Автоматические точки в конце сообщений игрока

### DIFF
--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -16,6 +16,7 @@
 	msg = lowertext(msg)
 
 	if(listening)
+		msg = copytext(msg, 1, length(msg)) // deleting last symbol
 		recorded = msg
 		listening = 0
 		audible_message("Activation message is '[recorded]'.", hearing_distance = 1)

--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -16,7 +16,9 @@
 	msg = lowertext(msg)
 
 	if(listening)
-		msg = copytext(msg, 1, length(msg)) // deleting last symbol
+		msg = trim(replace_characters(msg, list("." = "", "?" = "", "!" = "", ";" = ""))) // deleting last symbol
+		if(!msg)
+			return
 		recorded = msg
 		listening = 0
 		audible_message("Activation message is '[recorded]'.", hearing_distance = 1)

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -9,7 +9,7 @@
 	var/desc = "A language."         // Short description for 'Check Languages'.
 	var/speech_verb = "says"         // 'says', 'hisses', 'farts'.
 	var/ask_verb = "asks"            // Used when sentence ends in a ?
-	var/list/exclaim_verb = list("exclaims","shouts","yells") // Used when sentence ends in a !
+	var/exclaim_verb = "exclaims" // Used when sentence ends in a !
 	var/signlang_verb = list()       // list of emotes that might be displayed if this language has NONVERBAL or SIGNLANG flags
 	var/colour = "body"         // CSS style to use for strings in this language.
 	var/list/key = list()                    // Character used to speak in language eg. :o for Unathi.
@@ -59,7 +59,7 @@
 /datum/language/proc/get_spoken_verb(msg_end)
 	switch(msg_end)
 		if("!")
-			return pick(exclaim_verb)
+			return exclaim_verb
 		if("?")
 			return ask_verb
 	return speech_verb

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -9,7 +9,7 @@
 	var/desc = "A language."         // Short description for 'Check Languages'.
 	var/speech_verb = "says"         // 'says', 'hisses', 'farts'.
 	var/ask_verb = "asks"            // Used when sentence ends in a ?
-	var/exclaim_verb = "exclaims" // Used when sentence ends in a !
+	var/list/exclaim_verb = list("exclaims","shouts","yells") // Used when sentence ends in a !
 	var/signlang_verb = list()       // list of emotes that might be displayed if this language has NONVERBAL or SIGNLANG flags
 	var/colour = "body"         // CSS style to use for strings in this language.
 	var/list/key = list()                    // Character used to speak in language eg. :o for Unathi.
@@ -59,7 +59,7 @@
 /datum/language/proc/get_spoken_verb(msg_end)
 	switch(msg_end)
 		if("!")
-			return exclaim_verb
+			return pick(exclaim_verb)
 		if("?")
 			return ask_verb
 	return speech_verb

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -171,6 +171,10 @@
 				return ""
 
 	message = capitalize(trim(message))
+	if(findtext(message, ".", length(message)) || findtext(message, "?", length(message)) || \
+	   findtext(message, ";", length(message)) || findtext(message, "!", length(message)) || \
+	   findtext(message, ".", length(message)))
+	else message += "." // auto period at the end of the message
 	if(iszombie(src))
 		message = zombie_talk(message)
 

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -171,6 +171,8 @@
 				return ""
 
 	message = capitalize(trim(message))
+	if(message[length(message)] == ",")
+		message = splicetext(message, length(message), , ".")
 	if(message[length(message)] == "." || message[length(message)] == "?" || \
 	   message[length(message)] == "!" || message[length(message)] == ";")
 	else

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -69,6 +69,8 @@
 	add_conversation(speaker.GetVoice(), "hear", message)
 	H.add_conversation(GetVoice(), "say", message)
 
+var/global/list/punctuation_marks_final = list(".", "?", "!", ";")
+
 /mob/living/carbon/human/say(message, ignore_appearance)
 	var/verb = "says"
 	var/message_range = world.view
@@ -176,7 +178,6 @@
 		message = zombie_talk(message)
 
 	var/ending = copytext(message, -1)
-	var/global/list/punctuation_marks_final = list(".", "?", "!", ";")
 
 	if(!(ending in punctuation_marks_final))
 		if(ending == ",")

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -176,19 +176,22 @@
 		message = zombie_talk(message)
 
 	var/ending = copytext(message, -1)
-	if (speaking)
+
+	if(ending == "!" || ending == "?" || ending == ";" || ending == ".")
+	else
+		if(ending == ",")
+			message = splicetext(message, length(message), , ".")
+		else
+			message += "."
+
+	if(speaking)
 		//If we've gotten this far, keep going!
 		verb = speaking.get_spoken_verb(ending)
 	else
-		switch(ending)
-			if("!")
-				verb = pick("exclaims","shouts","yells")
-			if("?")
-				verb = "asks"
-			if(",")
-				message = splicetext(message, length(message), , ".")
-			if(!("." || ";"))
-				message += "."
+		if(ending == "!")
+			verb = pick("exclaims","shouts","yells")
+		if(ending == "?")
+			verb = "asks"
 
 	if(speech_problem_flag)
 		var/list/handle_r = handle_speech_problems(message, message_mode)

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -171,9 +171,10 @@
 				return ""
 
 	message = capitalize(trim(message))
-	if(findtext(message, ".", length(message)) || findtext(message, "?", length(message)) || \
-	   findtext(message, ";", length(message)) || findtext(message, "!", length(message)))
-	else message += "." // auto period at the end of the message
+	if(message[length(message)] == "." || message[length(message)] == "?" || \
+	   message[length(message)] == "!" || message[length(message)] == ";")
+	else
+		message += "." // auto period at the end of the message
 	if(iszombie(src))
 		message = zombie_talk(message)
 

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -177,8 +177,7 @@
 
 	var/ending = copytext(message, -1)
 
-	if(ending == "!" || ending == "?" || ending == ";" || ending == ".")
-	else
+	if(!(ending == "!" || ending == "?" || ending == ";" || ending == "."))
 		if(ending == ",")
 			message = splicetext(message, length(message), , ".")
 		else

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -172,8 +172,7 @@
 
 	message = capitalize(trim(message))
 	if(findtext(message, ".", length(message)) || findtext(message, "?", length(message)) || \
-	   findtext(message, ";", length(message)) || findtext(message, "!", length(message)) || \
-	   findtext(message, ".", length(message)))
+	   findtext(message, ";", length(message)) || findtext(message, "!", length(message)))
 	else message += "." // auto period at the end of the message
 	if(iszombie(src))
 		message = zombie_talk(message)

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -171,12 +171,7 @@
 				return ""
 
 	message = capitalize(trim(message))
-	if(message[length(message)] == ",")
-		message = splicetext(message, length(message), , ".")
-	if(message[length(message)] == "." || message[length(message)] == "?" || \
-	   message[length(message)] == "!" || message[length(message)] == ";")
-	else
-		message += "." // auto period at the end of the message
+
 	if(iszombie(src))
 		message = zombie_talk(message)
 
@@ -185,10 +180,15 @@
 		//If we've gotten this far, keep going!
 		verb = speaking.get_spoken_verb(ending)
 	else
-		if(ending=="!")
-			verb=pick("exclaims","shouts","yells")
-		if(ending=="?")
-			verb="asks"
+		switch(ending)
+			if("!")
+				verb = pick("exclaims","shouts","yells")
+			if("?")
+				verb = "asks"
+			if(",")
+				message = splicetext(message, length(message), , ".")
+			if(!("." || ";"))
+				message += "."
 
 	if(speech_problem_flag)
 		var/list/handle_r = handle_speech_problems(message, message_mode)

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -176,8 +176,9 @@
 		message = zombie_talk(message)
 
 	var/ending = copytext(message, -1)
+	var/global/list/punctuation_marks_final = list(".", "?", "!", ";")
 
-	if(!(ending == "!" || ending == "?" || ending == ";" || ending == "."))
+	if(!(ending in punctuation_marks_final))
 		if(ending == ",")
 			message = splicetext(message, length(message), , ".")
 		else


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Ставит точку в конце сообщений игрока:

![image](https://user-images.githubusercontent.com/75007994/146542276-254775f5-47a7-4677-a0e2-4ffa8f8f3599.png)

После знаков вопроса, восклицания и т.д. еще одна точка не ставится.
ООК, ЛООК, админпмки не трогал. Синтетов тоже оставил без точек.
## Почему и что этот ПР улучшит
Красиво
## Авторство
Идея - другие билды
## Чеинжлог
:cl: notkripton
- tweak: игра теперь автоматически ставит точки в конце сообщений в игровой чат