### PR TITLE
Replace directly call of destroy on qdel

### DIFF
--- a/code/game/gamemodes/modes_gameplays/blob/powers.dm
+++ b/code/game/gamemodes/modes_gameplays/blob/powers.dm
@@ -166,7 +166,7 @@
 	var/turf/T = get_turf(src)
 	remove_blob(T)
 
-/mob/camera/blob/verb/remove_blob(turf/T)	
+/mob/camera/blob/verb/remove_blob(turf/T)
 	var/obj/effect/blob/B = locate(/obj/effect/blob) in T
 	if(!B)
 		to_chat(src, "You must be on a blob!")
@@ -176,7 +176,7 @@
 		to_chat(src, "Unable to remove this blob.")
 		return
 
-	B.Destroy()
+	qdel(B)
 
 
 /mob/camera/blob/verb/expand_blob_power()

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1098,7 +1098,7 @@
 			message += "It melts in a puddle of plastic."
 		else
 			message += "Your [P] shatters in a thousand pieces!"
-		qlde(P)
+		qdel(P)
 
 	if(M && isliving(M))
 		message = "<span class='warning'></span>" + message

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1094,11 +1094,11 @@
 		j = prob(10)
 
 	if(j) //This kills the PDA
-		P.Destroy()
 		if(message)
 			message += "It melts in a puddle of plastic."
 		else
 			message += "Your [P] shatters in a thousand pieces!"
+		qlde(P)
 
 	if(M && isliving(M))
 		message = "<span class='warning'></span>" + message

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -607,7 +607,7 @@
 				C.r_arm = new/obj/item/robot_parts/r_arm(C)
 				C.update_icon()
 				new/obj/item/robot_parts/chest(loc)
-				Destroy()
+				qdel(src)
 			else
 				// Okay we're not removing the cell or an MMI, but maybe something else?
 				var/list/removable_components = list()

--- a/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
+++ b/code/modules/mob/living/simple_animal/friendly/spiderbot.dm
@@ -209,7 +209,7 @@
 		held_item = null
 
 	robogibs(loc, viruses)
-	Destroy()
+	qdel(src)
 
 //copy paste from alien/larva, if that func is updated please update this one alsoghost
 /mob/living/simple_animal/spiderbot/verb/hide()

--- a/code/modules/research/xenoarchaeology/artifact/artifact_bluespace_crystal.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact_bluespace_crystal.dm
@@ -56,7 +56,7 @@
 	tesla_zap(src,round(damage/10),round(damage/5)*25000)
 	empulse(src, round(damage/10),round(damage/5))
 	if(health < 0)
-		Destroy()
+		qdel(src)
 
 /obj/machinery/artifact/bluespace_crystal/bullet_act(obj/item/projectile/Proj)
 	if(prob(Proj.damage))


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Destroy() не должен вызываться напрямую, обходя наш GC, который стоило бы обновить.

## Почему и что этот ПР улучшит
Оптимизация?

## Авторство

## Чеинжлог
