### PR TITLE
Shadowling veil can turn off glowstick and flare

### DIFF
--- a/code/game/gamemodes/modes_gameplays/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/modes_gameplays/shadowling/shadowling_abilities.dm
@@ -48,7 +48,7 @@
 		for(var/obj/item/F in T.contents)
 			if(is_type_in_list(F, blacklisted_lights))
 				for(var/obj/item/device/flashlight/flare/P)
-					P.fuel = max(P.fuel - 750, 0)
+					P.fuel = max(P.fuel - 750, 0) //-750 fuel in flare, number cannot be 0<
 				F.visible_message("<span class='danger'>[F] goes slightly dim for a moment.</span>")
 				return
 			F.set_light(0)

--- a/code/game/gamemodes/modes_gameplays/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/modes_gameplays/shadowling/shadowling_abilities.dm
@@ -47,6 +47,8 @@
 	for(var/turf/T in targets)
 		for(var/obj/item/F in T.contents)
 			if(is_type_in_list(F, blacklisted_lights))
+				for(var/obj/item/device/flashlight/flare/P)
+					P.fuel = max(P.fuel - 750, 0)
 				F.visible_message("<span class='danger'>[F] goes slightly dim for a moment.</span>")
 				return
 			F.set_light(0)

--- a/code/game/gamemodes/modes_gameplays/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/modes_gameplays/shadowling/shadowling_abilities.dm
@@ -48,7 +48,7 @@
 		for(var/obj/item/F in T.contents)
 			if(is_type_in_list(F, blacklisted_lights))
 				for(var/obj/item/device/flashlight/flare/P)
-					P.fuel = max(P.fuel - 750, 0) //-750 fuel in flare, number cannot be 0<
+					P.fuel = max(P.fuel - 700, 0) //-700 fuel in flare, number cannot be 0<
 				F.visible_message("<span class='danger'>[F] goes slightly dim for a moment.</span>")
 				return
 			F.set_light(0)

--- a/code/game/gamemodes/modes_gameplays/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/modes_gameplays/shadowling/shadowling_abilities.dm
@@ -47,7 +47,8 @@
 	for(var/turf/T in targets)
 		for(var/obj/item/F in T.contents)
 			if(is_type_in_list(F, blacklisted_lights))
-				F.visible_message("<span class='danger'>[F] goes slightly dim for a moment.</span>")
+				if(istype(F, /obj/item/device/flashlight/slime))
+					F.visible_message("<span class='danger'>[F] goes slightly dim for a moment.</span>")
 				if(istype(F, /obj/item/device/flashlight/flare))
 					var/obj/item/device/flashlight/flare/P = F
 					P.adjust_fuel(950)
@@ -62,7 +63,8 @@
 		for(var/mob/living/carbon/human/H in T.contents)
 			for(var/obj/item/F in H)
 				if(is_type_in_list(F, blacklisted_lights))
-					F.visible_message("<span class='danger'>[F] goes slightly dim for a moment.</span>")
+					if(istype(F, /obj/item/device/flashlight/slime))
+						F.visible_message("<span class='danger'>[F] goes slightly dim for a moment.</span>")
 					if(istype(F, /obj/item/device/flashlight/flare))
 						var/obj/item/device/flashlight/flare/P = F
 						P.adjust_fuel(875)

--- a/code/game/gamemodes/modes_gameplays/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/modes_gameplays/shadowling/shadowling_abilities.dm
@@ -51,7 +51,8 @@
 					F.visible_message("<span class='danger'>[F] goes slightly dim for a moment.</span>")
 				if(istype(F, /obj/item/device/flashlight/flare))
 					var/obj/item/device/flashlight/flare/P = F
-					P.adjust_fuel(950)
+					P.adjust_fuel(1000)
+					P.check_fuel()
 				continue
 			F.set_light(0)
 
@@ -67,7 +68,8 @@
 						F.visible_message("<span class='danger'>[F] goes slightly dim for a moment.</span>")
 					if(istype(F, /obj/item/device/flashlight/flare))
 						var/obj/item/device/flashlight/flare/P = F
-						P.adjust_fuel(875)
+						P.adjust_fuel(975)
+						P.check_fuel()
 					continue
 				F.set_light(0)
 			H.set_light(0) //This is required with the object-based lighting

--- a/code/game/gamemodes/modes_gameplays/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/modes_gameplays/shadowling/shadowling_abilities.dm
@@ -43,15 +43,15 @@
 	light_off_range(targets, usr)
 
 /proc/light_off_range(list/targets, atom/center)
-	var/list/blacklisted_lights = list(/obj/item/device/flashlight/slime)
+	var/list/blacklisted_lights = list(/obj/item/device/flashlight/slime, /obj/item/device/flashlight/flare)
 	for(var/turf/T in targets)
 		for(var/obj/item/F in T.contents)
 			if(is_type_in_list(F, blacklisted_lights))
 				F.visible_message("<span class='danger'>[F] goes slightly dim for a moment.</span>")
+				if(istype(F, /obj/item/device/flashlight/flare))
+					var/obj/item/device/flashlight/flare/P = F
+					P.adjust_fuel(950)
 				continue
-			if(istype(F, /obj/item/device/flashlight/flare))
-				var/obj/item/device/flashlight/flare/P = F
-				P.fuel = max(P.fuel - 1000, 0)
 			F.set_light(0)
 
 		for(var/obj/machinery/light/L in T.contents)
@@ -63,10 +63,10 @@
 			for(var/obj/item/F in H)
 				if(is_type_in_list(F, blacklisted_lights))
 					F.visible_message("<span class='danger'>[F] goes slightly dim for a moment.</span>")
+					if(istype(F, /obj/item/device/flashlight/flare))
+						var/obj/item/device/flashlight/flare/P = F
+						P.adjust_fuel(875)
 					continue
-				if(istype(F, /obj/item/device/flashlight/flare))
-					var/obj/item/device/flashlight/flare/P = F
-					P.fuel = max(P.fuel - 1000, 0)
 				F.set_light(0)
 			H.set_light(0) //This is required with the object-based lighting
 

--- a/code/game/gamemodes/modes_gameplays/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/modes_gameplays/shadowling/shadowling_abilities.dm
@@ -43,14 +43,15 @@
 	light_off_range(targets, usr)
 
 /proc/light_off_range(list/targets, atom/center)
-	var/list/blacklisted_lights = list(/obj/item/device/flashlight/flare, /obj/item/device/flashlight/slime, /obj/item/weapon/reagent_containers/food/snacks/glowstick)
+	var/list/blacklisted_lights = list(/obj/item/device/flashlight/slime)
 	for(var/turf/T in targets)
 		for(var/obj/item/F in T.contents)
 			if(is_type_in_list(F, blacklisted_lights))
-				for(var/obj/item/device/flashlight/flare/P)
-					P.fuel = max(P.fuel - 350, 0) //-350 fuel in flare, number cannot be 0<
 				F.visible_message("<span class='danger'>[F] goes slightly dim for a moment.</span>")
-				return
+				continue
+			if(istype(F, /obj/item/device/flashlight/flare))
+				var/obj/item/device/flashlight/flare/P = F
+				P.fuel = max(P.fuel - 1000, 0)
 			F.set_light(0)
 
 		for(var/obj/machinery/light/L in T.contents)
@@ -62,7 +63,10 @@
 			for(var/obj/item/F in H)
 				if(is_type_in_list(F, blacklisted_lights))
 					F.visible_message("<span class='danger'>[F] goes slightly dim for a moment.</span>")
-					return
+					continue
+				if(istype(F, /obj/item/device/flashlight/flare))
+					var/obj/item/device/flashlight/flare/P = F
+					P.fuel = max(P.fuel - 1000, 0)
 				F.set_light(0)
 			H.set_light(0) //This is required with the object-based lighting
 

--- a/code/game/gamemodes/modes_gameplays/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/modes_gameplays/shadowling/shadowling_abilities.dm
@@ -48,7 +48,7 @@
 		for(var/obj/item/F in T.contents)
 			if(is_type_in_list(F, blacklisted_lights))
 				for(var/obj/item/device/flashlight/flare/P)
-					P.fuel = max(P.fuel - 450, 0) //-450 fuel in flare, number cannot be 0<
+					P.fuel = max(P.fuel - 350, 0) //-350 fuel in flare, number cannot be 0<
 				F.visible_message("<span class='danger'>[F] goes slightly dim for a moment.</span>")
 				return
 			F.set_light(0)

--- a/code/game/gamemodes/modes_gameplays/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/modes_gameplays/shadowling/shadowling_abilities.dm
@@ -48,7 +48,7 @@
 		for(var/obj/item/F in T.contents)
 			if(is_type_in_list(F, blacklisted_lights))
 				for(var/obj/item/device/flashlight/flare/P)
-					P.fuel = max(P.fuel - 700, 0) //-700 fuel in flare, number cannot be 0<
+					P.fuel = max(P.fuel - 450, 0) //-450 fuel in flare, number cannot be 0<
 				F.visible_message("<span class='danger'>[F] goes slightly dim for a moment.</span>")
 				return
 			F.set_light(0)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -183,6 +183,11 @@
 	fuel = rand(800, 1000) // Sorry for changing this so much but I keep under-estimating how long X number of ticks last in seconds.
 	. = ..()
 
+/obj/item/device/flashlight/flare/proc/adjust_fuel(value)
+	fuel = max(fuel - value, 0)
+	if(fuel == 0)
+		turn_off()
+
 /obj/item/device/flashlight/flare/process()
 	var/turf/pos = get_turf(src)
 	if(pos)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -185,7 +185,8 @@
 
 /obj/item/device/flashlight/flare/proc/adjust_fuel(value)
 	fuel = max(fuel - value, 0)
-	if(fuel == 0)
+	if(fuel <= 0)
+		visible_message("<span class='danger'>Flare started flickering with a hissing sound and stopped burning.</span>")
 		turn_off()
 
 /obj/item/device/flashlight/flare/process()

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -180,13 +180,21 @@
 
 
 /obj/item/device/flashlight/flare/atom_init()
-	fuel = rand(800, 1000) // Sorry for changing this so much but I keep under-estimating how long X number of ticks last in seconds.
+	fuel = rand(980, 1000) // Sorry for changing this so much but I keep under-estimating how long X number of ticks last in seconds.
 	. = ..()
+
+/obj/item/device/flashlight/flare/use(used = 1, mob/M = null)
+	if(used < 0)
+		stack_trace("[src.type]/use() called with a negative parameter [used]")
+		return 0
+	if(!fuel || !on)
+		return 0
 
 /obj/item/device/flashlight/flare/proc/adjust_fuel(value)
 	fuel = max(fuel - value, 0)
+
+/obj/item/device/flashlight/flare/proc/check_fuel()
 	if(fuel <= 0)
-		visible_message("<span class='danger'>Flare started flickering with a hissing sound and stopped burning.</span>")
 		turn_off()
 
 /obj/item/device/flashlight/flare/process()


### PR DESCRIPTION
## Описание изменений
Вуаль тушит флаеры и глоустики.
При использовании способности Veil(вуаль) из флаера будет вычитаться всё топливо, если он на земле. Если человек держит флаер в руках, топлива в флаере останется на ~2,5 - 15 сек, это время позволит человеку убежать/выйграть время, но флаер больше он не использует и ему нужно будет найти новый, а на станции их не так много.
## Почему и что этот ПР улучшит
Теперь антаг не беспомощен перед этими вещами. Но флаер не стал бесполезным, он может спасти жизнь человеку.

return заменён на continue, теперь если в радиусе использования вуали есть запрещённый предмет для неё, предметы вокруг выключатся в любом случае.
## Авторство
Rahmano
## Чеинжлог
:cl: Rahmano
* rscadd: Шедоулинги теперь могут тушить флаеры и глоустики вуалью.