### PR TITLE
Фиксит общий доступ кнопок управления дверьми общака

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -7585,20 +7585,18 @@
 	name = "Security Cadet"
 	},
 /obj/machinery/door_control{
-	desc = "A remote control switch for the brig foyer.";
 	id = "prisonexit";
 	name = "Exit Doors";
 	pixel_x = 6;
 	pixel_y = -24;
-	range = 10
+	req_access = list(2)
 	},
 /obj/machinery/door_control{
-	desc = "A remote control switch for the brig foyer.";
 	id = "prisonentry";
 	name = "Entry Doors";
 	pixel_x = 6;
 	pixel_y = -36;
-	range = 10
+	req_access = list(2)
 	},
 /turf/simulated/floor{
 	icon_state = "redcorner"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Фиксит общий доступ кнопок управления дверьми общака в бриге 
## Почему и что этот ПР улучшит
Нельзя будет устроить побег братану зеку из тюрьмы тупо забежав через лобби и открыв нужные аирлоки кнопками (в коридор брига все еще можно)
## Авторство

## Чеинжлог
