### PR TITLE
Парочка фиксов hard del-итов

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -845,8 +845,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 						if(!O.simulated)
 							continue
 						O.loc = X
-						if (length(O.client_mobs_in_contents))
-							O.update_parallax_contents()
+						O.update_parallax_contents()
 					for(var/mob/M in T)
 						if(!istype(M,/mob) || istype(M, /mob/camera)) continue // If we need to check for more mobs, I'll add a variable
 						M.loc = X

--- a/code/_onclick/hud/parallax.dm
+++ b/code/_onclick/hud/parallax.dm
@@ -204,18 +204,17 @@
 		L.screen_loc = "CENTER-7:[round(L.offset_x,1)],CENTER-7:[round(L.offset_y,1)]"
 
 /atom/movable/proc/update_parallax_contents()
-	if(length(client_mobs_in_contents))
-		for(var/thing in client_mobs_in_contents)
-			var/mob/M = thing
-			if(M && M.client && M.hud_used && length(M.client.parallax_layers))
-				M.hud_used.update_parallax()
+	if(length(clients_in_contents))
+		for(var/thing in clients_in_contents)
+			var/client/C = thing
+			if(C && length(C.parallax_layers))
+				C.mob?.hud_used?.update_parallax()
 
 /area/proc/parallax_slowdown()
 	if(parallax_movedir)
 		parallax_movedir = FALSE
 		for(var/atom/movable/AM in src)
-			if(length(AM.client_mobs_in_contents))
-				AM.update_parallax_contents()
+			AM.update_parallax_contents()
 
 /atom/movable/screen/parallax_layer
 	var/speed = 1

--- a/code/controllers/subsystem/parallax.dm
+++ b/code/controllers/subsystem/parallax.dm
@@ -1,8 +1,8 @@
 SUBSYSTEM_DEF(parallax)
 	name = "Parallax"
 
-	priority = SS_PRIORITY_PARALLAX
 	wait     = SS_WAIT_PARALLAX
+	priority = SS_PRIORITY_PARALLAX
 
 	flags = SS_POST_FIRE_TIMING | SS_BACKGROUND | SS_NO_INIT
 	runlevels = RUNLEVEL_LOBBY | RUNLEVELS_DEFAULT
@@ -11,10 +11,9 @@ SUBSYSTEM_DEF(parallax)
 	var/planet_x_offset = 128
 	var/planet_y_offset = 128
 
-/datum/controller/subsystem/parallax/Initialize(timeofday)
+/datum/controller/subsystem/parallax/PreInit()
 	planet_y_offset = rand(100, 160)
 	planet_x_offset = rand(100, 160)
-	..()
 
 /datum/controller/subsystem/parallax/fire(resumed = 0)
 	if (!resumed)
@@ -27,21 +26,18 @@ SUBSYSTEM_DEF(parallax)
 		var/client/C = currentrun[currentrun.len]
 		currentrun.len--
 
-		if (!C || !C.eye)
+		var/atom/movable/A = C?.eye
+		if(!A)
 			if (MC_TICK_CHECK)
 				return
 			continue
-		var/atom/movable/A = C.eye
-		if(!A)
-			return
+
 		for (A; isloc(A.loc) && !isturf(A.loc); A = A.loc);
 
 		if(A != C.movingmob)
 			if(C.movingmob != null)
-				C.movingmob.client_mobs_in_contents -= C.mob
-				UNSETEMPTY(C.movingmob.client_mobs_in_contents)
-			LAZYINITLIST(A.client_mobs_in_contents)
-			A.client_mobs_in_contents += C.mob
+				LAZYREMOVE(C.movingmob.clients_in_contents, C)
+			LAZYADD(A.clients_in_contents, C)
 			C.movingmob = A
 		if (MC_TICK_CHECK)
 			return

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -288,6 +288,7 @@ SUBSYSTEM_DEF(ticker)
 			if(N.client)
 				N.show_titlescreen()
 		//Cleanup some stuff
+		SSjob.fallback_landmark = null
 		for(var/obj/effect/landmark/start/S in landmarks_list)
 			//Deleting Startpoints but we need the ai point to AI-ize people later
 			if (S.name != "AI")

--- a/code/datums/progressbar.dm
+++ b/code/datums/progressbar.dm
@@ -80,6 +80,7 @@
 	if(!bars.len)
 		LAZYREMOVE(user.progressbars, bar.loc)
 
+	user = null
 	if (client)
 		client.images -= bar
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -43,13 +43,13 @@
 		loc.handle_atom_del(src)
 	for(var/atom/movable/AM in contents)
 		qdel(AM)
-	loc = null
 	invisibility = 101
 	if(pulledby)
 		pulledby.stop_pulling()
 
 	. = ..()
 
+	loc = null
 	// If we have opacity, make sure to tell (potentially) affected light sources.
 	if (opacity && istype(T))
 		var/old_has_opaque_atom = T.has_opaque_atom

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -27,7 +27,7 @@
 
 	var/datum/forced_movement/force_moving = null	//handled soley by forced_movement.dm
 
-	var/list/client_mobs_in_contents
+	var/list/clients_in_contents
 	var/freeze_movement = FALSE
 
 	// A (nested) list of contents that need to be sent signals to when moving between areas. Can include src.
@@ -132,8 +132,8 @@
 	if (!inertia_moving)
 		inertia_next_move = world.time + inertia_move_delay
 		newtonian_move(Dir)
-	if(length(client_mobs_in_contents))
-		update_parallax_contents()
+
+	update_parallax_contents()
 
 	if (orbiters)
 		for (var/thing in orbiters)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -79,10 +79,6 @@
 	// Whether this item is currently being swiped.
 	var/swiping = FALSE
 
-/obj/item/atom_init()
-	. = ..()
-	AddElement(/datum/element/beauty, -w_class)
-
 /obj/item/proc/check_allowed_items(atom/target, not_inside, target_self)
 	if(((src in target) && !target_self) || ((!istype(target.loc, /turf)) && (!istype(target, /turf)) && (not_inside)) || is_type_in_list(target, can_be_placed_into))
 		return 0

--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -360,9 +360,7 @@ var/global/list/blacklisted_builds = list(
 	mentors -= src
 	clients -= src
 	QDEL_LIST_ASSOC_VAL(char_render_holders)
-	if(movingmob != null)
-		movingmob.client_mobs_in_contents -= mob
-		UNSETEMPTY(movingmob.client_mobs_in_contents)
+	LAZYREMOVE(movingmob?.clients_in_contents, src)
 	return ..()
 
 /client/proc/handle_autokick_reasons()

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -232,11 +232,12 @@ var/global/obj/machinery/blackbox_recorder/blackbox
 /obj/machinery/blackbox_recorder/atom_init()
 	. = ..()
 	if(blackbox)
-		if(istype(blackbox,/obj/machinery/blackbox_recorder))
-			qdel(src)
+		return INITIALIZE_HINT_QDEL
 	blackbox = src
 
 /obj/machinery/blackbox_recorder/Destroy()
+	if(blackbox != src)
+		return ..() 
 	var/centcom_z = SSmapping.level_by_trait(ZTRAIT_CENTCOM)
 	var/turf/T = locate(1,1, centcom_z)
 	if(T)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Переписал подсистему парралакса с мобов на клиентов + немного почистил. Убирает за собой мусор намного лучше чем предыдущая (что вообще не убирала). Убирает хард делит обсёрверов, хард делит новых плееров занимает меньше чем обычный дестрой (около 0.05мс).
Хард делит лэндмарка.
Хард делит парочки существ из-за прогресс бара.
Правильный выход из зоны мувабла при qdel (раньше лока занулялась до попытки покинуть зону в предке).
Блекбокс который мы и так не используем. Он само-удалялся и заставлял себя занулить.
Убрал бьюти компоненту из предметов, сейчас слишком много предметов передвигающихся через .loc, а не forceMove. Да и нагружать это должно относительно сильно, учитывая что на каждую смену зоны вызывались 60+ колбеков на каждого человека. Это связано с хард делитом прожектайлов и многих других предметов.

Что не сделано из важного и я чёт задобался. .loc для персонала при передвижении на лэндмарки (их колбеки остаются на зоне спавна нью плееров).
Обновить подсистему мусора, это должно либо сократить, либо вообще убрать проблемы с очень маленькими по времени хард делитами (QDEL_IN, new_player). 

## Почему и что этот ПР улучшит
Скорость.

## Авторство

## Чеинжлог
