### PR TITLE
simple tracker fix

### DIFF
--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -131,8 +131,8 @@
 		return
 	if(((src.last_shot + src.fire_delay) <= world.time) && (src.active == 1))
 
-		if(!active_power_usage || active_power_usage <= max(surplus(), 0))
-			add_load(active_power_usage)
+		if(!active_power_usage || active_power_usage <= delayed_surplus())
+			add_delayedload(active_power_usage)
 			if(!powered)
 				powered = TRUE
 				update_icon()

--- a/code/modules/power/tracker.dm
+++ b/code/modules/power/tracker.dm
@@ -73,10 +73,10 @@
 // make sure we can draw power from the powernet
 /obj/machinery/power/tracker/process()
 
-	var/avail = surplus()
+	var/avail = delayed_surplus()
 
 	if(avail > 500)
-		add_load(500)
+		add_delayedload(500)
 		stat &= ~NOPOWER
 	else
 		stat |= NOPOWER


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Кривовато починил трекер и эммитер, теперь у них есть приоритет перед смесами на потребление энергии.

## Почему и что этот ПР улучшит
\- баг.
\- инжинеры не понимающие почему эммитеры не запускаются когда смес подаёт питание.

## Авторство

## Чеинжлог
