### PR TITLE
guard autoban notes

### DIFF
--- a/code/modules/admin/player_notes.dm
+++ b/code/modules/admin/player_notes.dm
@@ -5,10 +5,11 @@
 	if (!key || !note)
 		return
 
-	if(!(check_rights(R_LOG) && check_rights(R_BAN)))
-		return
+	if(admin)
+		if(!(check_rights(R_LOG) && check_rights(R_BAN)))
+			return
 
-	
+
 	if(!establish_db_connection("erro_messages"))
 		return
 

--- a/code/modules/client/guard.dm
+++ b/code/modules/client/guard.dm
@@ -291,6 +291,8 @@
 	log_admin("Tau Kitty has banned [holder.ckey].\nReason: [reason]\nThis is a permanent ban.")
 	message_admins("Tau Kitty has banned [holder.ckey].\nReason: [reason]\nThis is a permanent ban.")
 
+	notes_add(holder.ckey, "Guard Autoban. [short_report]")
+
 	if(config.guard_autoban_sticky)
 		var/list/ban = list()
 		ban[BANKEY_ADMIN] = "Tau Kitty"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Гард добавляет в нотесы информацию про автобан.

## Почему и что этот ПР улучшит
Админы смогут легче разбирать случаи с ложными срабатываниями.

## Авторство

## Чеинжлог
