### PR TITLE
Фикс бага у спавнер панели

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -822,6 +822,10 @@
 #define LAZYSET(L, K, V) if(!L) { L = list(); } L[K] = V;
 //#define LAZYLEN(L) length(L) // don't return it, pointless now
 #define LAZYCLEARLIST(L) if(L) L.Cut()
+// This is used to add onto lazy assoc list when the value you're adding is a /list/. This one has extra safety over lazyaddassoc because the value could be null (and thus cant be used to += objects)
+#define LAZYADDASSOCLIST(L, K, V) if(!L) { L = list(); } L[K] += list(V);
+// Removes value V and key K from associative list L
+#define LAZYREMOVEASSOC(L, K, V) if(L) { if(L[K]) { L[K] -= V; if(!length(L[K])) L -= K; } if(!length(L)) L = null; }
 #define LAZYCOPY(L) L && L.len ? L.Copy() : null
 #define SANITIZE_LIST(L) ( islist(L) ? L : list() )
 

--- a/code/datums/spawners_menu/spawners.dm
+++ b/code/datums/spawners_menu/spawners.dm
@@ -15,9 +15,6 @@ var/global/list/datum/spawners_cooldown = list()
 		if(!ghost.client)
 			continue
 
-		if(ghost.spawners_menu)
-			SStgui.update_uis(ghost.spawners_menu)
-
 		var/datum/hud/ghost/ghost_hud = ghost.hud_used
 		var/image/I = image(ghost_hud.spawners_menu_button.icon, ghost_hud.spawners_menu_button, "spawners_update")
 		flick_overlay(I, list(ghost.client), 10 SECONDS)

--- a/code/datums/spawners_menu/spawners.dm
+++ b/code/datums/spawners_menu/spawners.dm
@@ -9,9 +9,7 @@ var/global/list/datum/spawners_cooldown = list()
 
 	for(var/i in 1 to num)
 		var/datum/spawner/spawner = new type(arglist(arguments))
-
-		spawner.id = id
-		LAZYADD(global.spawners[id], spawner)
+		spawner.add_to_global_list(id)
 
 	for(var/mob/dead/observer/ghost in observer_list)
 		if(!ghost.client)
@@ -42,7 +40,7 @@ var/global/list/datum/spawners_cooldown = list()
 	// Roles and jobs that will be checked for jobban and minutes
 	var/list/ranks
 	// Delete spawner after use
-	var/del_after_spawn = TRUE
+	var/infinity = FALSE
 	// Cooldown between the opportunity become a role
 	var/cooldown = 10 MINUTES
 
@@ -59,12 +57,17 @@ var/global/list/datum/spawners_cooldown = list()
 		timer_to_expiration = QDEL_IN(src, time_to_del)
 
 /datum/spawner/Destroy()
-	var/list/spawn_list = global.spawners[id]
-	LAZYREMOVE(spawn_list, src)
-	if(!length(spawn_list))
-		global.spawners -= id
+	remove_from_global_list()
 
 	deltimer(timer_to_expiration)
+
+	return ..()
+
+/datum/spawner/proc/add_to_global_list(_id)
+	if(!isnull(_id))
+		id = _id
+
+	LAZYADDASSOCLIST(global.spawners, id, src)
 
 	for(var/mob/dead/observer/ghost in observer_list)
 		if(!ghost.client)
@@ -73,7 +76,15 @@ var/global/list/datum/spawners_cooldown = list()
 		if(ghost.spawners_menu)
 			SStgui.update_uis(ghost.spawners_menu)
 
-	return ..()
+/datum/spawner/proc/remove_from_global_list()
+	LAZYREMOVEASSOC(global.spawners, id, src)
+
+	for(var/mob/dead/observer/ghost in observer_list)
+		if(!ghost.client)
+			continue
+
+		if(ghost.spawners_menu)
+			SStgui.update_uis(ghost.spawners_menu)
 
 /datum/spawner/proc/add_client_cooldown(client/C)
 	if(cooldown)
@@ -95,17 +106,22 @@ var/global/list/datum/spawners_cooldown = list()
 	if(!can_spawn(ghost))
 		return
 
+	if(!infinity)
+		remove_from_global_list()
+
 	var/client/C = ghost.client
 	spawn_ghost(ghost)
 
 	// check if the ghost really become a role
 	if(ghost.client == C)
+		if(!infinity)
+			add_to_global_list()
 		return
 
 	message_admins("[C.ckey] as \"[name]\" has spawned at [COORD(C.mob)] [ADMIN_JMP(C.mob)] [ADMIN_FLW(C.mob)].")
 	add_client_cooldown(C)
 
-	if(del_after_spawn)
+	if(!infinity)
 		qdel(src)
 
 /datum/spawner/proc/can_spawn(mob/dead/observer/ghost)
@@ -406,7 +422,7 @@ var/global/list/datum/spawners_cooldown = list()
 
 	ranks = list(ROLE_GHOSTLY)
 	cooldown = 0
-	del_after_spawn = FALSE
+	infinity = TRUE
 
 /datum/spawner/gladiator/jump(mob/dead/observer/ghost)
 	var/jump_to = pick(eorgwarp)
@@ -421,7 +437,7 @@ var/global/list/datum/spawners_cooldown = list()
 	wiki_ref = "Mouse"
 
 	ranks = list("Mouse")
-	del_after_spawn = FALSE
+	infinity = TRUE
 
 /datum/spawner/mouse/can_spawn(mob/dead/observer/ghost)
 	if(config.disable_player_mice)
@@ -437,7 +453,7 @@ var/global/list/datum/spawners_cooldown = list()
 	desc = "Вы появляетесь где-то на свалке."
 	wiki_ref = "Junkyard"
 
-	del_after_spawn = FALSE
+	infinity = TRUE
 
 /datum/spawner/space_bum/jump(mob/dead/observer/ghost)
 	var/jump_to = pick(junkyard_bum_list)
@@ -453,7 +469,7 @@ var/global/list/datum/spawners_cooldown = list()
 
 	ranks = list(ROLE_DRONE)
 
-	del_after_spawn = FALSE
+	infinity = TRUE
 
 /datum/spawner/drone/can_spawn(mob/dead/observer/ghost)
 	if(!config.allow_drone_spawn)

--- a/code/datums/spawners_menu/spawners_menu.dm
+++ b/code/datums/spawners_menu/spawners_menu.dm
@@ -1,7 +1,7 @@
 /datum/spawners_menu
 	var/mob/dead/observer/owner
 
-	var/role_choosed = FALSE
+	var/role_selected = FALSE
 
 /datum/spawners_menu/New(mob/dead/observer/new_owner)
 	if(!istype(new_owner))
@@ -54,7 +54,7 @@
 	if(.)
 		return
 
-	if(role_choosed)
+	if(role_selected)
 		to_chat(owner, "<span class='notice'>Вы уже выбрали роль!</span>")
 		return
 
@@ -75,7 +75,7 @@
 			spawner.jump(owner)
 			return TRUE
 		if("spawn")
-			role_choosed = TRUE
+			role_selected = TRUE
 			spawner.do_spawn(owner)
-			role_choosed = FALSE
+			role_selected = FALSE
 			return TRUE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Проблема заключалась в том, что если spawn_ghost() как-то блокирует выполнение кода ниже (выбор прикида ЕРТшника), то спавнер оставался активным и кто-то еще мог на него нажать.
Теперь же на время настроек спавнер удаляется из листа, но не удаляется сам по себе, а значит, что если клиент каким-то образом отклонит роль ЕРТшника, то позиция вернется.

А так же небольшой рефактор и фикс ошибки.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
