### PR TITLE
[Alien] Лицехвата может взять только квина или дрон

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/humanoid/caste/drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/humanoid/caste/drone.dm
@@ -33,5 +33,4 @@
 /mob/living/carbon/xenomorph/humanoid/drone/can_pickup(obj/O)
 	if(istype(O, /obj/item/clothing/mask/facehugger))
 		return TRUE
-	else
-		return FALSE
+	return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/humanoid/caste/drone.dm
+++ b/code/modules/mob/living/carbon/xenomorph/humanoid/caste/drone.dm
@@ -29,3 +29,9 @@
 
 /mob/living/carbon/xenomorph/humanoid/drone/movement_delay()
 	return(1 + move_delay_add + config.alien_delay)
+
+/mob/living/carbon/xenomorph/humanoid/drone/can_pickup(obj/O)
+	if(istype(O, /obj/item/clothing/mask/facehugger))
+		return TRUE
+	else
+		return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/xenomorph/humanoid/humanoid.dm
@@ -42,7 +42,7 @@
 	return (move_delay_add + config.alien_delay)
 
 /mob/living/carbon/xenomorph/humanoid/can_pickup(obj/O)
-	if(..() && istype(O, /obj/item/clothing/mask/facehugger))
+	if(..() && istype(O, /obj/item/clothing/mask/facehugger) && (isxenoqueen(src) || isxenodrone(src)))
 		return TRUE
 	else
 		return FALSE

--- a/code/modules/mob/living/carbon/xenomorph/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/xenomorph/humanoid/humanoid.dm
@@ -42,10 +42,7 @@
 	return (move_delay_add + config.alien_delay)
 
 /mob/living/carbon/xenomorph/humanoid/can_pickup(obj/O)
-	if(..() && istype(O, /obj/item/clothing/mask/facehugger) && (isxenoqueen(src) || isxenodrone(src)))
-		return TRUE
-	else
-		return FALSE
+	return FALSE
 
 /mob/living/carbon/xenomorph/humanoid/set_m_intent(intent)
 	. = ..()

--- a/code/modules/mob/living/carbon/xenomorph/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/humanoid/queen.dm
@@ -57,6 +57,12 @@
 /mob/living/carbon/xenomorph/humanoid/queen/can_inject(mob/user, def_zone, show_message = TRUE, penetrate_thick = FALSE)
 	return FALSE
 
+/mob/living/carbon/xenomorph/humanoid/queen/can_pickup(obj/O)
+	if(istype(O, /obj/item/clothing/mask/facehugger))
+		return TRUE
+	else
+		return FALSE
+
 /mob/living/carbon/xenomorph/humanoid/queen/large
 	icon = 'icons/mob/alienqueen.dmi'
 	icon_state = "queen_s-old"

--- a/code/modules/mob/living/carbon/xenomorph/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/humanoid/queen.dm
@@ -60,8 +60,7 @@
 /mob/living/carbon/xenomorph/humanoid/queen/can_pickup(obj/O)
 	if(istype(O, /obj/item/clothing/mask/facehugger))
 		return TRUE
-	else
-		return FALSE
+	return FALSE
 
 /mob/living/carbon/xenomorph/humanoid/queen/large
 	icon = 'icons/mob/alienqueen.dmi'


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
resolve #8447
## Почему и что этот ПР улучшит

## Авторство
Ahio
## Чеинжлог
:cl: Ahio
 - balance: Неигровых лицехватов может подбирать только королева ксеноморфов или трутень.