### PR TITLE
Замена смартфриджа у химиков

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -80290,13 +80290,7 @@
 	},
 /area/station/hallway/primary/central)
 "qNb" = (
-/obj/machinery/smartfridge/chemistry,
-/obj/machinery/door/window/eastright{
-	dir = 2;
-	layer = 2.9;
-	name = "Chemistry Storage";
-	req_access = list(5)
-	},
+/obj/machinery/smartfridge/secure/medbay,
 /turf/simulated/wall/r_wall,
 /area/station/medical/chemistry)
 "qNK" = (


### PR DESCRIPTION
## Описание изменений
Смартфридж чемикал сменён на смартфридж медикал. Что это даёт? Возможность убрать к чертям стеклянную дверь и брать что-либо из холодрыльника лишь людям с медицинским доступом.
## Почему и что этот ПР улучшит
Медики перестанут дрочить стеклянную дверцу перед холодильником, как в какой-то заМКАДовской аптеке.
## Авторство
Unchi.
P.S: В душе не чаю за приколы с файлами карт, тупо поставил другой холодильник в strongdmm и залил. Если что-то не так и будет пояснение што - буду рад.

:cl:
 - rscadd: Смартфридж химиков теперь требует доступ для вынимания из него хлорки. 