### PR TITLE
Понерфил Пирометр. 

### DIFF
--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -161,7 +161,7 @@
 /obj/item/ammo_casing/energy/pyrometer/emagged
 	projectile_type = /obj/item/projectile/pyrometer/emagged
 	select_name = "pyrometer (overloaded)"
-	e_cost = 100
+	e_cost = 1000
 
 /obj/item/ammo_casing/energy/pyrometer/emagged/fire(atom/target, mob/living/user, params, distro, quiet)
 	var/obj/item/weapon/gun/energy/pyrometer/pyro = loc

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -381,7 +381,7 @@
 	fire_delay = 12
 	origin_tech += ";syndicate=1"
 	emagged = TRUE
-	to_chat(user, "<span class='warning'>Ошибка: Обнаружен несовместимый модуль. Ошибкаошибкаошибка</span>")
+	to_chat(user, "<span class='warning'>Ошибка: Обнаружен несовместимый модуль. Ошибкаошибкаошибка.</span>")
 	return TRUE
 
 /obj/item/weapon/gun/energy/pyrometer/update_icon()

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -375,11 +375,14 @@
 		return ..()
 
 /obj/item/weapon/gun/energy/pyrometer/emag_act(mob/user)
-	if(!emagged)
-		ammo_type += new /obj/item/ammo_casing/energy/pyrometer/emagged(src)
-		origin_tech += ";syndicate=1"
-
-		emagged = TRUE
+	if(emagged)
+		return FALSE
+	ammo_type += new /obj/item/ammo_casing/energy/pyrometer/emagged(src)
+	fire_delay = 12
+	origin_tech += ";syndicate=1"
+	emagged = TRUE
+	to_chat(user, "<span class='warning'>Ошибка: Обнаружен несовместимый модуль. Ошибкаошибкаошибка</span>")
+	return TRUE
 
 /obj/item/weapon/gun/energy/pyrometer/update_icon()
 	return


### PR DESCRIPTION
## Описание изменений
Стандартное потребление энерговепона не подходит в случае пирометра т.к. в пирометре заменяется батарейка. При дефолтной 10к батарейке это сто выстрелов.  Так же добавил правильные ретёрны при емаг акте чтобы не тратились лишние заряды и формальное сообщение с уведомлением. Пирометр всё ещё страшно-вырубай т.к. в него всё ещё можно запихнуть большую батарейку, он не замедляет и есть наличие Зума. 
## Почему и что этот ПР улучшит
Боланс, Фидбек при емаге
## Авторство

## Чеинжлог
:cl: 
 - balance: Нерф пирометра. Увеличение стоимости выстрела и задержки перед выстрелом при емагнутом пирометре.