### PR TITLE
#6670 fix

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -3,6 +3,7 @@
 	icon = 'icons/mob/animal.dmi'
 	health = 20
 	maxHealth = 20
+	immune_to_ssd = TRUE
 
 	var/icon_living = ""
 	var/icon_dead = ""
@@ -78,12 +79,6 @@
 	. = ..()
 	if(footstep_type)
 		AddComponent(/datum/component/footstep, footstep_type)
-
-/mob/living/simple_animal/Login()
-	..()
-	blinded = FALSE
-	stat = CONSCIOUS
-	update_canmove()
 
 /mob/living/simple_animal/Grab(atom/movable/target, force_state, show_warnings = TRUE)
 	return


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

В пре #6670 вместо перегрузки логина достаточно добавить симп_мобам immune_to_ssd
<details>
Сорян, не заметил просьбу гетапа пофиксить это в том пре
</details>

## Почему и что этот ПР улучшит

Костылем меньше
## Авторство

## Чеинжлог
