### PR TITLE
Медхуды отображают данные с датчиков при экзамайне.

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -518,6 +518,10 @@
 		msg += "<span class = 'deptradio'>Physical status:</span> <a href='?src=\ref[src];medical=1'>\[[medical]\]</a>\n"
 		msg += "<span class = 'deptradio'>Medical records:</span> <a href='?src=\ref[src];medrecord=`'>\[View\]</a> <a href='?src=\ref[src];medrecordadd=`'>\[Add comment\]</a>\n"
 
+		var/obj/item/clothing/under/C = w_uniform
+		if(C.sensor_mode >= SUIT_SENSOR_VITAL)
+			msg += "<span class = 'deptradio'>Damage Specifics:</span> (<font color='blue'>[round(getOxyLoss(), 1)]</font>/<font color='green'>[round(getToxLoss(), 1)]</font>/<font color='#FFA500'>[round(getFireLoss(), 1)]</font>/<font color='red'>[round(getBruteLoss(), 1)]</font>)<br>"
+
 	var/datum/component/mood/mood = GetComponent(/datum/component/mood)
 	if(!skipface && mood)
 		switch(mood.shown_mood)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -519,7 +519,7 @@
 		msg += "<span class = 'deptradio'>Medical records:</span> <a href='?src=\ref[src];medrecord=`'>\[View\]</a> <a href='?src=\ref[src];medrecordadd=`'>\[Add comment\]</a>\n"
 
 		var/obj/item/clothing/under/C = w_uniform
-		if(C.sensor_mode >= SUIT_SENSOR_VITAL)
+		if(C?.sensor_mode >= SUIT_SENSOR_VITAL)
 			msg += "<span class = 'deptradio'>Damage Specifics:</span> (<font color='blue'>[round(getOxyLoss(), 1)]</font>/<font color='green'>[round(getToxLoss(), 1)]</font>/<font color='#FFA500'>[round(getFireLoss(), 1)]</font>/<font color='red'>[round(getBruteLoss(), 1)]</font>)<br>"
 
 	var/datum/component/mood/mood = GetComponent(/datum/component/mood)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Если у человечка включены датчики во второй или третий режим, то медхуд при экзамайне отобразит инфу с них, как это происходит в консоли.
![медхуд](https://user-images.githubusercontent.com/88531962/148531152-7c0d5e1e-d588-4a27-9989-2e4d48b06bc3.PNG)
![медхуд2](https://user-images.githubusercontent.com/88531962/148531166-bd4fa8b4-6da1-402c-aded-0e4ed8f0a733.PNG)
Если датчики выключены, то строка дэмедж спецификс просто не отображается.
## Почему и что этот ПР улучшит
Качество жизни.
## Авторство
Tap0r
## Чеинжлог
:cl:
 - tweak: Медхуды отображают данные с датчиков при экзамайне.