### PR TITLE
Update varedit.dm

### DIFF
--- a/code/__DEFINES/varedit.dm
+++ b/code/__DEFINES/varedit.dm
@@ -23,7 +23,7 @@
 #define VE_DEBUG \
 	list("vars", "virus", "viruses", "mutantrace", "summon_type", "AI_Interact", "key", "ckey", "client")
 #define VE_FULLY_LOCKED \
-	list("holder", "pixel_step_size", "player_next_age_tick", "player_ingame_age", "resize_rev", "step_x", "step_y", "smooth_icon_initial", "current_power_usage", "current_power_area", "script", "command_text")
+	list("holder", "glide_size", "player_next_age_tick", "player_ingame_age", "resize_rev", "step_x", "step_y", "smooth_icon_initial", "current_power_usage", "current_power_area", "script", "command_text")
 
 
 /* massmodify protected */
@@ -33,7 +33,7 @@
 #define VE_MASS_DEBUG \
 	list("vars", "virus", "viruses", "mutantrace", "summon_type", "AI_Interact")
 #define VE_MASS_FULLY_LOCKED \
-	list("holder", "pixel_step_size", "player_next_age_tick", "player_ingame_age", "resize_rev", "step_x", "step_y", "key", "ckey", "client", "smooth_icon_initial", "current_power_usage", "current_power_area", "script", "command_text")
+	list("holder", "glide_size", "player_next_age_tick", "player_ingame_age", "resize_rev", "step_x", "step_y", "key", "ckey", "client", "smooth_icon_initial", "current_power_usage", "current_power_area", "script", "command_text")
 
 /* hidden variables */
 #define VE_HIDDEN_LOG \


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Замена не используемого, по причине переименования, pixel_step_size на glide_size
## Почему и что этот ПР улучшит
Неизвестно что из-за этого не работало, но по идее теперь должно работать.