### PR TITLE
Раундстартовые 3ие датчики рабочей форме

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -737,7 +737,7 @@ BLIND     // can't see anything
 		to_chat(usr, "<span class='notice'>You cannot roll down the uniform!</span>")
 
 /obj/item/clothing/under/rank/atom_init()
-	sensor_mode = pick(SUIT_SENSOR_OFF, SUIT_SENSOR_BINARY, SUIT_SENSOR_VITAL, SUIT_SENSOR_TRACKING)
+	sensor_mode = SUIT_SENSOR_TRACKING
 	. = ..()
 
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
</br>

<details>
  <summary>Спойлер</summary>
</br>

 ![image](https://user-images.githubusercontent.com/75007994/149515036-f440d72f-2b21-4eab-87a6-0c4edd974c43.png)

</details>
</br>
</br>

![image](https://user-images.githubusercontent.com/75007994/149514110-afa6ac4f-8c89-4115-b2a3-bb454260c407.png)
^ ^ ^
Полностью согласен с киборгом

Датчики рабочей одежды теперь по умолчанию не в случайном режиме, а в третьем.

## Почему и что этот ПР улучшит
QoL медикам
## Авторство
## Чеинжлог
:cl:
- tweak: Датчики рабочей одежды теперь по умолчанию в третьем режиме.