### PR TITLE
Исправляем фаер алярм в эйр алярме в техах отбытия

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -38735,10 +38735,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 25
@@ -71111,6 +71107,20 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"fHn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "fIV" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Chief Engineer";
@@ -102570,7 +102580,7 @@ cnZ
 dib
 brq
 brK
-bbn
+fHn
 bbn
 bbn
 bee


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Было:
![Screenshot_782](https://user-images.githubusercontent.com/67812445/149570922-f0c93f2e-ed58-4d72-a271-f4ffe3062128.png)
Стало:
![Screenshot_783](https://user-images.githubusercontent.com/67812445/149570995-8ee2d7b6-7e4d-435d-ad4a-0293d8ed4e9f.png)
Так же можно посмотреть в мапдиффе
## Почему и что этот ПР улучшит
Недавно были ремапы и тд, исправляем ошибку

