### PR TITLE
Исправляем небольшие ошибки ремапа инженерного отдела

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -9417,6 +9417,10 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
+/obj/machinery/camera{
+	c_tag = "Engineering passage";
+	network = list("SS13","Engineering")
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "yellowcorner"
@@ -58898,11 +58902,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Engineering passage";
-	network = list("SS13","Engineering");
-	pixel_x = 32
-	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "yellow"
@@ -70488,14 +70487,6 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/station/medical/cmo)
-"eUe" = (
-/obj/machinery/light,
-/obj/machinery/atmospherics/components/binary/valve/digital/open,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/engineering/atmos)
 "eUl" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -120380,7 +120371,7 @@ bYU
 cen
 cfo
 cfV
-eUe
+uob
 cgV
 ctk
 chT


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
- removes universal pipe adapter
- changes posistion of camera

было:
![Screenshot_789](https://user-images.githubusercontent.com/67812445/149577002-a9a352af-f48b-4244-8a1c-69fe1f9b452c.png)
стало:
![Screenshot_790](https://user-images.githubusercontent.com/67812445/149577034-56106bfa-d9a5-48b2-a6e3-11426f689edf.png)
Где был удалён лишний адаптер нужно смотреть в мап диффе
## Почему и что этот ПР улучшит
Более правильное взаимодействие с камерой и не будет лишнего адаптера для труб не в положенном месте.
Из-за плохого расположения камеры, с ней можно было взаимодействовать с расстояния 2-х тайлов, сейчас нельзя.