### PR TITLE
Убирает требование доступа у консолей восстановления фауны и флоры

### DIFF
--- a/code/modules/research/xenoarchaeology/genetics/reconstitutor.dm
+++ b/code/modules/research/xenoarchaeology/genetics/reconstitutor.dm
@@ -14,7 +14,6 @@
 	icon = 'icons/obj/computer.dmi'
 	icon_state = "dna"
 	circuit = /obj/item/weapon/circuitboard/reconstitutor
-	req_access = list(access_xenoarch) //Only used for record deletion right now. //xenoarch couldn't use it when it was access_heads
 	var/obj/machinery/clonepod/pod1 = 1 //Linked cloning pod.
 	var/last_used = 0 // We don't want seeds getting spammed
 	var/temp = ""


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
fixes #6597
## Почему и что этот ПР улучшит
Ксенобиолог сможет пользоваться консолью восстановления фауны
## Авторство
SirSolar
## Чеинжлог
:cl:
 - bugfix: Для консолей восстановления фауны и флоры больше не требуется доступ ксеноархеологии.