### PR TITLE
Золото из хранилища лежит в сейфе, а не в незащищенном ящике

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -38372,17 +38372,6 @@
 /obj/structure/closet/crate{
 	name = "Gold Crate"
 	},
-/obj/item/stack/sheet/mineral/gold{
-	pixel_x = -1;
-	pixel_y = 5
-	},
-/obj/item/stack/sheet/mineral/gold{
-	pixel_y = 2
-	},
-/obj/item/stack/sheet/mineral/gold{
-	pixel_x = 1;
-	pixel_y = -2
-	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = -30
@@ -39324,6 +39313,17 @@
 /area/station/bridge/nuke_storage)
 "bsQ" = (
 /obj/structure/safe,
+/obj/item/stack/sheet/mineral/gold{
+	pixel_x = -1;
+	pixel_y = 5
+	},
+/obj/item/stack/sheet/mineral/gold{
+	pixel_y = 2
+	},
+/obj/item/stack/sheet/mineral/gold{
+	pixel_x = 1;
+	pixel_y = -2
+	},
 /obj/item/clothing/under/color/yellow,
 /obj/item/toy/katana,
 /turf/simulated/floor{


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Золотишко ушло в сейф, теперь вытаскивать его из хранилища раундстартом и плавить на всякие ништяки так просто не получится
## Почему и что этот ПР улучшит
Здравый смысл на месте и разного класса ролеплееры довольно урчат
## Авторство

## Чеинжлог
:cl:
 - map: Золото в хранилище находится в сейфе. 