### PR TITLE
Dreamcheker fixes and bump spacemanDMM version in ci

### DIFF
--- a/.github/workflows/ci_suite.yml
+++ b/.github/workflows/ci_suite.yml
@@ -9,7 +9,7 @@ on:
 env:
   BYOND_MAJOR: 514
   BYOND_MINOR: 1565
-  SPACEMAN_DMM_VERSION: suite-1.7
+  SPACEMAN_DMM_VERSION: suite-1.7.2
 jobs:
   DreamChecker:
     runs-on: ubuntu-20.04

--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -4,6 +4,11 @@
 //number of deciseconds in a day
 #define MIDNIGHT_ROLLOVER 864000
 
+// Define for coders.
+// If you want switch conditions to be fully specified in the switch body
+// and at the same time the empty condition do nothing.
+#define SWITCH_PASS ;
+
 //Ghost orbit types:
 #define GHOST_ORBIT_CIRCLE		"circle"
 #define GHOST_ORBIT_TRIANGLE	"triangle"

--- a/code/__DEFINES/spaceman_dmm.dm
+++ b/code/__DEFINES/spaceman_dmm.dm
@@ -2,7 +2,7 @@
 // is not in use.
 
 // The SPACEMAN_DMM define is set by the linter and other tooling when it runs.
-// See https://github.com/SpaceManiac/SpacemanDMM/tree/suite-1.6/src/dreamchecker
+// See https://github.com/SpaceManiac/SpacemanDMM/tree/suite-1.7.2/crates/dreamchecker
 #ifdef SPACEMAN_DMM
 	#define RETURN_TYPE(X) set SpacemanDMM_return_type = X
 	#define SHOULD_CALL_PARENT(X) set SpacemanDMM_should_call_parent = X

--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -270,9 +270,9 @@
 		switch(child)
 			if(/datum)
 				return null
-			if(/obj || /mob)
+			if(/obj, /mob)
 				return /atom/movable
-			if(/area || /turf)
+			if(/area, /turf)
 				return /atom
 			else
 				return /datum

--- a/code/datums/diseases/dna_spread.dm
+++ b/code/datums/diseases/dna_spread.dm
@@ -17,7 +17,7 @@
 /datum/disease/dnaspread/stage_act()
 	..()
 	switch(stage)
-		if(2 || 3) //Pretend to be a cold and give time to spread.
+		if(2, 3) //Pretend to be a cold and give time to spread.
 			if(prob(8))
 				affected_mob.emote("sneeze")
 			if(prob(8))

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -59,13 +59,12 @@
 			updateUsrDialog()
 			return
 		charges -= 1
-		switch(rand(1,2))
-			if(1)
-				temptext = "<font color=red><i><b>Double-crosser. You planned to betray us from the start. Allow us to repay the favor in kind.</b></i></font>"
-				updateUsrDialog()
-				spawn(rand(50,200))
-					selfdestruct()
-				return
+		if(prob(50))
+			temptext = "<font color=red><i><b>Double-crosser. You planned to betray us from the start. Allow us to repay the favor in kind.</b></i></font>"
+			updateUsrDialog()
+			spawn(rand(50,200))
+				selfdestruct()
+			return
 		if(istype(M, /mob/living/carbon/human))
 			var/mob/living/carbon/human/N = M
 			var/datum/role/traitor/wishgranter/T = create_and_setup_role(/datum/role/traitor/syndbeacon, N)

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -280,7 +280,7 @@ Gunshots/explosions/opening doors/less rare audio (done)
 					hal_screwyhud = 0
 
 			if(76 to 100)
-				break
+				continue
 
 	handling_hal = 0
 

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -279,6 +279,8 @@ Gunshots/explosions/opening doors/less rare audio (done)
 					hal_crit = 0
 					hal_screwyhud = 0
 
+			if(76 to 100)
+				break
 
 	handling_hal = 0
 

--- a/code/modules/mining/drilling/scanner.dm
+++ b/code/modules/mining/drilling/scanner.dm
@@ -58,10 +58,10 @@
 	for(var/ore in ore_list)
 		var/ore_type
 		switch(ore)
-			if("silicates" || "carbonaceous rock" || "iron") ore_type = "surface minerals"
-			if("gold" || "silver" || "diamond")              ore_type = "precious metals"
+			if("silicates", "carbonaceous rock", "iron") ore_type = "surface minerals"
+			if("gold", "silver", "diamond")              ore_type = "precious metals"
 			if("uranium")                                    ore_type = "nuclear fuel"
-			if("phoron" || "osmium" || "hydrogen")           ore_type = "exotic matter"
+			if("phoron", "osmium", "hydrogen")           ore_type = "exotic matter"
 
 		if(ore_type)
 			metals[ore_type] += ore_list[ore]

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -283,7 +283,7 @@
 						M.visible_message("<span class='notice'>[M] gently touches [src] trying to wake [t_him] up!</span>", \
 										"<span class='notice'>You gently touch [src] trying to wake [t_him] up!</span>")
 			else switch(M.get_targetzone())
-				if(BP_R_ARM || BP_L_ARM)
+				if(BP_R_ARM, BP_L_ARM)
 					M.visible_message( "<span class='notice'>[M] shakes [src]'s hand.</span>", \
 									"<span class='notice'>You shake [src]'s hand.</span>", )
 				if(BP_HEAD)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -247,6 +247,9 @@
 						if(3)
 							emote("drool")
 
+			if(19 to 200)
+				break
+
 /mob/living/carbon/human/proc/handle_mutations_and_radiation()
 
 	if(species.flags[IS_SYNTHETIC]) //Robots don't suffer from mutations or radloss.

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -248,7 +248,7 @@
 							emote("drool")
 
 			if(19 to 200)
-				break
+				return
 
 /mob/living/carbon/human/proc/handle_mutations_and_radiation()
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -209,7 +209,7 @@
 			if(10)
 				new_letter += "'"
 			if(11 to 15)
-				continue
+				SWITCH_PASS
 
 		new_text += new_letter
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -209,7 +209,7 @@
 			if(10)
 				new_letter += "'"
 			if(11 to 15)
-				break
+				continue
 
 		new_text += new_letter
 

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -202,12 +202,14 @@
 					new_letter = "х"
 
 		switch(rand(1,15))
-			if(1,3,5,8)
+			if(1 to 4)
 				new_letter = lowertext(new_letter)
-			if(2,4,6,15)
+			if(5 to 9)
 				new_letter = uppertext(new_letter)
-			if(7)
+			if(10)
 				new_letter += "'"
+			if(11 to 15)
+				break
 
 		new_text += new_letter
 

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -312,10 +312,10 @@
 	var/dir2 = 0
 	var/dir3 = 0
 	switch(direction)
-		if(NORTH||SOUTH)
+		if(NORTH, SOUTH)
 			dir2 = 4
 			dir3 = 8
-		if(EAST||WEST)
+		if(EAST, WEST)
 			dir2 = 1
 			dir3 = 2
 	var/turf/T2 = T


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Чел выпустил ПР, его замержили, и теперь ошибки в консоле ВСКода. Мне не нравится, поэтому ПР.

Бампнул версию в ci до актуального релиза.

## Почему и что этот ПР улучшит
Фикс ошибок. Послание автора

>is not uncommon in SS13 code. Sadly, it is also not uncommon for people to add new cases to a longer switch of this form and forget to change the rand arguments at the top. This PR adds a linter warning for when the rand range is not fully covered by the cases and for when a case lies completely outside of the rand range.
>This currently generates 7 warnings on tgstation master. Sadly, it is (at least to me) not quite clear if the omissions of a part of the rand range are intentional there or not. However, I believe that even if they are intentional it is worth adding the missing part of the range as a case with empty body explicitly to make the intent clear to future developers.
>As a less related (but perhaps more important) addition this PR now also adds a warning for switch branches of the form if(X || Y) which is pretty much always a mistake and should instead be if(X, Y). This lint generates 5 warnings on current tg code, seemingly all being actual mistakes.

## Авторство

## Чеинжлог
