### PR TITLE
Ритуалы, где требуется согласие, автоматические ассептяца у мобов без маенда

### DIFF
--- a/code/datums/components/rites/consent.dm
+++ b/code/datums/components/rites/consent.dm
@@ -39,6 +39,8 @@
 	if(!AOG.buckled_mob)
 		to_chat(user, "<span class='warning'>Требуется прикрепить жертву к алтарю.</span>")
 		return COMPONENT_CHECK_FAILED
+	if(!AOG.buckled_mob.mind)
+		return NONE
 	if(AOG.buckled_mob.mind && !AOG.buckled_mob.client)
 		to_chat(user, "<span class='warning'>Требуется сознательная жертва на алтаре.</span>")
 		return COMPONENT_CHECK_FAILED

--- a/code/datums/components/rites/consent.dm
+++ b/code/datums/components/rites/consent.dm
@@ -41,7 +41,7 @@
 		return COMPONENT_CHECK_FAILED
 	if(!AOG.buckled_mob.mind)
 		return NONE
-	if(AOG.buckled_mob.mind && !AOG.buckled_mob.client)
+	if(!AOG.buckled_mob.client)
 		to_chat(user, "<span class='warning'>Требуется сознательная жертва на алтаре.</span>")
 		return COMPONENT_CHECK_FAILED
 	if(!consent)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Ритуалы, где требуется согласие, автоматические ассептяца у мобов без маенда

## Почему и что этот ПР улучшит
Можно будет жертвовать пауками, макаками и прочей херней.

## Авторство

## Чеинжлог
:cl:
 - fix: Ритуалы, где требуется согласие, автоматические принимаются у мобов-ботов