### PR TITLE
Фикс рантаймов агента прослушки

### DIFF
--- a/code/datums/spawners_menu/spawners.dm
+++ b/code/datums/spawners_menu/spawners.dm
@@ -532,7 +532,6 @@ var/global/list/datum/spawners_cooldown = list()
 
 /datum/spawner/spy/spawn_ghost(mob/dead/observer/ghost)
 	var/spawnloc = pick(espionageagent_start)
-	espionageagent_start -= spawnloc
 
 	var/client/C = ghost.client
 
@@ -543,6 +542,7 @@ var/global/list/datum/spawners_cooldown = list()
 	H.loc = spawnloc
 	H.key = C.key
 	H.equipOutfit(/datum/outfit/spy)
+	espionageagent_start -= spawnloc
 
 	to_chat(H, "<B>Вы - <span class='boldwarning'>Агент Прослушки Синдиката</span>, в чьи задачи входит слежение за активностью на [station_name_ru()].</B>")
 	if(mode_has_antags())


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
```
    138 Runtime in spawners.dm:534 : pick() from empty list
    109 Runtime in spawners.dm:555 : pick() from empty list
```
Не знаю истинной причины этих рантаймов, но подозреваю, что какой-то игрок нажал на кнопку спавна и потом ливнул из игры. Лока убирается до инпута от юзера. А так как инпут, ПОИДЕЕ КРАШИТ ПРОК ЕСЛИ НЕТ ДОЛГОГО ОТВЕТА, то спавнер вернется в меню. А так как лока уже убралась из листа, то другие игроки не могут зайди поиграть.

На локалке я так и не убедился, что инпут реально крашит прок, а не тупо остается висеть.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
