### PR TITLE
Update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@
 
 ---
 
-[Baystation12](http://baystation12.net/)-based build with many changes from another upstream and sibling builds like:
-* [/tg/station13](https://tgstation13.org/)
-* [ParadiseSS13](http://nanotrasen.se/phpBB3/index.php)
-* [/vg/station13](http://ss13.pomf.se/)
-* [Goonstation](http://goonhub.com/)
+[Baystation12](https://bay.ss13.me)-based build with many changes from another upstream and sibling builds like:
+* [/tg/station13](https://tgstation13.org)
+* [ParadiseSS13](https://paradisestation.org)
+* [/vg/station13](http://ss13.moe)
+* [Goonstation](https://goonhub.com)
 
 
 ### LICENSE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Описание со старого сайта парадизов говорит само за себя

> The nanotrasen.se domain has been retired since early 2019.

> Please replace any links to nanotrasen.se with links to our new domain, paradisestation.org.

> AA07 2022-01-15: Youve had over 2 years to migrate your bookmarks, yet this domain still gets 2k hits a day. No more redirect. Update your bookmarks you lazy people

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
