### PR TITLE
miming cyborgs need not apply

### DIFF
--- a/code/datums/spells/mime.dm
+++ b/code/datums/spells/mime.dm
@@ -31,7 +31,7 @@
 	. = ..()
 	if(.)
 		var/mob/living/carbon/human/caster = user
-		if(!caster.miming)
+		if(!ishuman(caster) || !caster.miming)
 			return FALSE
 
 /obj/effect/proc_holder/spell/targeted/forcewall/mimewall/perform(list/targets, recharge, mob/living/carbon/human/user = usr)


### PR DESCRIPTION
## Описание изменений

`     51 Runtime in mime.dm:34 : undefined variable /mob/living/silicon/robot/var/miming`

истинная суть рантайма заключается в вопросе:
если мозг мима всадили киборгу, а потом достали и всадили в человека - мим должен мимировать?

я думаю да.

из-за того я думаю что да, нужно учитывать что спеллы полученные хуманом могут быть использованы вне тела хумана в процессе манипуляции мозгами которые наследуют майнд.

альтернативное решение: у мозга при доставании пропадают спеллы. оправдывается тем что мышечная память для колдунств остаётся в теле а не в мозге, и когда пересаживают в другое тело (или даже тоже) надо заново привыкать/учиться. но я на него не согласен, поэтому пока так

## Почему и что этот ПР улучшит

мелочь, но приятно
