### PR TITLE
Возвращение гиперцина. Простой нёрф.

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -316,6 +316,7 @@
 	charges["dermaline"]     = new /datum/rig_charge("dermaline",     "dermaline",     0)
 	charges["bicaridine"]    = new /datum/rig_charge("bicaridine",    "bicaridine",    0)
 	charges["oxycodone"]     = new /datum/rig_charge("oxycodone",     "oxycodone",     0)
+	charges["hyperzine"]     = new /datum/rig_charge("hyperzine",     "hyperzine",     0)
 
 /obj/item/rig_module/chem_dispenser/medical/ert // variant for the medical ert rigs
 	name = "hardsuit mounted chemical injector"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -294,14 +294,13 @@
 	required_reagents = list("lexorin" = 5, "peridaxon" = 5, "nanobots" = 1, "dexalinp" = 5, "sugar" = 5, "iron" = 5)
 	result_amount = 5
 
-/*
+
 /datum/chemical_reaction/hyperzine
 	name = "Hyperzine"
 	id = "hyperzine"
 	result = "hyperzine"
 	required_reagents = list("sugar" = 1, "phosphorus" = 1, "sulfur" = 1,)
 	result_amount = 3
-*/
 
 /datum/chemical_reaction/ryetalyn
 	name = "Ryetalyn"

--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -390,10 +390,11 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/ambrosiadeus/atom_init()
 	. = ..()
-	reagents.add_reagent("nutriment", 2)
-	reagents.add_reagent("bicaridine", 1+round(potency / 6, 1))
-	reagents.add_reagent("synaptizine", 1+round(potency / 6, 1))
-	reagents.add_reagent("space_drugs", 1+round(potency / 9, 1))
+	reagents.add_reagent("nutriment", 1)
+	reagents.add_reagent("bicaridine", 1+round(potency / 8, 1))
+	reagents.add_reagent("synaptizine", 1+round(potency / 8, 1))
+	reagents.add_reagent("hyperzine", 1+round(potency / 10, 1))
+	reagents.add_reagent("space_drugs", 1+round(potency / 10, 1))
 	bitesize = 1+round(reagents.total_volume / 2, 1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/apple

--- a/code/modules/reagents/reagent_types/Chemistry-Medicine.dm
+++ b/code/modules/reagents/reagent_types/Chemistry-Medicine.dm
@@ -549,15 +549,27 @@
 	description = "Hyperzine is a highly effective, long lasting, muscle stimulant."
 	reagent_state = LIQUID
 	color = "#ff4f00" // rgb: 200, 165, 220
-	custom_metabolism = 0.03
-	overdose = REAGENTS_OVERDOSE * 0.5
+	custom_metabolism = 0.1
+	overdose = REAGENTS_OVERDOSE * 0.3
 	taste_message = "speed"
 	restrict_species = list(IPC, DIONA)
 
-/datum/reagent/hyperizine/on_general_digest(mob/living/M)
+/datum/reagent/hyperzine/on_general_digest(mob/living/M)
 	..()
 	if(prob(5))
 		M.emote(pick("twitch","blink","shiver"))
+		M.adjustBrainLoss(1)
+	if(prob(20))
+		M.adjustOxyLoss(5)
+	if(prob(2))
+		M.adjustDrugginess(3)
+
+	if(volume >= overdose)
+		holder.remove_reagent("hyperzine", 0.1)
+		M.hallucination += 15
+		M.adjustDrugginess(2)
+		if(prob(30))
+			M.take_bodypart_damage(2, 0)
 
 /datum/reagent/cryoxadone
 	name = "Cryoxadone"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Гиперцин имеет те же свойства что раньше, но теперь имеет различные дебафы при использовании, а также передозировке. Уменьшено количество гиперцина в крови до передозировки, это означает, что наколоться гиперцином безнаказанно не получится, ко всему этому относится увеличение скорости усвоения гиперцина.
Если вколоть 5 единиц гиперцина, то его хватит на ~50 секунд, получается каждые ~50 секунд будет необходимо вкалывать по 5 единиц гиперцина. Передозировка наступает если вы вкололи более 9 единиц гиперцина, в принципе ничего страшного не будет, если вколоть 10 единиц, но вам накинется немного токси урона за это время.

Наложение дебафов:
При использовании гиперцина очень медленно будет накладываться брейндамаг, из-за чего в будущем нужно будет обратиться к врачу за алкизином. Персонажу тяжело дышать, в случае разгерметизации, если персонаж под гиперцином, но не имеет маски и баллона, есть шанс на разрыв лёгких.

Наложение дебафов при передозировке:
Это можно сравнить с наркотиком, у вас будут галлюцинации, страшные звуки, всё тело будет болеть.
Так же как и раньше при передозировке будет накидываться токсический урон.
## Почему и что этот ПР улучшит
Гиперцин более не является имбой, но можешь помочь игрокам на астероиде или просто быстро перенести человека в мед, данный препарат не действует долго, поэтому во время боя не сможет настолько сильно вносить импакта как раньше.
* closes: #7906
* closes: #7637

Исправлен баг из-за которого не отображались специальные эмоуты, которые вроде как должны были отображаться при использовании гиперцина.
## Авторство
Rahmano
## Чеинжлог
:cl: Rahmano
* tweak: Возвращение рецепта гиперцина в игру.
* balance[link]: Нёрф гиперцина.
* bugfix: Специальные эмоуты гиперцина теперь работают.