### PR TITLE
throwing items from within mobs

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -438,7 +438,14 @@
 
 	if(!item) return //Grab processing has a chance of returning null
 
-	remove_from_mob(item)
+	if(item.loc == src)
+		var/atom/to_loc = loc
+		if(ismob(to_loc))
+			to_loc = loc.loc
+		if(ismob(to_loc))
+			return
+		if(!remove_from_mob(item, to_loc))
+			return
 
 	//actually throw it!
 	if (item)


### PR DESCRIPTION
## Описание изменений

пока в телекинезе не изобрёл обобщеную систему для такого, вот такая вот затычечка.

если ты внутри моба предмет падает внутрь него, а не на пол - из-за чего и нельзя бросать

позволил бросать изнутри моба, но только на один слой рекурсии. мартышка в инвентаре мартышки в инвентаре моба бросать не сможет

## Почему и что этот ПР улучшит

fixes #8642 
