### PR TITLE
Pumped broken legs don't give speedup

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -65,8 +65,7 @@
 			tally += 0.8
 		else if(BP.status & ORGAN_BROKEN)
 			tally += 3
-
-		if(BP)
+		else
 			weight_negation += BP.pumped / 100
 
 	// hyperzine removes equipment slowdowns (no blood = no chemical effects).

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -66,7 +66,8 @@
 		else if(BP.status & ORGAN_BROKEN)
 			tally += 3
 
-		weight_negation += BP.pumped / 100
+		if(BP)
+			weight_negation += BP.pumped / 100
 
 	// hyperzine removes equipment slowdowns (no blood = no chemical effects).
 	var/chem_nullify_debuff = FALSE


### PR DESCRIPTION
## Описание изменений

поломанные или даже с шиной накачанные ноги баффа скорости не предоставляют

## Почему и что этот ПР улучшит

убирает рантайм, повышает градус ролевого плея

## Чеинжлог
:cl: Luduk
- tweak: Поломанные и ноги в шине не предоставляют баффа от накаченности