### PR TITLE
Технические ассистенты также смогут настраивать airlock electronics

### DIFF
--- a/code/game/machinery/doors/airlock_electronics.dm
+++ b/code/game/machinery/doors/airlock_electronics.dm
@@ -6,7 +6,7 @@
 	m_amt = 50
 	g_amt = 50
 
-	req_access = list(access_engine)
+	req_access = list(access_construction)
 
 	var/list/conf_access = list()
 	var/one_access = 0 //if set to 1, door would receive req_one_access instead of req_access


### PR DESCRIPTION
## Описание изменений
Понижает уровень допуска, нужный для настройки airlock electronics с engine - тот, который есть у полноценных инженеров и их подвидов, до construction, который есть ещё и у технических ассистентов (и у ГСБ и ГП?? ну это всё равно не их работа, и так сойдёт...)
## Почему и что этот ПР улучшит
Игровой процесс - теперь ещё больше игроков смогут самостоятельно построить свой собственный шлюз!
## Авторство

## Чеинжлог
:cl: Wandermu
 - tweak: Технические ассистенты смогут настраивать уровень доступа для шлюзов, которые они строят.