### PR TITLE
Фикс? Взрывов метеоритов в нуллспейсе

### DIFF
--- a/code/modules/events/meteors.dm
+++ b/code/modules/events/meteors.dm
@@ -215,7 +215,7 @@ var/global/list/obj/effect/meteor/meteors_dust = list(
 //or randomly when ramming turfs
 /obj/effect/meteor/proc/get_hit()
 	hits--
-	if(hits <= 0)
+	if(hits == 0)
 		make_debris()
 		meteor_effect()
 		qdel(src)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Понять причину рантайма было сложно даже с дебаггером, да даже с ним я не знаю точной причины, но я предполагаю, что могло быть виновато диагональное движение. Короче, почему-то по какой-то причине метеорит два раза вызывал /Bump() из-за чего два раза прокал взрыв. В первый раз взрыв был реальным, второй раз взрыв был в нуллспейсе.

<details> 
  <summary>Стак трейсы</summary>
  
![image](https://user-images.githubusercontent.com/26389417/155903619-2a5821ed-dad9-4f88-a1de-92116d5f93f9.png)

![image](https://user-images.githubusercontent.com/26389417/155903622-1887d17a-a9b9-4ade-bd0c-4d751b807a4a.png)


</details>

```

[14:43:35] Cannot read null.x in statistics_helpers.dm:60 :
proc name: add explosion stat (/datum/stat_collector/proc/add_explosion_stat)
  source file: statistics_helpers.dm,60
  usr: 0
  src: /datum/stat_collector (/datum/stat_collector)
  call stack:
/datum/stat_collector (/datum/stat_collector): add explosion stat(null, 1, 2, 3, 4)
explosion(null, 1, 2, 3, 4, 0, 1)
```

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
