### PR TITLE
sets point sampling as the default scaling. as it should be.

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -2,31 +2,31 @@ macro "default"
 
 
 menu "menu"
-	elem
+	elem 
 		name = "&File"
 		command = ""
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = "&Quick screenshot\tF2"
 		command = ".screenshot auto"
 		category = "&File"
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = "&Save screenshot as...\tShift+F2"
 		command = ".screenshot"
 		category = "&File"
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = ""
 		command = ""
 		category = "&File"
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = "&Quit"
 		command = ".quit"
 		category = "&File"
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = "&Icons"
 		command = ""
 		saved-params = "is-checked"
@@ -73,7 +73,7 @@ menu "menu"
 		can-check = true
 		group = "size"
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = ""
 		command = ""
 		category = "&Icons"
@@ -84,16 +84,9 @@ menu "menu"
 		category = "&Icons"
 		can-check = true
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = "&Scaling Mode"
 		command = ""
-		saved-params = "is-checked"
-	elem "nn"
-		name = "&Nearest Neighbor"
-		command = ".winset \"mapwindow.map.zoom-mode=distort\""
-		category = "&Scaling Mode"
-		can-check = true
-		group = "scaling"
 		saved-params = "is-checked"
 	elem "ps"
 		name = "&Point Sampling"
@@ -110,20 +103,27 @@ menu "menu"
 		can-check = true
 		group = "scaling"
 		saved-params = "is-checked"
-	elem
+	elem "nn"
+		name = "&Nearest Neighbor"
+		command = ".winset \"mapwindow.map.zoom-mode=distort\""
+		category = "&Scaling Mode"
+		can-check = true
+		group = "scaling"
+		saved-params = "is-checked"
+	elem 
 		name = "&Options"
 		command = ""
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = "&Audio"
 		command = ".showvolumecontrols"
 		category = "&Options"
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = "&Help"
 		command = ""
 		saved-params = "is-checked"
-	elem
+	elem 
 		name = "&Admin help\tF1"
 		command = "adminhelp"
 		category = "&Help"
@@ -135,25 +135,24 @@ window "mainwindow"
 		type = MAIN
 		pos = 281,0
 		size = 640x440
-		anchor1 = none
-		anchor2 = none
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		is-default = true
 		saved-params = "pos;size;is-minimized;is-maximized"
+		on-size = "onresize"
 		title = "Space Station 13"
 		statusbar = false
 		is-maximized = true
 		icon = 'icons\\ss13_64.png'
 		macro = "default"
 		menu = "menu"
-		on-size = "onresize"
 	elem "asset_cache_browser"
 		type = BROWSER
 		pos = 424,208
 		size = 1x1
-		anchor1 = none
-		anchor2 = none
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		is-visible = false
-		auto-format = false
 		saved-params = ""
 	elem "mainvsplit"
 		type = CHILD
@@ -168,21 +167,20 @@ window "mainwindow"
 		type = BROWSER
 		pos = 0,0
 		size = 999x999
-		anchor1 = none
-		anchor2 = none
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		text-color = #ffffff
 		background-color = #000000
 		is-visible = false
 		saved-params = ""
-		auto-format = false
 
 window "mapwindow"
 	elem "mapwindow"
 		type = MAIN
 		pos = 281,0
 		size = 640x480
-		anchor1 = none
-		anchor2 = none
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		saved-params = "pos;size;is-minimized;is-maximized"
 		titlebar = false
 		statusbar = false
@@ -210,20 +208,17 @@ window "mapwindow"
 		size = 640x480
 		anchor1 = 0,0
 		anchor2 = 100,100
-		background-color = none
 		is-visible = false
 		is-disabled = true
 		saved-params = ""
-		auto-format = false
 
 window "popupwindow"
 	elem "popupwindow"
 		type = MAIN
 		pos = 281,0
 		size = 120x120
-		anchor1 = none
-		anchor2 = none
-		background-color = none
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		is-visible = false
 		saved-params = "pos;size;is-minimized;is-maximized"
 		statusbar = false
@@ -234,8 +229,8 @@ window "outputwindow"
 		type = MAIN
 		pos = 281,0
 		size = 640x480
-		anchor1 = none
-		anchor2 = none
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		saved-params = "pos;size;is-minimized;is-maximized"
 		titlebar = false
 		statusbar = false
@@ -253,7 +248,6 @@ window "outputwindow"
 		is-visible = false
 		is-disabled = true
 		saved-params = ""
-		auto-format = false
 	elem "output"
 		type = OUTPUT
 		pos = 0,0
@@ -277,7 +271,7 @@ window "outputwindow"
 		pos = 600,460
 		size = 40x20
 		anchor1 = 100,100
-		anchor2 = none
+		anchor2 = -1,-1
 		saved-params = "is-checked"
 		text = "Chat"
 		command = ".winset \"saybutton.is-checked=true?input.command=\"!say \\\"\" macrobutton.is-checked=false:input.command=\"\"saybutton.is-checked=true?mebutton.is-checked=false\""
@@ -287,7 +281,7 @@ window "outputwindow"
 		pos = 560,460
 		size = 40x20
 		anchor1 = 100,100
-		anchor2 = none
+		anchor2 = -1,-1
 		saved-params = "is-checked"
 		text = "Emote"
 		command = ".winset \"mebutton.is-checked=true?input.command=\"!me \\\"\" macrobutton.is-checked=false:input.command=\"\"mebutton.is-checked=true?saybutton.is-checked=false\""
@@ -298,8 +292,8 @@ window "preferences_window"
 		type = MAIN
 		pos = 200,20
 		size = 810x770
-		anchor1 = none
-		anchor2 = none
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		is-visible = false
 		saved-params = ""
 		statusbar = false
@@ -327,8 +321,8 @@ window "barber_window"
 		type = MAIN
 		pos = 200,20
 		size = 620x680
-		anchor1 = none
-		anchor2 = none
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		is-visible = false
 		saved-params = ""
 		statusbar = false
@@ -356,8 +350,8 @@ window "rpane"
 		type = MAIN
 		pos = 281,0
 		size = 640x480
-		anchor1 = none
-		anchor2 = none
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		saved-params = "pos;size;is-minimized;is-maximized"
 		is-pane = true
 	elem "rpanewindow"
@@ -373,8 +367,8 @@ window "rpane"
 		type = BUTTON
 		pos = 278,0
 		size = 60x16
-		anchor1 = none
-		anchor2 = none
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		saved-params = "is-checked"
 		text = "Rules"
 		command = "rules"
@@ -383,16 +377,16 @@ window "rpane"
 		type = BROWSER
 		pos = 392,25
 		size = 1x1
-		anchor1 = none
-		anchor2 = none
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		is-visible = false
 		saved-params = ""
 	elem "changelog"
 		type = BUTTON
 		pos = 369,0
 		size = 67x16
-		anchor1 = none
-		anchor2 = none
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		saved-params = "is-checked"
 		text = "Changelog"
 		command = "Changelog"
@@ -401,8 +395,8 @@ window "rpane"
 		type = BUTTON
 		pos = 439,0
 		size = 67x16
-		anchor1 = none
-		anchor2 = none
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		font-style = "bold"
 		text-color = #ffffff
 		background-color = #7186f0
@@ -414,8 +408,8 @@ window "rpane"
 		type = BUTTON
 		pos = 509,0
 		size = 90x16
-		anchor1 = none
-		anchor2 = none
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		font-style = "bold"
 		text-color = #ffffff
 		background-color = #df3e3e
@@ -426,8 +420,8 @@ window "rpane"
 		type = BUTTON
 		pos = 215,0
 		size = 60x16
-		anchor1 = none
-		anchor2 = none
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		saved-params = "is-checked"
 		text = "Forum"
 		command = "forum"
@@ -436,8 +430,8 @@ window "rpane"
 		type = BUTTON
 		pos = 152,0
 		size = 60x16
-		anchor1 = none
-		anchor2 = none
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		saved-params = "is-checked"
 		text = "Wiki"
 		command = "wiki"
@@ -446,8 +440,8 @@ window "rpane"
 		type = BUTTON
 		pos = 0,0
 		size = 60x16
-		anchor1 = none
-		anchor2 = none
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		is-visible = false
 		saved-params = "is-checked"
 		text = "Text"
@@ -459,8 +453,8 @@ window "rpane"
 		type = BUTTON
 		pos = 464,0
 		size = 60x16
-		anchor1 = none
-		anchor2 = none
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		is-visible = false
 		saved-params = "is-checked"
 		text = "Browser"
@@ -471,8 +465,8 @@ window "rpane"
 		type = BUTTON
 		pos = 64,0
 		size = 60x16
-		anchor1 = none
-		anchor2 = none
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		is-visible = false
 		saved-params = "is-checked"
 		text = "Info"
@@ -485,8 +479,8 @@ window "browserwindow"
 		type = MAIN
 		pos = 281,0
 		size = 640x480
-		anchor1 = none
-		anchor2 = none
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		saved-params = "pos;size;is-minimized;is-maximized"
 		title = "Browser"
 		is-pane = true
@@ -507,8 +501,8 @@ window "infowindow"
 		type = MAIN
 		pos = 281,0
 		size = 640x480
-		anchor1 = none
-		anchor2 = none
+		anchor1 = -1,-1
+		anchor2 = -1,-1
 		saved-params = "pos;size;is-minimized;is-maximized"
 		title = "Info"
 		is-pane = true


### PR DESCRIPTION
## Описание изменений

![image](https://user-images.githubusercontent.com/17705613/156528139-837e91c1-0152-4bbd-b0fb-1eecfaa22659.png)

![image](https://user-images.githubusercontent.com/17705613/156528169-41e7e53b-aeaf-4dbb-8e43-cc258b988f4a.png)

Даже тут поинт сэмплинг называют "нормальным" скейлингом, в то время как ближайший сосед - искаженным.

Было:

![image](https://user-images.githubusercontent.com/17705613/156528306-e70db5b6-5e1a-4e6e-8cdf-20cc47edc167.png)

Стало:

![image](https://user-images.githubusercontent.com/17705613/156528325-71d141d2-5582-4967-9797-07c4a99e0762.png)

То есть просто сместил его вверх, чтобы он по дефолту был выбран.

## Почему и что этот ПР улучшит

Впервые заходящие космонавты не будут выкалывать себе глаза

## Проблемы

Я не знаю где оно сохраняет эти настройки у игроков и как, возможно у всех слетит эта настройка, плюс там что-то ещё кучу всего наменяло это я так понимаю обновило интерфейс?

## Чеинжлог
:cl: UDaV73rus
- tweak: Стандартный режим скейлинга установлен на "Point Sampling". Как и должно быть. У всех.