### PR TITLE
fixes runtime with revolver archaeo find

### DIFF
--- a/code/modules/research/xenoarchaeology/finds/finds.dm
+++ b/code/modules/research/xenoarchaeology/finds/finds.dm
@@ -386,10 +386,9 @@
 			if(prob(33))
 				new_gun.magazine.caliber = "999"
 
-			// 33% chance to fill it with a random amount of bullets
-			new_gun.magazine.max_ammo = rand(1,12)
+			// 33% chance to make the gun non-empty
 			if(prob(33))
-				var/num_bullets = rand(1,new_gun.magazine.max_ammo)
+				var/num_bullets = rand(1, new_gun.magazine.max_ammo)
 				new_gun.magazine.stored_ammo.len = num_bullets
 			else
 				new_gun.magazine.stored_ammo.len = 0


### PR DESCRIPTION
## Описание изменений

все мы знаем что в барабане револьвера 6 патронов.

не знают только пришельцы, в итоге иногда у револьвера были призрачные несуществующие патроны. список патронов говорил что в нём 12 элементов, а на деле 6 патронов и 6 null-ов.

мне влом выдумывать как правильно заполнять барабан для такого волшебного случая, потому просто сделал чтобы вместо рандом число от 1 до 12 - рандом число от 1 до макс. патронов в барабане.

## Почему и что этот ПР улучшит

меньше синих котов
