### PR TITLE
removing awaiting review exemptions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,7 +22,7 @@ jobs:
           close-pr-message: >
             ПР закрыт из-за длительного отсуствия активности. Для переоткрытия ПРа, пожалуйста, обратитесь к
             кому-либо из мейнтейнеров. Вы можете призвать их в комментарии слапнув ``@TauCetiStation/maintainers``.
-          exempt-pr-labels: 'Pinned, Awaiting Review [Translation Dep], Awaiting Review [Sprite Dep], Test Merge Candidate'
+          exempt-pr-labels: 'Pinned, Test Merge Candidate'
           stale-pr-label: 'Stalled PR'
           days-before-pr-stale: 14
           days-before-pr-close: 7


### PR DESCRIPTION
## Описание изменений

ПР-ы с метками Awaiting Review (спрайт/транс депом) не висят на гитхабе вечно.

## Почему и что этот ПР улучшит

Я надеюсь что напоминание что ПР скоро закроется по причине неактивности заставит авторов ПР-ов тормошить ревьюверов и байтить на ревью.

Если необходимо, можно добавить сообщение что-то типо "если отсутствие активности связано с отсутствием ревью, в зависимости от вида ПР-а дёрните ответственных людей, к примеру @Build Maintainers, @Translation Department, @Sprites Department"
