### PR TITLE
no runtimes on noticeboard qdel

### DIFF
--- a/code/game/objects/structures/noticeboard.dm
+++ b/code/game/objects/structures/noticeboard.dm
@@ -106,11 +106,14 @@
 
 	QDEL_LIST(notices)
 	for(var/hash in paper_icons)
-		var/list/icons = paper_icons[hash]
-		QDEL_LIST(icons)
+		var/I = paper_icons[hash]
+		qdel(I)
+	paper_icons = null
+
 	for(var/hash in photo_icons)
-		var/list/icons = photo_icons[hash]
-		QDEL_LIST(icons)
+		var/I = photo_icons[hash]
+		qdel(I)
+	photo_icons = null
 
 	QDEL_NULL(quest)
 


### PR DESCRIPTION
## Описание изменений

в связи с пережитком одной из имплементаций в которой по одному хешу было несколько картинок, то отдельные картинки интерпретировались как список, у них вызвыался прок .Cut которого у них нет, и рантайм.

## Почему и что этот ПР улучшит

меньше синих котов при взрывах

![image](https://user-images.githubusercontent.com/17705613/157450350-4e9191fc-709c-41c6-ae22-91b8a55fa9fd.png)

