### PR TITLE
Фикс статистики

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -223,8 +223,8 @@ var/global/list/frozen_items = list()
 			if(occupant && occupant.mind)
 				var/job = occupant.mind.assigned_role
 				SSjob.FreeRole(job)
-
-				SSStatistics.add_leave_stat(occupant.mind, "Cryopod")
+				if(occupant.ckey)
+					SSStatistics.add_leave_stat(occupant.mind, "Cryopod")
 
 			// Delete them from datacore.
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
К сожалению, я опять проебался. Щас дублируется в стате ливов инфа о ливе в крио и само крио. 


(лол хоп вошёл в игру на 4 минуты)
![image](https://user-images.githubusercontent.com/26389417/157727483-c45d64be-1835-4cfd-a87c-a1ff0d8f44f6.png)


## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
