### PR TITLE
Воксонёрфы

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -454,7 +454,7 @@
 			inhaled_gas_used = inhaling * ratio * BREATH_USED_PART
 		else
 			adjustOxyLoss(HUMAN_MAX_OXYLOSS)
-		
+
 		failed_last_breath = 1
 		throw_alert("oxy", /atom/movable/screen/alert/oxy)
 
@@ -660,7 +660,7 @@
 		throw_alert("pressure", /atom/movable/screen/alert/highpressure, 1)
 	else if(adjusted_pressure >= species.warning_low_pressure)
 		clear_alert("pressure")
-	else if(adjusted_pressure >= species.hazard_low_pressure)
+	else if(adjusted_pressure >= species.get_hazard_low_pressure(src))
 		throw_alert("pressure", /atom/movable/screen/alert/lowpressure, 1)
 	else
 		throw_alert("pressure", /atom/movable/screen/alert/lowpressure, 2)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -660,7 +660,7 @@
 		throw_alert("pressure", /atom/movable/screen/alert/highpressure, 1)
 	else if(adjusted_pressure >= species.warning_low_pressure)
 		clear_alert("pressure")
-	else if(adjusted_pressure >= species.get_hazard_low_pressure(src))
+	else if(adjusted_pressure >= species.hazard_low_pressure)
 		throw_alert("pressure", /atom/movable/screen/alert/lowpressure, 1)
 	else
 		throw_alert("pressure", /atom/movable/screen/alert/lowpressure, 2)

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -264,9 +264,6 @@
 /datum/species/proc/on_life(mob/living/carbon/human/H)
 	return
 
-/datum/species/proc/get_hazard_low_pressure(mob/living/carbon/human/H)
-	return hazard_low_pressure
-
 /datum/species/human
 	name = HUMAN
 	language = LANGUAGE_SOLCOMMON
@@ -479,6 +476,9 @@
 	unarmed_type = /datum/unarmed_attack/claws	//I dont think it will hurt to give vox claws too.
 	dietflags = DIET_OMNI
 
+	warning_low_pressure = 50
+	hazard_low_pressure = 0
+
 	cold_level_1 = 80
 	cold_level_2 = 50
 	cold_level_3 = 0
@@ -586,13 +586,6 @@
 		H.verbs -= /mob/living/carbon/human/proc/gut
 
 	..()
-
-/datum/species/vox/get_hazard_low_pressure(mob/living/carbon/human/H)
-	var/dam = H.getBruteLoss() + H.getFireLoss()
-	if(dam > 1)
-		return hazard_low_pressure
-
-	return 0
 
 /datum/species/vox/armalis
 	name = VOX_ARMALIS

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -264,6 +264,9 @@
 /datum/species/proc/on_life(mob/living/carbon/human/H)
 	return
 
+/datum/species/proc/get_hazard_low_pressure(mob/living/carbon/human/H)
+	return hazard_low_pressure
+
 /datum/species/human
 	name = HUMAN
 	language = LANGUAGE_SOLCOMMON
@@ -476,9 +479,6 @@
 	unarmed_type = /datum/unarmed_attack/claws	//I dont think it will hurt to give vox claws too.
 	dietflags = DIET_OMNI
 
-	warning_low_pressure = 50
-	hazard_low_pressure = 0
-
 	cold_level_1 = 80
 	cold_level_2 = 50
 	cold_level_3 = 0
@@ -586,6 +586,13 @@
 		H.verbs -= /mob/living/carbon/human/proc/gut
 
 	..()
+
+/datum/species/vox/get_hazard_low_pressure(mob/living/carbon/human/H)
+	var/dam = H.getBruteLoss() + H.getFireLoss()
+	if(dam > 1)
+		return hazard_low_pressure
+
+	return 0
 
 /datum/species/vox/armalis
 	name = VOX_ARMALIS

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -528,14 +528,12 @@
 		SPRITE_SHEET_GLOVES = 'icons/mob/species/vox/gloves.dmi'
 		)
 
-	survival_kit_items = list(/obj/item/weapon/tank/emergency_nitrogen,
-							/obj/item/clothing/mask/gas/vox,
-							/obj/item/weapon/storage/firstaid/small_firstaid_kit/nutriment,
-							/obj/item/weapon/reagent_containers/hypospray/autoinjector/antitox
-	                          )
+	survival_kit_items = list(
+		/obj/item/weapon/tank/emergency_nitrogen,
+		/obj/item/weapon/reagent_containers/syringe/nutriment,
+	)
 
 	prevent_survival_kit_items = list(/obj/item/weapon/tank/emergency_oxygen) // So they don't get the big engi oxy tank, since they need no tank.
-
 
 	min_age = 1
 	max_age = 100
@@ -545,30 +543,14 @@
 /datum/species/vox/handle_post_spawn(mob/living/carbon/human/H)
 	H.gender = NEUTER
 
-	replace_outfit = list(
-			/obj/item/clothing/shoes/boots/combat = /obj/item/clothing/shoes/magboots/vox
-			)
-
 /datum/species/vox/after_job_equip(mob/living/carbon/human/H, datum/job/J, visualsOnly = FALSE)
 	..()
+
 	if(H.wear_mask)
 		qdel(H.wear_mask)
 	H.equip_to_slot_or_del(new /obj/item/clothing/mask/gas/vox(src), SLOT_WEAR_MASK)
-	if(!H.r_store)
-		H.equip_to_slot_or_del(new /obj/item/weapon/tank/emergency_nitrogen/double(src), SLOT_R_STORE)
-		H.internal = H.r_store
-	else if(!H.l_store)
-		H.equip_to_slot_or_del(new /obj/item/weapon/tank/emergency_nitrogen/double(src), SLOT_L_STORE)
-		H.internal = H.l_store
-	else if(!H.r_hand)
-		H.equip_to_slot_or_del(new /obj/item/weapon/tank/emergency_nitrogen/double(src), SLOT_R_HAND)
-		H.internal = H.r_hand
-	else if(!H.l_hand)
-		H.equip_to_slot_or_del(new /obj/item/weapon/tank/emergency_nitrogen/double(src), SLOT_L_HAND)
-		H.internal = H.l_hand
-	if(H.shoes)
-		qdel(H.shoes)
-	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/magboots/vox(src), SLOT_SHOES)
+
+	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal(H), SLOT_SHOES, 1)
 
 /datum/species/vox/call_digest_proc(mob/living/M, datum/reagent/R)
 	return R.on_vox_digest(M)

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -455,3 +455,11 @@
 	reagents.add_reagent("mulligan", 1)
 	mode = SYRINGE_INJECT
 	update_icon()
+
+/obj/item/weapon/reagent_containers/syringe/nutriment
+
+/obj/item/weapon/reagent_containers/syringe/nutriment/atom_init()
+	. = ..()
+	reagents.add_reagent("nutriment", 15)
+	mode = SYRINGE_INJECT
+	update_icon()

--- a/code/modules/reagents/reagent_types/Chemistry-Core.dm
+++ b/code/modules/reagents/reagent_types/Chemistry-Core.dm
@@ -426,6 +426,11 @@
 	..()
 	M.nutrition += 4 * REM
 
+/datum/reagent/sugar/on_vox_digest(mob/living/M)
+	..()
+	M.adjustToxLoss(REAGENTS_METABOLISM * 0.5)
+	return FALSE
+
 /datum/reagent/radium
 	name = "Radium"
 	id = "radium"


### PR DESCRIPTION
## Описание изменений

Недостатки ксеносов не должны ставать поводом выдавать кучу гигаманчшмота. Если у ксеноса единственная слабость - химия, это не значит что ему нужно давать мгновенный контр недостатка (инъектор диловена)

Если у ксеноса недостаток - неумение кушать еду, это не повод давать подсумок на 6 слотов(аптечку) наполненную халявной едой (смотрю на ноющих о нехватке денег на еду ассистух)

Не относящееся к этому аргументу замечание, о том что выдача им на шару ноуслип магбутсов без замедла вообще ничем не оправдана.

Соответственно принял такие решения:
- Выпиливаю раундстартовые воксобутсы
- Выпиливаю аптечку с едой, заменяя на шприц с едой
- Выпиливаю инъектор диловена

Бонусом в связи с тем что воксу !!!шок!!! придётся теперь искать еду на станции запрещаю пользоваться самым простым реагентом для набирания веса - сахаром. У них теперь от сахара отравление.

Запасную маску и баллон выпиливаю по причине втф почему оно вообще есть

## Почему и что этот ПР улучшит

станционные воксы совсем чуть-чуть менее имба но лип это всё ещё пепега

Думаю что эти нерфы не должны затронуть режимных воксов так что пока плевать и не нужно делать радикальных изменений типо отдельного вида воксов для станции и для режима.

## Чеинжлог
:cl: Luduk
- balance: У станционных воксов пропали раундстарт магбутсы, инъектор диловена, запасная маска. Аптечка с едой заменена на один шприц с едой.
- rscadd: Воксы травятся сахаром.
