### PR TITLE
Возможный фикс особки с призраками

### DIFF
--- a/code/datums/atom_huds/alternate_apperance.dm
+++ b/code/datums/atom_huds/alternate_apperance.dm
@@ -333,8 +333,8 @@ var/global/list/active_alternate_appearances = list()
 		if(mobShouldSee(M))
 			add_hud_to(M)
 
-/datum/atom_hud/alternate_appearance/basic/ghost_buster/mobShouldSee(mob/living/carbon/human/H)
-	if(HAS_TRAIT(H, TRAIT_GHOST_BUSTER))
+/datum/atom_hud/alternate_appearance/basic/ghost_buster/mobShouldSee(mob/M)
+	if(HAS_TRAIT(M, TRAIT_GHOST_BUSTER))
 		return TRUE
 	return FALSE
 

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -1,8 +1,8 @@
 /mob/Logout()
+	global.player_list -= src
 	set_typing_indicator(FALSE)
 	nanomanager.user_logout(src) // this is used to clean up (remove) this user's Nano UIs
 	SStgui.on_logout(src)
-	player_list -= src
 	log_access("Logout: [key_name(src)]")
 	if(admin_datums[src.ckey])
 		if(!(src.ckey in stealth_keys))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -20,6 +20,9 @@
 	ghostize(bancheck = TRUE)
 	my_religion?.remove_member(src)
 
+	// I dont known how
+	global.player_list -= src
+
 	if(mind)
 		if(mind.current == src)
 			mind.set_current(null)

--- a/code/modules/orbit/orbit.dm
+++ b/code/modules/orbit/orbit.dm
@@ -16,7 +16,11 @@
 	if (orbiter.orbiting)
 		orbiter.stop_orbit()
 	orbiter.orbiting = src
-	Check()
+
+	// NEVERMIND
+	if(!Check())
+		return
+
 	lock = _lock
 
 	SEND_SIGNAL(orbiter, COMSIG_MOVABLE_ORBIT_BEGIN, orbiting)
@@ -41,10 +45,10 @@
 /datum/orbit/proc/Check(turf/targetloc)
 	if (!orbiter)
 		qdel(src)
-		return
+		return FALSE
 	if (!orbiting)
 		orbiter.stop_orbit()
-		return
+		return FALSE
 	if (!orbiter.orbiting) //admin wants to stop the orbit.
 		orbiter.orbiting = src //set it back to us first
 		orbiter.stop_orbit()
@@ -53,11 +57,12 @@
 		targetloc = get_turf(orbiting)
 	if (!targetloc || (!lock && orbiter.loc != lastloc && orbiter.loc != targetloc))
 		orbiter.stop_orbit()
-		return
+		return FALSE
 
 	orbiter.loc = targetloc
 	orbiter.update_parallax_contents()
 	lastloc = orbiter.loc
+	return TRUE
 
 
 /atom/movable/var/datum/orbit/orbiting = null


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Фиксит ли это `Cannot read null.comp_lookup in orbit.dm:22` ? Да, должно. Фиксит ли это ` Cannot read null.status_traits in alternate_apperance.dm:337` я незнаю. 

В раунде не было рантаймов в Logout и в Destroy, а значит моб должен был уйти из плеер листа, но он не ушёл..
Если что, при дестрое моба примерно такой стэк вызовов.
 * Before Ghostize
 * Before Logout
 * Logout
 * Login
 * After Logout
 * After Ghostize

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
