### PR TITLE
lectern can't be flipped while anchored

### DIFF
--- a/code/game/objects/structures/chapel.dm
+++ b/code/game/objects/structures/chapel.dm
@@ -502,7 +502,7 @@ ADD_TO_GLOBAL_LIST(/obj/effect/effect/bell, bells)
 	return ..()
 
 /obj/structure/stool/bed/chair/lectern/can_flip(mob/living/carbon/human/user)
-	if(!anchored)
+	if(anchored)
 		return FALSE
 	return ..()
 


### PR DESCRIPTION
## Описание изменений

трибуну можно было перевернуть не открутив из-за чего нельзя было потом поднять

## Почему и что этот ПР улучшит

трибуну сломать будет трудней

## Чеинжлог
:cl: Luduk
- bugfix: Трибуну капеллана нельзя опрокинуть не открутив.