### PR TITLE
Временное решение подсветкапроблемы

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -233,6 +233,8 @@ var/global/regex/code_response_highlight_rule
 	return
 
 /proc/highlight_traitor_codewords(message, datum/mind/traitor_mind)
+	return message
+	/*
 	if(!traitor_mind)
 		return message
 
@@ -260,3 +262,4 @@ var/global/regex/code_response_highlight_rule
 			message = highlight_codewords(message, global.code_response_highlight_rule, "deptradio")
 
 	return message
+	*/


### PR DESCRIPTION
## Описание изменений

ещё не разобрался конкретно что к чему, но даже если откатить #8810 проблема остаётся.

пока подозреваю только что 1582 Бьёнд и изменения Люммокса replacetext-а что-то сломали...

Шаги к восспроизведению проблемы:
- Зайти за таяру (даже откатив #8810)
- Выдать себе триторку
- Сказать "Рр".
- Текст подсветится 🤷 

## Почему и что этот ПР улучшит

не будет ужасных приколямбасов с обрывками <span class= или кракозябр у тритора в чате.

fixes #8865 
