### PR TITLE
dead mobs don't emote

### DIFF
--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -27,3 +27,6 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 
 /mob/dead/incapacitated(restrained_type = ARMS)
 	return !IsAdminGhost(src)
+
+/mob/dead/me_emote(message, message_type = SHOWMSG_VISUAL, intentional=FALSE)
+	return emote("me", message=message, auto=!intentional)


### PR DESCRIPTION
## Описание изменений

с рефактором эмоутов само собой пофиксилось бы, но баг критический так что пока так.

запрещает обзерверам эмоутить в чат живых.

## Почему и что этот ПР улучшит

атмосферу ролевой игры
