### PR TITLE
Фиксит баг когда можно было избежать задержки скила в tgui если прервать действие

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -342,7 +342,7 @@ Class Procs:
 	add_fingerprint(usr)
 
 	if(!do_skill_checks(usr))
-		return FALSE
+		return TRUE
 	return FALSE
 
 /obj/machinery/proc/issilicon_allowed(mob/living/silicon/S)


### PR DESCRIPTION
Фиксит #8982 . Теперь tgui_act возвращает нормальное значение если было прервано действие