### PR TITLE
Генокрады неправильно копировали умения своей жертвы

### DIFF
--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -40,8 +40,8 @@
 	update_available()
 
 /datum/skills/proc/transfer_skills(datum/mind/target)
-	for(var/datum/skillset/s as anything in target.skills.available_skillsets)
-		add_available_skillset(s)
+	LAZYADD(available_skillsets, target.skills.available_skillsets)
+	update_available()
 
 /datum/skills/proc/choose_value(skill_name,value)
 	var/datum/skill/skill = active.get_skill(skill_name)


### PR DESCRIPTION
Неправильно прибавлялись умения жертвы к умениям генокрада, из-за чего генокрад не мог использовать навыки жертвы.