### PR TITLE
Поправка наборов умений для некоторых профессий

### DIFF
--- a/code/modules/skills/skillsets.dm
+++ b/code/modules/skills/skillsets.dm
@@ -164,7 +164,8 @@
 		/datum/skill/surgery/trained,
 		/datum/skill/medical/pro,
 		/datum/skill/research/novice,
-		/datum/skill/firearms/trained
+		/datum/skill/firearms/trained,
+		/datum/skill/police/trained
 	)
 
 /datum/skillset/detective
@@ -172,7 +173,8 @@
 		/datum/skill/police/trained,
 		/datum/skill/firearms/master,
 		/datum/skill/medical/novice,
-		/datum/skill/melee/trained
+		/datum/skill/surgery/novice,
+		/datum/skill/melee/trained,
 	)
 
 //science
@@ -227,16 +229,24 @@
 
 /datum/skillset/roboticist/bio
 	initial_skills = list(
+		/datum/skill/research/pro,
 		/datum/skill/surgery/pro,
-		/datum/skill/civ_mech/trained
+		/datum/skill/medical/pro,
+		/datum/skill/construction/trained,
+		/datum/skill/engineering/novice,
+		/datum/skill/civ_mech/trained,
+		/datum/skill/combat_mech/trained
 	)
 
 /datum/skillset/roboticist/mecha
 	initial_skills = list(
+		/datum/skill/research/pro,
+		/datum/skill/surgery/novice,
+		/datum/skill/medical/novice,
 		/datum/skill/construction/pro,
-		/datum/skill/combat_mech/master,
+		/datum/skill/engineering/trained,
 		/datum/skill/civ_mech/master,
-		/datum/skill/surgery/novice
+		/datum/skill/combat_mech/master
 	)
 
 /datum/skillset/xenoarchaeologist


### PR DESCRIPTION
Исправляет:

- Подпрофы роботеха (раньше они не могли нормально работать со своими консолями). Теперь работает, как и было задумано: Базовая професия - универсальная что умерено хорошо ставит протезы, водит мехов, биомехатроник быстрее ставит протезы, но хуже водит мех, мехатроник лучше водит меха и чуть более продвинутый в инженерии, но хуже в хирургии и медицине.
- Добавляет криминалисту навык полиции
- Добавляет детективу чуть медицины и хирургии.