### PR TITLE
Флеши для боргов

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -112,6 +112,7 @@
 
 /obj/item/weapon/robot_module/medical/atom_init()
 	. = ..()
+	modules += new /obj/item/device/flash(src)
 	modules += new /obj/item/device/healthanalyzer(src)
 	modules += new /obj/item/weapon/reagent_containers/borghypo/medical(src)
 	modules += new /obj/item/weapon/scalpel/manager(src)
@@ -306,6 +307,7 @@
 
 /obj/item/weapon/robot_module/miner/atom_init()
 	. = ..()
+	modules += new /obj/item/device/flash(src)
 	modules += new /obj/item/borg/sight/meson(src)
 	modules += new /obj/item/weapon/wrench(src)
 	modules += new /obj/item/weapon/screwdriver(src)
@@ -364,6 +366,7 @@
 
 /obj/item/weapon/robot_module/science/atom_init()
 	. = ..()
+	modules += new /obj/item/device/flash(src)
 	modules += new /obj/item/weapon/gripper/science(src)
 	modules += new /obj/item/device/analyzer(src)
 	modules += new /obj/item/device/assembly/signaler(src)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
closes #9017 
При сборке боргов используются флешеры, так почему не дать флешер всем боргам?
Флешер почти всегда будет полезен при разрешении конфликтов между человеками.
Флешер остановит клоуна от кражи ящика с рудой.
При борьбе боргов с разными модулями борьба неравна: один имеет возможность косвенно застанить, а второй - нет.
У науч. модуля будет меньше поводов заливать смазку в петушитель
## Почему и что этот ПР улучшит
Боргам станет легче в жестоком мире человеков
## Авторство

## Чеинжлог
:cl:
- tweak: флеши всем боргам