### PR TITLE
Небольшие изменения в снаряжении ОБОПа

### DIFF
--- a/code/game/gamemodes/modes_gameplays/families/outfit.dm
+++ b/code/game/gamemodes/modes_gameplays/families/outfit.dm
@@ -72,7 +72,7 @@
 
 /datum/outfit/families_police/beatcop/fbi
 	name = "Families: Инспектор"
-	suit = /obj/item/clothing/suit/armor/laserproof
+	suit = /obj/item/clothing/suit/armor/vest/fullbody
 	back = /obj/item/weapon/storage/backpack/satchel
 	head = /obj/item/clothing/head/beret/spacepolice
 	glasses = /obj/item/clothing/glasses/sunglasses/big
@@ -87,7 +87,7 @@
 /datum/outfit/families_police/beatcop/military
 	name = "Families: Боец ВСНТ"
 	uniform = /obj/item/clothing/under/tactical/marinad
-	suit = /obj/item/clothing/suit/marinad
+	suit = /obj/item/clothing/suit/armor/marinad
 	head = /obj/item/clothing/head/helmet/tactical/marinad
 	belt = /obj/item/weapon/storage/belt/security/tactical/cops
 	gloves = /obj/item/clothing/gloves/security/marinad

--- a/code/game/objects/structures/crates_lockers/closets/wardrobe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/wardrobe.dm
@@ -410,7 +410,7 @@
 	new /obj/item/weapon/storage/backpack/dufflebag/marinad(src)
 	new /obj/item/clothing/gloves/security/marinad(src)
 	new /obj/item/clothing/head/helmet/tactical/marinad(src)
-	new /obj/item/clothing/suit/marinad(src)
+	new /obj/item/clothing/suit/armor/marinad(src)
 	new /obj/item/clothing/under/tactical/marinad(src)
 	new /obj/item/clothing/glasses/sunglasses/hud/sechud/tactical(src)
 	new /obj/item/weapon/storage/belt/security/tactical(src)

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -50,7 +50,7 @@
 	pockets = new/obj/item/weapon/storage/internal(src)
 	pockets.set_slots(slots = 4, slot_size = SIZE_TINY)
 
-/obj/item/clothing/suit/marinad
+/obj/item/clothing/suit/armor/marinad
 	name = "marine armor"
 	desc = "This thing will protect you from any angry flora or fauna."
 	icon_state = "marinad"

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -860,6 +860,9 @@
 	body_parts_covered = 1
 	pierce_protection = HEAD
 	flags = HEADCOVERSEYES
+	flags_inv = HIDEEARS
+	siemens_coefficient = 0.3
+	flashbang_protection = TRUE
 
 /obj/item/clothing/under/henchmen
 	name = "henchmen jumpsuit"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Заменил аблятивную броню у инспекторов ОБОПа на фуллбади армоур.
Добавил Нанотрасеновскому берету защиту ушей.
Пофиксил то что броня маринов почему-то была обычной одеждой с защитой, а не полноценной броней
## Почему и что этот ПР улучшит
Инспекторов больше не будут убивать тремя пулями из стечкина.
Инспектора больше не будут падать в стан из-за своих же флешек
## Авторство
## Чеинжлог
🆑 Simbaka
- balance: Аблятивная броня у инспекторов ОБОПа была заменена на стандартную.
- bugfix: Береты инспекторов не защищали уши от светошумовых гранат.