### PR TITLE
Воксы-синдикатовцы теперь появляются в combat boots

### DIFF
--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -543,6 +543,10 @@
 
 	prohibit_roles = list(ROLE_CHANGELING, ROLE_WIZARD)
 
+	replace_outfit = list(
+			/obj/item/clothing/shoes/boots/combat = /obj/item/clothing/shoes/boots/combat/cut
+			)
+
 /datum/species/vox/handle_post_spawn(mob/living/carbon/human/H)
 	H.gender = NEUTER
 


### PR DESCRIPTION
## Описание изменений
Добавил замену combat boots на mangled combat boots у воксов
## Почему и что этот ПР улучшит
Вокс-нюкер раньше появлялся без ботинок. Теперь у вокса есть ботиночки.
## Авторство
я
## Чеинжлог
:cl:
- bugfix: Вокс в режиме нюки будет появляться в combat boots