### PR TITLE
QoL у культа при уничтожении аномалий

### DIFF
--- a/code/game/gamemodes/modes_gameplays/cult/structures/cult_structures.dm
+++ b/code/game/gamemodes/modes_gameplays/cult/structures/cult_structures.dm
@@ -246,6 +246,8 @@
 		destroying(user.my_religion)
 
 /obj/structure/cult/anomaly/proc/async_destroying(datum/religion/cult/C)
+	density = FALSE
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	animate(src, 1 SECONDS, alpha = 0)
 	sleep(1 SECONDS)
 	qdel(src)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
При клике на аномалию она мгновенно становится прозрачной для мышки, теряет прозрачность. Раньше же ты когда кликаешь на скопление аномалий на одном турфе, то нужно было ждать 1 секунду прежде чем была возможность сломать еще одну. короче бесило. 
Я же сделал процесс менее противным.

## Почему и что этот ПР улучшит
QoL

## Авторство

## Чеинжлог
:cl: 
 - tweak: Аномалии культа в раю при уничтожении сразу же теряют физические свойства, а не через 1 секунду.