### PR TITLE
Фикс скиллов гост ролей и дронов

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -644,15 +644,17 @@
 	if(mind)
 		mind.key = key
 	else
-		mind = new /datum/mind(key)
-		mind.original = src
-		if(SSticker)
-			SSticker.minds += mind
-		else
-			world.log << "## DEBUG: mind_initialize(): No SSticker ready yet! Please inform Carn"
+		create_mind()
 	if(!mind.name)	mind.name = real_name
 	mind.set_current(src)
 
+/mob/proc/create_mind()
+	mind = new /datum/mind(key)
+	mind.original = src
+	if(SSticker)
+		SSticker.minds += mind
+	else
+		world.log << "## DEBUG: mind_initialize(): No SSticker ready yet! Please inform Carn"
 
 //HUMAN
 /mob/living/carbon/human/mind_initialize()

--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -53,3 +53,6 @@
 		return
 	to_chat(usr, "<span class='notice'>You changed your skill proficiency in [skill_name] from [active.get_value(skill_name)] to [value].</span>")
 	active.set_value(skill_name, value)
+
+/datum/skills/proc/has_skillset_type(type)
+	return all_skillsets[type] in available_skillsets

--- a/code/datums/skills.dm
+++ b/code/datums/skills.dm
@@ -53,6 +53,3 @@
 		return
 	to_chat(usr, "<span class='notice'>You changed your skill proficiency in [skill_name] from [active.get_value(skill_name)] to [value].</span>")
 	active.set_value(skill_name, value)
-
-/datum/skills/proc/has_skillset_type(type)
-	return all_skillsets[type] in available_skillsets

--- a/code/datums/spawners_menu/spawners.dm
+++ b/code/datums/spawners_menu/spawners.dm
@@ -596,6 +596,8 @@ var/global/list/datum/spawners_cooldown = list()
 	H.loc = spawnloc
 	H.key = C.key
 	H.equipOutfit(/datum/outfit/spy)
+	H.mind.skills.add_available_skillset(/datum/skillset/max)
+	H.mind.skills.maximize_active_skills()
 
 	to_chat(H, "<B>Вы - <span class='boldwarning'>Агент Прослушки Синдиката</span>, в чьи задачи входит слежение за активностью на [station_name_ru()].</B>")
 	if(mode_has_antags())

--- a/code/datums/spawners_menu/spawners.dm
+++ b/code/datums/spawners_menu/spawners.dm
@@ -596,7 +596,7 @@ var/global/list/datum/spawners_cooldown = list()
 	H.loc = spawnloc
 	H.key = C.key
 	H.equipOutfit(/datum/outfit/spy)
-	H.mind.skills.add_available_skillset(/datum/skillset/max)
+	H.mind.skills.add_available_skillset(/datum/skillset/cyborg)
 	H.mind.skills.maximize_active_skills()
 
 	to_chat(H, "<B>Вы - <span class='boldwarning'>Агент Прослушки Синдиката</span>, в чьи задачи входит слежение за активностью на [station_name_ru()].</B>")

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -241,6 +241,7 @@
 
 			O.job = "Cyborg"
 			O.mind.skills.add_available_skillset(/datum/skillset/cyborg)
+			O.mind.skills.maximize_active_skills()
 			O.cell = chest.cell
 			O.cell.forceMove(O)
 			I.forceMove(O) //Should fix cybros run time erroring when blown up. It got deleted before, along with the frame.

--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -240,7 +240,7 @@
 				O.mind.store_memory("In case you look at this after being borged, the objectives are only here until I find a way to make them not show up for you, as I can't simply delete them without screwing up round-end reporting. --NeoFite")
 
 			O.job = "Cyborg"
-			O.mind.skills.add_available_skillset(/datum/skillset/max)
+			O.mind.skills.add_available_skillset(/datum/skillset/cyborg)
 			O.cell = chest.cell
 			O.cell.forceMove(O)
 			I.forceMove(O) //Should fix cybros run time erroring when blown up. It got deleted before, along with the frame.

--- a/code/modules/mob/living/carbon/metroid/metroid.dm
+++ b/code/modules/mob/living/carbon/metroid/metroid.dm
@@ -744,6 +744,8 @@
 
 	to_chat(G, "You are an adamantine golem. You move slowly, but are highly resistant to heat and cold as well as blunt trauma. You are unable to wear clothes, but can still use most tools. Serve [H], and assist them in completing their goals at any cost.")
 	G.mind.memory += "<B>[H]</B> - your master."
+	G.mind.skills.add_available_skillset(/datum/skillset/max)
+	G.mind.skills.maximize_active_skills()
 	qdel(src)
 
 /obj/effect/golemrune/proc/announce_to_ghosts()

--- a/code/modules/mob/living/carbon/metroid/metroid.dm
+++ b/code/modules/mob/living/carbon/metroid/metroid.dm
@@ -744,7 +744,7 @@
 
 	to_chat(G, "You are an adamantine golem. You move slowly, but are highly resistant to heat and cold as well as blunt trauma. You are unable to wear clothes, but can still use most tools. Serve [H], and assist them in completing their goals at any cost.")
 	G.mind.memory += "<B>[H]</B> - your master."
-	G.mind.skills.add_available_skillset(/datum/skillset/max)
+	G.mind.skills.add_available_skillset(/datum/skillset/golem)
 	G.mind.skills.maximize_active_skills()
 	qdel(src)
 

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -224,6 +224,7 @@ var/global/list/ai_verbs_default = list(
 
 	if(mind)
 		mind.skills.add_available_skillset(/datum/skillset/max)
+		mind.skills.maximize_active_skills()
 
 /mob/living/silicon/ai/proc/announce_role()
 	to_chat(src, "<B>You are playing the station's AI. The AI cannot move, but can interact with many objects while viewing them (through cameras).</B>")

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -72,7 +72,8 @@
 	time_last_drone = world.time
 	var/mob/living/silicon/robot/drone/maintenance/new_drone = new(get_turf(src))
 	new_drone.transfer_personality(player)
-
+	new_drone.mind.skills.add_available_skillset(/datum/skillset/max)
+	new_drone.mind.skills.maximize_active_skills()
 	drone_progress = 0
 
 /mob/proc/dronize()

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -72,7 +72,7 @@
 	time_last_drone = world.time
 	var/mob/living/silicon/robot/drone/maintenance/new_drone = new(get_turf(src))
 	new_drone.transfer_personality(player)
-	new_drone.mind.skills.add_available_skillset(/datum/skillset/max)
+	new_drone.mind.skills.add_available_skillset(/datum/skillset/cyborg)
 	new_drone.mind.skills.maximize_active_skills()
 	drone_progress = 0
 

--- a/code/modules/mob/living/silicon/robot/syndi/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/syndi/drone/drone.dm
@@ -76,6 +76,10 @@
 	msg_cooldown = 5//in 2x of seconds (so 'cooldown 5' is 10 seconds)
 	key = M.key
 	M.key = "@[key]"
+	if(mind)
+		if(!(all_skillsets[/datum/skillset/max] in mind.skills.available_skillsets))
+			mind.skills.add_available_skillset(/datum/skillset/max)
+			mind.skills.maximize_active_skills()
 	to_chat(src, "You're now controlling the [name].")
 
 /mob/living/silicon/robot/drone/syndi/proc/loose_control()

--- a/code/modules/mob/living/silicon/robot/syndi/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/syndi/drone/drone.dm
@@ -76,11 +76,12 @@
 	msg_cooldown = 5//in 2x of seconds (so 'cooldown 5' is 10 seconds)
 	key = M.key
 	M.key = "@[key]"
-	if(mind)
-		if(!mind.skills.has_skillset_type(/datum/skillset/cyborg))
-			mind.skills.add_available_skillset(/datum/skillset/cyborg)
-			mind.skills.maximize_active_skills()
 	to_chat(src, "You're now controlling the [name].")
+
+/mob/living/silicon/robot/drone/syndi/create_mind()
+	..()
+	mind.skills.add_available_skillset(/datum/skillset/cyborg)
+	mind.skills.maximize_active_skills()
 
 /mob/living/silicon/robot/drone/syndi/proc/loose_control()
 	if(!operator)

--- a/code/modules/mob/living/silicon/robot/syndi/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/syndi/drone/drone.dm
@@ -77,7 +77,7 @@
 	key = M.key
 	M.key = "@[key]"
 	if(mind)
-		if(!(all_skillsets[/datum/skillset/cyborg] in mind.skills.available_skillsets))
+		if(!mind.skills.has_skillset_type(/datum/skillset/cyborg))
 			mind.skills.add_available_skillset(/datum/skillset/cyborg)
 			mind.skills.maximize_active_skills()
 	to_chat(src, "You're now controlling the [name].")

--- a/code/modules/mob/living/silicon/robot/syndi/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/syndi/drone/drone.dm
@@ -77,8 +77,8 @@
 	key = M.key
 	M.key = "@[key]"
 	if(mind)
-		if(!(all_skillsets[/datum/skillset/max] in mind.skills.available_skillsets))
-			mind.skills.add_available_skillset(/datum/skillset/max)
+		if(!(all_skillsets[/datum/skillset/cyborg] in mind.skills.available_skillsets))
+			mind.skills.add_available_skillset(/datum/skillset/cyborg)
 			mind.skills.maximize_active_skills()
 	to_chat(src, "You're now controlling the [name].")
 

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -380,7 +380,7 @@
 
 	if(mind)		//TODO
 		mind.transfer_to(O)
-		O.mind.skills.add_available_skillset(/datum/skillset/max)
+		O.mind.skills.add_available_skillset(/datum/skillset/cyborg)
 		O.mind.skills.maximize_active_skills()
 		if(O.mind.assigned_role == "Cyborg")
 			O.mind.original = O

--- a/code/modules/skills/skillsets.dm
+++ b/code/modules/skills/skillsets.dm
@@ -512,3 +512,33 @@
 		/datum/skill/command/pro,
 		/datum/skill/melee/master
 	)
+
+/datum/skillset/cyborg
+	initial_skills = list(
+		/datum/skill/police/master,
+		/datum/skill/firearms/master,
+		/datum/skill/engineering/master,
+		/datum/skill/construction/pro,
+		/datum/skill/atmospherics/master,
+		/datum/skill/civ_mech/master,
+		/datum/skill/combat_mech/master,
+		/datum/skill/surgery/pro,
+		/datum/skill/medical/expert,
+		/datum/skill/chemistry/master,
+		/datum/skill/research/pro,
+		/datum/skill/command/novice
+	)
+
+/datum/skillset/golem
+	initial_skills = list(
+		/datum/skill/police/master,
+		/datum/skill/engineering/pro,
+		/datum/skill/construction/trained,
+		/datum/skill/atmospherics/master,
+		/datum/skill/civ_mech/trained,
+		/datum/skill/combat_mech/trained,
+		/datum/skill/surgery/pro,
+		/datum/skill/medical/pro,
+		/datum/skill/chemistry/master,
+		/datum/skill/research/trained,
+	)

--- a/code/modules/skills/skillsets.dm
+++ b/code/modules/skills/skillsets.dm
@@ -531,14 +531,12 @@
 
 /datum/skillset/golem
 	initial_skills = list(
-		/datum/skill/police/master,
 		/datum/skill/engineering/pro,
 		/datum/skill/construction/trained,
 		/datum/skill/atmospherics/master,
-		/datum/skill/civ_mech/trained,
-		/datum/skill/combat_mech/trained,
 		/datum/skill/surgery/pro,
 		/datum/skill/medical/pro,
 		/datum/skill/chemistry/master,
 		/datum/skill/research/trained,
+		/datum/skill/melee/weak // beacause fuck golems
 	)


### PR DESCRIPTION
Фиксит #9042 и #9058. Так же фискит скилы агента прослушки.  Так же заменил скилы у дронов/киборгов не на макс умения в некоторых областях. 

Насчёт умений голема то добавил ему их, но тоже не максимум во всех областях, поскольку сейчас скиллы не запрещают выполнять действия.