### PR TITLE
Salarian -> Salackyi

### DIFF
--- a/code/__DEFINES/language.dm
+++ b/code/__DEFINES/language.dm
@@ -22,7 +22,7 @@
 #define LANGUAGE_XENOMORPH "Xenomorph language"
 // ё priovioiols!
 #define LANGUAGE_SHKIONDIONIOVIOION "Shkёndёnёvёёёn"
-#define LANGUAGE_SALARIAN "Salarian"
+#define LANGUAGE_SALACKYI "Salackyi"
 
 #define LANGUAGE_CAN_UNDERSTAND 0
 #define LANGUAGE_CAN_SPEAK 1

--- a/code/datums/qualities/negativeish.dm
+++ b/code/datums/qualities/negativeish.dm
@@ -191,16 +191,16 @@
 		H.remove_language(language.name)
 
 
-/datum/quality/negativeish/salarian
-	name = "Salarian"
+/datum/quality/negativeish/salackyi
+	name = "Салацькый"
 	desc = "Ну що хлопче, готовий?"
 	requirement = "Нема."
 
-/datum/quality/negativeish/salarian/add_effect(mob/living/carbon/human/H, latespawn)
+/datum/quality/negativeish/salackyi/add_effect(mob/living/carbon/human/H, latespawn)
 	to_chat(H, "<span class='notice'>Тебе известны новые языки. Нажми 'IC > Check Known Languages' чтобы узнать какие.</span>")
 
-	H.add_language(LANGUAGE_SALARIAN)
-	H.common_language = LANGUAGE_SALARIAN
+	H.add_language(LANGUAGE_SALACKYI)
+	H.common_language = LANGUAGE_SALACKYI
 
 
 /datum/quality/negativeish/clumsy

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -326,8 +326,8 @@
 /datum/language/shkiondioniovioion/scramble(input)
 	return replace_characters(input, replacements)
 
-/datum/language/salarian
-	name = LANGUAGE_SALARIAN
+/datum/language/salackyi
+	name = LANGUAGE_SALACKYI
 	desc = "One of the most prominent space-slavic languages out there. Consists of many funny sounds, as well as deep, melodic structure."
 	speech_verb = "says"
 	ask_verb = "asks"
@@ -342,7 +342,7 @@
 
 	var/list/replacements
 
-/datum/language/salarian/New()
+/datum/language/salackyi/New()
 	var/list/lowercase_letters = list(
 		"и" = "і",
 		"ы" = "и",
@@ -358,7 +358,7 @@
 		var/replacement = lowercase_letters[letter]
 		replacements[letter] = replacement
 
-/datum/language/salarian/scramble(input)
+/datum/language/salackyi/scramble(input)
 	return replace_characters(input, replacements)
 
 // Language handling.


### PR DESCRIPTION
## Описание изменений

убирает любой конфуз с реально существующим языком, так как это совпадение было абсолютно случайным.

название нативное, написанное на диалекте тех кто этим языком говорит с сохранением звучания. "Салацький", кирилицей "Salackyi"

## Почему и что этот ПР улучшит

никакого конфуза
