### PR TITLE
toolsaregone

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -64,10 +64,6 @@ var/global/list/trash_loot = list(
 //common: basic items
 var/global/list/common_loot = list(
 	list(
-		/obj/item/weapon/screwdriver = 1,
-		/obj/item/weapon/wirecutters = 1,
-		/obj/item/weapon/wrench = 1,
-		/obj/item/weapon/crowbar = 1,
 		/obj/item/device/t_scanner = 1,
 		/obj/item/device/analyzer = 1,
 		/obj/item/weapon/mop = 1,
@@ -137,8 +133,6 @@ var/global/list/common_loot = list(
 //uncommon: useful items
 var/global/list/uncommon_loot = list(
 	list(
-		/obj/item/weapon/weldingtool = 1,
-		/obj/item/device/multitool = 1,
 		/obj/item/weapon/hatchet = 1,
 		/obj/item/roller = 1,
 		/obj/item/weapon/legcuffs/bola = 1,

--- a/code/datums/emotes/emote.dm
+++ b/code/datums/emotes/emote.dm
@@ -70,18 +70,12 @@ var/global/list/all_emotes
 	return cooldown_group
 
 /datum/emote/proc/check_cooldown(list/cooldowns, intentional)
-	if(!intentional)
-		return TRUE
-
 	if(!cooldowns)
 		return TRUE
 
 	return cooldowns[get_cooldown_group()] < world.time
 
 /datum/emote/proc/set_cooldown(list/cooldowns, value, intentional)
-	if(!intentional)
-		return
-
 	LAZYSET(cooldowns, get_cooldown_group(), world.time + value)
 
 /datum/emote/proc/can_play_sound(mob/living/carbon/human/user, intentional)

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -123,6 +123,21 @@
 /obj/effect/landmark/start/assistant/waiter
 	name = "Waiter"
 
+/obj/effect/landmark/start/assistant/lawyer
+	name = "Lawyer"
+
+/obj/effect/landmark/start/assistant/private_eye
+	name = "Private Eye"
+
+/obj/effect/landmark/start/assistant/reporter
+	name = "Reporter"
+
+/obj/effect/landmark/start/assistant/vice_officer
+	name = "Vice Officer"
+
+/obj/effect/landmark/start/assistant/paranormal_investigator
+	name = "Paranormal Investigator"
+
 //Civilians
 /obj/effect/landmark/start/captain
 	name = "Captain"

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -4871,6 +4871,21 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/main)
+"ait" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "aiu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5467,6 +5482,15 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/brig)
+"ajt" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(12)
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/station/maintenance/escape)
 "aju" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -6104,6 +6128,17 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
+"aks" = (
+/obj/structure/stool/bed,
+/obj/item/weapon/bedsheet/orange,
+/obj/effect/landmark/start/assistant/test_subject,
+/obj/structure/sign/poster/contraband/lusty_xenomorph{
+	pixel_x = 32
+	},
+/turf/simulated/floor{
+	icon_state = "floorgrime"
+	},
+/area/station/maintenance/escape)
 "akt" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -6294,10 +6329,17 @@
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "akK" = (
-/obj/effect/decal/cleanable/greenglow,
-/obj/effect/landmark/start/assistant/test_subject,
-/obj/structure/stool,
-/turf/simulated/floor/plating,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/station/maintenance/escape)
+"akL" = (
+/obj/machinery/atmospherics/components/binary/pump/on,
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/station/maintenance/escape)
 "akM" = (
 /obj/structure/grille,
@@ -6360,6 +6402,16 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
+"akR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/station/maintenance/escape)
 "akS" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6418,10 +6470,25 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/brig)
-"akZ" = (
-/obj/structure/stool/bed,
-/obj/item/clothing/head/soft/grey,
+"akX" = (
+/obj/item/weapon/flora/pottedplant/dead,
 /obj/effect/landmark/start/assistant/test_subject,
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/station/maintenance/escape)
+"akY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/shard,
+/obj/effect/decal/cleanable/vomit{
+	icon_state = "vomittox_2"
+	},
+/obj/effect/landmark/start/assistant/test_subject,
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
+"akZ" = (
+/obj/structure/reagent_dispensers/watertank,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "ala" = (
@@ -14462,6 +14529,7 @@
 /obj/item/clothing/mask/gas/coloured,
 /obj/item/weapon/reagent_containers/spray/extinguisher,
 /obj/item/weapon/reagent_containers/spray/extinguisher,
+/obj/item/weapon/wrench,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "azw" = (
@@ -16715,25 +16783,15 @@
 	},
 /area/station/ai_monitored/eva)
 "aDH" = (
-/obj/structure/table/reinforced,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/item/weapon/storage/firstaid/regular{
-	pixel_x = -7;
-	pixel_y = 8
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
 	},
-/obj/item/weapon/storage/firstaid/toxin{
-	pixel_x = 5;
-	pixel_y = 2
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "warning"
-	},
-/area/station/ai_monitored/eva)
+/area/station/maintenance/escape)
 "aDI" = (
 /obj/machinery/vending/dinnerware,
 /obj/machinery/newscaster{
@@ -18428,6 +18486,18 @@
 	icon_state = "2-4,5,6"
 	},
 /area/shuttle/mining/station)
+"aGW" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "aGX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -18875,6 +18945,14 @@
 	icon_state = "wooden-2"
 	},
 /area/station/civilian/gym)
+"aHQ" = (
+/obj/structure/stool/bed,
+/obj/effect/landmark/start/assistant/test_subject,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "floorscorched2"
+	},
+/area/station/maintenance/escape)
 "aHR" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/four,
@@ -18947,6 +19025,22 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/genetics)
+"aIb" = (
+/obj/effect/landmark/start/assistant/test_subject,
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/station/maintenance/escape)
+"aIc" = (
+/obj/effect/decal/cleanable/generic,
+/obj/effect/landmark/start/assistant/test_subject,
+/mob/living/simple_animal/mouse/gray{
+	name = "Tidey"
+	},
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/station/maintenance/escape)
 "aId" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -19597,13 +19691,7 @@
 	},
 /area/station/rnd/mixing)
 "aJk" = (
-/obj/structure/stool/bed,
-/obj/item/weapon/bedsheet/blue,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/assistant/test_subject,
-/obj/structure/sign/poster/contraband/lusty_xenomorph{
-	pixel_y = 32
-	},
+/obj/structure/stool/bed/chair/metal/black,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "aJl" = (
@@ -19644,6 +19732,19 @@
 	icon_state = "delivery"
 	},
 /area/station/rnd/mixing)
+"aJo" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/cigbutt{
+	pixel_x = 13
+	},
+/obj/machinery/space_heater,
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/station/maintenance/escape)
 "aJp" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -20582,7 +20683,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "aKZ" = (
-/obj/effect/decal/cleanable/generic,
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "aLa" = (
@@ -21683,6 +21786,14 @@
 /obj/item/weapon/reagent_containers/glass/bucket,
 /turf/simulated/floor/grass,
 /area/station/civilian/hydroponics)
+"aMY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "aMZ" = (
 /turf/simulated/wall,
 /area/station/civilian/kitchen)
@@ -21691,6 +21802,15 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"aNb" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/foods/food_trash,
+/obj/effect/decal/cleanable/cobweb,
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/station/maintenance/escape)
 "aNc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -21979,6 +22099,12 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"aNF" = (
+/obj/structure/stool/bed/chair/metal/black,
+/obj/effect/decal/cleanable/generic,
+/obj/effect/landmark/start/assistant/test_subject,
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "aNG" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -22353,6 +22479,18 @@
 	icon_state = "dark"
 	},
 /area/station/ai_monitored/eva)
+"aOr" = (
+/obj/effect/landmark/start/assistant/test_subject,
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg1"
+	},
+/area/station/maintenance/escape)
+"aOs" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/assistant/test_subject,
+/obj/effect/decal/cleanable/mucus,
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "aOt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -22371,6 +22509,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/mixing)
+"aOv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/assistant/test_subject,
+/obj/effect/decal/cleanable/molten_item,
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
+"aOw" = (
+/obj/effect/landmark/start/assistant/test_subject,
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/station/maintenance/escape)
+"aOx" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille{
+	destroyed = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "aOy" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -23085,8 +23242,21 @@
 	},
 /area/station/hallway/secondary/exit)
 "aPL" = (
-/obj/structure/closet/firecloset,
-/turf/simulated/floor/plating,
+/obj/structure/stool/bed,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/effect/landmark/start/assistant/test_subject,
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/station/maintenance/escape)
+"aPM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/emcloset,
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/station/maintenance/escape)
 "aPN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -23096,7 +23266,7 @@
 /area/station/hallway/secondary/entry)
 "aPO" = (
 /obj/structure/table,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "aPP" = (
@@ -23108,9 +23278,19 @@
 /area/station/security/vacantoffice)
 "aPQ" = (
 /obj/structure/table,
-/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,
-/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,
-/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,
+/obj/item/weapon/reagent_containers/food/drinks/drinkingglass{
+	pixel_x = -8;
+	pixel_y = 12
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
+"aPR" = (
+/obj/structure/table,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka{
+	pixel_x = 7;
+	pixel_y = 10
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "aPS" = (
@@ -23684,22 +23864,34 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "aQS" = (
-/obj/structure/table,
-/obj/item/weapon/reagent_containers/dropper,
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/escape)
+/obj/item/weapon/wrench,
+/obj/item/weapon/crowbar,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
+/area/station/ai_monitored/eva)
 "aQT" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance/two,
-/turf/simulated/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/station/maintenance/escape)
 "aQU" = (
-/obj/structure/stool/bed,
-/obj/item/toy/plushie/grey_cat,
-/obj/effect/landmark/start/assistant/test_subject,
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/station/maintenance/escape)
+"aQV" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "aQW" = (
@@ -24345,10 +24537,10 @@
 	},
 /area/station/hallway/secondary/exit)
 "aSg" = (
-/obj/structure/urinal{
-	pixel_y = 32
+/obj/structure/girder,
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
 	},
-/turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "aSh" = (
 /obj/machinery/camera{
@@ -24365,6 +24557,17 @@
 	icon_state = "escapecorner"
 	},
 /area/station/medical/hallway)
+"aSi" = (
+/obj/machinery/light/small,
+/obj/structure/stool/bed,
+/obj/machinery/light/small,
+/obj/effect/decal/cleanable/greenglow,
+/obj/item/weapon/bedsheet/brown,
+/obj/effect/landmark/start/assistant/test_subject,
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/station/maintenance/escape)
 "aSj" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/med_data/laptop,
@@ -24433,6 +24636,15 @@
 	icon_state = "wood-broken3"
 	},
 /area/station/civilian/library)
+"aSr" = (
+/obj/structure/stool/bed,
+/obj/effect/decal/cleanable/dirt,
+/obj/random/foods/food_trash,
+/obj/effect/landmark/start/assistant/test_subject,
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/station/maintenance/escape)
 "aSs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/intercom{
@@ -24444,10 +24656,28 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
+"aSt" = (
+/obj/structure/closet,
+/obj/item/clothing/under/color/grey,
+/obj/item/clothing/under/color/grey,
+/obj/item/weapon/wrench,
+/turf/simulated/floor{
+	icon_state = "floorgrime"
+	},
+/area/station/maintenance/escape)
 "aSu" = (
 /obj/item/weapon/flora/pottedplant/minitree,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
+"aSv" = (
+/obj/structure/stool/bed,
+/obj/item/weapon/bedsheet/purple,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/assistant/test_subject,
+/turf/simulated/floor{
+	icon_state = "floorgrime"
+	},
+/area/station/maintenance/escape)
 "aSw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/assistant/test_subject,
@@ -25199,6 +25429,13 @@
 	icon_state = "whiteblue"
 	},
 /area/station/hallway/secondary/exit)
+"aTK" = (
+/obj/structure/stool/bed,
+/obj/effect/landmark/start/assistant/test_subject,
+/turf/simulated/floor{
+	icon_state = "floorgrime"
+	},
+/area/station/maintenance/escape)
 "aTL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -25208,9 +25445,31 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/hallway)
+"aTM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/port)
+"aTN" = (
+/obj/structure/table,
+/obj/item/weapon/wrench,
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "aTO" = (
-/obj/structure/reagent_dispensers/aqueous_foam_tank,
-/turf/simulated/floor/plating,
+/obj/random/foods/food_trash,
+/obj/effect/landmark/start/assistant/test_subject,
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/station/maintenance/escape)
 "aTP" = (
 /obj/structure/stool/bed/chair/metal/black,
@@ -25992,13 +26251,20 @@
 /turf/simulated/floor/carpet,
 /area/station/civilian/library)
 "aVl" = (
-/obj/machinery/space_heater,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/decal/cleanable/generic,
+/obj/effect/landmark/start/assistant/test_subject,
+/obj/item/weapon/cigbutt{
+	pixel_x = 13
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/station/maintenance/escape)
+"aVm" = (
+/obj/structure/table,
+/obj/item/weapon/crowbar,
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "aVn" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -26012,6 +26278,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"aVo" = (
+/obj/structure/table,
+/obj/item/device/destTagger,
+/obj/item/weapon/wrench,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "brown"
+	},
+/area/station/cargo/office)
 "aVp" = (
 /turf/simulated/floor/carpet,
 /area/station/civilian/chapel)
@@ -26019,11 +26294,12 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "aVr" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/grille{
+	destroyed = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/station/maintenance/escape)
 "aVs" = (
 /obj/structure/closet/secure_closet/personal,
@@ -26832,19 +27108,21 @@
 /area/station/security/main)
 "aWG" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/assistant/test_subject,
-/mob/living/simple_animal/mouse/gray{
-	name = "Tidey"
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
 	},
-/turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "aWH" = (
-/obj/effect/landmark/start/assistant/test_subject,
-/turf/simulated/floor/plating,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/closet/crate,
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/station/maintenance/escape)
 "aWI" = (
-/obj/effect/decal/cleanable/flour,
+/obj/structure/stool,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
@@ -26856,9 +27134,10 @@
 	},
 /area/station/civilian/garden)
 "aWK" = (
-/obj/structure/stool/bed,
-/obj/item/weapon/bedsheet/purple,
-/obj/effect/landmark/start/assistant/test_subject,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(12)
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "aWL" = (
@@ -26886,11 +27165,12 @@
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "aWN" = (
-/obj/structure/closet,
-/obj/item/clothing/under/color/grey,
-/obj/item/clothing/under/color/grey,
-/obj/item/clothing/under/color/grey,
-/turf/simulated/floor/plating,
+/obj/structure/stool/bed,
+/obj/item/weapon/bedsheet/blue,
+/obj/effect/landmark/start/assistant/test_subject,
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/station/maintenance/escape)
 "aWO" = (
 /obj/machinery/power/apc{
@@ -26909,9 +27189,11 @@
 	},
 /area/station/cargo/qm)
 "aWQ" = (
+/obj/machinery/space_heater,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/station/maintenance/escape)
 "aWR" = (
 /obj/structure/closet/secure_closet/personal,
@@ -31046,6 +31328,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "bef" = (
@@ -31412,8 +31695,13 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/port)
 "beI" = (
-/obj/machinery/space_heater,
-/turf/simulated/floor/plating,
+/obj/item/weapon/bedsheet/red,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/stool/bed,
+/obj/effect/landmark/start/assistant/test_subject,
+/turf/simulated/floor{
+	icon_state = "floorgrime"
+	},
 /area/station/maintenance/escape)
 "beJ" = (
 /obj/machinery/washing_machine,
@@ -31918,8 +32206,13 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "bfz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/turf/simulated/floor/plating,
+/obj/structure/stool/bed,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/landmark/start/assistant/test_subject,
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor{
+	icon_state = "floorgrime"
+	},
 /area/station/maintenance/escape)
 "bfA" = (
 /turf/simulated/floor{
@@ -32472,8 +32765,8 @@
 	},
 /area/station/maintenance/engineering)
 "bgz" = (
-/obj/structure/rack,
-/obj/item/device/flashlight,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "bgA" = (
@@ -32518,8 +32811,11 @@
 /turf/simulated/floor/plating,
 /area/station/bridge/meeting_room)
 "bgD" = (
-/obj/machinery/atmospherics/components/binary/pump/on,
-/turf/simulated/floor/plating,
+/obj/item/weapon/scrap_lump,
+/obj/effect/landmark/start/assistant/test_subject,
+/turf/simulated/floor{
+	icon_state = "floorscorched1"
+	},
 /area/station/maintenance/escape)
 "bgE" = (
 /turf/simulated/floor{
@@ -33452,10 +33748,13 @@
 	},
 /area/station/medical/genetics)
 "biv" = (
-/obj/structure/table,
-/obj/item/weapon/storage/toolbox/mechanical,
-/turf/simulated/floor,
-/area/station/civilian/locker)
+/obj/structure/rack,
+/obj/item/device/flashlight,
+/obj/item/weapon/wrench,
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/station/maintenance/escape)
 "biw" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
@@ -39691,6 +39990,14 @@
 /area/station/medical/hallway)
 "btV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "btW" = (
@@ -44996,13 +45303,14 @@
 	},
 /area/station/medical/medbreak)
 "bDm" = (
-/obj/structure/table,
-/obj/item/device/destTagger,
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "brown"
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/scrap_lump,
+/obj/effect/landmark/start/assistant/test_subject,
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = -32
 	},
-/area/station/cargo/office)
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "bDn" = (
 /turf/simulated/wall,
 /area/station/civilian/theatre)
@@ -56436,11 +56744,17 @@
 	},
 /area/station/construction/assembly_line)
 "cdL" = (
-/obj/structure/stool/bed,
-/obj/item/weapon/bedsheet/rainbow,
-/obj/effect/decal/cleanable/cobweb2,
-/obj/effect/landmark/start/assistant/test_subject,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/station/maintenance/escape)
 "cdM" = (
 /obj/machinery/constructable_frame/machine_frame,
@@ -70952,7 +71266,9 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/station/maintenance/escape)
 "fIV" = (
 /obj/machinery/door/airlock/command/glass{
@@ -96592,7 +96908,7 @@ fec
 bBv
 ofi
 glx
-bDm
+aVo
 cTO
 bHe
 bHe
@@ -101464,9 +101780,9 @@ bhj
 aqg
 bxs
 aRm
-biv
+aTN
 bfb
-biv
+aVm
 aSP
 aSM
 kFh
@@ -102477,12 +102793,12 @@ dib
 brq
 brK
 fHn
-bbn
+cdL
 bbn
 bee
 btV
-bfz
-bgD
+bgz
+akL
 bgR
 bii
 clm
@@ -102734,13 +103050,13 @@ clm
 aIs
 clm
 clm
-bdt
-cnZ
+aDH
+aQU
 bdS
-beI
-bgz
+bbf
 cnZ
-cnZ
+aQU
+bbf
 cnZ
 bik
 bbI
@@ -102991,14 +103307,14 @@ aHH
 aJU
 aUY
 clm
-clm
-bik
-clm
-clm
-clm
-clm
-clm
-clm
+aJk
+aQT
+aQT
+bbf
+aQU
+akR
+aMY
+aPM
 clm
 bbJ
 bdM
@@ -103248,14 +103564,14 @@ prb
 aJX
 aWD
 clm
-bfM
-cnZ
-aPL
-clm
+bdt
 aSg
-cnZ
-cnZ
-cnZ
+aQU
+aWQ
+biv
+clm
+clm
+clm
 clm
 bdv
 bes
@@ -103505,14 +103821,14 @@ aHe
 aKi
 atR
 clm
-cnZ
+clm
+clm
+aWK
 clm
 clm
 clm
-aKZ
-clm
-clm
-bik
+aNb
+aPR
 clm
 bdv
 bdM
@@ -103762,14 +104078,14 @@ aJR
 aMp
 atQ
 clm
-cnZ
-clm
-aPO
+aKZ
+aTO
+aSw
 akK
-cnZ
-clm
-aJk
-aWG
+ait
+akX
+aNF
+aQV
 clm
 bdo
 bdY
@@ -104019,14 +104335,14 @@ cnO
 clm
 clm
 clm
-cnZ
-clm
-aPQ
-aQS
-cnZ
-clm
-akZ
-aWH
+aPL
+aWG
+aVl
+aVr
+ajt
+aWG
+aSw
+aSi
 clm
 bbK
 bdZ
@@ -104276,14 +104592,14 @@ whb
 mjb
 nVb
 clm
-cnZ
-clm
-clm
-clm
-cnZ
-clm
-aVl
+aPO
 aWI
+aWG
+bDm
+clm
+akY
+aOr
+aSr
 aYX
 cki
 bdZ
@@ -104533,14 +104849,14 @@ whb
 avp
 avp
 clm
-aKZ
-cnZ
+aPQ
+aWH
+aWN
+akZ
+clm
+aGW
 bik
-cnZ
-cnZ
-bik
-aSw
-aWK
+clm
 aYY
 bdv
 coa
@@ -104794,10 +105110,10 @@ clm
 clm
 clm
 clm
-cnZ
 clm
-cdL
-aWN
+aHQ
+aOs
+aSt
 clm
 alz
 bdZ
@@ -105050,12 +105366,12 @@ avp
 cnt
 cnz
 clm
-aQT
-cnZ
-clm
-clm
-clm
-clm
+beI
+aWG
+aIb
+aOv
+aTO
+ajt
 bdv
 bdZ
 bmY
@@ -105307,13 +105623,13 @@ hpb
 cnu
 cnx
 clm
-aQU
-cnZ
-cnZ
-bbf
-cnZ
-bik
-bdv
+bgD
+aTO
+aIc
+aOw
+aSv
+clm
+aTM
 bep
 cjM
 aMZ
@@ -105564,11 +105880,11 @@ avp
 qJb
 cny
 clm
-beI
-aSw
-aTO
-aVr
-aWQ
+bfz
+aks
+aJo
+aOx
+aTK
 clm
 bdv
 cpJ
@@ -112243,7 +112559,7 @@ alZ
 aYi
 hGb
 aCx
-aDH
+aQS
 aBQ
 aDm
 aED

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -25445,20 +25445,6 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/hallway)
-"aTM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/port)
 "aTN" = (
 /obj/structure/table,
 /obj/item/weapon/wrench,
@@ -105629,7 +105615,7 @@ aIc
 aOw
 aSv
 clm
-aTM
+bdv
 bep
 cjM
 aMZ

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -765,7 +765,7 @@
 "aby" = (
 /obj/machinery/light/small/emergency,
 /obj/structure/rack,
-/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/weapon/crowbar,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "vault"
@@ -4871,20 +4871,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/main)
-"ait" = (
-/obj/structure/rack,
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/item/weapon/airlock_electronics,
-/obj/item/weapon/module/power_control,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor{
-	dir = 9;
-	icon_state = "yellow"
-	},
-/area/station/storage/tools)
 "aiu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5481,21 +5467,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/brig)
-"ajt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Primary Tool Storage"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/storage/primary)
 "aju" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -6133,18 +6104,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
-"aks" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/storage/primary)
 "akt" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -6335,36 +6294,11 @@
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "akK" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/storage/primary)
-"akL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/effect/decal/cleanable/greenglow,
 /obj/effect/landmark/start/assistant/test_subject,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/station/storage/primary)
+/obj/structure/stool,
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "akM" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -6426,25 +6360,6 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
-"akR" = (
-/obj/structure/table,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Primary Tool Storage APC";
-	pixel_x = -1;
-	pixel_y = 26
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/item/device/t_scanner,
-/obj/item/clothing/gloves/fyellow,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/station/storage/primary)
 "akS" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6503,38 +6418,12 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/brig)
-"akX" = (
-/obj/structure/table,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/item/weapon/storage/toolbox/electrical,
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutral"
-	},
-/area/station/storage/primary)
-"akY" = (
-/obj/structure/stool,
-/obj/effect/landmark/start/assistant/test_subject,
-/turf/simulated/floor,
-/area/station/storage/primary)
 "akZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
+/obj/structure/stool/bed,
+/obj/item/clothing/head/soft/grey,
 /obj/effect/landmark/start/assistant/test_subject,
-/turf/simulated/floor,
-/area/station/storage/primary)
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "ala" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -11476,7 +11365,6 @@
 	},
 /area/station/rnd/xenobiology)
 "atx" = (
-/obj/item/weapon/wrench,
 /obj/machinery/atmospherics/components/trinary/tvalve/mirrored/digital,
 /turf/simulated/floor/plating{
 	dir = 8;
@@ -14502,7 +14390,6 @@
 /area/station/hallway/primary/starboard)
 "azn" = (
 /obj/structure/table,
-/obj/item/weapon/storage/toolbox/mechanical,
 /obj/item/device/flashlight,
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
@@ -15098,6 +14985,7 @@
 	dir = 1;
 	network = list("SS13","Security")
 	},
+/obj/effect/landmark/start/assistant/lawyer,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "redcorner"
@@ -15108,6 +14996,7 @@
 /obj/structure/stool/bed/chair/metal/red{
 	dir = 1
 	},
+/obj/effect/landmark/start/assistant/lawyer,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "redcorner"
@@ -15121,6 +15010,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/effect/landmark/start/assistant/lawyer,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "redcorner"
@@ -15886,10 +15776,6 @@
 	pixel_x = -32
 	},
 /obj/structure/table/reinforced,
-/obj/item/weapon/storage/toolbox/electrical{
-	pixel_y = 6
-	},
-/obj/item/weapon/storage/toolbox/mechanical,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -15898,6 +15784,15 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/item/device/gps{
+	pixel_x = 6;
+	pixel_y = 6
+	},
+/obj/item/device/gps{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/device/gps,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "warning"
@@ -16076,7 +15971,6 @@
 /area/station/cargo/qm)
 "aCh" = (
 /obj/structure/rack,
-/obj/item/weapon/wrench,
 /obj/item/device/flashlight/seclite,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
@@ -16582,10 +16476,6 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
-/obj/item/device/multitool{
-	pixel_x = -3;
-	pixel_y = -2
-	},
 /obj/item/device/assembly/signaler{
 	pixel_x = 3;
 	pixel_y = 1
@@ -16826,12 +16716,18 @@
 /area/station/ai_monitored/eva)
 "aDH" = (
 /obj/structure/table/reinforced,
-/obj/item/clothing/head/welding,
-/obj/item/weapon/storage/belt/utility,
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/item/weapon/storage/firstaid/regular{
+	pixel_x = -7;
+	pixel_y = 8
+	},
+/obj/item/weapon/storage/firstaid/toxin{
+	pixel_x = 5;
+	pixel_y = 2
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -17895,8 +17791,10 @@
 	},
 /area/station/civilian/fitness)
 "aFL" = (
-/turf/simulated/wall,
-/area/station/storage/primary)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "aFM" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/light/small{
@@ -18530,9 +18428,6 @@
 	icon_state = "2-4,5,6"
 	},
 /area/shuttle/mining/station)
-"aGW" = (
-/turf/simulated/wall,
-/area/station/storage/tools)
 "aGX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -18980,13 +18875,6 @@
 	icon_state = "wooden-2"
 	},
 /area/station/civilian/gym)
-"aHQ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Primary Tool Storage"
-	},
-/turf/simulated/floor,
-/area/station/storage/primary)
 "aHR" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/four,
@@ -19059,40 +18947,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/genetics)
-"aIb" = (
-/obj/structure/table,
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 20
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/stack/rods{
-	amount = 50
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "yellow"
-	},
-/area/station/storage/tools)
-"aIc" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Auxiliary Tool Storage APC";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 1
-	},
-/obj/structure/closet/toolcloset,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "yellow"
-	},
-/area/station/storage/tools)
 "aId" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -19743,9 +19597,15 @@
 	},
 /area/station/rnd/mixing)
 "aJk" = (
+/obj/structure/stool/bed,
+/obj/item/weapon/bedsheet/blue,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/assistant/test_subject,
-/turf/simulated/floor,
-/area/station/storage/primary)
+/obj/structure/sign/poster/contraband/lusty_xenomorph{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "aJl" = (
 /obj/machinery/portable_atmospherics/powered/pump,
 /obj/machinery/power/apc{
@@ -19784,9 +19644,6 @@
 	icon_state = "delivery"
 	},
 /area/station/rnd/mixing)
-"aJo" = (
-/turf/simulated/floor,
-/area/station/storage/tools)
 "aJp" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -20725,16 +20582,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "aKZ" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/weapon/storage/box/lights/mixed,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "yellow"
-	},
-/area/station/storage/tools)
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "aLa" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -21674,7 +21524,6 @@
 	},
 /area/station/ai_monitored/eva)
 "aMG" = (
-/obj/item/clothing/gloves/yellow,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /obj/structure/closet,
 /turf/simulated/floor/plating,
@@ -21834,19 +21683,6 @@
 /obj/item/weapon/reagent_containers/glass/bucket,
 /turf/simulated/floor/grass,
 /area/station/civilian/hydroponics)
-"aMY" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/rack,
-/obj/item/clothing/gloves/fyellow,
-/obj/item/clothing/suit/storage/hazardvest,
-/obj/item/device/multitool,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "yellow"
-	},
-/area/station/storage/tools)
 "aMZ" = (
 /turf/simulated/wall,
 /area/station/civilian/kitchen)
@@ -21855,16 +21691,6 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
-"aNb" = (
-/obj/structure/closet/toolcloset,
-/obj/machinery/camera{
-	c_tag = "Auxiliary Tool Storage"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "yellow"
-	},
-/area/station/storage/tools)
 "aNc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -22153,21 +21979,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
-"aNF" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/storage/primary)
 "aNG" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -22542,19 +22353,6 @@
 	icon_state = "dark"
 	},
 /area/station/ai_monitored/eva)
-"aOr" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access = list(12)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/storage/tools)
-"aOs" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/storage/tools)
 "aOt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -22573,34 +22371,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/mixing)
-"aOv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/storage/tools)
-"aOw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/storage/tools)
-"aOx" = (
-/obj/structure/table,
-/obj/item/weapon/storage/toolbox/emergency,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "yellow"
-	},
-/area/station/storage/tools)
 "aOy" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -23315,21 +23085,9 @@
 	},
 /area/station/hallway/secondary/exit)
 "aPL" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
-	},
-/turf/simulated/floor{
-	dir = 10;
-	icon_state = "yellow"
-	},
-/area/station/storage/tools)
-"aPM" = (
-/obj/structure/reagent_dispensers/aqueous_foam_tank,
-/turf/simulated/floor{
-	icon_state = "yellow"
-	},
-/area/station/storage/tools)
+/obj/structure/closet/firecloset,
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "aPN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -23337,10 +23095,10 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "aPO" = (
-/turf/simulated/floor{
-	icon_state = "yellow"
-	},
-/area/station/storage/tools)
+/obj/structure/table,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka,
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "aPP" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -23349,24 +23107,12 @@
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
 "aPQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor{
-	icon_state = "yellow"
-	},
-/area/station/storage/tools)
-"aPR" = (
-/obj/item/weapon/flora/random,
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "yellow"
-	},
-/area/station/storage/tools)
+/obj/structure/table,
+/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,
+/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,
+/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "aPS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -23938,50 +23684,24 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "aQS" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Auxiliary Tool Storage";
-	req_access = list(12)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/storage/primary)
-"aQT" = (
 /obj/structure/table,
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = 32
+/obj/item/weapon/reagent_containers/dropper,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/item/weapon/storage/belt/utility,
-/obj/item/weapon/storage/firstaid,
-/turf/simulated/floor{
-	dir = 9;
-	icon_state = "neutral"
-	},
-/area/station/storage/primary)
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
+"aQT" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance/two,
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "aQU" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 20
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/station/storage/primary)
-"aQV" = (
-/obj/machinery/vending/tool,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "neutral"
-	},
-/area/station/storage/primary)
+/obj/structure/stool/bed,
+/obj/item/toy/plushie/grey_cat,
+/obj/effect/landmark/start/assistant/test_subject,
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "aQW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -24625,15 +24345,11 @@
 	},
 /area/station/hallway/secondary/exit)
 "aSg" = (
-/obj/machinery/vending/assist,
-/obj/machinery/requests_console/tool_storage{
-	pixel_y = 30
+/obj/structure/urinal{
+	pixel_y = 32
 	},
-/turf/simulated/floor{
-	dir = 9;
-	icon_state = "neutral"
-	},
-/area/station/storage/primary)
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "aSh" = (
 /obj/machinery/camera{
 	c_tag = "Secondary Storage";
@@ -24649,13 +24365,6 @@
 	icon_state = "escapecorner"
 	},
 /area/station/medical/hallway)
-"aSi" = (
-/obj/effect/landmark/start/assistant/test_subject,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/station/storage/primary)
 "aSj" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/med_data/laptop,
@@ -24724,25 +24433,6 @@
 	icon_state = "wood-broken3"
 	},
 /area/station/civilian/library)
-"aSr" = (
-/obj/structure/table,
-/obj/machinery/alarm{
-	pixel_y = 23
-	},
-/obj/item/device/assembly/igniter{
-	pixel_x = -5;
-	pixel_y = 3
-	},
-/obj/item/device/assembly/igniter{
-	pixel_x = 5;
-	pixel_y = -4
-	},
-/obj/item/weapon/screwdriver,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/station/storage/primary)
 "aSs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/radio/intercom{
@@ -24754,46 +24444,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
-"aSt" = (
-/obj/structure/table,
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
-/obj/machinery/camera{
-	c_tag = "Primary Tool Storage"
-	},
-/obj/item/device/assembly/prox_sensor{
-	pixel_x = 8;
-	pixel_y = 4
-	},
-/obj/item/weapon/storage/toolbox/mechanical,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/station/storage/primary)
 "aSu" = (
 /obj/item/weapon/flora/pottedplant/minitree,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
-"aSv" = (
-/obj/structure/table,
-/obj/item/device/assembly/signaler,
-/obj/item/device/assembly/signaler,
-/obj/item/weapon/crowbar,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/storage/primary)
 "aSw" = (
-/obj/structure/stool,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/assistant/test_subject,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutral"
-	},
-/area/station/storage/primary)
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "aSx" = (
 /obj/structure/closet/lasertag/red,
 /turf/simulated/floor{
@@ -25540,21 +25199,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/hallway/secondary/exit)
-"aTK" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/stack/cable_coil/random,
-/obj/item/stack/cable_coil/random{
-	pixel_y = -4
-	},
-/obj/item/weapon/screwdriver,
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutral"
-	},
-/area/station/storage/primary)
 "aTL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -25564,33 +25208,10 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/hallway)
-"aTM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/start/assistant/test_subject,
-/turf/simulated/floor,
-/area/station/storage/primary)
-"aTN" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/effect/landmark/start/assistant/test_subject,
-/turf/simulated/floor,
-/area/station/storage/primary)
 "aTO" = (
-/obj/structure/table,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/weapon/storage/toolbox/mechanical,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutral"
-	},
-/area/station/storage/primary)
+/obj/structure/reagent_dispensers/aqueous_foam_tank,
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "aTP" = (
 /obj/structure/stool/bed/chair/metal/black,
 /obj/machinery/light/small{
@@ -26371,33 +25992,13 @@
 /turf/simulated/floor/carpet,
 /area/station/civilian/library)
 "aVl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/landmark/start/assistant/test_subject,
-/turf/simulated/floor,
-/area/station/storage/primary)
-"aVm" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/machinery/space_heater,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/landmark/start/assistant/test_subject,
-/turf/simulated/floor,
-/area/station/storage/primary)
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "aVn" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -26411,21 +26012,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
-"aVo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/landmark/start/assistant/test_subject,
-/turf/simulated/floor,
-/area/station/storage/primary)
 "aVp" = (
 /turf/simulated/floor/carpet,
 /area/station/civilian/chapel)
@@ -26433,12 +26019,12 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "aVr" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutral"
+/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/area/station/storage/primary)
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "aVs" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor{
@@ -27244,37 +26830,24 @@
 	icon_state = "red"
 	},
 /area/station/security/main)
-"aWF" = (
-/obj/structure/table,
-/obj/item/weapon/wrench,
-/obj/item/device/analyzer,
-/turf/simulated/floor{
-	dir = 10;
-	icon_state = "neutral"
-	},
-/area/station/storage/primary)
 "aWG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/start/assistant/test_subject,
-/turf/simulated/floor{
-	icon_state = "neutral"
+/mob/living/simple_animal/mouse/gray{
+	name = "Tidey"
 	},
-/area/station/storage/primary)
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "aWH" = (
-/obj/structure/table,
-/obj/item/weapon/weldingtool,
-/obj/item/weapon/packageWrap,
-/turf/simulated/floor{
-	icon_state = "neutral"
-	},
-/area/station/storage/primary)
+/obj/effect/landmark/start/assistant/test_subject,
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "aWI" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/item/weapon/stock_parts/cell/high,
-/turf/simulated/floor{
-	icon_state = "neutral"
-	},
-/area/station/storage/primary)
+/obj/effect/decal/cleanable/flour,
+/obj/effect/landmark/start/assistant/test_subject,
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "aWJ" = (
 /obj/structure/flora/junglebush/b,
 /turf/simulated/floor/grass,
@@ -27283,16 +26856,11 @@
 	},
 /area/station/civilian/garden)
 "aWK" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/item/weapon/wirecutters,
-/obj/item/device/flashlight,
-/turf/simulated/floor{
-	icon_state = "neutral"
-	},
-/area/station/storage/primary)
+/obj/structure/stool/bed,
+/obj/item/weapon/bedsheet/purple,
+/obj/effect/landmark/start/assistant/test_subject,
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "aWL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -27318,14 +26886,12 @@
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "aWN" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutral"
-	},
-/area/station/storage/primary)
+/obj/structure/closet,
+/obj/item/clothing/under/color/grey,
+/obj/item/clothing/under/color/grey,
+/obj/item/clothing/under/color/grey,
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "aWO" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -27342,30 +26908,11 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/qm)
-"aWP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/landmark/start/assistant/test_subject,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor{
-	icon_state = "neutral"
-	},
-/area/station/storage/primary)
 "aWQ" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "neutral"
-	},
-/area/station/storage/primary)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "aWR" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor{
@@ -27803,11 +27350,6 @@
 	icon_state = "wood_siding4"
 	},
 /area/station/civilian/garden)
-"aXH" = (
-/obj/machinery/door/firedoor,
-/obj/item/weapon/wrench,
-/turf/simulated/floor/plating,
-/area/station/maintenance/chapel)
 "aXI" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/drinks/bottle/holywater,
@@ -28558,11 +28100,11 @@
 "aYX" = (
 /obj/structure/sign/map/left,
 /turf/simulated/wall,
-/area/station/storage/primary)
+/area/station/maintenance/escape)
 "aYY" = (
 /obj/structure/sign/map/right,
 /turf/simulated/wall,
-/area/station/storage/primary)
+/area/station/maintenance/escape)
 "aYZ" = (
 /obj/structure/stool/bed/chair/metal/red{
 	dir = 1
@@ -30214,20 +29756,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
-"bbO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/port)
 "bbP" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -31636,17 +31164,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 4;
-	name = "Primary Tool Storage";
-	sortType = "Primary Tool Storage"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/port)
@@ -32948,7 +32473,6 @@
 /area/station/maintenance/engineering)
 "bgz" = (
 /obj/structure/rack,
-/obj/item/weapon/storage/toolbox/mechanical,
 /obj/item/device/flashlight,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
@@ -35795,6 +35319,7 @@
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 1
 	},
+/obj/effect/landmark/start/assistant/private_eye,
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
 "blZ" = (
@@ -35999,12 +35524,6 @@
 	icon_state = "darkred"
 	},
 /area/station/civilian/bar)
-"bmo" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/weapon/storage/belt/utility,
-/turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
 "bmp" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -38797,6 +38316,7 @@
 	dir = 1
 	},
 /obj/machinery/hologram/holopad,
+/obj/effect/landmark/start/assistant/waiter,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -41712,6 +41232,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/landmark/start/assistant/waiter,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -42146,15 +41667,8 @@
 /area/station/cargo/storage)
 "bxl" = (
 /obj/structure/closet/crate,
-/obj/item/device/multitool,
-/obj/item/device/multitool,
 /obj/item/device/assembly/prox_sensor,
 /obj/item/device/flashlight,
-/turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
-"bxm" = (
-/obj/structure/rack,
-/obj/item/weapon/storage/toolbox/mechanical,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "bxn" = (
@@ -42468,7 +41982,6 @@
 /area/station/civilian/library)
 "bxS" = (
 /obj/structure/table,
-/obj/item/weapon/wrench,
 /obj/item/weapon/reagent_containers/food/drinks/bottle/beer,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
@@ -53292,7 +52805,6 @@
 /obj/item/weapon/stock_parts/cell{
 	maxcharge = 2000
 	},
-/obj/item/weapon/storage/belt/utility,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "bSd" = (
@@ -56924,11 +56436,12 @@
 	},
 /area/station/construction/assembly_line)
 "cdL" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/weapon/storage/belt/utility,
+/obj/structure/stool/bed,
+/obj/item/weapon/bedsheet/rainbow,
+/obj/effect/decal/cleanable/cobweb2,
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor/plating,
-/area/station/construction/assembly_line)
+/area/station/maintenance/escape)
 "cdM" = (
 /obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor/plating,
@@ -56946,9 +56459,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "cdR" = (
-/obj/structure/closet/toolcloset,
-/turf/simulated/floor/plating,
-/area/station/maintenance/atmos)
+/obj/structure/stool/bed/chair/pew/left,
+/obj/effect/landmark/start/assistant/paranormal_investigator,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/station/civilian/chapel)
 "cdS" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -59135,14 +58652,13 @@
 /turf/simulated/floor/engine,
 /area/station/rnd/xenobiology)
 "ckE" = (
-/obj/effect/landmark/start/assistant/test_subject,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/stool/bed/chair/pew/right,
+/obj/effect/landmark/start/assistant/paranormal_investigator,
 /turf/simulated/floor{
-	icon_state = "neutral"
+	dir = 5;
+	icon_state = "vault"
 	},
-/area/station/storage/primary)
+/area/station/civilian/chapel)
 "ckF" = (
 /obj/machinery/door/window/northleft{
 	dir = 4;
@@ -59856,10 +59372,9 @@
 	},
 /area/station/solar/port)
 "cmx" = (
-/obj/structure/table,
-/obj/item/weapon/screwdriver,
-/turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
+/obj/effect/landmark/start/assistant/private_eye,
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
 "cmz" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -60157,11 +59672,10 @@
 	},
 /area/station/rnd/hallway)
 "cnw" = (
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "yellow"
-	},
-/area/station/storage/tools)
+/obj/structure/stool/bed/chair/comfy/brown,
+/obj/effect/landmark/start/assistant/reporter,
+/turf/simulated/floor/carpet/black,
+/area/station/civilian/library)
 "cnx" = (
 /obj/structure/stool,
 /turf/simulated/floor{
@@ -62558,12 +62072,12 @@
 /turf/simulated/floor/wood,
 /area/station/maintenance/engineering)
 "csJ" = (
-/obj/item/stack/sheet/wood{
-	amount = 10
+/obj/structure/stool/bed/chair/comfy/brown{
+	dir = 1
 	},
-/obj/item/weapon/wrench,
-/turf/simulated/floor/wood,
-/area/station/maintenance/engineering)
+/obj/effect/landmark/start/assistant/reporter,
+/turf/simulated/floor/carpet/black,
+/area/station/civilian/library)
 "csM" = (
 /obj/machinery/recharge_station,
 /obj/machinery/status_display{
@@ -65581,6 +65095,7 @@
 /obj/structure/stool/bed/chair/comfy/brown{
 	dir = 4
 	},
+/obj/effect/landmark/start/assistant/reporter,
 /turf/simulated/floor/carpet,
 /area/station/civilian/library)
 "cBB" = (
@@ -68173,7 +67688,6 @@
 "cKi" = (
 /obj/structure/table,
 /obj/item/device/t_scanner,
-/obj/item/weapon/storage/belt/utility,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/flashlight,
 /turf/simulated/floor/plating,
@@ -71731,6 +71245,7 @@
 /area/station/maintenance/cargo)
 "fXV" = (
 /obj/structure/stool/bed/chair/comfy/black,
+/obj/effect/landmark/start/assistant/private_eye,
 /turf/simulated/floor/carpet/black,
 /area/station/security/vacantoffice)
 "fYb" = (
@@ -72631,8 +72146,7 @@
 /area/station/maintenance/cargo)
 "gYZ" = (
 /obj/structure/rack,
-/obj/item/weapon/storage/toolbox/electrical,
-/obj/item/device/multitool,
+/obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "gZb" = (
@@ -75089,7 +74603,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "jMb" = (
-/obj/item/clothing/gloves/yellow,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /obj/structure/closet/crate,
 /turf/simulated/floor/plating,
@@ -75438,6 +74951,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/effect/landmark/start/assistant/private_eye,
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
 "kgz" = (
@@ -77326,6 +76840,7 @@
 /obj/structure/stool/bed/chair/comfy/brown{
 	dir = 8
 	},
+/obj/effect/landmark/start/assistant/reporter,
 /turf/simulated/floor/carpet,
 /area/station/civilian/library)
 "msb" = (
@@ -77541,9 +77056,10 @@
 	},
 /area/station/medical/genetics)
 "mHb" = (
-/obj/structure/closet/toolcloset,
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/station/maintenance/medbay)
+/area/station/maintenance/engineering)
 "mIb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -79243,7 +78759,6 @@
 "oQM" = (
 /obj/structure/rack,
 /obj/item/weapon/reagent_containers/spray/extinguisher,
-/obj/item/weapon/storage/belt/utility,
 /obj/item/clothing/mask/gas/coloured,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
@@ -79320,6 +78835,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/effect/landmark/start/assistant/waiter,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -79879,9 +79395,7 @@
 "pNN" = (
 /obj/structure/rack,
 /obj/item/device/flashlight,
-/obj/item/weapon/wrench,
 /obj/item/device/t_scanner,
-/obj/item/weapon/wirecutters,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "pOb" = (
@@ -80318,7 +79832,6 @@
 "qoW" = (
 /obj/structure/rack,
 /obj/item/weapon/reagent_containers/spray/extinguisher,
-/obj/item/weapon/storage/toolbox/mechanical,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "qpb" = (
@@ -80771,13 +80284,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "qTb" = (
-/obj/machinery/light_switch{
-	pixel_y = -28
-	},
-/turf/simulated/floor{
-	icon_state = "yellow"
-	},
-/area/station/storage/tools)
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/station/construction/assembly_line)
 "qTO" = (
 /obj/machinery/power/apc{
 	pixel_y = -26
@@ -83890,10 +83400,9 @@
 /turf/simulated/floor/plating,
 /area/station/security/vacantoffice)
 "vls" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/toolcloset,
+/obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
+/area/station/maintenance/atmos)
 "vmY" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced{
@@ -84451,7 +83960,6 @@
 /area/station/civilian/hydroponics)
 "wEL" = (
 /obj/structure/closet/crate,
-/obj/item/weapon/screwdriver,
 /obj/item/weapon/crowbar,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
@@ -84492,7 +84000,6 @@
 "wFY" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/weapon/reagent_containers/glass/bucket,
-/obj/item/weapon/screwdriver,
 /obj/item/weapon/shovel/spade,
 /obj/item/weapon/wrench,
 /obj/item/weapon/minihoe{
@@ -84683,6 +84190,7 @@
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 4
 	},
+/obj/effect/landmark/start/assistant/private_eye,
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
 "xiQ" = (
@@ -99128,7 +98636,7 @@ aYm
 bhj
 vhl
 aHM
-aZw
+cmx
 aZw
 bcy
 fXV
@@ -103482,16 +102990,16 @@ clm
 aHH
 aJU
 aUY
-aGW
-aGW
-aOr
-aGW
-aFL
-aFL
-aFL
-aFL
-aFL
-aFL
+clm
+clm
+bik
+clm
+clm
+clm
+clm
+clm
+clm
+clm
 bbJ
 bdM
 ipb
@@ -103739,16 +103247,16 @@ clm
 prb
 aJX
 aWD
-aGW
-ait
-cnw
+clm
+bfM
+cnZ
 aPL
-aFL
+clm
 aSg
-aTK
-akX
-aWF
-aNF
+cnZ
+cnZ
+cnZ
+clm
 bdv
 bes
 ipb
@@ -103996,16 +103504,16 @@ clm
 aHe
 aKi
 atR
-aGW
-aMY
-aJo
-aPM
-aks
-aSi
-aJk
-akY
-aWG
-aHQ
+clm
+cnZ
+clm
+clm
+clm
+aKZ
+clm
+clm
+bik
+clm
 bdv
 bdM
 ipb
@@ -104253,16 +103761,16 @@ clm
 aJR
 aMp
 atQ
-aGW
-aNb
-aOs
+clm
+cnZ
+clm
 aPO
 akK
-aSi
-aJk
+cnZ
+clm
 aJk
 aWG
-aNF
+clm
 bdo
 bdY
 isb
@@ -104510,16 +104018,16 @@ clm
 cnO
 clm
 clm
-aGW
-aIc
-aOv
+clm
+cnZ
+clm
 aPQ
 aQS
-akL
-aTM
+cnZ
+clm
 akZ
 aWH
-aFL
+clm
 bbK
 bdZ
 ipb
@@ -104767,13 +104275,13 @@ avp
 whb
 mjb
 nVb
-aGW
-aIb
-aOw
-qTb
-aFL
-akR
-aJk
+clm
+cnZ
+clm
+clm
+clm
+cnZ
+clm
 aVl
 aWI
 aYX
@@ -105024,14 +104532,14 @@ aFK
 whb
 avp
 avp
-aGW
+clm
 aKZ
-aOx
-aPR
-aFL
-aSr
-aTN
-aVm
+cnZ
+bik
+cnZ
+cnZ
+bik
+aSw
 aWK
 aYY
 bdv
@@ -105281,16 +104789,16 @@ aFM
 whb
 mmb
 aKc
-aGW
-aGW
-aGW
-aGW
-aFL
-aSt
-aJk
-aVl
+clm
+clm
+clm
+clm
+clm
+cnZ
+clm
+cdL
 aWN
-aFL
+clm
 alz
 bdZ
 cjM
@@ -105541,13 +105049,13 @@ avp
 avp
 cnt
 cnz
-aFL
+clm
 aQT
-aSv
-aJk
-aVl
-ckE
-aNF
+cnZ
+clm
+clm
+clm
+clm
 bdv
 bdZ
 bmY
@@ -105798,14 +105306,14 @@ aKe
 hpb
 cnu
 cnx
-aFL
+clm
 aQU
-aJk
-aJk
-aVo
-aWP
-ajt
-bbO
+cnZ
+cnZ
+bbf
+cnZ
+bik
+bdv
 bep
 cjM
 aMZ
@@ -106055,13 +105563,13 @@ aKf
 avp
 qJb
 cny
-aFL
-aQV
+clm
+beI
 aSw
 aTO
 aVr
 aWQ
-aNF
+clm
 bdv
 cpJ
 cqt
@@ -106312,13 +105820,13 @@ aKg
 avp
 cnx
 cnx
-aFL
-aFL
-aFL
-aFL
-aFL
-aFL
-aFL
+clm
+clm
+clm
+clm
+clm
+clm
+clm
 akt
 cpL
 bns
@@ -107408,7 +106916,7 @@ clf
 cMs
 nIb
 clf
-csJ
+cld
 ctZ
 bIZ
 cfb
@@ -108180,7 +107688,7 @@ coV
 bIZ
 bmc
 bmc
-bmo
+mHb
 bIZ
 cfe
 obb
@@ -109175,7 +108683,7 @@ bEW
 qaV
 tFz
 pvb
-bxm
+bVq
 cap
 cij
 cuZ
@@ -109208,7 +108716,7 @@ cpg
 bXY
 bRo
 bQl
-vls
+aFL
 bIZ
 bmB
 cqd
@@ -112273,7 +111781,7 @@ aaa
 bIZ
 bKr
 bIZ
-cmx
+mHb
 cnr
 bIZ
 cMo
@@ -114333,7 +113841,7 @@ bZC
 bZD
 lmg
 bPG
-cdL
+qTb
 bVo
 uRb
 cGl
@@ -122038,7 +121546,7 @@ ckl
 ckt
 bPz
 bLF
-cdR
+vls
 cdE
 cdA
 cyG
@@ -130762,7 +130270,7 @@ bYr
 aKs
 bYe
 cLD
-asl
+cnw
 asE
 avU
 bLp
@@ -131021,7 +130529,7 @@ jvb
 cLE
 asl
 atl
-avU
+csJ
 awB
 aKs
 kob
@@ -131276,7 +130784,7 @@ aSu
 aKs
 cLA
 cLz
-asl
+cnw
 atn
 avU
 awD
@@ -131492,7 +131000,7 @@ awm
 axj
 axj
 azP
-aXH
+auu
 axj
 awm
 axj
@@ -131508,8 +131016,8 @@ bJF
 bdr
 pkf
 bsd
-buK
-buK
+cdR
+cdR
 buK
 ihZ
 tFA
@@ -131765,8 +131273,8 @@ eCz
 bMe
 ngQ
 bsd
-buL
-buL
+ckE
+ckE
 buL
 buL
 xat
@@ -132569,8 +132077,8 @@ jKb
 aGu
 cak
 bFo
-mHb
-mHb
+kob
+cFs
 ngb
 bFo
 lOb
@@ -132793,8 +132301,8 @@ bPQ
 bMe
 pkf
 bsd
-buK
-buK
+cdR
+cdR
 buK
 buK
 buK
@@ -133050,8 +132558,8 @@ bMd
 bMe
 ngQ
 bsd
-buL
-buL
+ckE
+ckE
 buL
 bsk
 uml


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
ассистентская заменена на кусок техтоннелей, в котором спавнятся подопытные. маперы, если захотят, поменяют на что-то более прикольные
спавны подпроф раскиданы по карте 

из техтонеллей удалены инструменты
## Почему и что этот ПР улучшит
инструментами пользоваться должны только инженеры, так что и свободный доступ к ним будет только у инженеров и некоторых других проф.
## Авторство

## Чеинжлог
:cl:
- map: Ассистентскую снесли и заменили порцией технических тоннелей.
- rscdel: Из техов удалены инструменты.
