### PR TITLE
Нёрф мыла

### DIFF
--- a/code/datums/qualities/positiveish.dm
+++ b/code/datums/qualities/positiveish.dm
@@ -157,7 +157,7 @@
 	requirement = "Нет."
 
 /datum/quality/positiveish/hygiene/add_effect(mob/living/carbon/human/H, latespawn)
-	H.equip_or_collect(new /obj/item/weapon/reagent_containers/food/snacks/soap(H), SLOT_R_STORE)
+	H.equip_or_collect(new /obj/item/weapon/reagent_containers/food/snacks/soap/syndie(H), SLOT_R_STORE)
 
 
 /datum/quality/positiveish/vaccinated

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1846,6 +1846,19 @@ var/global/list/all_supply_groups = list("Operations","Security","Hospitality","
 	crate_name = "Pizza crate"
 	group = "Hospitality"
 
+/datum/supply_pack/randomised/soap
+	num_contained = 10
+	contains = list(
+		/obj/item/weapon/reagent_containers/food/snacks/soap,
+		/obj/item/weapon/reagent_containers/food/snacks/soap/deluxe,
+		/obj/item/weapon/reagent_containers/food/snacks/soap/nanotrasen,
+		)
+	name = "Large set of soap"
+	cost = 1500
+	crate_type = /obj/structure/closet/crate/freezer
+	crate_name = "Soap crate"
+	group = "Hospitality"
+
 /datum/supply_pack/randomised/costume
 	num_contained = 2
 	contains = list(/obj/item/clothing/suit/pirate,

--- a/maps/asteroid/asteroid.dmm
+++ b/maps/asteroid/asteroid.dmm
@@ -11930,6 +11930,12 @@
 	icon_state = "warning"
 	},
 /area/asteroid/research_outpost/hallway)
+"AZ" = (
+/obj/structure/table,
+/obj/machinery/light/small,
+/obj/item/weapon/reagent_containers/food/snacks/soap/deluxe,
+/turf/simulated/floor/carpet,
+/area/asteroid/mine/living_quarters)
 "Ba" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -47273,7 +47279,7 @@ us
 pw
 uo
 us
-pw
+AZ
 uo
 ww
 yv

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -702,6 +702,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/item/weapon/reagent_containers/food/snacks/soap,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -5632,6 +5633,7 @@
 	},
 /obj/item/weapon/reagent_containers/glass/bottle/inaprovaline,
 /obj/item/clothing/gloves/latex,
+/obj/item/weapon/reagent_containers/food/snacks/soap/nanotrasen,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "whitered"
@@ -18121,6 +18123,11 @@
 /obj/item/clothing/under/bathtowel,
 /obj/item/clothing/under/bathtowel,
 /obj/item/clothing/under/bathtowel,
+/obj/item/weapon/reagent_containers/food/snacks/soap,
+/obj/item/weapon/reagent_containers/food/snacks/soap,
+/obj/item/weapon/reagent_containers/food/snacks/soap,
+/obj/item/weapon/reagent_containers/food/snacks/soap,
+/obj/item/weapon/reagent_containers/food/snacks/soap,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -44093,6 +44100,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/structure/mopbucket,
+/obj/item/weapon/reagent_containers/food/snacks/soap/nanotrasen,
 /obj/item/weapon/mop,
 /turf/simulated/floor,
 /area/station/civilian/janitor)
@@ -53783,6 +53791,9 @@
 "bTh" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
+/obj/item/weapon/reagent_containers/food/snacks/soap,
+/obj/item/weapon/reagent_containers/food/snacks/soap,
+/obj/item/weapon/reagent_containers/food/snacks/soap,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -71475,6 +71486,7 @@
 	pixel_y = 24
 	},
 /obj/structure/drain,
+/obj/item/weapon/reagent_containers/food/snacks/soap/deluxe,
 /turf/simulated/floor{
 	icon_state = "freezerfloor2"
 	},
@@ -71484,6 +71496,7 @@
 /obj/machinery/shower{
 	dir = 1
 	},
+/obj/item/weapon/reagent_containers/food/snacks/soap/deluxe,
 /turf/simulated/floor{
 	icon_state = "freezerfloor2"
 	},

--- a/maps/falcon/falcon.dmm
+++ b/maps/falcon/falcon.dmm
@@ -12592,6 +12592,10 @@
 /obj/item/weapon/bikehorn/rubberducky{
 	pixel_y = 4
 	},
+/obj/item/weapon/reagent_containers/food/snacks/soap,
+/obj/item/weapon/reagent_containers/food/snacks/soap,
+/obj/item/weapon/reagent_containers/food/snacks/soap,
+/obj/item/weapon/reagent_containers/food/snacks/soap,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -29152,6 +29156,7 @@
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
 	},
+/obj/item/weapon/reagent_containers/food/snacks/soap,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "tgk" = (


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Мыло на станции перестало быть скользким. Вообще. Мыло же синдиката остаётся таковым.

Раз все носят мыло для гигиены, то оно перестало быть предметом роскоши. Бери те все кто хочет. Но теперь мыло смывает грязь не моментально, а очистка одежды происходит еще медленнее. 

А еще можно купить в карго 10 штук за 1500

## Почему и что этот ПР улучшит
Ушла эпоха робаста мылом. Каждый сможет быть чистым.

## Авторство

## Чеинжлог
:cl:
 - del: Мыло нанотрейзена перестало быть скользким. Мыло синдиката осталось таким же.
 - tweak: Мыло теперь лежит во многих уголках станции в большом количестве.
 - tweak: Можно в карго заказать набор с мылом.