### PR TITLE
Examine не показывает пол куклы

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -58,11 +58,22 @@
 				t_His = "His"
 				t_his = "his"
 				t_him = "him"
+				t_has = "has"
+				t_is = "is"
 			if(FEMALE)
 				t_He = "She"
 				t_His = "Her"
 				t_his = "her"
 				t_him = "her"
+				t_has = "has"
+				t_is = "is"
+			else
+				t_He = "It"
+				t_His = "Its"
+				t_his = "its"
+				t_him = "it"
+				t_has = "has"
+				t_is = "is"
 
 	msg += "</EM>!\n"
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -67,13 +67,6 @@
 				t_him = "her"
 				t_has = "has"
 				t_is = "is"
-			else
-				t_He = "It"
-				t_His = "Its"
-				t_his = "its"
-				t_him = "it"
-				t_has = "has"
-				t_is = "is"
 
 	msg += "</EM>!\n"
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -29,35 +29,14 @@
 		skipface = TRUE
 
 	// crappy hacks because you can't do \his[src] etc. I'm sorry this proc is so unreadable, blame the text macros :<
-	var/t_He = "It" //capitalised for use at the start of each line.
-	var/t_His = "Its"
-	var/t_his = "its"
-	var/t_him = "it"
-	var/t_has = "has"
-	var/t_is = "is"
+	var/t_He = "They" //capitalised for use at the start of each line.
+	var/t_His = "Their"
+	var/t_his = "their"
+	var/t_him = "them"
+	var/t_has = "have"
+	var/t_is = "are"
 
 	var/msg = "<span class='info'>*---------*\nThis is "
-
-	if( skipjumpsuit && skipface ) //big suits/masks/helmets make it hard to tell their gender
-		t_He = "They"
-		t_His = "Their"
-		t_his = "their"
-		t_him = "them"
-		t_has = "have"
-		t_is = "are"
-	else
-		switch(gender)
-			if(MALE)
-				t_He = "He"
-				t_His = "His"
-				t_his = "his"
-				t_him = "him"
-			if(FEMALE)
-				t_He = "She"
-				t_His = "Her"
-				t_his = "her"
-				t_him = "her"
-
 	msg += "<EM>[name]"
 
 	if(HAS_TRAIT_FROM(user, TRAIT_ANATOMIST, QUALITY_TRAIT) && !(skipface && skipjumpsuit))

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -39,7 +39,7 @@
 	var/msg = "<span class='info'>*---------*\nThis is "
 	msg += "<EM>[name]"
 
-	if(HAS_TRAIT_FROM(user, TRAIT_ANATOMIST, QUALITY_TRAIT) && !(skipface && skipjumpsuit))
+	if((HAS_TRAIT_FROM(user, TRAIT_ANATOMIST, QUALITY_TRAIT) && !(skipface && skipjumpsuit)) || isobserver(user))
 		var/species_color = species.flesh_color
 		var/species_name = get_species()
 		if(!species.is_common)
@@ -52,6 +52,17 @@
 			var/min_bound = (text2ascii(name_hash[1]) + text2ascii(name_hash[2]) + text2ascii(name_hash[3])) % accuracy
 			var/max_bound = (text2ascii(name_hash[length(name_hash)-3]) + text2ascii(name_hash[length(name_hash)-1]) + text2ascii(name_hash[length(name_hash)])) % accuracy
 			msg += ", age between [max(age - min_bound, species.min_age)] and [min(age + max_bound, species.max_age)]"
+		switch(gender)
+			if(MALE)
+				t_He = "He"
+				t_His = "His"
+				t_his = "his"
+				t_him = "him"
+			if(FEMALE)
+				t_He = "She"
+				t_His = "Her"
+				t_his = "her"
+				t_him = "her"
 
 	msg += "</EM>!\n"
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
![image](https://user-images.githubusercontent.com/26389417/169350451-43647ea1-2546-4398-b6e1-6f56b50aa229.png)

В екзамине нету точной инфы о поле, но трейт анатома опять спасает ситуацию!

## Почему и что этот ПР улучшит
Этот ПР создаст пару смешных ситуаций, когда по кукле невозможно определить пол игроку.
Станет легче отыгрывать трапов.
Ну и наконец будет непонятно обычному игроку, какого скрелл пола перед тобой.

## Авторство

## Чеинжлог
:cl:
 - del: В Examine не видно пол персонажа.