### PR TITLE
Стелс костюм воксов работал без шлема

### DIFF
--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -309,6 +309,7 @@
 	else if(!deactive)
 		if(!istype(wearer.head, /obj/item/clothing/head/helmet/space/vox/stealth))
 			to_chat(wearer, "<span class='warning'>The cloaking system cannot function without a helmet.</span>")
+			return
 		if(last_try > world.time)
 			return
 		if(wearer.is_busy())


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Стелс костюм воксов работал без шлема
## Почему и что этот ПР улучшит
Минус баг
## Авторство

## Чеинжлог
:cl:
 - fix: Стелс костюм воксов работал без шлема