### PR TITLE
Fixes Radiocarbon Spectrometer

### DIFF
--- a/code/modules/research/xenoarchaeology/machinery/geosample_scanner.dm
+++ b/code/modules/research/xenoarchaeology/machinery/geosample_scanner.dm
@@ -88,8 +88,11 @@
 				to_chat(user, "<span class='info'>You remove [amount_transferred]u of coolant from [src].</span>")
 				update_coolant()
 				return
-		user.drop_from_inventory(I, src)
-		scanned_item = I
+		if(!scanned_item)
+			user.drop_from_inventory(I, src)
+			scanned_item = I
+		else
+			to_chat(user, "<span class='warning'>There is already something in [src].</span>")
 
 /obj/machinery/radiocarbon_spectrometer/proc/update_coolant()
 	var/total_purity = 0


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Можно было положить в спектрометр предмет, не смотря на то, что там уже лежит предмет.
## Почему и что этот ПР улучшит
fixes #4882
## Чеинжлог
:cl: Richard Jones
- bugfix: Больше не пропадают вещи в спектрометре археологов.