### PR TITLE
Удаляет сообщение позитронному мозгу, что он может говорить в бинарный канал.

### DIFF
--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -61,7 +61,6 @@
 	to_chat(src.brainmob, "<b>You are a positronic brain, brought into existence on [station_name()].</b>")
 	to_chat(src.brainmob, "<b>As a synthetic intelligence, you answer to all crewmembers, as well as the AI.</b>")
 	to_chat(src.brainmob, "<b>Remember, the purpose of your existence is to serve the crew and the station. Above all else, do no harm.</b>")
-	to_chat(src.brainmob, "<b>Use say :b to speak to other artificial intelligences.</b>")
 	src.brainmob.mind.assigned_role = "Positronic Brain"
 
 	visible_message("<span class='notice'>\The [src] chimes quietly.</span>")


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Удаляет сообщение позитронному мозгу, что он может говорить в бинарный канал.
## Почему и что этот ПР улучшит
По решению пра #8348, позитронкам был вырезан доступ в бинарный канал, но сообщение об этой возможности осталось.
![Screenshot_1508](https://user-images.githubusercontent.com/67812445/169951307-abb786cb-4acf-433e-82ff-0f8ed7801c0d.png)
## Чеинжлог
:cl: Rahmano
- rscdel: Удаляет сообщение позитронному мозгу, что он может говорить в бинарный канал.