### PR TITLE
Фикс багов головы

### DIFF
--- a/code/datums/datumvars.dm
+++ b/code/datums/datumvars.dm
@@ -182,12 +182,12 @@
 			body += "<br><font size='1'><a href='?_src_=vars;datumedit=\ref[D];varnameedit=ckey'>[M.ckey ? M.ckey : "No ckey"]</a> / <a href='?_src_=vars;datumedit=\ref[D];varnameedit=real_name'>[M.real_name ? M.real_name : "No real name"]</a></font>"
 			body += {"
 			<br><font size='1'>
-			BRUTE:<a href='?_src_=vars;mobToDamage=\ref[D];adjustDamage=brute'>[M.getBruteLoss()]</a>
-			FIRE:<a href='?_src_=vars;mobToDamage=\ref[D];adjustDamage=fire'>[M.getFireLoss()]</a>
-			TOXIN:<a href='?_src_=vars;mobToDamage=\ref[D];adjustDamage=toxin'>[M.getToxLoss()]</a>
-			OXY:<a href='?_src_=vars;mobToDamage=\ref[D];adjustDamage=oxygen'>[M.getOxyLoss()]</a>
-			CLONE:<a href='?_src_=vars;mobToDamage=\ref[D];adjustDamage=clone'>[M.getCloneLoss()]</a>
-			BRAIN:<a href='?_src_=vars;mobToDamage=\ref[D];adjustDamage=brain'>[M.getBrainLoss()]</a>
+			BRUTE:<a href='?_src_=vars;mobToDamage=\ref[M];adjustDamage=brute'>[M.getBruteLoss()]</a>
+			FIRE:<a href='?_src_=vars;mobToDamage=\ref[M];adjustDamage=fire'>[M.getFireLoss()]</a>
+			TOXIN:<a href='?_src_=vars;mobToDamage=\ref[M];adjustDamage=toxin'>[M.getToxLoss()]</a>
+			OXY:<a href='?_src_=vars;mobToDamage=\ref[M];adjustDamage=oxygen'>[M.getOxyLoss()]</a>
+			CLONE:<a href='?_src_=vars;mobToDamage=\ref[M];adjustDamage=clone'>[M.getCloneLoss()]</a>
+			BRAIN:<a href='?_src_=vars;mobToDamage=\ref[M];adjustDamage=brain'>[M.getBrainLoss()]</a>
 			</font>
 
 

--- a/code/modules/mob/living/carbon/brain/brain_item.dm
+++ b/code/modules/mob/living/carbon/brain/brain_item.dm
@@ -30,6 +30,9 @@
 	if(H.mind)
 		H.mind.transfer_to(brainmob)
 
+	if(HAS_TRAIT(H, TRAIT_NO_CLONE))
+		ADD_TRAIT(brainmob, TRAIT_NO_CLONE, GENERIC_TRAIT)
+
 	to_chat(brainmob, "<span class='notice'>You feel slightly disoriented. That's normal when you're just a brain.</span>")
 /obj/item/brain/examine(mob/user) // -- TLE
 	..()

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -142,6 +142,8 @@
 		H.mind.transfer_to(brainmob)
 	brainmob.container = src
 
+	if(HAS_TRAIT(H, TRAIT_NO_CLONE))
+		ADD_TRAIT(brainmob, TRAIT_NO_CLONE, GENERIC_TRAIT)
 
 /mob/living/carbon/human/proc/makeSkeleton()
 	if(!species || (species.name == SKELETON))

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -347,14 +347,7 @@ This function restores the subjects blood to max.
 This function restores all bodyparts.
 */
 /mob/living/carbon/human/restore_all_bodyparts()
-	for(var/obj/item/organ/external/BP in bodyparts)
-		BP.rejuvenate()
-	for(var/BP_ZONE in species.has_bodypart)
-		if(!bodyparts_by_name[BP_ZONE])
-			var/path = species.has_bodypart[BP_ZONE]
-			var/obj/item/organ/external/E = new path(null)
-			E.insert_organ(src)
-
+	species.create_organs(src, deleteOld = TRUE)
 /mob/living/carbon/human/proc/HealDamage(zone, brute, burn)
 	var/obj/item/organ/external/BP = get_bodypart(zone)
 	if(isbodypart(BP))

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -444,6 +444,13 @@ Note that amputating the affected organ does in fact remove the infection from t
 		S.insert_organ(owner, FALSE)
 	owner.updatehealth()
 
+	if(disintegrate == DROPLIMB_EDGE)
+		if(istype(src, /obj/item/organ/external/head))
+			var/obj/item/organ/external/head/H = src
+			if(HAS_TRAIT(owner, TRAIT_NO_CLONE))
+				if(H.brainmob)
+					ADD_TRAIT(H.brainmob, TRAIT_NO_CLONE, GENERIC_TRAIT)
+
 	if(!should_delete)
 		handle_cut()
 		owner = null

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -444,13 +444,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 		S.insert_organ(owner, FALSE)
 	owner.updatehealth()
 
-	if(disintegrate == DROPLIMB_EDGE)
-		if(istype(src, /obj/item/organ/external/head))
-			var/obj/item/organ/external/head/H = src
-			if(HAS_TRAIT(owner, TRAIT_NO_CLONE))
-				if(H.brainmob)
-					ADD_TRAIT(H.brainmob, TRAIT_NO_CLONE, GENERIC_TRAIT)
-
 	if(!should_delete)
 		handle_cut()
 		owner = null

--- a/code/modules/surgery/braincore.dm
+++ b/code/modules/surgery/braincore.dm
@@ -161,6 +161,7 @@
 		target.dna = B.brainmob.dna
 	var/obj/item/organ/internal/brain/brain = new(null)
 	brain.insert_organ(target)
+	target.timeofdeath = min(target.timeofdeath, world.time - DEFIB_TIME_LIMIT) // so they cannot be defibbed
 	if(HAS_TRAIT(B.brainmob, TRAIT_NO_CLONE))
 		ADD_TRAIT(target, TRAIT_NO_CLONE, GENERIC_TRAIT)
 	qdel(tool)

--- a/code/modules/surgery/braincore.dm
+++ b/code/modules/surgery/braincore.dm
@@ -161,8 +161,8 @@
 		target.dna = B.brainmob.dna
 	var/obj/item/organ/internal/brain/brain = new(null)
 	brain.insert_organ(target)
-	target.timeofdeath = min(target.timeofdeath, world.time - DEFIB_TIME_LIMIT) // so they cannot be defibbed
-	ADD_TRAIT(target, TRAIT_NO_CLONE, GENERIC_TRAIT) // so they cannot be cloned
+	if(HAS_TRAIT(B.brainmob, TRAIT_NO_CLONE))
+		ADD_TRAIT(target, TRAIT_NO_CLONE, GENERIC_TRAIT)
 	qdel(tool)
 
 /datum/surgery_step/brain/insert_brain/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/limbs.dm
+++ b/code/modules/surgery/limbs.dm
@@ -203,8 +203,8 @@
 		target.b_grad = B.b_grad
 		target.hair_painted = B.hair_painted
 		target.update_hair()
-		target.timeofdeath = min(target.timeofdeath, world.time - DEFIB_TIME_LIMIT) // so they cannot be defibbed
-		ADD_TRAIT(target, TRAIT_NO_CLONE, GENERIC_TRAIT) // so they cannot be cloned
+		if(HAS_TRAIT(B.brainmob, TRAIT_NO_CLONE))
+			ADD_TRAIT(target, TRAIT_NO_CLONE, GENERIC_TRAIT)
 
 /datum/surgery_step/limb/attach/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/BP = target.get_bodypart(BP_CHEST)

--- a/code/modules/surgery/limbs.dm
+++ b/code/modules/surgery/limbs.dm
@@ -203,6 +203,7 @@
 		target.b_grad = B.b_grad
 		target.hair_painted = B.hair_painted
 		target.update_hair()
+		target.timeofdeath = min(target.timeofdeath, world.time - DEFIB_TIME_LIMIT) // so they cannot be defibbed
 		if(HAS_TRAIT(B.brainmob, TRAIT_NO_CLONE))
 			ADD_TRAIT(target, TRAIT_NO_CLONE, GENERIC_TRAIT)
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Фиксит реджув когда у цели нет головы
Фиксит исчезновение ноклон трейта при отрубании головы/мозга
## Почему и что этот ПР улучшит
## Авторство
## Чеинжлог
:cl:
 - bugfix: При отращивании головы генокраду больше не накидывается неизлечимый урон.
 - bugfix: Голову и мозг больше нельзя клонировать, если целиковое тело нельзя было.