### PR TITLE
Немного меняет скиллы у всяких проф

### DIFF
--- a/code/modules/skills/skillsets.dm
+++ b/code/modules/skills/skillsets.dm
@@ -183,7 +183,6 @@
 /datum/skillset/forensic
 	name = "Forensic Technician"
 	initial_skills = list(
-		/datum/skill/police/trained,
 		/datum/skill/surgery/pro,
 		/datum/skill/medical/trained,
 		/datum/skill/research/novice,

--- a/code/modules/skills/skillsets.dm
+++ b/code/modules/skills/skillsets.dm
@@ -111,7 +111,7 @@
 /datum/skillset/engineer
 	name = "Station Engineer"
 	initial_skills = list(
-		/datum/skill/construction/master,
+		/datum/skill/construction/pro,
 		/datum/skill/engineering/master,
 		/datum/skill/atmospherics/trained,
 		/datum/skill/civ_mech/trained

--- a/code/modules/skills/skillsets.dm
+++ b/code/modules/skills/skillsets.dm
@@ -442,7 +442,7 @@
 /datum/skillset/test_subject/detective
 	name = "Private Eye"
 	initial_skills = list(
-		/datum/skill/firearms/trained,
+		/datum/skill/firearms/trained
 	)
 
 /datum/skillset/test_subject/reporter
@@ -461,7 +461,6 @@
 /datum/skillset/test_subject/vice_officer
 	name = "Vice Officer"
 	initial_skills = list(
-		/datum/skill/command/trained,
 		/datum/skill/police/master
 	)
 

--- a/code/modules/skills/skillsets.dm
+++ b/code/modules/skills/skillsets.dm
@@ -111,8 +111,8 @@
 /datum/skillset/engineer
 	name = "Station Engineer"
 	initial_skills = list(
-		/datum/skill/construction/pro,
-		/datum/skill/engineering/pro,
+		/datum/skill/construction/master,
+		/datum/skill/engineering/master,
 		/datum/skill/atmospherics/trained,
 		/datum/skill/civ_mech/trained
 	)
@@ -122,7 +122,7 @@
 	initial_skills = list(
 		/datum/skill/atmospherics/master,
 		/datum/skill/construction/pro,
-		/datum/skill/engineering/trained,
+		/datum/skill/engineering/pro,
 		/datum/skill/melee/trained,
 		/datum/skill/civ_mech/trained
 	)
@@ -144,7 +144,9 @@
 		/datum/skill/command/pro,
 		/datum/skill/police/master,
 		/datum/skill/melee/master,
+		/datum/skill/surgery/pro,
 		/datum/skill/medical/trained,
+		/datum/skill/chemistry/novice,
 		/datum/skill/research/novice,
 		/datum/skill/combat_mech/master
 	)
@@ -181,6 +183,7 @@
 /datum/skillset/forensic
 	name = "Forensic Technician"
 	initial_skills = list(
+		/datum/skill/police/trained,
 		/datum/skill/surgery/pro,
 		/datum/skill/medical/trained,
 		/datum/skill/research/novice,
@@ -352,7 +355,7 @@
 /datum/skillset/hop
 	name = "Head of Personnel"
 	initial_skills = list(
-	/datum/skill/command/pro,
+	/datum/skill/command/master,
 	/datum/skill/firearms/trained,
 	/datum/skill/civ_mech/trained
 	)
@@ -426,7 +429,7 @@
 /datum/skillset/test_subject/lawyer
 	name = "Lawyer"
 	initial_skills = list(
-	/datum/skill/command/novice
+	/datum/skill/command/trained
 	)
 
 /datum/skillset/test_subject/mecha
@@ -439,27 +442,27 @@
 /datum/skillset/test_subject/detective
 	name = "Private Eye"
 	initial_skills = list(
-		/datum/skill/firearms/trained
+		/datum/skill/firearms/trained,
 	)
 
 /datum/skillset/test_subject/reporter
 	name = "Reporter"
 	initial_skills = list(
-		/datum/skill/command/novice
+		/datum/skill/command/trained
 	)
 
 /datum/skillset/test_subject/waiter
 	name = "Waiter"
 	initial_skills = list(
 		/datum/skill/chemistry/novice,
-		/datum/skill/police/trained
+		/datum/skill/medical/novice
 	)
 
 /datum/skillset/test_subject/vice_officer
 	name = "Vice Officer"
 	initial_skills = list(
 		/datum/skill/command/trained,
-		/datum/skill/police/trained
+		/datum/skill/police/master
 	)
 
 /datum/skillset/test_subject/paranormal
@@ -492,9 +495,9 @@
 /datum/skillset/revolutionary
 	name = REV
 	initial_skills = list(
-		/datum/skill/police/trained,
+		/datum/skill/police/master,
 		/datum/skill/firearms/trained,
-		/datum/skill/command/novice,
+		/datum/skill/command/trained,
 		/datum/skill/melee/trained
 	)
 
@@ -502,7 +505,8 @@
 	name = GANGSTER
 	initial_skills = list(
 		/datum/skill/firearms/master,
-		/datum/skill/melee/master
+		/datum/skill/melee/master,
+		/datum/skill/command/trained
 	)
 
 /datum/skillset/cultist
@@ -512,7 +516,8 @@
 		/datum/skill/surgery/master,
 		/datum/skill/medical/master,
 		/datum/skill/chemistry/novice,
-		/datum/skill/research/novice
+		/datum/skill/research/novice,
+		/datum/skill/command/trained
 	)
 
 /datum/skillset/cultist/leader
@@ -534,7 +539,7 @@
 		/datum/skill/firearms/master,
 		/datum/skill/police/master,
 		/datum/skill/medical/trained,
-		/datum/skill/surgery/novice,
+		/datum/skill/surgery/trained,
 		/datum/skill/research/novice
 	)
 
@@ -604,5 +609,4 @@
 		/datum/skill/medical/pro,
 		/datum/skill/chemistry/master,
 		/datum/skill/research/trained,
-		/datum/skill/melee/weak // beacause fuck golems
 	)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Инженеры получили максимальные навыки инженерии
ХоС получил навыки криминалиста.
ХоП получил максимальные навыки командования
Лаувеер и репортер получили 2 уровень командорства
Вейтер потерял свои навыки полицая и научился искусству медика
Вайс офицер получил 2 уровень полайса, но перестал быть командором второго уровня
Бунтовщики научились использовать дубинки и быстро надевать наручники на врагов революции
Агент абдукторов стал чуть лучше делать операции
Голем получил нулевой уровень мили веапона
Все командные роли получили 2 уровень команда...
## Почему и что этот ПР улучшит
Дюшесс сказал что мои предложения очень спорные и чтоб я сам сделал пр
Логику енд уникальность проф
По поводу спорных вещей
ХоП не имеет абсолютно ничего уникального или особенного в плане навыков, так он теперь хотя бы сможет быстро и незаметно выдавать себе и/или друзьям полный доступ.
Навыки у ассистентов вообще странные, вайс офицер имеет 2 уровень командования, в то время как у других подпроф максимум 1 уровень, у ОФИЦИАНТА вообще зачем-то есть навык мента.
Агенту дал хирургию чтоб можно было лечить переломы и всякую фигню учёному.
Командным ролям выдал навык команда чтоб они могли помогать друг-дружке.
## Авторство

## Чеинжлог
:cl: Simbaka
- tweak: Немного поменялись навыки у разных профессий и антагонистов.