### PR TITLE
Изменения в культе

### DIFF
--- a/code/game/gamemodes/modes_gameplays/cult/cult_items.dm
+++ b/code/game/gamemodes/modes_gameplays/cult/cult_items.dm
@@ -64,7 +64,6 @@
 	vision_flags = SEE_MOBS | SEE_TURFS
 
 /obj/item/clothing/glasses/cult_blindfold/mob_can_equip(M, slot)
-	. = ..()
 	if(!isliving(M))
 		return FALSE
 	var/mob/living/L = M

--- a/code/game/gamemodes/modes_gameplays/cult/cult_items.dm
+++ b/code/game/gamemodes/modes_gameplays/cult/cult_items.dm
@@ -55,12 +55,30 @@
 		return TRUE
 	return FALSE
 
-/obj/item/clothing/glasses/cult
+/obj/item/clothing/glasses/cult_blindfold
 	name = "blindfold"
-	desc = "Covers the eyes, preventing sight."
+	desc = "Covers the eyes, preventing sight. Altough, something wrong with this one..."
 	icon_state = "blindfold"
 	item_state = "blindfold"
-	darkness_view = -1
+	hud_types = list(DATA_HUD_MEDICAL)
+	vision_flags = SEE_MOBS | SEE_TURFS
+
+/obj/item/clothing/glasses/cult_blindfold/mob_can_equip(M, slot)
+	. = ..()
+	if(isliving(M))
+		var/mob/living/L = M
+		if(!iscultist(L) && slot == SLOT_GLASSES)
+			to_chat(L, "<span class='cult'>Глаза не нужны?!</span>")
+			L.make_dizzy(30)
+			L.apply_effects(eyeblur=45)
+			if(ishuman(L))
+				var/mob/living/carbon/human/H = L
+				var/obj/item/organ/internal/eyes/E = H.organs_by_name[O_EYES]
+				E.damage += rand(4, 8)
+			L.flash_eyes()
+			L.drop_item()
+			return FALSE
+	return ..()
 
 /obj/item/clothing/head/culthood
 	name = "cult hood"

--- a/code/game/gamemodes/modes_gameplays/cult/cult_items.dm
+++ b/code/game/gamemodes/modes_gameplays/cult/cult_items.dm
@@ -60,7 +60,7 @@
 	desc = "Covers the eyes, preventing sight. Altough, something wrong with this one..."
 	icon_state = "blindfold"
 	item_state = "blindfold"
-	hud_types = list(DATA_HUD_MEDICAL)
+	hud_types = list(DATA_HUD_MEDICAL_ADV)
 	vision_flags = SEE_MOBS | SEE_TURFS
 
 /obj/item/clothing/glasses/cult_blindfold/mob_can_equip(M, slot)

--- a/code/game/gamemodes/modes_gameplays/cult/cult_items.dm
+++ b/code/game/gamemodes/modes_gameplays/cult/cult_items.dm
@@ -7,10 +7,15 @@
 	force = 30
 	throwforce = 10
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
-	var/obj/item/weapon/shield/riot/mirror/secondary/shield //For spawned shield component, so we know it's source
 
 /obj/item/weapon/melee/cultblade/proc/only_cultists(datum/source, mob/M)
 	return iscultist(M)
+/obj/item/weapon/melee/cultblade/examine(mob/user)
+	. = ..()
+	if(iscultist(user))
+		var/datum/religion/cult/C = user.my_religion
+		if(C.get_tech(RTECH_MIRROR_SHIELD))
+			to_chat(user, "С помощью меча можно призвать щит-зеркало на защиту!")
 
 /obj/item/weapon/melee/cultblade/attack(mob/living/target, mob/living/carbon/human/user)
 	if(iscultist(user))
@@ -26,35 +31,20 @@
 	if(iscultist(user))
 		var/datum/religion/cult/C = user.my_religion
 		if(!GetComponent(/datum/component/self_effect) && C.get_tech(RTECH_MIRROR_SHIELD))
-			var/shield_type = /obj/item/weapon/shield/riot/mirror/secondary
-			var/datum/component/self_effect/shield_comp = AddComponent(/datum/component/self_effect, shield_type, "#51106bff", CALLBACK(src, .proc/only_cultists), 2 MINUTE, 30 SECONDS, 2 MINUTE)
-			if(shield_comp) //Do we have it in the first place?
-				if(istype(shield_comp.effect_type,/obj/item/weapon)) //Is it even an atom?
-					shield = shield_comp.effect_type //Let's write it in
+			var/shield_type = /obj/item/weapon/shield/riot/mirror
+			AddComponent(/datum/component/self_effect, shield_type, "#51106bff", CALLBACK(src, .proc/only_cultists), 2 MINUTE, 30 SECONDS, 2 MINUTE)
 	else
 		to_chat(user, "<span class='warning'>Ошеломляющее чувство страха охватывает тебя при поднятии красного меча, было бы разумно поскорее избавиться от него.</span>")
 		user.make_dizzy(120)
-
-/obj/item/weapon/melee/cultblade/attack_self(mob/user)
-	. = ..()
-	if(shield)
-		shield.Destroy()
-		shield = null
-
-/obj/item/weapon/melee/cultblade/dropped(mob/user)
-	. = ..()
-	if(shield)
-		shield.Destroy()
-		shield = null
 
 /obj/item/weapon/shield/riot/mirror
 	name = "mirror shield"
 	desc = "An infamous shield used by eldritch sects to confuse and disorient their enemies."
 	icon = 'icons/obj/cult.dmi'
 	icon_state = "mirror_shield"
+	flags = DROPDEL
 	slot_flags = FALSE
 	var/reflect_chance = 70
-	block_chance = 30 //It's a mirror, after all, not actual shield
 
 /obj/item/weapon/shield/riot/mirror/pickup(mob/living/user)
 	. = ..()
@@ -72,13 +62,6 @@
 		return TRUE
 	return FALSE
 
-/obj/item/weapon/shield/riot/mirror/secondary
-	flags = NODROP
-
-/obj/item/weapon/shield/riot/mirror/secondary/dropped(mob/user) //Sword's pair
-	. = ..()
-	Destroy()
-
 /obj/item/clothing/glasses/cult_blindfold
 	name = "blindfold"
 	desc = "Covers the eyes, preventing sight. Altough, something wrong with this one..."
@@ -87,7 +70,6 @@
 	vision_flags = SEE_TURFS
 	darkness_view = 7
 	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
-	var/flags2remove
 
 /obj/item/clothing/glasses/cult_blindfold/mob_can_equip(M, slot)
 	if(!isliving(M))

--- a/code/game/gamemodes/modes_gameplays/cult/cult_items.dm
+++ b/code/game/gamemodes/modes_gameplays/cult/cult_items.dm
@@ -7,6 +7,7 @@
 	force = 30
 	throwforce = 10
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	var/obj/item/weapon/shield/riot/mirror/secondary/shield //For spawned shield component, so we know it's source
 
 /obj/item/weapon/melee/cultblade/proc/only_cultists(datum/source, mob/M)
 	return iscultist(M)
@@ -25,11 +26,26 @@
 	if(iscultist(user))
 		var/datum/religion/cult/C = user.my_religion
 		if(!GetComponent(/datum/component/self_effect) && C.get_tech(RTECH_MIRROR_SHIELD))
-			var/shield_type = /obj/item/weapon/shield/riot/mirror
-			AddComponent(/datum/component/self_effect, shield_type, "#51106bff", CALLBACK(src, .proc/only_cultists), 5 MINUTE, 30 SECONDS, 2 MINUTE)
+			var/shield_type = /obj/item/weapon/shield/riot/mirror/secondary
+			var/datum/component/self_effect/shield_comp = AddComponent(/datum/component/self_effect, shield_type, "#51106bff", CALLBACK(src, .proc/only_cultists), 2 MINUTE, 30 SECONDS, 2 MINUTE)
+			if(shield_comp) //Do we have it in the first place?
+				if(istype(shield_comp.effect_type,/obj/item/weapon)) //Is it even an atom?
+					shield = shield_comp.effect_type //Let's write it in
 	else
 		to_chat(user, "<span class='warning'>Ошеломляющее чувство страха охватывает тебя при поднятии красного меча, было бы разумно поскорее избавиться от него.</span>")
 		user.make_dizzy(120)
+
+/obj/item/weapon/melee/cultblade/attack_self(mob/user)
+	. = ..()
+	if(shield)
+		shield.Destroy()
+		shield = null
+
+/obj/item/weapon/melee/cultblade/dropped(mob/user)
+	. = ..()
+	if(shield)
+		shield.Destroy()
+		shield = null
 
 /obj/item/weapon/shield/riot/mirror
 	name = "mirror shield"
@@ -38,6 +54,7 @@
 	icon_state = "mirror_shield"
 	slot_flags = FALSE
 	var/reflect_chance = 70
+	block_chance = 30 //It's a mirror, after all, not actual shield
 
 /obj/item/weapon/shield/riot/mirror/pickup(mob/living/user)
 	. = ..()
@@ -55,13 +72,22 @@
 		return TRUE
 	return FALSE
 
+/obj/item/weapon/shield/riot/mirror/secondary
+	flags = NODROP
+
+/obj/item/weapon/shield/riot/mirror/secondary/dropped(mob/user) //Sword's pair
+	. = ..()
+	Destroy()
+
 /obj/item/clothing/glasses/cult_blindfold
 	name = "blindfold"
 	desc = "Covers the eyes, preventing sight. Altough, something wrong with this one..."
 	icon_state = "blindfold"
 	item_state = "blindfold"
-	hud_types = list(DATA_HUD_MEDICAL_ADV)
-	vision_flags = SEE_MOBS | SEE_TURFS
+	vision_flags = SEE_TURFS
+	darkness_view = 7
+	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
+	var/flags2remove
 
 /obj/item/clothing/glasses/cult_blindfold/mob_can_equip(M, slot)
 	if(!isliving(M))

--- a/code/game/gamemodes/modes_gameplays/cult/cult_items.dm
+++ b/code/game/gamemodes/modes_gameplays/cult/cult_items.dm
@@ -36,14 +36,31 @@
 	desc = "An infamous shield used by eldritch sects to confuse and disorient their enemies."
 	icon = 'icons/obj/cult.dmi'
 	icon_state = "mirror_shield"
-	flags = ABSTRACT|DROPDEL
 	slot_flags = FALSE
 	var/reflect_chance = 70
+
+/obj/item/weapon/shield/riot/mirror/pickup(mob/living/user)
+	. = ..()
+	if(!iscultist(user))
+		user.make_dizzy(70)
+		if(ishuman(user))
+			var/mob/living/carbon/human/H = user
+			to_chat(user, "<span class='warning'>Тебя вдруг охватил страх, и ты схватил зеркало за острую кромку, порезавшись!</span>")
+			var/obj/item/organ/external/BP = H.bodyparts_by_name[H.hand ? BP_L_ARM : BP_R_ARM]
+			BP.take_damage(5)
+		return FALSE
 
 /obj/item/weapon/shield/riot/mirror/IsReflect(def_zone, hol_dir, hit_dir)
 	if(prob(reflect_chance) && is_the_opposite_dir(hol_dir, hit_dir))
 		return TRUE
 	return FALSE
+
+/obj/item/clothing/glasses/cult
+	name = "blindfold"
+	desc = "Covers the eyes, preventing sight."
+	icon_state = "blindfold"
+	item_state = "blindfold"
+	darkness_view = -1
 
 /obj/item/clothing/head/culthood
 	name = "cult hood"

--- a/code/game/gamemodes/modes_gameplays/cult/cult_items.dm
+++ b/code/game/gamemodes/modes_gameplays/cult/cult_items.dm
@@ -65,19 +65,20 @@
 
 /obj/item/clothing/glasses/cult_blindfold/mob_can_equip(M, slot)
 	. = ..()
-	if(isliving(M))
-		var/mob/living/L = M
-		if(!iscultist(L) && slot == SLOT_GLASSES)
-			to_chat(L, "<span class='cult'>Глаза не нужны?!</span>")
-			L.make_dizzy(30)
-			L.apply_effects(eyeblur=45)
-			if(ishuman(L))
-				var/mob/living/carbon/human/H = L
-				var/obj/item/organ/internal/eyes/E = H.organs_by_name[O_EYES]
-				E.damage += rand(4, 8)
-			L.flash_eyes()
-			L.drop_item()
-			return FALSE
+	if(!isliving(M))
+		return FALSE
+	var/mob/living/L = M
+	if(!iscultist(L) && slot == SLOT_GLASSES)
+		to_chat(L, "<span class='cult'>Глаза не нужны?!</span>")
+		L.make_dizzy(30)
+		L.apply_effects(eyeblur=45)
+		if(ishuman(L))
+			var/mob/living/carbon/human/H = L
+			var/obj/item/organ/internal/eyes/E = H.organs_by_name[O_EYES]
+			E.damage += rand(4, 8)
+		L.flash_eyes()
+		L.drop_item()
+		return FALSE
 	return ..()
 
 /obj/item/clothing/head/culthood

--- a/code/game/gamemodes/modes_gameplays/cult/structures/tech_table.dm
+++ b/code/game/gamemodes/modes_gameplays/cult/structures/tech_table.dm
@@ -15,7 +15,7 @@
 	var/static/list/category_images = list()
 
 	var/researching = FALSE
-	var/research_time = 18 MINUTES
+	var/research_time = 15 MINUTES
 	var/end_research_time
 
 	var/current_research = "Ничего"
@@ -171,7 +171,7 @@
 		P.icon_state = "pylon_glow"
 		P.can_unwrench = FALSE
 	researching = TRUE
-	var/time_reduce = sqrt(pylon_around.len)MINUTE
+	var/time_reduce = 2.2*sqrt(pylon_around.len)MINUTE //https://www.desmos.com/Calculator/2kclxsb9ld 1 pylon = 2 mins, 4 pyls = 4 mins, 10=7, 45=15
 	end_research_time = max(1, world.time + research_time - time_reduce)
 	can_unwrench = FALSE
 	tech_timer = addtimer(end_activity, research_time - time_reduce, TIMER_STOPPABLE)

--- a/code/game/gamemodes/modes_gameplays/cult/structures/tech_table.dm
+++ b/code/game/gamemodes/modes_gameplays/cult/structures/tech_table.dm
@@ -171,7 +171,7 @@
 		P.icon_state = "pylon_glow"
 		P.can_unwrench = FALSE
 	researching = TRUE
-	var/time_reduce = 2.2*sqrt(pylon_around.len)MINUTE //https://www.desmos.com/Calculator/2kclxsb9ld 1 pylon = 2 mins, 4 pyls = 4 mins, 10=7, 45=15
+	var/time_reduce = 2.2*sqrt(pylon_around.len)MINUTE //https://www.desmos.com/Calculator/acwqntgi7v 1 pylon = 2 mins, 4 pyls = 4 mins, 10=7, 45=15
 	end_research_time = max(1, world.time + research_time - time_reduce)
 	can_unwrench = FALSE
 	tech_timer = addtimer(end_activity, research_time - time_reduce, TIMER_STOPPABLE)

--- a/code/game/objects/items/weapons/storage/bible/tome.dm
+++ b/code/game/objects/items/weapons/storage/bible/tome.dm
@@ -197,6 +197,10 @@
 		return
 
 	var/turf/targeted_turf = get_step(src, user.dir)
+	for(var/atom/A in targeted_turf.contents)
+		if(A.density == 1)
+			to_chat(user, "<span class='warning'>Что-то мешает построить!</span>")
+			return FALSE
 	if(ispath(choice.building_type, /turf))
 		targeted_turf.ChangeTurf(choice.building_type)
 	else if(ispath(choice.building_type, /obj/structure/altar_of_gods/cult))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -931,6 +931,8 @@
 			number += 2
 	if(istype(glasses, /obj/item/clothing/glasses/night/shadowling))
 		number -= 1
+	if(istype(glasses, /obj/item/clothing/glasses/cult_blindfold))
+		number += 2
 	return number
 
 

--- a/code/modules/religion/building_agent.dm
+++ b/code/modules/religion/building_agent.dm
@@ -148,7 +148,7 @@
 	icon_state = "4"
 	building_type = /datum/religion_tech/cult/memorizing_rune
 	favor_cost = 300
-	piety_cost = 250
+	piety_cost = 230
 
 /datum/building_agent/tech/cult/reusable_runes
 	name = "Многоразовые Руны"
@@ -156,7 +156,7 @@
 	icon_state = "1"
 	building_type = /datum/religion_tech/cult/reusable_runes
 	favor_cost = 600
-	piety_cost = 10
+	piety_cost = 50
 
 /datum/building_agent/tech/cult/build_everywhere
 	name = "Строительство Везде"
@@ -164,7 +164,7 @@
 	icon_state = "pylon"
 	building_type = /datum/religion_tech/cult/build_everywhere
 	favor_cost = 400
-	piety_cost = 50
+	piety_cost = 100
 
 /datum/building_agent/tech/cult/mirror_shield
 	name = "Зеркальный Щит"

--- a/code/modules/religion/building_agent.dm
+++ b/code/modules/religion/building_agent.dm
@@ -199,6 +199,12 @@
 	building_type = /obj/item/weapon/melee/cultblade
 	favor_cost = 100
 
+/datum/building_agent/tool/cult/cult_blindfold
+	name = "Слепое Прозрение"
+	building_type = /obj/item/clothing/glasses/cult_blindfold
+	favor_cost = 120
+	piety_cost = 30
+
 /datum/building_agent/tool/cult/space_armor
 	name = "Набор Космической Брони"
 	building_type = /obj/item/weapon/storage/backpack/cultpack/space_armor


### PR DESCRIPTION
## Описание изменений
Данный ПР я задумывал как нечто, что сможет расшевелить культ, немного ускорить раунды, а может и внести нового. 
1) Повязка в целом, новая фича. Это не то, что убьёт кого-то, но может чуть скрасить игру. Почему бы и нет? Давно не было новых игрушек у культа. Также она делается в печке культа за 30 набожности, что не есть мало.
2) Пилоны смехотворно уменьшали время на изучение, теперь хоть их присутствие заметно. Основное время 18 минут - это крайне много, т.к. культ изучает запоминание рун в ~40 минут, а с делеем они начинают действовать к часу(за исключением когда в культе воруют автомат с кровью раундстартом). Я предполагаю, что с подобным изменением можно добиться большего актива в раунде от культа, а может и забавных комбинаций аспектов. Ах да, если кто скажет что люди заспамят из-за этого изменения, то нет. Спама гораздо проще добиться установив с 10 столов в раю.
3) По поводу фикса, я сомневаюсь, что кому-то интересно сдыхать от 20 пилонов в стенке. Так хоть можно адекватно оценить, сколько их там без райт-клика, да и баги не очень.
4) Вы когда-нибудь видели, как используется щит-зеркало? Я нет. Оказывается, его можно достать кликнув по мечу.  Может теперь увидим его в игре.
5) Сомневаюсь что нечто сильно изменится, но как-то странно видеть, что одна технология стоит 250 набожности, а другая 10. 
## Почему и что этот ПР улучшит
Фича, багфикс, докапывание до циферок, ностальгия по забытому
## Авторство
Идея блиндфолда с ТГ, код мой
## Чеинжлог
:cl: Chip11-n
- add: Повязка на глаза для культа, что даёт мезонки и ПНВ. Делается в печи.
- balance: Пилоны теперь сильнее уменьшают время изучения у культа, а также базовое время снижено с 18 до 15
- bugfix: Культ больше не сможет строить по 10 построек в тайле
- tweak: Теперь на мече дополнительно описан способ вызова зеркала-щита.
- tweak: Чуть изменены цены уникальных технологий.