### PR TITLE
dist and waste monitor gas composition text fix

### DIFF
--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -120,7 +120,7 @@
 				if(data["temperature"])
 					sensor_part += "   <B>Temperature:</B> [data["temperature"]] K<BR>"
 				if(data["oxygen"]||data["phoron"]||data["nitrogen"]||data["carbon_dioxide"])
-					sensor_part += "   <B>Gas Composition :</B>"
+					sensor_part += "   <B>Gas Composition:</B>"
 					if(data["oxygen"])
 						sensor_part += "[data["oxygen"]]% O2; "
 					if(data["nitrogen"])

--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -122,13 +122,13 @@
 				if(data["oxygen"]||data["phoron"]||data["nitrogen"]||data["carbon_dioxide"])
 					sensor_part += "   <B>Gas Composition:</B>"
 					if(data["oxygen"])
-						sensor_part += "[data["oxygen"]]% O2; "
+						sensor_part += " [data["oxygen"]]% O2; "
 					if(data["nitrogen"])
-						sensor_part += "[data["nitrogen"]]% N; "
+						sensor_part += " [data["nitrogen"]]% N; "
 					if(data["carbon_dioxide"])
-						sensor_part += "[data["carbon_dioxide"]]% CO2; "
+						sensor_part += " [data["carbon_dioxide"]]% CO2; "
 					if(data["phoron"])
-						sensor_part += "[data["phoron"]]% TX; "
+						sensor_part += " [data["phoron"]]% TX; "
 				sensor_part += "<HR>"
 
 			else


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Было:
![Screenshot_1613](https://user-images.githubusercontent.com/67812445/172675309-29cd8c78-a5eb-4c43-bd77-88d3ce14c8c6.png)
Стало:
![Screenshot_1612](https://user-images.githubusercontent.com/67812445/172675340-2b9fa837-6e9a-41b3-b889-8a7539789cb5.png)

## Почему и что этот ПР улучшит
QoL
## Авторство

## Чеинжлог
:cl: Rahmano
* spellcheck: Теперь отображение текста Gas composition в консоли dist and waste monitor красивое.