### PR TITLE
PDA light toggle

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -122,7 +122,7 @@
 		return
 
 	if(fon)
-		fon = 0
+		fon = FALSE
 		set_light(0)
 	else
 		fon = TRUE

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -125,7 +125,7 @@
 		fon = 0
 		set_light(0)
 	else
-		fon = 1
+		fon = TRUE
 		set_light(f_lum)
 
 /obj/item/device/pda/medical

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -70,6 +70,8 @@
 
 	var/obj/item/device/paicard/pai = null	// A slot for a personal AI device
 
+	action_button_name = "Toggle light"
+
 /obj/item/device/pda/atom_init()
 	. = ..()
 	PDAs += src
@@ -108,6 +110,23 @@
 		return
 
 	return ..()
+
+/obj/item/device/pda/ui_action_click()
+	toggle_light()
+
+/obj/item/device/pda/verb/toggle_light()
+	set name = "Toggle light"
+	set category = "Object"
+
+	if(usr.incapacitated())
+		return
+
+	if(fon)
+		fon = 0
+		set_light(0)
+	else
+		fon = 1
+		set_light(f_lum)
 
 /obj/item/device/pda/medical
 	default_cartridge = /obj/item/weapon/cartridge/medical


### PR DESCRIPTION
## Описание изменений
Теперь появляется возможность включить на ПДА свет не залезая в него

![image](https://user-images.githubusercontent.com/50750952/173182889-52308ca6-6a9e-4fe0-b0dc-f408a6582d37.png)

## Почему и что этот ПР улучшит
Это упростит и ускорит включение фонарика на ПДА, в особенности, если у кого-то ЮИ подлагивают. Очень быстро, фича мелкая, но это удобно по моему мнению.
## Авторство
Идея многих билдов, код мой
## Чеинжлог
:cl: Chip11-n
- rscadd: Кнопочка интерфейса для быстрого включения фонарика ПДА
