### PR TITLE
Твёрдость пожарной створки

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -347,7 +347,8 @@
 	var/turf/T = get_turf(AM)
 	for(var/direction in cardinal)
 		if(AM.Move(get_step(T, direction)))
-			break
+			return TRUE
+		return FALSE
 
 /proc/get_mob_by_key(key)
 	for(var/mob/M as anything in mob_list)

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -266,6 +266,7 @@
 	var/turf/T = get_turf(src)
 	for(var/atom/A in T)
 		if(istype(A, /obj/structure/closet))
+			var/obj/structure/closet/C = A
 			if(!try_move_adjacent(C))
 				C.welded = TRUE
 				C.update_icon()
@@ -273,8 +274,8 @@
 			if(!try_move_adjacent(A))
 				A.airlock_crush_act()
 		if(istype(A, /obj/machinery/porta_turret))
-			if(!try_move_adjacent(A))
-				var/obj/machinery/porta_turret/turret = A
+			var/obj/machinery/porta_turret/turret = A
+			if(!try_move_adjacent(turret))
 				turret.die()
 	..()
 

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -263,8 +263,19 @@
 	latetoggle()
 
 /obj/machinery/door/firedoor/do_afterclose()
-	for(var/mob/living/L in get_turf(src))
-		try_move_adjacent(L)
+	var/turf/T = get_turf(src)
+	for(var/atom/A in T)
+		if(istype(A, /obj/structure/closet))
+			if(!try_move_adjacent(C))
+				C.welded = TRUE
+				C.update_icon()
+		if(isliving(A))
+			if(!try_move_adjacent(A))
+				A.airlock_crush_act()
+		if(istype(A, /obj/machinery/porta_turret))
+			if(!try_move_adjacent(A))
+				var/obj/machinery/porta_turret/turret = A
+				turret.die()
 	..()
 
 /obj/machinery/door/firedoor/do_open()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Закрытая створка будет наказывать за абуз. Клосеты будут сдавливаться, препятствуя выходу. Оверлей сварки чисто чтобы игроку понятнее была причина и метод убирания этого состояния у ящика.
Хз что написать в чейнджлоге.
## Почему и что этот ПР улучшит
resolve #9455 
## Авторство

## Чеинжлог
:cl: Deahaka
- tweak: пожарные створки наносят урон при сдавливании.