### PR TITLE
Нерф бол

### DIFF
--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -135,7 +135,7 @@
 	breakouttime = 35 //easy to apply, easy to break out of
 	origin_tech = "engineering=3;combat=1"
 	throw_speed = 0.8
-	var/weaken = 0.8
+	var/weaken = 0
 
 /obj/item/weapon/legcuffs/bola/after_throw(datum/callback/callback)
 	..()

--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -134,8 +134,8 @@
 	icon_state = "bola"
 	breakouttime = 35 //easy to apply, easy to break out of
 	origin_tech = "engineering=3;combat=1"
-	throw_speed = 5
-	var/weaken = 0.8
+	throw_speed = 1
+	var/weaken = 0
 
 /obj/item/weapon/legcuffs/bola/after_throw(datum/callback/callback)
 	..()
@@ -160,7 +160,9 @@
 	icon_state = "bola_r"
 	breakouttime = 70
 	origin_tech = "engineering=4;combat=3"
-	weaken = 6
+	weaken = 2
+	throw_range = 5
+	throw_speed = 2
 
 
 /obj/item/weapon/caution

--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -134,8 +134,8 @@
 	icon_state = "bola"
 	breakouttime = 35 //easy to apply, easy to break out of
 	origin_tech = "engineering=3;combat=1"
-	throw_speed = 1
-	var/weaken = 0
+	throw_speed = 0.8
+	var/weaken = 0.8
 
 /obj/item/weapon/legcuffs/bola/after_throw(datum/callback/callback)
 	..()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Уменьшил скорость полёта бол, они теперь не хитскановые
Обычная бола больше не кнокает
Уменьшил кнок у крепкой болы до +- 2 секунд.
Уменьшил дальность броска крепкой болы до 5 тайлов
## Почему и что этот ПР улучшит
баланс наверное
Обычная бола делается буквально из говна и палок, доступного буквально любому ассистенту, а является нереально полезной и сильной штукой, буквально дизармом на расстоянии.
Трейторская бола это вообще многоразовый гранатомёт с резиной, который ещё и хитскан, и от которого даже щит не спасёт.
## Авторство

## Чеинжлог
:cl: Simbaka
- balance: Снижена скорость полёта у бол. Реинфорсед бола сбивает с ног на намного меньшее количество времени, а обычная бола вообще не сбивает с ног.