### PR TITLE
Позволяет вставлять пули обратно в спидлоадеры

### DIFF
--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -2,6 +2,7 @@
 /obj/item/ammo_box/a357
 	name = "speedloader (.357)"
 	desc = "A .357 speedloader."
+	caliber = "357"
 	icon_state = "357"
 	ammo_type = /obj/item/ammo_casing/a357
 	max_ammo = 7
@@ -10,6 +11,7 @@
 /obj/item/ammo_box/c38
 	name = "speedloader (.38 rubber)"
 	desc = "A .38 speedloader."
+	caliber = "38"
 	icon_state = "38"
 	ammo_type = /obj/item/ammo_casing/c38
 	max_ammo = 6
@@ -25,6 +27,7 @@
 /obj/item/ammo_box/c45rubber
 	name = "speedloader (.45 rubber)"
 	desc = "A .45 speedloader."
+	caliber = ".45"
 	icon_state = "38"
 	ammo_type = /obj/item/ammo_casing/c45r
 	max_ammo = 6
@@ -55,6 +58,7 @@
 
 /obj/item/ammo_box/c45
 	name = "Ammunition Box (.45)"
+	caliber = ".45"
 	icon_state = "c45"
 	origin_tech = "combat=2"
 	ammo_type = /obj/item/ammo_casing/c45
@@ -63,6 +67,7 @@
 
 /obj/item/ammo_box/c45r
 	name = "Ammunition Box (.45 rubber)"
+	caliber = ".45"
 	icon_state = "c45r"
 	origin_tech = "combat=2"
 	ammo_type = /obj/item/ammo_casing/c45r

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -85,6 +85,7 @@
 /obj/item/ammo_box/shotgun
 	name = "shotgun shells box (buckshot)"
 	icon = 'icons/obj/ammo.dmi'
+	caliber = "shotgun"
 	icon_state = "pellet_box"
 	w_class = SIZE_SMALL
 	origin_tech = "combat=2"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Прописал большинству аммо боксов калибр и тем самым позволил вставлять патроны в них.
## Почему и что этот ПР улучшит
fixes #7067 
fixes #7719
## Авторство

## Чеинжлог
:cl: Simbaka
- bugfix: В спидлоадеры нельзя было вставлять патроны.