### PR TITLE
Мелкие правки сообщения при емаге автоматов

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -251,7 +251,7 @@
 	src.emagged = 1
 	if(syndie.len)
 		to_chat(user, "You short out the product lock on [src] and reveal hidden products.")
-	else(!syndie.len)
+	else
 		to_chat(user, "You short out the product lock on [src].")
 	return TRUE
 

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -249,7 +249,10 @@
 	if(emagged)
 		return FALSE
 	src.emagged = 1
-	to_chat(user, "You short out the product lock on [src] and reveal hidden products.")
+	if(syndie.len)
+		to_chat(user, "You short out the product lock on [src] and reveal hidden products.")
+	else(!syndie.len)
+		to_chat(user, "You short out the product lock on [src].")
 	return TRUE
 
 /obj/machinery/vending/default_deconstruction_crowbar(obj/item/O)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Если в автомате который емагают нет скрытого для емага контента, то сообщение что были открыты какие-то товары не выводится, чтоб не вводить в заблуждение.
## Почему и что этот ПР улучшит
fixes #9477 
## Авторство

## Чеинжлог
