### PR TITLE
Mask and Quality of Life

### DIFF
--- a/code/_onclick/hud/ui_screens/basic.dm
+++ b/code/_onclick/hud/ui_screens/basic.dm
@@ -350,8 +350,12 @@
 		to_chat(C, "<span class='notice'>You are not wearing a mask.</span>")
 		internal_switch = world.time + 8
 		return
-
+	if(istype(C.wear_mask, /obj/item/clothing/mask/breath))
+		var/obj/item/clothing/mask/breath/M = C.wear_mask
+		if(M.hanging) // if mask on face but pushed down
+			M.attack_self() // adjust it back
 	if(!(C.wear_mask.flags & MASKINTERNALS))
+
 		to_chat(C, "<span class='notice'>This mask doesn't support breathing through the tanks.</span>")
 		return
 


### PR DESCRIPTION
## Описание изменений
Вы когда-нибудь бегали в дыхательной маске, а потом её опускали, чтоб поесть? А потом в каком-нибудь шлюзе судорожно пытаетесь клацнуть по той кнопочке, чтоб включить баллон. Теперь этого не будет! Персонаж сам натянет, приведёт маску в работоспособное состояние!
## Почему и что этот ПР улучшит
QoL
## Авторство
ТГ
## Чеинжлог
:cl: Chip11-n
- tweak: При попытке включить баллон, и опущенной маске, последняя автоматически будет надета.