### PR TITLE
Фикс построек Алиенов

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/powers.dm
@@ -310,6 +310,8 @@
 /obj/effect/proc_holder/spell/no_target/resin/cast(list/targets, mob/user = usr)
 	if(!build_name)
 		return
+	if(!cast_check())
+		return
 	var/mob/living/carbon/xenomorph/humanoid/alien = user
 	alien.adjustToxLoss(-plasma_cost)
 	user.visible_message("<span class='notice'><B>[user]</B> vomits up a thick purple substance and begins to shape it.</span>", "<span class='notice'>You shape a [build_name].</span>")


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Алиены больше не могут строить сразу несколько стен в одном тайле и больше не могут строить не на резиновом поле.
## Почему и что этот ПР улучшит
fixes #9462 
fixes #9461 
## Авторство

## Чеинжлог
