### PR TITLE
Force mobs zone change after template load, propper zone change for new player mobs

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -381,7 +381,7 @@ SUBSYSTEM_DEF(job)
 	return TRUE
 
 //Gives the player the stuff he should have with his rank
-/datum/controller/subsystem/job/proc/EquipRank(mob/living/carbon/human/H, rank, joined_late=0)
+/datum/controller/subsystem/job/proc/EquipRank(mob/living/carbon/human/H, rank, joined_late=FALSE)
 	if(!H)	return FALSE
 	var/datum/job/job = GetJob(rank)
 	var/list/spawn_in_storage = list()
@@ -467,11 +467,7 @@ SUBSYSTEM_DEF(job)
 			spawn_mark = fallback_landmark
 
 		if(istype(spawn_mark, /obj/effect/landmark/start) && istype(spawn_mark.loc, /turf))
-			H.loc = spawn_mark.loc
-		// Moving wheelchair if they have one
-		if(H.buckled && istype(H.buckled, /obj/structure/stool/bed/chair/wheelchair))
-			H.buckled.loc = H.loc
-			H.buckled.set_dir(H.dir)
+			H.forceMove(spawn_mark.loc, keep_buckled = TRUE)
 
 	//give them an account in the station database
 	var/datum/money_account/M = create_random_account_and_store_in_mind(H, job.salary)	//starting funds = salary

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -378,7 +378,6 @@ SUBSYSTEM_DEF(ticker)
 
 /datum/controller/subsystem/ticker/proc/create_characters()
 	for(var/mob/dead/new_player/player in player_list)
-		//sleep(1)//Maybe remove??
 		if(player && player.ready && player.mind)
 			joined_player_list += player.ckey
 			if(player.mind.assigned_role=="AI")
@@ -388,7 +387,7 @@ SUBSYSTEM_DEF(ticker)
 			//	continue
 			else
 				player.create_character()
-		CHECK_TICK // comment/remove this and uncomment sleep, if crashes at round start will come back.
+		CHECK_TICK
 
 /datum/controller/subsystem/ticker/proc/collect_minds()
 	for(var/mob/living/player in player_list)
@@ -404,7 +403,7 @@ SUBSYSTEM_DEF(ticker)
 				captainless=0
 			SSquirks.AssignQuirks(player, player.client, TRUE)
 			if(player.mind.assigned_role != "MODE")
-				SSjob.EquipRank(player, player.mind.assigned_role, 0)
+				SSjob.EquipRank(player, player.mind.assigned_role, FALSE)
 	if(captainless)
 		for(var/mob/M as anything in player_list)
 			if(!isnewplayer(M))

--- a/code/datums/helper_datums/map_template.dm
+++ b/code/datums/helper_datums/map_template.dm
@@ -62,7 +62,7 @@
 
 	if(forcemove_mobs) // if we need to register change of area/loc
 		for(var/mob/M in mobs)
-			M.forceMove(M.loc)
+			M.forceMove(M.loc, keep_buckled = TRUE)
 
 /datum/map_template/proc/load(turf/T, centered = FALSE, initBounds = TRUE)
 	if(centered)

--- a/code/datums/helper_datums/map_template.dm
+++ b/code/datums/helper_datums/map_template.dm
@@ -34,10 +34,11 @@
 	else
 		. = null
 
-/proc/initTemplateBounds(list/bounds)
+/proc/initTemplateBounds(list/bounds, forcemove_mobs = FALSE)
 	var/list/obj/machinery/atmospherics/atmos_machines = list()
 	var/list/obj/structure/cable/cables = list()
 	var/list/atom/atoms = list()
+	var/list/mob/mobs = list()
 
 	for(var/L in block(locate(bounds[MAP_MINX], bounds[MAP_MINY], bounds[MAP_MINZ]),
 	                   locate(bounds[MAP_MAXX], bounds[MAP_MAXY], bounds[MAP_MAXZ])))
@@ -51,10 +52,17 @@
 			if(istype(A,/obj/machinery/atmospherics))
 				atmos_machines += A
 				continue
+			if(ismob(A))
+				mobs += A
+				continue
 
 	SSatoms.InitializeAtoms(atoms)
 	SSmachines.setup_template_powernets(cables)
 	SSair.setup_template_machinery(atmos_machines)
+
+	if(forcemove_mobs) // if we need to register change of area/loc
+		for(var/mob/M in mobs)
+			M.forceMove(M.loc)
 
 /datum/map_template/proc/load(turf/T, centered = FALSE, initBounds = TRUE)
 	if(centered)
@@ -78,7 +86,7 @@
 	. = stuff
 	//initialize things that are normally initialized after map load
 	if(initBounds)
-		initTemplateBounds(bounds)
+		initTemplateBounds(bounds, forcemove_mobs = TRUE)
 
 	log_game("[name] loaded at [COORD(T)]")
 	loaded_stuff.Cut()

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -160,7 +160,7 @@
 		A.Bumped(src)
 
 
-/atom/movable/proc/forceMove(atom/destination, keep_pulling = FALSE)
+/atom/movable/proc/forceMove(atom/destination, keep_pulling = FALSE, keep_buckled = FALSE)
 	if(destination)
 		if(pulledby && !keep_pulling)
 			pulledby.stop_pulling()
@@ -190,15 +190,18 @@
 		return TRUE
 	return FALSE
 
-/mob/living/forceMove(atom/destination, keep_pulling = FALSE)
+/mob/forceMove(atom/destination, keep_pulling = FALSE, keep_buckled = FALSE)
 	if(!keep_pulling)
 		stop_pulling()
-	if(buckled)
+	if(buckled && !keep_buckled)
 		buckled.unbuckle_mob()
 	. = ..()
+	if(buckled && keep_buckled)
+		buckled.loc = loc
+		buckled.set_dir(dir)
 	update_canmove()
 
-/mob/dead/observer/forceMove(atom/destination, keep_pulling)
+/mob/dead/observer/forceMove(atom/destination, keep_pulling, keep_buckled)
 	if(destination)
 		if(loc)
 			loc.Exited(src)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -585,7 +585,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		var/datum/role/R = new_character.mind.GetRole(role)
 		R.OnPostSetup()
 
-	SSjob.EquipRank(new_character, new_character.mind.assigned_role, 1)
+	SSjob.EquipRank(new_character, new_character.mind.assigned_role, TRUE)
 
 	//Announces the character on all the systems, based on the record.
 	if(!issilicon(new_character))//If they are not a cyborg/AI.

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -222,7 +222,7 @@
 		SSquirks.AssignQuirks(character, character.client, TRUE)
 		SSqualities.give_quality(character, TRUE)
 
-	SSjob.EquipRank(character, rank, 1)					//equips the human
+	SSjob.EquipRank(character, rank, TRUE)					//equips the human
 
 
 	// AIs don't need a spawnpoint, they must spawn at an empty core
@@ -244,13 +244,8 @@
 		qdel(src)
 		return
 
-	character.loc = pick(latejoin)
-	character.lastarea = get_area(loc)
+	character.forceMove(pick(latejoin), keep_buckled = TRUE)
 	show_location_blurb(character.client)
-	// Moving wheelchair if they have one
-	if(character.buckled && istype(character.buckled, /obj/structure/stool/bed/chair/wheelchair))
-		character.buckled.loc = character.loc
-		character.buckled.set_dir(character.dir)
 
 	SSticker.mode.latespawn(character)
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

По мотивам обсуждения из #9526. Подгрузка темплейта не тригерила изменение зоны у мобов.

По хорошему, мы это должны делать не только для мобов, и даже не только при подгрузке карты, может даже еще в atominit, но это накладно и не столь критично.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
