### PR TITLE
Additional fix to #9412 (dna bound array out of boundaries)

### DIFF
--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -268,7 +268,7 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	if(on)
 		val=rand(BOUNDS[DNA_ON_LOWERBOUND],BOUNDS[DNA_ON_UPPERBOUND])
 	else
-		val=rand(DNA_OFF_LOWERBOUND,BOUNDS[DNA_OFF_UPPERBOUND])
+		val=rand(BOUNDS[DNA_OFF_LOWERBOUND],BOUNDS[DNA_OFF_UPPERBOUND])
 	SetSEValue(block,val,defer)
 
 // Get hex-encoded SE block.


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

В догонку к #9412

оно ничего не ломало, у нас всё равно нету ген с границами, начинающимися не с "1". 

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
