### PR TITLE
СПУ теперь могут выбрать роль блоба в настройках

### DIFF
--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -1011,7 +1011,7 @@
 
 	is_common = TRUE
 
-	prohibit_roles = list(ROLE_CHANGELING, ROLE_SHADOWLING, ROLE_CULTIST, ROLE_BLOB)
+	prohibit_roles = list(ROLE_CHANGELING, ROLE_SHADOWLING, ROLE_CULTIST)
 
 	emotes = list(
 		/datum/emote/robot/beep,
@@ -1303,7 +1303,7 @@
 
 /datum/species/shadowling/regen(mob/living/carbon/human/H)
 	H.nutrition = NUTRITION_LEVEL_NORMAL //i aint never get hongry
-	
+
 	var/light_amount = 0
 	if(isturf(H.loc))
 		var/turf/T = H.loc


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Так как блоб теперь начинается с мыши, а не зараженного члена экипажа, больше нет смысла запрещать игрокам на СПУ выбирать роль блоба.
## Почему и что этот ПР улучшит
Fixes #9546
## Авторство

## Чеинжлог
🆑 Motykoo
* tweak: СПУ могут включить роль Блоба в настройках персонажа.