### PR TITLE
Убран лимит для тестовиков на Falcon

### DIFF
--- a/maps/falcon/falcon.dmm
+++ b/maps/falcon/falcon.dmm
@@ -766,6 +766,7 @@
 	dir = 8;
 	pixel_x = 21
 	},
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "chapel"
@@ -2329,6 +2330,7 @@
 	pixel_x = 28
 	},
 /obj/structure/stool/bed/chair/comfy/brown,
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor/carpet/black,
 /area/station/civilian/dormitories/dormone)
 "adV" = (
@@ -3704,6 +3706,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -4173,6 +4176,7 @@
 /obj/machinery/newscaster{
 	pixel_y = 28
 	},
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -4186,6 +4190,7 @@
 	name = "Station Intercom (General)";
 	pixel_y = 22
 	},
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -4762,6 +4767,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/stool,
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor{
 	icon_state = "wooden-2"
 	},
@@ -5181,6 +5187,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/stool,
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor/carpet/blue,
 /area/station/civilian/locker)
 "ajf" = (
@@ -5223,6 +5230,7 @@
 /area/station/civilian/gym)
 "ajj" = (
 /obj/structure/stool,
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor/carpet/black,
 /area/station/civilian/gym)
 "ajk" = (
@@ -5489,6 +5497,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "chapel"
@@ -5561,6 +5570,7 @@
 	dir = 4
 	},
 /obj/structure/stool,
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor/carpet/blue,
 /area/station/civilian/locker)
 "ajP" = (
@@ -5605,6 +5615,7 @@
 /area/station/civilian/chapel/office)
 "ajS" = (
 /obj/structure/stool/bed/chair/pew/left,
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "chapel"
@@ -5641,6 +5652,7 @@
 /area/station/maintenance/escape)
 "ajW" = (
 /obj/structure/stool/bed/chair/pew/right,
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor{
 	icon_state = "chapel"
 	},
@@ -6091,6 +6103,7 @@
 /area/station/maintenance/escape)
 "ala" = (
 /obj/structure/stool,
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor{
 	icon_state = "wooden-2"
 	},
@@ -6107,6 +6120,7 @@
 	dir = 1
 	},
 /obj/structure/stool,
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor/carpet/black,
 /area/station/civilian/gym)
 "ald" = (
@@ -7332,6 +7346,7 @@
 	pixel_y = -28
 	},
 /obj/structure/stool,
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor{
 	icon_state = "wooden-2"
 	},
@@ -10612,6 +10627,7 @@
 /area/asteroid/mine/dwarf)
 "bez" = (
 /obj/structure/stool/bed/chair/metal/black,
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -11608,6 +11624,7 @@
 "ccc" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/stool,
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor{
 	icon_state = "asteroid"
 	},
@@ -12214,6 +12231,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor/carpet/black,
 /area/station/civilian/dormitories/dormone)
 "cMi" = (
@@ -13396,6 +13414,7 @@
 /area/asteroid/research_outpost/spectro)
 "dNp" = (
 /obj/structure/stool,
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor{
 	icon_state = "asteroid"
 	},
@@ -19692,6 +19711,7 @@
 /area/station/medical/reception)
 "kjB" = (
 /obj/structure/stool/bed/chair/pew/left,
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "chapel"
@@ -23944,6 +23964,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "darkredfull"
@@ -27755,6 +27776,7 @@
 "rGx" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/stool,
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor{
 	icon_state = "asteroid7"
 	},
@@ -28591,6 +28613,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "chapel"
@@ -28893,6 +28916,7 @@
 /obj/structure/stool/bed/chair/metal/red{
 	dir = 4
 	},
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "darkredfull"
@@ -29422,6 +29446,7 @@
 /area/station/maintenance/medbay)
 "twE" = (
 /obj/structure/stool,
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor{
 	icon_state = "grass1"
 	},
@@ -32171,6 +32196,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "brown"
@@ -34337,6 +34363,7 @@
 /obj/structure/stool/bed/chair/metal/yellow{
 	dir = 8
 	},
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "brown"

--- a/maps/falcon/job_changes.dm
+++ b/maps/falcon/job_changes.dm
@@ -1,11 +1,5 @@
 #define JOB_MODIFICATION_MAP_NAME "Falcon Station"
 
-/datum/job/assistant/New()
-	..()
-	MAP_JOB_CHECK
-	total_positions = 3
-	spawn_positions = 3
-
 /datum/job/cyborg/New()
 	..()
 	MAP_JOB_CHECK


### PR DESCRIPTION

<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Убран лимит для тестовиков на Falcon и увеличено количество точек спавна для них.
## Почему и что этот ПР улучшит
Приготовления к системе воутов
## Авторство

## Чеинжлог
:cl:
 - tweak: Убран лимит для профессии подопытного на карте Falcon