### PR TITLE
Vote for the next round map

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -877,6 +877,8 @@ var/global/bridge_secret = null
 				currentmap.config_max_users = text2num(data)
 			if ("votable")
 				currentmap.votable = TRUE
+			if ("voteweight")
+				currentmap.voteweight = text2num(data)
 			if ("default","defaultmap")
 				defaultmap = currentmap
 			if ("endmap")

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -875,6 +875,8 @@ var/global/bridge_secret = null
 				currentmap.config_min_users = text2num(data)
 			if ("maxplayers","maxplayer")
 				currentmap.config_max_users = text2num(data)
+			if ("votable")
+				currentmap.votable = TRUE
 			if ("default","defaultmap")
 				defaultmap = currentmap
 			if ("endmap")

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -262,5 +262,28 @@ SUBSYSTEM_DEF(mapping)
 	next_map_config = VM
 	return TRUE
 
+/datum/controller/subsystem/mapping/proc/autovote_next_map()
+	var/datum/map_config/current_next_map
+	var/should_revote = FALSE
+	
+	 // todo: for some reason maps in SSmapping don't have config/maps.txt params?
+	if(next_map_config)	// maybe we shouldn't if it's admin choice
+		current_next_map = global.config.maplist[next_map_config.map_name]
+	else
+		current_next_map =  global.config.maplist[src.config.map_name]
+
+	if (current_next_map.config_min_users > 0 && length(player_list) < current_next_map.config_min_users)
+		should_revote = TRUE
+	else if (current_next_map.config_max_users > 0 && length(player_list) > current_next_map.config_max_users)
+		should_revote = TRUE
+
+	if(!should_revote)
+		return
+
+	var/datum/poll/map_poll = SSvote.votes[/datum/poll/nextmap]
+	if(map_poll && map_poll.can_start())
+		to_chat(world, "<span class='notice'>Current next map is inappropriate for ammount of players online. Map vote will be forced.</span>")
+		SSvote.start_vote(map_poll.type)
+
 #undef SPACE_STRUCTURES_AMOUNT
 #undef MAX_MINING_SECRET_ROOM

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -23,7 +23,7 @@ SUBSYSTEM_DEF(ticker)
 
 	var/random_players = 0					// if set to nonzero, ALL players who latejoin or declare-ready join will have random appearances/genders
 
-	var/delay_end = 0						//if set to nonzero, the round will not restart on it's own
+	var/admin_delayed = 0						//if set to nonzero, the round will not restart on it's own
 
 	var/triai = 0							//Global holder for Triumvirate
 
@@ -42,6 +42,8 @@ SUBSYSTEM_DEF(ticker)
 	var/ert_call_in_progress = FALSE //when true players can join ERT
 	var/hacked_apcs = 0 //check the amount of hacked apcs either by a malf ai, or a traitor
 	var/Malf_announce_stage = 0//Used for announcement
+
+	var/end_timer_id
 
 /datum/controller/subsystem/ticker/PreInit()
 	login_music = pick(\
@@ -132,33 +134,46 @@ SUBSYSTEM_DEF(ticker)
 
 					SSStatistics.drop_round_stats()
 
+					SSmapping.autovote_next_map()
+
 					if (station_was_nuked)
 						feedback_set_details("end_proper","nuke")
-						if(!delay_end)
-							to_chat(world, "<span class='notice'><B>Rebooting due to destruction of station in [restart_timeout/10] seconds</B></span>")
+						if(!admin_delayed)
+							to_chat(world, "<span class='notice'><B>Restarting due to destruction of station in [restart_timeout/10] seconds</B></span>")
 					else
 						feedback_set_details("end_proper","proper completion")
-						if(!delay_end)
+						if(!admin_delayed)
 							to_chat(world, "<span class='notice'><B>Restarting in [restart_timeout/10] seconds</B></span>")
 
-					if(!delay_end)
-						sleep(restart_timeout)
-						if(!delay_end)
-							world.Reboot(end_state = station_was_nuked ? "nuke" : "proper completion") //Can be upgraded to remove unneded sleep here.
-						else
-							to_chat(world, "<span class='info bold'>An admin has delayed the round end</span>")
-							world.send2bridge(
-								type = list(BRIDGE_ROUNDSTAT),
-								attachment_msg = "An admin has delayed the round end",
-								attachment_color = BRIDGE_COLOR_ROUNDSTAT,
-							)
-					else
-						to_chat(world, "<span class='info bold'>An admin has delayed the round end</span>")
-						world.send2bridge(
-							type = list(BRIDGE_ROUNDSTAT),
-							attachment_msg = "An admin has delayed the round end",
-							attachment_color = BRIDGE_COLOR_ROUNDSTAT,
-						)
+					end_timer_id = addtimer(CALLBACK(src, .proc/try_to_end), restart_timeout, TIMER_UNIQUE|TIMER_OVERRIDE)
+
+
+/datum/controller/subsystem/ticker/proc/try_to_end()
+	var/delayed = FALSE
+
+	var/static/admin_delay_announced = FALSE //announce reason only first time
+	if(admin_delayed)
+		if(!admin_delay_announced)
+			to_chat(world, "<span class='info bold'>Restart delayed due to admin</span>")
+			world.send2bridge(
+				type = list(BRIDGE_ROUNDSTAT),
+				attachment_msg = "An admin has delayed the round end",
+				attachment_color = BRIDGE_COLOR_ROUNDSTAT,
+			)
+			admin_delay_announced = TRUE
+		delayed = TRUE
+
+	var/static/vote_delay_announced = FALSE
+	if(SSvote.active_vote)
+		if(!vote_delay_announced)
+			to_chat(world, "<span class='info bold'>Restart delayed due to vote</span>")
+			vote_delay_announced = TRUE
+		delayed = TRUE
+
+	if(delayed)
+		end_timer_id = addtimer(CALLBACK(src, .proc/try_to_end), 5 SECONDS, TIMER_UNIQUE|TIMER_OVERRIDE)
+	else
+		world.Reboot(end_state = station_was_nuked ? "nuke" : "proper completion")
 
 /datum/controller/subsystem/ticker/proc/setup()
 	to_chat(world, "<span class='boldannounce'>Starting game...</span>")

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -74,7 +74,14 @@ SUBSYSTEM_DEF(vote)
 	return TRUE
 
 /datum/controller/subsystem/vote/proc/get_vote_time()	//How many seconds vote lasts
-	return round((vote_start_time + config.vote_period - world.time)/10)
+	var/vote_period
+
+	if(active_vote && active_vote.vote_period)
+		vote_period = active_vote.vote_period
+	else
+		vote_period = config.vote_period
+
+	return round((vote_start_time + vote_period - world.time)/10)
 
 /datum/controller/subsystem/vote/proc/interface(client/C)
 	if(!C)

--- a/code/controllers/subsystem/voting/poll.dm
+++ b/code/controllers/subsystem/voting/poll.dm
@@ -100,7 +100,7 @@
 			choice.voters.Remove(ckey)
 	else
 		if(multiple_votes)
-			choice.voters[ckey] = get_vote_power(C)
+			choice.voters[ckey] = get_vote_power(C, choice)
 		else
 			var/already_voted = FALSE
 			for(var/datum/vote_choice/VC in choices)
@@ -109,12 +109,12 @@
 					if(can_revote)
 						VC.voters.Remove(ckey)
 			if(can_revote || !already_voted)
-				choice.voters[ckey] = get_vote_power(C)
+				choice.voters[ckey] = get_vote_power(C, choice)
 
 
 //How much does this person's vote count for?
-/datum/poll/proc/get_vote_power(client/C)
-	return VOTE_WEIGHT_NORMAL
+/datum/poll/proc/get_vote_power(client/C, datum/vote_choice/choice)
+	return VOTE_WEIGHT_NORMAL * choice.vote_weight
 
 //How many unique people have cast votes?
 /datum/poll/proc/total_voters()

--- a/code/controllers/subsystem/voting/poll.dm
+++ b/code/controllers/subsystem/voting/poll.dm
@@ -35,6 +35,8 @@
 	var/next_vote = 0 //When will we next be allowed to call it again?
 	//You can set this time to a nonzero value to force a minimum roundtime before the vote can be called
 
+	var/vote_period = null //overrides default config.vote_period
+
 /datum/poll/proc/init_choices()
 	for(var/ch in choice_types)
 		choices.Add(new ch)

--- a/code/controllers/subsystem/voting/poll_types.dm
+++ b/code/controllers/subsystem/voting/poll_types.dm
@@ -33,12 +33,14 @@
 	. = ..()
 	if(.)
 		return
+	if(world.has_round_finished())
+		return "Раунд закончен"
 	for(var/client/C as anything in admins)
 		if((C.holder.rights & R_ADMIN) && !C.holder.fakekey && !C.is_afk())
 			return "Администрация сейчас в сети"
 
-/datum/poll/restart/get_vote_power(client/C)
-	return get_vote_power_by_role(C)
+/datum/poll/restart/get_vote_power(client/C, datum/vote_choice/choice)
+	return get_vote_power_by_role(C) * choice.vote_weight
 
 /datum/vote_choice/restart
 	text = "Рестарт"
@@ -102,8 +104,8 @@
 	if(security_level >= SEC_LEVEL_RED)
 		return "Код безопасности КРАСНЫЙ или выше"
 
-/datum/poll/crew_transfer/get_vote_power(client/C)
-	return get_vote_power_by_role(C)
+/datum/poll/crew_transfer/get_vote_power(client/C, datum/vote_choice/choice)
+	return get_vote_power_by_role(C) * choice.vote_weight
 
 /datum/vote_choice/crew_transfer
 	text = "Конец смены"
@@ -245,7 +247,10 @@
 
 		var/datum/vote_choice/nextmap/vc = new
 		vc.text = VM.GetFullMapName()
+		if(VM.voteweight != 1)
+			vc.text += "\[vote weight: [VM.voteweight]\]"
 		vc.mapname = VM.map_name
+		vc.vote_weight = VM.voteweight
 		choices.Add(vc)
 
 /datum/vote_choice/nextmap

--- a/code/controllers/subsystem/voting/vote_choice.dm
+++ b/code/controllers/subsystem/voting/vote_choice.dm
@@ -1,5 +1,6 @@
 /datum/vote_choice
 	var/text = "Nothing"
+	var/vote_weight = 1
 	var/list/voters = list() //assoc list of ckeys of voters and the voting power they contributed
 
 /datum/vote_choice/proc/on_win()

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -20,7 +20,7 @@
 	var/config_min_users = 0
 
 	var/votable = FALSE
-	//var/voteweight
+	var/voteweight = 1
 
 	var/traits = null
 	var/space_ruin_levels = 2

--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -19,6 +19,9 @@
 	var/config_max_users = 0
 	var/config_min_users = 0
 
+	var/votable = FALSE
+	//var/voteweight
+
 	var/traits = null
 	var/space_ruin_levels = 2
 	var/space_empty_levels = 1

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -978,12 +978,12 @@ var/global/BSACooldown = 0
 
 	if(!check_rights(R_SERVER))	return
 	if(SSticker.current_state > GAME_STATE_PREGAME)
-		SSticker.delay_end = !SSticker.delay_end
-		log_admin("[key_name(usr)] [SSticker.delay_end ? "delayed the round end" : "has made the round end normally"].")
-		message_admins("<span class='adminnotice'>[key_name(usr)] [SSticker.delay_end ? "delayed the round end" : "has made the round end normally"].</span>")
+		SSticker.admin_delayed = !SSticker.admin_delayed
+		log_admin("[key_name(usr)] [SSticker.admin_delayed ? "delayed the round end" : "has made the round end normally"].")
+		message_admins("<span class='adminnotice'>[key_name(usr)] [SSticker.admin_delayed ? "delayed the round end" : "has made the round end normally"].</span>")
 		world.send2bridge(
 			type = list(BRIDGE_ROUNDSTAT),
-			attachment_msg = "**[key_name(usr)]** [SSticker.delay_end ? "delayed the round end" : "has made the round end normally"].",
+			attachment_msg = "**[key_name(usr)]** [SSticker.admin_delayed ? "delayed the round end" : "has made the round end normally"].",
 			attachment_color = BRIDGE_COLOR_ROUNDSTAT,
 		)
 	else

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -398,7 +398,7 @@
 					dat += "<a href='?src=\ref[src];call_shuttle=2'>Send Back</a><br>"
 				if(1)
 					dat += "ETA: <a href='?src=\ref[src];edit_shuttle_time=1'>[shuttleeta2text()]</a><BR>"
-		dat += "<a href='?src=\ref[src];delay_round_end=1'>[SSticker.delay_end ? "End Round Normally" : "Delay Round End"]</a><br>"
+		dat += "<a href='?src=\ref[src];delay_round_end=1'>[SSticker.admin_delayed ? "End Round Normally" : "Delay Round End"]</a><br>"
 
 		dat += SSticker.mode.AdminPanelEntry()
 

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -314,12 +314,12 @@
 	else if(href_list["delay_round_end"])
 		if(!check_rights(R_SERVER))	return
 
-		SSticker.delay_end = !SSticker.delay_end
-		log_admin("[key_name(usr)] [SSticker.delay_end ? "delayed the round end" : "has made the round end normally"].")
-		message_admins("[key_name(usr)] [SSticker.delay_end ? "delayed the round end" : "has made the round end normally"].")
+		SSticker.admin_delayed = !SSticker.admin_delayed
+		log_admin("[key_name(usr)] [SSticker.admin_delayed ? "delayed the round end" : "has made the round end normally"].")
+		message_admins("[key_name(usr)] [SSticker.admin_delayed ? "delayed the round end" : "has made the round end normally"].")
 		world.send2bridge(
 			type = list(BRIDGE_ROUNDSTAT),
-			attachment_msg = "**[key_name(usr)]** [SSticker.delay_end ? "delayed the round end" : "has made the round end normally"].",
+			attachment_msg = "**[key_name(usr)]** [SSticker.admin_delayed ? "delayed the round end" : "has made the round end normally"].",
 			attachment_color = BRIDGE_COLOR_ROUNDSTAT,
 		)
 

--- a/config/example/maps.txt
+++ b/config/example/maps.txt
@@ -20,6 +20,7 @@ endmap
 
 map boxstation_snow
 	votable
+	voteweight 0.7
 endmap
 
 map gamma
@@ -32,4 +33,5 @@ endmap
 map falcon
 	votable
 	maxplayers 25
+	voteweight 2
 endmap

--- a/config/example/maps.txt
+++ b/config/example/maps.txt
@@ -7,25 +7,29 @@ Format:
 #map [map name] (name of .json file in _maps folder without the .json part)
 	minplayers [number] (0 or less disables this requirement)
 	maxplayers [number] (0 or less disables this requirement)
-	default (The last map with this defined will get all votes of players who have not explicitly voted for a map)
+	(not implemented?) default (The last map with this defined will get all votes of players who have not explicitly voted for a map)
 	(not implemented) voteweight [number] (How much to count each player vote as, defaults to 1, setting to 0.5 counts each vote as half a vote, 2 as double, etc, Setting to 0 disables the map but allows players to still pick it)
 	disabled (disables the map)
-	(not implemented) votable (is this map votable)
+	votable (is this map votable)
 endmap
 
 map boxstation
+	votable
 	default
 endmap
 
 map boxstation_snow
+	votable
 endmap
 
 map gamma
+	votable
 endmap
 
 map testmap
 endmap
 
 map falcon
+	votable
 	maxplayers 25
 endmap

--- a/config/example/maps.txt
+++ b/config/example/maps.txt
@@ -8,7 +8,7 @@ Format:
 	minplayers [number] (0 or less disables this requirement)
 	maxplayers [number] (0 or less disables this requirement)
 	(not implemented?) default (The last map with this defined will get all votes of players who have not explicitly voted for a map)
-	(not implemented) voteweight [number] (How much to count each player vote as, defaults to 1, setting to 0.5 counts each vote as half a vote, 2 as double, etc, Setting to 0 disables the map but allows players to still pick it)
+	voteweight [number] (How much to count each player vote as, defaults to 1, setting to 0.5 counts each vote as half a vote, 2 as double, etc, Setting to 0 disables the map but allows players to still pick it)
 	disabled (disables the map)
 	votable (is this map votable)
 endmap


### PR DESCRIPTION
## Описание изменений

Возможность запустить голосование на карту в конце раунда, см. чеинжлог.

Лимит по времени - 60 секунд, раунд из-за голосования будет отложен не более чем в два раза. Чуть больше радости гладиаторам.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог

:cl:
 - add: В конце раунда можно запустить голосование за карту для следующего раунда.
 - add: Если текущая карта не подходит по лимитам для количества игроков онлайн, то сервер сам запустит голосование для смены карты в конце раунда.
 - tweak: Раунд будет отложен, если любое голосование в процессе.