### PR TITLE
Cult preset: Darkness cult

### DIFF
--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -169,8 +169,8 @@
 	convert_opener = "May the Darkness lead your way."
 	aspect_preset = list(
 		/datum/aspect/lightbending/darkness = 3,
-		/datum/aspect/technology = 2,
-		/datum/aspect/resources = 1,
+		/datum/aspect/weapon = 2,
+		/datum/aspect/technology = 1,
 	)
 
 /datum/religion_sect/custom/cult

--- a/code/modules/religion/religion_sects.dm
+++ b/code/modules/religion/religion_sects.dm
@@ -163,6 +163,16 @@
 		/datum/aspect/lightbending/darkness = 2,
 	)
 
+/datum/religion_sect/preset/cult/darkness
+	name = "The Cult of Darkness"
+	desc = "The seizure of territories can be not only aggressive for darkness"
+	convert_opener = "May the Darkness lead your way."
+	aspect_preset = list(
+		/datum/aspect/lightbending/darkness = 3,
+		/datum/aspect/technology = 2,
+		/datum/aspect/resources = 1,
+	)
+
 /datum/religion_sect/custom/cult
 	name = "Custom Cult"
 	convert_opener = "Chaos is power."


### PR DESCRIPTION
## Описание изменений
Новый пресет для культа, который в последнее время довольно популярен. Да и лишь два пресета как-то такое себе.
Культ тьмы: 3 обскурум(тьма), 2 телума(оружие), 1 арсус(технология)
Что это за пресет и с чем его едят:
С самого начала раунда есть из крупных возможностей:
А) Призвать улучшенный том
Б) Проклятая вода
Стратегия: Некоторые из начального культа с самого начала раунда идут в теха и распыляюют в темноте(попутно выбивая встречающиеся лампы) проклятую воду, а некоторые вербуют людей. После обхода всех техов, немного ждём, пока подкопятся очки. После этого начинаем изучать те аспекты, что нам нужны(будь то для драки, защиты или дополнительных ресурсов). В это время на нас уже активно охотятся и каппелан, и СБ.
Плюсы: Хорошая тактика для получения стабильного прироста очков и в последствии изучения аспектов на поздних этапа игры.
Минусы: Практически с начала раунда нам на хвост садятся каппелан, а затем и СБ. Практически полная недееспособность как опасности для станции с начала раунда.
## Почему и что этот ПР улучшит
Проще новичкам, хорошая стратегия для культа
## Авторство
Все те, кто использвовали культ 3 обскурум(тьма), 2 телума(оружие), 1 арсус(технология)
## Чеинжлог
:cl: Chip11-n
- tweak: В пресеты культа добавлен культ тьмы.