### PR TITLE
Добавлен аннонс для взлома гейтвея

### DIFF
--- a/code/datums/announcements/gamemode.dm
+++ b/code/datums/announcements/gamemode.dm
@@ -32,6 +32,11 @@
 		src.message = message
 	..()
 
+/datum/announcement/centcomm/nuclear/gateway
+	name = "Hacked gateway"
+	subtitle = "Активация гейтвея."
+	message = "Произведена синхронизация гейтвеев. Ожидайте гостей."
+
 /* Vox */
 /datum/announcement/centcomm/vox/arrival
 	name = "Vox: Shuttle Arrives"

--- a/code/game/objects/items/devices/gateway_locker.dm
+++ b/code/game/objects/items/devices/gateway_locker.dm
@@ -61,6 +61,8 @@
 		G.hacked = TRUE
 		G.update_icon()
 	opened = TRUE
+	var/datum/announcement/centcomm/nuclear/gateway/announce = new
+	announce.play()
 	playsound(src, 'sound/machines/twobeep.ogg', VOL_EFFECTS_MASTER)
 
 /obj/effect/landmark/syndie_gateway


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Добавил аннонс после взлома гейтвея.
Возможность нюкерам попасть в центр станции без каких-либо недостатков это не ок, а аннонс за десяток секунд до него (или сколько сам телепорт требует) будет хоть каким-то недостатком.

## Почему и что этот ПР улучшит
Немного менее OP способ попадания на стацию. 

## Авторство

## Чеинжлог
:cl:
- balance: добавлен аннонс после взлома гейтвея.
