### PR TITLE
Добавление наушников авд в шкафы авд

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -61,6 +61,8 @@
 	new /obj/item/clothing/shoes/brown(src)
 	new /obj/item/clothing/shoes/black(src)
 	new /obj/item/weapon/storage/briefcase/centcomm(src)
+	new /obj/item/device/radio/headset/headset_int(src)
+	new /obj/item/device/radio/headset/headset_int(src)
 
 /obj/structure/closet/secure_closet/hop
 	name = "Head of Personnel's Locker"

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -62,7 +62,6 @@
 	new /obj/item/clothing/shoes/black(src)
 	new /obj/item/weapon/storage/briefcase/centcomm(src)
 	new /obj/item/device/radio/headset/headset_int(src)
-	new /obj/item/device/radio/headset/headset_int(src)
 
 /obj/structure/closet/secure_closet/hop
 	name = "Head of Personnel's Locker"

--- a/maps/gamma/gamma.dmm
+++ b/maps/gamma/gamma.dmm
@@ -54390,7 +54390,7 @@
 	},
 /area/station/civilian/janitor)
 "qgH" = (
-/obj/structure/closet/lawcloset,
+/obj/structure/closet/secure_closet/iaa,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Добавил в шкаф авд наушник авд, заменил шкаф с одеждой на шкаф авд в кабинете авд на гамме
## Почему и что этот ПР улучшит
resolve #9604 
Авд которые попались на раундстарт ивент удаления наушников будут меньше страдать
## Авторство
Akellazp
## Чеинжлог
:cl:
- map: В шкаф АВД добавлен наушник АВД
- map: На Гамме в офисе АВД обычный шкаф с одеждой заменен на шкаф АВД