### PR TITLE
Апдейт игрушки-сингулярности

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -114,9 +114,101 @@
  */
 /obj/item/toy/spinningtoy
 	name = "Gravitational Singularity"
-	desc = "\"Singulo\" brand spinning toy."
+	desc = "A gravitational singularity."
 	icon = 'icons/obj/singularity.dmi'
 	icon_state = "singularity_s1"
+	plane = SINGULARITY_PLANE
+	layer = SINGULARITY_LAYER
+
+	var/on = FALSE
+	var/stage_of_effect = 0 // 0 - default, 1 - clown card, 2 - emag
+	var/atom/movable/singularity_effect/fake_effect
+
+/obj/item/toy/spinningtoy/attack_hand(mob/user)
+	turn_off()
+	return ..()
+
+/obj/item/toy/spinningtoy/proc/turn_off()
+	on = FALSE
+	update_icon()
+
+/obj/item/toy/spinningtoy/verb/toggle()
+	set src in oview(1)
+	set category = "Object"
+	set name = "Toggle"
+
+	try_toggle(usr)
+
+/obj/item/toy/spinningtoy/AltClick(mob/user)
+	try_toggle(user)
+
+/obj/item/toy/spinningtoy/proc/try_toggle(mob/user)
+	if(!user)
+		return
+	if(user.incapacitated() || !Adjacent(user))
+		return
+	if(!isturf(loc)) // we dont want to allow user toggling it while it is in someone's inventory
+		return
+	if(!iscarbon(user) || isbrain(user))
+		return
+
+	add_fingerprint(user)
+	on = !on
+	if(stage_of_effect != 1)
+		if(ishuman(user))
+			var/mob/living/carbon/human/H = user
+			if(H.job == "Clown")
+				to_chat(user, "<span class = 'notice'>You concentrate your power into a one big bad joke and make the [src] much stronger.</span>")
+				stage_of_effect = 1
+	update_icon()
+
+/obj/item/toy/spinningtoy/emag_act()
+	if(stage_of_effect == 2)
+		return FALSE
+	to_chat(usr, "<span class = 'notice'>You upgrade the [src] in the faith of Lord Sindicatulo.</span>")
+	stage_of_effect = 2
+	update_icon()
+	return TRUE
+
+/obj/item/toy/spinningtoy/apply_outline(color)
+	return
+
+/obj/item/toy/spinningtoy/update_icon()
+	if(!on)
+		icon = 'icons/obj/singularity.dmi'
+		icon_state = "singularity_s1"
+		vis_contents -= fake_effect
+		QDEL_NULL(fake_effect)
+		return
+
+	switch(stage_of_effect)
+		if(0)
+			icon = 'icons/obj/singularity.dmi'
+			icon_state = "singularity_s1"
+			pixel_x = 0
+			pixel_y = 0
+		if(1)
+			icon = 'icons/effects/96x96.dmi'
+			icon_state = "singularity_s3"
+			pixel_x = -32
+			pixel_y = -32
+		if(2)
+			icon = 'icons/effects/160x160.dmi'
+			icon_state = "singularity_s5"
+			pixel_x = -64
+			pixel_y = -64
+
+	if(!fake_effect)
+		fake_effect = new(src)
+		fake_effect.transform = matrix().Scale(2.4)
+		vis_contents += fake_effect
+
+	fake_effect.icon = icon
+	fake_effect.icon_state = icon_state
+
+/obj/item/toy/spinningtoy/Destroy()
+	turn_off()
+	return ..()
 
 /*
  * Toy gun: Why isnt this an /obj/item/weapon/gun?


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Игрушечная синга теперь никак визуально не отличается от своего настоящего собрата, а через соответствующий верб или альтклик ее можно включить и она будет издавать синго-эффект.

Также если сингу включит клоун она станет больше. А вот если ее емагн-

https://user-images.githubusercontent.com/75007994/178160651-823ea162-8421-4f3f-a90e-b1f01f327eae.mp4

## Почему и что этот ПР улучшит
Хонк контент
## Авторство
я
## Чеинжлог
:cl:
 - tweak: Игрушечная сингулярность издает такой же эффект как настоящая если ее включить. А что будет если попробовать ее емагнуть?