### PR TITLE
Удаляет остановку сердца от удара током

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -626,7 +626,6 @@
 	else if(def_zone)
 		var/obj/item/organ/external/BP = get_bodypart(check_zone(def_zone))
 		siemens_coeff *= get_siemens_coefficient_organ(BP)
-	attack_heart(clamp(((shock_damage - 10) ** 2) / 100, 0, 100), shock_damage) //small shock can heal your heart
 	if(species)
 		siemens_coeff *= species.siemens_coefficient
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Удаляет остановку сердца от удара током. Fix #9690
## Почему и что этот ПР улучшит
Ущербнейшая механика, которая с некоторым шансом ваншотит любого человека без перчаток и лечится только через удар деффибом, который почти никогда не выносят за пределы медбея.
Эта механика почти никому(кроме её автора, наверное) не нравится и никто не будет против её удаления.
## Авторство

## Чеинжлог
:cl: Simbaka
- del: Остановка сердца от удара током удалена.