### PR TITLE
Runtimes

### DIFF
--- a/code/game/gamemodes/modes_gameplays/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/modes_gameplays/abduction/abduction_gear.dm
@@ -86,16 +86,9 @@
 
 	DeactivateStealth()
 
-/obj/item/clothing/suit/armor/abductor/vest/proc/IsAbductor(user)
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(H.species.name != ABDUCTOR)
-			return FALSE
-		return TRUE
-	return FALSE
 
 /obj/item/clothing/suit/armor/abductor/vest/proc/AbductorCheck(user)
-	if(IsAbductor(user))
+	if(isabductor(user))
 		return TRUE
 	to_chat(user, "<span class='notice'>You can't figure how this works.</span>")
 	return FALSE
@@ -138,16 +131,8 @@
 
 
 //SCIENCE TOOL
-/obj/item/device/abductor/proc/IsAbductor(user)
-	if(ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(H.species.name != ABDUCTOR)
-			return FALSE
-		return TRUE
-	return FALSE
-
 /obj/item/device/abductor/proc/AbductorCheck(user)
-	if(IsAbductor(user))
+	if(isabductor(user))
 		return TRUE
 	to_chat(user, "<span class='notice'>You can't figure how this works.</span>")
 	return FALSE
@@ -218,7 +203,7 @@
 		to_chat(user, "<span class='notice'>This specimen is already marked.</span>")
 		return
 	if(ishuman(target))
-		if(IsAbductor(target))
+		if(isabductor(target))
 			marked = target
 			to_chat(user, "<span class='notice'>You mark [target] for future retrieval.</span>")
 		else
@@ -341,7 +326,7 @@
 	var/obj/machinery/camera/helm_cam
 
 /obj/item/clothing/head/helmet/abductor/attack_self(mob/living/carbon/human/user)
-	if(!IsAbductor(user))
+	if(!isabductor(user))
 		to_chat(user, "<span class='notice'>You can't figure how this works.</span>")
 		return
 	if(helm_cam)
@@ -366,17 +351,6 @@
 		to_chat(user, "<span class='notice'>Abductor detected. Camera activated.</span>")
 		return
 
-/obj/item/clothing/head/helmet/abductor/proc/IsAbductor(mob/living/user)
-	if(!ishuman(user))
-		return FALSE
-	var/mob/living/carbon/human/H = user
-	if(!H.species)
-		return FALSE
-	if(H.species.name != ABDUCTOR)
-		return FALSE
-	return TRUE
-
-
 //ADVANCED BATON
 #define BATON_STUN 0
 #define BATON_SLEEP 1
@@ -398,7 +372,7 @@
 	action_button_name = "Toggle Mode"
 
 /obj/item/weapon/abductor_baton/proc/toggle(mob/living/user=usr)
-	if(!IsAbductor(user))
+	if(!isabductor(user))
 		return
 	if(!AgentCheck(user))
 		to_chat(user, "<span class='notice'>You're not trained to use this</span>")
@@ -435,21 +409,11 @@
 			icon_state = "wonderprodProbe"
 			item_state = "wonderprodProbe"
 
-/obj/item/weapon/abductor_baton/proc/IsAbductor(mob/living/user)
-	if(!ishuman(user))
-		return FALSE
-	var/mob/living/carbon/human/H = user
-	if(!H.species)
-		return FALSE
-	if(H.species.name != ABDUCTOR)
-		return FALSE
-	return TRUE
-
 /obj/item/weapon/abductor_baton/proc/AgentCheck(mob/living/carbon/human/user)
 	return isabductoragent(user)
 
 /obj/item/weapon/abductor_baton/attack(mob/target, mob/living/user)
-	if(!IsAbductor(user))
+	if(!isabductor(user))
 		return
 
 	if(isrobot(target))

--- a/code/game/gamemodes/modes_gameplays/abduction/machinery/console.dm
+++ b/code/game/gamemodes/modes_gameplays/abduction/machinery/console.dm
@@ -11,9 +11,6 @@
 	abductor_machinery_list -= src
 	return ..()
 
-/obj/machinery/abductor/proc/IsAbductor(mob/living/carbon/human/H)
-	return H.species?.name == ABDUCTOR
-
 /obj/machinery/abductor/proc/IsAgent(mob/living/carbon/human/H)
 	return isabductoragent(H)
 
@@ -46,7 +43,7 @@
 /obj/machinery/abductor/console/interact(mob/user)
 	if(issilicon(user)) //Borgs probably shouldn't be able to interact with it
 		return
-	if(!IsAbductor(user) && !isobserver(user))
+	if(!isabductor(user) && !isobserver(user))
 		if(user.is_busy())
 			return
 		to_chat(user, "<span class='warning'>You start mashing alien buttons at random!</span>")

--- a/code/game/gamemodes/modes_gameplays/abduction/machinery/console.dm
+++ b/code/game/gamemodes/modes_gameplays/abduction/machinery/console.dm
@@ -44,7 +44,7 @@
 							"radio silencer"=1)
 
 /obj/machinery/abductor/console/interact(mob/user)
-	if(!IsAbductor(user) && !isAI(user) && !isobserver(user))
+	if(!issilicon(user) && !IsAbductor(user) && !isAI(user) && !isobserver(user))
 		if(user.is_busy())
 			return
 		to_chat(user, "<span class='warning'>You start mashing alien buttons at random!</span>")

--- a/code/game/gamemodes/modes_gameplays/abduction/machinery/console.dm
+++ b/code/game/gamemodes/modes_gameplays/abduction/machinery/console.dm
@@ -44,7 +44,9 @@
 							"radio silencer"=1)
 
 /obj/machinery/abductor/console/interact(mob/user)
-	if(!issilicon(user) && !IsAbductor(user) && !isAI(user) && !isobserver(user))
+	if(issilicon(user)) //Borgs probably shouldn't be able to interact with it
+		return
+	if(!IsAbductor(user) && !isobserver(user))
 		if(user.is_busy())
 			return
 		to_chat(user, "<span class='warning'>You start mashing alien buttons at random!</span>")

--- a/code/game/gamemodes/modes_gameplays/abduction/machinery/dispenser.dm
+++ b/code/game/gamemodes/modes_gameplays/abduction/machinery/dispenser.dm
@@ -26,7 +26,7 @@
 		amounts[i] = rand(1,5)
 
 /obj/machinery/abductor/gland_dispenser/interact(mob/user)
-	if(!IsAbductor(user) && !isobserver(user))
+	if(!isabductor(user) && !isobserver(user))
 		return
 	return ..()
 

--- a/code/game/gamemodes/modes_gameplays/abduction/machinery/experiment.dm
+++ b/code/game/gamemodes/modes_gameplays/abduction/machinery/experiment.dm
@@ -16,7 +16,7 @@
 /obj/machinery/abductor/experiment/MouseDrop_T(mob/target, mob/user)
 	if(user.incapacitated() || !ishuman(target))
 		return
-	if(IsAbductor(target))
+	if(isabductor(target))
 		return
 	if(!user.IsAdvancedToolUser())
 		to_chat(user, "<span class='warning'>You can not comprehend what to do with this.</span>")
@@ -32,7 +32,7 @@
 
 /obj/machinery/abductor/experiment/close_machine(mob/target)
 	for(var/mob/living/carbon/C in loc)
-		if(IsAbductor(C))
+		if(isabductor(C))
 			return
 	if(state_open && !panel_open)
 		..(target)

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -142,7 +142,8 @@
 /obj/effect/spider/spiderling/proc/cancel_vent_move()
 	if(!entry_vent)
 		forceMove(get_turf(src))
-	forceMove(entry_vent.loc)
+	else
+		forceMove(entry_vent.loc)
 	entry_vent = null
 
 /obj/effect/spider/spiderling/proc/vent_move(obj/machinery/atmospherics/components/unary/vent_pump/exit_vent)

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -142,8 +142,8 @@
 /obj/effect/spider/spiderling/proc/cancel_vent_move()
 	if(!entry_vent)
 		forceMove(get_turf(src))
-	else
-		forceMove(entry_vent.loc)
+		return
+	forceMove(entry_vent.loc)
 	entry_vent = null
 
 /obj/effect/spider/spiderling/proc/vent_move(obj/machinery/atmospherics/components/unary/vent_pump/exit_vent)

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -140,7 +140,7 @@
 		die()
 
 /obj/effect/spider/spiderling/proc/cancel_vent_move()
-	forceMove(entry_vent.loc)
+	forceMove(entry_vent?.loc)
 	entry_vent = null
 
 /obj/effect/spider/spiderling/proc/vent_move(obj/machinery/atmospherics/components/unary/vent_pump/exit_vent)

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -140,7 +140,9 @@
 		die()
 
 /obj/effect/spider/spiderling/proc/cancel_vent_move()
-	forceMove(entry_vent?.loc)
+	if(!entry_vent)
+		forceMove(get_turf(src))
+	forceMove(entry_vent.loc)
 	entry_vent = null
 
 /obj/effect/spider/spiderling/proc/vent_move(obj/machinery/atmospherics/components/unary/vent_pump/exit_vent)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -107,12 +107,6 @@
 	modules += new /obj/item/device/gps/cyborg(src)
 	emag = new /obj/item/weapon/melee/energy/sword(src)
 
-/obj/item/weapon/robot_module/standard/respawn_consumable(mob/living/silicon/robot/R)
-	..()
-	var/obj/item/weapon/melee/baton/B = locate() in src.modules
-	if(B?.charges < 10)
-		B.charges += 1
-
 /obj/item/weapon/robot_module/medical
 	name = "medical robot module"
 	stacktypes = list(

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -110,7 +110,7 @@
 /obj/item/weapon/robot_module/standard/respawn_consumable(mob/living/silicon/robot/R)
 	..()
 	var/obj/item/weapon/melee/baton/B = locate() in src.modules
-	if(B.charges < 10)
+	if(B?.charges < 10)
 		B.charges += 1
 
 /obj/item/weapon/robot_module/medical

--- a/code/modules/religion/altar_types/altar_of_gods.dm
+++ b/code/modules/religion/altar_types/altar_of_gods.dm
@@ -221,7 +221,7 @@
 
 	// Assume, that if we've gotten this far, it's a succesful tool use.
 	. = TRUE
-	if(!religion && user?.my_religion.religious_tool_type && istype(I, user.my_religion.religious_tool_type))
+	if(!religion && user?.my_religion?.religious_tool_type && istype(I, user.my_religion.religious_tool_type))
 		religion = user.my_religion
 		religion.altars |= src
 		interact_religious_tool(I, user)

--- a/code/modules/religion/aspect.dm
+++ b/code/modules/religion/aspect.dm
@@ -275,6 +275,8 @@
 		prev_gain = favor_for_turf[F]
 	var/favor_gain = get_light_gain(F)
 
+	if(!F?.holy?.religion)
+		return
 	if(favor_gain != 0.0)
 		START_PROCESSING(SSreligion, F.holy.religion)
 		LAZYSET(favor_for_turf, F, favor_gain)

--- a/code/modules/religion/aspect.dm
+++ b/code/modules/religion/aspect.dm
@@ -275,8 +275,6 @@
 		prev_gain = favor_for_turf[F]
 	var/favor_gain = get_light_gain(F)
 
-	if(!F?.holy?.religion)
-		return
 	if(favor_gain != 0.0)
 		START_PROCESSING(SSreligion, F.holy.religion)
 		LAZYSET(favor_for_turf, F, favor_gain)


### PR DESCRIPTION
## Описание изменений
Фикс нескольких рантаймов

Сами рантаймы:
- **Runtime in altar_of_gods.dm:224 : Cannot read null.religious_tool_type** - При попытке ударить нуллродом по алтарю(в моём случае культа) любой, у кого есть holy_role, но нет религии, вызывал рантайм
- **Runtime in spiders.dm:143 : Cannot read null.loc** - В случае удаления венты не могли понять что им делать
- **Runtime in robot_modules.dm:113 : Cannot read null.charges** - Несуществующий батон у стандартного борга
- **Runtime in console.dm:15 : undefined variable /mob/living/silicon/robot/var/species** - Силиконы пытаются интерактить с консолями абдукторов

Напишите, если я где-то накосячил. Вроде оно должно рантаймить чуток меньше.
## Почему и что этот ПР улучшит
Немного раундстартом меньше будет дёргать, надеюсь
## Авторство

## Чеинжлог
Не стоит, думаю?