### PR TITLE
Фикс поинтера. Вновь.

### DIFF
--- a/code/game/gamemodes/modes_gameplays/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/modes_gameplays/nuclear/pinpointer.dm
@@ -111,10 +111,10 @@
 						return
 					var/obj/item/item_path = itemlist.possible_items[targetitem]
 					for(var/obj/item/I in global.possible_items_for_steal)
+						if(!istype(I, item_path))
+							continue
 						var/turf/T = get_turf(I)
 						if(is_centcom_level(T.z))
-							continue
-						if(!istype(I, item_path))
 							continue
 						target = I
 						break


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Если сейчас включить поинтер, например, на антиквар, то вылетит рантайм, и ничего не будет работать. Из того, что я понял, поинтер проходится гет турфом по каждому объекту, который находится в списке целек, в том числе и по мясу корги/экстракту. Так как их нет раундстартом, то гет турф возвращает нулл, из-за чего поиск и ломается. Теперь же такого не будет.
## Почему и что этот ПР улучшит
На один рантайм меньше.
## Авторство
Я
## Чеинжлог
