### PR TITLE
remove the change_title_screen proc

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -100,7 +100,6 @@ var/global/list/admin_verbs_sounds = list(
 	/client/proc/play_server_sound
 	)
 var/global/list/admin_verbs_fun = list(
-	/client/proc/change_title_screen,
 	/client/proc/object_talk,
 	/client/proc/cmd_admin_dress,
 	/client/proc/cmd_admin_gib_self,
@@ -695,31 +694,6 @@ var/global/list/admin_verbs_hideable = list(
 
 	togglebuildmode(mob)
 	feedback_add_details("admin_verb","TBMS") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
-/client/proc/change_title_screen()
-	set name = "Title Screen: Change"
-	set category = "Fun"
-
-	if(!check_rights(R_FUN))
-		return
-
-	log_admin("[key_name(usr)] try change the title screen.")
-	message_admins("[key_name_admin(usr)] try change the title screen.")
-	feedback_add_details("admin_verb", "CTS")
-
-	switch(tgui_alert(usr, "How change Title Screen?", "Title Screen", list("Change", "Reset", "Cancel")))
-		if("Change")
-			var/file = input(usr) as icon|null
-			if(!file)
-				return
-			change_lobbyscreen(file)
-		if("Reset")
-			change_lobbyscreen()
-		if("Cancel")
-			return
-
-	for(var/mob/dead/new_player/N as anything in new_player_list)
-		N.show_titlescreen()
 
 /client/proc/object_talk(msg as text) // -- TLE
 	set category = "Special Verbs"


### PR DESCRIPTION
## Описание изменений
Убрал прок для изменения лоббискрина из-за злоупотребления. Никогда не видел чтобы этот прок юзался для чего-то дельного, там всегда какие-то мемы из вконтакта даже не на тематику сс13.

## Почему и что этот ПР улучшит
Меньше анрелейтед шитпостов на лоббискрине

## Авторство

## Чеинжлог
