### PR TITLE
Auto-select for one-target spells with one target

### DIFF
--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -93,7 +93,7 @@ var/global/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the
 		if(try_start)
 			to_chat(user, "Not when you're incapacitated.")
 		return FALSE
-	
+
 	if(plasma_cost && isxeno(user))
 		var/mob/living/carbon/xenomorph/alien = user
 		if(!alien.check_enough_plasma(plasma_cost))
@@ -291,7 +291,7 @@ var/global/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the
 			if(range < 0)
 				targets += user // use spell/no_target instead
 			else
-				var/possible_targets = list()
+				var/list/possible_targets = list()
 
 				for(var/mob/living/M in view_or_range(range, user, selection_type))
 					if(!include_user && user == M)
@@ -300,9 +300,12 @@ var/global/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the
 					I.appearance = M
 					possible_targets[M] = I
 
-				var/radial_choose = show_radial_menu(user, user, possible_targets, tooltips = TRUE)
-				if(radial_choose)
-					targets += radial_choose
+				if(possible_targets.len == 1) //We have only one possible target
+					targets += possible_targets[1]
+				else //We have 2 and more targets
+					var/radial_choose = show_radial_menu(user, user, possible_targets, tooltips = TRUE)
+					if(radial_choose)
+						targets += radial_choose
 		else
 			var/list/possible_targets = list()
 			for(var/mob/living/target in view_or_range(range, user, selection_type))


### PR DESCRIPTION
## Описание изменений
Это всё же перебор, когда надо спрашивать, какую же цель из списка в один пункт стоит выбрать для применения спелла.
## Почему и что этот ПР улучшит
Удобство
## Авторство

## Чеинжлог
:cl: Chip11-n
- bugfix: При единственной возможной цели для умения, первое будет выбрано автоматически