### PR TITLE
Umeltable power and comms

### DIFF
--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -5,6 +5,7 @@
 */
 
 /obj/machinery/telecomms
+	unacidable = 1
 	var/temp = "" // output message
 
 /obj/machinery/telecomms/attackby(obj/item/P, mob/user)

--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -8,6 +8,7 @@
 	light_color = "#b88b2e"
 	req_access = list(access_cargo)
 	circuit = /obj/item/weapon/circuitboard/computer/cargo
+	unacidable = 1
 	var/requestonly = FALSE
 	var/contraband = FALSE
 	var/hacked = FALSE

--- a/code/modules/locations/shuttles/mine_sci_shuttle.dm
+++ b/code/modules/locations/shuttles/mine_sci_shuttle.dm
@@ -17,6 +17,7 @@ var/global/area/asteroid/mine_sci_curr_location = null
 	state_broken_preset = "commb"
 	state_nopower_preset = "comm0"
 	circuit = /obj/item/weapon/circuitboard/mine_sci_shuttle
+	unacidable = 1
 
 	var/lastMove = 0
 

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -9,6 +9,7 @@ var/global/list/rad_collectors = list()
 	density = TRUE
 	req_access = list(access_engine_equip)
 	use_power = NO_POWER_USE
+	unacidable = 1
 	var/obj/item/weapon/tank/phoron/P = null
 	var/last_power = 0
 	var/active = FALSE

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -63,6 +63,7 @@ ADD_TO_GLOBAL_LIST(/obj/structure/particle_accelerator, particle_accelerator_lis
 	icon_state = "none"
 	anchored = FALSE
 	density = TRUE
+	unacidable = 1
 	var/obj/machinery/particle_accelerator/control_box/master = null
 	var/construction_state = 0
 	var/reference = null

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -14,6 +14,7 @@
 	anchored = TRUE
 	use_power = NO_POWER_USE
 	allowed_checks = ALLOWED_CHECK_NONE
+	unacidable = 1
 
 	process_last = TRUE
 


### PR DESCRIPTION
## Описание изменений
СМЕСы, УЧ, коллекторы, телекоммы теперь больше не расплавить кислотой. **Провода, АПЦ и подобное всё ещё можно.**

То, что плавят алени раундстартом:
1) УЧ - заменимо исключительно через карго, а в ситуации ксеноморфов на станции у карго точно не будет очков на это. Достаточно расплавить одну деталь для отключения.
2) СМЕСы - заменить можно только в РнД, а ему их ещё исследовать если оно не было расплавленно
3) Телекоммы. При чём расплавить достаточно 1 деталь для полного отключения телекоммов. Замена только через РнД(если оно есть).

Ещё конечно есть консоль РнД, плата консола на складе, сервера РнД. Если расплавить это - заменить не выйдет ни чем. А если и выйдет, то потребуется не мало времени, **но это мной не было затронуто.**

Если кому-то надо где-то убрать энергию, всё ещё можно расплавить АПЦ, провода и подобное, но на весь раунд выводить из строя то, что практически невозможно заменить, как по мне, говноедство.

ПР сделан не для удаления вреда важным отсекам, а уменьшение необратимости раунд стартового раша
#TacticoolAliensIsNoMore
## Почему и что этот ПР улучшит
- В таких раундах не так уж и мало людей погибает в разгерме. Почему? Потому что створки не работают, а одними из самых первых разряжаются корридоры.
- Метаёбства станет чутка меньше.
- Ксеносы вместо раша по всем точкам, станут чуть больше защищать свою королеву в начале раунда.
- Люди в подобных раундах смогут оказывать чуть более вменяемое сопротивление.
## Авторство

## Чеинжлог
:cl: Chip11-n
- balance: УЧ, телекоммы, СМЕСы и коллекторы радиации теперь нельзя расплавить