### PR TITLE
добавляет ионку в карго

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -350,6 +350,15 @@ var/global/list/all_supply_groups = list("Operations","Security","Hospitality","
 	access = access_armory
 	group = "Security"
 
+/datum/supply_pack/ion_rifle
+	name = "ion rifles"
+	contains = list(/obj/item/weapon/gun/energy/ionrifle,
+					/obj/item/weapon/gun/energy/ionrifle)
+	cost = 7000
+	crate_type = /obj/structure/closet/crate/secure/weapon
+	crate_name = "ion rifles crate"
+	access = access_armory
+	group = "Security"
 
 /datum/supply_pack/expenergy
 	name = "Experimental energy gear crate"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -354,7 +354,7 @@ var/global/list/all_supply_groups = list("Operations","Security","Hospitality","
 	name = "ion rifles"
 	contains = list(/obj/item/weapon/gun/energy/ionrifle,
 					/obj/item/weapon/gun/energy/ionrifle)
-	cost = 7000
+	cost = 14000
 	crate_type = /obj/structure/closet/crate/secure/weapon
 	crate_name = "ion rifles crate"
 	access = access_armory


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
даже две ионки по цене 7000 рублей
## Почему и что этот ПР улучшит
почему-то ионок в карго не было, это давало роботам и мехам слишком уж мощное преимущество над всякими реверами и прочими треллами
## Авторство

## Чеинжлог
:cl:
- rscadd: В карго добавлена ионка.