### PR TITLE
нерф светошумовых гранат

### DIFF
--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -80,13 +80,11 @@
 
 	else if(distance <= 2)
 		if(ear_safety > 1)
-			M.Stun(1.5)
+			M.AdjustConfused(1)
 		else if(ear_safety > 0)
-			M.Stun(2)
-			M.Weaken(1)
+			M.AdjustConfused(2)
 		else
-			M.Stun(10)
-			M.Weaken(3)
+			M.AdjustConfused(10)
 			if((prob(14) || (M == loc && prob(70))))
 				M.ear_damage += rand(1, 10)
 			else
@@ -95,12 +93,12 @@
 
 	else if(distance <= 5)
 		if(!ear_safety)
-			M.Stun(8)
+			M.AdjustConfused(8)
 			M.ear_damage += rand(0, 3)
 			M.ear_deaf = max(M.ear_deaf, 10)
 
 	else if(!ear_safety)
-		M.Stun(4)
+		M.AdjustConfused(2)
 		M.ear_damage += rand(0, 1)
 		M.ear_deaf = max(M.ear_deaf, 5)
 

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -82,9 +82,9 @@
 		if(ear_safety > 1)
 			M.AdjustConfused(1)
 		else if(ear_safety > 0)
-			M.AdjustConfused(2)
+			M.AdjustConfused(1)
 		else
-			M.AdjustConfused(10)
+			M.AdjustConfused(5)
 			if((prob(14) || (M == loc && prob(70))))
 				M.ear_damage += rand(1, 10)
 			else
@@ -93,12 +93,12 @@
 
 	else if(distance <= 5)
 		if(!ear_safety)
-			M.AdjustConfused(8)
+			M.AdjustConfused(4)
 			M.ear_damage += rand(0, 3)
 			M.ear_deaf = max(M.ear_deaf, 10)
 
 	else if(!ear_safety)
-		M.AdjustConfused(2)
+		M.AdjustConfused(1)
 		M.ear_damage += rand(0, 1)
 		M.ear_deaf = max(M.ear_deaf, 5)
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Флешки теперь накидывают конфусед, а не стан.
Уменьшено в два раза время действия эффекта флешбенгов.
Подрыв флешки в руках всё ещё станит на очень долго.
## Почему и что этот ПР улучшит
СБухи больше не смогут просто закидать врага флешками, тем самым оглушив его на сто лет.
## Авторство

## Чеинжлог
:cl: Simbaka
- balance: Светошумовые гранаты более не оглушают, а просто заставляют персонажа ходить в разные стороны, как алкоголь.