### PR TITLE
главы больше не могут вступать в революцию

### DIFF
--- a/code/game/gamemodes/factions/revolution.dm
+++ b/code/game/gamemodes/factions/revolution.dm
@@ -97,7 +97,7 @@
 		var/datum/objective/target/rp_rev/rev_obj = AppendObjective(/datum/objective/target/rp_rev, TRUE)
 		if(rev_obj)
 			rev_obj.target = M.mind
-			rev_obj.explanation_text = "Capture, convert or exile from station [M.mind.name], the [M.mind.assigned_role]. Assassinate if you have no choice."
+			rev_obj.explanation_text = "Capture or exile from station [M.mind.name], the [M.mind.assigned_role]. Assassinate if you have no choice."
 			AnnounceObjectives()
 
 /datum/faction/revolution/process()

--- a/code/game/gamemodes/factions/revolution.dm
+++ b/code/game/gamemodes/factions/revolution.dm
@@ -43,7 +43,7 @@
 		var/datum/objective/target/rp_rev/rev_obj = AppendObjective(/datum/objective/target/rp_rev, TRUE)
 		if(rev_obj)
 			rev_obj.target = head_mind
-			rev_obj.explanation_text = "Capture, convert or exile from station [head_mind.name], the [head_mind.assigned_role]. Assassinate if you have no choice."
+			rev_obj.explanation_text = "Capture or exile from station [head_mind.name], the [head_mind.assigned_role]. Assassinate if you have no choice."
 	return TRUE
 
 /datum/faction/revolution/proc/check_heads_victory()

--- a/code/game/gamemodes/roles/revolution.dm
+++ b/code/game/gamemodes/roles/revolution.dm
@@ -86,6 +86,8 @@
 		to_chat(src, "<span class='warning'><b>[M] is already be a revolutionary!</b></span>")
 	else if(M.ismindprotect())
 		to_chat(src, "<span class='warning'><b>[M] is implanted with a mind protected implant - Remove it first!</b></span>")
+	else if(M.is_head_role())
+		to_chat(src, "<span class='warning'><b>[M] is a head of staff, your sworn enemy! Kill or exile them, not convert these corporate dogs!</b></span>")
 	else if(jobban_isbanned(M, ROLE_REV) || jobban_isbanned(M, "Syndicate"))
 		to_chat(src, "<span class='warning'><b>[M] is a blacklisted player!</b></span>")
 	else


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
тайтл
## Почему и что этот ПР улучшит
законвертить главу для ревы - изи мод. не приходится морочиться с убийством, с захватом или с изгнанием глав со станции (capture и exile давно в последний раз использовались?). к тому же, как минимум хоп и рд дают абсолютно нечестное преимущество реверам в виде ии, доступа и кучи пушек.
меняется ход игры - из противостояния реверы против глав+сб превращается в реверы и главы против кэпа, хоса и офицеров, а самое смешное, что многие главы вступают в реву чуть ли не в начале раунда. поэтому вот так
## Авторство
я
## Чеинжлог
:cl:
- balance: Главы больше не могут вступать в революцию.