### PR TITLE
Позволяет конвертить людей с майндшилдом в реву и фэмилис

### DIFF
--- a/code/game/gamemodes/modes_gameplays/families/induction_package.dm
+++ b/code/game/gamemodes/modes_gameplays/families/induction_package.dm
@@ -18,9 +18,6 @@
 
 /obj/item/gang_induction_package/attack_self(mob/living/user)
 	..()
-	if(user.ismindprotect())
-		to_chat(user, "You attended a seminar on not signing up for a gang and are not interested.")
-		return
 	if(isanycop(user))
 		to_chat(user, "As a NanoTrasen officer, you can't join this family. However, you pretend to accept it to keep your cover up.")
 		for(var/threads in team_to_use.free_clothes)

--- a/code/game/gamemodes/roles/revolution.dm
+++ b/code/game/gamemodes/roles/revolution.dm
@@ -12,8 +12,6 @@
 /datum/role/rev/CanBeAssigned(datum/mind/M)
 	if(!..())
 		return FALSE
-	if(M.current.ismindprotect())
-		return FALSE
 	return TRUE
 
 /datum/role/rev/OnPreSetup(greeting, custom)
@@ -84,8 +82,6 @@
 
 	if(isrevhead(M) || isrev(M))
 		to_chat(src, "<span class='warning'><b>[M] is already be a revolutionary!</b></span>")
-	else if(M.ismindprotect())
-		to_chat(src, "<span class='warning'><b>[M] is implanted with a mind protected implant - Remove it first!</b></span>")
 	else if(jobban_isbanned(M, ROLE_REV) || jobban_isbanned(M, "Syndicate"))
 		to_chat(src, "<span class='warning'><b>[M] is a blacklisted player!</b></span>")
 	else


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Позволяет людям с мш становиться реверами или бандитами
## Почему и что этот ПР улучшит
Рева давно уже не промывка мозгов и имеет вполне себе добровольный конверт, аналогично и с бандами, потому запрещать людям с мш становиться бандосами или реверами бессмысленно.
## Авторство

## Чеинжлог
:cl: Simbaka
 - tweak: Человек с имплантом защиты разума может стать членом революции или банды-семьи. 