### PR TITLE
Фиксы синдиборга

### DIFF
--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -158,6 +158,7 @@
 		lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
 	else if (sight_mode & BORGNIGHT)
 		sight_modifier = "nvg"
+		lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 	else if (sight_mode & BORGTHERM)
 		sight_modifier = "thermal"
 		sight |= SEE_MOBS

--- a/code/modules/mob/living/silicon/robot/syndi/syndiborg.dm
+++ b/code/modules/mob/living/silicon/robot/syndi/syndiborg.dm
@@ -42,13 +42,7 @@
 /obj/item/device/radio/borg/syndicate/atom_init()
 	. = ..()
 	set_frequency(SYND_FREQ)
-	for(var/ch_name in keyslot.channels)
-		if(ch_name in src.channels)
-			continue
-		src.channels += ch_name
-		src.channels[ch_name] += keyslot.channels[ch_name]
-	for(var/ch_name in src.channels)
-		secure_radio_connections[ch_name] = radio_controller.add_object(src, radiochannels[ch_name],  RADIO_CHAT)
+	INVOKE_ASYNC(src, .proc/recalculateChannels)
 
 /obj/item/weapon/melee/energy/sword/cyborg
 	var/hitcost = 500

--- a/code/modules/mob/living/silicon/robot/syndi/syndiborg.dm
+++ b/code/modules/mob/living/silicon/robot/syndi/syndiborg.dm
@@ -42,7 +42,13 @@
 /obj/item/device/radio/borg/syndicate/atom_init()
 	. = ..()
 	set_frequency(SYND_FREQ)
-	recalculateChannels()
+	for(var/ch_name in keyslot.channels)
+		if(ch_name in src.channels)
+			continue
+		src.channels += ch_name
+		src.channels[ch_name] += keyslot.channels[ch_name]
+	for(var/ch_name in src.channels)
+		secure_radio_connections[ch_name] = radio_controller.add_object(src, radiochannels[ch_name],  RADIO_CHAT)
 
 /obj/item/weapon/melee/energy/sword/cyborg
 	var/hitcost = 500

--- a/code/modules/mob/living/silicon/robot/syndi/syndiborg.dm
+++ b/code/modules/mob/living/silicon/robot/syndi/syndiborg.dm
@@ -42,6 +42,7 @@
 /obj/item/device/radio/borg/syndicate/atom_init()
 	. = ..()
 	set_frequency(SYND_FREQ)
+	recalculateChannels()
 
 /obj/item/weapon/melee/energy/sword/cyborg
 	var/hitcost = 500

--- a/code/modules/mob/living/silicon/robot/syndi/syndiborg.dm
+++ b/code/modules/mob/living/silicon/robot/syndi/syndiborg.dm
@@ -42,7 +42,6 @@
 /obj/item/device/radio/borg/syndicate/atom_init()
 	. = ..()
 	set_frequency(SYND_FREQ)
-	recalculateChannels()
 
 /obj/item/weapon/melee/energy/sword/cyborg
 	var/hitcost = 500


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
ПНВ синдиборга не видел во тьме. Исправлено.
Если борг переключится с дефолтной частоты, то у него пропадет синди канал. Исправлено.
## Почему и что этот ПР улучшит
Синдиборг станет играбельней.
## Авторство

## Чеинжлог
