### PR TITLE
Фикс пропажи юбки на кукле у кадетский юбок

### DIFF
--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -462,6 +462,7 @@
 /obj/item/clothing/under/rank/cadet/skirt
 	name = "security cadet's jumpskirt"
 	icon_state = "skirt_cadet"
+	item_state = "skirt_cadet"
 
 /obj/item/clothing/under/rank/forensic_technician
 	desc = "It has a Forensics rank stripe on it."


### PR DESCRIPTION
## Описание изменений
Кадетская юбочная униформа имела спрайт стандартной кадетской униформы
## Почему и что этот ПР улучшит
Теперь юбочная униформа будет всёж юбочной униформой, а не обычной униформой
## Авторство
Felix Ruin - Winter Schock
## Чеинжлог
:cl: Winter Schock
- bugfix: Юбочная униформа имеет модельку обычной на кукле