### PR TITLE
При оглушении мили оружием учитывается броня

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -345,9 +345,14 @@
 
 		switch(hit_area)
 			if(BP_HEAD)//Harder to score a stun but if you do it lasts a bit longer
-				if(prob(force_with_melee_skill / (100 / armor + 0.1)))
-					apply_effect(20, PARALYZE, armor)
-					visible_message("<span class='userdanger'>[src] has been knocked unconscious!</span>")
+				if(armor >= 10)
+					if(prob(force_with_melee_skill / (100 / armor)))
+						apply_effect(20, PARALYZE, armor)
+						visible_message("<span class='userdanger'>[src] has been knocked unconscious!</span>")
+				if(armor == 0)
+					if(prob(force_with_melee_skill))
+						apply_effect(20, PARALYZE, armor)
+						visible_message("<span class='userdanger'>[src] has been knocked unconscious!</span>")
 				if(prob(force_with_melee_skill + min(100,100 - src.health)) && src != user && I.damtype == BRUTE)
 					if(src != user && I.damtype == BRUTE && mind)
 						for(var/id in list(HEADREV, REV))
@@ -367,10 +372,14 @@
 						update_inv_glasses()
 
 			if(BP_CHEST)//Easier to score a stun but lasts less time
-				if(prob(((force_with_melee_skill + 10) / (100 / armor + 0.1))))
-					apply_effect(5, WEAKEN, armor)
-					visible_message("<span class='userdanger'>[src] has been knocked down!</span>")
-
+				if(armor >= 10)
+					if(prob((force_with_melee_skill + 10) / (100 / armor)))
+						apply_effect(5, WEAKEN, armor)
+						visible_message("<span class='userdanger'>[src] has been knocked down!</span>")
+				if(armor == 0)
+					if(prob(force_with_melee_skill + 10))
+						apply_effect(5, WEAKEN, armor)
+						visible_message("<span class='userdanger'>[src] has been knocked down!</span>")
 				if(!(damage_flags & (DAM_SHARP|DAM_EDGE)) && prob(I.force + 10)) // A chance to force puke with a blunt hit.
 					for(var/obj/item/weapon/grab/G in grabbed_by)
 						if(G.state >= GRAB_AGGRESSIVE && G.assailant == user)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -345,7 +345,7 @@
 
 		switch(hit_area)
 			if(BP_HEAD)//Harder to score a stun but if you do it lasts a bit longer
-				if(prob(force_with_melee_skill / (1 + armor)))
+				if(prob(force_with_melee_skill / (100 / armor + 0.1)))
 					apply_effect(20, PARALYZE, armor)
 					visible_message("<span class='userdanger'>[src] has been knocked unconscious!</span>")
 				if(prob(force_with_melee_skill + min(100,100 - src.health)) && src != user && I.damtype == BRUTE)
@@ -367,7 +367,7 @@
 						update_inv_glasses()
 
 			if(BP_CHEST)//Easier to score a stun but lasts less time
-				if(prob(((force_with_melee_skill + 10) / (1 + armor))))
+				if(prob(((force_with_melee_skill + 10) / (100 / armor + 0.1))))
 					apply_effect(5, WEAKEN, armor)
 					visible_message("<span class='userdanger'>[src] has been knocked down!</span>")
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -345,14 +345,9 @@
 
 		switch(hit_area)
 			if(BP_HEAD)//Harder to score a stun but if you do it lasts a bit longer
-				if(armor >= 10)
-					if(prob(force_with_melee_skill / (100 / armor)))
-						apply_effect(20, PARALYZE, armor)
-						visible_message("<span class='userdanger'>[src] has been knocked unconscious!</span>")
-				if(armor == 0)
-					if(prob(force_with_melee_skill))
-						apply_effect(20, PARALYZE, armor)
-						visible_message("<span class='userdanger'>[src] has been knocked unconscious!</span>")
+				if(prob(force_with_melee_skill / (100 / armor + 0.1)))
+					apply_effect(20, PARALYZE, armor)
+					visible_message("<span class='userdanger'>[src] has been knocked unconscious!</span>")
 				if(prob(force_with_melee_skill + min(100,100 - src.health)) && src != user && I.damtype == BRUTE)
 					if(src != user && I.damtype == BRUTE && mind)
 						for(var/id in list(HEADREV, REV))
@@ -372,14 +367,10 @@
 						update_inv_glasses()
 
 			if(BP_CHEST)//Easier to score a stun but lasts less time
-				if(armor >= 10)
-					if(prob((force_with_melee_skill + 10) / (100 / armor)))
-						apply_effect(5, WEAKEN, armor)
-						visible_message("<span class='userdanger'>[src] has been knocked down!</span>")
-				if(armor == 0)
-					if(prob(force_with_melee_skill + 10))
-						apply_effect(5, WEAKEN, armor)
-						visible_message("<span class='userdanger'>[src] has been knocked down!</span>")
+				if(prob(((force_with_melee_skill + 10) / (100 / armor + 0.1))))
+					apply_effect(5, WEAKEN, armor)
+					visible_message("<span class='userdanger'>[src] has been knocked down!</span>")
+
 				if(!(damage_flags & (DAM_SHARP|DAM_EDGE)) && prob(I.force + 10)) // A chance to force puke with a blunt hit.
 					for(var/obj/item/weapon/grab/G in grabbed_by)
 						if(G.state >= GRAB_AGGRESSIVE && G.assailant == user)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -345,7 +345,7 @@
 
 		switch(hit_area)
 			if(BP_HEAD)//Harder to score a stun but if you do it lasts a bit longer
-				if(prob(force_with_melee_skill))
+				if(prob(force_with_melee_skill / (1 + armor)))
 					apply_effect(20, PARALYZE, armor)
 					visible_message("<span class='userdanger'>[src] has been knocked unconscious!</span>")
 				if(prob(force_with_melee_skill + min(100,100 - src.health)) && src != user && I.damtype == BRUTE)
@@ -367,7 +367,7 @@
 						update_inv_glasses()
 
 			if(BP_CHEST)//Easier to score a stun but lasts less time
-				if(prob((force_with_melee_skill + 10)))
+				if(prob(((force_with_melee_skill + 10) / (1 + armor))))
 					apply_effect(5, WEAKEN, armor)
 					visible_message("<span class='userdanger'>[src] has been knocked down!</span>")
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -345,7 +345,7 @@
 
 		switch(hit_area)
 			if(BP_HEAD)//Harder to score a stun but if you do it lasts a bit longer
-				if(prob(force_with_melee_skill / (100 / armor + 0.1)))
+				if(prob(force_with_melee_skill / (1 + armor)))
 					apply_effect(20, PARALYZE, armor)
 					visible_message("<span class='userdanger'>[src] has been knocked unconscious!</span>")
 				if(prob(force_with_melee_skill + min(100,100 - src.health)) && src != user && I.damtype == BRUTE)
@@ -367,7 +367,7 @@
 						update_inv_glasses()
 
 			if(BP_CHEST)//Easier to score a stun but lasts less time
-				if(prob(((force_with_melee_skill + 10) / (100 / armor + 0.1))))
+				if(prob(((force_with_melee_skill + 10) / (1 + armor))))
 					apply_effect(5, WEAKEN, armor)
 					visible_message("<span class='userdanger'>[src] has been knocked down!</span>")
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -367,7 +367,7 @@
 						update_inv_glasses()
 
 			if(BP_CHEST)//Easier to score a stun but lasts less time
-				if(prob(((force_with_melee_skill + 10) && (armor <= 50))))
+				if(prob(force_with_melee_skill + 10) && (armor <= 50))
 					apply_effect(5, WEAKEN, armor)
 					visible_message("<span class='userdanger'>[src] has been knocked down!</span>")
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -345,7 +345,7 @@
 
 		switch(hit_area)
 			if(BP_HEAD)//Harder to score a stun but if you do it lasts a bit longer
-				if(prob(force_with_melee_skill / (1 + armor)))
+				if(prob(force_with_melee_skill) && (armor <= 50))
 					apply_effect(20, PARALYZE, armor)
 					visible_message("<span class='userdanger'>[src] has been knocked unconscious!</span>")
 				if(prob(force_with_melee_skill + min(100,100 - src.health)) && src != user && I.damtype == BRUTE)
@@ -367,7 +367,7 @@
 						update_inv_glasses()
 
 			if(BP_CHEST)//Easier to score a stun but lasts less time
-				if(prob(((force_with_melee_skill + 10) / (1 + armor))))
+				if(prob(((force_with_melee_skill + 10) && (armor <= 50))))
 					apply_effect(5, WEAKEN, armor)
 					visible_message("<span class='userdanger'>[src] has been knocked down!</span>")
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Броня с хорошей защитой от мили урона(больше 50%) спасает человека от кноков.
## Почему и что этот ПР улучшит
fixes  #6093
fixes #7410
fixes #7780
## Авторство

## Чеинжлог
:cl: Simbaka
- balance: Человека с высоким показателем защиты в ближнем бою невозможно оглушить ударами ножей, топоров, мечей и ТД.