### PR TITLE
no empty event notifications

### DIFF
--- a/code/modules/admin/verbs/custom_event.dm
+++ b/code/modules/admin/verbs/custom_event.dm
@@ -25,7 +25,7 @@
 	to_chat(world, "<br>")
 
 
-	if(config.chat_bridge && \
+	if(config.chat_bridge && custom_event_msg && \
 		tgui_alert(usr, "Do you want to make an announcement to chat conference?", "Chat announcement", list("Yes", "No, I don't want these people at my party")) == "Yes")
 		world.send2bridge(
 			type = list(BRIDGE_ANNOUNCE),


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

У админов всегда есть выбор не отправлять слап в дискорд, но почему-то они любят присылать пустые

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
