### PR TITLE
No pulse if you are DEAD

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1235,11 +1235,11 @@
 	if(species && species.flags[NO_BLOOD])
 		return PULSE_NONE //No blood, no pulse.
 
-	if(stat == DEAD)
-		return PULSE_NONE	//that's it, you're dead, nothing can influence your pulse
-
 	if(HAS_TRAIT(src, TRAIT_CPB))
 		return PULSE_NORM
+
+	if(stat == DEAD)
+		return PULSE_NONE	//that's it, you're dead, nothing can influence your pulse
 
 	var/obj/item/organ/internal/heart/IO = organs_by_name[O_HEART]
 	if(life_tick % 10)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1235,6 +1235,9 @@
 	if(species && species.flags[NO_BLOOD])
 		return PULSE_NONE //No blood, no pulse.
 
+	if(stat == DEAD)
+		return PULSE_NONE	//that's it, you're dead, nothing can influence your pulse
+
 	if(HAS_TRAIT(src, TRAIT_CPB))
 		return PULSE_NORM
 
@@ -1250,9 +1253,6 @@
 				playsound_local(null, 'sound/machines/cardio/pulse_fibrillation.ogg', VOL_EFFECTS_MASTER, vary = FALSE)
 				apply_effect(1,AGONY,0)
 				return PULSE_SLOW
-
-	if(stat == DEAD)
-		return PULSE_NONE	//that's it, you're dead, nothing can influence your pulse
 
 	var/temp = PULSE_NORM
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Поправил приоритет проверок в ``handle_pulse``, а то мертвому может спамить про проблемы с сердцем. Истоками уходит к #5505

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог


