### PR TITLE
Исправлен абуз с получением научных очков

### DIFF
--- a/code/modules/organs/external/flesh.dm
+++ b/code/modules/organs/external/flesh.dm
@@ -93,11 +93,11 @@
 
 	if(used_weapon)
 		if(brute > 0 && burn == 0)
-			BP.add_autopsy_data("[used_weapon]", brute, type_damage = BRUTE)
+			BP.add_autopsy_data(used_weapon, brute, type_damage = BRUTE)
 		else if(brute == 0 && burn > 0)
-			BP.add_autopsy_data("[used_weapon]", burn, type_damage = BURN)
+			BP.add_autopsy_data(used_weapon, burn, type_damage = BURN)
 		else if(brute > 0 && burn > 0)
-			BP.add_autopsy_data("[used_weapon]", brute + burn, type_damage = "mixed")
+			BP.add_autopsy_data(used_weapon, brute + burn, type_damage = "mixed")
 
 	var/can_cut = (prob(brute * 2) || sharp) && (bodypart_type != BODYPART_ROBOTIC)
 

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -85,17 +85,26 @@
 
 //Adds autopsy data for used_weapon. Use type damage: brute, burn, mixed, bruise (weak punch, e.g. fist punch)
 /obj/item/organ/proc/add_autopsy_data(used_weapon, damage, type_damage)
-	var/datum/autopsy_data/W = autopsy_data[used_weapon + worldtime2text()]
+	var/weapon_name
+	
+	if(isatom(used_weapon))
+		var/atom/weapon = used_weapon
+		weapon_name = initial(weapon.name)
+	else
+		weapon_name = used_weapon
+
+	var/datum/autopsy_data/W = autopsy_data[weapon_name + worldtime2text()]
+
 	if(!W)
 		W = new()
-		W.weapon = used_weapon
-		autopsy_data[used_weapon + worldtime2text()] = W
+		W.weapon = weapon_name
+		autopsy_data[weapon_name + worldtime2text()] = W
 
 	var/time = W.time_inflicted
 	if(time != worldtime2text())
 		W = new()
-		W.weapon = used_weapon
-		autopsy_data[used_weapon + worldtime2text()] = W
+		W.weapon = weapon_name
+		autopsy_data[weapon_name + worldtime2text()] = W
 
 	W.hits += 1
 	W.damage += damage


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Fixes https://github.com/TauCetiStation/TauCetiClassic/issues/8307

Забавный факт, ``add_autopsy_data`` уже в большинстве случаев принимает атом, а не имя.

Не проверял, нужно в ТМ. Может где-то еще всплывут объекты, у который initial имя не прописано.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог

:cl:
 - fix: Исправлен абуз с получением научных очков через отчеты о вскрытии и ударами переименованными предметами.