### PR TITLE
Повышение живучести мага. Щит от урона.

### DIFF
--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -134,7 +134,7 @@ LINEN BINS
 	. = ..()
 
 	var/obj/effect/effect/forcefield/F = new
-	AddComponent(/datum/component/forcefield, "wizard field", 20, 5 SECONDS, 3 SECONDS, F, TRUE)
+	AddComponent(/datum/component/forcefield, "wizard field", 20, 3 SECONDS, 5 SECONDS, F, TRUE)
 
 /obj/item/weapon/bedsheet/wiz/proc/activate(mob/living/user)
 	if(iswizard(user) || iswizardapprentice(user))
@@ -148,8 +148,6 @@ LINEN BINS
 
 	if(slot == SLOT_BACK)
 		activate(user)
-	else if(slot_equipped == SLOT_BACK)
-		deactivate(user)
 
 /obj/item/weapon/bedsheet/wiz/dropped(mob/living/user)
 	. = ..()

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -130,6 +130,32 @@ LINEN BINS
 	desc = "A special fabric enchanted with magic so you can have an enchanted night.  It even glows!"
 	icon_state = "sheetwiz"
 
+/obj/item/weapon/bedsheet/wiz/atom_init()
+	. = ..()
+
+	var/obj/effect/effect/forcefield/F = new
+	AddComponent(/datum/component/forcefield, "wizard field", 20, 5 SECONDS, 3 SECONDS, F, TRUE)
+
+/obj/item/weapon/bedsheet/wiz/proc/activate(mob/living/user)
+	if(iswizard(user) || iswizardapprentice(user))
+		SEND_SIGNAL(src, COMSIG_FORCEFIELD_PROTECT, user)
+
+/obj/item/weapon/bedsheet/wiz/proc/deactivate(mob/living/user)
+	SEND_SIGNAL(src, COMSIG_FORCEFIELD_UNPROTECT, user)
+
+/obj/item/weapon/bedsheet/wiz/equipped(mob/living/user, slot)
+	. = ..()
+
+	if(slot == SLOT_BACK)
+		activate(user)
+	else if(slot_equipped == SLOT_BACK)
+		deactivate(user)
+
+/obj/item/weapon/bedsheet/wiz/dropped(mob/living/user)
+	. = ..()
+	if(slot_equipped == SLOT_BACK)
+		deactivate(user)
+
 /obj/item/weapon/bedsheet/gar
 	name = "gar bedsheet"
 	desc = "A surprisingly soft gar bedsheet."


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
![qwerq](https://user-images.githubusercontent.com/96499407/182616467-22a5f36e-9cb4-4372-adf1-b665e6cc56e6.png)

Я не знаю кто решил что магу нужны [нерфы](https://github.com/TauCetiStation/TauCetiClassic/pull/9618). Даёт щит как у каппелана/культа при экипировке одеяла мага на спину, чтобы защитить магусов хотя бы чуть-чуть. Одеяла есть в стартовой локе. Прочность щита на 3 удара лопатой.
## Почему и что этот ПР улучшит
баланс, геймплей
## Авторство

## Чеинжлог
:cl: 
- add: Магу добавлен щит при экипировке одеяла на спину