### PR TITLE
Lux and Obscurum rebalance

### DIFF
--- a/code/modules/religion/aspect.dm
+++ b/code/modules/religion/aspect.dm
@@ -295,7 +295,7 @@
 	god_desc = "Вам нужная тьма на святой земле."
 
 /datum/aspect/lightbending/darkness/get_light_gain(turf/simulated/floor/F)
-	return (0.6 - F.get_lumcount()) * power * 0.05
+	return (0.6 - F.get_lumcount()) * 0.05 * (1.4 * sqrt(power) + (power / 4)) //https://www.desmos.com/calculator?lang=ru
 
 //Gives mana from: light levels on holy turfs
 //Needed for: spells and rituals related to the theme of receiving light

--- a/code/modules/religion/aspect.dm
+++ b/code/modules/religion/aspect.dm
@@ -295,7 +295,7 @@
 	god_desc = "Вам нужная тьма на святой земле."
 
 /datum/aspect/lightbending/darkness/get_light_gain(turf/simulated/floor/F)
-	return (0.6 - F.get_lumcount()) * 0.05 * (1.4 * sqrt(power) + (power / 4)) //https://www.desmos.com/calculator?lang=ru
+	return (0.6 - F.get_lumcount()) * 0.05 * (1.4 * sqrt(power) + (power / 4)) //https://www.desmos.com/calculator/nwle5biewp
 
 //Gives mana from: light levels on holy turfs
 //Needed for: spells and rituals related to the theme of receiving light
@@ -309,7 +309,7 @@
 	god_desc = "Вам нужен свет на святой земле."
 
 /datum/aspect/lightbending/light/get_light_gain(turf/simulated/floor/F)
-	return (F.get_lumcount() - 0.4) * power * 0.03
+	return (F.get_lumcount() - 0.4)  * 0.03 * (1.4 * sqrt(power) + (power / 4)) //https://www.desmos.com/calculator/nwle5biewp
 
 //Gives mana for economical cost of an item.
 //Needed for: anything economy related

--- a/code/modules/religion/aspect.dm
+++ b/code/modules/religion/aspect.dm
@@ -309,7 +309,7 @@
 	god_desc = "Вам нужен свет на святой земле."
 
 /datum/aspect/lightbending/light/get_light_gain(turf/simulated/floor/F)
-	return (F.get_lumcount() - 0.4)  * 0.03 * (1.4 * sqrt(power) + (power / 4)) //https://www.desmos.com/calculator/nwle5biewp
+	return (F.get_lumcount() - 0.4) * 0.03 * (1.4 * sqrt(power) + (power / 4)) //https://www.desmos.com/calculator/nwle5biewp
 
 //Gives mana for economical cost of an item.
 //Needed for: anything economy related


### PR DESCRIPTION
## Описание изменений
Обскурум - популярный аспект у культа, для раскрытия который требует немало усилий и о нём ещё нужно знать. Когда ставят изначальные 3 обскурума, проблем нет, там вменяемый приток ресурсов, однако формула просто умножает силу аспекта, таким образом при 6-7 силе ресурсов уже будет становиться немеренно.

Вот моё решение: 
Теперь расчёт притока ресурсов будет расчитываться по этой [формуле](https://www.desmos.com/calculator/nwle5biewp?lang=ru). Наиболее оптимальным уровнем для обскурума станет 3, а всё, что выше - будет иметь всё меньше эффективности.
X = Уровень обскурума или люкса
Y = Эффективность. То, на сколько умножается базовый приток
## Почему и что этот ПР улучшит
Уравновешивание аспекта
## Авторство

## Чеинжлог
:cl: Chip11-n
- balance[link]: Изменена формула притока ресурсов от аспектов люкса и обскурума