### PR TITLE
Фикс опечатки в ритуалах

### DIFF
--- a/code/modules/religion/rites_type/rites.dm
+++ b/code/modules/religion/rites_type/rites.dm
@@ -127,7 +127,7 @@
 	end(user, AOG)
 	if(invoke_effect(user, AOG) && religion.check_costs(favor_cost, piety_cost, user))
 		religion.adjust_favor(-favor_cost)
-		religion.adjust_favor(-piety_cost)
+		religion.adjust_piety(-piety_cost)
 		religion.ritename_by_count[name]++
 	reset_rite_wrapper(src, user, AOG)
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Фикс опечатки в ритуалах
## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
:cl:
 - fix: Ритуалы не тратили piety при завершение.
