### PR TITLE
Abductor or human

### DIFF
--- a/code/game/gamemodes/roles/abductor.dm
+++ b/code/game/gamemodes/roles/abductor.dm
@@ -32,7 +32,10 @@
 
 /datum/role/abductor/OnPostSetup(laterole)
 	. = ..()
-	var/mob/living/carbon/human/abductor/H = antag.current
+	var/mob/living/S = antag.current
+	var/mob/living/carbon/human/abductor/H = new /mob/living/carbon/human/abductor(S.loc)
+	usr.mind.transfer_to(H)
+	qdel(S)
 	H.set_species(ABDUCTOR)
 	var/faction_name = faction ? faction.name : ""
 	H.real_name = faction_name + " " + name

--- a/code/game/gamemodes/roles/abductor.dm
+++ b/code/game/gamemodes/roles/abductor.dm
@@ -34,7 +34,7 @@
 	. = ..()
 	var/mob/living/S = antag.current
 	var/mob/living/carbon/human/abductor/H = new /mob/living/carbon/human/abductor(S.loc)
-	usr.mind.transfer_to(H)
+	S.mind.transfer_to(H)
 	qdel(S)
 	H.set_species(ABDUCTOR)
 	var/faction_name = faction ? faction.name : ""


### PR DESCRIPTION
## Описание изменений
Абдукторы теперь должны спавниться именно абдукторами, а не людьми с другой расой.
Делается это путём спавна нового абдуктора и переселением игрока в него вместе с удалением старого моба.

Надеюсь в этот раз ничего не сломается

P.S. лучше это ТМом проверить на всякий
## Почему и что этот ПР улучшит
fix #9807
## Авторство

## Чеинжлог
:cl: Chip11-n
- bugfix: Абдукторы вновь рабочие