### PR TITLE
Возвращение оператора меха в подпрофы тестовиков

### DIFF
--- a/code/datums/outfits/jobs/assistant.dm
+++ b/code/datums/outfits/jobs/assistant.dm
@@ -56,3 +56,10 @@
 	head = /obj/item/clothing/head/indiana
 	l_pocket = /obj/item/device/occult_scanner
 	r_pocket = /obj/item/weapon/occult_pinpointer
+
+/datum/outfit/job/assistant/mecha_operator
+    name = OUTFIT_JOB_NAME("Mecha Operator")
+
+    uniform = /obj/item/clothing/under/rank/mecha_operator
+    shoes = /obj/item/clothing/shoes/black
+    gloves = /obj/item/clothing/gloves/fingerless

--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -15,7 +15,8 @@
 		"Reporter"       = /datum/outfit/job/assistant/reporter,
 		"Waiter"         = /datum/outfit/job/assistant/waiter,
 		"Vice Officer"   = /datum/outfit/job/assistant/vice_officer,
-		"Paranormal Investigator" = /datum/outfit/job/assistant/paranormal_investigator
+		"Paranormal Investigator" = /datum/outfit/job/assistant/paranormal_investigator,
+		"Mecha Operator" = /datum/outfit/job/assistant/mecha_operator
 		)
 	outfit = /datum/outfit/job/assistant/test_subject
 	skillsets = list(


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Оператор мехов возвращен в подпрофы тестовика
## Почему и что этот ПР улучшит
Благодаря скиллам эта профессия может пользоваться спросом у профессий, связанных с управлением мехов.
## Авторство

## Чеинжлог
🆑 
- rscadd: Возвращение оператора мехов как подпрофессии тестовика