### PR TITLE
абдукторы больше не могут телепортироваться в отсеки с джаммером телепортаций

### DIFF
--- a/code/game/gamemodes/modes_gameplays/abduction/machinery/pad.dm
+++ b/code/game/gamemodes/modes_gameplays/abduction/machinery/pad.dm
@@ -14,6 +14,8 @@
 	if(!thearea)
 		return
 	for(var/turf/T in get_area_turfs(thearea.type))
+		if(SEND_SIGNAL(T, COMSIG_ATOM_INTERCEPT_TELEPORT))
+			continue
 		if(!T.density)
 			var/clear = 1
 			for(var/obj/O in T)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
тайтл
## Почему и что этот ПР улучшит
ноу мор лута капитанской карты на десятой секунде и лута оружейки на двадцатой
## Авторство
я
## Чеинжлог
:cl:
- fix: Абдукторы не могут телепортироваться в защищенные джаммером отсеки.