### PR TITLE
Mechs and aliens

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -452,7 +452,7 @@
 	user.do_attack_animation(src)
 	user.SetNextMove(CLICK_CD_MELEE)
 	if(!prob(src.deflect_chance))
-		take_damage(15)
+		take_damage(30)
 		check_for_internal_damage(list(MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH,MECHA_INT_CONTROL_LOST))
 		playsound(src, 'sound/weapons/slash.ogg', VOL_EFFECTS_MASTER)
 		to_chat(user, "<span class='warning'>You slash at the armored suit!</span>")

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -452,7 +452,7 @@
 	user.do_attack_animation(src)
 	user.SetNextMove(CLICK_CD_MELEE)
 	if(!prob(src.deflect_chance))
-		take_damage(30)
+		take_damage(40)
 		check_for_internal_damage(list(MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH,MECHA_INT_CONTROL_LOST))
 		playsound(src, 'sound/weapons/slash.ogg', VOL_EFFECTS_MASTER)
 		to_chat(user, "<span class='warning'>You slash at the armored suit!</span>")

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -241,7 +241,7 @@
 
 	if(istype(target,/obj/mecha))
 		var/obj/mecha/M = target
-		M.take_damage(damage)
+		M.take_damage(damage * 2)
 		M.check_for_internal_damage(list(MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH,MECHA_INT_CONTROL_LOST))
 
 	if(ishuman(target))

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -241,7 +241,7 @@
 
 	if(istype(target,/obj/mecha))
 		var/obj/mecha/M = target
-		M.take_damage(damage * 2)
+		M.take_damage(50)
 		M.check_for_internal_damage(list(MECHA_INT_TEMP_CONTROL,MECHA_INT_TANK_BREACH,MECHA_INT_CONTROL_LOST))
 
 	if(ishuman(target))


### PR DESCRIPTION
## Описание изменений
Как беспомощен экипаж когда выпиливают на станции РнД, карго и двигло без возможности восстановления, так и чужие беспомощны против мехов по типу виндикатора, который спокойно ходит и выпиливает всё гнездо из чужиков эдак 4-8 за раз, даже не садясь в оборонительный режим. Напомню, что у виндикатора также есть гарантированный станлок в ближнем бою, который кладёт кого-угодно в слип, так что совсем обездоленными мехи не становятся.

Итак, что изменилось?
- Урон по меху для чужих стал в 40 едениц, вместо 15 в ближнем бою. Это было просто бесполезно, сейчас это самоубийство, но хоть какая-то польза.
- Урон от кислоты станет в два раза больше. Кислотой могут плеваться всего две касты, другим же придётся либо идти самоубиваться, либо бежать.

## Почему и что этот ПР улучшит
Среднестатистические алиены смогут сражаться с мехами, а не только в панике сбегать от него или подыхать
## Авторство

## Чеинжлог
:cl: Chip11-n
- balance: Чужие стали наносить гораздо больше урона по мехам: кислотой и ударами