### PR TITLE
Gib and helmet for rig

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -52,6 +52,7 @@
 	if(rig_connect)
 		rig_connect.helmet = null
 		rig_connect = null
+		canremove = 1
 	return ..()
 
 /obj/item/clothing/suit/space/rig
@@ -131,6 +132,7 @@
 
 	selected_module = null
 	QDEL_NULL(cell)
+	QDEL_NULL(helmet)
 	QDEL_LIST(installed_modules)
 	. = ..()
 


### PR DESCRIPTION
## Описание изменений
Когда, к примеру, нюкера убивали, после него оставался шлем, надев который, снять можно было только отрубив себе голову. Теперь встроенный шлем, потерявший свой риг, можно будет снимать и одевать.
## Почему и что этот ПР улучшит
Баги
## Авторство

## Чеинжлог
:cl: Chip11-n
- bugfix: Больше не будет неснимающихся шлемов при гибе человека