### PR TITLE
Mage scroll should not ignore jammer

### DIFF
--- a/code/game/objects/items/weapons/scrolls.dm
+++ b/code/game/objects/items/weapons/scrolls.dm
@@ -61,7 +61,7 @@
 	smoke.start()
 	var/list/L = list()
 	for(var/turf/T in get_area_turfs(thearea.type))
-		if(!T.density)
+		if(!T.density && !SEND_SIGNAL(T, COMSIG_ATOM_INTERCEPT_TELEPORT))
 			var/clear = 1
 			for(var/obj/O in T)
 				if(O.density)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог

:cl:
- fix: Скролл мага больше не позволяет телепортироваться в защищенные джаммером отсеки.