### PR TITLE
Добавление в химию пилюль дексалина.

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -36226,6 +36226,10 @@
 	},
 /obj/structure/table/glass,
 /obj/item/weapon/storage/box/syringes,
+/obj/item/weapon/storage/pill_bottle/dexalin{
+	pixel_x = -13;
+	pixel_y = 6
+	},
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "warning"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Каждый раунд, каждые уважающие себя химики бегают на склад и выуживают из синих аптечек эти пилюли. Так почему бы не остановить это колесо сансары и не положить баночку пилюль дексалина в химию. Не вижу в этом ничего плохого, так как никакой социалочки тупая беготня до склада и обратно в себе не скрывает.

## Почему и что этот ПР улучшит
Химикам не придётся бегать на склад за пилюлями дексалина.

## Авторство

## Чеинжлог
:cl: 
 - map: В химии на столике теперь лежит баночка с пилюлями дексалина.