### PR TITLE
no list(" in factions

### DIFF
--- a/code/game/gamemodes/modes_gameplays/shadowling/ascendant_shadowling.dm
+++ b/code/game/gamemodes/modes_gameplays/shadowling/ascendant_shadowling.dm
@@ -36,7 +36,7 @@
 	maxbodytemp = INFINITY
 	environment_smash = 3
 
-	faction = list("faithless")
+	faction = "faithless"
 
 /mob/living/simple_animal/ascendant_shadowling/atom_init()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -153,7 +153,7 @@ ADD_TO_GLOBAL_LIST(/mob/living/simple_animal/cat/dusty, chief_animal_list)
 	 IS_SYNTHETIC = TRUE
 	,NO_BREATHE = TRUE
 	)
-	faction = list("syndicate")
+	faction = "syndicate"
 	//var/turns_since_scan = 0
 	//var/mob/living/simple_animal/mouse/movement_target
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Убрал вроде бы, нигде неиспользуемые list, которые к тому же еще и не работают.
Например: синдикошку убивает висцератор, потому что у синдикошки faction = list("syndicate"), а у висцератора faction = "syndicate". Тоже самое с возвышенным тенелингом и хостайл тенями(которых встретить анрил).

## Почему и что этот ПР улучшит
Минус баг.