### PR TITLE
Добавляет джетпак и магбутсы в РнД

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -23677,6 +23677,7 @@
 	},
 /obj/structure/rack,
 /obj/item/clothing/suit/space/rig/science/rd,
+/obj/item/clothing/shoes/magboots,
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/head/helmet/space/rig/science/rd,
 /turf/simulated/floor{
@@ -37475,9 +37476,11 @@
 	pixel_y = 28
 	},
 /obj/structure/rack,
+/obj/item/clothing/shoes/magboots,
 /obj/item/clothing/suit/space/rig/science,
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/head/helmet/space/rig/science,
+/obj/item/weapon/tank/jetpack/carbondioxide,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whitepurplecorner"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Добавляет один джетпак в телесайнс.
Добавляет магбутсы к ригу учёного и рд.
## Почему и что этот ПР улучшит
альтернатива #9844
На мой взгляд, выдавать учёным доступ в ЕВА это слишком, ведь там, кроме спейс сьютов и жетпаков, есть металл и стекло, которое они примерно всегда будут красть.
## Авторство

## Чеинжлог
:cl: Simbaka
- map: В РнД добавлены магнитные ботинки и реактивный ранец.