### PR TITLE
Меняет скиллсет предвестника культа

### DIFF
--- a/code/modules/skills/skillsets/roles.dm
+++ b/code/modules/skills/skillsets/roles.dm
@@ -121,9 +121,9 @@
 		/datum/skill/command = SKILL_LEVEL_PRO,
 		/datum/skill/police = SKILL_LEVEL_TRAINED,
 		/datum/skill/firearms = SKILL_LEVEL_TRAINED,
+		/datum/skill/surgery = SKILL_LEVEL_MASTER,
+		/datum/skill/medical = SKILL_LEVEL_MASTER,
 		/datum/skill/chemistry = SKILL_LEVEL_TRAINED,
-		/datum/skill/combat_mech = SKILL_LEVEL_TRAINED,
-		/datum/skill/civ_mech = SKILL_LEVEL_TRAINED,
 		/datum/skill/research = SKILL_LEVEL_TRAINED,
 		/datum/skill/melee = SKILL_LEVEL_MASTER,
 	)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Убрал у харбингера навыки управления мехами и добавил медицинские скиллы.
## Почему и что этот ПР улучшит
Почему-то обычные культисты являются мастерами медицины, а их лидер лошок какой-то, что даже бинтики использовать не умеет.
А навыки управления мехами я убрал потому что...ну, эээ, зачем они лидеру культа?
## Авторство

## Чеинжлог
:cl: Simbaka
- balance[link]: Изменён скиллсет предвестника культа.