### PR TITLE
Fixed magic projectile light color

### DIFF
--- a/code/__DEFINES/colors.dm
+++ b/code/__DEFINES/colors.dm
@@ -97,6 +97,7 @@
 #define LIGHT_COLOR_GHOST_CANDLE "#a2fad1" // Used by ghost candles. rgb(162, 250, 209)
 #define LIGHT_COLOR_PLASMA       "#2be4b8" // Used in plasma gun. rgb(43, 228, 184)
 #define LIGHT_COLOR_PLASMA_OC    "#e88893" // Used in plasma gun overcharge mode. rgb(232, 136, 147)
+#define LIGHT_COLOR_LIGHTNING	 "#5eacb6" // Used in lightning bolt projectiles
 
 //Human organ color mods
 #define HULK_SKIN_TONE rgb(48, 224, 40) // human

--- a/code/datums/spells/in_hand.dm
+++ b/code/datums/spells/in_hand.dm
@@ -134,6 +134,7 @@
 	damage = 10
 	damage_type = BRUTE
 	nodamage = 0
+	light_color = LIGHT_COLOR_FIRE
 
 /obj/item/projectile/magic/fireball/on_hit(atom/target, def_zone = BP_CHEST, blocked = 0)
 	if(isliving(target))
@@ -167,6 +168,7 @@
 	damage = 15
 	damage_type = BURN
 	nodamage = 0
+	light_color = LIGHT_COLOR_LIGHTNING
 
 /obj/item/projectile/magic/lightning/on_hit(atom/target, def_zone = BP_CHEST, blocked = 0)
 	..()
@@ -222,6 +224,7 @@
 	nodamage = 0
 	flag = "laser"
 	damage_type = BURN
+	light_color = COLOR_PINK
 
 //////////////////////////////////////////////////////////////
 
@@ -387,6 +390,7 @@
 	damage_type = OXY
 	nodamage = 1
 	flag = "magic"
+	light_color = "#00ff00"
 
 /obj/item/projectile/magic/healing_ball/atom_init()
 	. = ..()

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -1,7 +1,7 @@
 /obj/item/projectile/magic
 	name = "bolt of nothing"
 	icon_state = "energy"
-	light_color = "#00ff00"
+	light_color = "#ffffff"
 	light_power = 2
 	light_range = 2
 	nodamage = 1


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Починен цвет у свечения различных проджектайлов у спеллов мага

## Почему и что этот ПР улучшит

Более полная атмосфера

## Авторство

L4rever

## Чеинжлог

:cl:

- bugfix: У фаербола и прочих скилов теперь правильное свечение
