### PR TITLE
flash device for all borg modules

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -119,6 +119,7 @@
 
 /obj/item/weapon/robot_module/medical/atom_init()
 	. = ..()
+	modules += new /obj/item/device/flash(src)
 	modules += new /obj/item/device/healthanalyzer(src)
 	modules += new /obj/item/weapon/reagent_containers/borghypo/medical(src)
 	modules += new /obj/item/weapon/scalpel/manager(src)
@@ -314,6 +315,7 @@
 
 /obj/item/weapon/robot_module/miner/atom_init()
 	. = ..()
+	modules += new /obj/item/device/flash(src)
 	modules += new /obj/item/borg/sight/meson(src)
 	modules += new /obj/item/weapon/wrench(src)
 	modules += new /obj/item/weapon/screwdriver(src)
@@ -372,6 +374,7 @@
 
 /obj/item/weapon/robot_module/science/atom_init()
 	. = ..()
+	modules += new /obj/item/device/flash(src)
 	modules += new /obj/item/weapon/gripper/science(src)
 	modules += new /obj/item/device/analyzer(src)
 	modules += new /obj/item/device/assembly/signaler(src)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
У шахтёрского, медицинского и научного модулей боргов тоже появляется флешка.

## Почему и что этот ПР улучшит
Не понятно по какому принципу флешки распределялись среди модулей. У инженерного есть, у научного нет. Например, мед. боргу приходится для выполнения 3 закона (о защите членов экипажа) сразу же пилой бить, минуя нелетальные средства (потому что их нет!). 

## Чеинжлог
:cl: Elisei
 - balance: Добавил flash тем модулям боргов, у которых его не было