### PR TITLE
Удаление большей части рандомности молота генокрада

### DIFF
--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -727,8 +727,8 @@
 		user.SetNextMove(CLICK_CD_MELEE)
 		visible_message("<span class='warning'><B>[user]</B> has punched \the <B>[src]!</B></span>")
 		playsound(src, 'sound/effects/grillehit.ogg', VOL_EFFECTS_MASTER)
-		if(prob(50) && Ham.use_charge(user,6))
-			take_damage(Ham.force * 3)
+		if(Ham.use_charge(user,6))
+			take_damage(Ham.force * 2)
 	else
 		user.SetNextMove(CLICK_CD_MELEE)
 		call((proc_res["dynattackby"]||src), "dynattackby")(W,user)

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -32,7 +32,7 @@
 		visible_message("<span class='warning'><B>[user]</B> бьет каркас!</span>")
 		user.do_attack_animation(src)
 		user.SetNextMove(CLICK_CD_MELEE)
-		if(C.use_charge(user, 1) && prob(40))
+		if(C.use_charge(user, 1))
 			playsound(src, pick('sound/effects/explosion1.ogg', 'sound/effects/explosion2.ogg'), VOL_EFFECTS_MASTER)
 			qdel(src)
 	else if(iswrench(W) && state == 0)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -432,7 +432,7 @@
 		user.do_attack_animation(src)
 		if(C.use_charge(user))
 			playsound(user, pick('sound/effects/explosion1.ogg', 'sound/effects/explosion2.ogg'), VOL_EFFECTS_MASTER)
-			take_damage(pick(10, 20, 30))
+			take_damage(pick(30))
 		return
 
 	else if(istype(W,/obj/item/apc_frame))

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -432,7 +432,7 @@
 		user.do_attack_animation(src)
 		if(C.use_charge(user))
 			playsound(user, pick('sound/effects/explosion1.ogg', 'sound/effects/explosion2.ogg'), VOL_EFFECTS_MASTER)
-			take_damage(pick(30))
+			take_damage(30)
 		return
 
 	else if(istype(W,/obj/item/apc_frame))

--- a/code/game/turfs/simulated/walls_reinforced.dm
+++ b/code/game/turfs/simulated/walls_reinforced.dm
@@ -257,7 +257,7 @@
 		visible_message("<span class='warning'><B>[user]</B> бьет укрепленную стену!</span>")
 		if(C.use_charge(user, 4))
 			playsound(user, pick('sound/effects/explosion1.ogg', 'sound/effects/explosion2.ogg'), VOL_EFFECTS_MASTER)
-			take_damage(pick(10, 20, 30))
+			take_damage(30)
 		return
 	else if (istype(W, /obj/item/weapon/pickaxe/drill/diamond_drill))
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Продолжение начатого в ПРе #9867
Убрал почти все rand() в проверках молота генокрада.
Уменьшил немного урон по мехам (20% и 6 ударов > 10 гарантированных ударов). Возможно, виндикаторы или броня мехов всё ещё смеётся с жалких 30 урона, но я это подробно не изучал и по субъективной оценке - мехи обычно неразрушаемы без дальнобоя.
Не сделал только аирлоки, но убирать там шанс будет довольно спорным решением. Лучше подождать полной разрушаемости и тогда уже менять на цифры урона.
## Почему и что этот ПР улучшит
Боланс и геймплей
## Авторство

## Чеинжлог
:cl: Deahaka
- balance: Молот генокрада получил стабильный урон и взаимодействие с окружением.