### PR TITLE
Ребаланс захвата у хлыста генокрада

### DIFF
--- a/code/game/gamemodes/modes_gameplays/changeling/powers/Whip.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/Whip.dm
@@ -36,17 +36,14 @@
 		return
 	if(next_click > world.time)
 		return
-	if(!use_charge(user, 2))
-		return
 	next_click = world.time + 10
 	var/obj/item/projectile/changeling_whip/LE = new (get_turf(src))
 	switch(user.a_intent)
 		if(INTENT_GRAB)
 			LE.grabber = TRUE
 		if(INTENT_PUSH)
-			if(prob(65))
-				LE.weaken = 3
-				LE.stun = 2
+			LE.weaken = 3
+			LE.stun = 2
 		if(INTENT_HARM)
 			LE.damage = 30
 		else

--- a/code/game/gamemodes/modes_gameplays/changeling/powers/Whip.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/Whip.dm
@@ -69,7 +69,7 @@
 	tracer_type = /obj/effect/projectile/changeling/tracer
 	impact_type = /obj/effect/projectile/changeling/impact
 
-/obj/item/projectile/changeling_whip/on_hit(atom/target, blocked = 0)
+/obj/item/projectile/changeling_whip/on_hit(atom/target, def_zone, blocked = 0)
 	if(isturf(target))
 		return
 	var/atom/movable/T = target

--- a/code/game/gamemodes/modes_gameplays/changeling/powers/Whip.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/Whip.dm
@@ -69,7 +69,7 @@
 	tracer_type = /obj/effect/projectile/changeling/tracer
 	impact_type = /obj/effect/projectile/changeling/impact
 
-/obj/item/projectile/changeling_whip/on_hit(atom/target, def_zone, blocked = 0)
+/obj/item/projectile/changeling_whip/on_hit(atom/target, def_zone = BP_CHEST, blocked = 0)
 	if(isturf(target))
 		return
 	var/atom/movable/T = target

--- a/code/game/gamemodes/modes_gameplays/changeling/powers/Whip.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/Whip.dm
@@ -36,14 +36,17 @@
 		return
 	if(next_click > world.time)
 		return
+	if(!use_charge(user, 2))
+		return
 	next_click = world.time + 10
 	var/obj/item/projectile/changeling_whip/LE = new (get_turf(src))
 	switch(user.a_intent)
 		if(INTENT_GRAB)
 			LE.grabber = TRUE
 		if(INTENT_PUSH)
-			LE.weaken = 3
-			LE.stun = 2
+			if(prob(65))
+				LE.weaken = 3
+				LE.stun = 2
 		if(INTENT_HARM)
 			LE.damage = 30
 		else
@@ -66,17 +69,17 @@
 	tracer_type = /obj/effect/projectile/changeling/tracer
 	impact_type = /obj/effect/projectile/changeling/impact
 
-/obj/item/projectile/changeling_whip/on_hit(atom/target, def_zone = BP_CHEST, blocked = 0)
+/obj/item/projectile/changeling_whip/on_hit(atom/target, blocked = 0)
 	if(isturf(target))
 		return
 	var/atom/movable/T = target
 	if(grabber)
-		var/grab_chance
+		var/grab_chance = 100
 		if(iscarbon(T))
 			var/mob/living/carbon/C = T
-			grab_chance = 60 - (C.getarmor(BP_CHEST, "melee") * 0.4)
-		else
-			grab_chance = 90
+			grab_chance -= C.run_armor_check(def_zone, absorb_text = TRUE)
+			if(def_zone == BP_CHEST || def_zone == BP_GROIN)	//limbs are easier to catch with a tentacle
+				grab_chance -= 20
 		if(!T.anchored && prob(grab_chance))
 			T.throw_at(host, get_dist(host, T) - 1, 1, spin = FALSE, callback = CALLBACK(src, .proc/end_whipping, T))
 	return ..()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Хлыст на граб интенте с шансом притягивает предметы, а если это карбон - берёт его в синий захват.
Так как это реализовано как пуля - с расстоянием есть шанс просто попасть сквозь моба, мол уклонился.
Было: 
+ шанс 90 на некарбонов;
+ 60 - (броня торса * 0,4) для карбонов

Стало: 
+ шанс 100 на некарбонов;
+ 100 - броня атакуемой части - 20 штраф за атаку не в конечность или голову - 10 штраф за дальность атаки по конечностям (с шансом прокает).

[Х/Y/Z]:
- Х шанс в торс;
- Y шанс в голову;
- Z шанс в конечность;

ОБОП - проверялся самый сильный эквип, не инспектор. Штраф за дальность не указан в таблице.

| Тесты | Было | Стало |
|:-------------: |:---------------:| :-------------:|
| Голый | 60 |     **80/100/100** |
| Детектив | 40        |        **20/100/40** |
| Офицер | 40 |        **20/50/90**   |
| Булетпруф | 56        |        **60/90/80** |
| Риотка | 28        |        **-10/18/10** |
| ОБОП | 32        |       **10/30/40** |
| ОБР | 36        |        **20/40/40** |
| Дедсквад | 28        |       **0/20/20** |
| ХоС |    24    |       **-10/-10/20** |
| Риг ГСБ |    38    |       **35/55/55** |
| Риг охраны | 38        |       **25/55/45** |

Кратко: 
- голые челы теперь не рандомно притягиваются;
- всё что хорошо защищает от мили уменьшает шансы до 20% и меньше;
- всё что не защищает конечности - фактически делает вас "голым" против граба хлыста.

То есть теперь на граб можно положиться намного увереннее, не делая его оружием завязанном на удаче. ПР является частью #9867 уменьшения популярности армблейда, не нерфая армблейд.
## Почему и что этот ПР улучшит
Баланс и геймплей
## Авторство

## Чеинжлог
:cl: Deahaka
- balance: Переработан шанс на захват у хлыста генокрада.