### PR TITLE
Ускорение пшика перцовки

### DIFF
--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -403,6 +403,8 @@ ADD_TO_GLOBAL_LIST(/obj/item/weapon/reagent_containers/spray/cleaner, cleaners_l
 	possible_transfer_amounts = null
 	volume = 40
 	safety = 1
+	spray_cloud_move_delay = 1
+	spray_cloud_react_delay = 0.5
 
 
 /obj/item/weapon/reagent_containers/spray/pepper/atom_init()


### PR DESCRIPTION
## Описание изменений
Было ускорено облачко перцовки.
## Почему и что этот ПР улучшит
В данный момент перцовка нужна лишь для унижения уже лежачих, и сидячих, ввиду того, что облачко летит супер-медленно. Этот ПР ускоряет облачко, что по идее должно повысить юзабельность перцовки(не знаю как записывать гифки чтобы наглядно показать скорость, простите)
## Авторство
Unchi
## Чеинжлог
:cl:
- tweak: Облачко перцовки ускорено.