### PR TITLE
Delay to putting people on the operating table

### DIFF
--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -1,3 +1,5 @@
+#define OPTABLE_PUT_TIME 16
+
 /obj/machinery/optable
 	name = "Operating Table"
 	desc = "Used for advanced medical procedures."
@@ -96,6 +98,9 @@
 	if (C == user)
 		user.visible_message("<span class='rose'>[user] climbs on [src].</span>","<span class='notice'>You climb on [src].</span>")
 	else
+		visible_message("<span class='danger'>[user] is trying to put [C] on the operating table!</span>")
+		if(!do_after(user, OPTABLE_PUT_TIME, target = C))
+			return
 		visible_message("<span class='notice'>[C] has been laid on [src] by [user].</span>")
 	if (C.client)
 		C.client.perspective = EYE_PERSPECTIVE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Добавил задержку, когда человек кладет другого человека на операционный стол

## Почему и что этот ПР улучшит

Данная старая фича активно абузится робастерами всех мастей и приводит к тому, что человека можно уронить драг-н-дропом мгновенно, имея рядом оп. стол (т.к. ложась на стол прожимается кравл).
Например:
![dreamseeker_lW1Cy9FF08](https://user-images.githubusercontent.com/6051766/185785277-8df257e3-9ce0-4652-abcb-617baf2a2628.gif)


## Авторство

## Чеинжлог

:cl:
- tweak: Появилась задержка при помещении человека на операционный стол