### PR TITLE
Clown chem access

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -238,7 +238,7 @@
 	supervisors = "the head of personnel"
 	selection_color = "#dddddd"
 	idtype = /obj/item/weapon/card/id/clown
-	access = list(access_clown, access_theatre)
+	access = list(access_clown, access_theatre, access_chemistry)
 	salary = 20
 	minimal_player_ingame_minutes = 120
 	outfit = /datum/outfit/job/clown


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Добавление доступа клоуну в ХИМИЮ
## Почему и что этот ПР улучшит
Клоуну не придётся слёзно вымаливать у химиков смазку из диспенсера. Ну и ОЧЕНЬ странно, что у клоуна нет доступа в химию. Это всё равно, что если бы врачам для хирургии приходилось каждый раунд бегать выпрашивать хирургические инструменты в оружейку.
## Авторство

## Чеинжлог
:cl:
 - balance: Клоун будет сам доставать себе смазку из химии.