### PR TITLE
Delay to shooting from laser weapons

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -1,3 +1,5 @@
+#define LASERGUN_FIRE_TIME 16
+
 /obj/item/weapon/gun/energy
 	icon_state = "energy"
 	name = "energy gun"
@@ -31,6 +33,8 @@
 	update_icon()
 
 /obj/item/weapon/gun/energy/Fire(atom/target, mob/living/user, params, reflex = 0)
+	if(!do_after(user, LASERGUN_FIRE_TIME, target = user))
+		return
 	newshot()
 	..()
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Добавил задержку, когда человек стреляет из лазерки
## Почему и что этот ПР улучшит
Данная старая фича активно абузится робастерами всех мастей и приводит к тому, что человека можно просто убить мгновенно, имея в руках лазерное оружие (т.к. оно стреляет лазерами).
## Авторство

## Чеинжлог
:cl:
 - tweak: Появилась задержка при стрельбе из лазерного оружия.