### PR TITLE
added missing emergency shutters in vacant office

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -78546,6 +78546,7 @@
 /obj/structure/window/reinforced/polarized{
 	id = "privateoffice"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/security/vacantoffice)
 "nSy" = (
@@ -83996,6 +83997,7 @@
 /obj/structure/window/reinforced/polarized{
 	id = "privateoffice"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/security/vacantoffice)
 "vls" = (


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
![Screenshot_2223](https://user-images.githubusercontent.com/67812445/186215167-f6871ff0-1e31-42f1-b995-f0c9bfdf694d.png)
Добавил эмердженси шаттерс.
## Почему и что этот ПР улучшит
Стандарт, как и в других отделах под окнами, есть шаттеры, чтобы разгерма сложнее распространялась.