### PR TITLE
Fire alarm bug + runtime null fix

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -940,7 +940,6 @@ FIRE ALARM
 	icon = 'icons/obj/monitors.dmi'
 	icon_state = "fire0"
 	var/detecting = 1.0
-	var/working = TRUE
 	var/time = 10.0
 	var/timing = 0.0
 	var/lockdownbyai = 0
@@ -1047,10 +1046,10 @@ FIRE ALARM
 	return
 
 /obj/machinery/firealarm/process()//Note: this processing was mostly phased out due to other code, and only runs when needed
-	if(stat & (NOPOWER|BROKEN))
-		working = FALSE
+	if(!is_operational())
+		STOP_PROCESSING(SSobj, src)
 	else
-		working = TRUE
+		START_PROCESSING(SSobj, src)
 
 	if(timing)
 		if(time > 0)
@@ -1145,7 +1144,7 @@ FIRE ALARM
 	updateUsrDialog()
 
 /obj/machinery/firealarm/proc/reset()
-	if(!working)
+	if(!is_operational())
 		return
 	var/area/A = get_area(src)
 	A.firereset()
@@ -1154,7 +1153,7 @@ FIRE ALARM
 		FA.update_icon()
 
 /obj/machinery/firealarm/proc/alarm()
-	if(!working)
+	if(!is_operational())
 		return
 	var/area/A = get_area(src)
 	A.firealert()

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -940,7 +940,7 @@ FIRE ALARM
 	icon = 'icons/obj/monitors.dmi'
 	icon_state = "fire0"
 	var/detecting = 1.0
-	var/working = 1.0
+	var/working = TRUE
 	var/time = 10.0
 	var/timing = 0.0
 	var/lockdownbyai = 0
@@ -1048,6 +1048,7 @@ FIRE ALARM
 
 /obj/machinery/firealarm/process()//Note: this processing was mostly phased out due to other code, and only runs when needed
 	if(stat & (NOPOWER|BROKEN))
+		working = FALSE
 		return
 
 	if(timing)
@@ -1143,7 +1144,7 @@ FIRE ALARM
 	updateUsrDialog()
 
 /obj/machinery/firealarm/proc/reset()
-	if (!working)
+	if(!working)
 		return
 	var/area/A = get_area(src)
 	A.firereset()
@@ -1152,7 +1153,7 @@ FIRE ALARM
 		FA.update_icon()
 
 /obj/machinery/firealarm/proc/alarm()
-	if (!working)
+	if(!working)
 		return
 	var/area/A = get_area(src)
 	A.firealert()

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -975,6 +975,8 @@ FIRE ALARM
 
 /obj/machinery/firealarm/bullet_act(obj/item/projectile/P, def_zone)
 	. = ..()
+	if(!is_operational())
+		return
 	alarm()
 
 /obj/machinery/firealarm/emp_act(severity)
@@ -1042,14 +1044,14 @@ FIRE ALARM
 					qdel(src)
 		return
 
+	if(!is_operational())
+		return
 	alarm()
 	return
 
 /obj/machinery/firealarm/process()//Note: this processing was mostly phased out due to other code, and only runs when needed
 	if(!is_operational())
-		STOP_PROCESSING(SSobj, src)
-	else
-		START_PROCESSING(SSobj, src)
+		return
 
 	if(timing)
 		if(time > 0)
@@ -1127,6 +1129,8 @@ FIRE ALARM
 
 	if (buildstage != 2)
 		return FALSE
+	if(!is_operational())
+		return
 
 	if (href_list["reset"])
 		reset()
@@ -1144,8 +1148,6 @@ FIRE ALARM
 	updateUsrDialog()
 
 /obj/machinery/firealarm/proc/reset()
-	if(!is_operational())
-		return
 	var/area/A = get_area(src)
 	A.firereset()
 	for(var/obj/machinery/firealarm/FA in A)
@@ -1153,8 +1155,6 @@ FIRE ALARM
 		FA.update_icon()
 
 /obj/machinery/firealarm/proc/alarm()
-	if(!is_operational())
-		return
 	var/area/A = get_area(src)
 	A.firealert()
 	for(var/obj/machinery/firealarm/FA in A)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -1049,6 +1049,8 @@ FIRE ALARM
 /obj/machinery/firealarm/process()//Note: this processing was mostly phased out due to other code, and only runs when needed
 	if(stat & (NOPOWER|BROKEN))
 		working = FALSE
+	else
+		working = TRUE
 		return
 
 	if(timing)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -1051,7 +1051,6 @@ FIRE ALARM
 		working = FALSE
 	else
 		working = TRUE
-		return
 
 	if(timing)
 		if(time > 0)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Фаер алярмы можно было использовать в состояниях без питания или в сломанном, также это могло привести к редким рантаймам.
## Почему и что этот ПР улучшит
Минус баг
Не рантаймит?
## Авторство
Rahmano
## Чеинжлог
:cl: Rahmano
* bugfix: Фаер алярмы можно было использовать в сломанном состоянии или без питания.