### PR TITLE
fixes #9904

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1716,11 +1716,12 @@
 		..()
 
 /obj/item/weapon/reagent_containers/food/snacks/proc/try_slice(obj/item/weapon/W, mob/user)
+	user.SetNextMove(CLICK_CD_ACTION)
 	if((slices_num <= 0 || !slices_num) || !slice_path)
 		return FALSE
-	var/inaccurate = 0
-	if(!W.get_quality(QUALITY_CUTTING) || !W.sharp)
-		inaccurate = 1
+	var/inaccurate = FALSE
+	if(!W.get_quality(QUALITY_CUTTING))
+		inaccurate = TRUE
 
 	if ( \
 			!isturf(src.loc) || \
@@ -1731,24 +1732,25 @@
 		to_chat(user, "<span class='rose'>You cannot slice [src] here! You need a table or at least a tray to do it.</span>")
 		return FALSE
 	var/slices_lost = 0
-	if (inaccurate)
-		slices_lost = rand(1, min(1, round(slices_num * 0.5)))
-		if (istype(W, /obj/item/weapon/melee/energy/sword))
-			playsound(user, 'sound/items/esword_cutting.ogg', VOL_EFFECTS_MASTER, null, FALSE)
+	if(W.sharp)
+		if(inaccurate)
+			slices_lost = rand(1, min(1, round(slices_num * 0.5)))
+			if(istype(W, /obj/item/weapon/melee/energy/sword))
+				playsound(user, 'sound/items/esword_cutting.ogg', VOL_EFFECTS_MASTER, null, FALSE)
+			else
+				playsound(user, 'sound/items/shard_cutting.ogg', VOL_EFFECTS_MASTER, null, FALSE)
 		else
-			playsound(user, 'sound/items/shard_cutting.ogg', VOL_EFFECTS_MASTER, null, FALSE)
-	else
-		playsound(src, pick(SOUNDIN_KNIFE_CUTTING), VOL_EFFECTS_MASTER, null, FALSE)
-	if (do_after(user, 35, target = src, can_move = FALSE))
-		if (!inaccurate)
-			user.visible_message("<span class='info'>[user] slices \the [src]!</span>", "<span class='notice'>You slice \the [src]!</span>")
-		else
-			user.visible_message("<span class='info'>[user] inaccurately slices \the [src] with [W]!</span>", "<span class='notice'>You inaccurately slice \the [src] with your [W]!</span>")
-		var/reagents_per_slice = reagents.total_volume/slices_num
-		for(var/i=1 to (slices_num-slices_lost))
-			var/obj/slice = new slice_path (src.loc)
-			reagents.trans_to(slice,reagents_per_slice)
-		qdel(src)
+			playsound(src, pick(SOUNDIN_KNIFE_CUTTING), VOL_EFFECTS_MASTER, null, FALSE)
+		if(do_after(user, 35, target = src, can_move = FALSE))
+			if(!inaccurate)
+				user.visible_message("<span class='info'>[user] slices \the [src]!</span>", "<span class='notice'>You slice \the [src]!</span>")
+			else
+				user.visible_message("<span class='info'>[user] inaccurately slices \the [src] with [W]!</span>", "<span class='notice'>You inaccurately slice \the [src] with your [W]!</span>")
+			var/reagents_per_slice = reagents.total_volume/slices_num
+			for(var/i=1 to (slices_num-slices_lost))
+				var/obj/slice = new slice_path (src.loc)
+				reagents.trans_to(slice,reagents_per_slice)
+			qdel(src)
 
 /obj/item/weapon/reagent_containers/food/snacks/sliceable/attackby(obj/item/I, mob/user, params)
 	if(user.a_intent == INTENT_HARM)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Теперь бананами, бумагой, пончиками, т.е. любыми, не острыми предметами, нельзя резать пиццу, арбузы & т.д., что было немного cringe.

Добавил КД на резанье:
Во первых, можно было спамить звуком.
Во вторых, можно было нарезать очень много арбузов/блюд за пару секунд.
## Почему и что этот ПР улучшит
* Fixes: #9904.
* Нельзя спамить звуком нарезки.
* Нельзя абузить нарезку одновременно многого количества предметов.
* Возможно сделал лучше код.
## Авторство
Rahmano
## Чеинжлог
:cl: Rahmano
* bugfix: Блюда можно было нарезать неострыми предметами.