### PR TITLE
Gamma fix

### DIFF
--- a/maps/gamma/gamma.dmm
+++ b/maps/gamma/gamma.dmm
@@ -2003,9 +2003,6 @@
 /area/station/civilian/dormitories)
 "adj" = (
 /obj/structure/flora/ausbushes/ppflowers,
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
 	dir = 4;
@@ -2070,6 +2067,9 @@
 "adq" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/brflowers,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
 	icon_state = "wood_siding4"
@@ -2149,7 +2149,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/machinery/light,
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
 	icon_state = "wood_siding6"
@@ -4176,6 +4175,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/mob/living/simple_animal/det5,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -4445,6 +4445,8 @@
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
+/obj/item/clothing/suit/space/rig/science,
+/obj/item/clothing/head/helmet/space/rig/science,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whitepurple"
@@ -4533,6 +4535,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/alarm{
+	pixel_y = 26
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
@@ -5624,10 +5633,6 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/weapon/gun/projectile/shotgun/combat/nonlethal{
-	pixel_x = -3;
-	pixel_y = 3
-	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "vault"
@@ -5819,9 +5824,6 @@
 /area/station/rnd/hallway)
 "aQc" = (
 /obj/machinery/deepfryer,
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -6270,11 +6272,27 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "aZE" = (
-/obj/structure/stool,
-/obj/machinery/light/small,
-/turf/simulated/floor{
-	icon_state = "floorgrime"
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Armory Maintenance";
+	dir = 1;
+	pixel_x = 20
+	},
+/turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "aZL" = (
 /turf/simulated/wall,
@@ -8262,6 +8280,14 @@
 	},
 /turf/simulated/floor/goonplaque,
 /area/station/hallway/secondary/arrival)
+"bDZ" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "QMLoad3"
+	},
+/obj/machinery/light,
+/turf/simulated/floor/plating,
+/area/station/cargo/storage)
 "bEu" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -8516,6 +8542,7 @@
 	pixel_x = -2;
 	pixel_y = 4
 	},
+/obj/item/borg/upgrade/security,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -8565,10 +8592,20 @@
 /turf/simulated/wall/r_wall,
 /area/station/rnd/xenobiology)
 "bKs" = (
-/obj/structure/stool,
-/turf/simulated/floor{
-	icon_state = "floorgrime"
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "bKt" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9137,6 +9174,7 @@
 	},
 /obj/item/weapon/storage/box/r4046/rubber,
 /obj/item/weapon/storage/box/r4046/teargas,
+/obj/item/weapon/storage/box/r4046/EMP,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "vault"
@@ -9406,7 +9444,7 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "bWT" = (
-/obj/structure/holostool,
+/obj/structure/stool,
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken5"
 	},
@@ -10009,7 +10047,7 @@
 /obj/item/device/radio/intercom{
 	pixel_y = 25
 	},
-/obj/structure/closet/l3closet/security,
+/obj/structure/closet/secure_closet/pistols,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "vault"
@@ -10609,12 +10647,9 @@
 	},
 /area/station/hallway/primary/central)
 "cpx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/meter,
-/turf/simulated/floor/plating,
-/area/station/maintenance/brig)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/wall/r_wall,
+/area/station/security/armoury)
 "cpz" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -10770,9 +10805,6 @@
 /area/station/engineering/atmos)
 "csG" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/obj/machinery/light{
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -12317,6 +12349,7 @@
 /obj/item/device/taperecorder{
 	pixel_x = -3
 	},
+/obj/item/weapon/changeling_test,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -12394,17 +12427,17 @@
 /area/station/civilian/chapel/altar)
 "cQU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "rampbottom"
-	},
+/turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "cQV" = (
 /obj/machinery/conveyor{
@@ -12689,8 +12722,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -13186,6 +13219,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -13744,13 +13778,12 @@
 	},
 /area/station/civilian/dormitories)
 "dnW" = (
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/structure/closet/bombclosetsecurity,
 /turf/simulated/floor{
-	icon_state = "freezerfloor"
+	dir = 8;
+	icon_state = "vault"
 	},
-/area/station/civilian/toilet)
+/area/station/security/armoury)
 "doo" = (
 /obj/structure/rack,
 /obj/item/weapon/circuitboard/borgupload{
@@ -13787,7 +13820,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	dir = 1;
+	dir = 9;
 	icon_state = "yellow"
 	},
 /area/station/hallway/primary/bridgehall)
@@ -13810,21 +13843,19 @@
 	},
 /area/station/security/detectives_office)
 "doK" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/cable{
-	d1 = 2;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/alarm{
-	pixel_y = 26
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
@@ -14129,12 +14160,6 @@
 /area/station/medical/surgery)
 "duO" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -14143,10 +14168,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Armory Maintenance";
-	dir = 1;
-	pixel_x = 20
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
@@ -15970,6 +15996,10 @@
 "ebb" = (
 /obj/structure/mopbucket,
 /obj/item/weapon/mop,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27;
+	pixel_y = 1
+	},
 /turf/simulated/floor,
 /area/station/medical/cryo)
 "ebc" = (
@@ -18861,6 +18891,9 @@
 	pixel_x = -28
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/station/rnd/misc_lab)
 "eVq" = (
@@ -19036,9 +19069,10 @@
 /turf/simulated/floor,
 /area/station/civilian/hydroponics)
 "eXo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
+/obj/structure/rack,
+/obj/item/clothing/suit/space/rig/science/rd,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/head/helmet/space/rig/science/rd,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -21012,7 +21046,7 @@
 /turf/simulated/wall,
 /area/station/civilian/dormitories/dormtwo)
 "fBZ" = (
-/obj/structure/closet/bombclosetsecurity,
+/obj/structure/closet/l3closet/security,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "vault"
@@ -21309,9 +21343,6 @@
 /area/station/engineering/engine)
 "fHk" = (
 /obj/machinery/mineral/equipment_vendor,
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/simulated/floor,
 /area/station/cargo/miningoffice)
 "fHu" = (
@@ -21794,6 +21825,17 @@
 /obj/machinery/the_singularitygen/tesla,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"fOp" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
+/area/station/rnd/mixing)
 "fOs" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
@@ -22619,9 +22661,6 @@
 	},
 /area/station/hallway/primary/central)
 "gcT" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -24197,7 +24236,7 @@
 /obj/item/device/radio/beacon/interaction_watcher,
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "warningline"
+	icon_state = "warndark"
 	},
 /area/station/rnd/test_area)
 "gCu" = (
@@ -26900,9 +26939,6 @@
 /obj/structure/table,
 /obj/item/weapon/wrapping_paper,
 /obj/item/weapon/packageWrap,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
@@ -29859,6 +29895,15 @@
 	icon_state = "dark"
 	},
 /area/station/security/prison)
+"ivp" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/station/hallway/secondary/entry)
 "ivx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -30816,14 +30861,19 @@
 	},
 /area/station/security/brig)
 "iLi" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "redyellowfull"
+	dir = 1;
+	icon_state = "rampbottom"
 	},
-/area/station/civilian/bar)
+/area/station/maintenance/brig)
 "iLz" = (
 /obj/structure/disposaloutlet{
 	dir = 1
@@ -31180,9 +31230,6 @@
 /area/station/bridge/hop_office)
 "iSl" = (
 /obj/machinery/washing_machine,
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "barber"
@@ -33038,6 +33085,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/rnd/misc_lab)
+"jze" = (
+/obj/machinery/light,
+/turf/simulated/floor{
+	icon_state = "purplecorner"
+	},
+/area/station/hallway/primary/bridgehall)
 "jzi" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Teleporter Room";
@@ -33223,9 +33276,6 @@
 "jBp" = (
 /obj/item/weapon/book/manual/wiki/security_space_law,
 /obj/structure/table/woodentable,
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor/carpet,
 /area/station/bridge/meeting_room)
 "jBw" = (
@@ -33455,14 +33505,14 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
 	id = "ArmorDoors";
 	name = "Weapons locker";
 	req_access = list(3)
-	},
-/obj/machinery/light/small{
-	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -33510,22 +33560,28 @@
 	},
 /area/station/security/brig)
 "jFJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/rack,
+/obj/item/weapon/melee/baton,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/weapon/shield/riot,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/window/brigdoor{
+	dir = 8;
+	id = "ArmorDoors";
+	name = "Weapons locker";
+	req_access = list(3)
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/brig)
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "vault"
+	},
+/area/station/security/armoury)
 "jFK" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -34394,24 +34450,8 @@
 /turf/simulated/floor,
 /area/station/civilian/dormitories)
 "jRn" = (
-/obj/structure/rack,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/item/weapon/melee/baton,
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/weapon/shield/riot,
-/obj/machinery/door/window/brigdoor{
-	dir = 8;
-	id = "ArmorDoors";
-	name = "Weapons locker";
-	req_access = list(3)
-	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "vault"
+	icon_state = "warndark"
 	},
 /area/station/security/armoury)
 "jRz" = (
@@ -35570,7 +35610,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellowcorner"
+	},
 /area/station/hallway/primary/bridgehall)
 "kkh" = (
 /turf/simulated/shuttle/floor/mining{
@@ -38186,6 +38229,15 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/arrival)
+"laF" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/rnd/hor)
 "laJ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -38224,6 +38276,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/machinery/light,
 /turf/simulated/floor{
 	icon_state = "brown"
 	},
@@ -38405,17 +38458,10 @@
 	},
 /area/station/cargo/storage)
 "ldq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "ldy" = (
@@ -39055,17 +39101,13 @@
 	},
 /area/station/cargo/office)
 "lmw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/item/weapon/storage/secure/safe{
 	dir = 8;
 	pixel_x = 32
 	},
-/obj/item/weapon/flora/random,
+/obj/structure/lamarr,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "whitebot"
 	},
 /area/station/rnd/hor)
 "lmA" = (
@@ -40738,6 +40780,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
+/obj/machinery/portable_atmospherics/powered/pump,
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
@@ -41063,6 +41106,9 @@
 	},
 /obj/machinery/requests_console/cargo_bay{
 	pixel_x = 30
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -41501,7 +41547,9 @@
 "maN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/powered/scrubber,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
 /area/station/hallway/primary/bridgehall)
 "maO" = (
 /obj/structure/table,
@@ -42053,6 +42101,8 @@
 	pixel_x = 2;
 	pixel_y = 6
 	},
+/obj/item/weapon/coin/silver,
+/obj/item/weapon/coin/silver,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -42339,6 +42389,9 @@
 	pixel_y = 5
 	},
 /obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "warningcorner"
@@ -42454,7 +42507,7 @@
 "mnO" = (
 /turf/simulated/floor{
 	dir = 9;
-	icon_state = "warningline"
+	icon_state = "warndark"
 	},
 /area/station/rnd/test_area)
 "mnP" = (
@@ -42638,9 +42691,9 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories/theater)
 "mqu" = (
+/obj/machinery/portable_atmospherics/powered/pump,
 /turf/simulated/floor{
-	dir = 9;
-	icon_state = "yellow"
+	icon_state = "bot"
 	},
 /area/station/hallway/primary/bridgehall)
 "mqB" = (
@@ -42652,29 +42705,20 @@
 	},
 /area/station/hallway/primary/central)
 "mqJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 5
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /obj/structure/cable{
+	d1 = 1;
 	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/power/apc{
 	dir = 1;
-	name = "Security Maintenance APC";
-	pixel_y = 24
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
@@ -42824,9 +42868,26 @@
 /turf/simulated/floor,
 /area/station/maintenance/eva)
 "mtX" = (
-/obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/wall,
-/area/station/civilian/toilet)
+/obj/structure/rack,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/item/weapon/melee/baton,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/head/helmet/riot,
+/obj/item/weapon/shield/riot,
+/obj/machinery/door/window/brigdoor{
+	dir = 8;
+	id = "ArmorDoors";
+	name = "Weapons locker";
+	req_access = list(3)
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "vault"
+	},
+/area/station/security/armoury)
 "mun" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
@@ -43189,7 +43250,7 @@
 "mBE" = (
 /turf/simulated/floor{
 	dir = 5;
-	icon_state = "warningline"
+	icon_state = "warndark"
 	},
 /area/station/rnd/test_area)
 "mBN" = (
@@ -46651,7 +46712,11 @@
 /area/station/security/brig)
 "nGh" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/wall/r_wall,
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced{
+	dir = 6
+	},
+/turf/simulated/floor/engine/vacuum,
 /area/station/rnd/mixing)
 "nGp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -47160,7 +47225,7 @@
 "nPn" = (
 /obj/structure/sign/mark,
 /turf/simulated/floor{
-	icon_state = "warningline"
+	icon_state = "warndark"
 	},
 /area/station/rnd/test_area)
 "nPr" = (
@@ -47194,7 +47259,7 @@
 /area/station/ai_monitored/eva)
 "nPY" = (
 /turf/simulated/floor{
-	icon_state = "warningline"
+	icon_state = "warndark"
 	},
 /area/station/rnd/test_area)
 "nQc" = (
@@ -49035,21 +49100,8 @@
 	},
 /area/station/hallway/primary/central)
 "ouH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
+/obj/structure/stool,
+/obj/machinery/light/small,
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
@@ -49438,7 +49490,11 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/wall/r_wall,
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced{
+	dir = 6
+	},
+/turf/simulated/floor/engine/vacuum,
 /area/station/rnd/mixing)
 "oCP" = (
 /obj/structure/stool,
@@ -49769,7 +49825,7 @@
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "oHt" = (
-/obj/structure/holostool,
+/obj/structure/stool,
 /turf/simulated/floor/wood,
 /area/station/maintenance/eva)
 "oHz" = (
@@ -51875,9 +51931,11 @@
 	},
 /area/station/cargo/recycleroffice)
 "psT" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall/r_wall,
-/area/station/security/armoury)
+/obj/structure/stool,
+/turf/simulated/floor{
+	icon_state = "floorgrime"
+	},
+/area/station/maintenance/brig)
 "ptM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -52772,9 +52830,6 @@
 "pHQ" = (
 /obj/structure/closet/secure_closet/warden,
 /obj/item/clothing/mask/gas/sechailer,
-/obj/item/ammo_box/magazine/m9mm_2/rubber,
-/obj/item/ammo_box/magazine/m9mm_2/rubber,
-/obj/item/ammo_box/magazine/m9mm_2/rubber,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Sergeant APC";
@@ -54568,7 +54623,7 @@
 "qiV" = (
 /turf/simulated/floor{
 	dir = 1;
-	icon_state = "warningline"
+	icon_state = "warndark"
 	},
 /area/station/rnd/test_area)
 "qjr" = (
@@ -54755,7 +54810,9 @@
 	pixel_y = 23
 	},
 /obj/machinery/portable_atmospherics/powered/scrubber,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
 /area/station/hallway/primary/bridgehall)
 "qlz" = (
 /obj/structure/stool/bed/chair/metal/white{
@@ -55436,8 +55493,6 @@
 /obj/structure/rack,
 /obj/item/ammo_box/shotgun/beanbag,
 /obj/item/ammo_box/shotgun/beanbag,
-/obj/item/ammo_box/shotgun,
-/obj/item/ammo_box/shotgun,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "vault"
@@ -58001,6 +58056,9 @@
 /area/station/security/detectives_office)
 "rqA" = (
 /obj/machinery/photocopier,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "darkred"
@@ -58918,11 +58976,20 @@
 	},
 /area/station/maintenance/medbay)
 "rGo" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet,
-/area/station/civilian/library)
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "rGA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -59876,6 +59943,9 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/carpet,
 /area/station/bridge/meeting_room)
 "rVx" = (
@@ -60010,7 +60080,7 @@
 "rXx" = (
 /turf/simulated/floor{
 	dir = 10;
-	icon_state = "warningline"
+	icon_state = "warndark"
 	},
 /area/station/rnd/test_area)
 "rYe" = (
@@ -60285,7 +60355,7 @@
 "sdn" = (
 /turf/simulated/floor{
 	dir = 6;
-	icon_state = "warningline"
+	icon_state = "warndark"
 	},
 /area/station/rnd/test_area)
 "sds" = (
@@ -60393,7 +60463,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 8;
+	dir = 9;
 	icon_state = "yellow"
 	},
 /area/station/hallway/primary/bridgehall)
@@ -62788,6 +62858,24 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
+"sQW" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "whiteblue"
+	},
+/area/station/medical/hallway)
 "sRF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -63761,9 +63849,6 @@
 /area/station/bridge/hop_office)
 "thF" = (
 /obj/structure/table,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = 32
@@ -63950,18 +64035,12 @@
 	},
 /obj/item/weapon/pen,
 /obj/item/device/megaphone,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
 	},
 /area/station/rnd/hor)
 "tkK" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
@@ -66051,19 +66130,32 @@
 /turf/simulated/wall/r_wall,
 /area/station/hallway/secondary/entry)
 "tSf" = (
-/obj/machinery/light,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "QMLoad3"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/cargo/storage)
+/obj/machinery/light,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "tSi" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/meter,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = -28
+	},
+/obj/machinery/embedded_controller/radio/airlock_controller{
+	id_tag = "tox_airlock_control";
+	pixel_x = -28;
+	tag_airpump = "tox_airlock_pump";
+	tag_chamber_sensor = "tox_airlock_sensor";
+	tag_exterior_door = "tox_airlock_exterior";
+	tag_interior_door = "tox_airlock_interior";
+	pixel_y = -10
 	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
@@ -66264,12 +66356,10 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -67203,9 +67293,6 @@
 /turf/simulated/floor/plating,
 /area/station/medical/patient_b)
 "ulg" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -23
@@ -67291,11 +67378,14 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "umP" = (
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "warndark"
+/obj/machinery/light{
+	dir = 1
 	},
-/area/station/security/armoury)
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warningcorner"
+	},
+/area/station/hallway/secondary/entry)
 "umV" = (
 /obj/machinery/door/airlock/glass{
 	name = "Central Access"
@@ -67765,15 +67855,6 @@
 	},
 /area/station/medical/hallway)
 "usI" = (
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	id_tag = "tox_airlock_control";
-	pixel_x = -28;
-	pixel_y = -24;
-	tag_airpump = "tox_airlock_pump";
-	tag_chamber_sensor = "tox_airlock_sensor";
-	tag_exterior_door = "tox_airlock_exterior";
-	tag_interior_door = "tox_airlock_interior"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
@@ -69528,26 +69609,9 @@
 	},
 /area/station/security/brig)
 "uVO" = (
-/obj/structure/rack,
-/obj/item/weapon/melee/baton,
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/weapon/shield/riot,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 8;
-	id = "ArmorDoors";
-	name = "Weapons locker";
-	req_access = list(3)
-	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "vault"
+	dir = 5;
+	icon_state = "warndark"
 	},
 /area/station/security/armoury)
 "uVT" = (
@@ -70686,7 +70750,11 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/wall/r_wall,
+/obj/structure/grille,
+/obj/structure/window/phoronreinforced{
+	dir = 6
+	},
+/turf/simulated/floor/engine/vacuum,
 /area/station/rnd/mixing)
 "vqr" = (
 /obj/machinery/light/small{
@@ -72491,9 +72559,6 @@
 /obj/machinery/camera{
 	c_tag = "Hydroponics Pasture"
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /mob/living/simple_animal/cow{
 	name = "Betsy"
 	},
@@ -73600,9 +73665,6 @@
 "wen" = (
 /obj/structure/table/glass,
 /obj/item/device/detective_scanner,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/item/device/radio/intercom{
 	broadcasting = 1;
 	frequency = 1475;
@@ -75423,15 +75485,15 @@
 "wNV" = (
 /obj/machinery/ignition_switch{
 	id = "mixingsparker";
-	pixel_x = 10;
-	pixel_y = -25
+	pixel_x = 25;
+	pixel_y = -10
 	},
 /obj/machinery/door_control{
 	id = "mixvent";
 	name = "Mixing Room Vent Control";
-	pixel_x = -5;
-	pixel_y = -25;
-	req_access = list(8)
+	pixel_x = 25;
+	req_access = list(8);
+	pixel_y = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/meter,
@@ -75445,9 +75507,6 @@
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24
-	},
-/obj/machinery/light{
-	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -76404,9 +76463,6 @@
 /area/station/maintenance/science)
 "xeL" = (
 /obj/random/vending/snack,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /turf/simulated/floor{
 	icon_state = "bar"
 	},
@@ -78375,6 +78431,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/office)
+"xMl" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/station/medical/hallway)
 "xMD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -94830,7 +94897,7 @@ trc
 czH
 czH
 czH
-twf
+ivp
 rnh
 adD
 trc
@@ -95099,7 +95166,7 @@ plf
 plf
 plf
 rRX
-aho
+cBY
 cBY
 sJY
 cBY
@@ -95619,7 +95686,7 @@ jpS
 cBY
 cBY
 foG
-xxJ
+bDZ
 rRX
 cJF
 bIf
@@ -96133,7 +96200,7 @@ cBY
 cBY
 cBY
 foG
-tSf
+xxJ
 rRX
 jew
 lUw
@@ -97893,7 +97960,7 @@ rOh
 iGt
 qcn
 czH
-cXd
+umP
 tlB
 nas
 tmU
@@ -98400,7 +98467,7 @@ ncQ
 efy
 oNg
 oaT
-beg
+rGo
 beg
 pFe
 ouY
@@ -103029,7 +103096,7 @@ qzc
 qzc
 aQc
 vsI
-aPB
+tSf
 qzc
 qiR
 qiR
@@ -103064,7 +103131,7 @@ rIW
 exZ
 ats
 ats
-mtX
+ats
 ats
 ats
 eSA
@@ -103325,7 +103392,7 @@ ats
 pDB
 ats
 ddl
-dnW
+ddl
 ddl
 ats
 oTp
@@ -103795,7 +103862,7 @@ bwK
 xac
 hoL
 bea
-vsI
+mKG
 ohm
 mxS
 vsI
@@ -104835,7 +104902,7 @@ dXw
 lzL
 dTp
 abr
-iLi
+hSM
 jDH
 hSM
 hSM
@@ -106582,9 +106649,9 @@ vzw
 duO
 dsQ
 fBZ
-umP
-hHJ
-piU
+jza
+wKY
+jRn
 pxM
 tTw
 dNc
@@ -106836,12 +106903,12 @@ bKU
 dVb
 gbs
 gbs
-ppz
-psT
+aZE
 dsQ
+dnW
 uVO
-jFs
-jRn
+hHJ
+piU
 tWL
 tWL
 wme
@@ -107093,12 +107160,12 @@ ibM
 kfx
 hAI
 mRW
-jFJ
+ppz
 cpx
-sCr
-sCr
-sCr
-sCr
+dsQ
+jFs
+jFJ
+mtX
 tWL
 frM
 gyJ
@@ -107352,10 +107419,10 @@ mRW
 mRW
 doK
 ldq
-cQU
-ouH
-cms
-aZE
+sCr
+sCr
+sCr
+sCr
 tWL
 rnA
 bec
@@ -107607,12 +107674,12 @@ qZg
 nMV
 dnD
 mRW
-dVb
-gbs
-mRW
+bKs
+cQU
+iLi
 mqJ
-gbs
-bmm
+cms
+ouH
 tWL
 gFt
 upp
@@ -107869,7 +107936,7 @@ psl
 mRW
 atM
 sgr
-bKs
+bmm
 tWL
 wCz
 bec
@@ -108126,7 +108193,7 @@ mRW
 mRW
 mRW
 qoq
-cms
+psT
 tWL
 lIf
 nxI
@@ -110762,7 +110829,7 @@ cao
 uBD
 pUo
 xXU
-rGo
+dyd
 nKl
 gmg
 qRf
@@ -113349,7 +113416,7 @@ usG
 mXp
 phZ
 pry
-oTf
+xMl
 cDh
 wEZ
 uMy
@@ -114318,7 +114385,7 @@ fMQ
 fMQ
 chS
 npk
-wZZ
+mqu
 oeT
 dKv
 dKv
@@ -116176,7 +116243,7 @@ khf
 qnq
 hid
 ePM
-lrh
+sQW
 lBL
 inJ
 hly
@@ -121064,7 +121131,7 @@ nES
 tTD
 ape
 tUP
-wvH
+laF
 oxS
 uiq
 aby
@@ -122581,7 +122648,7 @@ vOc
 jIl
 fHu
 lJe
-kCI
+jze
 bOw
 vzf
 bbF
@@ -126392,7 +126459,7 @@ gjC
 bnu
 hBk
 csG
-rom
+gjC
 icd
 uHH
 fVC
@@ -126981,7 +127048,7 @@ lLH
 ulg
 jgI
 rKi
-ikm
+fOp
 ikm
 ikm
 dhk

--- a/maps/gamma/gamma.dmm
+++ b/maps/gamma/gamma.dmm
@@ -2067,7 +2067,7 @@
 "adq" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/flora/ausbushes/brflowers,
-/obj/machinery/light{
+/obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor/grass,
@@ -2353,29 +2353,19 @@
 	icon_state = "siding1"
 	},
 /area/station/civilian/chapel)
-"adP" = (
-/turf/simulated/floor/engine/vacuum,
-/turf/simulated/floor{
-	icon_state = "warningline"
-	},
-/area/station/rnd/test_area)
 "adQ" = (
 /obj/structure/sign/mark{
 	icon_state = "b4"
 	},
 /turf/simulated/floor/engine/vacuum,
-/turf/simulated/floor{
-	icon_state = "warningline"
-	},
+/turf/simulated/floor/engine/vacuum,
 /area/station/rnd/test_area)
 "adR" = (
 /obj/structure/sign/mark{
 	icon_state = "b3"
 	},
 /turf/simulated/floor/engine/vacuum,
-/turf/simulated/floor{
-	icon_state = "warningline"
-	},
+/turf/simulated/floor/engine/vacuum,
 /area/station/rnd/test_area)
 "adS" = (
 /obj/machinery/computer/crew{
@@ -2400,9 +2390,7 @@
 	icon_state = "b2"
 	},
 /turf/simulated/floor/engine/vacuum,
-/turf/simulated/floor{
-	icon_state = "warningline"
-	},
+/turf/simulated/floor/engine/vacuum,
 /area/station/rnd/test_area)
 "adW" = (
 /obj/structure/stool/bed/chair/office/light{
@@ -2510,13 +2498,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/hallway/secondary/exit)
-"aef" = (
-/turf/simulated/floor/engine/vacuum,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "warningline"
-	},
-/area/station/rnd/test_area)
 "aeg" = (
 /obj/machinery/camera{
 	c_tag = "Dorm Game Room";
@@ -2542,7 +2523,7 @@
 	},
 /area/station/hallway/secondary/exit)
 "aei" = (
-/turf/environment/space,
+/turf/simulated/floor/engine/vacuum,
 /turf/simulated/floor/engine/vacuum,
 /area/station/rnd/test_area)
 "aej" = (
@@ -4145,6 +4126,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "neutral"
@@ -4536,12 +4520,14 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/alarm{
-	pixel_y = 26
-	},
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Security Maintenance APC";
+	pixel_y = 24
 	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
@@ -4817,10 +4803,6 @@
 	},
 /area/station/civilian/bar)
 "aAo" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
@@ -4833,6 +4815,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/technical_assistant,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/bridgehall)
 "aAq" = (
@@ -4876,7 +4859,6 @@
 /area/station/cargo/recycleroffice)
 "aAZ" = (
 /obj/structure/table,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/computer/stockexchange{
 	dir = 4
 	},
@@ -7269,10 +7251,6 @@
 	},
 /area/station/hallway/primary/central)
 "boq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
@@ -7799,6 +7777,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -9574,19 +9555,18 @@
 	},
 /area/station/medical/surgeryobs)
 "bYW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/brig)
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 2;
+	name = "Atmospherics";
+	sortType = "Atmospherics"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/bridgehall)
 "bZi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -9734,19 +9714,13 @@
 	},
 /area/station/medical/hallway)
 "cbg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/turf/simulated/floor{
+	icon_state = "freezerfloor"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/brig)
+/area/station/civilian/toilet)
 "cbk" = (
 /turf/simulated/wall,
 /area/station/security/main)
@@ -13857,6 +13831,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/alarm{
+	pixel_y = 26
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "doL" = (
@@ -15615,9 +15592,6 @@
 /area/station/civilian/bar)
 "dTr" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor{
 	icon_state = "cafeteria"
 	},
@@ -18357,6 +18331,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "eMy" = (
@@ -19052,6 +19027,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "eXe" = (
@@ -19155,16 +19131,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
-"eYR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "freezerfloor"
-	},
-/area/station/civilian/toilet)
 "eYS" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/disposalpipe/sortjunction{
@@ -21844,9 +21810,6 @@
 /area/station/civilian/dormitories/dormtwo)
 "fOv" = (
 /obj/structure/closet/toolcloset,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/camera{
 	c_tag = "Auxiliary Tool Storage"
 	},
@@ -22185,6 +22148,9 @@
 	},
 /obj/machinery/door/airlock/glass{
 	name = "Chapel"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -24234,10 +24200,7 @@
 /area/station/maintenance/brig)
 "gBW" = (
 /obj/item/device/radio/beacon/interaction_watcher,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "warndark"
-	},
+/turf/simulated/floor/engine/vacuum,
 /area/station/rnd/test_area)
 "gCu" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -30780,6 +30743,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "neutral"
@@ -32032,9 +31998,6 @@
 	c_tag = "Toxins Test Chamber North";
 	network = list("Toxins Test Area")
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/rnd/test_area)
 "jhv" = (
@@ -32126,6 +32089,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -34568,14 +34534,12 @@
 	},
 /area/station/hallway/secondary/entry)
 "jTk" = (
-/obj/structure/disposalpipe/sortjunction/flipped{
-	dir = 2;
-	name = "Atmospherics";
-	sortType = "Atmospherics"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/landmark/start/technical_assistant,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "yellowcorner"
 	},
@@ -35952,6 +35916,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/bridgehall)
 "krx" = (
@@ -36871,6 +36836,7 @@
 /obj/item/weapon/storage/belt/utility,
 /obj/item/weapon/storage/box/lights/mixed,
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/light,
 /turf/simulated/floor,
 /area/station/storage/tools)
 "kFx" = (
@@ -39426,7 +39392,6 @@
 /area/station/security/brig)
 "lsm" = (
 /obj/machinery/computer/med_data,
-/obj/machinery/light,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "darkredfull"
@@ -40408,12 +40373,10 @@
 "lKl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
 /obj/structure/sign/departments/engineering{
 	pixel_x = 32
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	icon_state = "yellowcorner"
 	},
@@ -42505,10 +42468,10 @@
 	},
 /area/station/security/brig)
 "mnO" = (
-/turf/simulated/floor{
-	dir = 9;
-	icon_state = "warndark"
+/obj/machinery/light{
+	dir = 1
 	},
+/turf/simulated/floor/engine/vacuum,
 /area/station/rnd/test_area)
 "mnP" = (
 /obj/machinery/smartfridge/secure/virology,
@@ -43248,10 +43211,8 @@
 	},
 /area/station/civilian/kitchen)
 "mBE" = (
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "warndark"
-	},
+/obj/machinery/light,
+/turf/simulated/floor/engine/vacuum,
 /area/station/rnd/test_area)
 "mBN" = (
 /obj/item/weapon/cigbutt,
@@ -44445,9 +44406,6 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
-	},
-/obj/machinery/light{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -46419,7 +46377,8 @@
 	icon_state = "1-4"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
@@ -47224,9 +47183,7 @@
 /area/station/engineering/monitoring)
 "nPn" = (
 /obj/structure/sign/mark,
-/turf/simulated/floor{
-	icon_state = "warndark"
-	},
+/turf/simulated/floor/engine/vacuum,
 /area/station/rnd/test_area)
 "nPr" = (
 /obj/machinery/door_control{
@@ -47257,11 +47214,6 @@
 "nPT" = (
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
-"nPY" = (
-/turf/simulated/floor{
-	icon_state = "warndark"
-	},
-/area/station/rnd/test_area)
 "nQc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -50019,9 +49971,6 @@
 /area/station/civilian/dormitories/dormone)
 "oKY" = (
 /obj/structure/table,
-/obj/machinery/light{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
@@ -51124,6 +51073,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -53826,9 +53778,6 @@
 	dir = 8;
 	network = list("Toxins Test Area")
 	},
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/rnd/test_area)
 "pWR" = (
@@ -54620,12 +54569,6 @@
 /obj/machinery/hydroponics/constructable,
 /turf/simulated/floor/grass,
 /area/station/civilian/hydroponics)
-"qiV" = (
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "warndark"
-	},
-/area/station/rnd/test_area)
 "qjr" = (
 /obj/item/weapon/transparant/no_nt,
 /turf/simulated/floor/plating,
@@ -54904,8 +54847,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -56863,6 +56805,9 @@
 	name = "Station Intercom (General)";
 	pixel_x = 27
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whiteblue"
@@ -58056,9 +58001,6 @@
 /area/station/security/detectives_office)
 "rqA" = (
 /obj/machinery/photocopier,
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "darkred"
@@ -60077,12 +60019,6 @@
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/port)
-"rXx" = (
-/turf/simulated/floor{
-	dir = 10;
-	icon_state = "warndark"
-	},
-/area/station/rnd/test_area)
 "rYe" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/disposalpipe/segment{
@@ -60352,12 +60288,6 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/eva)
-"sdn" = (
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "warndark"
-	},
-/area/station/rnd/test_area)
 "sds" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/cable_coil,
@@ -65062,6 +64992,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/bridgehall)
 "tAX" = (
@@ -66985,11 +66919,8 @@
 /area/station/maintenance/science)
 "ugH" = (
 /obj/structure/table,
-/obj/machinery/computer/skills{
-	dir = 8;
-	icon_state = "medlaptop"
-	},
 /obj/item/weapon/paper/space_structures,
+/obj/machinery/computer/skills,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -67587,6 +67518,9 @@
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = 20
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/station/storage/primary)
@@ -70585,6 +70519,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "neutral"
@@ -72041,7 +71978,6 @@
 	c_tag = "Dormitory Toilets";
 	dir = 1
 	},
-/obj/machinery/light,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -73671,6 +73607,9 @@
 	listening = 0;
 	name = "Station Intercom (Security)";
 	pixel_x = 28
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -75586,20 +75525,6 @@
 	icon_state = "floorgrime"
 	},
 /area/station/maintenance/medbay)
-"wPF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/brig)
 "wPG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -76411,7 +76336,6 @@
 	dir = 1;
 	network = list("Toxins Test Area")
 	},
-/obj/machinery/light,
 /turf/simulated/floor/engine/vacuum,
 /area/station/rnd/test_area)
 "xdL" = (
@@ -104159,9 +104083,9 @@ tyI
 tyI
 hAC
 aNI
-eYR
+aNI
 lot
-ddl
+cbg
 ddl
 akg
 fmb
@@ -108706,7 +108630,7 @@ mRW
 mRW
 mRW
 mRW
-wPF
+uHO
 esk
 ruI
 wCN
@@ -108963,7 +108887,7 @@ irA
 irA
 uop
 eOJ
-wPF
+uHO
 mRW
 ruI
 ruI
@@ -109220,7 +109144,7 @@ rWv
 tuV
 xaZ
 dVb
-wPF
+uHO
 mRW
 ftG
 ftG
@@ -109477,10 +109401,10 @@ irA
 dVb
 dVb
 dVb
-cbg
+fvo
 eMu
 eXd
-bYW
+kaH
 ruI
 wNA
 rVV
@@ -109737,7 +109661,7 @@ wiX
 pWN
 mRW
 dVb
-wPF
+uHO
 ruI
 ruI
 ruI
@@ -109994,7 +109918,7 @@ mRW
 mRW
 mRW
 kGW
-cbg
+fvo
 eXd
 eXd
 eXd
@@ -114903,7 +114827,7 @@ dos
 kkb
 wWH
 aAo
-wqj
+bYW
 kru
 tAH
 wqj
@@ -134760,7 +134684,7 @@ lzW
 jjN
 adQ
 jjN
-aef
+aei
 jjN
 lzW
 jjN
@@ -135015,9 +134939,9 @@ jjN
 jjN
 jjN
 jjN
-adP
+aei
 jjN
-aef
+aei
 jjN
 jjN
 jjN
@@ -135274,7 +135198,7 @@ aei
 jjN
 adR
 jjN
-aef
+aei
 jjN
 aei
 jjN
@@ -135529,9 +135453,9 @@ jjN
 jjN
 jjN
 aei
-adP
+aei
 jjN
-aef
+aei
 aei
 jjN
 jjN
@@ -135784,13 +135708,13 @@ jjN
 jjN
 jjN
 jjN
-mnO
+jjN
 jjN
 adU
 jjN
-aef
+aei
 jjN
-rXx
+jjN
 jjN
 jjN
 jjN
@@ -136042,11 +135966,11 @@ jjN
 jjN
 jjN
 jjN
-mnO
-adP
+jjN
 aei
-aef
-rXx
+aei
+aei
+jjN
 jjN
 jjN
 jjN
@@ -136302,7 +136226,7 @@ jjN
 jjN
 nPn
 jjN
-qiV
+jjN
 jjN
 jjN
 jjN
@@ -136551,21 +136475,21 @@ plf
 plf
 kHU
 ogZ
-jjN
+mnO
 bFU
 jht
 jjN
 jjN
 aei
-nPY
+jjN
 gBW
-qiV
+jjN
 aei
 jjN
 jjN
 xdE
 bFU
-jjN
+mBE
 ogZ
 kHU
 plf
@@ -137070,11 +136994,11 @@ jjN
 jjN
 jjN
 jjN
-mBE
+jjN
 jjN
 lzW
 jjN
-sdn
+jjN
 jjN
 jjN
 jjN
@@ -137326,13 +137250,13 @@ ogZ
 jjN
 jjN
 jjN
-mBE
+jjN
 jjN
 qLD
 jjN
 qLD
 jjN
-sdn
+jjN
 jjN
 jjN
 jjN


### PR DESCRIPTION
<!-- Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md --> 
## Описание изменений 
1. Удалено лишнее освещение 
2. В медбее больше огнетушителей 
3. У СБ есть глоки - Fix https://github.com/TauCetiStation/TauCetiClassic/issues/6962 
4. Восстановлен утерянный провод от АПЦ в прибытии - Fix https://github.com/TauCetiStation/TauCetiClassic/issues/9014 
5. У РД появилась плата сброса протоколов безопасности - Fix https://github.com/TauCetiStation/TauCetiClassic/issues/9685 
6. У РД появился тест генокрадов 
7. У ученых появились риги 
8. В старом баре больше нет голодековских стульев, теперь там нормальные
9. В форонной теперь укрепленные фороновые стекла вместо укрепленных стен
10. Мелкие исправления и оптимизация места (Верхний склад брига стал шире на один тайл) 
## Почему и что этот ПР улучшит 
Исправляет множество проблем гаммы 
## Авторство 
## Чеинжлог 
:cl: Enerty 
-  map: Исправление большого количества проблем Гаммы