### PR TITLE
Модуль защиты от ЭМП для ригов

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -361,6 +361,13 @@
 	active_power_cost = round((temp_adj/max_cooling)*charge_consumption)
 	return active_power_cost
 
+/obj/item/rig_module/emp_shield
+	name = "hardsuit EMP shield"
+	icon_state = "powersink"
+	origin_tech = "engineering=2;magnets=2"
+	interface_name = "EMP shield"
+	interface_desc = "Device for protecting hardsuit against EMPs."
+
 /obj/item/rig_module/teleporter_stabilizer
 	name = "hardsuit teleporter stabilizer"
 	icon_state = "scanner"

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -10,6 +10,7 @@
 	allowed = list(/obj/item/device/flashlight)
 	var/brightness_on = 4 //luminosity when on
 	var/on = 0
+
 	heat_protection = HEAD
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	var/obj/item/clothing/suit/space/rig/rig_connect
@@ -488,6 +489,10 @@
 	to_chat(user, "Its mag-pulse traction system appears to be [magpulse ? "enabled" : "disabled"].")
 
 /obj/item/clothing/suit/space/rig/emp_act(severity)
+	for(var/obj/item/rig_module/installed_mod in installed_modules)
+		if(installed_mod.type == /obj/item/rig_module/emp_shield)
+			to_chat(wearer, "<span class='warning'>[installed_mod.name] absorbs EMP.</span>")
+			return
 	//drain some charge
 	if(cell)
 		cell.emplode(severity + 1)
@@ -609,8 +614,8 @@
 	slowdown = 0.5
 	armor = list(melee = 55, bullet = 5, laser = 15,energy = 10, bomb = 65, bio = 100, rad = 90)
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
-	max_mounted_devices = 6
-	initial_modules = list(/obj/item/rig_module/simple_ai/advanced, /obj/item/rig_module/selfrepair, /obj/item/rig_module/device/rcd, /obj/item/rig_module/nuclear_generator, /obj/item/rig_module/device/extinguisher, /obj/item/rig_module/cooling_unit)
+	max_mounted_devices = 7
+	initial_modules = list(/obj/item/rig_module/simple_ai/advanced, /obj/item/rig_module/selfrepair, /obj/item/rig_module/device/rcd, /obj/item/rig_module/nuclear_generator, /obj/item/rig_module/device/extinguisher, /obj/item/rig_module/cooling_unit, /obj/item/rig_module/emp_shield)
 
 //Mining rig
 /obj/item/clothing/head/helmet/space/rig/mining

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -2784,3 +2784,12 @@ other types of metals and chemistry for reagents).
 	materials = list(MAT_METAL = 2000, MAT_GLASS = 2000, MAT_GOLD = 2000, MAT_PHORON = 4000)
 	build_path = /obj/item/rig_module/teleporter_stabilizer
 	category = list("Rig Modules")
+
+/datum/design/hardsuit_emp_shield
+	name = "Hardsuit EMP shield"
+	desc = "Device for protecting hardsuit against EMPs."
+	id = "rigempshield"
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 2000, MAT_GLASS = 1000)
+	build_path = /obj/item/rig_module/emp_shield
+	category = list("Rig Modules")

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -1567,7 +1567,7 @@ The tech datums are the actual "tech trees" that you improve through researching
 	required_tech_levels = list()
 	cost = 2000
 
-	unlocks_designs = list("rigadvancedai", "riggrenadelauncherflashbang", "rigdrill", "rigselfrepair", "rigmountedtaser", "rigcombatinjector", "rigmedicalinjector", "rigstabilizer")
+	unlocks_designs = list("rigadvancedai", "riggrenadelauncherflashbang", "rigdrill", "rigselfrepair", "rigmountedtaser", "rigcombatinjector", "rigmedicalinjector", "rigstabilizer", "rigempshield")
 
 /datum/technology/toptier_hardsuit_modules
 	name = "Top-Tier Hardsuit Modules"


### PR DESCRIPTION
## Описание изменений
тайтл. раундстартом доступен СЕ (дабы синга не ломала хардсьюит через 3-4 импульса) в двух экземплярах; внутри его рига и на столе.

## Почему и что этот ПР улучшит
+1 к удобству инженеров

## Авторство

## Чеинжлог
:cl: M104
- add: Модуль защиты от ЭМП для ригов. Доступен у СЕ, можно изучить и сделать больше.
