### PR TITLE
Ремонт хостайл мобов

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -1,5 +1,6 @@
 /mob/living/simple_animal/hostile
-	faction = "hostile"
+	faction = list("hostile")
+	stop_automated_movement_when_pulled = 0
 
 	a_intent = INTENT_HARM
 


### PR DESCRIPTION
## Описание изменений
Позволяет на всех Hostile мобах брать управление в свои руки при вселении в них
## Почему и что этот ПР улучшит
Новые возможности админов на ивенте
Closes #9905 
## Авторство
DarkMinikin
## Чеинжлог
:cl:
- bugfix Ремонт хостайл мобов, теперь управление при вселении в моба возможно