### PR TITLE
Альтернативный фикс абдукторов

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -19,8 +19,6 @@
 
 // HUMAN
 
-#define isabductor(A) (istype(A, /mob/living/carbon/human/abductor))
-
 #define ishuman(A) (istype(A, /mob/living/carbon/human))
 
 #define isskeleton(A) (A.get_species() in list(SKELETON, SKELETON_UNATHI, SKELETON_TAJARAN, SKELETON_SKRELL, SKELETON_VOX))
@@ -160,6 +158,8 @@
 #define isrolebytype(type, H) (H?.mind ? H.mind.GetRoleByType(type) : FALSE)
 
 #define isanyantag(H) (H?.mind && H.mind.antag_roles.len)
+
+#define isabductor(H) isrolebytype(/datum/role/abductor, H)
 
 #define isabductorsci(H) isrole(ABDUCTOR_SCI, H)
 

--- a/code/game/gamemodes/modes_gameplays/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/modes_gameplays/abduction/abduction_gear.dm
@@ -87,19 +87,16 @@
 	DeactivateStealth()
 
 
-/obj/item/clothing/suit/armor/abductor/vest/proc/AbductorCheck(user)
+/obj/item/clothing/suit/armor/abductor/vest/proc/AbductorCheck(mob/user)
 	if(isabductor(user))
 		return TRUE
 	to_chat(user, "<span class='notice'>You can't figure how this works.</span>")
 	return FALSE
 
-/obj/item/clothing/suit/armor/abductor/vest/proc/AgentCheck(mob/living/carbon/human/user)
-	return isabductoragent(user)
-
 /obj/item/clothing/suit/armor/abductor/vest/attack_self(mob/user)
 	if(!AbductorCheck(user))
 		return
-	if(!AgentCheck(user))
+	if(!isabductoragent(user))
 		to_chat(user, "<span class='notice'>You're not trained to use this</span>")
 		return
 	switch(mode)
@@ -131,14 +128,11 @@
 
 
 //SCIENCE TOOL
-/obj/item/device/abductor/proc/AbductorCheck(user)
+/obj/item/device/abductor/proc/AbductorCheck(mob/user)
 	if(isabductor(user))
 		return TRUE
 	to_chat(user, "<span class='notice'>You can't figure how this works.</span>")
 	return FALSE
-
-/obj/item/device/abductor/proc/ScientistCheck(mob/living/carbon/human/user)
-	return isabductorsci(user)
 
 /obj/item/device/abductor/gizmo
 	name = "science tool"
@@ -154,7 +148,7 @@
 /obj/item/device/abductor/gizmo/attack_self(mob/user)
 	if(!AbductorCheck(user))
 		return
-	if(!ScientistCheck(user))
+	if(!isabductorsci(user))
 		to_chat(user, "<span class='notice'>You're not trained to use this</span>")
 		return
 	if(mode == GIZMO_SCAN)
@@ -168,7 +162,7 @@
 /obj/item/device/abductor/gizmo/attack(mob/living/M, mob/user)
 	if(!AbductorCheck(user))
 		return
-	if(!ScientistCheck(user))
+	if(!isabductorsci(user))
 		to_chat(user, "<span class='notice'>You're not trained to use this</span>")
 		return
 	switch(mode)
@@ -183,7 +177,7 @@
 		return
 	if(!AbductorCheck(user))
 		return
-	if(!ScientistCheck(user))
+	if(!isabductorsci(user))
 		to_chat(user, "<span class='notice'>You're not trained to use this</span>")
 		return
 	switch(mode)
@@ -203,7 +197,8 @@
 		to_chat(user, "<span class='notice'>This specimen is already marked.</span>")
 		return
 	if(ishuman(target))
-		if(isabductor(target))
+		var/mob/M = target
+		if(isabductor(M))
 			marked = target
 			to_chat(user, "<span class='notice'>You mark [target] for future retrieval.</span>")
 		else
@@ -374,7 +369,7 @@
 /obj/item/weapon/abductor_baton/proc/toggle(mob/living/user=usr)
 	if(!isabductor(user))
 		return
-	if(!AgentCheck(user))
+	if(!isabductoragent(user))
 		to_chat(user, "<span class='notice'>You're not trained to use this</span>")
 		return
 	mode = (mode + 1) % BATON_MODES
@@ -408,9 +403,6 @@
 		if(BATON_PROBE)
 			icon_state = "wonderprodProbe"
 			item_state = "wonderprodProbe"
-
-/obj/item/weapon/abductor_baton/proc/AgentCheck(mob/living/carbon/human/user)
-	return isabductoragent(user)
 
 /obj/item/weapon/abductor_baton/attack(mob/target, mob/living/user)
 	if(!isabductor(user))

--- a/code/game/gamemodes/modes_gameplays/abduction/machinery/console.dm
+++ b/code/game/gamemodes/modes_gameplays/abduction/machinery/console.dm
@@ -11,12 +11,6 @@
 	abductor_machinery_list -= src
 	return ..()
 
-/obj/machinery/abductor/proc/IsAgent(mob/living/carbon/human/H)
-	return isabductoragent(H)
-
-/obj/machinery/abductor/proc/IsScientist(mob/living/carbon/human/H)
-	return isabductorsci(H)
-
 //*************-Console-*************//
 
 /obj/machinery/abductor/console


### PR DESCRIPTION
Альтернатива #9808
## Описание изменений
Проверки по абдукторам изменились на роль, а не на тип
Удалены странные проверки повторяющиеся

Не уверен, стоит ли вписывать проверку на хумана, дабы исключить некоторые действия или же оставить как есть создавая потенциальные прикольные ситуации с боргами-абдукторами

Должен был открыть его 2 недели назад, но как вышло
## Почему и что этот ПР улучшит
fix https://github.com/TauCetiStation/TauCetiClassic/issues/9807
## Авторство

## Чеинжлог
:cl: Chip11-n
- bugfix: Абдукторы вновь рабочие