### PR TITLE
Огнетушители киборгов теперь самозаряжаются

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -92,7 +92,7 @@
 /obj/item/weapon/robot_module/standard/atom_init()
 	. = ..()
 	modules += new /obj/item/device/flash(src)
-	modules += new /obj/item/weapon/reagent_containers/spray/extinguisher(src)
+	modules += new /obj/item/weapon/reagent_containers/spray/extinguisher/cyborg(src)
 	modules += new /obj/item/weapon/weldingtool(src)
 	modules += new /obj/item/weapon/screwdriver(src)
 	modules += new /obj/item/weapon/wrench(src)
@@ -131,7 +131,7 @@
 	modules += new /obj/item/weapon/circular_saw(src)
 	modules += new /obj/item/weapon/surgicaldrill(src)
 	modules += new /obj/item/weapon/razor(src)
-	modules += new /obj/item/weapon/reagent_containers/spray/extinguisher/mini(src)
+	modules += new /obj/item/weapon/reagent_containers/spray/extinguisher/cyborg/mini(src)
 	modules += new /obj/item/stack/medical/advanced/bruise_pack(src)
 	modules += new /obj/item/stack/medical/advanced/ointment(src)
 	modules += new /obj/item/stack/nanopaste(src)
@@ -180,7 +180,7 @@
 	. = ..()
 	modules += new /obj/item/device/flash(src)
 	modules += new /obj/item/borg/sight/meson(src)
-	modules += new /obj/item/weapon/reagent_containers/spray/extinguisher(src)
+	modules += new /obj/item/weapon/reagent_containers/spray/extinguisher/cyborg(src)
 	modules += new /obj/item/weapon/weldingtool/largetank(src)
 	modules += new /obj/item/weapon/screwdriver(src)
 	modules += new /obj/item/weapon/wrench(src)
@@ -389,7 +389,7 @@
 
 	modules += new /obj/item/weapon/circular_saw(src)
 	modules += new /obj/item/weapon/scalpel(src)
-	modules += new /obj/item/weapon/reagent_containers/spray/extinguisher(src) //To unfuck xenobiology up
+	modules += new /obj/item/weapon/reagent_containers/spray/extinguisher/cyborg(src) //To unfuck xenobiology up
 
 	modules += new /obj/item/weapon/crowbar/red(src)
 	modules += new /obj/item/weapon/wrench(src)

--- a/code/modules/reagents/reagent_containers/extinguisher.dm
+++ b/code/modules/reagents/reagent_containers/extinguisher.dm
@@ -114,8 +114,10 @@ ADD_TO_GLOBAL_LIST(/obj/item/weapon/reagent_containers/spray/extinguisher, extin
 /obj/item/weapon/reagent_containers/spray/extinguisher/cyborg
 	name = "rechargeable fire extinguisher"
 	desc = "self-recharging traditional red fire extinguisher."
+	var/energy_cost = 200
 
 /obj/item/weapon/reagent_containers/spray/extinguisher/cyborg/attackby(obj/item/I, mob/user, params)
+	to_chat(user, "<span class='notice'>[src] reagents under pressure, don't open.</span>")
 	return FALSE
 
 /obj/item/weapon/reagent_containers/spray/extinguisher/cyborg/afterattack(atom/target, mob/user, proximity, params)
@@ -128,3 +130,21 @@ ADD_TO_GLOBAL_LIST(/obj/item/weapon/reagent_containers/spray/extinguisher, extin
 		STOP_PROCESSING(SSobj, src)
 		return
 	reagents.add_reagent(reagent_inside, reagents.maximum_volume / 10)
+	var/mob/living/silicon/robot/R = loc
+		if(R && R.cell)
+			R.cell.use(energy_cost)
+
+/obj/item/weapon/reagent_containers/spray/extinguisher/cyborg/mini
+	name = "rechargeable fire extinguisher"
+	desc = "A light, self-recharging and compact fibreglass-framed model fire extinguisher."
+	icon_state = "miniFE"
+	item_state = "miniFE"
+	hitsound = null
+	throwforce = 2
+	w_class = SIZE_TINY
+	force = 3.0
+	m_amt = 0
+	volume = 120
+	random_overlay = FALSE
+	FE_type = "mini"
+	energy_cost = 50

--- a/code/modules/reagents/reagent_containers/extinguisher.dm
+++ b/code/modules/reagents/reagent_containers/extinguisher.dm
@@ -114,14 +114,16 @@ ADD_TO_GLOBAL_LIST(/obj/item/weapon/reagent_containers/spray/extinguisher, extin
 /obj/item/weapon/reagent_containers/spray/extinguisher/cyborg
 	name = "rechargeable fire extinguisher"
 	desc = "self-recharging traditional red fire extinguisher."
-	var/energy_cost = 20
 
 /obj/item/weapon/reagent_containers/spray/extinguisher/cyborg/attackby(obj/item/I, mob/user, params)
 	to_chat(user, "<span class='notice'>[src] reagents under pressure, don't open.</span>")
 	return FALSE
 
 /obj/item/weapon/reagent_containers/spray/extinguisher/cyborg/afterattack(atom/target, mob/user, proximity, params)
-	. = ..()
+	if(..())
+		var/mob/living/silicon/robot/R = loc
+		if(R && R.cell)
+			R.cell.use(amount_per_transfer_from_this)
 	if(reagents.total_volume < reagents.maximum_volume)
 		START_PROCESSING(SSobj, src)
 
@@ -129,11 +131,8 @@ ADD_TO_GLOBAL_LIST(/obj/item/weapon/reagent_containers/spray/extinguisher, extin
 	if(reagents.total_volume == reagents.maximum_volume)
 		STOP_PROCESSING(SSobj, src)
 		return
-	var/mob/living/silicon/robot/R = loc
-	if(!R || !R.cell)
-		return
-	R.cell.use(energy_cost)
-	reagents.add_reagent(reagent_inside, reagents.maximum_volume / 20)
+	//12/600 and 2,4/120 foam per 2 seconds
+	reagents.add_reagent(reagent_inside, reagents.maximum_volume / 50)
 
 /obj/item/weapon/reagent_containers/spray/extinguisher/cyborg/mini
 	name = "rechargeable fire extinguisher"
@@ -148,4 +147,3 @@ ADD_TO_GLOBAL_LIST(/obj/item/weapon/reagent_containers/spray/extinguisher, extin
 	volume = 120
 	random_overlay = FALSE
 	FE_type = "mini"
-	energy_cost = 5

--- a/code/modules/reagents/reagent_containers/extinguisher.dm
+++ b/code/modules/reagents/reagent_containers/extinguisher.dm
@@ -114,7 +114,7 @@ ADD_TO_GLOBAL_LIST(/obj/item/weapon/reagent_containers/spray/extinguisher, extin
 /obj/item/weapon/reagent_containers/spray/extinguisher/cyborg
 	name = "rechargeable fire extinguisher"
 	desc = "self-recharging traditional red fire extinguisher."
-	var/energy_cost = 200
+	var/energy_cost = 20
 
 /obj/item/weapon/reagent_containers/spray/extinguisher/cyborg/attackby(obj/item/I, mob/user, params)
 	to_chat(user, "<span class='notice'>[src] reagents under pressure, don't open.</span>")
@@ -129,10 +129,11 @@ ADD_TO_GLOBAL_LIST(/obj/item/weapon/reagent_containers/spray/extinguisher, extin
 	if(reagents.total_volume == reagents.maximum_volume)
 		STOP_PROCESSING(SSobj, src)
 		return
-	reagents.add_reagent(reagent_inside, reagents.maximum_volume / 10)
 	var/mob/living/silicon/robot/R = loc
-		if(R && R.cell)
-			R.cell.use(energy_cost)
+	if(!R || !R.cell)
+		return
+	R.cell.use(energy_cost)
+	reagents.add_reagent(reagent_inside, reagents.maximum_volume / 20)
 
 /obj/item/weapon/reagent_containers/spray/extinguisher/cyborg/mini
 	name = "rechargeable fire extinguisher"
@@ -147,4 +148,4 @@ ADD_TO_GLOBAL_LIST(/obj/item/weapon/reagent_containers/spray/extinguisher, extin
 	volume = 120
 	random_overlay = FALSE
 	FE_type = "mini"
-	energy_cost = 50
+	energy_cost = 5

--- a/code/modules/reagents/reagent_containers/extinguisher.dm
+++ b/code/modules/reagents/reagent_containers/extinguisher.dm
@@ -110,3 +110,21 @@ ADD_TO_GLOBAL_LIST(/obj/item/weapon/reagent_containers/spray/extinguisher, extin
 	random_overlay = FALSE
 	reagent_inside = "champagne"
 	FE_type = "golden"
+
+/obj/item/weapon/reagent_containers/spray/extinguisher/cyborg
+	name = "rechargeable fire extinguisher"
+	desc = "self-recharging traditional red fire extinguisher."
+
+/obj/item/weapon/reagent_containers/spray/extinguisher/cyborg/attackby(obj/item/I, mob/user, params)
+	return FALSE
+
+/obj/item/weapon/reagent_containers/spray/extinguisher/cyborg/afterattack(atom/target, mob/user, proximity, params)
+	. = ..()
+	if(reagents.total_volume < reagents.maximum_volume)
+		START_PROCESSING(SSobj, src)
+
+/obj/item/weapon/reagent_containers/spray/extinguisher/cyborg/process()
+	if(reagents.total_volume == reagents.maximum_volume)
+		STOP_PROCESSING(SSobj, src)
+		return
+	reagents.add_reagent(reagent_inside, reagents.maximum_volume / 10)

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -35,36 +35,36 @@
 /obj/item/weapon/reagent_containers/spray/afterattack(atom/target, mob/user, proximity, params)
 	if(istype(target, /obj/structure/table) || istype(target, /obj/structure/rack) || istype(target, /obj/structure/closet) \
 	|| istype(target, /obj/item/weapon/reagent_containers) || istype(target, /obj/structure/sink) || istype(target, /obj/structure/stool/bed/chair/janitorialcart))
-		return
+		return FALSE
 
 	if(istype(target, /obj/effect/proc_holder/spell))
-		return
+		return FALSE
 
 	if(istype(target, /obj/structure/reagent_dispensers) && proximity) //this block copypasted from reagent_containers/glass, for lack of a better solution
 		var/obj/structure/reagent_dispensers/RD = target
 		if(!is_open_container())
 			to_chat(user, "<span class='notice'>[src] can't be filled right now.</span>")
-			return
+			return FALSE
 
 		if(!RD.reagents.total_volume && RD.reagents)
 			to_chat(user, "<span class='notice'>[RD] does not have enough liquids.</span>")
-			return
+			return FALSE
 
 		if(reagents.total_volume >= reagents.maximum_volume)
 			to_chat(user, "<span class='notice'>\The [src] is full.</span>")
-			return
+			return FALSE
 
 		var/trans = RD.reagents.trans_to(src, RD.amount_per_transfer_from_this)
 		to_chat(user, "<span class='notice'>You fill \the [src] with [trans] units of the contents of \the [RD].</span>")
-		return
+		return FALSE
 
 	if(reagents.total_volume < amount_per_transfer_from_this)
 		to_chat(user, "<span class='notice'>\The [src] is empty!</span>")
-		return
+		return FALSE
 
 	if(safety)
 		to_chat(usr, "<span class = 'warning'>The safety is on!</span>")
-		return
+		return FALSE
 
 	playsound(src, spray_sound, VOL_EFFECTS_MASTER, null, FALSE, null, volume_modifier)
 
@@ -99,6 +99,7 @@
 		INVOKE_ASYNC(src, .proc/Spray_at, T_start, T)
 
 	INVOKE_ASYNC(src, .proc/on_spray, T, user) // A proc where we do all the dirty chair riding stuff.
+	return TRUE
 
 /obj/item/weapon/reagent_containers/spray/proc/on_spray(turf/T, mob/user)
 	if(!triple_shot) // Currently only the big baddies have this mechanic.


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Огнетушители не потребляли энергию и требовали заправки. А при внезапном опустошении в космосе обрекали киборга на вывод из игры. Теперь огнетушители будут по-немногу заряжаться прямо в киборге, как шейкеры у сервис и медборга. Так как заправлять его больше не надо, убрал возможность откручивать тушитель гаечным ключём.
## Почему и что этот ПР улучшит
боланс и геймплей
## Авторство

## Чеинжлог
:cl: Deahaka
- add: Огнетушители киборгов стали самозарядными