### PR TITLE
Revert "нерф смазки (#8647)"

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -71,6 +71,6 @@
 		if(WATER_FLOOR)
 			AddComponent(/datum/component/slippery, 2, NO_SLIP_WHEN_WALKING)
 		if(LUBE_FLOOR)
-			AddComponent(/datum/component/slippery, 5, SLIDE)
+			AddComponent(/datum/component/slippery, 5, SLIDE | GALOSHES_DONT_HELP)
 		else
 			qdel(GetComponent(/datum/component/slippery))


### PR DESCRIPTION
This reverts commit f74108b7e17475a7e844c44588e83f55c995d8ac.

<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Мержить только после: https://github.com/TauCetiStation/TauCetiClassic/pull/9940
Из #8647:
![111111](https://user-images.githubusercontent.com/96499407/187393186-be7f6732-0a26-4902-b85a-eb2c5633a00e.png)
Причина для нерфа была следующая: киборги под втеком набегали на антагов и заливали всё что можно смазкой из огнетушителя, из-за чего антаг не мог куда-либо сместится, ведь повсюду уже скользко. 

Таким образом борги пользовались иммунитетом к смазке, большой скоростью и танковостью своей брони того времени, чтобы выматывать нюкеров: заставлять потратить все адреналины, уронить всё оружие, использовать все ЕМП. После этого (в случае с революционерами переходили сразу к этому этапу), они пулили уже беспомощные тела по смазке и забивали огнетушителем/сдавливали шлюзами, без возможности получить помощь от кого-либо рядом (ведь они также попадут в смазку).
 
Нерф смазки, которую всегда было чем контрить, если разливает хуман, теперь не нужен, ведь причина для него была уничтожена здесь https://github.com/TauCetiStation/TauCetiClassic/pull/9312 и здесь https://github.com/TauCetiStation/TauCetiClassic/pull/9940
## Почему и что этот ПР улучшит
боланс и геймплей
## Авторство

## Чеинжлог
:cl: Deahaka
- balance: Комбат бутсы и галоши уборщика не защищают от смазки.