### PR TITLE
Крыс нельзя пикапить

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -212,6 +212,7 @@ ADD_TO_GLOBAL_LIST(/mob/living/simple_animal/mouse/brown/Tom, chief_animal_list)
 	health = 50
 	changes_color = FALSE
 	can_emote_snuffles = FALSE
+	holder_type = null
 
 /mob/living/simple_animal/mouse/rat/atom_init()
 	. = ..()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Увидел смешные баги от Сергея Киселёва с киданием крыс, удалил возможность брать в руки.
## Почему и что этот ПР улучшит
не продуманное взаимодействие убрано.
## Авторство

## Чеинжлог
