### PR TITLE
Закрытие консоли аккаунтов

### DIFF
--- a/code/modules/economy/Accounts_DB.dm
+++ b/code/modules/economy/Accounts_DB.dm
@@ -150,9 +150,7 @@
 					var/trx = create_transation(account_name, "New account activation", "([starting_funds])")
 					station_account.transaction_log.Add(trx)
 
-					creating_new_account = 0
-					ui.close()
-
+				ui.close()
 				creating_new_account = 0
 			if("insert_card")
 				if(held_card)


### PR DESCRIPTION
## Описание изменений

Скорее всего была опечатка табуляции.


## Почему и что этот ПР улучшит

После создания аккаунта и выдачи упаковки с документом окно консоли закрывается.

## Чеинжлог

:cl:
 - bugfix: Окно консоли аккаунтов теперь закрывается после создания нового аккаунта
