### PR TITLE
Исправление автозамены C.mob.stat

### DIFF
--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -14,7 +14,7 @@
 			if(C.holder && C.holder.fakekey)
 				entry += " <i>(as [C.holder.fakekey])</i>"
 			entry += " - Playing as [C.mob.real_name]"
-			switch(C.mob.stat != CONSCIOUS)
+			switch(C.mob.stat)
 				if(UNCONSCIOUS)
 					entry += " - <font color='darkgray'><b>Unconscious</b></font>"
 				if(DEAD)


### PR DESCRIPTION
## Описание изменений

Недавно при автозамене `C.mob.stat` на `C.mob.stat != CONSCIOUS` изменились не только if-ы, но и пара switch-ей. Один исправлен тут, второй в PR про вопросы призракам.


## Почему и что этот ПР улучшит

Команда `OOC -> Who`, скорее всего, не показывала админам, кто мёртв.
