### PR TITLE
нерф майнинг рига

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -627,7 +627,7 @@
 	name = "mining hardsuit"
 	desc = "A special suit that protects against hazardous, low pressure environments. Has reinforced plating."
 	item_state = "mining_hardsuit"
-	armor = list(melee = 90, bullet = 5, laser = 10,energy = 5, bomb = 55, bio = 100, rad = 20)
+	armor = list(melee = 80, bullet = 5, laser = 10,energy = 5, bomb = 55, bio = 100, rad = 20)
 	breach_threshold = 26
 	max_mounted_devices = 4
 	initial_modules = list(/obj/item/rig_module/simple_ai, /obj/item/rig_module/device/orescanner, /obj/item/rig_module/device/drill)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
немного уменьшил мили защиту у шахтёрского рига
## Почему и что этот ПР улучшит
баланс
90% это как-то слишком уж дофига, а если заиметь жампсьют офицера то можно вообще стать неуязвимым для мили атак, так что такие дела
## Авторство

## Чеинжлог
:cl: Simbaka
- balance: Хардсьют шахтёра стал чуть хуже защищать от различных ударов.