### PR TITLE
Удаляет магазин на 16 патронов для стечкина из аплинка нюки и дилера

### DIFF
--- a/code/datums/uplinks_items.dm
+++ b/code/datums/uplinks_items.dm
@@ -372,12 +372,22 @@
 	cost = 2
 	uplink_types = list("nuclear", "traitor")
 
-/datum/uplink_item/ammo/pistol
-	name = "9mm Handgun Magazine"
+/datum/uplink_item/ammo/pistol_extended
+	name = "Extended Capacity 9mm Handgun Magazine"
 	desc = "An additional 16-round 9mm magazine; compatible with the Stechkin Pistol. These subsonic rounds \
 			are dirt cheap but are half as effective as .357 rounds."
 	item = /obj/item/ammo_box/magazine/m9mm/ex
 	cost = 1
+	uplink_types = list("traitor")
+
+/datum/uplink_item/ammo/pistol
+	name = "9mm Handgun Magazine"
+	desc = "An additional 7-round 9mm magazine; compatible with the Stechkin Pistol. These subsonic rounds \
+			are dirt cheap but are half as effective as .357 rounds."
+	item = /obj/item/ammo_box/magazine/m9mm
+	cost = 1
+	uplink_types = list("nuclear", "dealer")
+
 
 /datum/uplink_item/ammo/revolver
 	name = "Speedloader-.357"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Магазин на 16 патронов для стечкина был заменён на самый обычный, на 7 патронов.
## Почему и что этот ПР улучшит
Не вижу смысла в существовании этого магазина у всяких дилеров и нюкеров, ведь у них есть всякие смгшки, пулемёты и так далее. 
## Авторство

## Чеинжлог
:cl: Simbaka
- tweak: В аплинках ядерных оперативников и дилера теперь продаются обычные магазины для стечкина, а не расширенные.