### PR TITLE
Свободный спавн подпроф

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -451,8 +451,11 @@ SUBSYSTEM_DEF(job)
 
 	if(!joined_late)
 		var/obj/effect/landmark/start/spawn_mark = null
+		var/occupation_name = rank
+		if(H.mind.role_alt_title != rank)
+			occupation_name = H.mind.role_alt_title
 		for(var/obj/effect/landmark/start/landmark in landmarks_list)
-			if((landmark.name == rank) && !(locate(/mob/living) in landmark.loc))
+			if((landmark.name == occupation_name) && !(locate(/mob/living) in landmark.loc))
 				spawn_mark = landmark
 				break
 		if(!spawn_mark)

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -123,6 +123,21 @@
 /obj/effect/landmark/start/assistant/waiter
 	name = "Waiter"
 
+/obj/effect/landmark/start/assistant/lawyer
+	name = "Lawyer"
+
+/obj/effect/landmark/start/assistant/private_eye
+	name = "Private Eye"
+
+/obj/effect/landmark/start/assistant/reporter
+	name = "Reporter"
+
+/obj/effect/landmark/start/assistant/vice_officer
+	name = "Vice Officer"
+
+/obj/effect/landmark/start/assistant/paranormal_investigator
+	name = "Paranormal Investigator"
+
 //Civilians
 /obj/effect/landmark/start/captain
 	name = "Captain"
@@ -140,13 +155,21 @@
 	name = "Chef"
 	icon_state = "Chef"
 
+/obj/effect/landmark/start/chef/cook
+	name = "Cook"
+
 /obj/effect/landmark/start/botanist
 	name = "Botanist"
 	icon_state = "Botanist"
 
+/obj/effect/landmark/start/botanist/hydroponicist
+	name = "Hydroponicist"
+
 /obj/effect/landmark/start/barber
 	name = "Barber"
 	icon_state = "Barber"
+/obj/effect/landmark/start/barber/stylist
+	name = "Stylist"
 
 /obj/effect/landmark/start/janitor
 	name = "Janitor"
@@ -156,9 +179,15 @@
 	name = "Librarian"
 	icon_state = "Librarian"
 
+/obj/effect/landmark/start/librarian/journalist
+	name = "Journalist"
+
 /obj/effect/landmark/start/chaplain
 	name = "Chaplain"
 	icon_state = "Chaplain"
+
+/obj/effect/landmark/start/chaplain/counselor
+	name = "Counselor"
 
 /obj/effect/landmark/start/internal_affairs_agent
 	name = "Internal Affairs Agent"
@@ -223,6 +252,15 @@
 	name = "Station Engineer"
 	icon_state = "Station Engineer"
 
+/obj/effect/landmark/start/station_engineer/maintenance_technician
+	name = "Maintenance Technician"
+
+/obj/effect/landmark/start/station_engineer/engine_technician
+	name = "Engine Technician"
+
+/obj/effect/landmark/start/station_engineer/electrician
+	name = "Electrician"
+
 /obj/effect/landmark/start/atmospheric_technician
 	name = "Atmospheric Technician"
 	icon_state = "Atmospheric Technician"
@@ -241,6 +279,12 @@
 	name = "Medical Doctor"
 	icon_state = "Medical Doctor"
 
+/obj/effect/landmark/start/medical_doctor/surgeon
+	name = "Surgeon"
+
+/obj/effect/landmark/start/medical_doctor/nurse
+	name = "Nurse"
+
 /obj/effect/landmark/start/paramedic
 	name = "Paramedic"
 	icon_state = "Paramedic"
@@ -249,13 +293,25 @@
 	name = "Chemist"
 	icon_state = "Chemist"
 
+/obj/effect/landmark/start/chemist/pharmacist
+	name = "Pharmacist"
+
 /obj/effect/landmark/start/virologist
 	name = "Virologist"
 	icon_state = "Virologist"
 
+/obj/effect/landmark/start/virologist/pathologist
+	name = "Pathologist"
+
+/obj/effect/landmark/start/virologist/microbiologist
+	name = "Microbiologist"
+
 /obj/effect/landmark/start/psychiatrist
 	name = "Psychiatrist"
 	icon_state = "Psychiatrist"
+
+/obj/effect/landmark/start/psychiatrist/psychologist
+	name = "Psychologist"
 
 /obj/effect/landmark/start/medical_intern
 	name = "Medical Intern"
@@ -275,6 +331,9 @@
 	name = "Scientist"
 	icon_state = "Scientist"
 
+/obj/effect/landmark/start/scientist/phoron_researcher
+	name = "Phoron Researcher"
+
 /obj/effect/landmark/start/xenoarchaeologist
 	name = "Xenoarchaeologist"
 	icon_state = "Xenoarchaeologist"
@@ -286,6 +345,12 @@
 /obj/effect/landmark/start/roboticist
 	name = "Roboticist"
 	icon_state = "Roboticist"
+
+/obj/effect/landmark/start/roboticist/biomechanical_engineer
+	name = "Biomechanical Engineer"
+
+/obj/effect/landmark/start/roboticist/mechatronic_engineer
+	name = "Mechatronic Engineer"
 
 /obj/effect/landmark/start/research_assistant
 	name = "Research Assistant"
@@ -300,6 +365,12 @@
 /obj/effect/landmark/start/cyborg
 	name = "Cyborg"
 	icon_state = "Cyborg"
+
+/obj/effect/landmark/start/cyborg/android
+	name = "Android"
+
+/obj/effect/landmark/start/cyborg/robot
+	name = "Robot"
 
 
 // Roles

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -15111,6 +15111,7 @@
 	dir = 1;
 	network = list("SS13","Security")
 	},
+/obj/effect/landmark/start/assistant/lawyer,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "redcorner"
@@ -15134,6 +15135,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/effect/landmark/start/assistant/lawyer,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "redcorner"
@@ -17640,6 +17642,7 @@
 	dir = 8
 	},
 /obj/machinery/recharge_station,
+/obj/effect/landmark/start/cyborg/robot,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -23505,6 +23508,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/landmark/start/assistant/reporter,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "neutral"
@@ -25661,6 +25665,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/landmark/start/assistant/reporter,
 /turf/simulated/floor,
 /area/station/civilian/playroom)
 "aTV" = (
@@ -27034,6 +27039,7 @@
 /obj/structure/stool/bed/chair/comfy/black{
 	dir = 4
 	},
+/obj/effect/landmark/start/chaplain/counselor,
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -35800,6 +35806,7 @@
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 1
 	},
+/obj/effect/landmark/start/assistant/private_eye,
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
 "blZ" = (
@@ -35888,6 +35895,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/chemist,
+/obj/effect/landmark/start/chemist/pharmacist,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "bot"
@@ -37250,6 +37258,8 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/roboticist,
+/obj/effect/landmark/start/roboticist/biomechanical_engineer,
+/obj/effect/landmark/start/roboticist/mechatronic_engineer,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "bot"
@@ -41715,6 +41725,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/landmark/start/assistant/waiter,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -47363,6 +47374,8 @@
 "bGH" = (
 /obj/structure/stool/bed/chair/office/light,
 /obj/effect/landmark/start/roboticist,
+/obj/effect/landmark/start/roboticist/biomechanical_engineer,
+/obj/effect/landmark/start/roboticist/mechatronic_engineer,
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "warning"
@@ -47521,6 +47534,7 @@
 /area/station/rnd/chargebay)
 "bGU" = (
 /obj/machinery/recharge_station,
+/obj/effect/landmark/start/cyborg/android,
 /turf/simulated/floor{
 	icon_state = "delivery"
 	},
@@ -47729,6 +47743,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/barber,
+/obj/effect/landmark/start/barber/stylist,
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
@@ -48916,6 +48931,7 @@
 	dir = 4;
 	network = list("SS13","Research")
 	},
+/obj/effect/landmark/start/cyborg/android,
 /turf/simulated/floor{
 	icon_state = "delivery"
 	},
@@ -49560,6 +49576,7 @@
 /area/station/storage/tech)
 "bKH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/effect/landmark/start/medical_doctor/surgeon,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -49668,6 +49685,7 @@
 /obj/structure/stool/bed/chair/office/light{
 	dir = 8
 	},
+/obj/effect/landmark/start/scientist/phoron_researcher,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -51420,6 +51438,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/landmark/start/assistant/vice_officer,
 /turf/simulated/floor,
 /area/station/civilian/dormitories)
 "bNZ" = (
@@ -54142,6 +54161,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/effect/landmark/start/medical_doctor/surgeon,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -54424,6 +54444,7 @@
 /obj/structure/stool/bed/chair/metal/yellow{
 	dir = 8
 	},
+/obj/effect/landmark/start/station_engineer/maintenance_technician,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "yellow"
@@ -56752,6 +56773,7 @@
 /obj/machinery/light_switch{
 	pixel_y = -27
 	},
+/obj/effect/landmark/start/psychiatrist/psychologist,
 /turf/simulated/floor/wood,
 /area/station/medical/psych)
 "ccN" = (
@@ -58576,6 +58598,7 @@
 /obj/structure/stool/bed/chair/metal/yellow{
 	dir = 1
 	},
+/obj/effect/landmark/start/station_engineer/maintenance_technician,
 /turf/simulated/floor,
 /area/station/engineering/engine)
 "ciw" = (
@@ -62666,6 +62689,7 @@
 	layer = 4;
 	pixel_y = 32
 	},
+/obj/effect/landmark/start/cyborg/robot,
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
@@ -70103,6 +70127,11 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/bar)
+"dTL" = (
+/obj/structure/stool,
+/obj/effect/landmark/start/assistant/vice_officer,
+/turf/simulated/floor,
+/area/station/civilian/dormitories)
 "dUb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -75770,6 +75799,7 @@
 "kss" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/landmark/start/botanist,
+/obj/effect/landmark/start/botanist/hydroponicist,
 /turf/simulated/floor,
 /area/station/civilian/hydroponics)
 "ksR" = (
@@ -76003,6 +76033,7 @@
 /area/station/cargo/recycleroffice)
 "kFe" = (
 /obj/effect/landmark/start/botanist,
+/obj/effect/landmark/start/botanist/hydroponicist,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "green"
@@ -76410,6 +76441,7 @@
 /area/station/hallway/primary/central)
 "ljQ" = (
 /obj/structure/stool/bed/chair/metal/yellow,
+/obj/effect/landmark/start/station_engineer/electrician,
 /turf/simulated/floor,
 /area/station/engineering/engine)
 "lkb" = (
@@ -79141,6 +79173,13 @@
 	icon_state = "vault"
 	},
 /area/station/civilian/chapel/altar)
+"oyZ" = (
+/obj/structure/stool/bed/chair/metal/yellow{
+	dir = 1
+	},
+/obj/effect/landmark/start/station_engineer/engine_technician,
+/turf/simulated/floor,
+/area/station/engineering/engine)
 "ozb" = (
 /obj/structure/sign/warning/lethal_turrets,
 /turf/simulated/wall/r_wall,
@@ -79266,6 +79305,13 @@
 	icon_state = "blue"
 	},
 /area/station/hallway/primary/central)
+"oIR" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/obj/effect/landmark/start/medical_doctor/nurse,
+/turf/simulated/floor,
+/area/station/medical/cryo)
 "oJr" = (
 /obj/machinery/door/airlock/glass{
 	name = "Gym"
@@ -80728,6 +80774,11 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/aft)
+"qIm" = (
+/obj/structure/stool,
+/obj/effect/landmark/start/assistant/paranormal_investigator,
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "qJb" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -82162,6 +82213,7 @@
 /area/station/medical/virology)
 "slc" = (
 /obj/effect/landmark/start/chef,
+/obj/effect/landmark/start/chef/cook,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -82768,6 +82820,8 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/virologist,
+/obj/effect/landmark/start/virologist/microbiologist,
+/obj/effect/landmark/start/virologist/pathologist,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -83100,6 +83154,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"tlK" = (
+/obj/structure/stool/bed/chair/metal/yellow,
+/obj/effect/landmark/start/station_engineer/engine_technician,
+/turf/simulated/floor,
+/area/station/engineering/engine)
 "tlY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -83449,6 +83508,13 @@
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
+"tTQ" = (
+/obj/structure/stool/bed/chair/metal/yellow{
+	dir = 1
+	},
+/obj/effect/landmark/start/station_engineer/electrician,
+/turf/simulated/floor,
+/area/station/engineering/engine)
 "tVb" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -83994,6 +84060,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/librarian,
+/obj/effect/landmark/start/librarian/journalist,
 /turf/simulated/floor{
 	icon_state = "cult"
 	},
@@ -84205,6 +84272,7 @@
 "vTP" = (
 /obj/structure/stool,
 /obj/effect/landmark/start/botanist,
+/obj/effect/landmark/start/botanist/hydroponicist,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -84831,6 +84899,7 @@
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 4
 	},
+/obj/effect/landmark/start/assistant/private_eye,
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
 "xiQ" = (
@@ -101847,9 +101916,9 @@ bmT
 boc
 bwD
 bEm
+qIm
 beY
-beY
-beY
+qIm
 tMk
 aSM
 sCd
@@ -111681,7 +111750,7 @@ rzj
 cuf
 ljQ
 cls
-civ
+oyZ
 pAV
 cpp
 aaa
@@ -111936,9 +112005,9 @@ cAK
 cAK
 lLL
 dbK
-ljQ
+tlK
 fWB
-civ
+tTQ
 pAV
 cpp
 aaa
@@ -118793,7 +118862,7 @@ awT
 bMG
 bOe
 bOF
-bOh
+dTL
 bPT
 aEa
 aGg
@@ -123204,7 +123273,7 @@ bAS
 bKZ
 bkV
 bDg
-qrb
+oIR
 bFe
 bAX
 bJo
@@ -124232,7 +124301,7 @@ bAy
 bKe
 bkV
 bDj
-qrb
+oIR
 aiD
 bLA
 bJo

--- a/maps/falcon/falcon.dmm
+++ b/maps/falcon/falcon.dmm
@@ -226,7 +226,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/start/assistant/test_subject,
+/obj/effect/landmark/start/assistant/waiter,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -522,6 +522,7 @@
 /obj/structure/stool/bed/chair/metal/white{
 	dir = 4
 	},
+/obj/effect/landmark/start/medical_doctor/surgeon,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whitehall"
@@ -3904,6 +3905,7 @@
 /area/station/maintenance/engineering)
 "ahd" = (
 /obj/machinery/recharge_station,
+/obj/effect/landmark/start/cyborg/robot,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "darkpurple"
@@ -4165,7 +4167,7 @@
 /obj/machinery/newscaster{
 	pixel_y = 28
 	},
-/obj/effect/landmark/start/assistant/test_subject,
+/obj/effect/landmark/start/assistant/paranormal_investigator,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -4179,7 +4181,7 @@
 	name = "Station Intercom (General)";
 	pixel_y = 22
 	},
-/obj/effect/landmark/start/assistant/test_subject,
+/obj/effect/landmark/start/assistant/paranormal_investigator,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -4882,7 +4884,7 @@
 /obj/structure/sign/double/barsign{
 	pixel_y = 32
 	},
-/obj/effect/landmark/start/assistant/test_subject,
+/obj/effect/landmark/start/assistant/vice_officer,
 /turf/simulated/floor/carpet/green,
 /area/station/civilian/bar)
 "aiF" = (
@@ -6612,6 +6614,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/effect/landmark/start/scientist/phoron_researcher,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "darkpurple"
@@ -6809,6 +6812,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/effect/landmark/start/assistant/private_eye,
 /turf/simulated/floor/carpet/black,
 /area/station/civilian/gym)
 "amC" = (
@@ -8056,6 +8060,7 @@
 	pixel_y = 22
 	},
 /obj/machinery/recharge_station,
+/obj/effect/landmark/start/cyborg/android,
 /turf/simulated/floor/plating{
 	icon_state = "platebot"
 	},
@@ -10662,7 +10667,7 @@
 /area/asteroid/mine/dwarf)
 "bez" = (
 /obj/structure/stool/bed/chair/metal/black,
-/obj/effect/landmark/start/assistant/test_subject,
+/obj/effect/landmark/start/assistant/reporter,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -11424,6 +11429,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/landmark/start/medical_doctor,
+/obj/effect/landmark/start/medical_doctor/nurse,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -21294,6 +21300,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/effect/landmark/start/medical_doctor/surgeon,
 /turf/simulated/floor{
 	icon_state = "whitehall"
 	},
@@ -22724,6 +22731,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/chaplain,
+/obj/effect/landmark/start/chaplain/counselor,
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -23263,6 +23271,7 @@
 /obj/effect/landmark/start/chef,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/landmark/start/chef/cook,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -24014,7 +24023,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/landmark/start/assistant/test_subject,
+/obj/effect/landmark/start/assistant/lawyer,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "darkredfull"
@@ -25821,6 +25830,10 @@
 "pON" = (
 /turf/simulated/wall,
 /area/asteroid/research_outpost/spectro)
+"pPH" = (
+/obj/effect/landmark/start/assistant/private_eye,
+/turf/simulated/floor/carpet/black,
+/area/station/civilian/gym)
 "pPU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
 	dir = 5
@@ -27203,6 +27216,7 @@
 	dir = 6;
 	network = list("SS13","Medical")
 	},
+/obj/effect/landmark/start/medical_doctor/nurse,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "blue"
@@ -28967,7 +28981,7 @@
 /obj/structure/stool/bed/chair/metal/red{
 	dir = 4
 	},
-/obj/effect/landmark/start/assistant/test_subject,
+/obj/effect/landmark/start/assistant/lawyer,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "darkredfull"
@@ -32174,6 +32188,8 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/effect/landmark/start/station_engineer/electrician,
+/obj/effect/landmark/start/station_engineer/engine_technician,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "warndarkcorners"
@@ -32268,7 +32284,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/landmark/start/assistant/test_subject,
+/obj/effect/landmark/start/assistant/vice_officer,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "brown"
@@ -33345,6 +33361,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/effect/landmark/start/medical_doctor/nurse,
 /turf/simulated/floor,
 /area/station/medical/reception)
 "xjf" = (
@@ -33582,6 +33599,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/start/assistant/waiter,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -34457,7 +34475,7 @@
 /obj/structure/stool/bed/chair/metal/yellow{
 	dir = 8
 	},
-/obj/effect/landmark/start/assistant/test_subject,
+/obj/effect/landmark/start/assistant/reporter,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "brown"
@@ -58066,7 +58084,7 @@ sMI
 ajh
 ajj
 aku
-akD
+pPH
 anY
 aik
 aqk

--- a/maps/gamma/gamma.dmm
+++ b/maps/gamma/gamma.dmm
@@ -53,6 +53,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/atmospheric_technician,
+/obj/effect/landmark/start/station_engineer/electrician,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -166,6 +167,8 @@
 /obj/structure/stool/bed/chair/office/dark,
 /obj/effect/landmark/start/station_engineer,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/landmark/start/station_engineer/maintenance_technician,
+/obj/effect/landmark/start/station_engineer/electrician,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -10602,6 +10605,15 @@
 	temperature = 80
 	},
 /area/station/tcommsat/chamber)
+"coR" = (
+/obj/structure/stool/bed/chair/metal/red{
+	dir = 1
+	},
+/obj/effect/landmark/start/assistant/vice_officer,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/bar)
 "coT" = (
 /obj/structure/table/woodentable/fancy/black,
 /obj/item/trash/candle{
@@ -11271,6 +11283,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/barber,
+/obj/effect/landmark/start/barber/stylist,
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
@@ -16747,6 +16760,13 @@
 	icon_state = "white"
 	},
 /area/station/medical/morgue)
+"ekx" = (
+/obj/structure/stool/bed/chair/metal/red,
+/obj/effect/landmark/start/assistant/vice_officer,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/bar)
 "ekJ" = (
 /obj/structure/sign/warning/server_room,
 /turf/simulated/wall/r_wall,
@@ -18365,6 +18385,7 @@
 /obj/structure/stool/bed/chair/metal/yellow{
 	dir = 8
 	},
+/obj/effect/landmark/start/station_engineer/maintenance_technician,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "yellowcorner"
@@ -20672,6 +20693,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/psychiatrist,
+/obj/effect/landmark/start/psychiatrist/psychologist,
 /turf/simulated/floor/wood,
 /area/station/medical/psych)
 "fwL" = (
@@ -21157,6 +21179,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/start/medical_doctor/surgeon,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whitehall"
@@ -22508,6 +22531,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
+"gaA" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/stool/bed/chair/metal/red{
+	dir = 4
+	},
+/obj/effect/landmark/start/assistant/lawyer,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/station/security/lobby)
 "gaU" = (
 /obj/machinery/newscaster{
 	dir = 1;
@@ -24221,6 +24257,15 @@
 "gCD" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/kitchen/utensil/fork,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/bar)
+"gCJ" = (
+/obj/structure/stool/bed/chair/metal/red{
+	dir = 4
+	},
+/obj/effect/landmark/start/assistant/private_eye,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -26535,6 +26580,13 @@
 	icon_state = "warnplate"
 	},
 /area/station/aisat)
+"hnD" = (
+/obj/effect/landmark/start/scientist/phoron_researcher,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "whitehall"
+	},
+/area/station/rnd/mixing)
 "hnF" = (
 /obj/machinery/bookbinder,
 /turf/simulated/floor/carpet,
@@ -28786,6 +28838,13 @@
 	icon_state = "wood-broken5"
 	},
 /area/station/maintenance/eva)
+"icy" = (
+/obj/effect/landmark/start/station_engineer/maintenance_technician,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
+/area/station/engineering/equip)
 "icH" = (
 /obj/machinery/requests_console/hop{
 	pixel_x = 30
@@ -32224,6 +32283,7 @@
 /area/station/engineering/break_room)
 "jjY" = (
 /obj/machinery/recharge_station,
+/obj/effect/landmark/start/cyborg/robot,
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "yellow"
@@ -34100,6 +34160,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
+/obj/effect/landmark/start/station_engineer/maintenance_technician,
 /turf/simulated/floor{
 	icon_state = "bar"
 	},
@@ -36059,6 +36120,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/landmark/start/cyborg/robot,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -39024,6 +39086,13 @@
 	icon_state = "dark"
 	},
 /area/station/security/forensic_office)
+"llI" = (
+/obj/structure/stool/bed/chair/metal/red,
+/obj/effect/landmark/start/assistant/paranormal_investigator,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/bar)
 "llS" = (
 /turf/simulated/floor/plating/airless,
 /area/station/hallway/secondary/entry)
@@ -40494,6 +40563,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/landmark/start/medical_doctor/nurse,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -43718,6 +43788,7 @@
 /area/station/engineering/atmos)
 "mKG" = (
 /obj/effect/landmark/start/chef,
+/obj/effect/landmark/start/chef/cook,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -47504,6 +47575,7 @@
 /obj/structure/stool/bed/chair/office/dark,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/landmark/start/librarian/journalist,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "nUl" = (
@@ -49716,6 +49788,15 @@
 	icon_state = "floorgrime"
 	},
 /area/station/maintenance/science)
+"oFH" = (
+/obj/structure/stool/bed/chair/metal/red{
+	dir = 8
+	},
+/obj/effect/landmark/start/assistant/private_eye,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/bar)
 "oFP" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -51411,6 +51492,8 @@
 /area/space)
 "plA" = (
 /obj/effect/landmark/start/virologist,
+/obj/effect/landmark/start/virologist/microbiologist,
+/obj/effect/landmark/start/virologist/pathologist,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -52072,6 +52155,19 @@
 	icon_state = "white"
 	},
 /area/station/medical/virology)
+"pvI" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/stool/bed/chair/metal/red{
+	dir = 8
+	},
+/obj/effect/landmark/start/assistant/reporter,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "darkred"
+	},
+/area/station/security/lobby)
 "pvL" = (
 /obj/machinery/chem_dispenser{
 	name = "old chem dispenser"
@@ -52940,6 +53036,7 @@
 "pKH" = (
 /obj/structure/stool/bed/chair/office/light,
 /obj/effect/landmark/start/chemist,
+/obj/effect/landmark/start/chemist/pharmacist,
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "whitedelivery"
@@ -55622,6 +55719,7 @@
 	pixel_x = 25;
 	pixel_y = -25
 	},
+/obj/effect/landmark/start/chaplain/counselor,
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -55882,7 +55980,7 @@
 /area/station/maintenance/eva)
 "qDC" = (
 /obj/structure/stool/bar,
-/obj/effect/landmark/start/assistant/test_subject,
+/obj/effect/landmark/start/assistant/waiter,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "redyellowfull"
@@ -57456,6 +57554,7 @@
 "rdf" = (
 /obj/machinery/light,
 /obj/structure/stool,
+/obj/effect/landmark/start/station_engineer/engine_technician,
 /turf/simulated/floor{
 	icon_state = "yellow"
 	},
@@ -58283,6 +58382,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/landmark/start/station_engineer,
+/obj/effect/landmark/start/station_engineer/electrician,
 /turf/simulated/floor,
 /area/station/engineering/equip)
 "rtL" = (
@@ -59345,6 +59445,7 @@
 /obj/structure/stool/bed/chair/comfy/black{
 	dir = 4
 	},
+/obj/effect/landmark/start/station_engineer/maintenance_technician,
 /turf/simulated/floor{
 	icon_state = "bar"
 	},
@@ -60908,6 +61009,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/chemist,
+/obj/effect/landmark/start/chemist/pharmacist,
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "whitedelivery"
@@ -63253,6 +63355,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/landmark/start/medical_doctor/surgeon,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "whitehall"
@@ -64023,6 +64126,8 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/effect/landmark/start/roboticist/biomechanical_engineer,
+/obj/effect/landmark/start/roboticist/mechatronic_engineer,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "vault"
@@ -64996,6 +65101,7 @@
 "tAo" = (
 /obj/structure/stool,
 /obj/effect/landmark/start/botanist,
+/obj/effect/landmark/start/botanist/hydroponicist,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "green"
@@ -65070,6 +65176,8 @@
 "tBj" = (
 /obj/structure/stool,
 /obj/effect/landmark/start/roboticist,
+/obj/effect/landmark/start/roboticist/biomechanical_engineer,
+/obj/effect/landmark/start/roboticist/mechatronic_engineer,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -65227,6 +65335,7 @@
 /area/station/hallway/secondary/arrival)
 "tEL" = (
 /obj/effect/landmark/start/botanist,
+/obj/effect/landmark/start/botanist/hydroponicist,
 /turf/simulated/floor,
 /area/station/civilian/hydroponics)
 "tEU" = (
@@ -67968,6 +68077,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
+/obj/effect/landmark/start/cyborg/android,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "warning"
@@ -68275,6 +68385,7 @@
 /obj/structure/stool/bed/chair/metal/red{
 	dir = 4
 	},
+/obj/effect/landmark/start/assistant/reporter,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkred"
@@ -74958,6 +75069,7 @@
 /turf/simulated/floor/plating,
 /area/station/civilian/janitor)
 "wGn" = (
+/obj/effect/landmark/start/medical_doctor/nurse,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -75132,6 +75244,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/station_engineer,
+/obj/effect/landmark/start/station_engineer/maintenance_technician,
 /turf/simulated/floor{
 	icon_state = "bar"
 	},
@@ -75966,6 +76079,7 @@
 /area/station/rnd/hallway)
 "wYb" = (
 /obj/structure/stool,
+/obj/effect/landmark/start/station_engineer/engine_technician,
 /turf/simulated/floor{
 	icon_state = "yellow"
 	},
@@ -77958,10 +78072,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/landmark/start/assistant/test_subject,
 /obj/structure/stool/bed/chair/metal/red{
 	dir = 8
 	},
+/obj/effect/landmark/start/assistant/lawyer,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "darkred"
@@ -78728,6 +78842,7 @@
 	dir = 4
 	},
 /obj/machinery/recharge_station,
+/obj/effect/landmark/start/cyborg/android,
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "warning"
@@ -105097,7 +105212,7 @@ hUm
 gUU
 cQg
 xrX
-xrX
+pvI
 cQg
 qYu
 bFH
@@ -105354,7 +105469,7 @@ mMJ
 blY
 nnZ
 cDM
-cDM
+gaA
 cQg
 cQg
 kKo
@@ -105382,10 +105497,10 @@ eRd
 dTp
 dTp
 ejH
-oDZ
+ekx
 ryx
 gCD
-xQG
+coR
 eXe
 dTp
 wIL
@@ -105885,13 +106000,13 @@ wIL
 dTp
 dTp
 eKj
-oDZ
+llI
 gCD
 ryx
 xQG
 dTp
 ejH
-oDZ
+llI
 bYg
 xQG
 dTp
@@ -106402,7 +106517,7 @@ vTd
 oUf
 qDC
 oUf
-oUf
+qDC
 hSM
 abg
 dTp
@@ -107433,7 +107548,7 @@ dPi
 hal
 oCg
 abT
-aGp
+gCJ
 nWX
 aGp
 abt
@@ -107949,7 +108064,7 @@ oCg
 abV
 pML
 haX
-pML
+oFH
 abt
 gYQ
 rHn
@@ -117938,7 +118053,7 @@ lKv
 lWZ
 llT
 kSE
-bnH
+icy
 sCO
 sCO
 bnH
@@ -125209,8 +125324,8 @@ cSV
 qyq
 rKi
 sgc
-pJh
-pJh
+hnD
+hnD
 tXC
 pJh
 mSb


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Теперь можно спавнить подпрофы где хотите, а не держать их на спавне профы. В билде сейчас есть только спавн официанта, который теперь будет появлятся в баре, а не в ассистентской.
Мне это может понадобится для новой карты.
## Почему и что этот ПР улучшит
![111111111111](https://user-images.githubusercontent.com/96499407/188954764-c1b21e5c-4da2-46e3-9ca0-92e57a2bfccd.png)
![11111111111111111](https://user-images.githubusercontent.com/96499407/188954781-3102583c-9f5c-4bb2-9abf-0b77061bfcf0.png)

## Авторство

## Чеинжлог
