### PR TITLE
[Ready] Кнопка показа титров

### DIFF
--- a/code/__HELPERS/logging.dm
+++ b/code/__HELPERS/logging.dm
@@ -278,3 +278,12 @@
 		text += "no antagonists this moment"
 
 	log_game(text)
+
+//returns the id of the last round on the current port, which ended with 'proper completion' and has all the logs
+/proc/get_last_proper_ended_round_id()
+	if(!establish_db_connection("erro_round"))
+		return
+	var/DBQuery/query = dbcon.NewQuery("SELECT id FROM erro_round WHERE server_port = '[sanitize_sql(world.port)]' AND end_state = 'proper completion' ORDER BY id DESC LIMIT 1")
+	query.Execute()
+	if(query.NextRow())
+		return query.item[1]

--- a/code/controllers/admin.dm
+++ b/code/controllers/admin.dm
@@ -68,7 +68,7 @@ INITIALIZE_IMMEDIATE(/obj/effect/statclick)
 		if(tgui_alert(mob, "Вы уверены? Три.", "Вы уверены?", list("Дa", "Да", "Нет")) != "Да")
 			return
 
-	SSticker.generate_scoreboard(mob)
+	SSStatistics.generate_scoreboard(mob)
 	message_admins("Admin [key_name_admin(usr)] has forced made a scoreboard.")
 
 /client/proc/save_statistics()

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -424,12 +424,6 @@ SUBSYSTEM_DEF(ticker)
 			if(!isnewplayer(M))
 				to_chat(M, "Captainship not forced on anyone.")
 
-/datum/controller/subsystem/ticker/proc/generate_scoreboard(mob/one_mob)
-	var/completition = "<h1>Round End Information</h1><HR>"
-	completition += get_ai_completition()
-	completition += mode.declare_completion()
-	scoreboard(completition, one_mob)
-
 /datum/controller/subsystem/ticker/proc/get_ai_completition()
 	var/ai_completions = ""
 	if(silicon_list.len)
@@ -533,8 +527,6 @@ SUBSYSTEM_DEF(ticker)
 
 	//Print a list of antagonists to the server log
 	antagonist_announce()
-
-	generate_scoreboard()
 
 	mode.ShuttleDocked(location)
 

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -54,7 +54,8 @@ SUBSYSTEM_DEF(vote)
 	vote_start_time = world.time
 
 	for(var/client/C in clients)
-		interface_client(C)
+		if(C.prefs.votes_autoopening)
+			interface_client(C)
 
 	var/text = "[poll.initiator] начал голосование \"[poll.name]\"."
 	log_vote(text)

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -119,8 +119,8 @@
 
 	completions += scorestats()
 
-	fdel("data/scoreboard/last_score.txt")
-	text2file(completions, "data/scoreboard/last_score.txt")
+	fdel("data/last_score.txt")
+	text2file(completions, "data/last_score.txt")
 
 	if(one_mob)
 		show_scoreboard(one_mob)
@@ -135,13 +135,7 @@
 	to_chat(M, "<b>The crew's final score is:</b>")
 	to_chat(M, "<b><font size='4'>[SSStatistics.score.crewscore]</font></b>")
 
-	fdel("data/scoreboard/end_icons/") // deleting all we saved last round
-	for(var/i in 1 to end_icons.len)
-
-		var/F = file("data/scoreboard/end_icons/logo_[i].png") // and save new
-		F << end_icons[i]
-
-	to_chat(M, "<span class='vote'>Чтобы посмотреть титры раунда нажмите <a href='?src=\ref[M]'>сюда</a> или Show Last Scoreboard во вкладке OOC.</span>")
+	to_chat(M, "<span class='vote'>Чтобы посмотреть титры раунда нажмите <a href='?src=\ref[src]'>сюда</a> или Show Last Scoreboard во вкладке OOC.</span>")
 	if(M.client.prefs.votes_autoopening)
 		M.client.scoreboard(global.round_id)
 
@@ -227,14 +221,12 @@
 	return dat
 
 /datum/controller/subsystem/ticker/Topic(href, href_list[], hsrc)
-	if(href_list["src"])
-		var/mob/M = href_list["src"]
-		M?.client?.scoreboard(global.round_id)
+	usr?.client?.scoreboard(global.round_id)
 
 /client/proc/scoreboard(roundid)
-	var/list/F = flist("data/scoreboard/end_icons/")
-	for(var/i in 1 to F.len)
-		src << browse_rsc(F[i], "logo_[i].png")
+	for(var/i in 1 to end_icons.len)
+		src << browse_rsc(end_icons[i],"logo_[i].png")
+
 	var/datum/browser/popup = new(src, "roundstats", "[roundid ? "Round #[roundid]" : "Last Round"] Stats", 1000, 600)
 	popup.set_content(file2text("data/last_score.txt"))
 	popup.open()

--- a/code/game/gamemodes/scoreboard.dm
+++ b/code/game/gamemodes/scoreboard.dm
@@ -1,20 +1,97 @@
-/datum/controller/subsystem/ticker/proc/scoreboard(completions, mob/one_mob)
-	if(SSStatistics.achievements.len)
-		completions += "<div class='Section'>[achievement_declare_completion()]</div>"
+/datum/stat_collector/proc/generate_scoreboard()
+	var/completions = "<h1>Round End Information</h1><HR>"
+	completions += SSticker.get_ai_completition()
+	completions += SSticker.mode.declare_completion()
 
+	if(achievements.len)
+		completions += "<div class='Section'>[SSticker.achievement_declare_completion()]</div>"
+
+	calculate_score()
+
+	completions += {"<h2>Round Statistics and Score</h2><div class='Section'>"}
+
+	for(var/datum/faction/F in SSticker.mode.factions)
+		var/stat = F.get_scorestat()
+		if(stat)
+			completions += stat
+			completions += "<hr>"
+
+	if(global.deconverted_roles.len)
+		completions += "<B>Deconverted roles:</B><BR>"
+		completions += "<ul>"
+		for(var/name in global.deconverted_roles)
+			completions += "<li>"
+			completions += "[name]: [get_english_list(global.deconverted_roles[name])]."
+			completions += "</li>"
+		completions += "</ul>"
+
+	var/totalfunds = station_account.money
+	completions += {"<B><U>GENERAL STATS</U></B><BR>
+	<U>THE GOOD:</U><BR>
+	<B>Useful Crates Shipped:</B> [score.stuffshipped] ([score.stuffshipped * 75] Points)<BR>
+	<B>Hydroponics Harvests:</B> [score.stuffharvested] ([score.stuffharvested] Points)<BR>
+	<B>Ore Mined:</B> [score.oremined] ([score.oremined] Points)<BR>
+	<B>Refreshments Prepared:</B> [score.meals] ([score.meals * 5] Points)<BR>
+	<B>Research Completed:</B> [score.researchdone] ([score.researchdone * 30] Points)<BR>"}
+	completions += "<B>Shuttle Escapees:</B> [score.crew_escaped] ([score.crew_escaped * 25] Points)<BR>"
+	completions += {"<B>Random Events Endured:</B> [score.eventsendured] ([score.eventsendured * 50] Points)<BR>
+	<B>Whole Station Powered:</B> [score.powerbonus ? "Yes" : "No"] ([score.powerbonus * 2500] Points)<BR>
+	<B>Ultra-Clean Station:</B> [score.mess ? "No" : "Yes"] ([score.messbonus * 3000] Points)<BR><BR>
+	<U>THE BAD:</U><BR>
+	<B>Roles successful:</B> [score.roleswon] (-[score.roleswon * 250] Points)<BR>
+	<B>Dead Bodies on Station:</B> [score.crew_dead] (-[score.crew_dead * 250] Points)<BR>
+	<B>Uncleaned Messes:</B> [score.mess] (-[score.mess] Points)<BR>
+	<B>Station Power Issues:</B> [score.powerloss] (-[score.powerloss * 30] Points)<BR>
+	<B>Rampant Diseases:</B> [score.disease] (-[score.disease * 30] Points)<BR>
+	<B>AI Destroyed:</B> [score.deadaipenalty ? "Yes" : "No"] (-[score.deadaipenalty * 250] Points)<BR><BR>
+	<U>THE WEIRD</U><BR>
+	<B>Final Station Budget:</B> $[num2text(totalfunds,50)]<BR>"}
+	var/profit = totalfunds - global.initial_station_money
+	if (profit > 0)
+		completions += "<B>Station Profit:</B> +[num2text(profit,50)]<BR>"
+	else if (profit < 0)
+		completions += "<B>Station Deficit:</B> [num2text(profit,50)]<BR>"
+	completions += {"<B>Food Eaten:</b> [score.foodeaten]<BR>
+	<B>Times a Clown was Abused:</B> [score.clownabuse]<BR><BR>"}
+	if (score.crew_escaped)
+		completions += "<B>Most Richest Escapee:</B> [score.richestname], [score.richestjob]: [score.richestcash] credits ([score.richestkey])<BR>"
+		completions += "<B>Most Battered Escapee:</B> [score.dmgestname], [score.dmgestjob]: [score.dmgestdamage] damage ([score.dmgestkey])<BR>"
+	else
+		completions += "The station wasn't evacuated or no one escaped!<BR>"
+	completions += {"<HR><BR><B><U>
+					FINAL SCORE: [score.crewscore]<BR>
+					RATING: [score.rating]<BR>
+					</U></B>"}
+
+	completions += "</div>"
+
+	log_game(completions)
+
+	for(var/mob/M in player_list)
+		if(!M.client)
+			continue
+
+		to_chat(M, "<b>The crew's final score is:</b>")
+		to_chat(M, "<b><font size='4'>[score.crewscore]</font></b>")
+
+		to_chat(M, "<span class='vote'>Чтобы посмотреть титры раунда нажмите <a href='?src=\ref[src]'>сюда</a> или Show Last Scoreboard во вкладке OOC.</span>")
+		if(M.client.prefs.votes_autoopening)
+			M.client.show_scoreboard(global.round_id)
+
+/datum/stat_collector/proc/calculate_score()
 	// Who is alive/dead, who escaped
 	for (var/mob/living/silicon/ai/I as anything in ai_list)
 		if (I.stat == DEAD && is_station_level(I.z))
-			SSStatistics.score.deadaipenalty = 1
-			SSStatistics.score.crew_dead += 1
+			score.deadaipenalty = 1
+			score.crew_dead += 1
 
 	for (var/mob/living/carbon/human/I as anything in human_list)
 		if (I.stat == DEAD && is_station_level(I.z))
-			SSStatistics.score.crew_dead += 1
+			score.crew_dead += 1
 		if (I.job == "Clown")
 			for(var/thing in I.attack_log)
 				if(findtext(thing, "<font color='orange'>")) //</font>
-					SSStatistics.score.clownabuse++
+					score.clownabuse++
 
 	var/area/escape_zone = get_area_by_type(/area/shuttle/escape/centcom)
 
@@ -33,17 +110,17 @@
 			for (var/obj/item/weapon/spacecash/C2 in get_contents_in_object(E, /obj/item/weapon/spacecash))
 				cashscore += C2.worth
 
-			if (cashscore > SSStatistics.score.richestcash)
-				SSStatistics.score.richestcash = cashscore
-				SSStatistics.score.richestname = E.real_name
-				SSStatistics.score.richestjob = E.job
-				SSStatistics.score.richestkey = E.key
+			if (cashscore > score.richestcash)
+				score.richestcash = cashscore
+				score.richestname = E.real_name
+				score.richestjob = E.job
+				score.richestkey = E.key
 			dmgscore = E.bruteloss + E.fireloss + E.toxloss + E.oxyloss
-			if (dmgscore > SSStatistics.score.dmgestdamage)
-				SSStatistics.score.dmgestdamage = dmgscore
-				SSStatistics.score.dmgestname = E.real_name
-				SSStatistics.score.dmgestjob = E.job
-				SSStatistics.score.dmgestkey = E.key
+			if (dmgscore > score.dmgestdamage)
+				score.dmgestdamage = dmgscore
+				score.dmgestname = E.real_name
+				score.dmgestjob = E.job
+				score.dmgestkey = E.key
 
 	// Check station's power levels
 	for (var/obj/machinery/power/apc/A in apc_list)
@@ -51,23 +128,23 @@
 			continue
 		for (var/obj/item/weapon/stock_parts/cell/C in A.contents)
 			if (C.charge < 2300)
-				SSStatistics.score.powerloss += 1 // 200 charge leeway
+				score.powerloss += 1 // 200 charge leeway
 
 	// Check how much uncleaned mess is on the station
 	for (var/obj/effect/decal/cleanable/M in decal_cleanable)
 		if (!is_station_level(M.z))
 			continue
 		if (istype(M, /obj/effect/decal/cleanable/blood/gibs))
-			SSStatistics.score.mess += 3
+			score.mess += 3
 		if (istype(M, /obj/effect/decal/cleanable/blood))
-			SSStatistics.score.mess += 1
+			score.mess += 1
 		if (istype(M, /obj/effect/decal/cleanable/vomit))
-			SSStatistics.score.mess += 1
+			score.mess += 1
 
 	// How many antags did we deconvert
 	for(var/name in global.deconverted_roles)
 		var/list/L = global.deconverted_roles[name]
-		SSStatistics.score.rec_antags += L.len
+		score.rec_antags += L.len
 
 	//Research Levels
 	var/research_levels = 0
@@ -77,156 +154,92 @@
 			research_levels += T.level
 
 	if(research_levels)
-		SSStatistics.score.researchdone += research_levels
+		score.researchdone += research_levels
 
 	// Bonus Modifiers
-	var/rolesuccess = SSStatistics.score.roleswon * 250
-	var/deathpoints = SSStatistics.score.crew_dead * 250 //done
-	var/researchpoints = SSStatistics.score.researchdone * 30
-	var/eventpoints = SSStatistics.score.eventsendured * 50
-	var/escapoints = SSStatistics.score.crew_escaped * 25 //done
-	var/harvests = SSStatistics.score.stuffharvested //done
-	var/shipping = SSStatistics.score.stuffshipped * 75
-	var/mining = SSStatistics.score.oremined //done
-	var/meals = SSStatistics.score.meals * 5 //done, but this only counts cooked meals, not drinks served
-	var/power = SSStatistics.score.powerloss * 30
-	var/plaguepoints = SSStatistics.score.disease * 30
-	var/messpoints = SSStatistics.score.mess != 0 ? SSStatistics.score.mess : null
+	var/rolesuccess = score.roleswon * 250
+	var/deathpoints = score.crew_dead * 250 //done
+	var/researchpoints = score.researchdone * 30
+	var/eventpoints = score.eventsendured * 50
+	var/escapoints = score.crew_escaped * 25 //done
+	var/harvests = score.stuffharvested //done
+	var/shipping = score.stuffshipped * 75
+	var/mining = score.oremined //done
+	var/meals = score.meals * 5 //done, but this only counts cooked meals, not drinks served
+	var/power = score.powerloss * 30
+	var/plaguepoints = score.disease * 30
+	var/messpoints = score.mess != 0 ? score.mess : null
 
-	for(var/datum/faction/F in mode.factions)
+	for(var/datum/faction/F in SSticker.mode.factions)
 		F.build_scorestat()
 
 	// Good Things
-	SSStatistics.score.crewscore += shipping + harvests + mining + meals + researchpoints + eventpoints + escapoints
+	score.crewscore += shipping + harvests + mining + meals + researchpoints + eventpoints + escapoints
 
 	if (power == 0)
-		SSStatistics.score.crewscore += 2500
-		SSStatistics.score.powerbonus = 1
-	if (SSStatistics.score.mess == 0)
-		SSStatistics.score.crewscore += 3000
-		SSStatistics.score.messbonus = 1
-	if (SSStatistics.score.allarrested)
-		SSStatistics.score.crewscore *= 3 // This needs to be here for the bonus to be applied properly
+		score.crewscore += 2500
+		score.powerbonus = 1
+	if (score.mess == 0)
+		score.crewscore += 3000
+		score.messbonus = 1
+	if (score.allarrested)
+		score.crewscore *= 3 // This needs to be here for the bonus to be applied properly
 
 	// Bad Things
-	SSStatistics.score.crewscore -= rolesuccess
-	SSStatistics.score.crewscore -= deathpoints
-	if (SSStatistics.score.deadaipenalty)
-		SSStatistics.score.crewscore -= 250
-	SSStatistics.score.crewscore -= power
-	SSStatistics.score.crewscore -= messpoints
-	SSStatistics.score.crewscore -= plaguepoints
+	score.crewscore -= rolesuccess
+	score.crewscore -= deathpoints
+	if (score.deadaipenalty)
+		score.crewscore -= 250
+	score.crewscore -= power
+	score.crewscore -= messpoints
+	score.crewscore -= plaguepoints
 
-	completions += scorestats()
+	score.rating = "The Aristocrats!"
+	switch(score.crewscore)
+		if(-99999 to -50000) score.rating = "Even the Singularity Deserves Better"
+		if(-49999 to -5000) score.rating = "Singularity Fodder"
+		if(-4999 to -1000) score.rating = "You're All Fired"
+		if(-999 to -500) score.rating = "A Waste of Perfectly Good Oxygen"
+		if(-499 to -250) score.rating = "A Wretched Heap of Scum and Incompetence"
+		if(-249 to -100) score.rating = "Outclassed by Lab Monkeys"
+		if(-99 to -21) score.rating = "The Undesirables"
+		if(-20 to -1) score.rating = "Not So Good"
+		if(0) score.rating = "Nothing of Value"
+		if(1 to 20) score.rating = "Ambivalently Average"
+		if(21 to 99) score.rating = "Not Bad, but Not Good"
+		if(100 to 249) score.rating = "Skillful Servants of Science"
+		if(250 to 499) score.rating = "Best of a Good Bunch"
+		if(500 to 999) score.rating = "Lean Mean Machine Thirteen"
+		if(1000 to 4999) score.rating = "Promotions for Everyone"
+		if(5000 to 9999) score.rating = "Ambassadors of Discovery"
+		if(10000 to 49999) score.rating = "The Pride of Science Itself"
+		if(50000 to INFINITY) score.rating = "NanoTrasen's Finest"
 
-	fdel("data/last_score.txt")
-	text2file(completions, "data/last_score.txt")
+/datum/stat_collector/Topic(href, href_list[], hsrc)
+	usr?.client?.show_scoreboard()
 
-	if(one_mob)
-		show_scoreboard(one_mob)
-	else
-		for(var/mob/E in player_list)
-			show_scoreboard(E)
-
-/datum/controller/subsystem/ticker/proc/show_scoreboard(mob/M)
-	if(!M.client)
-		return
-
-	to_chat(M, "<b>The crew's final score is:</b>")
-	to_chat(M, "<b><font size='4'>[SSStatistics.score.crewscore]</font></b>")
-
-	to_chat(M, "<span class='vote'>Чтобы посмотреть титры раунда нажмите <a href='?src=\ref[src]'>сюда</a> или Show Last Scoreboard во вкладке OOC.</span>")
-	if(M.client.prefs.votes_autoopening)
-		M.client.scoreboard(global.round_id)
-
-/datum/controller/subsystem/ticker/proc/scorestats(completions)
-	var/dat = completions
-	dat += {"<h2>Round Statistics and Score</h2><div class='Section'>"}
-
-	for(var/datum/faction/F in SSticker.mode.factions)
-		var/stat = F.get_scorestat()
-		if(stat)
-			dat += stat
-			dat += "<hr>"
-
-	if(global.deconverted_roles.len)
-		dat += "<B>Deconverted roles:</B><BR>"
-		dat += "<ul>"
-		for(var/name in global.deconverted_roles)
-			dat += "<li>"
-			dat += "[name]: [get_english_list(global.deconverted_roles[name])]."
-			dat += "</li>"
-		dat += "</ul>"
-
-	var/totalfunds = station_account.money
-	dat += {"<B><U>GENERAL STATS</U></B><BR>
-	<U>THE GOOD:</U><BR>
-	<B>Useful Crates Shipped:</B> [SSStatistics.score.stuffshipped] ([SSStatistics.score.stuffshipped * 75] Points)<BR>
-	<B>Hydroponics Harvests:</B> [SSStatistics.score.stuffharvested] ([SSStatistics.score.stuffharvested] Points)<BR>
-	<B>Ore Mined:</B> [SSStatistics.score.oremined] ([SSStatistics.score.oremined] Points)<BR>
-	<B>Refreshments Prepared:</B> [SSStatistics.score.meals] ([SSStatistics.score.meals * 5] Points)<BR>
-	<B>Research Completed:</B> [SSStatistics.score.researchdone] ([SSStatistics.score.researchdone * 30] Points)<BR>"}
-	dat += "<B>Shuttle Escapees:</B> [SSStatistics.score.crew_escaped] ([SSStatistics.score.crew_escaped * 25] Points)<BR>"
-	dat += {"<B>Random Events Endured:</B> [SSStatistics.score.eventsendured] ([SSStatistics.score.eventsendured * 50] Points)<BR>
-	<B>Whole Station Powered:</B> [SSStatistics.score.powerbonus ? "Yes" : "No"] ([SSStatistics.score.powerbonus * 2500] Points)<BR>
-	<B>Ultra-Clean Station:</B> [SSStatistics.score.mess ? "No" : "Yes"] ([SSStatistics.score.messbonus * 3000] Points)<BR><BR>
-	<U>THE BAD:</U><BR>
-	<B>Roles successful:</B> [SSStatistics.score.roleswon] (-[SSStatistics.score.roleswon * 250] Points)<BR>
-	<B>Dead Bodies on Station:</B> [SSStatistics.score.crew_dead] (-[SSStatistics.score.crew_dead * 250] Points)<BR>
-	<B>Uncleaned Messes:</B> [SSStatistics.score.mess] (-[SSStatistics.score.mess] Points)<BR>
-	<B>Station Power Issues:</B> [SSStatistics.score.powerloss] (-[SSStatistics.score.powerloss * 30] Points)<BR>
-	<B>Rampant Diseases:</B> [SSStatistics.score.disease] (-[SSStatistics.score.disease * 30] Points)<BR>
-	<B>AI Destroyed:</B> [SSStatistics.score.deadaipenalty ? "Yes" : "No"] (-[SSStatistics.score.deadaipenalty * 250] Points)<BR><BR>
-	<U>THE WEIRD</U><BR>
-	<B>Final Station Budget:</B> $[num2text(totalfunds,50)]<BR>"}
-	var/profit = totalfunds - global.initial_station_money
-	if (profit > 0)
-		dat += "<B>Station Profit:</B> +[num2text(profit,50)]<BR>"
-	else if (profit < 0)
-		dat += "<B>Station Deficit:</B> [num2text(profit,50)]<BR>"
-	dat += {"<B>Food Eaten:</b> [SSStatistics.score.foodeaten]<BR>
-	<B>Times a Clown was Abused:</B> [SSStatistics.score.clownabuse]<BR><BR>"}
-	if (SSStatistics.score.crew_escaped)
-		dat += "<B>Most Richest Escapee:</B> [SSStatistics.score.richestname], [SSStatistics.score.richestjob]: [SSStatistics.score.richestcash] credits ([SSStatistics.score.richestkey])<BR>"
-		dat += "<B>Most Battered Escapee:</B> [SSStatistics.score.dmgestname], [SSStatistics.score.dmgestjob]: [SSStatistics.score.dmgestdamage] damage ([SSStatistics.score.dmgestkey])<BR>"
-	else
-		dat += "The station wasn't evacuated or no one escaped!<BR>"
-	dat += {"<HR><BR>
-	<B><U>FINAL SCORE: [SSStatistics.score.crewscore]</U></B><BR>"}
-	SSStatistics.score.rating = "The Aristocrats!"
-	switch(SSStatistics.score.crewscore)
-		if(-99999 to -50000) SSStatistics.score.rating = "Even the Singularity Deserves Better"
-		if(-49999 to -5000) SSStatistics.score.rating = "Singularity Fodder"
-		if(-4999 to -1000) SSStatistics.score.rating = "You're All Fired"
-		if(-999 to -500) SSStatistics.score.rating = "A Waste of Perfectly Good Oxygen"
-		if(-499 to -250) SSStatistics.score.rating = "A Wretched Heap of Scum and Incompetence"
-		if(-249 to -100) SSStatistics.score.rating = "Outclassed by Lab Monkeys"
-		if(-99 to -21) SSStatistics.score.rating = "The Undesirables"
-		if(-20 to -1) SSStatistics.score.rating = "Not So Good"
-		if(0) SSStatistics.score.rating = "Nothing of Value"
-		if(1 to 20) SSStatistics.score.rating = "Ambivalently Average"
-		if(21 to 99) SSStatistics.score.rating = "Not Bad, but Not Good"
-		if(100 to 249) SSStatistics.score.rating = "Skillful Servants of Science"
-		if(250 to 499) SSStatistics.score.rating = "Best of a Good Bunch"
-		if(500 to 999) SSStatistics.score.rating = "Lean Mean Machine Thirteen"
-		if(1000 to 4999) SSStatistics.score.rating = "Promotions for Everyone"
-		if(5000 to 9999) SSStatistics.score.rating = "Ambassadors of Discovery"
-		if(10000 to 49999) SSStatistics.score.rating = "The Pride of Science Itself"
-		if(50000 to INFINITY) SSStatistics.score.rating = "NanoTrasen's Finest"
-	dat += "<B><U>RATING:</U></B> [SSStatistics.score.rating]"
-	dat += "</div>"
-
-	log_game(dat)
-
-	return dat
-
-/datum/controller/subsystem/ticker/Topic(href, href_list[], hsrc)
-	usr?.client?.scoreboard(global.round_id)
-
-/client/proc/scoreboard(roundid)
+/client/proc/show_scoreboard(roundid)
 	for(var/i in 1 to end_icons.len)
 		src << browse_rsc(end_icons[i],"logo_[i].png")
 
-	var/datum/browser/popup = new(src, "roundstats", "[roundid ? "Round #[roundid]" : "Last Round"] Stats", 1000, 600)
-	popup.set_content(file2text("data/last_score.txt"))
+	if(!establish_db_connection("erro_round"))
+		return
+
+	if(!roundid)
+		roundid = global.get_last_proper_ended_round_id()
+
+	var/DBQuery/round_query = dbcon.NewQuery("SELECT DATE_FORMAT(initialize_datetime, '%Y/%m/%d') FROM erro_round WHERE id = [roundid];")
+	round_query.Execute()
+
+	var/round_date
+	if(round_query.NextRow())
+		round_date = round_query.item[1]
+
+	var/statfile = file("data/logs/[round_date]/round-[roundid]/stat.json")
+	if(!fexists(statfile))
+		to_chat(usr, "<span class='info'>Титры по раунду #[roundid] не обнаружены.</span>")
+		return
+
+	var/datum/browser/popup = new(src, "roundstats", "Round #[roundid] Stats", 1000, 600)
+	popup.set_content(json_decode(statfile))
 	popup.open()

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -209,3 +209,9 @@ var/global/bridge_ooc_colour = "#7b804f"
 
 	to_chat(src, "<span class='notice'>UI resource files resent successfully. If you are still having issues, please try manually clearing your BYOND cache.</span>")
 
+/client/verb/show_scoreboard()
+	set name = "Show Last Scoreboard"
+	set desc = "Shows the scoreboard of the last round."
+	set category = "OOC"
+
+	scoreboard()

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -209,9 +209,11 @@ var/global/bridge_ooc_colour = "#7b804f"
 
 	to_chat(src, "<span class='notice'>UI resource files resent successfully. If you are still having issues, please try manually clearing your BYOND cache.</span>")
 
-/client/verb/show_scoreboard()
-	set name = "Show Last Scoreboard"
-	set desc = "Shows the scoreboard of the last round."
+/client/verb/show_scoreboard_verb()
+	set name = "Show Round Scoreboard"
+	set desc = "Shows the scoreboard of the last rounds."
 	set category = "OOC"
 
-	scoreboard()
+	var/roundid = input("Введите номер раунда, титры которого желаете посмотреть. Оставьте пустым и будет выбран последний закончившийся раунд.", "Номер раунда") as num|null
+
+	show_scoreboard(roundid)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -50,6 +50,7 @@ var/global/const/MAX_SAVE_SLOTS = 10
 	var/outline_enabled = TRUE
 	var/outline_color = COLOR_BLUE_LIGHT
 	var/eorg_enabled = TRUE
+	var/votes_autoopening = TRUE
 
 	var/show_runechat = TRUE
 

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -104,6 +104,15 @@
 	to_chat(src, "You will receive requests for \"[role]\" again")
 	feedback_add_details("admin_verb","TBeSpecialIgnore") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/client/verb/toggle_votes_autoopening()
+	set name = "Toggle Votes Autoopening"
+	set category = "Preferences"
+	set desc = "Toggle votes and scoreboard autoopening (you can still open them via a link)."
+	prefs.votes_autoopening = !prefs.votes_autoopening
+	to_chat(src, "Voting and scoreboard interfaces will [prefs.votes_autoopening ? "now" : "no longer"] open automatically (you can still open them via a link).")
+	prefs.save_preferences()
+	feedback_add_details("admin_verb","TVA") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
 /client/verb/change_ui()
 	set name = "Change UI"
 	set category = "Preferences"

--- a/code/modules/statistic/statistics.dm
+++ b/code/modules/statistic/statistics.dm
@@ -30,8 +30,6 @@ var/global/datum/stat_collector/SSStatistics = new /datum/stat_collector
 	// int, [1...]
 	var/round_id
 	// int, [1...]
-	var/last_round_id
-	// string, [hh:mm:ss]
 	var/start_time
 	// string, [hh:mm:ss]
 	var/end_time

--- a/code/modules/statistic/statistics.dm
+++ b/code/modules/statistic/statistics.dm
@@ -29,7 +29,7 @@ var/global/datum/stat_collector/SSStatistics = new /datum/stat_collector
 	var/const/version = STAT_OUTPUT_VERSION
 	// int, [1...]
 	var/round_id
-	// int, [1...]
+	// string, [hh:mm:ss]
 	var/start_time
 	// string, [hh:mm:ss]
 	var/end_time

--- a/code/modules/statistic/statistics.dm
+++ b/code/modules/statistic/statistics.dm
@@ -29,6 +29,8 @@ var/global/datum/stat_collector/SSStatistics = new /datum/stat_collector
 	var/const/version = STAT_OUTPUT_VERSION
 	// int, [1...]
 	var/round_id
+	// int, [1...]
+	var/last_round_id
 	// string, [hh:mm:ss]
 	var/start_time
 	// string, [hh:mm:ss]
@@ -95,6 +97,8 @@ var/global/datum/stat_collector/SSStatistics = new /datum/stat_collector
 	message_admins("<font color='blue'>Статистика была записана в файл за [(start_time - world.realtime)/10] секунд.</font>")
 
 	to_chat(stealth ? usr : world, "<span class='info'>Статистика по этому раунду вскоре будет доступа по ссылке [generate_url()]</span>")
+
+	generate_scoreboard()
 
 /datum/stat_collector/proc/generate_url()
 	var/root = "https://stat.taucetistation.org/html"

--- a/code/modules/statistic/statistics.dm
+++ b/code/modules/statistic/statistics.dm
@@ -91,7 +91,8 @@ var/global/datum/stat_collector/SSStatistics = new /datum/stat_collector
 
 	var/start_time = world.realtime
 	statfile << datum2json(src)
-	to_chat(stealth ? usr : world, "<span class='info'>Статистика была записана в файл за [(start_time - world.realtime)/10] секунд. </span>")
+	log_admin("Статистика была записана в файл за [(start_time - world.realtime)/10] секунд.")
+	message_admins("<font color='blue'>Статистика была записана в файл за [(start_time - world.realtime)/10] секунд.</font>")
 
 	to_chat(stealth ? usr : world, "<span class='info'>Статистика по этому раунду вскоре будет доступа по ссылке [generate_url()]</span>")
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

https://user-images.githubusercontent.com/75007994/189112058-1ecb3e96-2d0e-495a-afad-dd18e31a0a60.mp4

Титры раунда теперь можно открывать через ссылку, которая появится в чате или через кнопку Show Round Scoreboard во вкладке оок. Нажатие кнопки в раунде покажет титры последнего завершенного раунда.

UPD: Через Show Last Scoreboard можно посмотреть титры **любого** раунда, введя его айди или последнего, оставив поле пустым.

Добавлен преф, позволяющий отключить автооткрытие титров и воутов.

Также сообщение в чате за сколько секунд была сохранена статистика будет показываться только педалям, а не всему серверу.
## Почему и что этот ПР улучшит
Титры и воуты не будут выскакивать в лицо и мешать тру робасту. Титры можно будет посмотреть в красивой форме прямо в игре.
## Авторство

## Чеинжлог
:cl:
 - add: Добавлена кнопка Show Round Scoreboard для просмотра титров любых раундов.
 - add: Добавлен преференс Toggle Votes Autoopening, запрещающий интерфейсам воутов и титр выскакивать автоматически.