### PR TITLE
Separate world icons like on mojave-sun

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -61,6 +61,9 @@ var/global/list/bitflags = list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define HEAR_PASS_SAY          (1<<21)   // temp for say code, for objects that need to pass SAY to inner mobs through get_listeners()
 #define HEAR_TA_SAY            (1<<22)   // temp for talking_atoms
 
+#define IN_INVENTORY           (1<<23)
+#define IN_STORAGE             (1<<23) // reuse of last bit we have
+
 /* Secondary atom flags, for the flags_2 var, denoted with a _2 */
 #define HOLOGRAM_2         (1<<0)
 /// atom queued to SSoverlay

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -421,7 +421,7 @@
 /obj/item/proc/after_throw(datum/callback/callback)
 	if (callback) //call the original callback
 		. = callback.Invoke()
-	flags &= ~IN_INVENTORY
+	flags &= ~IN_INVENTORY // #10047
 	update_world_icon()
 
 /obj/item/proc/talk_into(mob/M, text)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -4,7 +4,6 @@
 	w_class = SIZE_SMALL
 	var/image/blood_overlay = null //this saves our blood splatter overlay, which will be processed not to go over the edges of the sprite
 	var/abstract = 0
-	var/item_state = null
 	var/lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	var/righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 	var/r_speed = 1.0
@@ -60,7 +59,9 @@
 	var/toolspeed = 1
 	var/obj/item/device/uplink/hidden/hidden_uplink = null // All items can have an uplink hidden inside, just remember to add the triggers.
 
-	var/icon_override = null  //Used to override hardcoded clothing dmis in human clothing proc.
+	var/item_state = null         // has priority over icon_state for on-mob sprites
+	var/item_state_world = null   // has priority over icon_state for world (not in inventory) sprites
+	var/icon_override = null      // Used to override hardcoded clothing dmis in human clothing proc (see also icon_custom)
 
 	/* Species-specific sprite sheets for inventory sprites
 	Works similarly to worn sprite_sheets, except the alternate sprites are used when the clothing/refit_for_species() proc is called.
@@ -420,6 +421,8 @@
 /obj/item/proc/after_throw(datum/callback/callback)
 	if (callback) //call the original callback
 		. = callback.Invoke()
+	flags &= ~IN_INVENTORY
+	update_world_icon()
 
 /obj/item/proc/talk_into(mob/M, text)
 	return FALSE
@@ -431,8 +434,10 @@
 /obj/item/proc/dropped(mob/user)
 	SHOULD_CALL_PARENT(TRUE)
 	SEND_SIGNAL(src, COMSIG_ITEM_DROPPED, user)
+	flags &= ~IN_INVENTORY
 	if(flags & DROPDEL)
 		qdel(src)
+	update_world_icon()
 	set_alt_apperances_layers()
 
 // called just as an item is picked up (loc is not yet changed)
@@ -444,10 +449,14 @@
 
 // called when this item is removed from a storage item, which is passed on as S. The loc variable is already set to the new destination before this is called.
 /obj/item/proc/on_exit_storage(obj/item/weapon/storage/S)
+	flags |= IN_STORAGE
+	update_world_icon()
 	return
 
 // called when this item is added into a storage item, which is passed on as S. The loc variable is already set to the storage item.
 /obj/item/proc/on_enter_storage(obj/item/weapon/storage/S)
+	flags &= ~IN_STORAGE
+	update_world_icon()
 	return
 
 // called when "found" in pockets and storage items. Returns 1 if the search should end.
@@ -461,8 +470,10 @@
 // note this isn't called during the initial dressing of a player
 /obj/item/proc/equipped(mob/user, slot)
 	SHOULD_CALL_PARENT(TRUE)
+	flags |= IN_INVENTORY
 	SEND_SIGNAL(src, COMSIG_ITEM_EQUIPPED, user, slot)
 	SEND_SIGNAL(user, COMSIG_MOB_EQUIPPED, src, slot)
+	update_world_icon()
 	set_alt_apperances_layers()
 
 //the mob M is attempting to equip this item into the slot passed through as 'slot'. Return 1 if it can do this and 0 if it can't.
@@ -1092,3 +1103,17 @@
 	icon_state = initial(dye_type.icon_state)
 	item_state = initial(dye_type.item_state)
 	desc = "The colors are a bit dodgy."
+
+// swap between world (small) and ui (big) icons when item changes location
+// feel free to override for items with complicated icon mechanics
+/obj/item/proc/update_world_icon()
+	if(!item_state_world)
+		return
+
+	if((flags && IN_INVENTORY || flags && IN_STORAGE) && icon_state == item_state_world)
+		// moving to inventory, restore icon
+		icon_state = initial(icon_state)
+
+	else if(icon_state != item_state_world)
+		// moving to world, change icon
+		icon_state = item_state_world


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Позволяет иконкам устанавливать отличную in world иконку, как на Mojave Sun. 

Это будет полезно для мелких предметов со здоровыми иконками, которые со своим масштабом странно выглядят в миру. 

Пример реализации идеи с resize вместо отдельных иконок (Скрин Вальтера):
![изображение](https://user-images.githubusercontent.com/4064061/189231949-d16030d2-c7b2-4893-9666-41fbc0818672.png)
Мелкие иконки - как оно будет на карте, большие - как в инвентаре. Это только пример, т.к. resize шакалит спрайты.

Данный ПР добавляет только механику, спрайты будут отдельно.

\+ новые флаги IN_INVENTORY (соответствует подобному с tg) и IN_STORAGE

## Почему и что этот ПР улучшит

Визуал игры.

## Авторство

Первоначальная идея и реализация Mojave Sun
https://github.com/Mojave-Sun/mojave-sun-13/blob/9faa640681e1ab07318824be2b954f6e4b860c77/mojave/elements/world_icon.dm

Адаптировано к нам по реквесту Вальтера.

## Чеинжлог
