### PR TITLE
QoL для Мед и Уборко Боргов

### DIFF
--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -125,9 +125,9 @@
 	uses = min(max(uses + amount, 0), max_uses)
 
 /obj/item/device/lightreplacer/proc/Charge(mob/user)
-	charge += 1
+	charge += 5
 	if(charge > 7)
-		AddUses(1)
+		AddUses(5)
 		charge = 1
 
 /obj/item/device/lightreplacer/proc/ReplaceLight(obj/machinery/light/target, mob/living/U)

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -202,6 +202,7 @@
 		/obj/item/robot_parts/l_leg,
 		/obj/item/robot_parts/r_leg,
 		/obj/item/stack/sheet/mineral/phoron,
+		/obj/item/weapon/tank/anesthetic,
 		)
 
 /obj/item/weapon/gripper/examine(mob/user)

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -147,6 +147,7 @@
 	modules += new /obj/item/weapon/shockpaddles/robot(src)
 	modules += new /obj/item/device/gps/cyborg(src)
 	modules += new /obj/item/stack/medical/suture(src)
+	modules += new /obj/item/weapon/reagent_containers/spray/cleaner(src)
 
 	emag = new /obj/item/weapon/reagent_containers/spray(src)
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -433,7 +433,7 @@
 	modules += new /obj/item/device/t_scanner(src)
 	modules += new /obj/item/weapon/gripper(src)
 	modules += new /obj/item/weapon/matter_decompiler(src)
-	modules += new /obj/item/weapon/reagent_containers/spray/cleaner/drone(src)
+	modules += new /obj/item/weapon/reagent_containers/spray/cleaner/cyborg/drone(src)
 
 	emag = new /obj/item/weapon/pickaxe/plasmacutter(src)
 	emag.name = "Plasma Cutter"

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -147,7 +147,7 @@
 	modules += new /obj/item/weapon/shockpaddles/robot(src)
 	modules += new /obj/item/device/gps/cyborg(src)
 	modules += new /obj/item/stack/medical/suture(src)
-	modules += new /obj/item/weapon/reagent_containers/spray/cleaner(src)
+	modules += new /obj/item/weapon/reagent_containers/spray/cleaner/cyborg(src)
 
 	emag = new /obj/item/weapon/reagent_containers/spray(src)
 

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -391,10 +391,19 @@ ADD_TO_GLOBAL_LIST(/obj/item/weapon/reagent_containers/spray/cleaner, cleaners_l
 	desc = "BLAM!-brand non-foaming space cleaner!"
 	volume = 50
 
+
+/obj/item/weapon/reagent_containers/spray/cleaner/atom_init()
+	. = ..()
+	reagents.add_reagent(space_cleaner, volume)
+
 /obj/item/weapon/reagent_containers/spray/cleaner/cyborg //Credit @Deahaka for rechargable extinguisher
 	name = "Cyborg cleaner"
 	desc = "Self-recharging cleaner spray."
-	var/closed = TRUE
+
+/obj/item/weapon/reagent_containers/spray/cleaner/cyborg/drone
+	name = "Drone cleaner"
+	desc = "Self-recharging cleaner spray."
+	volume = 50
 
 /obj/item/weapon/reagent_containers/spray/cleaner/cyborg/attackby(obj/item/I, mob/user, params)
 	to_chat(user, "<span class='notice'>[src] reagents are under pressure, don't open.</span>")
@@ -415,9 +424,6 @@ ADD_TO_GLOBAL_LIST(/obj/item/weapon/reagent_containers/spray/cleaner, cleaners_l
 	// 5/250 cleaner per 2 seconds
 	reagents.add_reagent(space_cleaner, reagents.maximum_volume / 50)
 
-/obj/item/weapon/reagent_containers/spray/cleaner/atom_init()
-	. = ..()
-	reagents.add_reagent("cleaner", volume)
 
 //pepperspray
 /obj/item/weapon/reagent_containers/spray/pepper

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -24,6 +24,7 @@
 
 	var/spray_sound = 'sound/effects/spray2.ogg'
 	var/volume_modifier = -6
+	var/space_cleaner = "cleaner"
 
 	var/spray_cloud_move_delay = 3
 	var/spray_cloud_react_delay = 2
@@ -389,6 +390,30 @@ ADD_TO_GLOBAL_LIST(/obj/item/weapon/reagent_containers/spray/cleaner, cleaners_l
 	name = "space cleaner"
 	desc = "BLAM!-brand non-foaming space cleaner!"
 	volume = 50
+
+/obj/item/weapon/reagent_containers/spray/cleaner/cyborg //Credit @Deahaka for rechargable extinguisher
+	name = "Cyborg cleaner"
+	desc = "Self-recharging cleaner spray."
+	var/closed = TRUE
+
+/obj/item/weapon/reagent_containers/spray/cleaner/cyborg/attackby(obj/item/I, mob/user, params)
+	to_chat(user, "<span class='notice'>[src] reagents are under pressure, don't open.</span>")
+	return TRUE
+
+/obj/item/weapon/reagent_containers/spray/cleaner/cyborg/afterattack(atom/target, mob/user, proximity, params)
+	if(..())
+		var/mob/living/silicon/robot/R = loc
+		if(R && R.cell)
+			R.cell.use(amount_per_transfer_from_this)
+	if(reagents.total_volume < reagents.maximum_volume)
+		START_PROCESSING(SSobj, src)
+
+/obj/item/weapon/reagent_containers/spray/cleaner/cyborg/process()
+	if(reagents.total_volume == reagents.maximum_volume)
+		STOP_PROCESSING(SSobj, src)
+		return
+	// 5/250 cleaner per 2 seconds
+	reagents.add_reagent(space_cleaner, reagents.maximum_volume / 50)
 
 /obj/item/weapon/reagent_containers/spray/cleaner/atom_init()
 	. = ..()


### PR DESCRIPTION
## Описание изменений
1) Позволяет МедБоргу самому брать баллон анестезии в МедГриппер (Для вставления его в Artificial Ventillation machine)
2) Возвращает МедБоргу клинер для уборки медбея
3) Ускоряет перезарядку лампочек у УборкоБорга 
#9897
## Почему и что этот ПР улучшит
1) Если Борг был сделан позже начала, а в операционной никто не удосужился поставить баллон - приходится либо тратить дракоценное время для просьб анестезии, либо экипировки гипоспрея и переключения\использования трамадола (Если на станции пиздец и хаос - затруднительнее)
2) Медбей будет менее засран
3) Не будет ожидания УборкоБоргов регена ламп с пустого состояния по 1 штуке, что занимало ~4 минуты непрерывной зарядки
## Авторство
4Donic
## Чеинжлог
:cl: 4Donic
 - add: Гриппер МедБорга теперь может брать баллон с анестезией
 - balance: Лампочки УборкоБорга теперь перезаряжаются быстрее
 - add: У МедБорга появился спрей с клинером, что перезаряжается сам и не позволяет себя пополнить извне
 - balance : Клинер Дрона тоже стал самозаряжаемым.