### PR TITLE
[fix]doublebarrel reload minifix

### DIFF
--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -123,10 +123,9 @@
 			to_chat(user, "<span class='notice'>You load shell into \the [src]!</span>")
 			playsound(src, 'sound/weapons/guns/reload_shotgun.ogg', VOL_EFFECTS_MASTER)
 			chamber_round()
+			return ..()
 		else
 			to_chat(user, "<span class='notice'>You can't load shell while [src] is closed!</span>")
-
-	return ..()
 
 /obj/item/weapon/gun/projectile/revolver/doublebarrel/attack_self(mob/living/user)
 	add_fingerprint(user)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Переместил возврат функции зарядки туда, где она должна быть.
## Почему и что этот ПР улучшит
Теперь нельзя заряжать двухстволку, когда она закрыта.
## Авторство

## Чеинжлог
