### PR TITLE
Better runtime stacking for negative use/add/give call

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -194,7 +194,7 @@
 
 /obj/item/stack/use(used, transfer = FALSE)
 	if(used < 0)
-		stack_trace("[src.type]/use() called with a negative parameter [used]")
+		stack_trace("[src.type]/use() called with a negative parameter")
 		return FALSE
 	if(zero_amount())
 		return FALSE
@@ -245,7 +245,7 @@
 
 /obj/item/stack/proc/add(_amount)
 	if(_amount < 0)
-		stack_trace("[src.type]/add() called with a negative parameter [_amount]")
+		stack_trace("[src.type]/add() called with a negative parameter")
 		return
 	amount += _amount
 	update_icon()

--- a/code/game/objects/items/weapons/airlock_painter.dm
+++ b/code/game/objects/items/weapons/airlock_painter.dm
@@ -30,7 +30,7 @@
 	//Only call this if you are certain that the painter will be used right after this check!
 /obj/item/weapon/airlock_painter/use(cost)
 	if(cost < 0)
-		stack_trace("[src.type]/use() called with a negative parameter [cost]")
+		stack_trace("[src.type]/use() called with a negative parameter")
 		return 0
 	if(can_use(usr, cost))
 		ink.charges -= cost

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -384,7 +384,7 @@
 // Removes fuel from the welding tool. If a mob is passed, it will perform an eyecheck on the mob. This should probably be renamed to use()
 /obj/item/weapon/weldingtool/use(used = 1, mob/M = null)
 	if(used < 0)
-		stack_trace("[src.type]/use() called with a negative parameter [used]")
+		stack_trace("[src.type]/use() called with a negative parameter")
 		return 0
 	if(!active || !check_fuel())
 		return 0

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -24,7 +24,7 @@
 // use power from a cell, returns the amount actually used
 /obj/item/weapon/stock_parts/cell/use(amount)
 	if(amount < 0)
-		stack_trace("[src.type]/use() called with a negative parameter [amount]")
+		stack_trace("[src.type]/use() called with a negative parameter")
 		return 0
 	if(rigged && amount > 0)
 		explode()
@@ -38,7 +38,7 @@
 // recharge the cell
 /obj/item/weapon/stock_parts/cell/proc/give(amount)
 	if(amount < 0)
-		stack_trace("[src.type]/give() called with a negative parameter [amount]")
+		stack_trace("[src.type]/give() called with a negative parameter")
 		return 0
 	if(rigged && amount > 0)
 		explode()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Параметр и так есть в stack trace, а из-за разных чисел в ошибке у нас рантайм-бот их не может нормально подсчитать.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
