### PR TITLE
Твик простыни мага

### DIFF
--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -134,7 +134,7 @@ LINEN BINS
 	. = ..()
 
 	var/obj/effect/effect/forcefield/F = new
-	AddComponent(/datum/component/forcefield, "wizard field", 20, 3 SECONDS, 5 SECONDS, F, TRUE)
+	AddComponent(/datum/component/forcefield, "wizard field", 20, 3 SECONDS, 5 SECONDS, F, TRUE, TRUE)
 
 /obj/item/weapon/bedsheet/wiz/proc/activate(mob/living/user)
 	if(iswizard(user) || iswizardapprentice(user))


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Без этого щит мага может забагать некоторые заклинания при перепоявлении. Из щита можно будет нормально взаимодействовать с миром.
## Почему и что этот ПР улучшит
геймплей
## Авторство

## Чеинжлог
:cl: Deahaka
- tweak: Щит мага от одеяла на спине перестал блокировать взаимодействия с предметами.