### PR TITLE
Удаляет абдукторов из тим бейседа

### DIFF
--- a/code/game/gamemodes/modesbundle.dm
+++ b/code/game/gamemodes/modesbundle.dm
@@ -43,7 +43,6 @@
 /datum/modesbundle/teambased
 	name = "Team Based"
 	possible_gamemodes = list(
-		/datum/game_mode/abduction,
 		/datum/game_mode/blob,
 		/datum/game_mode/cult,
 		/datum/game_mode/infestation,


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Удаляет абдукторов из тим бейседа
## Почему и что этот ПР улучшит
абдукторы не вписываются в набор режимов под названием "team based"
Не вписываются потому что почти все режимы из данного набора базируются на открытом противостоянии антагонистов и станции, или же в тех режимах задействуется весь экипаж, а не только офицерики, как в абдукторах.
closes #8414
## Авторство

## Чеинжлог
:cl: Simbaka
- del: Абдукторы удалены из набора режимов "Team Based".