### PR TITLE
Фикс факса на прометее

### DIFF
--- a/maps/prometheus/prometheus.dmm
+++ b/maps/prometheus/prometheus.dmm
@@ -88702,7 +88702,7 @@
 "vIV" = (
 /obj/structure/table/woodentable,
 /obj/machinery/faxmachine{
-	department = "Captain's Office"
+	department = "Bridge"
 	},
 /turf/simulated/floor{
 	dir = 9;


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
На мостике стоял капитанский факс, а не мостика.
## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
ну это нереально микроизменение, которое игроки даж не заметят никак, просто админов не будет путать отправление капитанского отчёта через мостик.