### PR TITLE
Фикс занавесок прометея

### DIFF
--- a/maps/prometheus/prometheus.dmm
+++ b/maps/prometheus/prometheus.dmm
@@ -17596,6 +17596,7 @@
 /obj/structure/curtain/medical{
 	icon_state = "open"
 	},
+/obj/structure/curtain/open/privacy,
 /turf/simulated/floor{
 	icon_state = "whiteblue"
 	},
@@ -88325,9 +88326,7 @@
 	},
 /area/station/medical/cryo)
 "vEd" = (
-/obj/structure/curtain/medical{
-	icon_state = "open"
-	},
+/obj/structure/curtain/open/privacy,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "whiteblue"
@@ -90008,9 +90007,7 @@
 /area/station/cargo/recycler)
 "vZR" = (
 /obj/machinery/hologram/holopad,
-/obj/structure/curtain/medical{
-	icon_state = "open"
-	},
+/obj/structure/curtain/open/privacy,
 /turf/simulated/floor{
 	icon_state = "white"
 	},


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
В хирургии дебильные занавески были, которые открыты, но не позволяют смотреть сквозь себя.
## Почему и что этот ПР улучшит
минус баг
## Авторство

## Чеинжлог
:cl: 
 - fix: в хирургии прометея теперь нормальные занавески.