### PR TITLE
Мыши, слаймы и прочие теперь не смогут подбирать стопку бумаг

### DIFF
--- a/code/modules/mob/living/carbon/metroid/metroid.dm
+++ b/code/modules/mob/living/carbon/metroid/metroid.dm
@@ -334,6 +334,9 @@
 /mob/living/carbon/slime/is_usable_leg(targetzone = null)
 	return FALSE
 
+/mob/living/carbon/slime/can_pickup(obj/O)
+	return FALSE
+
 /mob/living/carbon/slime/get_species()
 	return SLIME
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -404,3 +404,6 @@
 
 /mob/living/simple_animal/crawl()
 	return FALSE
+
+mob/living/simple_animal/can_pickup(obj/O)
+	return FALSE

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -405,5 +405,5 @@
 /mob/living/simple_animal/crawl()
 	return FALSE
 
-mob/living/simple_animal/can_pickup(obj/O)
+/mob/living/simple_animal/can_pickup(obj/O)
 	return FALSE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Симпл мобы и слаймы теперь не могут подбирать стопку бумаг

## Почему и что этот ПР улучшит
Одной неприятной вещью меньше
## Авторство

## Чеинжлог
:cl:
 - bugfix: Мыши больше не могут подбирать стопку бумаг.