### PR TITLE
Aspects, cost and scale

### DIFF
--- a/code/game/gamemodes/modes_gameplays/cult/structures/tech_table.dm
+++ b/code/game/gamemodes/modes_gameplays/cult/structures/tech_table.dm
@@ -137,7 +137,11 @@
 
 /obj/structure/cult/tech_table/proc/get_upgrade_cost(datum/aspect/in_religion)
 	if(!in_religion)
-		return 300
+		var/all_aspects = 0
+		for(var/datum/aspect/I in cult_religion.aspects)
+			all_aspects += I.power
+		var/cost = max(50, 50*all_aspects-300) //We don't count 6 initial aspects and scale for +50 piety for each new aspect
+		return cost
 	return in_religion.power * 50
 
 /obj/structure/cult/tech_table/proc/gen_category_images()

--- a/code/game/gamemodes/modes_gameplays/cult/structures/tech_table.dm
+++ b/code/game/gamemodes/modes_gameplays/cult/structures/tech_table.dm
@@ -141,7 +141,7 @@
 		for(var/aspect_name in cult_religion.aspects)
 			var/datum/aspect/asp = cult_religion.aspects[aspect_name]
 			all_aspects += asp.power
-		var/cost = max(50, 50*all_aspects-250) //We don't count 6 initial aspects and scale for static 50, +50 piety for each new aspect
+		var/cost = max(50, 50*all_aspects-150) //We don't count 6 initial aspects and scale for static 150, +50 piety for each new aspect
 		return cost
 	return in_religion.power * 50
 

--- a/code/game/gamemodes/modes_gameplays/cult/structures/tech_table.dm
+++ b/code/game/gamemodes/modes_gameplays/cult/structures/tech_table.dm
@@ -139,9 +139,8 @@
 	if(!in_religion)
 		var/all_aspects = 0
 		for(var/aspect_name in cult_religion.aspects)
-			var/datum/aspect/asp = cult_religion.aspects[aspect_name]
-			all_aspects += asp.power
-		var/cost = max(50, 50*all_aspects-150) //We don't count 6 initial aspects and scale for static 150, +50 piety for each new aspect
+			all_aspects++
+		var/cost = max(100, 50 + 25 * all_aspects) //We don't count 6 initial aspects and scale for static 150, +50 piety for each new aspect
 		return cost
 	return in_religion.power * 50
 

--- a/code/game/gamemodes/modes_gameplays/cult/structures/tech_table.dm
+++ b/code/game/gamemodes/modes_gameplays/cult/structures/tech_table.dm
@@ -138,9 +138,10 @@
 /obj/structure/cult/tech_table/proc/get_upgrade_cost(datum/aspect/in_religion)
 	if(!in_religion)
 		var/all_aspects = 0
-		for(var/datum/aspect/I in cult_religion.aspects)
-			all_aspects += I.power
-		var/cost = max(50, 50*all_aspects-300) //We don't count 6 initial aspects and scale for +50 piety for each new aspect
+		for(var/aspect_name in cult_religion.aspects)
+			var/datum/aspect/asp = cult_religion.aspects[aspect_name]
+			all_aspects += asp.power
+		var/cost = max(50, 50*all_aspects-250) //We don't count 6 initial aspects and scale for static 50, +50 piety for each new aspect
 		return cost
 	return in_religion.power * 50
 


### PR DESCRIPTION
## Описание изменений
В общем-то, попытаюсь немного подсобить разнообразию в ритуалах культа.

Что было раньше? Улучшить с первого на второй уровень стоит 50. А с нулевого до первого - 300.

Что предлагаю я? Новые аспекты стоят по 150. Однако, за каждый дополнительный новый аспект И уровни уже имеющихся аспектов, к 150 прибавляется ещё по 50. 
P.s. Изначальные аспекты не входят в эти расчёты, т.е. цена будет всё те же 150 с самого начала

К примеру, 4 аспекта в культе, каждый по 3-у уровню. Для приобретения нового аспекта им потребуется 12 * 50 - 150 = 450

## Почему и что этот ПР улучшит
Попытка привести культ к большему разнообразию, возможно чуть больше прощать за ошибки, но на лейте заставлять задумываться что ты вообще делаешь
## Авторство

## Чеинжлог
:cl: Chip11-n
- balance[link]: Изменились цены для неизученных аспектов в культе.