### PR TITLE
Cultists and Revs trying their best now

### DIFF
--- a/code/game/gamemodes/roles/cultist.dm
+++ b/code/game/gamemodes/roles/cultist.dm
@@ -13,7 +13,7 @@
 
 	var/holy_rank = CULT_ROLE_HIGHPRIEST
 	skillset_type = /datum/skillset/cultist
-	change_to_maximum_skills = FALSE
+	change_to_maximum_skills = TRUE
 
 /datum/role/cultist/CanBeAssigned(datum/mind/M, laterole)
 	if(laterole == FALSE) // can be null
@@ -95,4 +95,3 @@
 
 	holy_rank = CULT_ROLE_MASTER
 	skillset_type = /datum/skillset/cultist/leader
-	change_to_maximum_skills = FALSE

--- a/code/game/gamemodes/roles/revolution.dm
+++ b/code/game/gamemodes/roles/revolution.dm
@@ -7,7 +7,6 @@
 	antag_hud_type = ANTAG_HUD_REV
 	antag_hud_name = "hudrevolutionary"
 	skillset_type = /datum/skillset/revolutionary
-	change_to_maximum_skills = FALSE
 
 /datum/role/rev/CanBeAssigned(datum/mind/M)
 	if(!..())


### PR DESCRIPTION
## Описание изменений
Культистам и реверам ставятся сразу максимальные скиллы для них. То-есть не нужно каждый раз лезть в скилл панельку ради того, что бы нажать на кнопочку. Как много вообще знало, что они получают баффы к скиллам?
## Почему и что этот ПР улучшит
Скорее как QoL. Новичкам тоже будет в разы полезнее иметь максимальные скиллы в том же самом бою, чем опасность спалиться из-за скорости как они накладывают бинтики на себя, а у реверов это вовсе будет спалено только когда тебя забьют твоей же дубинкой
## Авторство

## Чеинжлог
:cl: Chip11-n
- tweak: Культистам и революционерам сразу выставляются максимально доступные для них навыки