### PR TITLE
В оповещениях от ЦК пишется изначальное название зоны

### DIFF
--- a/code/datums/announcements/events.dm
+++ b/code/datums/announcements/events.dm
@@ -63,7 +63,7 @@
 	sound = "bluspaceanom"
 /datum/announcement/centcomm/anomaly/bluespace/play(area/A)
 	if(A)
-		message = "На сканерах дальнего действия обнаружена нестабильная блюспейс аномалия. Ожидаемое местоположение: [A.name]."
+		message = "На сканерах дальнего действия обнаружена нестабильная блюспейс аномалия. Ожидаемое местоположение: [initial(A.name)]."
 	..()
 
 /datum/announcement/centcomm/anomaly/massive_portals
@@ -82,7 +82,7 @@
 	sound = "fluxanom"
 /datum/announcement/centcomm/anomaly/flux/play(area/A)
 	if(A)
-		message = "На сканерах дальнего действия зафиксирован гиперэнерегетический волновой поток. Ожидаемое местоположение: [A.name]."
+		message = "На сканерах дальнего действия зафиксирован гиперэнерегетический волновой поток. Ожидаемое местоположение: [initial(A.name)]."
 	..()
 
 /datum/announcement/centcomm/anomaly/gravity
@@ -91,7 +91,7 @@
 	sound = "gravanom"
 /datum/announcement/centcomm/anomaly/gravity/play(area/A)
 	if(A)
-		message = "На сканерах дальнего действия обнаружена гравитационная аномалия. Ожидаемое местоположение: [A.name]."
+		message = "На сканерах дальнего действия обнаружена гравитационная аномалия. Ожидаемое местоположение: [initial(A.name)]."
 	..()
 
 /datum/announcement/centcomm/anomaly/pyro
@@ -100,7 +100,7 @@
 	sound = "pyroanom"
 /datum/announcement/centcomm/anomaly/pyro/play(area/A)
 	if(A)
-		message = "На сканерах дальнего действия обнаружена пирокластическая аномалия. Ожидаемое местоположение: [A.name]."
+		message = "На сканерах дальнего действия обнаружена пирокластическая аномалия. Ожидаемое местоположение: [initial(A.name)]."
 	..()
 
 /datum/announcement/centcomm/anomaly/vortex
@@ -109,7 +109,7 @@
 	sound = "vortexanom"
 /datum/announcement/centcomm/anomaly/vortex/play(area/A)
 	if(A)
-		message = "На сканерах дальнего действия зафиксирована вихревая аномалия. Ожидаемое местоположение: [A.name]."
+		message = "На сканерах дальнего действия зафиксирована вихревая аномалия. Ожидаемое местоположение: [initial(A.name)]."
 	..()
 
 /datum/announcement/centcomm/brand

--- a/code/datums/announcements/events.dm
+++ b/code/datums/announcements/events.dm
@@ -100,7 +100,7 @@
 	sound = "pyroanom"
 /datum/announcement/centcomm/anomaly/pyro/play(area/A)
 	if(A)
-		message = "На сканерах дальнего действия обнаружена пирокластическая аномалия. Ожидаемое местоположение: [initial(A.name)]."
+		message = "На сканерах дальнего действия обнаружена пирокластическая аномалия. Ожидаемое местоположение: [A.name != initial(A.name) ? initial(A.name) : A.name]."
 	..()
 
 /datum/announcement/centcomm/anomaly/vortex

--- a/code/datums/announcements/events.dm
+++ b/code/datums/announcements/events.dm
@@ -100,7 +100,7 @@
 	sound = "pyroanom"
 /datum/announcement/centcomm/anomaly/pyro/play(area/A)
 	if(A)
-		message = "На сканерах дальнего действия обнаружена пирокластическая аномалия. Ожидаемое местоположение: [A.name != initial(A.name) ? initial(A.name) : A.name]."
+		message = "На сканерах дальнего действия обнаружена пирокластическая аномалия. Ожидаемое местоположение: [initial(A.name)]."
 	..()
 
 /datum/announcement/centcomm/anomaly/vortex


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Теперь в аннонсах пишется изначальное название зоны
## Почему и что этот ПР улучшит
fix #10146
## Авторство

## Чеинжлог
:cl: Simbaka
- tweak: В оповещениях от ЦК, в которых идет речь про аномалии, пишется изначальное название зоны, вне зависимости, была ли она переименована чертежами или нет.