### PR TITLE
[WiP] Глобальный множитель урона (и эффектов)

### DIFF
--- a/code/_globalvars/station.dm
+++ b/code/_globalvars/station.dm
@@ -10,3 +10,5 @@ var/global/datum/moduletypes/mods = new()
 
 // Reference list for disposal sort junctions. Filled up by sorting junction's New()
 var/global/list/tagger_locations = list()
+
+var/global/damage_multiplier = 1.0

--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -226,7 +226,7 @@
 	else if(ismonkey(user))
 		var/mob/living/carbon/monkey/M = user
 		to_chat(M, "<span class='warning'>[src] cuts into your hand!</span>")
-		M.adjustBruteLoss(force / 2)
+		M.apply_damage(force / 2, BRUTE)
 
 /*/obj/item/weapon/syndicate_uplink
 	name = "station bounced radio"

--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -152,7 +152,7 @@
 		C.update_inv_legcuffed()
 		feedback_add_details("handcuffs","B")
 		to_chat(C,"<span class='userdanger'>\The [src] ensnares you!</span>")
-		C.Weaken(weaken)
+		C.apply_effect(weaken, WEAKEN)
 
 /obj/item/weapon/legcuffs/bola/tactical//traitor variant
 	name = "reinforced bola"

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -490,11 +490,9 @@ var/global/list/ghostteleportlocs = list()
 			return
 
 		if(H.m_intent == "run")
-			H.AdjustStunned(2)
-			H.AdjustWeakened(2)
+			H.apply_effects(stun = 2, weaken = 2)
 		else
-			H.AdjustStunned(1)
-			H.AdjustWeakened(1)
+			H.apply_effects(stun = 1, weaken = 1)
 		to_chat(mob, "<span class='notice'>The sudden appearance of gravity makes you fall to the floor!</span>")
 
 /proc/has_gravity(atom/AT, turf/T)

--- a/code/game/gamemodes/modes_gameplays/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/modes_gameplays/shadowling/shadowling_abilities.dm
@@ -69,13 +69,13 @@
 			if(get_dist(center, G) <= 2) //Very small radius
 				G.visible_message("<span class='warning'>\The [G] withers away!</span>")
 				qdel(G)
-		
+
 		if(T.is_light_floor())
 			var/turf/simulated/floor/F = T
 			F.set_lightfloor_on(FALSE)
 			F.visible_message("<span class='danger'>\The [T] suddenly turns off!</span>")
 			F.update_icon()
-				
+
 /obj/effect/proc_holder/spell/aoe_turf/flashfreeze
 	name = "Flash Freeze"
 	desc = "Instantly freezes the blood of nearby people, stunning them and causing burn damage."
@@ -432,7 +432,7 @@
 			U.adjustOxyLoss(-10)
 			U.AdjustWeakened(-1)
 			U.AdjustStunned(-1)
-			M.adjustOxyLoss(20)
+			M.apply_damage(20, OXY)
 			to_chat(M, "<span class='boldannounce'>You feel a wave of exhaustion and a curious draining sensation directed towards [usr]!</span>")
 			to_chat(usr, "<span class='shadowling'>You draw the life from [M] to heal your wounds.</span>")
 	if(!targetsDrained)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -126,8 +126,8 @@ var/global/list/airlock_overlays = list()
 				return
 		else if(user.hallucination > 50 && prob(10) && !operating)
 			to_chat(user, "<span class='warning'><B>You feel a powerful shock course through your body!</B></span>")
-			user.halloss += 10
-			user.AdjustStunned(10)
+			user.apply_damage(10, HALLOS)
+			user.apply_effect(10, STUN)
 			return
 	..(user)
 

--- a/code/game/objects/items/weapons/kitchen.dm
+++ b/code/game/objects/items/weapons/kitchen.dm
@@ -243,9 +243,9 @@
 					return
 				var/time = rand(2, 6)
 				if (prob(75))
-					H.Paralyse(time)
+					H.apply_effects(time, PARALYZE)
 				else
-					H.Stun(time)
+					H.apply_effects(time, STUN)
 				if(H.stat != DEAD)	H.stat = UNCONSCIOUS
 				user.visible_message("<span class='warning'><B>[H] has been knocked unconscious!</B></span>", "<span class='warning'><B>You knock [H] unconscious!</B></span>")
 				return

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -146,8 +146,8 @@
 	m.Turn(180)
 	animate(L, transform = m, time = 3)
 	L.pixel_y = L.default_pixel_y
-	L.adjustBruteLoss(15)
+	L.apply_damage(15, BRUTE)
 	visible_message("<span class='danger'>[L] falls free of the [src]!</span>")
 	unbuckle_mob()
 	L.emote("scream")
-	L.AdjustWeakened(10)
+	L.apply_effect(10, WEAKEN)

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -335,7 +335,7 @@
 		L.visible_message(
 			"<span class='warning'>[L] unties the noose over their neck!</span>",
 			"<span class='notice'>You untie the noose over your neck!</span>")
-	L.AdjustWeakened(5)
+	L.apply_effect(5, WEAKEN)
 	unbuckle_mob(L)
 
 /obj/structure/stool/bed/chair/noose/can_user_buckle(mob/living/carbon/human/M, mob/user)
@@ -414,7 +414,7 @@
 			playsound(src, 'sound/effects/noose_idle.ogg', VOL_EFFECTS_MASTER)
 		else
 			bm.visible_message("<span class='danger'>[bm] drops from the noose!</span>")
-			bm.AdjustWeakened(5)
+			bm.apply_effect(5, WEAKEN)
 			bm.pixel_z = initial(bm.pixel_z)
 			pixel_z = initial(pixel_z)
 			bm.pixel_x = initial(bm.pixel_x)
@@ -438,8 +438,8 @@
 	if(has_buckled_mobs() && buckled_mob.mob_has_gravity())
 		buckled_mob.visible_message("<span class='danger'>[buckled_mob] falls over and hits the ground!</span>")
 		to_chat(buckled_mob, "<span class='userdanger'>You fall over and hit the ground!</span>")
-		buckled_mob.adjustBruteLoss(10)
-		buckled_mob.AdjustWeakened(5)
+		buckled_mob.apply_damage(10, BRUTE)
+		buckled_mob.apply_effect(5, WEAKEN)
 		unbuckle_mob(buckled_mob)
 	if(forced)
 		var/obj/item/stack/cable_coil/C = new(get_turf(src))

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -589,17 +589,16 @@ ADD_TO_GLOBAL_LIST(/obj/structure/toilet, toilet_list)
 				return
 			if("freezing")
 				C.adjust_bodytemperature(-80, min_temp = 80)
-				C.adjustHalLoss(1)
+				C.apply_damage(1, HALLOS)
 				C.AdjustStunned(-1)
-				C.AdjustWeakened(1)
+				C.apply_effect(1, WEAKEN)
 				to_chat(C, "<span class='warning'>The water is freezing!</span>")
 				return
 			if("boiling")
 				C.adjust_bodytemperature(35, max_temp = 500)
-				C.adjustFireLoss(5)
-				C.adjustHalLoss(1)
+				C.apply_damages(burn = 5, hallos = 1)
 				C.AdjustStunned(-1)
-				C.AdjustWeakened(1)
+				C.apply_effect(1, WEAKEN)
 				to_chat(C, "<span class='danger'>The water is searing!</span>")
 				return
 

--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -29,6 +29,7 @@
 					<A href='?src=\ref[src];secretsadmin=night_shift_set'>Set Night Shift Mode</A><BR>
 					<A href='?src=\ref[src];secretsadmin=clear_virus'>Cure all diseases currently in existence</A><BR>
 					<A href='?src=\ref[src];secretsadmin=restore_air'>Restore air in your zone</A><BR>
+					<A href='?src=\ref[src];secretsadmin=damage_multiplier'>Global Damage Multiplier</A><BR>
 					<h4>Bombs</h4>
 					[check_rights(R_SERVER,0) ? "<A href='?src=\ref[src];secretsfun=togglebombcap'>Toggle bomb cap</A><BR>" : "<BR>"]
 					<h4>Lists</h4>
@@ -585,6 +586,13 @@
 				message_admins("[key_name_admin(usr)] has restored air in [COORD(T)] <a href='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</a>.")
 			else
 				to_chat(usr, "<span class='userdanger'>You are staying on incorrect turf.</span>")
+		if("damage_multiplier")
+			if(!check_rights(R_VAREDIT, 0))
+				return
+			var/var_value = input(usr, ">1.0 - battles will speed up, <1.0 battles will go longer and bloodier!","Enter new number") as null|num
+			if(var_value)
+				global.damage_multiplier = var_value
+				message_admins("<span class='notice'>[key_name_admin(usr)] change Global Damage Multiplier to [var_value].</span>", 1)
 		// Bombing List
 		if("list_bombers")
 			var/dat = ""

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1600,10 +1600,8 @@
 		if(M.health == 1)
 			M.gib()
 		else
-			M.adjustBruteLoss( min( 99 , (M.health - 1) )    )
-			M.Stun(20)
-			M.Weaken(20)
-			M.setStuttering(20)
+			M.apply_damage((min(99,(M.health - 1))), BRUTE)
+			M.apply_effects(20, 20, 0, 0, 20)
 
 	else if(href_list["CentcommReply"])
 		var/mob/living/H = locate(href_list["CentcommReply"])

--- a/code/modules/mining/monsters.dm
+++ b/code/modules/mining/monsters.dm
@@ -107,9 +107,9 @@
 		if(EXPLODE_DEVASTATE)
 			gib()
 		if(EXPLODE_HEAVY)
-			adjustBruteLoss(maxHealth * 0.8)
+			apply_damage((maxHealth * 0.8), BRUTE)
 		if(EXPLODE_LIGHT)
-			adjustBruteLoss(maxHealth * 0.4)
+			apply_damage((maxHealth * 0.4), BRUTE)
 
 ////////////Drone(miniBoss)/////////////
 
@@ -466,7 +466,7 @@
 		visible_message("<span class='warning'>The [src.name] knocks [M.name] down!</span>")
 		playsound(M, 'sound/misc/goliath_tentacle_hit.ogg', VOL_EFFECTS_MASTER, 100, FALSE)
 		M.Weaken(strength * 0.1)
-		M.adjustBruteLoss(strength * 0.4) // 40% pure damage of Goliath force
+		M.apply_damage((strength * 0.4), BRUTE) // 40% pure damage of Goliath force
 	qdel(src)
 
 /obj/effect/goliath_tentacle/Crossed(atom/movable/AM)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1347,7 +1347,7 @@
 				if(!BP.is_robotic()) //There is no blood in protheses.
 					if(!reagents.has_reagent("metatrombine")) // metatrombine just prevents bleeding, not toxication
 						BP.status |= ORGAN_BLEEDING
-					adjustToxLoss(rand(1,3))
+					apply_damage(rand(1,3), TOX)
 
 /mob/living/carbon/human/verb/check_pulse()
 	set category = "Object"
@@ -2470,7 +2470,7 @@
 				next_allergy_message = world.time + 10 SECONDS
 				to_chat(src, "<span class='userdanger'>I THINK I'M DYING!</span>")
 
-	adjustToxLoss(effect_coeff)
+	apply_damage(effect_coeff, TOX)
 
 	adjust_bodytemperature(10 * effect_coeff * TEMPERATURE_DAMAGE_COEFFICIENT, max_temp = BODYTEMP_NORMAL + 20)
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1028,8 +1028,7 @@
 			else
 				if(!prob((reagents.total_volume * 9) + 10))
 					H.visible_message("<span class='warning'>[H] convulses in place, gagging!</span>", "<span class='warning'>You try to throw up, but it gets stuck in your throat!</span>")
-					H.adjustOxyLoss(3)
-					H.adjustHalLoss(5)
+					H.apply_damages(oxy = 3, hallos = 5)
 					return FALSE
 				H.vomit()
 		else
@@ -2465,7 +2464,7 @@
 			to_chat(src, "<span class='danger'>AAAH THE RASH IS UNBEARABLE!</span>")
 		if(ALLERGY_LETHAL to INFINITY)
 			effect_coeff = 2.0
-			adjustOxyLoss(effect_coeff)
+			apply_damage(effect_coeff, OXY)
 			if(next_allergy_message < world.time)
 				next_allergy_message = world.time + 10 SECONDS
 				to_chat(src, "<span class='userdanger'>I THINK I'M DYING!</span>")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1828,17 +1828,15 @@
 		var/mob/living/L = hit_atom
 		L.visible_message("<span class='danger'>\The [src] leaps at [L]!</span>", "<span class='userdanger'>[src] leaps on you!</span>")
 		if(issilicon(L))
-			L.Stun(1) //Only brief stun
+			L.apply_effect(1, STUN) //Only brief stun
 			step_towards(src, L)
 		else
-			L.Stun(2)
-			L.Weaken(2)
+			L.apply_effects(2, 2)
 			step_towards(src, L)
 
 	else if(hit_atom.density)
 		visible_message("<span class='danger'>[src] smashes into [hit_atom]!</span>", "<span class='danger'>You smash into [hit_atom]!</span>")
-		Stun(2)
-		Weaken(2)
+		apply_effects(2, 2)
 
 	update_canmove()
 

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -14,17 +14,17 @@
 
 	switch(damagetype)
 		if(BRUTE)
-			adjustBruteLoss(damage * blocked_mult(blocked))
+			adjustBruteLoss(damage * blocked_mult(blocked) * global.damage_multiplier)
 		if(BURN)
-			adjustFireLoss(damage * blocked_mult(blocked))
+			adjustFireLoss(damage * blocked_mult(blocked) * global.damage_multiplier)
 		if(TOX)
-			adjustToxLoss(damage * blocked_mult(blocked))
+			adjustToxLoss(damage * blocked_mult(blocked) * global.damage_multiplier)
 		if(OXY)
-			adjustOxyLoss(damage * blocked_mult(blocked))
+			adjustOxyLoss(damage * blocked_mult(blocked) * global.damage_multiplier)
 		if(CLONE)
-			adjustCloneLoss(damage * blocked_mult(blocked))
+			adjustCloneLoss(damage * blocked_mult(blocked) * global.damage_multiplier)
 		if(HALLOSS)
-			adjustHalLoss(damage * blocked_mult(blocked))
+			adjustHalLoss(damage * blocked_mult(blocked) * global.damage_multiplier)
 
 	updatehealth()
 	return TRUE
@@ -49,22 +49,22 @@
 	if(!effect || (blocked <= 0))	return 0
 	switch(effecttype)
 		if(STUN)
-			Stun(effect * blocked)
+			Stun(effect * blocked * global.damage_multiplier)
 		if(WEAKEN)
-			Weaken(effect * blocked)
+			Weaken(effect * blocked * global.damage_multiplier)
 		if(PARALYZE)
-			Paralyse(effect * blocked)
+			Paralyse(effect * blocked * global.damage_multiplier)
 		if(AGONY)
-			adjustHalLoss(effect) // Useful for objects that cause "subdual" damage. PAIN!
+			adjustHalLoss(effect * global.damage_multiplier) // Useful for objects that cause "subdual" damage. PAIN!
 		if(IRRADIATE)
-			radiation += max(effect * ((100-run_armor_check(null, "rad", "Your clothes feel warm.", "Your clothes feel warm."))/100),0)//Rads auto check armor
+			radiation += max(effect * ((100-run_armor_check(null, "rad", "Your clothes feel warm.", "Your clothes feel warm."))/100) * global.damage_multiplier,0)//Rads auto check armor
 		if(STUTTER)
 			if(status_flags & CANSTUN) // stun is usually associated with stutter
-				Stuttering(effect * blocked)
+				Stuttering(effect * blocked * global.damage_multiplier)
 		if(EYE_BLUR)
-			blurEyes(effect * blocked)
+			blurEyes(effect * blocked * global.damage_multiplier)
 		if(DROWSY)
-			drowsyness = max(drowsyness,(effect * blocked))
+			drowsyness = max(drowsyness,(effect * blocked * global.damage_multiplier))
 	updatehealth()
 	return 1
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -454,8 +454,7 @@
 		var/turf/new_turf = get_step(mob_turf, dir)
 		if(Move(new_turf))
 			break
-	AdjustStunned(5)
-	AdjustWeakened(5)
+	apply_effects(stun = 5, weaken = 5)
 	take_overall_damage(brute = DOOR_CRUSH_DAMAGE, used_weapon = "Crushed")
 	visible_message("<span class='red'>[src] was crushed by the door.</span>",
 					"<span class='danger'>The door crushed you.</span>")

--- a/code/modules/mob/living/simple_animal/hulk_powers.dm
+++ b/code/modules/mob/living/simple_animal/hulk_powers.dm
@@ -101,8 +101,7 @@
 	if (istype(usr.loc,/obj))
 		var/obj/container = usr.loc
 		to_chat(usr, "<span class='warning'>You leap and slam your head against the inside of [container]! Ouch!</span>")
-		usr.AdjustParalysis(3)
-		usr.AdjustWeakened(5)
+		usr.apply_effects(weaken = 5, paralyze = 3)
 		container.visible_message("<span class='warning'><b>[usr.loc]</b> emits a loud thump and rattles a bit.</span>")
 		playsound(usr, 'sound/effects/bang.ogg', VOL_EFFECTS_MASTER)
 		var/wiggle = 6
@@ -277,8 +276,7 @@
 	if (istype(usr.loc,/obj))
 		var/obj/container = usr.loc
 		to_chat(usr, "<span class='warning'>You dash and slam your head against the inside of [container]! Ouch!</span>")
-		usr.AdjustParalysis(3)
-		usr.AdjustWeakened(5)
+		apply_effects(weaken = 5, paralyze = 3)
 		container.visible_message("<span class='warning'><b>[usr.loc]</b> emits a loud thump and rattles a bit.</span>")
 		playsound(usr, 'sound/effects/bang.ogg', VOL_EFFECTS_MASTER)
 		var/wiggle = 6

--- a/code/modules/mob/living/simple_animal/hulk_powers.dm
+++ b/code/modules/mob/living/simple_animal/hulk_powers.dm
@@ -89,8 +89,7 @@
 		if (HAS_TRAIT(usr, TRAIT_FAT) && prob(66))
 			usr.visible_message("<span class='warning'><b>[usr.name]</b> crashes due to their heavy weight!</span>")
 			playsound(usr, 'sound/misc/slip.ogg', VOL_EFFECTS_MASTER)
-			usr.AdjustStunned(5)
-			usr.AdjustWeakened(10)
+			usr.apply_effects(stun = 5, weaken = 10)
 
 		usr.density = TRUE
 		usr.canmove = 1
@@ -266,8 +265,7 @@
 		if (HAS_TRAIT(usr, TRAIT_FAT) && prob(66))
 			usr.visible_message("<span class='warning'><b>[usr.name]</b> crashes due to their heavy weight!</span>")
 			playsound(usr, 'sound/misc/slip.ogg', VOL_EFFECTS_MASTER)
-			usr.AdjustStunned(5)
-			usr.AdjustWeakened(10)
+			usr.apply_effects(stun = 5, weaken = 10)
 
 		usr.density = TRUE
 		usr.canmove = 1
@@ -700,10 +698,8 @@
 				var/mob/living/carbon/human/H = M
 				if(istype(H.l_ear, /obj/item/clothing/ears/earmuffs) || istype(H.r_ear, /obj/item/clothing/ears/earmuffs))
 					continue
-			M.AdjustStuttering(2)
+			M.apply_effects(stun = 1, weaken = 2, stutter = 2)
 			M.ear_deaf += 2
-			M.Stun(1)
-			M.Weaken(2)
 			M.make_jittery(500)
 
 /obj/item/organ/attack_hulk(mob/living/simple_animal/hulk/unathi/user)

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -100,8 +100,7 @@
 		if((H.species.flags[IS_PLANT]) && (M.nutrition < 500))
 			if(prob(15))
 				M.apply_effect((rand(30,80)),IRRADIATE)
-				M.Stun(2)
-				M.Weaken(5)
+				M.apply_effects(2, 5)
 				visible_message("<span class='warning'>[M] writhes in pain as \his vacuoles boil.</span>", blind_message = "<span class='warning'>You hear the crunching of leaves.</span>")
 			if(prob(35))
 			//	for (var/mob/V in viewers(src)) //Public messages commented out to prevent possible metaish genetics experimentation and stuff. - Cheridan
@@ -237,7 +236,7 @@
 	if(issilicon(target))
 		var/mob/living/silicon/S = target
 		S.take_bodypart_damage(damage)
-		S.Stun(2)
+		S.apply_effect(2, STUN)
 
 	if(istype(target,/obj/mecha))
 		var/obj/mecha/M = target

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -99,8 +99,7 @@
 		var/mob/living/carbon/human/H = M
 		if((H.species.flags[IS_PLANT]) && (M.nutrition < 500))
 			if(prob(15))
-				M.apply_effect((rand(30,80)),IRRADIATE)
-				M.apply_effects(2, 5)
+				M.apply_effects(stun = 2, weaken = 5, irradiate = (rand(30,80)))
 				visible_message("<span class='warning'>[M] writhes in pain as \his vacuoles boil.</span>", blind_message = "<span class='warning'>You hear the crunching of leaves.</span>")
 			if(prob(35))
 			//	for (var/mob/V in viewers(src)) //Public messages commented out to prevent possible metaish genetics experimentation and stuff. - Cheridan
@@ -112,7 +111,7 @@
 					randmutg(M)
 					domutcheck(M,null)
 			else
-				M.adjustFireLoss(rand(5,15))
+				M.apply_damage(rand(5,15), BURN)
 				to_chat(M, "<span class='warning'>The radiation beam singes you!</span>")
 			//	for (var/mob/V in viewers(src))
 			//		V.show_messageold("<span class='warning'>[M] is singed by the radiation beam.</span>", 3, "<span class='warning'>You hear the crackle of burning leaves.</span>", 2)

--- a/code/modules/research/xenoarchaeology/artifact/effects/stun.dm
+++ b/code/modules/research/xenoarchaeology/artifact/effects/stun.dm
@@ -38,7 +38,5 @@
 	var/weakened = get_anomaly_protection(receiver)
 	if(!weakened)
 		return FALSE
-	receiver.AdjustWeakened(power)
-	receiver.AdjustStunned(power)
-	receiver.AdjustStuttering(power)
+	receiver.apply_effects(stun = power, weaken = power, stutter = power)
 	return TRUE

--- a/code/modules/research/xenoarchaeology/machinery/suspension_generator.dm
+++ b/code/modules/research/xenoarchaeology/machinery/suspension_generator.dm
@@ -221,8 +221,7 @@
 		if("carbon")
 			success = 1
 			for(var/mob/living/carbon/C in T)
-				C.AdjustStunned(5)
-				C.AdjustWeakened(5)
+				C.apply_effects(stun = 5, weaken = 5)
 				C.visible_message("<span class='notice'>[bicon(C)] [C] begins to float in the air!</span>","You feel tingly and light, but it is difficult to move.")
 		if("nitrogen")
 			success = 1
@@ -245,7 +244,7 @@
 		if("iron")
 			success = 1
 			for(var/mob/living/silicon/R in T)
-				R.AdjustStunned(5)
+				R.apply_effect(5, STUN)
 				R.visible_message("<span class='notice'>[bicon(R)] [R] begins to float in the air!</span>","You feel tingly and light, but it is difficult to move.")
 			//
 	//in case we have a bad field type
@@ -254,8 +253,7 @@
 
 	for(var/mob/living/simple_animal/C in T)
 		C.visible_message("<span class='notice'>[bicon(C)] [C] begins to float in the air!</span>","You feel tingly and light, but it is difficult to move.")
-		C.AdjustStunned(5)
-		C.AdjustWeakened(5)
+		C.apply_effects(stun = 5, weaken = 5)
 
 	suspension_field = new(T)
 	suspension_field.field_type = field_type

--- a/code/modules/unarmed_combat/combos/helping.dm
+++ b/code/modules/unarmed_combat/combos/helping.dm
@@ -76,9 +76,8 @@
 
 	var/wake_up_amount = -shake_time * effectiveness
 
-	victim.adjustHalLoss(wake_up_amount)
-	victim.AdjustStunned(wake_up_amount)
-	victim.AdjustWeakened(wake_up_amount)
+	victim.apply_damage(wake_up_amount, HALLOS)
+	victim.apply_effects(stun = wake_up_amount, weaken = wake_up_amount)
 
 	step_away(victim, attacker)
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Причины для WiP: надо переставить все Adjust... и прямые вызовы эффектов на apply_damage и apply_effect, пока что не для всего сделал. Выкатил сейчас чтобы мне вовремя сказали "стой это не надо делать потому что это так не задумывалось" и тп. Не менял там, где накладывается отрицательное значение, мол снимает эффект/урон.
Решил что прикольно будет иметь возможность уменьшать урон от всего глобально. Эффекты, такие как стан, будут также уменьшаться пропорционально урону. Таким образом можно, ставя модификатор <1, удлинять бои между куклами... и бутылки будут менее эффективными, и комбо-боёвка будет не навсегда станить... Вобщем я бы хотел поиграть с 0,25 и меньше множителем.
## Почему и что этот ПР улучшит
Крутое влияние на игру для всех! Правда можно было бы ограничить возможность увеличивать всё. Может поставить проверку на гейм-админа если значение >1?
## Авторство

## Чеинжлог
:cl: Deahaka
- add: Админам добавлена новая кнопка в "Secrets", добавлена возможность увеличивать/уменьшать весь наносимый урон.