### PR TITLE
Меняем вывод информации о здоровье на сканерах

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -6,6 +6,7 @@
 #define OXY       "oxy"
 #define CLONE     "clone"
 #define HALLOSS   "halloss"
+#define BRAINLOSS "brainloss"
 
 //Damage flag defines //
 /// Involves a melee attack or a thrown object.

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -183,14 +183,14 @@
 				if(occupant.virus2.len)
 					dat += text("<font color='red'>Viral pathogen detected in blood stream.</font><BR>")
 
-				dat += text("<font color='[]'>\t-Brute Damage %: []</font><BR>", (occupant.getBruteLoss() < 60 ? "blue" : "red"), occupant.getBruteLoss())
-				dat += text("<font color='[]'>\t-Respiratory Damage %: []</font><BR>", (occupant.getOxyLoss() < 60 ? "blue" : "red"), occupant.getOxyLoss())
-				dat += text("<font color='[]'>\t-Toxin Content %: []</font><BR>", (occupant.getToxLoss() < 60 ? "blue" : "red"), occupant.getToxLoss())
-				dat += text("<font color='[]'>\t-Burn Severity %: []</font><BR><BR>", (occupant.getFireLoss() < 60 ? "blue" : "red"), occupant.getFireLoss())
+				dat += text("<font color='[]'>\t-Brute Damage: []</font><BR>", (occupant.getBruteLoss() < 60 ? "blue" : "red"), occupant.getLossString(BRUTE))
+				dat += text("<font color='[]'>\t-Respiratory Damage: []</font><BR>", (occupant.getOxyLoss() < 60 ? "blue" : "red"), occupant.getLossString(OXY))
+				dat += text("<font color='[]'>\t-Toxin Content: []</font><BR>", (occupant.getToxLoss() < 60 ? "blue" : "red"), occupant.getLossString(TOX))
+				dat += text("<font color='[]'>\t-Burn Severity: []</font><BR><BR>", (occupant.getFireLoss() < 60 ? "blue" : "red"), occupant.getLossString(BURN))
 
-				dat += text("<font color='[]'>\tRadiation Level %: []</font><BR>", (occupant.radiation < 10 ?"blue" : "red"), occupant.radiation)
-				dat += text("<font color='[]'>\tGenetic Tissue Damage %: []</font><BR>", (occupant.getCloneLoss() < 1 ?"blue" : "red"), occupant.getCloneLoss())
-				dat += text("<font color='[]'>\tApprox. Brain Damage %: []</font><BR>", (occupant.getBrainLoss() < 1 ?"blue" : "red"), occupant.getBrainLoss())
+				dat += text("<font color='[]'>\tRadiation Level: []</font><BR>", (occupant.radiation < 10 ?"blue" : "red"), occupant.getLossString(IRRADIATE))
+				dat += text("<font color='[]'>\tGenetic Tissue Damage: []</font><BR>", (occupant.getCloneLoss() < 1 ?"blue" : "red"), occupant.getLossString(CLONE))
+				dat += text("<font color='[]'>\tApprox. Brain Damage: []</font><BR>", (occupant.getBrainLoss() < 1 ?"blue" : "red"), occupant.getLossString(BRAINLOSS))
 				var/occupant_paralysis = occupant.AmountParalyzed()
 				dat += text("Paralysis Summary %: [] ([] seconds left!)<BR>", occupant_paralysis, round(occupant_paralysis / 4))
 				dat += text("Body Temperature: [occupant.bodytemperature-T0C]&deg;C ([occupant.bodytemperature*1.8-459.67]&deg;F)<BR><HR>")
@@ -281,8 +281,8 @@
 					if(!AN && !open && !infected && !imp)
 						AN = "None:"
 					if(!(BP.is_stump))
-						dat += "<td>[BP.name]</td><td>[BP.burn_dam]</td><td>[BP.brute_dam]</td><td>[robot][bled][AN][splint][open][infected][imp][arterial_bleeding][rejecting]</td>"
-						storedinfo += "<td>[BP.name]</td><td>[BP.burn_dam]</td><td>[BP.brute_dam]</td><td>[robot][bled][AN][splint][open][infected][imp][arterial_bleeding][rejecting]</td>"
+						dat += "<td>[BP.name]</td><td>[BP.getExternalOrganDamageString(BURN)]</td><td>[BP.getExternalOrganDamageString(BRUTE)]</td><td>[robot][bled][AN][splint][open][infected][imp][arterial_bleeding][rejecting]</td>"
+						storedinfo += "<td>[BP.name]</td><td>[BP.getExternalOrganDamageString(BURN)]</td><td>[BP.getExternalOrganDamageString(BRUTE)]</td><td>[robot][bled][AN][splint][open][infected][imp][arterial_bleeding][rejecting]</td>"
 					else
 						dat += "<td>[parse_zone(BP.body_zone)]</td><td>-</td><td>-</td><td>Not Found</td>"
 						storedinfo += "<td>[parse_zone(BP.body_zone)]</td><td>-</td><td>-</td><td>Not Found</td>"
@@ -334,10 +334,10 @@
 					if(!organ_status && !infection)
 						infection = "None:"
 					dat += "<tr>"
-					dat += "<td>[IO.name]</td><td>N/A</td><td>[IO.damage]</td><td>[infection][organ_status]|[mech]</td><td></td>"
+					dat += "<td>[IO.name]</td><td>N/A</td><td>[IO.getInternalOrganDamageString()]</td><td>[infection][organ_status]|[mech]</td><td></td>"
 					dat += "</tr>"
 					storedinfo += "<tr>"
-					storedinfo += "<td>[IO.name]</td><td>N/A</td><td>[IO.damage]</td><td>[infection][organ_status]|[mech]</td><td></td>"
+					storedinfo += "<td>[IO.name]</td><td>N/A</td><td>[IO.getInternalOrganDamageString()]</td><td>[infection][organ_status]|[mech]</td><td></td>"
 					storedinfo += "</tr>"
 				dat += "</table>"
 				storedinfo += "</table>"

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -166,10 +166,10 @@
 			t1 = "Unknown"
 	return {"<font color="[occupant.health > 50 ? "blue" : "red"]"><b>Health:</b> [occupant.health]% ([t1])</font><br />
 				<font color="[occupant.bodytemperature > 50 ? "blue" : "red"]"><b>Core Temperature:</b> [src.occupant.bodytemperature-T0C]&deg;C ([src.occupant.bodytemperature*1.8-459.67]&deg;F)</font><br />
-				<font color="[occupant.getBruteLoss() < 60 ? "blue" : "red"]"><b>Brute Damage:</b> [occupant.getBruteLoss()]%</font><br />
-				<font color="[occupant.getOxyLoss() < 60 ? "blue" : "red"]"><b>Respiratory Damage:</b> [occupant.getOxyLoss()]%</font><br />
-				<font color="[occupant.getToxLoss() < 60 ? "blue" : "red"]"><b>Toxin Content:</b> [occupant.getToxLoss()]%</font><br />
-				<font color="[occupant.getFireLoss() < 60 ? "blue" : "red"]"><b>Burn Severity:</b> [occupant.getFireLoss()]%</font><br />
+				<font color="[occupant.getBruteLoss() < 60 ? "blue" : "red"]"><b>Brute Damage:</b> [occupant.getLossString(BRUTE)]%</font><br />
+				<font color="[occupant.getOxyLoss() < 60 ? "blue" : "red"]"><b>Respiratory Damage:</b> [occupant.getLossString(OXY)]%</font><br />
+				<font color="[occupant.getToxLoss() < 60 ? "blue" : "red"]"><b>Toxin Content:</b> [occupant.getLossString(TOX)]%</font><br />
+				<font color="[occupant.getFireLoss() < 60 ? "blue" : "red"]"><b>Burn Severity:</b> [occupant.getLossString(BURN)]%</font><br />
 				"}
 
 /obj/item/mecha_parts/mecha_equipment/sleeper/proc/get_occupant_reagents()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -111,7 +111,7 @@
 	var/OX = M.getOxyLoss() > 50 	? 	"<b>[M.getLossString(OXY)]</b>" 		: M.getLossString(OXY)
 	var/TX = M.getToxLoss() > 50 	? 	"<b>[M.getLossString(TOX)]</b>" 		: M.getLossString(TOX)
 	var/BU = M.getFireLoss() > 50 	? 	"<b>[M.getLossString(BURN)]</b>" 		: M.getLossString(BURN)
-	var/BR = M.getBruteLoss() > 50 	? 	"<b>[M.getLossString(BRUTE)]</b>" 	: M.getLossString(BRUTE)
+	var/BR = M.getBruteLoss() > 50 	? 	"<b>[M.getLossString(BRUTE)]</b>" 		: M.getLossString(BRUTE)
 	if(M.status_flags & FAKEDEATH)
 		OX = fake_oxy > 50 			? 	"<b>[fake_oxy]</b>" 			: fake_oxy
 		message += "<span class='notice'>Analyzing Results for [M]:\n&emsp; Overall Status: dead</span><br>"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -99,7 +99,7 @@
 	if(((CLUMSY in user.mutations) || user.getBrainLoss() >= 60) && prob(50))
 		user.visible_message("<span class='warning'>[user] has analyzed the floor's vitals!</span>", "<span class = 'warning'>You try to analyze the floor's vitals!</span>")
 		message += "<span class='notice'>Analyzing Results for The floor:\n&emsp; Overall Status: Healthy</span><br>"
-		message += "<span class='notice'>&emsp; Damage Specifics: [0]-[0]-[0]-[0]</span><br>"
+		message += "<span class='notice'>&emsp; Damage: [0]-[0]-[0]-[0]</span><br>"
 		message += "<span class='notice'>Key: Suffocation/Toxin/Burns/Brute</span><br>"
 		message += "<span class='notice'>Body Temperature: ???</span>"
 		if(!output_to_chat)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -128,7 +128,7 @@
 		message += "<span class='notice'>Localized Damage, Brute/Burn:</span><br>"
 		if(length(damaged))
 			for(var/obj/item/organ/external/BP in damaged)
-				message += "<span class='notice'>&emsp; [capitalize(BP.name)]: [(BP.brute_dam > 0) ? "<span class='warning'>[BP.getOrganDamageString(BRUTE)]</span>" : "None"][(BP.status & ORGAN_BLEEDING) ? "<span class='warning bold'>\[Bleeding\]</span>" : "&emsp;"] - [(BP.burn_dam > 0) ? "<font color='#FFA500'>[BP.getOrganDamageString(BURN)]</font>" : "None"]</span><br>"
+				message += "<span class='notice'>&emsp; [capitalize(BP.name)]: [(BP.brute_dam > 0) ? "<span class='warning'>[BP.getExternalOrganDamageString(BRUTE)]</span>" : "None"][(BP.status & ORGAN_BLEEDING) ? "<span class='warning bold'>\[Bleeding\]</span>" : "&emsp;"] - [(BP.burn_dam > 0) ? "<font color='#FFA500'>[BP.getExternalOrganDamageString(BURN)]</font>" : "None"]</span><br>"
 		else
 			message += "<span class='notice'>&emsp; Limbs are OK.</span><br>"
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -107,18 +107,18 @@
 		return message
 	user.visible_message("<span class='notice'>[user] has analyzed [M]'s vitals.</span>","<span class='notice'>You have analyzed [M]'s vitals.</span>")
 
-	var/fake_oxy = max(rand(1,40), M.getOxyLoss(), (300 - (M.getToxLoss() + M.getFireLoss() + M.getBruteLoss())))
-	var/OX = M.getOxyLoss() > 50 	? 	"<b>[M.getOxyLoss()]</b>" 		: M.getOxyLoss()
-	var/TX = M.getToxLoss() > 50 	? 	"<b>[M.getToxLoss()]</b>" 		: M.getToxLoss()
-	var/BU = M.getFireLoss() > 50 	? 	"<b>[M.getFireLoss()]</b>" 		: M.getFireLoss()
-	var/BR = M.getBruteLoss() > 50 	? 	"<b>[M.getBruteLoss()]</b>" 	: M.getBruteLoss()
+	var/fake_oxy = M.getLossString(OXY, fake = TRUE)
+	var/OX = M.getOxyLoss() > 50 	? 	"<b>[M.getLossString(OXY)]</b>" 		: M.getLossString(OXY)
+	var/TX = M.getToxLoss() > 50 	? 	"<b>[M.getLossString(TOX)]</b>" 		: M.getLossString(TOX)
+	var/BU = M.getFireLoss() > 50 	? 	"<b>[M.getLossString(BURN)]</b>" 		: M.getLossString(BURN)
+	var/BR = M.getBruteLoss() > 50 	? 	"<b>[M.getLossString(BRUTE)]</b>" 	: M.getLossString(BRUTE)
 	if(M.status_flags & FAKEDEATH)
 		OX = fake_oxy > 50 			? 	"<b>[fake_oxy]</b>" 			: fake_oxy
 		message += "<span class='notice'>Analyzing Results for [M]:\n&emsp; Overall Status: dead</span><br>"
 	else
 		message += "<span class='notice'>Analyzing Results for [M]:\n&emsp; Overall Status: [M.stat > 1 ? "dead" : "[M.health - M.halloss]% healthy"]</span><br>"
 	message += "&emsp; Key: <font color='blue'>Suffocation</font>/<font color='green'>Toxin</font>/<font color='#FFA500'>Burns</font>/<font color='red'>Brute</font><br>"
-	message += "&emsp; Damage Specifics: <font color='blue'>[OX]</font> - <font color='green'>[TX]</font> - <font color='#FFA500'>[BU]</font> - <font color='red'>[BR]</font><br>"
+	message += "&emsp; Damage: <font color='blue'>[OX]</font> - <font color='green'>[TX]</font> - <font color='#FFA500'>[BU]</font> - <font color='red'>[BR]</font><br>"
 	message += "<span class='notice'>Body Temperature: [M.bodytemperature-T0C]&deg;C ([M.bodytemperature*1.8-459.67]&deg;F)</span><br>"
 	if(M.tod && (M.stat == DEAD || (M.status_flags & FAKEDEATH)))
 		message += "<span class='notice'>Time of Death: [M.tod]</span><br>"
@@ -128,7 +128,7 @@
 		message += "<span class='notice'>Localized Damage, Brute/Burn:</span><br>"
 		if(length(damaged))
 			for(var/obj/item/organ/external/BP in damaged)
-				message += "<span class='notice'>&emsp; [capitalize(BP.name)]: [(BP.brute_dam > 0) ? "<span class='warning'>[BP.brute_dam]</span>" : 0][(BP.status & ORGAN_BLEEDING) ? "<span class='warning bold'>\[Bleeding\]</span>" : "&emsp;"] - [(BP.burn_dam > 0) ? "<font color='#FFA500'>[BP.burn_dam]</font>" : 0]</span><br>"
+				message += "<span class='notice'>&emsp; [capitalize(BP.name)]: [(BP.brute_dam > 0) ? "<span class='warning'>[BP.getOrganDamageString(BRUTE)]</span>" : "None"][(BP.status & ORGAN_BLEEDING) ? "<span class='warning bold'>\[Bleeding\]</span>" : "&emsp;"] - [(BP.burn_dam > 0) ? "<font color='#FFA500'>[BP.getOrganDamageString(BURN)]</font>" : "None"]</span><br>"
 		else
 			message += "<span class='notice'>&emsp; Limbs are OK.</span><br>"
 
@@ -1108,7 +1108,7 @@
 
 /obj/item/burn()
 	var/turf/T = get_turf(src)
-	var/ash_type 
+	var/ash_type
 	if(w_class >= SIZE_BIG)
 		ash_type = /obj/effect/decal/cleanable/ash/large
 	else

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1442,7 +1442,7 @@
 				var/has_tox_damage = (C.getToxLoss() > 50)
 				var/has_fire_damage = (C.getFireLoss() > 50)
 				var/has_brute_damage = (C.getBruteLoss() > 50)
-				data_message += "<span class='notice'>&emsp; Damage Specifics: <span class='[has_oxy_damage ? "warning" : "notice"]'>[C.getLossString(OXY)]</span>-<span class='[has_tox_damage ? "warning" : "notice"]'>[C.getLossString(TOX)]</span>-<span class='[has_fire_damage ? "warning" : "notice"]'>[C.getLossString(BURN)]</span>-<span class='[has_brute_damage ? "warning" : "notice"]'>[C.getLossString(BRUTE)]</span></span>"
+				data_message += "<span class='notice'>&emsp; Damage: <span class='[has_oxy_damage ? "warning" : "notice"]'>[C.getLossString(OXY)]</span>-<span class='[has_tox_damage ? "warning" : "notice"]'>[C.getLossString(TOX)]</span>-<span class='[has_fire_damage ? "warning" : "notice"]'>[C.getLossString(BURN)]</span>-<span class='[has_brute_damage ? "warning" : "notice"]'>[C.getLossString(BRUTE)]</span></span>"
 				data_message += "<span class='notice'>&emsp; Key: Suffocation/Toxin/Burns/Brute</span>"
 				data_message += "<span class='notice'>&emsp; Body Temperature: [C.bodytemperature-T0C]&deg;C ([C.bodytemperature*1.8-459.67]&deg;F)</span>"
 				if(C.tod && (C.stat == DEAD || (C.status_flags & FAKEDEATH)))

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1442,7 +1442,7 @@
 				var/has_tox_damage = (C.getToxLoss() > 50)
 				var/has_fire_damage = (C.getFireLoss() > 50)
 				var/has_brute_damage = (C.getBruteLoss() > 50)
-				data_message += "<span class='notice'>&emsp; Damage Specifics: <span class='[has_oxy_damage ? "warning" : "notice"]'>[C.getOxyLoss()]</span>-<span class='[has_tox_damage ? "warning" : "notice"]'>[C.getToxLoss()]</span>-<span class='[has_fire_damage ? "warning" : "notice"]'>[C.getFireLoss()]</span>-<span class='[has_brute_damage ? "warning" : "notice"]'>[C.getBruteLoss()]</span></span>"
+				data_message += "<span class='notice'>&emsp; Damage Specifics: <span class='[has_oxy_damage ? "warning" : "notice"]'>[C.getLossString(OXY)]</span>-<span class='[has_tox_damage ? "warning" : "notice"]'>[C.getLossString(TOX)]</span>-<span class='[has_fire_damage ? "warning" : "notice"]'>[C.getLossString(BURN)]</span>-<span class='[has_brute_damage ? "warning" : "notice"]'>[C.getLossString(BRUTE)]</span></span>"
 				data_message += "<span class='notice'>&emsp; Key: Suffocation/Toxin/Burns/Brute</span>"
 				data_message += "<span class='notice'>&emsp; Body Temperature: [C.bodytemperature-T0C]&deg;C ([C.bodytemperature*1.8-459.67]&deg;F)</span>"
 				if(C.tod && (C.stat == DEAD || (C.status_flags & FAKEDEATH)))
@@ -1453,7 +1453,7 @@
 					data_message += "<span class='notice'>Localized Damage, Brute/Burn:</span>"
 					if(length(damaged)>0)
 						for(var/obj/item/organ/external/BP in damaged)
-							data_message += text("<span class='notice'>&emsp; []: []-[]</span>",capitalize(BP.name),(BP.brute_dam > 0)?"<span class='warning'>[BP.brute_dam]</span>":0,(BP.burn_dam > 0)?"<span class='warning'>[BP.burn_dam]</span>":0)
+							data_message += text("<span class='notice'>&emsp; []: []-[]</span>",capitalize(BP.name),(BP.brute_dam > 0)?"<span class='warning'>[BP.getOrganDamageString(BRUTE)]</span>": "None",(BP.burn_dam > 0)?"<span class='warning'>[BP.getOrganDamageString(BURN)]</span>": "None")
 					else
 						data_message += "<span class='notice'>&emsp; Limbs are OK.</span>"
 

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1453,7 +1453,7 @@
 					data_message += "<span class='notice'>Localized Damage, Brute/Burn:</span>"
 					if(length(damaged)>0)
 						for(var/obj/item/organ/external/BP in damaged)
-							data_message += text("<span class='notice'>&emsp; []: []-[]</span>",capitalize(BP.name),(BP.brute_dam > 0)?"<span class='warning'>[BP.getOrganDamageString(BRUTE)]</span>":"None",(BP.burn_dam > 0)?"<span class='warning'>[BP.getOrganDamageString(BURN)]</span>":"None")
+							data_message += text("<span class='notice'>&emsp; []: []-[]</span>",capitalize(BP.name),(BP.brute_dam > 0)?"<span class='warning'>[BP.getExternalOrganDamageString(BRUTE)]</span>":"None",(BP.burn_dam > 0)?"<span class='warning'>[BP.getExternalOrganDamageString(BURN)]</span>":"None")
 					else
 						data_message += "<span class='notice'>&emsp; Limbs are OK.</span>"
 

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1453,7 +1453,7 @@
 					data_message += "<span class='notice'>Localized Damage, Brute/Burn:</span>"
 					if(length(damaged)>0)
 						for(var/obj/item/organ/external/BP in damaged)
-							data_message += text("<span class='notice'>&emsp; []: []-[]</span>",capitalize(BP.name),(BP.brute_dam > 0)?"<span class='warning'>[BP.getOrganDamageString(BRUTE)]</span>": "None",(BP.burn_dam > 0)?"<span class='warning'>[BP.getOrganDamageString(BURN)]</span>": "None")
+							data_message += text("<span class='notice'>&emsp; []: []-[]</span>",capitalize(BP.name),(BP.brute_dam > 0)?"<span class='warning'>[BP.getOrganDamageString(BRUTE)]</span>":"None",(BP.burn_dam > 0)?"<span class='warning'>[BP.getOrganDamageString(BURN)]</span>":"None")
 					else
 						data_message += "<span class='notice'>&emsp; Limbs are OK.</span>"
 

--- a/code/game/objects/items/devices/scanners/health_analyzer.dm
+++ b/code/game/objects/items/devices/scanners/health_analyzer.dm
@@ -23,7 +23,7 @@
 			var/message = ""
 			message += "<span class = 'notice'>Analyzing Results for ERROR:\n&emsp; Overall Status: ERROR</span><br>"
 			message += "&emsp; Key: <font color='blue'>Suffocation</font>/<font color='green'>Toxin</font>/<font color='#FFA500'>Burns</font>/<font color='red'>Brute</font><br>"
-			message += "&emsp; Damage Specifics: <font color='blue'>?</font> - <font color='green'>?</font> - <font color='#FFA500'>?</font> - <font color='red'>?</font><br>"
+			message += "&emsp; Damage: <font color='blue'>?</font> - <font color='green'>?</font> - <font color='#FFA500'>?</font> - <font color='red'>?</font><br>"
 			message += "<span class = 'notice'>Body Temperature: [H.bodytemperature-T0C]&deg;C ([H.bodytemperature*1.8-459.67]&deg;F)</span><br>"
 			message += "<span class = 'warning bold'>Warning: Blood Level ERROR: --% --cl.</span><span class = 'notice bold'>Type: ERROR</span><br>"
 			message += "<span class = 'notice'>Subject's pulse:</span><font color='red'>-- bpm.</font><br>"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -527,7 +527,7 @@
 
 		var/obj/item/clothing/under/C = w_uniform
 		if(C?.sensor_mode >= SUIT_SENSOR_VITAL)
-			msg += "<span class = 'deptradio'>Damage Specifics:</span> (<font color='blue'>[round(getOxyLoss(), 1)]</font>/<font color='green'>[round(getToxLoss(), 1)]</font>/<font color='#FFA500'>[round(getFireLoss(), 1)]</font>/<font color='red'>[round(getBruteLoss(), 1)]</font>)<br>"
+			msg += "<span class = 'deptradio'>Damage Specifics:</span> (<font color='blue'>[round(getLossString(OXY))]</font>/<font color='green'>[getLossString(TOX)]</font>/<font color='#FFA500'>[getLossString(BURN)]</font>/<font color='red'>[getLossString(BRUTE)]</font>)<br>"
 
 	var/datum/component/mood/mood = GetComponent(/datum/component/mood)
 	if(!skipface && mood)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -527,7 +527,7 @@
 
 		var/obj/item/clothing/under/C = w_uniform
 		if(C?.sensor_mode >= SUIT_SENSOR_VITAL)
-			msg += "<span class = 'deptradio'>Damage:</span> (<font color='blue'>[round(getLossString(OXY))]</font>/<font color='green'>[getLossString(TOX)]</font>/<font color='#FFA500'>[getLossString(BURN)]</font>/<font color='red'>[getLossString(BRUTE)]</font>)<br>"
+			msg += "<span class = 'deptradio'>Damage:</span> (<font color='blue'>[getLossString(OXY)]</font>/<font color='green'>[getLossString(TOX)]</font>/<font color='#FFA500'>[getLossString(BURN)]</font>/<font color='red'>[getLossString(BRUTE)]</font>)<br>"
 
 	var/datum/component/mood/mood = GetComponent(/datum/component/mood)
 	if(!skipface && mood)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -527,7 +527,7 @@
 
 		var/obj/item/clothing/under/C = w_uniform
 		if(C?.sensor_mode >= SUIT_SENSOR_VITAL)
-			msg += "<span class = 'deptradio'>Damage Specifics:</span> (<font color='blue'>[round(getLossString(OXY))]</font>/<font color='green'>[getLossString(TOX)]</font>/<font color='#FFA500'>[getLossString(BURN)]</font>/<font color='red'>[getLossString(BRUTE)]</font>)<br>"
+			msg += "<span class = 'deptradio'>Damage:</span> (<font color='blue'>[round(getLossString(OXY))]</font>/<font color='green'>[getLossString(TOX)]</font>/<font color='#FFA500'>[getLossString(BURN)]</font>/<font color='red'>[getLossString(BRUTE)]</font>)<br>"
 
 	var/datum/component/mood/mood = GetComponent(/datum/component/mood)
 	if(!skipface && mood)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -324,9 +324,9 @@
 			text = NO_DAMAGE
 		if(1 to 50)
 			text = MILD_DAMAGE
-		if(50 to 100)
+		if(51 to 100)
 			text = SEVERE_DAMAGE
-		if(100 to INFINITY)
+		if(101 to INFINITY)
 			text = ACUTE_DAMAGE
 	return text
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1,3 +1,8 @@
+#define NO_DAMAGE "None"
+#define MILD_DAMAGE "Mild"
+#define SEVERE_DAMAGE "Severe"
+#define ACUTE_DAMAGE "Acute"
+
 /mob/living/atom_init()
 	. = ..()
 	living_list += src
@@ -291,6 +296,33 @@
 // ==================================
 // ========== DAMAGE PROCS ==========
 // ==================================
+
+/mob/living/proc/getLossString(type_damage, fake = FALSE)
+	var/function
+	switch(type_damage)
+		if(BRUTE)
+			function = getBruteLoss()
+		if(OXY)
+			function = getOxyLoss()
+		if(TOX)
+			function = getToxLoss()
+		if(BURN)
+			function = getFireLoss()
+	var/numbers = function
+	if(fake)
+		//copypast from healthanalyzer
+		numbers = max(rand(1,40), getOxyLoss(), (300 - (getToxLoss() + getFireLoss() + getBruteLoss())))
+	var/text = ""
+	switch(numbers)
+		if(0)
+			text = NO_DAMAGE
+		if(1 to 50)
+			text = MILD_DAMAGE
+		if(50 to 100)
+			text = SEVERE_DAMAGE
+		if(100 to INFINITY)
+			text = ACUTE_DAMAGE
+	return text
 
 // ========== BRUTE ==========
 /mob/living/proc/getBruteLoss()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -308,6 +308,12 @@
 			function = getToxLoss()
 		if(BURN)
 			function = getFireLoss()
+		if(IRRADIATE)
+			function = radiation
+		if(CLONE)
+			function = getCloneLoss()
+		if(BRAINLOSS)
+			function = getBrainLoss()
 	var/numbers = function
 	if(fake)
 		//copypast from healthanalyzer
@@ -1542,3 +1548,8 @@
 
 /mob/living/proc/get_pumped(bodypart)
 	return 0
+
+#undef NO_DAMAGE
+#undef MILD_DAMAGE
+#undef SEVERE_DAMAGE
+#undef ACUTE_DAMAGE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1,7 +1,7 @@
 #define NO_DAMAGE "None"
 #define MILD_DAMAGE "Mild"
 #define SEVERE_DAMAGE "Severe"
-#define ACUTE_DAMAGE "Acute"
+#define CRITICAL_DAMAGE "Critical"
 
 /mob/living/atom_init()
 	. = ..()
@@ -314,12 +314,11 @@
 			function = getCloneLoss()
 		if(BRAINLOSS)
 			function = getBrainLoss()
-	var/numbers = function
 	if(fake)
 		//copypast from healthanalyzer
-		numbers = max(rand(1,40), getOxyLoss(), (300 - (getToxLoss() + getFireLoss() + getBruteLoss())))
+		function = max(rand(1,40), getOxyLoss(), (300 - (getToxLoss() + getFireLoss() + getBruteLoss())))
 	var/text = ""
-	switch(numbers)
+	switch(function)
 		if(0)
 			text = NO_DAMAGE
 		if(1 to 50)
@@ -327,7 +326,7 @@
 		if(51 to 100)
 			text = SEVERE_DAMAGE
 		if(101 to INFINITY)
-			text = ACUTE_DAMAGE
+			text = CRITICAL_DAMAGE
 	return text
 
 // ========== BRUTE ==========
@@ -1552,4 +1551,4 @@
 #undef NO_DAMAGE
 #undef MILD_DAMAGE
 #undef SEVERE_DAMAGE
-#undef ACUTE_DAMAGE
+#undef CRITICAL_DAMAGE

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -821,10 +821,10 @@
 		Overall Status: [M.stat > 1 ? "dead" : "[M.health]% healthy"] <br><br>
 
 		<b>Scan Breakdown</b>: <br>
-		Respiratory: [M.getOxyLoss() > 50 ? "<font color=#FF5555>[M.getOxyLoss()]</font>" : "<font color=#55FF55>[M.getOxyLoss()]</font>"]<br>
-		Toxicology: [M.getToxLoss() > 50 ? "<font color=#FF5555>[M.getToxLoss()]</font>" : "<font color=#55FF55>[M.getToxLoss()]</font>"]<br>
-		Burns: [M.getFireLoss() > 50 ? "<font color=#FF5555>[M.getFireLoss()]</font>" : "<font color=#55FF55>[M.getFireLoss()]</font>"]<br>
-		Structural Integrity: [M.getBruteLoss() > 50 ? "<font color=#FF5555>[M.getBruteLoss()]</font>" : "<font color=#55FF55>[M.getBruteLoss()]</font>"]<br>
+		Respiratory: [M.getOxyLoss() > 50 ? "<font color=#FF5555>[M.getLossString(OXY)]</font>" : "<font color=#55FF55>[M.getLossString(OXY)]</font>"]<br>
+		Toxicology: [M.getToxLoss() > 50 ? "<font color=#FF5555>[M.getLossString(TOX)]</font>" : "<font color=#55FF55>[M.getLossString(TOX)]</font>"]<br>
+		Burns: [M.getFireLoss() > 50 ? "<font color=#FF5555>[M.getLossString(BURN)]</font>" : "<font color=#55FF55>[M.getLossString(BURN)]</font>"]<br>
+		Structural Integrity: [M.getBruteLoss() > 50 ? "<font color=#FF5555>[M.getLossString(BRUTE)]</font>" : "<font color=#55FF55>[M.getLossString(BRUTE)]</font>"]<br>
 		Body Temperature: [M.bodytemperature-T0C]&deg;C ([M.bodytemperature*1.8-459.67]&deg;F)<br>
 		"}
 

--- a/code/modules/nano/modules/crew_monitor.dm
+++ b/code/modules/nano/modules/crew_monitor.dm
@@ -47,10 +47,10 @@
 					crewmemberData["dead"] = H.stat > UNCONSCIOUS
 
 				if(C.sensor_mode >= SUIT_SENSOR_VITAL)
-					crewmemberData["oxy"] = H.getLossString(OXY) //round(H.getOxyLoss(), 1)
-					crewmemberData["tox"] = H.getLossString(TOX) //round(H.getToxLoss(), 1)
-					crewmemberData["fire"] = H.getLossString(BURN) //round(H.getFireLoss(), 1)
-					crewmemberData["brute"] = H.getLossString(BRUTE) //round(H.getBruteLoss(), 1)
+					crewmemberData["oxy"] = H.getLossString(OXY)
+					crewmemberData["tox"] = H.getLossString(TOX)
+					crewmemberData["fire"] = H.getLossString(BURN)
+					crewmemberData["brute"] = H.getLossString(BRUTE)
 
 				if(C.sensor_mode >= SUIT_SENSOR_TRACKING)
 					var/area/A = get_area(H)

--- a/code/modules/nano/modules/crew_monitor.dm
+++ b/code/modules/nano/modules/crew_monitor.dm
@@ -47,10 +47,10 @@
 					crewmemberData["dead"] = H.stat > UNCONSCIOUS
 
 				if(C.sensor_mode >= SUIT_SENSOR_VITAL)
-					crewmemberData["oxy"] = round(H.getOxyLoss(), 1)
-					crewmemberData["tox"] = round(H.getToxLoss(), 1)
-					crewmemberData["fire"] = round(H.getFireLoss(), 1)
-					crewmemberData["brute"] = round(H.getBruteLoss(), 1)
+					crewmemberData["oxy"] = H.getLossString(OXY) //round(H.getOxyLoss(), 1)
+					crewmemberData["tox"] = H.getLossString(TOX) //round(H.getToxLoss(), 1)
+					crewmemberData["fire"] = H.getLossString(BURN) //round(H.getFireLoss(), 1)
+					crewmemberData["brute"] = H.getLossString(BRUTE) //round(H.getBruteLoss(), 1)
 
 				if(C.sensor_mode >= SUIT_SENSOR_TRACKING)
 					var/area/A = get_area(H)

--- a/code/modules/organs/external/flesh.dm
+++ b/code/modules/organs/external/flesh.dm
@@ -1,8 +1,3 @@
-#define NO_ORGAN_DAMAGE "None"
-#define MILD_ORGAN_DAMAGE "Mild"
-#define SEVERE_ORGAN_DAMAGE "Severe"
-#define ACUTE_ORGAN_DAMAGE "Acute"
-
 // This thing allows to create unique bodyparts very easy just by changing bodypart controller type
 /datum/bodypart_controller
 	var/name = "Flesh bodypart controller"

--- a/code/modules/organs/external/flesh.dm
+++ b/code/modules/organs/external/flesh.dm
@@ -1,3 +1,8 @@
+#define NO_ORGAN_DAMAGE "None"
+#define MILD_ORGAN_DAMAGE "Mild"
+#define SEVERE_ORGAN_DAMAGE "Severe"
+#define ACUTE_ORGAN_DAMAGE "Acute"
+
 // This thing allows to create unique bodyparts very easy just by changing bodypart controller type
 /datum/bodypart_controller
 	var/name = "Flesh bodypart controller"

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -568,9 +568,9 @@ Note that amputating the affected organ does in fact remove the infection from t
 			text = NO_EXT_ORGAN_DAMAGE
 		if(1 to 25)
 			text = MILD_EXT_ORGAN_DAMAGE
-		if(25 to 50)
+		if(26 to 50)
 			text = SEVERE_EXT_ORGAN_DAMAGE
-		if(50 to INFINITY)
+		if(51 to INFINITY)
 			text = ACUTE_EXT_ORGAN_DAMAGE
 	return text
 

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1,7 +1,7 @@
 #define NO_EXT_ORGAN_DAMAGE "None"
 #define MILD_EXT_ORGAN_DAMAGE "Mild"
 #define SEVERE_EXT_ORGAN_DAMAGE "Severe"
-#define ACUTE_EXT_ORGAN_DAMAGE "Acute"
+#define CRITICAL_EXT_ORGAN_DAMAGE "Critical"
 
 /****************************************************
 				BODYPARTS
@@ -571,7 +571,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		if(26 to 50)
 			text = SEVERE_EXT_ORGAN_DAMAGE
 		if(51 to INFINITY)
-			text = ACUTE_EXT_ORGAN_DAMAGE
+			text = CRITICAL_EXT_ORGAN_DAMAGE
 	return text
 
 /obj/item/organ/external/proc/has_infected_wound()
@@ -1201,4 +1201,4 @@ Note that amputating the affected organ does in fact remove the infection from t
 #undef NO_EXT_ORGAN_DAMAGE
 #undef MILD_EXT_ORGAN_DAMAGE
 #undef SEVERE_EXT_ORGAN_DAMAGE
-#undef ACUTE_EXT_ORGAN_DAMAGE
+#undef CRITICAL_EXT_ORGAN_DAMAGE

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -550,6 +550,25 @@ Note that amputating the affected organ does in fact remove the infection from t
 /obj/item/organ/external/proc/get_damage()	//returns total damage
 	return max(brute_dam + burn_dam - perma_injury, perma_injury)	//could use health?
 
+/obj/item/organ/external/proc/getOrganDamageString(type_damage)
+	var/numbers = 0
+	switch(type_damage)
+		if(BRUTE)
+			numbers = brute_dam
+		if(BURN)
+			numbers = burn_dam
+	var/text = ""
+	switch(numbers)
+		if(0)
+			text = NO_DAMAGE
+		if(1 to 25)
+			text = MILD_DAMAGE
+		if(25 to 50)
+			text = SEVERE_DAMAGE
+		if(50 to INFINITY)
+			text = ACUTE_DAMAGE
+	return text
+
 /obj/item/organ/external/proc/has_infected_wound()
 	for(var/datum/wound/W in wounds)
 		if(W.germ_level > INFECTION_LEVEL_ONE)

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -1,3 +1,8 @@
+#define NO_EXT_ORGAN_DAMAGE "None"
+#define MILD_EXT_ORGAN_DAMAGE "Mild"
+#define SEVERE_EXT_ORGAN_DAMAGE "Severe"
+#define ACUTE_EXT_ORGAN_DAMAGE "Acute"
+
 /****************************************************
 				BODYPARTS
 ****************************************************/
@@ -550,7 +555,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 /obj/item/organ/external/proc/get_damage()	//returns total damage
 	return max(brute_dam + burn_dam - perma_injury, perma_injury)	//could use health?
 
-/obj/item/organ/external/proc/getOrganDamageString(type_damage)
+/obj/item/organ/external/proc/getExternalOrganDamageString(type_damage)
 	var/numbers = 0
 	switch(type_damage)
 		if(BRUTE)
@@ -560,13 +565,13 @@ Note that amputating the affected organ does in fact remove the infection from t
 	var/text = ""
 	switch(numbers)
 		if(0)
-			text = NO_DAMAGE
+			text = NO_EXT_ORGAN_DAMAGE
 		if(1 to 25)
-			text = MILD_DAMAGE
+			text = MILD_EXT_ORGAN_DAMAGE
 		if(25 to 50)
-			text = SEVERE_DAMAGE
+			text = SEVERE_EXT_ORGAN_DAMAGE
 		if(50 to INFINITY)
-			text = ACUTE_DAMAGE
+			text = ACUTE_EXT_ORGAN_DAMAGE
 	return text
 
 /obj/item/organ/external/proc/has_infected_wound()
@@ -1193,3 +1198,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NO_SACRIFICE, RELIGION_TRAIT)
 
+#undef NO_EXT_ORGAN_DAMAGE
+#undef MILD_EXT_ORGAN_DAMAGE
+#undef SEVERE_EXT_ORGAN_DAMAGE
+#undef ACUTE_EXT_ORGAN_DAMAGE

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -1,3 +1,8 @@
+#define NO_INT_ORGAN_DAMAGE "None"
+#define MILD_INT_ORGAN_DAMAGE "Mild"
+#define SEVERE_INT_ORGAN_DAMAGE "Severe"
+#define ACUTE_INT_ORGAN_DAMAGE "Acute"
+
 /****************************************************
 				INTERNAL ORGANS
 ****************************************************/
@@ -44,6 +49,18 @@
 /obj/item/organ/internal/proc/is_broken()
 	return damage >= min_broken_damage
 
+/obj/item/organ/internal/proc/getInternalOrganDamageString()
+	var/text = ""
+	switch(damage)
+		if(0)
+			text = NO_INT_ORGAN_DAMAGE
+		if(1 to 25)
+			text = MILD_INT_ORGAN_DAMAGE
+		if(25 to 50)
+			text = SEVERE_INT_ORGAN_DAMAGE
+		if(50 to INFINITY)
+			text = ACUTE_INT_ORGAN_DAMAGE
+	return text
 
 /obj/item/organ/internal/process()
 	//Process infections
@@ -418,3 +435,8 @@
 		owner.blurEyes(20)
 	if(is_broken())
 		owner.eye_blind = 20
+
+#undef NO_INT_ORGAN_DAMAGE
+#undef MILD_INT_ORGAN_DAMAGE
+#undef SEVERE_INT_ORGAN_DAMAGE
+#undef ACUTE_INT_ORGAN_DAMAGE

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -54,11 +54,11 @@
 	switch(damage)
 		if(0)
 			text = NO_INT_ORGAN_DAMAGE
-		if(1 to 25)
+		if(1 to 5)
 			text = MILD_INT_ORGAN_DAMAGE
-		if(25 to 50)
+		if(6 to 10)
 			text = SEVERE_INT_ORGAN_DAMAGE
-		if(50 to INFINITY)
+		if(11 to INFINITY)
 			text = ACUTE_INT_ORGAN_DAMAGE
 	return text
 

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -1,7 +1,7 @@
 #define NO_INT_ORGAN_DAMAGE "None"
 #define MILD_INT_ORGAN_DAMAGE "Mild"
 #define SEVERE_INT_ORGAN_DAMAGE "Severe"
-#define ACUTE_INT_ORGAN_DAMAGE "Acute"
+#define CRITICAL_INT_ORGAN_DAMAGE "Critical"
 
 /****************************************************
 				INTERNAL ORGANS
@@ -54,12 +54,12 @@
 	switch(damage)
 		if(0)
 			text = NO_INT_ORGAN_DAMAGE
-		if(1 to 5)
+		if(1 to 10)
 			text = MILD_INT_ORGAN_DAMAGE
-		if(6 to 10)
+		if(11 to 20)
 			text = SEVERE_INT_ORGAN_DAMAGE
-		if(11 to INFINITY)
-			text = ACUTE_INT_ORGAN_DAMAGE
+		if(21 to INFINITY)
+			text = CRITICAL_INT_ORGAN_DAMAGE
 	return text
 
 /obj/item/organ/internal/process()
@@ -439,4 +439,4 @@
 #undef NO_INT_ORGAN_DAMAGE
 #undef MILD_INT_ORGAN_DAMAGE
 #undef SEVERE_INT_ORGAN_DAMAGE
-#undef ACUTE_INT_ORGAN_DAMAGE
+#undef CRITICAL_INT_ORGAN_DAMAGE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Не менял в пип-бое, в сканере роботов и у ниндзи.
Циферки стали словами. 
![Aboba](https://user-images.githubusercontent.com/96499407/193752799-42935ab4-009e-4611-86a9-b7fa007dc485.png)
Это вариант с Mild, Severe, Acute градацией. Есть попроще с Minor, Significant, Critical.
## Почему и что этот ПР улучшит
Цифры уходят, РП приходит
## Авторство

## Чеинжлог
:cl: Deahaka
- tweak: Цифры урона в сканерах здоровья заменены на слова.