### PR TITLE
Баланс каст алиенов

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/xenomorph/humanoid/humanoid.dm
@@ -23,8 +23,7 @@
 	var/last_screech = 0
 	var/screech_delay = 900
 	butcher_results = list(/obj/item/weapon/reagent_containers/food/snacks/xenomeat = 5)
-	alien_spells = list(/obj/effect/proc_holder/spell/no_target/weeds,
-						/obj/effect/proc_holder/spell/targeted/xeno_whisp,
+	alien_spells = list(/obj/effect/proc_holder/spell/targeted/xeno_whisp,
 						/obj/effect/proc_holder/spell/no_target/xenowinds,
 						/obj/effect/proc_holder/spell/targeted/transfer_plasma)
 

--- a/code/modules/mob/living/carbon/xenomorph/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/humanoid/queen.dm
@@ -19,8 +19,7 @@
 						/obj/effect/proc_holder/spell/targeted/transfer_plasma,
 						/obj/effect/proc_holder/spell/no_target/resin,
 						/obj/effect/proc_holder/spell/no_target/lay_egg,
-						/obj/effect/proc_holder/spell/targeted/screech,
-						/obj/effect/proc_holder/spell/no_target/air_plant)
+						/obj/effect/proc_holder/spell/targeted/screech)
 
 
 /mob/living/carbon/xenomorph/humanoid/queen/atom_init()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Дрон является мини-квиной, а мог бы быть кастой инженер улья. Не придумал пока как убрать у квины возможность строить только кровати и мембраны, ведь так один спелл на всё.
Теперь только дрон и квина могут сеять траву, квина потеряла возможность строить воздушное растение.
## Почему и что этот ПР улучшит
Геймплей дрона, боланс. Поидее без травы чужие будут стараться меньше уходить из гнезда.
## Авторство
Димшик предложил, но так и не сказал что должен уметь уникального дрон, поэтому я додумал сам
## Чеинжлог
:cl: Deahaka
- del: Королева чужих больше не может строить воздушное растение.
- balance: Только дрон и королева чужих могут сеять траву на плитках.