### PR TITLE
Update Chemistry-Machinery.dm

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -231,7 +231,7 @@
 				"ethanol",
 				"chlorine",
 				"potassium",
-				"aluminium",
+				"aluminum",
 				"radium",
 				"fluorine",
 				"iron",


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Из-за опечатки в названии реагента в portable chem dispenser не появлялся алюминий.
## Почему и что этот ПР улучшит
Исправление бага
## Авторство

## Чеинжлог
