### PR TITLE
Возвращает спидлоадеры 357 в автолат

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -127,7 +127,7 @@ var/global/list/datum/autolathe_recipe/autolathe_recipes_hidden = list(
 	R(/obj/item/weapon/flamethrower/full, CATEGORY_TOOLS),
 	R(/obj/item/weapon/rcd, CATEGORY_TOOLS),
 	R(/obj/item/weapon/weldingtool/largetank, CATEGORY_TOOLS),
-	R(/obj/item/ammo_casing/a357, CATEGORY_AMMO),
+	R(/obj/item/ammo_box/a357, CATEGORY_AMMO),
 	R(/obj/item/ammo_box/magazine/m9mm, CATEGORY_AMMO),
 	R(/obj/item/ammo_box/magazine/c45m, CATEGORY_AMMO),
 	R(/obj/item/ammo_box/magazine/m9mm_2, CATEGORY_AMMO),


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
В автолате вместо одной пульки калибра 357 делается целый спидлоадер
## Почему и что этот ПР улучшит
Револьвер чаще будут брать.
А берут редко его потому что существует стечкин, что наносит лишь немного меньше урона и который можно по нормальному перезаряжать, не тратя ТК на возможность быстрой перезарядки.
## Авторство

## Чеинжлог
:cl: Simbaka
- tweak: В автолате снова можно создавать спидлоадеры для револьвера предателя.