### PR TITLE
Настройки на плате теперь влияют на консоль камер

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -56,6 +56,10 @@
 	cam_background = new
 	cam_background.assigned_map = map_name
 	cam_background.del_on_map_removal = FALSE
+	var/obj/item/weapon/circuitboard/security/board = circuit
+	var/list/circuitboard_network = board.network
+	if(circuitboard_network.len)
+		network = circuitboard_network
 
 /obj/machinery/computer/security/Destroy()
 	qdel(cam_screen)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
На плате консоли камер возможно настроить сети камер которые будут отображаться в консоли, но сама консоль всегда создается с сетью SS13. Теперь консоль корректно считывает настройки сети с платы.
## Почему и что этот ПР улучшит
Теперь будет возможно восстановить кастомные консоли камер, например Alarms Monitoring Cameras в инженерном отделе и другие подобные консоли.
## Авторство

## Чеинжлог
