### PR TITLE
Stunshot nerf

### DIFF
--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -8,6 +8,7 @@
 	embed = 1
 	sharp = 1
 	var/stoping_power = 0
+	var/shake_camera = TRUE
 
 	muzzle_type = /obj/effect/projectile/bullet/muzzle
 
@@ -17,6 +18,8 @@
 
 /obj/item/projectile/bullet/on_hit(atom/target, def_zone = BP_CHEST, blocked = 0)
 	if (..())
+		if(!shake_camera)
+			return
 		var/mob/living/L = target
 		shake_camera(L, 3, 2)
 
@@ -208,14 +211,18 @@
 	name = "stunshot"
 	icon_state = "spark"
 	flag = ENERGY
+	damage_type = HALLOSS
 	damage = 5
 	stun = 0
 	weaken = 0
 	stutter = 10
-	agony = 80
+	agony = 30
 	embed = 0
-	sharp = 0
+	sharp = FALSE
+	shake_camera = FALSE
 	dispersion = 2.0
+	light_power = 2
+	light_range = 2
 
 /obj/item/projectile/bullet/stunshot/atom_init()
 	. = ..()


### PR DESCRIPTION
## Описание изменений
В общем-то нёрф, как меня и попросили. Говорят, стало проблемой с ПБшками, нюкерами различных мастей, дедсадовцев и убийством за выстрел.
У стан патронов для дробовиков:
- Появился прикольный свет
- Потенциальный урон упал с 400 до 150
- Убрана тряска экрана
## Почему и что этот ПР улучшит
Хоть и забавно, но немного не в тему: 400 халлосс. То-есть 1-о хорошего попадания хватит для дедсадовца. Другими словами, нечто вроде баланса.
## Авторство

## Чеинжлог
:cl: Chip11-n
- balance: Оглушающие патроны для дробовиков стали слабее.