### PR TITLE
removing yellow gloves and magboots from ert base

### DIFF
--- a/maps/centcom/centcom.dmm
+++ b/maps/centcom/centcom.dmm
@@ -12011,11 +12011,9 @@
 "aBH" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/space/rig/ert/engineer,
-/obj/item/clothing/shoes/magboots,
 /obj/item/clothing/head/helmet/space/rig/ert/engineer,
 /obj/item/device/flash,
 /obj/item/device/multitool,
-/obj/item/clothing/gloves/yellow,
 /obj/item/clothing/accessory/storage/brown_vest,
 /obj/item/weapon/storage/belt/utility/full,
 /obj/item/clothing/glasses/meson,
@@ -12181,7 +12179,6 @@
 /obj/structure/rack,
 /obj/item/clothing/head/helmet/space/rig/ert/commander,
 /obj/item/clothing/suit/space/rig/ert/commander,
-/obj/item/clothing/shoes/magboots,
 /obj/item/weapon/storage/firstaid/small_firstaid_kit/combat,
 /turf/unsimulated/floor{
 	dir = 8;
@@ -24802,11 +24799,9 @@
 "gbb" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/space/rig/ert/engineer,
-/obj/item/clothing/shoes/magboots,
 /obj/item/clothing/head/helmet/space/rig/ert/engineer,
 /obj/item/device/flash,
 /obj/item/device/multitool,
-/obj/item/clothing/gloves/yellow,
 /obj/item/clothing/accessory/storage/brown_vest,
 /obj/item/weapon/storage/belt/utility/full,
 /obj/item/clothing/glasses/meson,


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
убрал перчатки и магбутсы из базы обр
## Почему и что этот ПР улучшит
эти предметы итак есть у оперативников.
## Авторство

## Чеинжлог
