### PR TITLE
бафф гибрид сьютов синдиката и ригов сб

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -795,7 +795,7 @@
 	cell_type = /obj/item/weapon/stock_parts/cell/super
 	var/combat_mode = FALSE
 	var/combat_armor = list(melee = 60, bullet = 65, laser = 55, energy = 45, bomb = 50, bio = 100, rad = 60)
-	var/space_armor = list(melee = 50, bullet = 45, laser = 40, energy = 30, bomb = 50, bio = 100, rad = 60)
+	var/space_armor = list(melee = 60, bullet = 55, laser = 45, energy = 30, bomb = 50, bio = 100, rad = 60)
 	var/combat_slowdown = 0
 
 /obj/item/clothing/suit/space/rig/syndi/atom_init()
@@ -865,7 +865,7 @@
 	slowdown = 1.2
 	initial_modules = list(/obj/item/rig_module/simple_ai/advanced, /obj/item/rig_module/selfrepair, /obj/item/rig_module/chem_dispenser/combat)
 	combat_armor = list(melee = 75, bullet = 80, laser = 70,energy = 55, bomb = 50, bio = 100, rad = 30)
-	space_armor = list(melee = 60, bullet = 50, laser = 50, energy = 45, bomb = 50, bio = 100, rad = 60)
+	space_armor = list(melee = 60, bullet = 65, laser = 55, energy = 45, bomb = 50, bio = 100, rad = 60)
 	combat_slowdown = 0.5
 
 /obj/item/clothing/head/helmet/space/rig/syndi/elite
@@ -913,7 +913,7 @@
 	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
 	unacidable = TRUE
 	combat_armor = list(melee = 55, bullet = 60, laser = 50, energy = 55, bomb = 100, bio = 100, rad = 100)
-	space_armor = list(melee = 55, bullet = 50, laser = 40, energy = 45, bomb = 80, bio = 100, rad = 80)
+	space_armor = list(melee = 60, bullet = 55, laser = 45, energy = 45, bomb = 80, bio = 100, rad = 80)
 	glowtype = "terrohazmat"
 	rig_type = "hazmat"
 

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -936,7 +936,7 @@
 	               /obj/item/weapon/melee/energy/sword,
 	               /obj/item/weapon/handcuffs)
 	combat_armor = list(melee = 55, bullet = 60, laser = 50, energy = 55, bomb = 100, bio = 100, rad = 100)
-	space_armor = list(melee = 30, bullet = 20, laser = 20, energy = 45, bomb = 80, bio = 100, rad = 80)
+	space_armor = list(melee = 50, bullet = 45, laser = 40, energy = 45, bomb = 80, bio = 100, rad = 80)
 
 //Wizard Rig
 /obj/item/clothing/head/helmet/space/rig/wizard

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -795,7 +795,7 @@
 	cell_type = /obj/item/weapon/stock_parts/cell/super
 	var/combat_mode = FALSE
 	var/combat_armor = list(melee = 60, bullet = 65, laser = 55, energy = 45, bomb = 50, bio = 100, rad = 60)
-	var/space_armor = list(melee = 30, bullet = 20, laser = 20, energy = 30, bomb = 50, bio = 100, rad = 60)
+	var/space_armor = list(melee = 50, bullet = 45, laser = 40, energy = 30, bomb = 50, bio = 100, rad = 60)
 	var/combat_slowdown = 0
 
 /obj/item/clothing/suit/space/rig/syndi/atom_init()
@@ -865,7 +865,7 @@
 	slowdown = 1.2
 	initial_modules = list(/obj/item/rig_module/simple_ai/advanced, /obj/item/rig_module/selfrepair, /obj/item/rig_module/chem_dispenser/combat)
 	combat_armor = list(melee = 75, bullet = 80, laser = 70,energy = 55, bomb = 50, bio = 100, rad = 30)
-	space_armor = list(melee = 45, bullet = 30, laser = 30, energy = 45, bomb = 50, bio = 100, rad = 60)
+	space_armor = list(melee = 60, bullet = 50, laser = 50, energy = 45, bomb = 50, bio = 100, rad = 60)
 	combat_slowdown = 0.5
 
 /obj/item/clothing/head/helmet/space/rig/syndi/elite
@@ -1010,14 +1010,14 @@
 	icon_state = "rig0-sec"
 	item_state = "sec_helm"
 	rig_variant = "sec"
-	armor = list(melee = 45, bullet = 30, laser = 30, energy = 30, bomb = 65, bio = 100, rad = 10)
+	armor = list(melee = 60, bullet = 60, laser = 60, energy = 30, bomb = 65, bio = 100, rad = 10)
 
 /obj/item/clothing/suit/space/rig/security
 	icon_state = "rig-sec"
 	name = "security hardsuit"
 	desc = "A special suit that protects against hazardous, low pressure environments. Has an additional layer of armor."
 	item_state = "sec_hardsuit"
-	armor = list(melee = 45, bullet = 30, laser = 30, energy = 30, bomb = 65, bio = 100, rad = 10)
+	armor = list(melee = 60, bullet = 60, laser = 60, energy = 30, bomb = 65, bio = 100, rad = 10)
 	allowed = list(/obj/item/weapon/gun,/obj/item/device/flashlight,/obj/item/weapon/tank,/obj/item/device/suit_cooling_unit,/obj/item/weapon/melee/baton)
 	breach_threshold = 20
 	slowdown = 0.7


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
| Броня       | Было (мили/пули/лазеры)             | Стало (мили/пули/лазеры) |
| ------------- |:------------------:| -----:|
| Риг СБ     | 45/30/30    | 60/60/60 |
| Гибрид сьют (спейс мод)  | 30/20/20 |   60/55/45 |
| Хэви гибрид сьют (спейс мод) |   45/30/30       |    60/65/55 |
## Почему и что этот ПР улучшит
Баланс, очевидно.
Риги сб сейчас являются невероятно слабой броней, что не защищает даже от пуль стечкина и не позволяет нормально передвигаться, из-за чего многим в нюку выгоднее вообще не менять броню и бегать в стандартных брониках.
А повысил броню синдиригам затем, чтобы экипаж намеренно не делал разгермы потому что у них космическая броня наамного лучше защищает чем у синдикатовцев.
## Авторство

## Чеинжлог
:cl: Simbaka
- balance: Риги охраны и синдиката защищают намного лучше.