### PR TITLE
Boxstation - Бар вернулся домой

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -6128,13 +6128,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/storage/primary)
-"akt" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/port)
 "aku" = (
 /obj/structure/sign/departments/science,
 /turf/simulated/wall,
@@ -6820,6 +6813,7 @@
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -9404,9 +9398,6 @@
 "apE" = (
 /obj/machinery/chem_dispenser/soda,
 /obj/structure/table,
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/simulated/floor{
 	icon_state = "cafeteria"
 	},
@@ -12592,6 +12583,10 @@
 /area/station/rnd/xenobiology)
 "avD" = (
 /obj/machinery/hydroponics/constructable,
+/obj/machinery/camera{
+	c_tag = "Central Hallway East";
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -13658,13 +13653,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
 "axI" = (
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/machinery/camera{
 	c_tag = "Cargo Office"
 	},
 /obj/machinery/photocopier,
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = 32
+	},
 /turf/simulated/floor,
 /area/station/cargo/office)
 "axJ" = (
@@ -21229,9 +21225,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
 "aLW" = (
 /obj/structure/table,
@@ -33847,7 +33841,6 @@
 /area/station/tcommsat/computer)
 "bie" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -35178,10 +35171,7 @@
 	req_access = list(67)
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
-	},
+/turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
 "bkS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -35588,29 +35578,15 @@
 	},
 /area/station/bridge/meeting_room)
 "blz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/camera{
-	c_tag = "Hydroponics Pasture"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "asteroid"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "siding2"
-	},
-/area/station/civilian/kitchen)
+/turf/simulated/floor,
+/area/station/cargo/office)
 "blA" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -36298,10 +36274,6 @@
 "bmD" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Bay North"
-	},
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = 32
 	},
 /obj/structure/table,
 /obj/item/weapon/folder/yellow,
@@ -41551,6 +41523,9 @@
 /area/station/hallway/secondary/entry)
 "bwf" = (
 /obj/structure/device/piano/royal,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -43322,9 +43297,6 @@
 	},
 /area/station/medical/surgery)
 "bzc" = (
-/obj/machinery/camera{
-	c_tag = "Kitchen"
-	},
 /obj/structure/table,
 /obj/machinery/kitchen_machine/microwave{
 	pixel_x = -3;
@@ -43917,10 +43889,6 @@
 	name = "Loading Doors";
 	pixel_x = 6;
 	pixel_y = -32
-	},
-/obj/machinery/camera{
-	c_tag = "Cargo Recieving Dock";
-	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "warning"
@@ -47374,6 +47342,9 @@
 	req_access = list(31)
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "brown"
@@ -48066,6 +48037,9 @@
 /obj/structure/sign/poster/contraband{
 	pixel_x = 32
 	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "brown"
@@ -48147,7 +48121,7 @@
 /obj/item/device/radio/intercom{
 	dir = 4;
 	name = "Station Intercom (General)";
-	pixel_x = 27
+	pixel_x = 28
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -48721,9 +48695,6 @@
 /obj/machinery/cell_charger,
 /obj/item/clothing/head/soft,
 /obj/item/clothing/head/soft,
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "brown"
@@ -59123,6 +59094,7 @@
 /area/station/rnd/brainstorm_center)
 "cjM" = (
 /obj/machinery/light,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	icon_state = "browncorner"
 	},
@@ -61484,7 +61456,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/sortjunction{
 	dir = 4;
 	name = "Kitchen";
@@ -63474,9 +63445,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
-	},
-/obj/machinery/light{
-	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
@@ -69455,7 +69423,7 @@
 "cUv" = (
 /obj/structure/table,
 /obj/machinery/light_switch{
-	pixel_x = -23
+	pixel_x = -29
 	},
 /turf/simulated/floor{
 	icon_state = "grimy"
@@ -70863,6 +70831,10 @@
 	freq = 1400;
 	location = "QM #3"
 	},
+/obj/machinery/camera{
+	c_tag = "Central Hallway South-East";
+	dir = 8
+	},
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
@@ -71107,6 +71079,9 @@
 "eVv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -81641,9 +81616,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
 "rib" = (
 /obj/structure/table/glass,
@@ -84440,13 +84413,16 @@
 /area/station/civilian/chapel/mass_driver)
 "uMv" = (
 /obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/camera{
+	c_tag = "Kitchen"
+	},
 /obj/machinery/door_control{
 	id = "kitchen";
 	name = "Kitchen Shutters Control";
-	pixel_y = 24;
+	pixel_y = 29;
 	req_access = list(28)
 	},
-/obj/structure/disposalpipe/trunk,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -85063,7 +85039,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light/small,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -85540,14 +85515,23 @@
 	},
 /area/station/civilian/hydroponics)
 "xvY" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/structure/stool/bar,
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/area/station/civilian/bar)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor,
+/area/station/hallway/primary/port)
 "xwj" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -85889,6 +85873,9 @@
 /obj/structure/closet/secure_closet/freezer/fridge,
 /obj/machinery/light_switch{
 	pixel_x = -23
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -96889,7 +96876,7 @@ aGp
 apT
 wwg
 bvg
-bfZ
+bvg
 bvg
 bkQ
 bvg
@@ -98423,7 +98410,7 @@ bkz
 baQ
 bgJ
 crY
-blz
+fcK
 lwo
 bpV
 cTO
@@ -102789,7 +102776,7 @@ aSM
 qcd
 aRm
 aGn
-xvY
+bHL
 hvE
 bvI
 bxD
@@ -105878,7 +105865,7 @@ kss
 aEK
 brg
 aNv
-lJr
+blz
 aMQ
 aFg
 bxs
@@ -106124,7 +106111,7 @@ aVl
 aWN
 aFL
 alz
-bdZ
+xvY
 cjM
 bHe
 bHe
@@ -107151,7 +107138,7 @@ aFL
 aFL
 aFL
 aFL
-akt
+bdv
 cpL
 bns
 cox

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -72092,8 +72092,7 @@
 "gdb" = (
 /obj/structure/table/woodentable,
 /obj/item/device/flashlight/lamp/green,
-/obj/structure/sign/poster{
-	official = 1;
+/obj/structure/sign/poster/contraband{
 	pixel_x = -32
 	},
 /turf/simulated/floor/wood,

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -4969,6 +4969,11 @@
 /area/station/medical/cryo)
 "aiE" = (
 /obj/structure/table,
+/obj/item/device/camera{
+	desc = "A one use - polaroid camera. 30 photos left.";
+	name = "detectives camera";
+	pictures_left = 30
+	},
 /obj/item/device/taperecorder,
 /obj/item/weapon/storage/box/evidence,
 /obj/machinery/camera{
@@ -4977,7 +4982,6 @@
 	network = list("SS13","Security");
 	pixel_y = -18
 	},
-/obj/item/device/camera/polar/detective,
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "darkred"
@@ -5248,11 +5252,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "ajb" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -23
+	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "browncorner"
+	icon_state = "greencorner"
 	},
 /area/station/hallway/secondary/entry)
 "ajc" = (
@@ -5816,17 +5824,13 @@
 	},
 /area/station/security/main)
 "ajV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "warning"
-	},
-/area/station/civilian/cold_room)
+/turf/simulated/floor,
+/area/station/cargo/storage)
 "ajW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -6528,8 +6532,11 @@
 /turf/simulated/floor,
 /area/station/storage/primary)
 "ala" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/power/apc{
+	name = "Arrival Shuttle Hallway APC";
+	pixel_y = -24
+	},
+/obj/structure/cable,
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
@@ -7500,14 +7507,16 @@
 	},
 /area/station/engineering/engine)
 "amz" = (
-/obj/machinery/alarm{
-	pixel_y = 28
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/requests_console{
+	department = "Hydroponics";
+	departmentType = 2;
+	pixel_y = 30
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "brown"
+	icon_state = "dark"
 	},
-/area/station/cargo/office)
+/area/station/civilian/hydroponics)
 "amA" = (
 /obj/machinery/door_control{
 	desc = "A remote control switch for the brig foyer.";
@@ -8621,13 +8630,13 @@
 /turf/simulated/floor,
 /area/station/security/lobby)
 "aok" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Bay";
-	req_one_access = list(31,48,67)
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -24
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/vending/clothing,
 /turf/simulated/floor,
-/area/station/cargo/storage)
+/area/station/civilian/locker)
 "aol" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -8644,9 +8653,14 @@
 	},
 /area/station/security/lobby)
 "aon" = (
-/obj/structure/sign/departments/cargo,
-/turf/simulated/wall,
-/area/station/cargo/office)
+/obj/machinery/light_switch{
+	pixel_x = -27
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/station/cargo/recycleroffice)
 "aoo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/stool,
@@ -8970,20 +8984,13 @@
 /area/station/rnd/test_area)
 "aoS" = (
 /obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /obj/machinery/door/firedoor,
-/obj/structure/window/reinforced/polarized{
-	dir = 1;
-	id = "kitchen"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "kitchen"
-	},
-/obj/structure/window/reinforced/polarized{
-	id = "kitchen"
-	},
 /turf/simulated/floor/plating,
-/area/station/civilian/kitchen)
+/area/station/cargo/qm)
 "aoT" = (
 /obj/structure/table,
 /obj/item/weapon/cigbutt,
@@ -9226,16 +9233,14 @@
 	},
 /area/station/security/prison)
 "apr" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	name = "Honk Office APC";
-	pixel_y = -30
+/obj/structure/sink/kitchen{
+	pixel_y = 28
 	},
-/obj/structure/table/woodentable,
-/obj/item/clothing/suit/batman,
-/obj/item/clothing/head/batman_helmet,
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "aps" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -9246,15 +9251,20 @@
 /turf/simulated/floor/plating/airless,
 /area/station/rnd/test_area)
 "apt" = (
-/obj/machinery/door/airlock{
-	name = "Private Office"
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/wood,
-/area/station/security/vacantoffice)
+/turf/simulated/floor/plating,
+/area/station/civilian/bar)
 "apu" = (
 /obj/structure/stool/bed/chair{
 	dir = 4
@@ -9402,12 +9412,15 @@
 	},
 /area/station/engineering/engine)
 "apE" = (
-/obj/machinery/vending/coffee,
-/turf/simulated/floor{
-	dir = 9;
-	icon_state = "brown"
+/obj/machinery/chem_dispenser/soda,
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 8
 	},
-/area/station/cargo/office)
+/turf/simulated/floor{
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "apF" = (
 /obj/structure/table,
 /obj/item/weapon/newspaper,
@@ -9624,30 +9637,37 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "aqe" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
-/area/station/civilian/locker)
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
+	},
+/area/station/cargo/miningoffice)
 "aqf" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "aqg" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	icon_state = "shutter0";
+	id = "Bar_Privacy1";
+	name = "Privacy Shutters";
+	opacity = 0
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /turf/simulated/floor/plating,
-/area/station/civilian/locker)
+/area/station/civilian/bar)
 "aqh" = (
 /obj/machinery/light,
 /turf/simulated/floor/plating/airless{
@@ -9917,17 +9937,11 @@
 	},
 /area/station/security/detectives_office)
 "aqD" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/civilian/hydroponics)
+/turf/simulated/floor,
+/area/station/cargo/storage)
 "aqE" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -10076,9 +10090,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "aqQ" = (
@@ -10127,9 +10138,6 @@
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = 29
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
@@ -10241,26 +10249,23 @@
 	},
 /area/station/security/prison)
 "arh" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/civilian/hydroponics)
-"ari" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
+/obj/structure/reagent_dispensers/watertank,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/turf/simulated/floor{
+	icon_state = "delivery"
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/civilian/hydroponics)
+/area/station/civilian/locker)
+"ari" = (
+/obj/structure/table/woodentable,
+/obj/item/device/taperecorder,
+/obj/item/device/camera,
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
 "arj" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/closet,
@@ -10502,6 +10507,11 @@
 /area/station/security/detectives_office)
 "arL" = (
 /obj/structure/table/woodentable,
+/obj/item/device/camera{
+	desc = "A one use - polaroid camera. 30 photos left.";
+	name = "detectives camera";
+	pictures_left = 30
+	},
 /obj/item/weapon/storage/photo_album{
 	pixel_y = -10
 	},
@@ -10511,7 +10521,6 @@
 	dir = 1;
 	network = list("SS13","Security")
 	},
-/obj/item/device/camera/polar/detective,
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -10697,16 +10706,12 @@
 /turf/simulated/wall,
 /area/station/civilian/bar)
 "asa" = (
-/obj/structure/rack,
-/obj/item/stack/cable_coil/red{
-	amount = 12
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
 	},
-/obj/item/stack/rods{
-	amount = 23
-	},
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/turf/simulated/floor/wood,
+/area/station/civilian/bar)
 "asb" = (
 /obj/structure/stool/bed/roller,
 /obj/machinery/iv_drip,
@@ -10715,25 +10720,14 @@
 	},
 /area/station/hallway/secondary/exit)
 "asc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/stool/bed/chair/office/dark{
+	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
+	dir = 5;
+	icon_state = "vault"
 	},
-/area/station/cargo/office)
+/area/station/cargo/recycleroffice)
 "asd" = (
 /obj/structure/window/reinforced{
 	dir = 5
@@ -10863,17 +10857,25 @@
 	},
 /area/station/security/prison)
 "asp" = (
-/obj/machinery/door/window/westright{
-	name = "Kitchen Maintenance";
-	req_access = list(28)
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	icon_state = "delivery"
+	dir = 4;
+	icon_state = "brown"
 	},
-/area/station/civilian/cold_room)
+/area/station/cargo/storage)
 "asq" = (
 /obj/structure/table/woodentable,
 /obj/item/device/camera_film{
@@ -11173,14 +11175,15 @@
 	},
 /area/station/hallway/secondary/exit)
 "asT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/washing_machine,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "green"
+	dir = 8;
+	icon_state = "barber"
 	},
-/area/station/civilian/hydroponics)
+/area/station/civilian/locker)
 "asU" = (
 /obj/structure/table,
 /obj/item/weapon/storage/fancy/egg_box,
@@ -11234,14 +11237,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "ata" = (
-/obj/machinery/vending/hydroseeds,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "brown"
 	},
-/area/station/civilian/hydroponics)
+/area/station/cargo/miningbreaktime)
 "atb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
@@ -11264,24 +11267,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "ate" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/shutters{
-	id = "bar-m";
-	name = "Bar Shutters"
-	},
-/turf/simulated/floor/plating,
-/area/station/civilian/bar)
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "atf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor/plating{
@@ -11340,18 +11336,11 @@
 /turf/simulated/floor/engine,
 /area/station/rnd/xenobiology)
 "atk" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance{
-	name = "Kitchen Cold Room Maintenance";
-	req_access = list(28)
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/civilian/cold_room)
+/turf/simulated/floor,
+/area/station/cargo/storage)
 "atl" = (
 /obj/structure/table/woodentable/poker,
 /obj/item/toy/cards,
@@ -11585,13 +11574,28 @@
 /turf/environment/space,
 /area/shuttle/mining/station)
 "atK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/cable{
-	d1 = 2;
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/civilian/cold_room)
+/area/station/cargo/storage)
 "atL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/firealarm{
@@ -11689,11 +11693,18 @@
 	},
 /area/shuttle/mining/station)
 "atT" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
-/area/station/civilian/bar)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/station/maintenance/cargo)
 "atU" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -11746,25 +11757,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "atX" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Bay";
-	req_one_access = list(31,48,67)
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 9
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/cargo/storage)
 "atY" = (
@@ -11790,12 +11789,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "atZ" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
+/obj/structure/filingcabinet/filingcabinet,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "arrival"
 	},
-/area/station/civilian/hydroponics)
+/area/station/cargo/office)
 "aua" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -11925,22 +11924,11 @@
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/auxsolarstarboard)
 "aum" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
+/turf/simulated/floor,
+/area/station/cargo/office)
 "aun" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sink{
@@ -11979,12 +11967,15 @@
 /turf/simulated/wall,
 /area/station/maintenance/chapel)
 "auq" = (
-/obj/machinery/kitchen_machine/grill,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/area/station/civilian/kitchen)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/station/cargo/office)
 "aur" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/meter,
@@ -12011,14 +12002,19 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "auv" = (
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/area/station/civilian/bar)
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "auw" = (
 /obj/machinery/deepfryer,
 /turf/simulated/floor{
@@ -12140,16 +12136,23 @@
 	},
 /area/station/civilian/kitchen)
 "auL" = (
-/obj/structure/table,
-/obj/machinery/kitchen_machine/microwave{
-	pixel_x = -3;
-	pixel_y = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	dir = 8;
+	icon_state = "brown"
 	},
-/area/station/civilian/kitchen)
+/area/station/cargo/storage)
 "auM" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -12158,47 +12161,38 @@
 	},
 /area/station/maintenance/eva)
 "auN" = (
-/obj/structure/table,
-/obj/machinery/kitchen_machine/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/structure/filingcabinet,
 /turf/simulated/floor{
 	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "vault"
 	},
-/area/station/civilian/kitchen)
+/area/station/cargo/recycleroffice)
 "auO" = (
-/obj/item/weapon/flora/random,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor{
+	icon_state = "bar"
+	},
+/area/station/cargo/miningbreaktime)
+"auP" = (
+/obj/machinery/computer/security/mining,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor{
+	dir = 1;
 	icon_state = "brown"
 	},
-/area/station/cargo/storage)
-"auP" = (
-/obj/item/weapon/reagent_containers/food/condiment/enzyme{
-	pixel_x = 10
-	},
-/obj/structure/table,
-/obj/machinery/windowtint{
-	id = "kitchen";
-	pixel_x = 24
-	},
-/obj/structure/condiment_shelf{
-	pixel_y = 32
-	},
-/obj/item/weapon/reagent_containers/food/condiment/saltshaker,
-/obj/item/weapon/reagent_containers/food/condiment/sugar,
-/obj/item/weapon/reagent_containers/food/condiment/peppermill,
-/obj/item/weapon/reagent_containers/food/condiment/rice,
-/obj/item/weapon/reagent_containers/food/condiment/ketchup,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
+/area/station/cargo/qm)
 "auQ" = (
 /mob/living/pbag,
 /turf/simulated/floor{
@@ -12239,6 +12233,10 @@
 /obj/machinery/newscaster{
 	pixel_x = -28
 	},
+/obj/item/device/camera{
+	pixel_x = -4;
+	pixel_y = 8
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/painting_frame{
 	pixel_y = -10
@@ -12250,7 +12248,6 @@
 	amount = 50;
 	pixel_y = -11
 	},
-/obj/item/device/camera/lomo,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "auV" = (
@@ -12334,15 +12331,22 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
 "ave" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/food/snacks/pie,
-/turf/simulated/floor{
-	icon_state = "cafeteria"
+/obj/machinery/door/firedoor,
+/obj/structure/noticeboard{
+	dir = 4;
+	pixel_x = -32
 	},
-/area/station/civilian/bar)
+/obj/machinery/door/window/eastright{
+	base_state = "left";
+	dir = 2;
+	icon_state = "left";
+	name = "Cargo Desk";
+	req_access = list(50)
+	},
+/obj/item/weapon/bell,
+/turf/simulated/floor,
+/area/station/cargo/office)
 "avf" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -12353,10 +12357,15 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "avg" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "avh" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
@@ -12436,20 +12445,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "avr" = (
-/obj/structure/plasticflaps{
-	opacity = 1
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=1";
-	freq = 1400;
-	location = "Kitchen"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "bot"
-	},
-/area/station/civilian/cold_room)
+/obj/item/weapon/storage/fancy/crayons,
+/obj/structure/table/glass,
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "avs" = (
 /obj/structure/table/woodentable,
 /obj/item/device/radio/intercom{
@@ -12602,15 +12601,12 @@
 /turf/simulated/floor/engine,
 /area/station/rnd/xenobiology)
 "avD" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -23
-	},
+/obj/machinery/hydroponics/constructable,
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "brown"
+	dir = 5;
+	icon_state = "vault"
 	},
-/area/station/cargo/office)
+/area/station/civilian/kitchen)
 "avE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -12701,18 +12697,21 @@
 	},
 /area/station/rnd/xenobiology)
 "avM" = (
-/obj/item/weapon/flora/floorleaf,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood,
-/area/station/civilian/bar)
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "avN" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+/obj/structure/table,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/machinery/light{
+	dir = 1
 	},
-/area/station/civilian/bar)
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "avO" = (
 /obj/machinery/vending/sustenance,
 /turf/simulated/floor{
@@ -12720,12 +12719,23 @@
 	},
 /area/station/security/prison)
 "avP" = (
-/obj/structure/stool/bed/chair/comfy/black,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/area/station/civilian/bar)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "avQ" = (
 /obj/structure/sign/poster/official/obey{
 	pixel_y = -32
@@ -12753,15 +12763,19 @@
 	},
 /area/station/security/prison)
 "avT" = (
-/obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/window/westleft{
-	dir = 2;
-	name = "Hydroponics";
-	req_access = list(35)
+/obj/machinery/door/window{
+	base_state = "right";
+	dir = 1;
+	icon_state = "right";
+	name = "Mailing Room"
 	},
-/turf/simulated/floor,
-/area/station/civilian/hydroponics)
+/obj/structure/table/reinforced,
+/obj/item/weapon/paper_bin,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
+/area/station/cargo/office)
 "avU" = (
 /obj/structure/stool/bed/chair/comfy/brown{
 	dir = 1
@@ -12888,14 +12902,25 @@
 	},
 /area/station/rnd/xenobiology)
 "awg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
 /turf/simulated/floor{
-	icon_state = "bar"
+	dir = 5;
+	icon_state = "vault"
 	},
-/area/station/cargo/miningoffice)
+/area/station/civilian/bar)
 "awh" = (
 /turf/simulated/floor/engine{
 	name = "Holodeck Projector Floor"
@@ -12972,21 +12997,10 @@
 	},
 /area/station/rnd/xenobiology)
 "awq" = (
-/obj/machinery/door/airlock/glass{
-	name = "Hydroponics";
-	req_access = list(35)
+/turf/simulated/floor{
+	icon_state = "loadingarea"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/civilian/hydroponics)
+/area/station/cargo/office)
 "awr" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -13031,16 +13045,16 @@
 /area/station/maintenance/dormitory)
 "awu" = (
 /obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /obj/machinery/door/firedoor,
-/obj/structure/window/reinforced/polarized{
-	id = "kitchen"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 1;
-	id = "kitchen"
-	},
 /turf/simulated/floor/plating,
-/area/station/civilian/kitchen)
+/area/station/cargo/qm)
 "awv" = (
 /obj/random/vending/cola,
 /turf/simulated/floor{
@@ -13238,11 +13252,13 @@
 	},
 /area/station/rnd/xenobiology)
 "awS" = (
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/area/station/civilian/bar)
+/turf/simulated/floor,
+/area/station/cargo/miningoffice)
 "awT" = (
 /turf/simulated/wall,
 /area/station/civilian/dormitories)
@@ -13300,24 +13316,15 @@
 	},
 /area/station/rnd/xenobiology)
 "awZ" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50;
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/device/multitool,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "brown"
+	dir = 5;
+	icon_state = "vault"
 	},
-/area/station/cargo/office)
+/area/station/civilian/kitchen)
 "axa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -13437,7 +13444,9 @@
 	pixel_x = -4;
 	pixel_y = 15
 	},
-/obj/item/device/camera,
+/obj/item/device/camera{
+	pixel_x = -5
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkblue"
@@ -13604,16 +13613,9 @@
 	},
 /area/station/civilian/gym)
 "axC" = (
-/obj/item/weapon/kitchen/utensil/fork{
-	pixel_x = 4
-	},
-/obj/item/weapon/kitchen/utensil/spoon,
-/obj/structure/table/woodentable/fancy/black,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
-	},
-/area/station/civilian/bar)
+/obj/structure/stool/bed/chair/office/dark,
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
 "axD" = (
 /obj/structure/rack,
 /obj/item/device/suit_cooling_unit,
@@ -13666,15 +13668,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
 "axI" = (
-/obj/machinery/computer/cargo,
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "brown"
+/obj/machinery/camera{
+	c_tag = "Cargo Office"
 	},
-/area/station/cargo/qm)
+/obj/machinery/photocopier,
+/turf/simulated/floor,
+/area/station/cargo/office)
 "axJ" = (
 /obj/structure/stool/bed/chair/comfy/black{
 	dir = 8
@@ -13682,12 +13684,15 @@
 /turf/simulated/floor/wood,
 /area/station/maintenance/eva)
 "axK" = (
-/obj/machinery/computer/security/mining,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "brown"
+/obj/machinery/door/airlock{
+	name = "Kitchen Cold Room";
+	req_access = list(28)
 	},
-/area/station/cargo/qm)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/station/civilian/kitchen)
 "axL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
@@ -14013,20 +14018,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "ayv" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(12)
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
-/area/station/civilian/bar)
+/area/station/maintenance/engineering)
 "ayw" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/fire/firefighter,
@@ -14061,18 +14063,12 @@
 	},
 /area/station/civilian/hydroponics)
 "ayz" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	icon_state = "bar"
+	dir = 8;
+	icon_state = "cautioncorner"
 	},
-/area/station/cargo/miningoffice)
+/area/station/hallway/secondary/entry)
 "ayA" = (
 /obj/structure/closet/athletic_mixed,
 /obj/item/clothing/under/pants/black_sport,
@@ -14309,18 +14305,12 @@
 /turf/simulated/floor,
 /area/station/rnd/misc_lab)
 "ayX" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(12)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "bar"
-	},
-/area/station/cargo/miningoffice)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "ayY" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -14362,19 +14352,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "azc" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/computer/arcade,
+/obj/structure/sign/poster{
+	pixel_y = -32
 	},
-/obj/structure/window/reinforced{
-	dir = 4
+/turf/simulated/floor{
+	icon_state = "dark"
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
 /area/station/civilian/bar)
 "azd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -14615,13 +14599,20 @@
 	},
 /area/station/civilian/dormitories)
 "azA" = (
-/obj/structure/table,
-/obj/item/weapon/reagent_containers/food/snacks/mint,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -30
 	},
-/area/station/civilian/kitchen)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor{
+	icon_state = "floorgrime"
+	},
+/area/station/cargo/storage)
 "azB" = (
 /obj/structure/closet,
 /obj/item/device/flashlight,
@@ -14762,14 +14753,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "azO" = (
-/obj/structure/stool/bed/chair/comfy/black{
-	dir = 1
+/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
-/area/station/civilian/bar)
+/area/station/civilian/locker)
 "azP" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -14967,12 +14958,18 @@
 /turf/simulated/floor/plating,
 /area/station/storage/tech/north)
 "aAf" = (
-/obj/structure/closet/secure_closet/hydroponics,
-/obj/machinery/vending/wallmed1{
-	pixel_y = 30
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/grass,
-/area/station/civilian/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/station/cargo/office)
 "aAg" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -15191,13 +15188,11 @@
 /turf/simulated/floor/mech_bay_recharge_floor,
 /area/station/maintenance/science)
 "aAB" = (
-/obj/machinery/door/airlock/glass{
-	name = "Hydroponics Pasture";
-	req_access = list(35)
+/obj/machinery/light_switch{
+	pixel_x = 28
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor,
-/area/station/civilian/hydroponics)
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
 "aAC" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -15219,26 +15214,32 @@
 	},
 /area/station/maintenance/science)
 "aAF" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/area/station/civilian/bar)
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "aAG" = (
-/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+	dir = 4
 	},
-/turf/simulated/floor/grass,
-/area/station/civilian/hydroponics)
+/turf/simulated/floor,
+/area/station/cargo/office)
 "aAH" = (
 /obj/structure/window/reinforced,
 /obj/structure/table,
@@ -15291,13 +15292,9 @@
 /turf/simulated/floor/plating,
 /area/station/rnd/tox_launch)
 "aAN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
+/obj/machinery/computer/cargo,
+/turf/simulated/floor,
+/area/station/cargo/office)
 "aAO" = (
 /obj/structure/table,
 /obj/item/weapon/storage/toolbox/electrical{
@@ -15336,16 +15333,10 @@
 	},
 /area/station/storage/tech/north)
 "aAR" = (
-/obj/structure/table,
-/obj/item/weapon/kitchen/rollingpin,
-/obj/item/weapon/reagent_containers/glass/beaker{
-	pixel_x = 5
-	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "delivery"
 	},
-/area/station/civilian/kitchen)
+/area/station/cargo/storage)
 "aAS" = (
 /turf/simulated/floor/plating{
 	icon_state = "platingdmg1"
@@ -15395,20 +15386,11 @@
 /turf/simulated/floor/plating,
 /area/station/security/lobby)
 "aAX" = (
-/obj/structure/table,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -24
+/obj/structure/disposalpipe/sortjunction/untagged{
+	dir = 8
 	},
-/obj/item/weapon/book/manual/wiki/chefs_recipes,
-/obj/machinery/camera{
-	c_tag = "Kitchen";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
+/turf/simulated/wall,
+/area/station/cargo/storage)
 "aAY" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
@@ -15465,9 +15447,24 @@
 	},
 /area/station/hallway/primary/central)
 "aBd" = (
-/obj/item/airbag,
-/turf/environment/space,
-/area/space)
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	icon_state = "shutter0";
+	id = "kitchen";
+	name = "Kitchen Shutters";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/item/weapon/reagent_containers/food/snacks/mint,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "aBe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15507,15 +15504,12 @@
 /turf/simulated/floor/beach/water/waterpool,
 /area/station/civilian/gym)
 "aBi" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/soda{
-	pixel_y = 4
-	},
+/obj/machinery/computer/cargo,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	dir = 1;
+	icon_state = "brown"
 	},
-/area/station/civilian/kitchen)
+/area/station/cargo/qm)
 "aBj" = (
 /obj/machinery/camera{
 	c_tag = "EVA Maintenance";
@@ -15830,22 +15824,16 @@
 	},
 /area/station/civilian/dormitories)
 "aBN" = (
-/obj/structure/table,
-/obj/machinery/power/apc{
-	name = "Kitchen APC";
-	pixel_y = -26
+/obj/structure/stool/bed/chair/metal/yellow,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23
 	},
-/obj/structure/cable,
-/obj/item/weapon/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/weapon/packageWrap,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	dir = 1;
+	icon_state = "brown"
 	},
-/area/station/civilian/kitchen)
+/area/station/cargo/office)
 "aBO" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -15968,14 +15956,19 @@
 	},
 /area/station/ai_monitored/eva)
 "aBW" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
-	d1 = 1;
 	d2 = 4;
-	icon_state = "1-4"
+	icon_state = "0-4"
 	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Cargo Maintenance APC";
+	pixel_x = -24;
+	pixel_y = -1
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/area/station/maintenance/cargo)
 "aBX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -15987,14 +15980,10 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "aBY" = (
-/obj/structure/table,
-/obj/machinery/light,
-/obj/machinery/reagentgrinder,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/mob/living/simple_animal/walle,
+/turf/simulated/floor,
+/area/station/cargo/qm)
 "aBZ" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -16006,13 +15995,20 @@
 	},
 /area/station/security/prison)
 "aCa" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Kitchen APC";
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor{
 	dir = 5;
-	icon_state = "brown"
+	icon_state = "cafeteria"
 	},
-/area/station/cargo/qm)
+/area/station/civilian/kitchen)
 "aCb" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -16038,18 +16034,23 @@
 /turf/simulated/floor,
 /area/station/cargo/office)
 "aCe" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -16063,17 +16064,10 @@
 	},
 /area/station/civilian/holodeck/alphadeck)
 "aCg" = (
-/obj/machinery/requests_console/cargo_bay{
-	pixel_x = -30
-	},
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "brown"
+	icon_state = "bot"
 	},
-/area/station/cargo/qm)
+/area/station/cargo/office)
 "aCh" = (
 /obj/structure/rack,
 /obj/item/weapon/wrench,
@@ -16125,11 +16119,13 @@
 	},
 /area/station/rnd/tox_launch)
 "aCn" = (
-/obj/structure/stool/bed/chair/comfy/black{
-	dir = 4
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/simulated/floor/carpet,
-/area/station/civilian/bar)
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "aCo" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -16290,19 +16286,19 @@
 	},
 /area/station/hallway/primary/fore)
 "aCI" = (
-/turf/simulated/floor,
-/area/station/cargo/qm)
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/station/civilian/kitchen)
 "aCJ" = (
-/obj/structure/disposalpipe/segment,
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 28
+/obj/structure/kitchenspike,
+/obj/machinery/camera{
+	c_tag = "Kitchen Cold Room"
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
+	icon_state = "showroomfloor"
 	},
-/area/station/cargo/qm)
+/area/station/civilian/kitchen)
 "aCK" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -16526,7 +16522,6 @@
 "aDg" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/razor,
-/obj/item/device/camera/polar,
 /turf/simulated/floor/wood,
 /area/station/maintenance/chapel)
 "aDh" = (
@@ -16720,13 +16715,9 @@
 /turf/simulated/floor/carpet,
 /area/station/civilian/chapel)
 "aDw" = (
-/obj/structure/stool/bed/chair/comfy/brown{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
+/obj/structure/filingcabinet,
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
 "aDx" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -16746,19 +16737,15 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "aDz" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/refined_scrap,
+/turf/simulated/floor{
+	icon_state = "bot"
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/civilian/bar)
+/area/station/cargo/storage)
 "aDA" = (
 /obj/effect/spawner/lootdrop/maintenance/three,
 /obj/structure/closet/theatrecloset,
@@ -16840,15 +16827,21 @@
 	},
 /area/station/ai_monitored/eva)
 "aDI" = (
-/obj/machinery/vending/dinnerware,
-/obj/machinery/newscaster{
-	pixel_x = -30
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/area/station/civilian/kitchen)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/station/maintenance/cargo)
 "aDJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
@@ -16922,16 +16915,15 @@
 	},
 /area/station/hallway/primary/fore)
 "aDQ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/table,
+/obj/machinery/kitchen_machine/microwave{
+	pixel_x = -3;
+	pixel_y = 6
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
+/turf/simulated/floor{
+	icon_state = "cafeteria"
 	},
-/turf/simulated/floor/plating,
-/area/station/civilian/bar)
+/area/station/civilian/kitchen)
 "aDR" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -17055,8 +17047,15 @@
 /turf/simulated/floor/plating,
 /area/station/storage/tech/north)
 "aEh" = (
-/turf/simulated/floor/wood,
-/area/station/civilian/bar)
+/obj/machinery/power/apc{
+	name = "Port Hall APC";
+	pixel_y = -26
+	},
+/obj/structure/cable,
+/turf/simulated/floor{
+	icon_state = "browncorner"
+	},
+/area/station/hallway/primary/port)
 "aEi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -17128,33 +17127,27 @@
 	},
 /area/station/maintenance/atmos)
 "aEr" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/pen/blue{
-	pixel_x = 2;
-	pixel_y = 6
+/obj/structure/plasticflaps{
+	opacity = 1
 	},
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = 32
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=1";
+	freq = 1400;
+	location = "Kitchen"
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "darkred"
-	},
-/area/station/civilian/bar)
-"aEs" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "bot"
 	},
-/obj/structure/window/reinforced{
-	dir = 4
+/area/station/civilian/kitchen)
+"aEs" = (
+/obj/machinery/status_display{
+	pixel_y = 2;
+	supply_display = 1
 	},
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/station/cargo/office)
+/turf/simulated/wall,
+/area/station/cargo/qm)
 "aEt" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 8
@@ -17223,14 +17216,13 @@
 	},
 /area/station/security/main)
 "aEz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/civilian/bar)
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
 "aEA" = (
 /obj/machinery/door/airlock/maintenance{
 	req_one_access = list(11,12)
@@ -17305,48 +17297,57 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "aEJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=8";
+	freq = 1400;
+	location = "QM #4"
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "green"
+	icon_state = "bot"
 	},
-/area/station/civilian/hydroponics)
+/area/station/cargo/storage)
 "aEK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/mining/glass{
+	name = "Delivery Office";
+	req_access = list(50)
 	},
-/turf/simulated/floor{
-	icon_state = "green"
-	},
-/area/station/civilian/hydroponics)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor,
+/area/station/cargo/office)
 "aEL" = (
-/obj/machinery/atm{
-	pixel_y = -32
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
+"aEM" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id = "Bar";
+	name = "Bar Shutters";
+	opacity = 0
+	},
+/obj/item/weapon/flora/pottedplant/shoot{
+	pixel_x = -8;
+	pixel_y = 16
 	},
 /turf/simulated/floor{
-	icon_state = "neutralcorner"
+	icon_state = "grimy"
 	},
-/area/station/hallway/secondary/entry)
-"aEM" = (
-/obj/machinery/power/apc{
-	name = "Port Maintenance APC";
-	pixel_y = -24
-	},
-/obj/structure/cable,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/civilian/bar)
 "aEN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -17445,18 +17446,19 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "aET" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/obj/machinery/light_switch{
-	pixel_x = -30
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/obj/machinery/vending/boozeomat,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/station/civilian/bar)
+/turf/simulated/floor,
+/area/station/cargo/miningoffice)
 "aEU" = (
 /obj/machinery/optable,
 /obj/effect/decal/cleanable/vomit,
@@ -17570,11 +17572,13 @@
 	},
 /area/station/medical/hallway)
 "aFf" = (
-/obj/structure/flora/ausbushes/ppflowers{
-	pixel_x = 11
+/obj/structure/grille,
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
+	name = "KEEP CLEAR: DOCKING AREA"
 	},
-/turf/simulated/floor/grass,
-/area/station/civilian/hydroponics)
+/turf/environment/space,
+/area/space)
 "aFg" = (
 /turf/simulated/wall,
 /area/station/cargo/storage)
@@ -17615,11 +17619,13 @@
 	},
 /area/station/maintenance/eva)
 "aFl" = (
-/mob/living/simple_animal/cow{
-	name = "Betsy"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/grass,
-/area/station/civilian/hydroponics)
+/turf/simulated/floor,
+/area/station/cargo/office)
 "aFm" = (
 /obj/effect/landmark{
 	name = "blobstart"
@@ -17633,11 +17639,9 @@
 	},
 /area/station/civilian/toilet)
 "aFn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/simulated/floor/grass,
-/area/station/civilian/hydroponics)
+/turf/simulated/floor,
+/area/station/cargo/office)
 "aFo" = (
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/science)
@@ -17852,15 +17856,9 @@
 /turf/simulated/wall,
 /area/station/security/checkpoint)
 "aFH" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/civilian/hydroponics)
+/obj/structure/closet/toolcloset,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "aFI" = (
 /obj/machinery/portable_atmospherics/canister/hydrogen,
 /turf/simulated/floor{
@@ -17868,15 +17866,19 @@
 	},
 /area/station/rnd/storage)
 "aFJ" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
+/obj/structure/rack,
+/obj/item/weapon/module/power_control,
+/obj/item/weapon/stock_parts/cell{
+	maxcharge = 2000
 	},
-/obj/machinery/hydroponics/constructable,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "floorgrime"
 	},
-/area/station/civilian/hydroponics)
+/area/station/cargo/storage)
 "aFK" = (
 /obj/structure/sink{
 	dir = 8;
@@ -17917,20 +17919,14 @@
 	},
 /area/station/medical/genetics_cloning)
 "aFO" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/structure/sign/monkey_painting{
-	pixel_y = 32
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/mob/living/carbon/monkey/punpun,
-/turf/simulated/floor/wood,
-/area/station/civilian/bar)
+/area/station/civilian/kitchen)
 "aFP" = (
 /obj/structure/noticeboard{
 	pixel_y = 32
@@ -17943,28 +17939,19 @@
 	},
 /area/station/security/main)
 "aFQ" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/effect/landmark/start/assistant/waiter,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
-	},
-/area/station/civilian/bar)
+/obj/structure/table/woodentable,
+/obj/item/device/flashlight/lamp/green,
+/turf/simulated/floor/carpet/black,
+/area/station/security/vacantoffice)
 "aFR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor,
 /area/station/civilian/fitness)
 "aFS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/civilian/bar)
+/obj/structure/table/woodentable,
+/obj/item/weapon/paper_bin,
+/turf/simulated/floor/carpet/black,
+/area/station/security/vacantoffice)
 "aFT" = (
 /obj/machinery/computer/secure_data,
 /turf/simulated/floor{
@@ -18145,14 +18132,16 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "aGk" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/structure/stool/bed/chair/comfy/black{
+	dir = 8
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/station/civilian/bar)
+/turf/simulated/floor/carpet/black,
+/area/station/security/vacantoffice)
 "aGl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/stool,
@@ -18453,6 +18442,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "aGN" = (
@@ -18474,15 +18464,20 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "aGQ" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Office";
-	req_access = list(50)
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor,
-/area/station/cargo/office)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "aGR" = (
 /obj/machinery/computer/arcade,
 /turf/simulated/floor/plating,
@@ -18596,12 +18591,11 @@
 	},
 /area/station/maintenance/science)
 "aHc" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	icon_state = "neutralcorner"
+	icon_state = "arrivalcorner"
 	},
 /area/station/hallway/secondary/entry)
 "aHd" = (
@@ -18631,10 +18625,10 @@
 /obj/structure/table/woodentable,
 /obj/item/device/camera_film,
 /obj/item/device/camera_film,
+/obj/item/device/camera,
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/item/device/camera/polar,
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
 "aHh" = (
@@ -19003,6 +18997,10 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "aHV" = (
@@ -19352,7 +19350,6 @@
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/item/device/lens/invert,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "aIA" = (
@@ -19393,16 +19390,11 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
 "aID" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "escapecorner"
 	},
-/obj/machinery/windowtint{
-	id = "privateoffice";
-	pixel_y = 25
-	},
-/turf/simulated/floor/wood,
-/area/station/security/vacantoffice)
+/area/station/civilian/bar)
 "aIE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19621,22 +19613,28 @@
 	},
 /area/station/security/range)
 "aIY" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/requests_console{
+	department = "Locker Room";
+	pixel_y = 32
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/cargo/office)
-"aIZ" = (
-/obj/structure/table/glass,
-/obj/item/weapon/storage/fancy/crayons,
 /turf/simulated/floor,
 /area/station/civilian/locker)
+"aIZ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/light_switch{
+	pixel_x = 27
+	},
+/turf/simulated/floor,
+/area/station/cargo/office)
 "aJa" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -19823,13 +19821,11 @@
 /turf/simulated/floor,
 /area/station/civilian/janitor)
 "aJs" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/stool/bed/chair/comfy/brown{
+	dir = 4
 	},
-/obj/structure/table/glass,
-/obj/item/weapon/razor,
-/turf/simulated/floor,
-/area/station/civilian/locker)
+/turf/simulated/floor/carpet/blue,
+/area/station/civilian/bar)
 "aJt" = (
 /obj/machinery/status_display{
 	layer = 4;
@@ -20105,17 +20101,10 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "aJT" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=CHW";
-	location = "Bar"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -20218,12 +20207,6 @@
 	},
 /area/station/maintenance/atmos)
 "aKb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -20231,6 +20214,12 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor/goonplaque,
 /area/station/hallway/secondary/entry)
@@ -20497,14 +20486,17 @@
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
 "aKF" = (
-/obj/structure/stool/bed/chair/comfy/brown{
+/obj/structure/grille,
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "brown"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/area/station/cargo/storage)
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/cargo/miningbreaktime)
 "aKG" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -21130,6 +21122,7 @@
 /area/station/maintenance/chapel)
 "aLG" = (
 /obj/structure/rack,
+/obj/item/device/camera,
 /obj/item/device/camera_film,
 /obj/item/device/camera_film,
 /turf/simulated/floor/wood{
@@ -21173,12 +21166,13 @@
 	},
 /area/station/maintenance/engineering)
 "aLK" = (
-/obj/machinery/light{
+/obj/structure/stool/bed/chair/office/dark{
 	dir = 4
 	},
-/obj/structure/closet/secure_closet/hydroponics,
-/turf/simulated/floor/grass,
-/area/station/civilian/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/landmark/start/cargo_technician,
+/turf/simulated/floor,
+/area/station/cargo/office)
 "aLL" = (
 /obj/effect/decal/cleanable/spiderling_remains,
 /turf/simulated/floor/plating,
@@ -21238,15 +21232,16 @@
 	},
 /area/station/civilian/gym)
 "aLT" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "qm_warehouse";
-	name = "Warehouse Shutters"
+/obj/machinery/power/apc{
+	name = "Law Office APC";
+	pixel_y = -24
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	icon_state = "floorgrime"
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/area/station/cargo/storage)
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "aLU" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid/regular,
@@ -21259,14 +21254,16 @@
 	name = "Recycler's workplace";
 	req_access = list(67)
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "aLW" = (
 /obj/structure/table,
@@ -21344,7 +21341,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "neutralcorner"
+	icon_state = "greencorner"
 	},
 /area/station/hallway/secondary/entry)
 "aMc" = (
@@ -21394,17 +21391,14 @@
 	},
 /area/station/ai_monitored/eva)
 "aMg" = (
-/obj/item/device/radio/intercom{
-	dir = 0;
-	name = "Station Intercom (General)";
-	pixel_x = 27
-	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/table,
+/obj/item/weapon/folder/yellow,
+/obj/item/weapon/packageWrap,
+/obj/machinery/light,
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "browncorner"
+	icon_state = "brown"
 	},
-/area/station/cargo/storage)
+/area/station/cargo/miningoffice)
 "aMh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -21456,14 +21450,14 @@
 	},
 /area/station/maintenance/eva)
 "aMl" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
-/obj/structure/sign/poster/official/space_cops{
-	pixel_x = 32
-	},
-/turf/simulated/floor/wood,
-/area/station/security/vacantoffice)
+/area/station/civilian/bar)
 "aMm" = (
 /obj/item/weapon/shard,
 /turf/simulated/floor/plating,
@@ -21477,13 +21471,15 @@
 	},
 /area/station/rnd/mixing)
 "aMo" = (
-/obj/structure/table/glass,
-/obj/item/clothing/head/soft/grey,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/table/woodentable,
+/obj/item/device/flashlight/lamp/green,
+/obj/item/ashtray/bronze,
+/obj/item/weapon/lighter/zippo{
+	pixel_x = -5;
+	pixel_y = 5
 	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
+/turf/simulated/floor/carpet/blue,
+/area/station/civilian/bar)
 "aMp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -21754,17 +21750,14 @@
 	},
 /area/station/hallway/primary/central)
 "aMQ" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/window/eastleft{
-	name = "Hydroponics";
-	req_access = list(35)
+/obj/machinery/autolathe,
+/obj/machinery/light_switch{
+	pixel_y = -28
 	},
 /turf/simulated/floor{
-	icon_state = "delivery"
+	icon_state = "brown"
 	},
-/area/station/civilian/hydroponics)
+/area/station/cargo/office)
 "aMR" = (
 /turf/simulated/wall,
 /area/station/hallway/primary/central)
@@ -21775,21 +21768,15 @@
 	},
 /area/station/hallway/primary/central)
 "aMT" = (
-/obj/structure/sign/warning/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector{
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/plating{
-	icon_state = "platebotc"
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "green"
 	},
-/area/station/maintenance/cargo)
+/area/station/civilian/hydroponics)
 "aMU" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/firstaid/regular{
@@ -21826,9 +21813,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "aMX" = (
-/obj/item/weapon/reagent_containers/glass/bucket,
-/turf/simulated/floor/grass,
-/area/station/civilian/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/station/cargo/office)
 "aMY" = (
 /obj/machinery/light{
 	dir = 1
@@ -21935,30 +21924,24 @@
 	},
 /area/station/civilian/fitness)
 "aNk" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/eastright{
-	name = "Kitchen";
-	req_access = list(28)
+/obj/structure/stool/bed/chair/metal/yellow,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	dir = 1;
+	icon_state = "brown"
 	},
-/area/station/civilian/bar)
+/area/station/cargo/office)
 "aNl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+	dir = 10
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/structure/stool/bed/chair/comfy/black{
+	dir = 1
 	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
 "aNm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -21970,17 +21953,9 @@
 	},
 /area/station/security/prison)
 "aNn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
-	},
-/area/station/civilian/bar)
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor/carpet/black,
+/area/station/security/vacantoffice)
 "aNo" = (
 /turf/simulated/floor{
 	icon_state = "black"
@@ -22046,14 +22021,28 @@
 	},
 /area/station/rnd/brainstorm_center)
 "aNv" = (
-/turf/simulated/floor/grass,
-/area/station/civilian/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/computer/guestpass{
+	dir = 8;
+	pixel_x = -28
+	},
+/turf/simulated/floor,
+/area/station/cargo/office)
 "aNw" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "browncorner"
+	dir = 4;
+	icon_state = "arrival"
 	},
 /area/station/hallway/secondary/entry)
 "aNx" = (
@@ -22189,16 +22178,16 @@
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
 "aNK" = (
-/obj/structure/grille,
 /obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Bay";
+	req_one_access = list(31,48,67)
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/civilian/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/station/cargo/storage)
 "aNL" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/camera{
@@ -22370,12 +22359,14 @@
 	},
 /area/station/hallway/primary/central)
 "aOb" = (
-/obj/structure/table,
-/obj/item/weapon/folder/brown,
-/obj/item/weapon/clipboard,
-/obj/item/weapon/stamp/qm,
-/turf/simulated/floor,
-/area/station/cargo/qm)
+/obj/structure/dryer{
+	dir = 4;
+	pixel_x = -6
+	},
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/station/civilian/kitchen)
 "aOc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -22506,18 +22497,13 @@
 /turf/environment/space,
 /area/shuttle/mining/station)
 "aOo" = (
-/obj/structure/stool/bed/chair/metal/yellow{
-	dir = 8
-	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 30
-	},
+/obj/structure/table,
+/obj/item/weapon/packageWrap,
 /turf/simulated/floor{
 	dir = 5;
-	icon_state = "brown"
+	icon_state = "cafeteria"
 	},
-/area/station/cargo/office)
+/area/station/civilian/kitchen)
 "aOp" = (
 /obj/structure/table/glass,
 /obj/item/weapon/paper_bin,
@@ -22650,10 +22636,20 @@
 	},
 /area/station/gateway)
 "aOD" = (
-/turf/simulated/floor{
-	icon_state = "greencorner"
+/obj/structure/table/reinforced,
+/obj/item/weapon/lighter/zippo,
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id = "Bar";
+	name = "Bar Shutters";
+	opacity = 0
 	},
-/area/station/hallway/primary/port)
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/bar)
 "aOE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22693,32 +22689,32 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "aOH" = (
-/obj/structure/table,
-/obj/machinery/computer/stockexchange,
-/turf/simulated/floor,
-/area/station/cargo/qm)
-"aOI" = (
-/obj/machinery/camera{
-	c_tag = "Quartermaster's Office";
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atm{
-	pixel_x = 32
+/obj/effect/landmark{
+	name = "xeno_spawn";
+	pixel_x = -1
 	},
 /turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/station/civilian/kitchen)
+"aOI" = (
+/obj/structure/sink{
 	dir = 4;
+	pixel_x = 12
+	},
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/station/civilian/kitchen)
+"aOJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
 	icon_state = "brown"
 	},
-/area/station/cargo/qm)
-"aOJ" = (
-/obj/machinery/camera{
-	c_tag = "Hydroponics Pasture";
-	dir = 1
-	},
-/obj/structure/chicken_feeder,
-/turf/simulated/floor/grass,
-/area/station/civilian/hydroponics)
+/area/station/cargo/office)
 "aOK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -22903,12 +22899,13 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/port)
 "aOY" = (
-/obj/item/weapon/cigbutt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/lizard{
-	name = "Lizzy"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "aOZ" = (
 /obj/machinery/firealarm{
@@ -23334,12 +23331,18 @@
 	},
 /area/station/storage/tools)
 "aPP" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/structure/sign/poster{
+	official = 1;
+	pixel_x = 30
 	},
-/turf/simulated/floor/wood,
-/area/station/security/vacantoffice)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/civilian/bar)
 "aPQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -23471,16 +23474,10 @@
 	},
 /area/station/civilian/garden)
 "aQc" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken"
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/civilian/hydroponics)
+/area/station/security/vacantoffice)
 "aQd" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/simulated/floor{
@@ -23568,36 +23565,19 @@
 	},
 /area/station/civilian/garden)
 "aQm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
-"aQn" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -28
-	},
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 12
+/obj/structure/stool/bed/chair/comfy/black{
+	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "dark"
 	},
-/area/station/civilian/kitchen)
+/area/station/civilian/bar)
+"aQn" = (
+/obj/structure/table,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/computer/stockexchange,
+/turf/simulated/floor,
+/area/station/cargo/qm)
 "aQo" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -23620,14 +23600,18 @@
 	},
 /area/station/rnd/hor)
 "aQq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/machinery/chem_master/condimaster{
+	name = "CondiMaster Neo";
+	pixel_x = -5
 	},
-/mob/living/simple_animal/walle,
-/turf/simulated/floor,
-/area/station/cargo/qm)
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/station/civilian/kitchen)
 "aQr" = (
 /turf/simulated/floor{
 	dir = 9;
@@ -23994,20 +23978,15 @@
 /turf/simulated/floor,
 /area/station/civilian/locker)
 "aQY" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/table/woodentable,
+/obj/item/device/flashlight/lamp/green{
+	on = 0;
+	pixel_x = -3;
+	pixel_y = 8
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/civilian/bar)
+/obj/item/clothing/suit/superman,
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "aQZ" = (
 /obj/structure/closet/lasertag/blue,
 /turf/simulated/floor{
@@ -24103,31 +24082,29 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "aRi" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
+/obj/machinery/gibber,
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
+	icon_state = "showroomfloor"
 	},
-/area/station/cargo/qm)
+/area/station/civilian/kitchen)
 "aRj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/door/airlock{
+	name = "Private Office"
 	},
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/area/station/hallway/primary/central)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
 "aRk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -24151,14 +24128,14 @@
 	},
 /area/station/rnd/brainstorm_center)
 "aRm" = (
-/obj/machinery/vending/clothing,
-/turf/simulated/floor,
-/area/station/civilian/locker)
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "aRn" = (
 /turf/simulated/wall,
 /area/station/hallway/secondary/exit)
 "aRo" = (
-/obj/structure/displaycase/labcage,
+/obj/structure/lamarr,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -24558,27 +24535,30 @@
 	},
 /area/station/security/checkpoint)
 "aRY" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 30
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/item/weapon/flora/random,
-/turf/simulated/floor/wood,
-/area/station/security/vacantoffice)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/civilian/bar)
 "aRZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/security/checkpoint)
 "aSa" = (
-/obj/structure/closet/crate/medical,
-/obj/machinery/camera{
-	c_tag = "Cargo Bay Storage";
-	dir = 0
-	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor,
 /area/station/cargo/storage)
 "aSb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -24587,16 +24567,26 @@
 /turf/simulated/floor,
 /area/station/security/main)
 "aSc" = (
-/obj/structure/rack,
-/obj/item/weapon/module/power_control,
-/obj/item/weapon/stock_parts/cell{
-	maxcharge = 2000
+/obj/structure/table,
+/obj/item/device/camera,
+/obj/item/device/taperecorder{
+	pixel_y = -10
 	},
-/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/dice{
+	pixel_x = 3;
+	pixel_y = 2
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Bar APC";
+	pixel_x = -24;
+	pixel_y = -1
+	},
+/obj/structure/cable,
 /turf/simulated/floor{
-	icon_state = "floorgrime"
+	icon_state = "dark"
 	},
-/area/station/cargo/storage)
+/area/station/civilian/bar)
 "aSd" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
@@ -25279,23 +25269,12 @@
 	},
 /area/station/civilian/chapel/office)
 "aTp" = (
-/obj/structure/closet/gmcloset{
-	name = "formal wardrobe"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/obj/item/weapon/book/manual/wiki/barman_recipes{
-	pixel_y = 10
+/turf/simulated/floor{
+	icon_state = "dark"
 	},
-/obj/item/device/eftpos{
-	eftpos_name = "Bar EFTPOS scanner"
-	},
-/obj/item/device/radio/intercom{
-	pixel_x = -25
-	},
-/obj/machinery/camera{
-	c_tag = "Bar Backroom";
-	dir = 4
-	},
-/turf/simulated/floor/wood,
 /area/station/civilian/bar)
 "aTq" = (
 /obj/structure/window/reinforced/polarized{
@@ -25498,18 +25477,14 @@
 	},
 /area/station/security/checkpoint)
 "aTH" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/soda{
-	dir = 4
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+	icon_state = "bar"
 	},
-/area/station/civilian/bar)
+/area/station/cargo/miningbreaktime)
 "aTI" = (
 /obj/structure/reagent_dispensers/acid{
 	density = 0;
@@ -25888,18 +25863,20 @@
 	},
 /area/station/rnd/hor)
 "aUs" = (
-/obj/structure/closet/wardrobe/xenos,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1379;
+	master_tag = "arrival_dock_airlock";
+	name = "interior access button";
+	pixel_x = -20;
+	pixel_y = -20;
+	req_one_access = list(13,45,1)
 	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
-/area/station/civilian/locker)
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "aUt" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -25912,16 +25889,11 @@
 /turf/simulated/floor,
 /area/station/rnd/misc_lab)
 "aUu" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/civilian/bar)
+/obj/structure/table/woodentable,
+/obj/item/weapon/folder,
+/obj/item/weapon/pen,
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
 "aUv" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
@@ -26321,14 +26293,12 @@
 	},
 /area/station/medical/cryo)
 "aVf" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/civilian/hydroponics)
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "aVg" = (
 /turf/simulated/floor,
 /area/station/civilian/hydroponics)
@@ -26561,17 +26531,18 @@
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/medbay)
 "aVG" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/item/weapon/stamp/denied{
+	pixel_x = 4;
+	pixel_y = -2
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/item/weapon/stamp/approve{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/station/civilian/bar)
+/obj/structure/table,
+/obj/item/weapon/folder/brown,
+/turf/simulated/floor,
+/area/station/cargo/office)
 "aVH" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -26667,26 +26638,31 @@
 	},
 /area/station/cargo/qm)
 "aVO" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/closet/crate/freezer,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/cargo/qm)
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/station/civilian/kitchen)
 "aVP" = (
-/obj/machinery/hologram/holopad,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/turf/simulated/floor,
-/area/station/cargo/qm)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/station/civilian/kitchen)
 "aVQ" = (
 /obj/structure/window/reinforced{
 	dir = 5
@@ -27094,6 +27070,10 @@
 	pixel_x = -24
 	},
 /obj/structure/table,
+/obj/item/device/camera{
+	pixel_x = -2;
+	pixel_y = 5
+	},
 /obj/item/weapon/paper/pamphlet{
 	pixel_x = 9;
 	pixel_y = 1
@@ -27135,25 +27115,22 @@
 	},
 /area/station/civilian/kitchen)
 "aWx" = (
-/obj/structure/stool/bed/chair/metal/yellow{
-	dir = 8
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 5
 	},
-/obj/machinery/camera{
-	c_tag = "Cargo Lobby";
-	dir = 8
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/station/cargo/office)
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "aWy" = (
-/obj/structure/table/reinforced,
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
 /turf/simulated/floor{
-	dir = 4;
 	icon_state = "dark"
 	},
-/area/station/civilian/bar)
+/area/station/civilian/hydroponics)
 "aWz" = (
 /obj/item/weapon/crowbar,
 /obj/item/device/flash,
@@ -27182,16 +27159,15 @@
 	},
 /area/station/security/checkpoint)
 "aWB" = (
-/obj/structure/rack,
-/obj/machinery/requests_console/private_office{
-	pixel_x = -30
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/obj/item/weapon/storage/briefcase/centcomm{
-	pixel_y = 6
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
 	},
-/obj/item/weapon/storage/briefcase,
-/turf/simulated/floor/wood,
-/area/station/security/vacantoffice)
+/area/station/cargo/qm)
 "aWC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -27400,14 +27376,13 @@
 /turf/simulated/wall,
 /area/station/security/vacantoffice)
 "aWX" = (
-/obj/item/device/flashlight/lamp/fir,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 1;
+	name = "Bar";
+	sortType = "Bar"
 	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
-/area/station/cargo/storage)
+/turf/simulated/floor/carpet,
+/area/station/civilian/bar)
 "aWY" = (
 /obj/machinery/light,
 /turf/simulated/floor{
@@ -27716,12 +27691,23 @@
 	},
 /area/station/medical/cmo)
 "aXz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate,
-/turf/simulated/floor{
-	icon_state = "floorgrime"
+/obj/structure/closet/gmcloset{
+	name = "formal wardrobe"
 	},
-/area/station/cargo/storage)
+/obj/item/weapon/book/manual/wiki/barman_recipes{
+	pixel_y = 10
+	},
+/obj/item/device/eftpos{
+	eftpos_name = "Bar EFTPOS scanner"
+	},
+/obj/item/device/radio/intercom{
+	pixel_x = -25
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/station/civilian/bar)
 "aXA" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -27796,7 +27782,6 @@
 /area/station/maintenance/chapel)
 "aXI" = (
 /obj/structure/table/woodentable,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/holywater,
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -27943,24 +27928,46 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "aXW" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 4
+	dir = 8
 	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
+/obj/structure/window/reinforced,
+/obj/structure/grille,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	icon_state = "shutter0";
+	id = "kitchen";
+	name = "Kitchen Shutters";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
-/area/station/cargo/office)
+/area/station/civilian/kitchen)
 "aXX" = (
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "aXY" = (
-/obj/structure/reagent_dispensers/water_cooler,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor,
-/area/station/civilian/locker)
+/area/station/hallway/primary/port)
 "aXZ" = (
 /turf/environment/space,
 /area/shuttle/transport1/station)
@@ -27984,10 +27991,21 @@
 /turf/simulated/floor/plating,
 /area/station/rnd/misc_lab)
 "aYb" = (
-/obj/structure/table/glass,
-/obj/item/weapon/storage/box/cups,
-/turf/simulated/floor,
-/area/station/civilian/locker)
+/obj/machinery/door/airlock/glass{
+	name = "Private Room"
+	},
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	icon_state = "shutter0";
+	id = "Bar_Privacy1";
+	name = "Privacy Shutters";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/bar)
 "aYc" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -28028,14 +28046,16 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "aYf" = (
-/obj/item/weapon/flora/pottedplant{
-	icon_state = "plant-22"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "aYg" = (
 /obj/item/stack/medical/bruise_pack{
 	pixel_x = 10;
@@ -28231,13 +28251,18 @@
 /turf/simulated/floor/carpet,
 /area/station/tcommsat/computer)
 "aYv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/mob/living/simple_animal/chicken{
-	name = "Commander Clucky"
+/obj/structure/table,
+/obj/item/weapon/folder/yellow,
+/obj/item/device/eftpos{
+	eftpos_name = "Cargo Bay EFTPOS scanner"
 	},
-/turf/simulated/floor/grass,
-/area/station/civilian/hydroponics)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "brown"
+	},
+/area/station/cargo/office)
 "aYw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -28256,13 +28281,25 @@
 	},
 /area/station/hallway/secondary/entry)
 "aYy" = (
-/obj/structure/closet/secure_closet/hydroponics,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
+/obj/structure/table,
+/obj/item/weapon/storage/belt/utility,
+/obj/machinery/newscaster{
+	pixel_y = -28
 	},
-/turf/simulated/floor/grass,
-/area/station/civilian/hydroponics)
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/storage/fancy/cigarettes{
+	pixel_x = -4
+	},
+/obj/item/weapon/lighter/random{
+	pixel_x = 5
+	},
+/turf/simulated/floor{
+	icon_state = "brown"
+	},
+/area/station/cargo/office)
 "aYz" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -28297,10 +28334,15 @@
 	},
 /area/station/maintenance/medbay)
 "aYC" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/effect/landmark/start/botanist,
-/turf/simulated/floor/grass,
-/area/station/civilian/hydroponics)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor{
+	icon_state = "brown"
+	},
+/area/station/cargo/office)
 "aYD" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Quartermaster";
@@ -28623,20 +28665,16 @@
 /turf/simulated/floor/carpet,
 /area/station/tcommsat/computer)
 "aZe" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -25
+/obj/structure/closet/secure_closet/personal,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -28
-	},
-/obj/item/weapon/flora/random,
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "vault"
 	},
-/area/station/civilian/bar)
+/area/station/civilian/locker)
 "aZf" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -29046,32 +29084,27 @@
 /turf/simulated/floor/carpet,
 /area/station/tcommsat/computer)
 "aZM" = (
-/obj/structure/closet/secure_closet/quartermaster,
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/structure/closet/crate{
+	desc = "It's a storage unit for kitchen clothes and equipment.";
+	name = "Kitchen Crate"
 	},
-/turf/simulated/floor{
-	icon_state = "brown"
-	},
-/area/station/cargo/qm)
-"aZN" = (
-/obj/structure/table,
-/obj/item/weapon/coin/silver{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/weapon/coin/silver,
+/obj/item/clothing/head/chefhat,
+/obj/item/clothing/under/rank/chef,
+/obj/item/weapon/storage/box/mousetraps,
+/obj/item/weapon/storage/box/mousetraps,
+/obj/item/clothing/under/waiter,
+/obj/item/clothing/under/waiter,
+/obj/item/clothing/under/sundress,
 /obj/item/device/eftpos{
-	eftpos_name = "Quartermaster EFTPOS scanner"
+	eftpos_name = "Kitchen EFTPOS scanner"
 	},
-/obj/machinery/newscaster{
-	pixel_y = -30
-	},
-/turf/simulated/floor{
-	icon_state = "brown"
-	},
-/area/station/cargo/qm)
+/turf/simulated/floor,
+/area/station/civilian/kitchen)
+"aZN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor,
+/area/station/civilian/kitchen)
 "aZO" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Research Director";
@@ -29384,9 +29417,6 @@
 	},
 /area/station/bridge/nuke_storage)
 "baq" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
 /obj/machinery/camera{
 	c_tag = "Arrival Dock's North";
 	dir = 8
@@ -29395,7 +29425,8 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "browncorner"
+	dir = 4;
+	icon_state = "arrival"
 	},
 /area/station/hallway/secondary/entry)
 "bar" = (
@@ -29440,9 +29471,9 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "bav" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_x = -32
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -29497,23 +29528,16 @@
 	},
 /area/station/aisat/teleport)
 "baB" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/eastright{
-	base_state = "left";
-	dir = 2;
-	icon_state = "left";
-	name = "Cargo Desk";
-	req_access = list(50)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/item/weapon/bell,
-/obj/machinery/status_display{
-	layer = 3.3;
-	pixel_x = -32;
-	supply_display = 1
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
 	},
-/turf/simulated/floor,
-/area/station/cargo/office)
+/area/station/civilian/kitchen)
 "baC" = (
 /obj/structure/flora/ausbushes/reedbush,
 /turf/simulated/floor/grass,
@@ -29587,9 +29611,14 @@
 /area/station/civilian/library)
 "baI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "baJ" = (
 /obj/machinery/light_switch{
@@ -29668,20 +29697,17 @@
 	},
 /area/station/engineering/engine)
 "baQ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/effect/landmark/start/chef,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
 	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/cargo/office)
+/area/station/civilian/kitchen)
 "baR" = (
 /obj/item/weapon/flora/pottedplant{
 	icon_state = "plant-6"
@@ -29741,18 +29767,19 @@
 /turf/simulated/floor,
 /area/station/gateway)
 "baX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 5
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Diner"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/turf/simulated/floor,
-/area/station/civilian/bar)
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
 "baY" = (
 /obj/machinery/door/airlock/external{
 	name = "Arrival Airlock"
@@ -29765,20 +29792,20 @@
 /turf/simulated/floor/carpet/blue2,
 /area/station/bridge/captain_quarters)
 "bba" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/firealarm{
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
 	dir = 4;
-	pixel_x = 24
+	icon_state = "shutter0";
+	id = "Bar";
+	name = "Bar Shutters";
+	opacity = 0
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/closet/crate,
+/obj/item/clothing/head/cakehat,
 /turf/simulated/floor{
-	icon_state = "floorgrime"
+	icon_state = "grimy"
 	},
-/area/station/cargo/storage)
+/area/station/civilian/bar)
 "bbb" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -29949,14 +29976,16 @@
 /turf/simulated/floor/plating,
 /area/station/cargo/office)
 "bbq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/door/airlock{
+	name = "Bar Backroom";
+	req_access = list(25)
 	},
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "grimy"
 	},
-/area/station/civilian/kitchen)
+/area/station/civilian/bar)
 "bbr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -30189,17 +30218,30 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/starboard)
 "bbN" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Coworking APC";
-	pixel_x = -26
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood,
-/area/station/security/vacantoffice)
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "bbO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -30257,8 +30299,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor{
-	icon_state = "browncorner"
+	icon_state = "greencorner"
 	},
 /area/station/hallway/secondary/entry)
 "bbU" = (
@@ -30594,11 +30639,14 @@
 	},
 /area/station/rnd/xenobiology)
 "bcw" = (
-/obj/structure/stool/bed/chair/office/dark,
-/turf/simulated/floor{
-	icon_state = "bar"
+/obj/machinery/light{
+	dir = 4
 	},
-/area/station/cargo/miningoffice)
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry)
 "bcx" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -30614,13 +30662,37 @@
 	},
 /area/station/tcommsat/chamber)
 "bcy" = (
+/obj/machinery/door/airlock/glass{
+	name = "Kitchen";
+	req_access = list(28)
+	},
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	icon_state = "shutter0";
+	id = "kitchen";
+	name = "Kitchen Shutters";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/black,
-/area/station/security/vacantoffice)
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "bcz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -30669,27 +30741,25 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "bcD" = (
-/obj/item/stack/sheet/wood,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/wood,
-/area/station/maintenance/cargo)
-"bcE" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Mining Equipment Maintenance";
-	req_access = list(48)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/floor,
+/area/station/cargo/storage)
+"bcE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25
 	},
 /turf/simulated/floor/plating,
-/area/station/cargo/miningoffice)
+/area/station/maintenance/cargo)
 "bcF" = (
 /obj/structure/closet{
 	name = "Evidence Closet"
 	},
+/obj/item/device/camera,
 /obj/item/device/taperecorder,
 /obj/item/weapon/storage/box/evidence,
 /turf/simulated/floor/wood,
@@ -30734,14 +30804,26 @@
 /turf/environment/space,
 /area/shuttle/escape_pod1/station)
 "bcK" = (
-/obj/machinery/hologram/holopad,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/carpet/black,
-/area/station/security/vacantoffice)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "escapecorner"
+	},
+/area/station/civilian/bar)
 "bcL" = (
 /obj/structure/window/reinforced{
 	dir = 5
@@ -31079,9 +31161,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "bdu" = (
-/obj/structure/girder,
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance{
+	name = "Kitchen Cold Room Maintenance";
+	req_access = list(28)
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/civilian/kitchen)
 "bdv" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -31132,10 +31220,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -31147,21 +31231,19 @@
 	},
 /area/station/hallway/secondary/entry)
 "bdB" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 4;
-	name = "Private Office";
-	sortType = "Private Office"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
@@ -31308,19 +31390,14 @@
 	},
 /area/station/hallway/primary/port)
 "bdO" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "yellow"
@@ -31341,13 +31418,18 @@
 	},
 /area/station/hallway/primary/port)
 "bdQ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/alarm{
 	pixel_y = 26
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -31404,27 +31486,15 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "bdX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "brown"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/port)
+/area/station/cargo/qm)
 "bdY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -31477,16 +31547,15 @@
 	},
 /area/station/hallway/primary/port)
 "bec" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/item/clothing/mask/gas/coloured,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/station/cargo/recycleroffice)
 "bed" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor{
@@ -31601,22 +31670,23 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/meeting_room)
 "beo" = (
-/obj/machinery/door/airlock{
-	name = "Bar Backroom";
-	req_access = list(25)
+/obj/structure/table,
+/obj/item/weapon/coin/silver{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/item/weapon/coin/silver,
+/obj/item/device/eftpos{
+	eftpos_name = "Quartermaster EFTPOS scanner"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+	icon_state = "brown"
 	},
-/area/station/civilian/bar)
+/area/station/cargo/qm)
 "bep" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -31832,44 +31902,33 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "beF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/item/weapon/flora/monkey,
+/obj/structure/window/reinforced,
+/obj/structure/closet,
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "neutral"
+	icon_state = "barber"
 	},
-/area/station/hallway/primary/central)
+/area/station/civilian/locker)
 "beG" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/civilian/bar)
-"beH" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
+"beH" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/port)
@@ -31878,15 +31937,21 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "beJ" = (
-/obj/machinery/washing_machine,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "barber"
+	icon_state = "dark"
 	},
-/area/station/civilian/locker)
+/area/station/civilian/bar)
 "beK" = (
 /obj/machinery/camera{
 	c_tag = "Central Hallway North-West"
@@ -32024,18 +32089,22 @@
 	},
 /area/station/rnd/hallway)
 "beW" = (
-/obj/machinery/washing_machine,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/door_control{
+	id = "Bar_Privacy1";
+	name = "Privacy Shutters";
+	pixel_y = 25;
+	req_access = list(25)
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "barber"
+	dir = 5;
+	icon_state = "vault"
 	},
-/area/station/civilian/locker)
+/area/station/civilian/bar)
 "beX" = (
 /obj/machinery/camera{
 	c_tag = "Research Division Mid";
@@ -32149,27 +32218,26 @@
 	},
 /area/station/civilian/locker)
 "bfh" = (
-/obj/machinery/computer/cargo/request{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 10;
-	icon_state = "brown"
+	icon_state = "delivery"
 	},
-/area/station/cargo/office)
+/area/station/cargo/storage)
 "bfi" = (
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/clipboard,
-/obj/item/weapon/pen/red,
-/obj/structure/table,
-/obj/machinery/requests_console/cargo_bay{
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/obj/machinery/requests_console{
+	department = "Kitchen";
+	departmentType = 2;
+	name = "Kitchen RC";
 	pixel_x = -30
 	},
 /turf/simulated/floor{
-	dir = 9;
-	icon_state = "brown"
+	dir = 5;
+	icon_state = "cafeteria"
 	},
-/area/station/cargo/office)
+/area/station/civilian/kitchen)
 "bfj" = (
 /obj/structure/flora/junglebush/large,
 /turf/simulated/floor/grass,
@@ -32241,10 +32309,20 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "bfn" = (
-/obj/structure/grille,
-/obj/item/weapon/shard,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/maintenance/engineering)
 "bfo" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -32630,7 +32708,7 @@
 "bfZ" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	icon_state = "neutralcorner"
+	icon_state = "greencorner"
 	},
 /area/station/hallway/secondary/entry)
 "bga" = (
@@ -32852,7 +32930,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor{
-	icon_state = "whitecorner"
+	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/port)
 "bgs" = (
@@ -32877,16 +32955,22 @@
 	},
 /area/station/medical/morgue)
 "bgu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "brown"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/station/cargo/miningoffice)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "bgv" = (
 /obj/machinery/ai_status_display{
 	pixel_y = 32
@@ -32987,15 +33071,16 @@
 	},
 /area/station/hallway/primary/port)
 "bgF" = (
-/obj/effect/landmark/start/cargo_technician,
-/obj/structure/stool/bed/chair/office/dark{
-	dir = 1
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "brown"
+	dir = 5;
+	icon_state = "cafeteria"
 	},
-/area/station/cargo/office)
+/area/station/civilian/kitchen)
 "bgG" = (
 /obj/item/weapon/hand_labeler,
 /obj/item/device/assembly/timer,
@@ -33017,20 +33102,20 @@
 /turf/simulated/floor/carpet/blue2,
 /area/station/bridge/meeting_room)
 "bgJ" = (
-/obj/machinery/computer/cargo,
+/obj/machinery/icecream_vat,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "brown"
+	dir = 5;
+	icon_state = "cafeteria"
 	},
-/area/station/cargo/office)
+/area/station/civilian/kitchen)
 "bgK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/table,
+/obj/item/weapon/book/manual/wiki/chefs_recipes,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "brown"
+	dir = 5;
+	icon_state = "cafeteria"
 	},
-/area/station/cargo/office)
+/area/station/civilian/kitchen)
 "bgL" = (
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=HoP";
@@ -33065,20 +33150,12 @@
 	},
 /area/station/tcommsat/chamber)
 "bgN" = (
-/obj/structure/stool/bed/chair/metal/yellow{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 30
-	},
+/obj/structure/closet/crate,
+/obj/random/tools/tool,
 /turf/simulated/floor{
-	dir = 6;
-	icon_state = "brown"
+	icon_state = "delivery"
 	},
-/area/station/cargo/office)
+/area/station/cargo/storage)
 "bgO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -33089,18 +33166,17 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "bgP" = (
-/obj/machinery/camera{
-	c_tag = "Arrival Dock's South 2";
+/obj/structure/grille,
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics)
 "bgQ" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/flora/deskferntrim,
@@ -33231,47 +33307,88 @@
 "bhc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
 "bhd" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 25
+/obj/structure/table,
+/obj/item/clothing/under/suit_jacket/female{
+	pixel_x = 3;
+	pixel_y = 1
+	},
+/obj/item/clothing/under/lawyer/oldman,
+/obj/item/clothing/under/suit_jacket/really_black{
+	pixel_x = -2
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "barber"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/civilian/locker)
 "bhe" = (
-/obj/machinery/camera{
-	c_tag = "Coworking";
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance{
+	name = "Bar Maintenance";
+	req_one_access = list(12,25,28)
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/bar)
+"bhf" = (
+/obj/structure/table/woodentable,
+/obj/machinery/reagentgrinder{
+	layer = 3.1;
+	pixel_y = 5
+	},
+/obj/structure/sign/warning/securearea{
+	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
+	icon_state = "monkey_painting";
+	name = "Mr. Deempisi portrait";
+	pixel_x = 28;
+	pixel_y = -4
+	},
+/obj/item/weapon/reagent_containers/food/drinks/flask/barflask{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/filingcabinet/chestdrawer/black,
-/turf/simulated/floor/wood,
-/area/station/security/vacantoffice)
-"bhf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/item/weapon/reagent_containers/food/drinks/flask/vacuumflask{
+	pixel_y = 10
+	},
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/lighter/zippo{
+	pixel_x = -5;
+	pixel_y = 5
+	},
+/turf/simulated/floor/carpet,
+/area/station/civilian/bar)
+"bhg" = (
 /turf/simulated/floor{
-	icon_state = "neutralcorner"
+	dir = 6;
+	icon_state = "neutral"
 	},
 /area/station/hallway/secondary/entry)
-"bhg" = (
-/turf/simulated/floor/carpet/black,
-/area/station/security/vacantoffice)
 "bhh" = (
+/obj/machinery/atm{
+	pixel_y = -32
+	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
-	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
 	},
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
@@ -33281,9 +33398,6 @@
 /obj/machinery/camera{
 	c_tag = "Arrival East";
 	dir = 1
-	},
-/obj/machinery/status_display{
-	pixel_y = -32
 	},
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
@@ -33346,28 +33460,35 @@
 	},
 /area/station/storage/emergency)
 "bhp" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
-	},
-/area/station/civilian/bar)
-"bhq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet/black,
-/area/station/security/vacantoffice)
+/turf/simulated/floor{
+	icon_state = "floorgrime"
+	},
+/area/station/cargo/storage)
+"bhq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/civilian/bar)
 "bhr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet/black,
-/area/station/security/vacantoffice)
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 1;
+	name = "Kitchen";
+	sortType = "Kitchen"
+	},
+/turf/simulated/floor,
+/area/station/civilian/bar)
 "bhs" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -33399,16 +33520,19 @@
 	},
 /area/station/medical/virology)
 "bhv" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/area/station/hallway/primary/central)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated,
+/area/station/security/vacantoffice)
 "bhw" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
@@ -33510,20 +33634,19 @@
 /turf/simulated/floor/whitegreed,
 /area/station/bridge/ai_upload)
 "bhH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/noticeboard/bar{
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/station/hallway/primary/central)
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
 "bhI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33581,14 +33704,18 @@
 	},
 /area/station/hallway/primary/central)
 "bhO" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/structure/rack,
+/obj/machinery/requests_console{
+	department = "Private Office";
+	name = "Private Office RC";
+	pixel_x = -30
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/obj/item/weapon/storage/briefcase/centcomm{
+	pixel_y = 6
+	},
+/obj/item/weapon/storage/briefcase,
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
 "bhP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -33609,9 +33736,9 @@
 	amount = 23
 	},
 /obj/item/stack/cable_coil/red,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/random/tools/tech_supply,
 /turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/area/station/maintenance/cargo)
 "bhS" = (
 /obj/machinery/camera{
 	c_tag = "Research Division West";
@@ -33754,10 +33881,9 @@
 "bie" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
@@ -33831,18 +33957,16 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "bil" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/book/manual/wiki/security_space_law,
-/obj/machinery/light/small{
-	dir = 4
+/obj/item/weapon/reagent_containers/food/drinks/flask/barflask{
+	pixel_y = 8
 	},
-/obj/machinery/status_display{
-	pixel_x = 32
+/obj/item/weapon/reagent_containers/glass/rag,
+/obj/item/weapon/reagent_containers/food/drinks/shaker,
+/obj/structure/table/reinforced,
+/turf/simulated/floor{
+	icon_state = "grimy"
 	},
-/obj/item/weapon/stamp/law,
-/turf/simulated/floor/wood,
-/area/station/security/vacantoffice)
+/area/station/civilian/bar)
 "bim" = (
 /obj/structure/extinguisher_cabinet/highrisk{
 	pixel_x = 30
@@ -33891,14 +34015,13 @@
 /area/station/maintenance/disposal)
 "bis" = (
 /turf/simulated/floor{
-	icon_state = "browncorner"
+	dir = 4;
+	icon_state = "arrival"
 	},
 /area/station/hallway/secondary/entry)
 "bit" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	icon_state = "browncorner"
+	icon_state = "arrival"
 	},
 /area/station/hallway/secondary/entry)
 "biu" = (
@@ -34101,15 +34224,11 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/meeting_room)
 "biP" = (
-/obj/structure/closet/wardrobe/black,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
 	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
-/area/station/civilian/locker)
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
 "biQ" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall,
@@ -34160,24 +34279,21 @@
 	pixel_x = 24
 	},
 /turf/simulated/floor{
-	icon_state = "browncorner"
+	dir = 4;
+	icon_state = "arrival"
 	},
 /area/station/hallway/secondary/entry)
 "biW" = (
-/obj/item/weapon/stamp/denied{
-	pixel_x = 4;
-	pixel_y = -2
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/item/weapon/stamp/approve{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/structure/table,
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "brown"
-	},
-/area/station/cargo/office)
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "biX" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -34202,16 +34318,20 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "bja" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/light_switch{
-	pixel_y = 28
+/obj/structure/table,
+/obj/item/weapon/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
 	},
 /turf/simulated/floor{
 	dir = 5;
-	icon_state = "brown"
+	icon_state = "cafeteria"
 	},
-/area/station/cargo/office)
+/area/station/civilian/kitchen)
 "bjb" = (
 /turf/simulated/floor/plating/airless{
 	dir = 1;
@@ -34383,13 +34503,17 @@
 /turf/simulated/floor/carpet/black,
 /area/station/security/iaa_office)
 "bjA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/cargo/office)
+/turf/simulated/floor/plating,
+/area/station/civilian/kitchen)
 "bjB" = (
 /obj/machinery/light,
 /obj/machinery/disposal,
@@ -34428,14 +34552,18 @@
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "bjG" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
 	},
-/turf/simulated/floor/wood,
-/area/station/security/vacantoffice)
+/area/station/civilian/kitchen)
 "bjH" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet/black,
@@ -34539,15 +34667,15 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "bjT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	id_tag = "arrival_dock_outer";
+	locked = 1;
+	name = "Arrival Dock External Access";
+	req_one_access = list(13,45,1)
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/station/cargo/office)
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "bjU" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -34555,6 +34683,11 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -34744,7 +34877,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -34781,27 +34913,35 @@
 	},
 /area/station/medical/reception)
 "bkr" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/book/manual/wiki/security_space_law,
-/turf/simulated/floor/wood,
-/area/station/security/vacantoffice)
-"bks" = (
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/obj/machinery/camera{
-	c_tag = "Cargo Bay East";
-	pixel_x = 22
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/item/weapon/flora/random,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
+/area/station/civilian/locker)
+"bks" = (
+/obj/item/weapon/hand_labeler,
+/obj/item/weapon/packageWrap,
+/obj/structure/table/glass,
 /turf/simulated/floor{
 	dir = 1;
-	icon_state = "brown"
+	icon_state = "green"
 	},
-/area/station/cargo/storage)
+/area/station/civilian/hydroponics)
 "bkt" = (
 /obj/structure/rack,
 /obj/item/weapon/reagent_containers/spray/extinguisher{
@@ -34812,11 +34952,16 @@
 /turf/simulated/floor/plating,
 /area/station/storage/emergency3)
 "bku" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/door/airlock/glass{
+	name = "Bar";
+	req_access = list(25)
 	},
-/turf/simulated/floor/wood,
-/area/station/security/vacantoffice)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/bar)
 "bkv" = (
 /obj/machinery/requests_console/captain{
 	pixel_x = -30
@@ -34838,28 +34983,27 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "bky" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/maintenance{
-	req_access = list(12)
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
-"bkz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/structure/stool/bed/chair/comfy/black{
+	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "bot"
+	dir = 5;
+	icon_state = "vault"
 	},
-/area/station/cargo/office)
+/area/station/civilian/bar)
+"bkz" = (
+/obj/structure/table,
+/obj/item/weapon/storage/fancy/donut_box,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "bkA" = (
 /obj/structure/table/woodentable,
 /obj/machinery/alarm{
@@ -34875,7 +35019,8 @@
 	pixel_x = 25
 	},
 /turf/simulated/floor{
-	icon_state = "browncorner"
+	dir = 4;
+	icon_state = "arrival"
 	},
 /area/station/hallway/secondary/entry)
 "bkC" = (
@@ -34962,15 +35107,18 @@
 	},
 /area/station/maintenance/medbay)
 "bkJ" = (
-/obj/machinery/light{
-	dir = 8
+/obj/item/device/radio/intercom{
+	pixel_y = 25
 	},
-/obj/structure/filingcabinet/filingcabinet,
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "brown"
+	dir = 5;
+	icon_state = "vault"
 	},
-/area/station/cargo/office)
+/area/station/civilian/kitchen)
 "bkK" = (
 /obj/machinery/camera{
 	c_tag = "Genetics Reception";
@@ -35047,27 +35195,27 @@
 	},
 /area/station/construction/assembly_line)
 "bkQ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "greencorner"
+	},
+/area/station/hallway/secondary/entry)
+"bkR" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
-"bkR" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/door/airlock/mining{
+	name = "Recycler office";
+	req_access = list(67)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "browncorner"
+	dir = 5;
+	icon_state = "vault"
 	},
-/area/station/cargo/storage)
+/area/station/cargo/recycleroffice)
 "bkS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
@@ -35402,12 +35550,14 @@
 /area/station/rnd/hallway)
 "bls" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+	dir = 4
 	},
-/obj/machinery/vending/cigarette,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "brown"
+	icon_state = "floorgrime"
 	},
 /area/station/cargo/storage)
 "blt" = (
@@ -35471,12 +35621,29 @@
 	},
 /area/station/bridge/meeting_room)
 "blz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/cargo/office)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/camera{
+	c_tag = "Hydroponics Pasture"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "asteroid"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "siding2"
+	},
+/area/station/civilian/kitchen)
 "blA" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -35510,12 +35677,29 @@
 	},
 /area/shuttle/escape_pod2/station)
 "blD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/cargo/office)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/mob/living/simple_animal/cow{
+	name = "Betsy"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "asteroid"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "siding2"
+	},
+/area/station/civilian/kitchen)
 "blE" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal{
@@ -35650,22 +35834,28 @@
 	},
 /area/station/rnd/server)
 "blJ" = (
-/obj/structure/table/woodentable,
-/obj/item/ashtray/glass,
-/turf/simulated/floor/wood,
-/area/station/security/vacantoffice)
+/obj/structure/table,
+/obj/item/weapon/kitchen/rollingpin,
+/obj/structure/sign/warning/nosmoking/circle{
+	pixel_x = 32
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "blK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/closet/secure_closet/quartermaster,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor{
+	icon_state = "brown"
 	},
-/obj/machinery/alarm{
-	pixel_y = 28
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/bar)
+/area/station/cargo/qm)
 "blL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/random{
@@ -35691,15 +35881,17 @@
 /turf/simulated/floor/carpet,
 /area/station/civilian/chapel)
 "blO" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/chem_dispenser/beer{
+	dir = 4
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken4"
+/obj/structure/table,
+/obj/machinery/alarm{
+	pixel_y = 26
 	},
-/area/station/security/vacantoffice)
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/bar)
 "blP" = (
 /obj/structure/window/reinforced{
 	dir = 5
@@ -35771,39 +35963,55 @@
 /turf/simulated/wall/r_wall,
 /area/station/bridge/nuke_storage)
 "blX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/bar)
+/area/station/hallway/secondary/entry)
 "blY" = (
-/obj/structure/stool/bed/chair/office/dark{
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/station/security/vacantoffice)
-"blZ" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Cargo Office North";
-	dir = 8
-	},
 /obj/structure/table,
-/obj/item/weapon/folder/brown,
-/obj/item/device/eftpos{
-	eftpos_name = "Cargo Bay EFTPOS scanner"
+/obj/item/weapon/reagent_containers/glass/beaker{
+	pixel_x = 5
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/item/weapon/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/obj/item/weapon/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
+	dir = 5;
+	icon_state = "cafeteria"
 	},
-/area/station/cargo/office)
+/area/station/civilian/kitchen)
+"blZ" = (
+/obj/machinery/door/airlock/glass{
+	name = "Hydroponics Pasture";
+	req_access = list(28)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "bma" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/flora/pottedplant/crystal{
@@ -35818,33 +36026,30 @@
 	},
 /area/station/tcommsat/chamber)
 "bmb" = (
-/obj/machinery/light,
-/obj/structure/sign/departments/lawyer{
-	pixel_y = -32
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
+/turf/simulated/floor,
+/area/station/cargo/miningoffice)
 "bmc" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "bmd" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/beer{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/obj/machinery/camera{
-	c_tag = "Bar West";
-	dir = 4
+/obj/machinery/vending/hydroseeds{
+	slogan_delay = 700
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/area/station/civilian/bar)
+/turf/simulated/floor,
+/area/station/civilian/hydroponics)
 "bme" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -35980,13 +36185,9 @@
 /turf/simulated/floor/carpet/blue2,
 /area/station/bridge/hop_office)
 "bmn" = (
-/obj/structure/table/reinforced,
-/obj/item/ashtray/plastic,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "darkred"
-	},
-/area/station/civilian/bar)
+/obj/machinery/biogenerator,
+/turf/simulated/floor,
+/area/station/civilian/hydroponics)
 "bmo" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -35994,22 +36195,28 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "bmp" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/station/hallway/primary/central)
+/obj/machinery/camera{
+	c_tag = "Hydroponics Storage"
+	},
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
+/turf/simulated/floor{
+	icon_state = "green"
+	},
+/area/station/civilian/hydroponics)
 "bmq" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 28
-	},
 /turf/simulated/floor{
-	icon_state = "browncorner"
+	icon_state = "greencorner"
 	},
 /area/station/hallway/secondary/entry)
 "bmr" = (
@@ -36032,18 +36239,13 @@
 	},
 /area/station/medical/chemistry)
 "bms" = (
-/obj/machinery/door/airlock/glass{
-	name = "Hydroponics Pasture";
-	req_access = list(28)
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
+/turf/simulated/floor,
+/area/station/cargo/office)
 "bmt" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor{
@@ -36065,38 +36267,28 @@
 	},
 /area/station/medical/reception)
 "bmw" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
-"bmx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+	icon_state = "grimy"
 	},
 /area/station/civilian/bar)
-"bmy" = (
+"bmx" = (
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Diner"
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
-/area/station/civilian/bar)
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
+"bmy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
 "bmz" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
@@ -36112,12 +36304,13 @@
 	},
 /area/station/cargo/storage)
 "bmA" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "loadingarea"
+/obj/structure/barricade/wooden,
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(12)
 	},
-/area/station/cargo/storage)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "bmB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -36136,27 +36329,27 @@
 	},
 /area/station/hallway/primary/central)
 "bmD" = (
-/obj/structure/table/woodentable,
-/obj/item/device/flashlight/lamp,
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
+/obj/machinery/camera{
+	c_tag = "Cargo Bay North"
 	},
-/turf/simulated/floor/wood,
-/area/station/security/vacantoffice)
-"bmE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = 32
 	},
-/obj/machinery/alarm{
-	pixel_y = 28
-	},
-/obj/machinery/vending/snack,
+/obj/structure/table,
+/obj/item/weapon/folder/yellow,
+/obj/item/weapon/pen,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
+"bmE" = (
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor{
+	icon_state = "bar"
+	},
+/area/station/cargo/miningbreaktime)
 "bmF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36225,6 +36418,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/item/device/camera,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -36245,21 +36439,12 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "bmR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "loadingarea"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/cargo/storage)
 "bmS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -36281,23 +36466,17 @@
 	},
 /area/station/hallway/primary/central)
 "bmT" = (
-/obj/structure/disposalpipe/segment,
+/obj/machinery/light,
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
 "bmU" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/closet/crate/internals,
+/turf/simulated/floor{
+	icon_state = "floorgrime"
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/civilian/hydroponics)
+/area/station/cargo/storage)
 "bmV" = (
 /obj/machinery/camera{
 	c_tag = "Chapel Altar";
@@ -36323,13 +36502,16 @@
 	},
 /area/station/rnd/lab)
 "bmY" = (
-/obj/machinery/light,
-/turf/simulated/floor{
-	icon_state = "whitecorner"
+/obj/machinery/light/small{
+	dir = 4
 	},
-/area/station/hallway/primary/port)
-"bmZ" = (
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	icon_state = "floorgrime"
+	},
+/area/station/cargo/storage)
+"bmZ" = (
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
@@ -36398,9 +36580,6 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "bnf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/structure/stool,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
@@ -36482,18 +36661,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "bnp" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/alarm{
-	pixel_y = 28
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "bnq" = (
 /obj/effect/landmark/start/medical_doctor,
 /turf/simulated/floor{
@@ -36519,9 +36691,11 @@
 	},
 /area/station/tcommsat/computer)
 "bns" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	icon_state = "whitecorner"
+	icon_state = "browncorner"
 	},
 /area/station/hallway/primary/port)
 "bnt" = (
@@ -36529,7 +36703,7 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "whitecorner"
+	icon_state = "browncorner"
 	},
 /area/station/hallway/primary/port)
 "bnu" = (
@@ -36591,11 +36765,24 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "bnB" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/grille,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
-/area/station/cargo/office)
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	icon_state = "shutter0";
+	id = "kitchen";
+	name = "Kitchen Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/kitchen)
 "bnC" = (
 /obj/machinery/computer/security,
 /turf/simulated/floor{
@@ -36663,20 +36850,29 @@
 	},
 /area/station/hallway/secondary/exit)
 "bnI" = (
+/obj/machinery/door/airlock/mining/glass{
+	name = "Miner Breaktime room";
+	req_access = list(50)
+	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
+	icon_state = "bar"
 	},
-/area/station/cargo/storage)
+/area/station/cargo/miningbreaktime)
 "bnJ" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 4
@@ -36849,22 +37045,23 @@
 /turf/simulated/floor,
 /area/station/medical/surgeryobs)
 "boc" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/civilian/locker)
-"bod" = (
+/obj/machinery/door/window/westright{
+	name = "Bar Maintenance";
+	req_access = list(25)
+	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 4
+/turf/simulated/floor{
+	icon_state = "delivery"
 	},
-/obj/structure/sign/departments/botany,
-/turf/simulated/floor/plating,
-/area/station/civilian/hydroponics)
+/area/station/civilian/bar)
+"bod" = (
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "boe" = (
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "4-5"
@@ -36958,16 +37155,14 @@
 /turf/simulated/floor,
 /area/station/medical/surgery)
 "bom" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "packageSort1"
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(12)
 	},
-/obj/structure/plasticflaps/mining,
-/turf/simulated/floor/plating{
-	dir = 4;
-	icon_state = "warnplate"
-	},
-/area/station/cargo/office)
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "bon" = (
 /obj/machinery/dna_scannernew,
 /obj/machinery/alarm{
@@ -36978,12 +37173,14 @@
 	},
 /area/station/medical/genetics)
 "boo" = (
-/obj/structure/closet/secure_closet/cargotech,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
+/obj/machinery/hydroponics/constructable,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
-/area/station/cargo/office)
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/hydroponics)
 "bop" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
@@ -36992,12 +37189,18 @@
 	},
 /area/station/cargo/miningoffice)
 "boq" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor{
-	icon_state = "brown"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
-/area/station/cargo/miningoffice)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/cargo/storage)
 "bor" = (
 /obj/structure/object_wall/pod{
 	icon_state = "3,0"
@@ -37114,19 +37317,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "boB" = (
-/obj/structure/table,
-/obj/item/weapon/folder/brown,
-/obj/item/weapon/packageWrap,
-/obj/machinery/light,
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	name = "Mining Office APC";
-	pixel_y = -30
-	},
-/turf/simulated/floor{
-	icon_state = "brown"
-	},
-/area/station/cargo/miningoffice)
+/obj/structure/closet/crate,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "boC" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -37294,19 +37487,16 @@
 	},
 /area/station/tcommsat/computer)
 "boS" = (
-/obj/structure/table/reinforced,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/door/airlock/maintenance{
+	name = "Private Maintenance";
+	req_access = list(12)
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/item/clothing/head/cakehat,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "darkred"
-	},
-/area/station/civilian/bar)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/security/vacantoffice)
 "boT" = (
 /turf/simulated/floor{
 	dir = 5;
@@ -37350,9 +37540,21 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "boX" = (
@@ -37587,14 +37789,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "bpt" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/poddoor/shutters{
+	id = "qm_warehouse";
+	name = "Warehouse Shutters"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
+/area/station/cargo/storage)
 "bpu" = (
 /obj/structure/stool/bed/roller,
 /turf/simulated/floor{
@@ -37871,12 +38073,14 @@
 /turf/simulated/floor,
 /area/station/cargo/office)
 "bpV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/mob/living/simple_animal/chicken{
+	name = "Commander Clucky"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/cargo/office)
+/turf/simulated/floor/grass,
+/turf/simulated/floor{
+	icon_state = "siding8"
+	},
+/area/station/civilian/kitchen)
 "bpW" = (
 /obj/structure/stool/bed/roller,
 /turf/simulated/floor{
@@ -37904,33 +38108,45 @@
 	},
 /area/station/medical/surgery)
 "bpY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor,
-/area/station/cargo/office)
+/area/station/civilian/hydroponics)
 "bpZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/structure/plasticflaps{
+	opacity = 1
 	},
-/obj/effect/landmark/start/cargo_technician,
-/turf/simulated/floor,
-/area/station/cargo/office)
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=1";
+	freq = 1400;
+	location = "Hydroponics"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "bot"
+	},
+/area/station/civilian/hydroponics)
 "bqa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "bqb" = (
 /obj/item/weapon/flora/random,
 /obj/structure/reagent_dispensers/peppertank{
@@ -38162,22 +38378,9 @@
 	},
 /area/station/bridge)
 "bqy" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=8";
-	freq = 1400;
-	location = "QM #2"
-	},
-/obj/machinery/bot/mulebot{
-	home_destination = "QM #2";
-	suffix = "#2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "bot"
-	},
-/area/station/cargo/storage)
+/obj/structure/dresser,
+/turf/simulated/floor/wood,
+/area/station/maintenance/cargo)
 "bqz" = (
 /obj/item/stack/cable_coil/red,
 /obj/item/stack/cable_coil/red{
@@ -38364,39 +38567,34 @@
 /turf/environment/space/shuttle,
 /area/shuttle/escape_pod1/station)
 "bqM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/item/weapon/shard{
-	icon_state = "small"
-	},
+/obj/structure/rack,
+/obj/item/device/flashlight,
+/obj/item/weapon/wrench,
+/obj/item/device/t_scanner,
+/obj/item/weapon/wirecutters,
 /turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/maintenance/engineering)
 "bqN" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	icon_state = "shutter0";
+	id = "kitchen";
+	name = "Kitchen Shutters";
+	opacity = 0
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/eastright{
+	name = "Kitchen";
+	req_access = list(28)
 	},
-/area/station/security/vacantoffice)
+/obj/item/weapon/reagent_containers/food/snacks/pie,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "bqO" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
@@ -38526,8 +38724,18 @@
 /area/station/bridge/hop_office)
 "brb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "brc" = (
 /obj/machinery/camera{
 	c_tag = "Vault";
@@ -38579,31 +38787,29 @@
 	},
 /area/station/bridge/nuke_storage)
 "brf" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/machinery/door/window/westright{
+	name = "Hydroponics Maintenance";
+	req_access = list(35)
 	},
-/obj/machinery/disposal/deliveryChute{
-	dir = 8
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/station/cargo/office)
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
+/area/station/civilian/hydroponics)
 "brg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/cargo/office)
 "brh" = (
-/obj/structure/stool/bar,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/civilian/bar)
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
 "bri" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -38755,26 +38961,24 @@
 	},
 /area/station/hallway/secondary/exit)
 "brw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
+"brx" = (
+/obj/structure/stool/bed/chair/office/dark{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
-	},
-/area/station/civilian/bar)
-"brx" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/civilian/bar)
+/turf/simulated/floor/carpet/black,
+/area/station/security/vacantoffice)
 "bry" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -38793,14 +38997,16 @@
 /turf/simulated/floor/plating,
 /area/station/rnd/hor)
 "brz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/structure/table/woodentable,
+/obj/item/weapon/folder/blue,
+/obj/item/weapon/pen,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
-	},
-/area/station/civilian/bar)
+/turf/simulated/floor/carpet/black,
+/area/station/security/vacantoffice)
 "brA" = (
 /obj/effect/landmark{
 	name = "carpspawn"
@@ -38815,20 +39021,10 @@
 	},
 /area/station/construction/assembly_line)
 "brC" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=8";
-	freq = 1400;
-	location = "QM #3"
-	},
-/obj/machinery/camera{
-	c_tag = "Cargo Bay West";
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor{
-	icon_state = "bot"
-	},
-/area/station/cargo/storage)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/sheet/wood,
+/turf/simulated/floor/wood,
+/area/station/maintenance/cargo)
 "brD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -38842,19 +39038,30 @@
 	},
 /area/station/rnd/robotics)
 "brF" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "loadingarea"
+/obj/structure/grille{
+	destroyed = 1
 	},
-/area/station/cargo/storage)
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken3"
+	},
+/area/station/maintenance/cargo)
 "brG" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/airlock/maintenance{
+	name = "Mining Equipment Maintenance";
+	req_access = list(48)
 	},
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/cargo/miningoffice)
 "brH" = (
 /obj/machinery/mecha_part_fabricator{
 	dir = 8
@@ -39354,32 +39561,26 @@
 	},
 /area/station/aisat)
 "bsC" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
 /area/station/cargo/storage)
 "bsD" = (
-/obj/structure/table/woodentable,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/item/weapon/storage/fancy/cigarettes{
-	pixel_x = -4
-	},
-/obj/item/weapon/lighter/random{
-	pixel_x = 5
+/obj/structure/table,
+/obj/random/foods/food_trash,
+/obj/machinery/camera{
+	c_tag = "Cargo cafe"
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "brown"
+	icon_state = "bar"
 	},
-/area/station/cargo/storage)
+/area/station/cargo/miningbreaktime)
 "bsE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -39413,20 +39614,27 @@
 	},
 /area/station/cargo/office)
 "bsH" = (
-/obj/structure/table,
-/obj/item/device/destTagger,
-/obj/item/device/destTagger,
-/turf/simulated/floor{
-	icon_state = "brown"
+/obj/machinery/space_heater,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/station/cargo/office)
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "bsI" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood,
-/area/station/civilian/bar)
+/obj/structure/grille{
+	destroyed = 1
+	},
+/obj/item/weapon/shard,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "bsJ" = (
 /obj/structure/object_wall/pod{
 	icon_state = "0,0"
@@ -39434,34 +39642,25 @@
 /turf/environment/space/shuttle,
 /area/shuttle/escape_pod1/station)
 "bsK" = (
-/obj/structure/table,
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/packageWrap,
-/turf/simulated/floor{
-	icon_state = "brown"
+/obj/item/device/radio/intercom{
+	dir = 0;
+	name = "Station Intercom (General)";
+	pixel_x = -27
 	},
-/area/station/cargo/office)
+/turf/simulated/floor{
+	icon_state = "floorgrime"
+	},
+/area/station/cargo/storage)
 "bsL" = (
-/obj/structure/table,
-/obj/item/weapon/hand_labeler,
-/obj/item/weapon/stamp{
-	name = "cargo rubber stamp";
-	pixel_x = -3;
-	pixel_y = 3;
-	stamp_message = "Cargo"
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/camera{
+	c_tag = "Hydroponics South";
+	dir = 8
 	},
-/obj/item/weapon/hand_labeler,
 /turf/simulated/floor{
-	dir = 6;
-	icon_state = "brown"
+	icon_state = "dark"
 	},
-/area/station/cargo/office)
+/area/station/civilian/hydroponics)
 "bsM" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -39476,19 +39675,19 @@
 	},
 /area/station/bridge/nuke_storage)
 "bsO" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 20
+/obj/structure/table,
+/obj/item/ashtray/bronze{
+	pixel_x = 5;
+	pixel_y = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/item/weapon/cigbutt,
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
-/obj/machinery/vending/coffee,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "brown"
+	icon_state = "bar"
 	},
-/area/station/cargo/storage)
+/area/station/cargo/miningbreaktime)
 "bsP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -39610,14 +39809,11 @@
 	},
 /area/station/hallway/secondary/entry)
 "bsZ" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "loadingarea"
 	},
-/area/station/cargo/recycleroffice)
+/area/station/cargo/storage)
 "bta" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -40092,7 +40288,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "cautioncorner"
@@ -40162,13 +40357,22 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "btW" = (
-/obj/structure/window/reinforced,
-/obj/machinery/media/jukebox/bar,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/station/civilian/bar)
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "btX" = (
 /turf/simulated/floor{
 	icon_state = "delivery"
@@ -40381,20 +40585,21 @@
 /turf/simulated/floor,
 /area/station/rnd/robotics)
 "buu" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/window/reinforced{
-	dir = 4
+/turf/simulated/floor{
+	icon_state = "floorgrime"
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/station/cargo/recycleroffice)
+/area/station/cargo/storage)
 "buv" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/plasteel{
@@ -40460,22 +40665,24 @@
 /area/station/rnd/telesci)
 "buA" = (
 /obj/structure/table,
-/obj/item/weapon/storage/box,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+/obj/item/weapon/storage/firstaid/regular,
+/obj/machinery/power/apc{
+	name = "Cargo Office APC";
+	pixel_y = -24
 	},
-/area/station/cargo/recycleroffice)
+/obj/structure/cable,
+/turf/simulated/floor{
+	icon_state = "brown"
+	},
+/area/station/cargo/office)
 "buB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/machinery/firealarm{
-	pixel_y = 28
+/obj/machinery/door_control{
+	id = "Bar_Privacy1";
+	name = "Privacy Shutters";
+	pixel_y = -25
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/cargo/recycleroffice)
+/turf/simulated/floor/carpet/blue,
+/area/station/civilian/bar)
 "buC" = (
 /obj/machinery/light{
 	dir = 8
@@ -40486,11 +40693,12 @@
 	},
 /area/station/medical/hallway)
 "buD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
 	dir = 1;
-	icon_state = "brown"
+	icon_state = "greenchecker"
 	},
-/area/station/cargo/office)
+/area/station/civilian/hydroponics)
 "buE" = (
 /obj/machinery/shower{
 	dir = 4
@@ -40515,20 +40723,11 @@
 /turf/environment/space/shuttle,
 /area/shuttle/escape_pod1/station)
 "buG" = (
-/obj/machinery/atmospherics/components/binary/pump/on,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/random/vending/snack,
+/turf/simulated/floor{
+	icon_state = "bar"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/cargo/miningbreaktime)
 "buH" = (
 /turf/simulated/floor{
 	dir = 9;
@@ -40690,43 +40889,52 @@
 	},
 /area/station/tcommsat/computer)
 "buV" = (
-/obj/structure/table,
-/obj/item/weapon/folder/brown,
-/obj/item/weapon/stamp{
-	name = "recycler's rubber stamp";
-	stamp_message = "Recycler"
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 20
+/obj/machinery/power/apc{
+	cell_type = 2500;
+	dir = 8;
+	name = "Recycler office APC";
+	pixel_x = -27
 	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor{
-	dir = 4;
 	icon_state = "dark"
 	},
 /area/station/cargo/recycleroffice)
 "buW" = (
-/obj/effect/landmark/start/bartender,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/station/civilian/bar)
-"buX" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor{
-	dir = 10;
-	icon_state = "brown"
-	},
+/obj/structure/table,
+/obj/machinery/computer/stockexchange,
+/turf/simulated/floor,
 /area/station/cargo/office)
-"buY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+"buX" = (
+/mob/living/carbon/monkey/punpun,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	icon_state = "brown"
+	icon_state = "grimy"
 	},
+/area/station/civilian/bar)
+"buY" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
 /area/station/cargo/office)
 "buZ" = (
 /obj/structure/stool/bed/chair/comfy/black{
@@ -40756,25 +40964,19 @@
 	},
 /area/station/tcommsat/chamber)
 "bvb" = (
-/obj/structure/sign/warning/securearea{
-	desc = "A warning sign which reads 'LANDFILL'";
-	icon_state = "space";
-	layer = 4;
-	name = "LANDFILL";
-	pixel_x = 32
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/obj/machinery/conveyor_switch/oneway{
-	id = "packageSort2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "brown"
-	},
-/area/station/cargo/office)
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "bvc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -40817,11 +41019,8 @@
 	},
 /area/station/hallway/secondary/exit)
 "bvg" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
 /turf/simulated/floor{
-	icon_state = "neutralcorner"
+	icon_state = "greencorner"
 	},
 /area/station/hallway/secondary/entry)
 "bvh" = (
@@ -40839,19 +41038,11 @@
 	},
 /area/station/hallway/primary/central)
 "bvj" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=8";
-	freq = 1400;
-	location = "QM #4"
+/obj/structure/barricade/wooden,
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken5"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "bot"
-	},
-/area/station/cargo/storage)
+/area/station/maintenance/cargo)
 "bvk" = (
 /turf/simulated/floor{
 	icon_state = "bot"
@@ -40883,15 +41074,19 @@
 	name = "Cyborg Station"
 	})
 "bvm" = (
-/obj/machinery/door/window/southright{
-	name = "Bar Door";
-	req_one_access = list(25)
+/obj/machinery/camera{
+	c_tag = "Recycler office";
+	dir = 1
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
-/area/station/civilian/bar)
+/area/station/cargo/recycleroffice)
 "bvn" = (
 /turf/simulated/floor,
 /area/station/bridge/hop_office)
@@ -40904,25 +41099,23 @@
 /turf/simulated/floor/carpet/blue2,
 /area/station/bridge/hop_office)
 "bvq" = (
-/obj/machinery/door/airlock/mining{
-	name = "Recycler office";
-	req_access = list(67)
-	},
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/cargo/recycleroffice)
+/turf/simulated/floor,
+/area/station/cargo/storage)
 "bvr" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -40937,20 +41130,11 @@
 	},
 /area/station/hallway/secondary/exit)
 "bvs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+	dir = 10;
+	icon_state = "brown"
 	},
-/area/station/cargo/recycleroffice)
+/area/station/cargo/office)
 "bvt" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -40958,19 +41142,26 @@
 	},
 /area/station/medical/hallway)
 "bvu" = (
-/obj/effect/landmark/start/recycler,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/area/station/cargo/recycleroffice)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "loadingarea"
+	},
+/area/station/cargo/storage)
 "bvv" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -40978,25 +41169,24 @@
 	},
 /area/station/medical/storage)
 "bvw" = (
-/obj/machinery/door/airlock/mining{
-	name = "Recycler office";
-	req_access = list(67)
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/station/cargo/recycleroffice)
+/turf/simulated/floor{
+	icon_state = "warningcorner"
+	},
+/area/station/cargo/storage)
 "bvx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
@@ -41039,50 +41229,52 @@
 	},
 /area/station/medical/genetics_cloning)
 "bvA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/cargo/recycleroffice)
-"bvB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/item/device/radio/intercom{
+	dir = 0;
+	name = "Station Intercom (General)";
+	pixel_x = 27
 	},
 /obj/structure/cable{
 	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/cargo/recycleroffice)
-"bvC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/turf/simulated/floor,
+/area/station/cargo/storage)
+"bvB" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
+"bvC" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -41104,12 +41296,7 @@
 /turf/simulated/floor/plating,
 /area/station/medical/genetics)
 "bvE" = (
-/obj/machinery/door/airlock/mining{
-	name = "Recycler's workplace";
-	req_access = list(67)
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -41117,10 +41304,15 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "bvF" = (
 /obj/structure/disposalpipe/segment{
@@ -41140,23 +41332,32 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/maintenance/engineering)
 "bvI" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
-"bvJ" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/obj/machinery/vending/cigarette,
+/obj/structure/stool/bed/chair/comfy/black,
 /turf/simulated/floor{
-	dir = 4;
 	icon_state = "dark"
+	},
+/area/station/civilian/bar)
+"bvJ" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen/blue{
+	pixel_x = 2;
+	pixel_y = 6
+	},
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id = "Bar";
+	name = "Bar Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
 	},
 /area/station/civilian/bar)
 "bvK" = (
@@ -41171,25 +41372,25 @@
 	},
 /area/station/hallway/secondary/exit)
 "bvL" = (
-/obj/structure/disposaloutlet{
-	dir = 4
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "vault"
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/station/cargo/office)
+/area/station/civilian/hydroponics)
 "bvM" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "packageSort2"
+/obj/structure/closet/crate/hydroponics,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/item/weapon/screwdriver,
+/obj/item/weapon/shovel/spade,
+/obj/item/weapon/wrench,
+/obj/item/weapon/minihoe,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "vault"
 	},
-/obj/structure/plasticflaps/mining,
-/turf/simulated/floor/plating{
-	dir = 1;
-	icon_state = "warnplate"
-	},
-/area/station/cargo/office)
+/area/station/civilian/hydroponics)
 "bvN" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -41215,12 +41416,11 @@
 /turf/simulated/floor/plating/airless,
 /area/station/maintenance/chapel)
 "bvQ" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "packageSort2"
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "vault"
 	},
-/turf/simulated/floor/plating,
-/area/station/cargo/office)
+/area/station/civilian/hydroponics)
 "bvR" = (
 /turf/simulated/wall,
 /area/station/medical/genetics_cloning)
@@ -41263,23 +41463,10 @@
 	},
 /area/station/hallway/secondary/arrival)
 "bvV" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
+/turf/simulated/floor{
+	icon_state = "bot"
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/cargo/recycleroffice)
+/area/station/cargo/storage)
 "bvW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -41304,18 +41491,16 @@
 	},
 /area/station/hallway/secondary/entry)
 "bvX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/power/apc{
+	name = "Cargo Bay APC";
+	pixel_x = 1;
+	pixel_y = -24
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/cable,
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+	icon_state = "bot"
 	},
-/area/station/cargo/recycleroffice)
+/area/station/cargo/storage)
 "bvY" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -41345,56 +41530,49 @@
 	},
 /area/station/hallway/secondary/entry)
 "bwa" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/structure/disposaloutlet{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+	icon_state = "delivery"
 	},
-/area/station/cargo/recycleroffice)
+/area/station/cargo/storage)
 "bwb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
 /area/station/cargo/recycleroffice)
 "bwc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/civilian/bar)
+"bwd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/wood,
-/area/station/security/vacantoffice)
-"bwd" = (
-/obj/item/weapon/reagent_containers/food/drinks/flask/barflask{
-	pixel_y = 8
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/item/weapon/reagent_containers/glass/rag,
-/obj/item/weapon/reagent_containers/food/drinks/shaker,
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/civilian/bar)
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "bwe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -41405,15 +41583,10 @@
 	},
 /area/station/hallway/secondary/entry)
 "bwf" = (
-/obj/structure/table/reinforced,
-/obj/structure/window/reinforced,
-/obj/item/weapon/flora/pottedplant/shoot{
-	pixel_x = -8;
-	pixel_y = 16
-	},
+/obj/structure/device/piano/royal,
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "darkred"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/civilian/bar)
 "bwg" = (
@@ -41691,74 +41864,56 @@
 	},
 /area/station/hallway/secondary/entry)
 "bwy" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/cargo/storage)
+"bwz" = (
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	dir = 5;
-	icon_state = "vault"
+	icon_state = "cafeteria"
 	},
-/area/station/civilian/bar)
-"bwz" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	id_tag = "arrival_dock_inner";
-	locked = 1;
-	name = "Arrival Dock External Access";
-	req_one_access = list(13,45,1)
-	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/civilian/kitchen)
 "bwA" = (
-/obj/machinery/power/port_gen/pacman/scrap,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor{
+/obj/machinery/firealarm{
 	dir = 4;
-	icon_state = "dark"
+	pixel_x = 24
 	},
-/area/station/cargo/recycleroffice)
+/turf/simulated/floor,
+/area/station/cargo/office)
 "bwB" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_x = -32
+/obj/item/device/radio/intercom{
+	freerange = 1;
+	name = "Station Intercom (General)";
+	pixel_x = -30
 	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
+/turf/simulated/floor,
+/area/station/cargo/office)
 "bwC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/stool/bed/chair/comfy/brown{
+	dir = 8
 	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
+/turf/simulated/floor/carpet/blue,
+/area/station/civilian/bar)
 "bwD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/structure/filingcabinet/filingcabinet,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
-/area/station/civilian/locker)
+/area/station/cargo/office)
 "bwE" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -41809,20 +41964,25 @@
 	},
 /area/station/aisat)
 "bwJ" = (
-/obj/structure/table/woodentable,
-/obj/machinery/reagentgrinder{
-	layer = 3.1;
-	pixel_y = 5
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/item/weapon/reagent_containers/food/drinks/flask/barflask{
-	pixel_x = -5;
-	pixel_y = 5
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/turf/simulated/floor/wood,
-/area/station/civilian/bar)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/cargo/recycleroffice)
 "bwK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -41836,14 +41996,11 @@
 	},
 /area/station/hallway/primary/central)
 "bwL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/item/device/flashlight/lamp/fir,
+/turf/simulated/floor{
+	icon_state = "floorgrime"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/bar)
+/area/station/cargo/storage)
 "bwM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -41892,22 +42049,11 @@
 	},
 /area/station/medical/sleeper)
 "bwQ" = (
-/obj/structure/closet/secure_closet/bar,
-/obj/item/weapon/gun/projectile/revolver/doublebarrel,
-/obj/item/weapon/paper{
-	info = "This permit signifies that the Bartender is permitted to posess this firearm in the bar, and ONLY the bar. Failure to adhere to this permit will result in confiscation of the weapon and possibly arrest.";
-	name = "Shotgun permit"
-	},
-/obj/item/clothing/suit/armor/vest,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/item/weapon/storage/firstaid/regular,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/bar)
+/obj/structure/table,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/item/weapon/reagent_containers/glass/bucket,
+/turf/simulated/floor/grass,
+/area/station/civilian/kitchen)
 "bwR" = (
 /obj/structure/closet/crate/freezer,
 /turf/simulated/floor,
@@ -42016,14 +42162,15 @@
 	},
 /area/station/aisat)
 "bxb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "browncorner"
-	},
-/area/station/cargo/storage)
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "bxc" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -42034,18 +42181,11 @@
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
 "bxd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/power/port_gen/pacman/scrap,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/cargo/recycleroffice)
+/obj/structure/closet/crate,
+/obj/random/tools/tech_supply,
+/obj/random/tools/tech_supply,
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "bxe" = (
 /obj/machinery/camera{
 	c_tag = "Teleporter"
@@ -42056,26 +42196,30 @@
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
 "bxf" = (
-/obj/machinery/light{
-	dir = 4
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken4"
 	},
-/obj/machinery/newscaster{
-	pixel_x = 32
+/area/station/security/vacantoffice)
+"bxg" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "browncorner"
 	},
-/area/station/civilian/bar)
-"bxg" = (
-/obj/structure/table/woodentable,
-/obj/item/device/flashlight/lamp/green,
-/obj/item/ashtray/bronze,
-/obj/item/weapon/lighter/zippo{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/bar)
+/area/station/cargo/storage)
 "bxh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -42123,12 +42267,24 @@
 	name = "Cyborg Station"
 	})
 "bxk" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "loadingarea"
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_x = -32
 	},
-/area/station/cargo/storage)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
+	dir = 4;
+	frequency = 1379;
+	id_tag = "arrival_dock_pump";
+	name = "Arrival Dock Large Air Vent"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "bxl" = (
 /obj/structure/closet/crate,
 /obj/item/device/multitool,
@@ -42199,16 +42355,20 @@
 	},
 /area/station/hallway/primary/central)
 "bxs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = 20
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/table,
+/obj/item/weapon/paper_bin,
+/obj/machinery/light_switch{
+	pixel_x = -23
 	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "bxt" = (
 /turf/simulated/wall,
 /area/station/medical/patient_a)
@@ -42225,17 +42385,16 @@
 	},
 /area/station/medical/sleeper)
 "bxv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/closet/secure_closet/bar,
+/obj/item/weapon/gun/projectile/revolver/doublebarrel,
+/obj/item/weapon/paper{
+	info = "This permit signifies that the Bartender is permitted to posess this firearm in the bar, and ONLY the bar. Failure to adhere to this permit will result in confiscation of the weapon and possibly arrest.";
+	name = "Shotgun permit"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
-/area/station/cargo/storage)
+/obj/item/clothing/suit/armor/vest,
+/obj/item/weapon/storage/firstaid/regular,
+/turf/simulated/floor/carpet,
+/area/station/civilian/bar)
 "bxw" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -42246,12 +42405,25 @@
 	},
 /area/station/medical/sleeper)
 "bxx" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "warningcorner"
+/obj/machinery/airlock_sensor{
+	id_tag = "arrival_dock_sensor";
+	pixel_x = 25;
+	pixel_y = 12
 	},
-/area/station/cargo/storage)
+/obj/machinery/embedded_controller/radio/airlock_controller{
+	id_tag = "arrival_dock_airlock";
+	pixel_x = 25;
+	req_one_access = list(13,45,1);
+	tag_airpump = "arrival_dock_pump";
+	tag_chamber_sensor = "arrival_dock_sensor";
+	tag_exterior_door = "arrival_dock_outer";
+	tag_interior_door = "arrival_dock_inner"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "bxy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -42277,31 +42449,47 @@
 	},
 /area/station/rnd/hallway)
 "bxB" = (
-/obj/structure/table,
-/obj/item/device/flashlight,
-/obj/item/weapon/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
+/obj/structure/table/woodentable,
+/obj/machinery/newscaster{
+	pixel_x = -28;
+	pixel_y = 1
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/item/weapon/lipstick/purple{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/area/station/cargo/recycleroffice)
+/obj/item/weapon/lipstick/jade,
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "bxC" = (
-/turf/simulated/floor{
-	icon_state = "warningcorner"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/area/station/cargo/storage)
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics)
 "bxD" = (
-/obj/structure/stool,
-/obj/effect/landmark/start/recycler,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 32
+	},
+/obj/structure/table/woodentable,
+/obj/item/weapon/reagent_containers/food/condiment/saltshaker,
+/obj/item/weapon/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
-/area/station/cargo/recycleroffice)
+/area/station/civilian/bar)
 "bxE" = (
 /obj/structure/table,
 /obj/structure/window/reinforced{
@@ -42351,13 +42539,23 @@
 	},
 /area/station/rnd/robotics)
 "bxH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/westleft{
+	name = "Kitchen";
+	req_access = list(28);
+	dir = 1
+	},
+/obj/machinery/door/window/westleft{
+	name = "Hydroponics";
+	req_access = list(35);
+	dir = 0
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "cafeteria"
 	},
-/area/station/cargo/recycleroffice)
+/area/station/civilian/kitchen)
 "bxI" = (
 /obj/machinery/light_switch{
 	pixel_x = 27
@@ -42396,21 +42594,13 @@
 	},
 /area/station/rnd/chargebay)
 "bxN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/sign/poster{
+	pixel_y = -32
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor{
-	dir = 10;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/flashlight/seclite,
+/turf/simulated/floor/wood,
+/area/station/maintenance/cargo)
 "bxO" = (
 /obj/machinery/access_button{
 	command = "cycle_exterior";
@@ -42430,19 +42620,10 @@
 	},
 /area/station/rnd/chargebay)
 "bxQ" = (
-/obj/machinery/light/small{
-	dir = 8
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken6"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
-	dir = 4;
-	frequency = 1379;
-	id_tag = "arrival_dock_pump";
-	name = "Arrival Dock Large Air Vent"
-	},
-/turf/simulated/floor/plating{
-	icon_state = "platebotc"
-	},
-/area/station/maintenance/cargo)
+/area/station/civilian/theatre)
 "bxR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -42721,10 +42902,15 @@
 	},
 /area/station/medical/sleeper)
 "byo" = (
-/turf/simulated/floor{
-	icon_state = "loadingareadirty2"
+/obj/machinery/power/apc{
+	name = "Mining office APC";
+	pixel_y = -24
 	},
-/area/station/cargo/storage)
+/obj/structure/cable,
+/turf/simulated/floor{
+	icon_state = "brown"
+	},
+/area/station/cargo/miningoffice)
 "byp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -42743,11 +42929,13 @@
 	},
 /area/station/medical/hallway)
 "byq" = (
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "warningcorner"
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
-/area/station/cargo/storage)
+/turf/simulated/floor{
+	icon_state = "bar"
+	},
+/area/station/cargo/miningbreaktime)
 "byr" = (
 /obj/item/device/radio/intercom{
 	frequency = 1485;
@@ -42793,18 +42981,17 @@
 	},
 /area/station/bridge/cmf_room)
 "byv" = (
-/obj/machinery/camera{
-	c_tag = "Recycler Lobby";
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/grille,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/area/station/cargo/recycleroffice)
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/cargo/office)
 "byw" = (
 /turf/simulated/wall/r_wall,
 /area/station/bridge/cmf_room)
@@ -43011,40 +43198,46 @@
 	},
 /area/station/bridge/hop_office)
 "byO" = (
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1379;
-	master_tag = "arrival_dock_airlock";
-	name = "interior access button";
-	pixel_x = -20;
-	pixel_y = -20;
-	req_one_access = list(13,45,1)
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible{
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/obj/machinery/door/firedoor,
+/turf/simulated,
+/area/station/security/vacantoffice)
 "byP" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/grass,
-/area/station/civilian/hydroponics)
+/obj/structure/table,
+/obj/machinery/requests_console{
+	department = "Cargo Bay";
+	departmentType = 2;
+	pixel_y = -32
+	},
+/obj/item/stack/sheet/glass{
+	amount = 50;
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/device/multitool,
+/turf/simulated/floor{
+	icon_state = "brown"
+	},
+/area/station/cargo/office)
 "byQ" = (
-/obj/structure/flora/ausbushes/sunnybush{
-	pixel_x = -12;
-	pixel_y = 16
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/obj/structure/flora/ausbushes/leafybush,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/turf/simulated/floor{
+	icon_state = "brown"
 	},
-/turf/simulated/floor/grass,
-/area/station/civilian/hydroponics)
+/area/station/cargo/office)
 "byR" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=1";
@@ -43082,29 +43275,26 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "byV" = (
-/obj/machinery/airlock_sensor{
-	id_tag = "arrival_dock_sensor";
-	pixel_x = 25;
-	pixel_y = 12
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
 	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	id_tag = "arrival_dock_airlock";
-	pixel_x = 25;
-	req_one_access = list(13,45,1);
-	tag_airpump = "arrival_dock_pump";
-	tag_chamber_sensor = "arrival_dock_sensor";
-	tag_exterior_door = "arrival_dock_outer";
-	tag_interior_door = "arrival_dock_inner"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "byW" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "QMLoad2"
@@ -43168,16 +43358,19 @@
 	},
 /area/station/medical/surgery)
 "bzc" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	id_tag = "arrival_dock_outer";
-	locked = 1;
-	name = "Arrival Dock External Access";
-	req_one_access = list(13,45,1)
+/obj/machinery/camera{
+	c_tag = "Kitchen"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/obj/structure/table,
+/obj/machinery/kitchen_machine/microwave{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "bzd" = (
 /obj/machinery/conveyor{
 	id = "QMLoad"
@@ -43195,14 +43388,13 @@
 /turf/simulated/floor/plating/airless,
 /area/station/cargo/recycler)
 "bzg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 5
 	},
-/turf/simulated/floor{
-	icon_state = "bot"
-	},
-/area/station/cargo/storage)
+/turf/simulated/floor/plating,
+/area/station/cargo/miningoffice)
 "bzh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -43222,23 +43414,27 @@
 	},
 /area/station/civilian/bar)
 "bzj" = (
-/obj/structure/disposaloutlet{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/light_switch{
+	pixel_x = 27
 	},
 /turf/simulated/floor{
-	icon_state = "delivery"
+	dir = 1;
+	icon_state = "warning"
 	},
-/area/station/cargo/storage)
+/area/station/civilian/locker)
 "bzk" = (
-/obj/machinery/light,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/machinery/light/small{
+	dir = 4
 	},
-/area/station/civilian/bar)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/station/civilian/kitchen)
 "bzl" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -43249,15 +43445,18 @@
 	},
 /area/station/medical/hallway)
 "bzm" = (
+/obj/structure/stool/bed/chair/metal/yellow{
+	dir = 4
+	},
 /obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+	dir = 4;
+	pixel_x = 24
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
+	dir = 1;
+	icon_state = "brown"
 	},
-/area/station/civilian/bar)
+/area/station/cargo/office)
 "bzn" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/paper_bin,
@@ -43330,22 +43529,15 @@
 	},
 /area/station/rnd/server)
 "bzv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/obj/machinery/light_switch{
-	pixel_y = 25
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
-/obj/machinery/camera{
-	c_tag = "Locker Room"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "bzw" = (
 /obj/machinery/computer/message_monitor,
 /turf/simulated/floor{
@@ -43353,20 +43545,22 @@
 	},
 /area/station/rnd/server)
 "bzx" = (
-/obj/effect/landmark{
-	name = "xeno_spawn";
-	pixel_x = -1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	dir = 5;
+	icon_state = "cafeteria"
 	},
-/area/station/civilian/cold_room)
+/area/station/civilian/kitchen)
 "bzy" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -43548,20 +43742,17 @@
 	},
 /area/station/bridge/cmf_room)
 "bzP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Operation Observation Room APC";
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg3"
 	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
+/area/station/maintenance/cargo)
 "bzQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -43616,7 +43807,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "bzS" = (
@@ -43627,6 +43817,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
@@ -43874,7 +44068,7 @@
 	},
 /area/station/medical/sleeper)
 "bAs" = (
-/obj/structure/displaycase/captain,
+/obj/structure/displaycase,
 /turf/simulated/floor/carpet/blue,
 /area/station/bridge/captain_quarters)
 "bAt" = (
@@ -43895,14 +44089,7 @@
 	},
 /area/station/medical/sleeper)
 "bAu" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	name = "Bar APC";
-	pixel_y = -30
-	},
+/obj/effect/landmark/start/assistant/waiter,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -44203,14 +44390,15 @@
 	},
 /area/station/medical/cryo)
 "bAY" = (
-/obj/machinery/status_display{
-	pixel_x = 32
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/stool/bed/chair/comfy/black{
-	dir = 1
+/turf/simulated/floor{
+	icon_state = "yellow"
 	},
-/turf/simulated/floor/carpet,
-/area/station/civilian/bar)
+/area/station/hallway/primary/port)
 "bAZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -44220,18 +44408,19 @@
 	},
 /area/station/medical/hallway)
 "bBa" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Private Maintenance";
-	req_access = list(12)
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Vacant Office APC";
+	pixel_x = -26
 	},
-/obj/machinery/door/firedoor,
+/obj/structure/table/woodentable,
+/obj/item/weapon/book/manual/wiki/security_space_law,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
 "bBb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -44393,21 +44582,20 @@
 	},
 /area/station/bridge)
 "bBp" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
-"bBq" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance";
-	req_one_access = list(25)
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/station/civilian/bar)
+/area/station/maintenance/cargo)
+"bBq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/station/civilian/locker)
 "bBr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -44456,24 +44644,18 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "bBv" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/stool,
+/obj/effect/landmark/start/botanist,
+/turf/simulated/floor{
+	icon_state = "green"
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/cargo/office)
+/area/station/civilian/hydroponics)
 "bBw" = (
-/obj/random/scrap/safe_even,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/bar)
 "bBx" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -44533,6 +44715,10 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "bBC" = (
@@ -44544,6 +44730,10 @@
 "bBD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
@@ -44593,7 +44783,10 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "bBK" = (
@@ -44757,9 +44950,27 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "bCd" = (
-/obj/structure/device/piano/royal,
-/turf/simulated/floor/wood,
-/area/station/civilian/bar)
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/eastleft{
+	name = "Bar Desk";
+	req_access = list(25)
+	},
+/obj/machinery/door/window/westleft{
+	name = "Kitchen Desk";
+	req_access = list(28)
+	},
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	icon_state = "shutter0";
+	id = "kitchen";
+	name = "Kitchen Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
+/area/station/civilian/kitchen)
 "bCe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -45041,20 +45252,11 @@
 /turf/simulated/floor/engine,
 /area/station/rnd/telesci)
 "bCD" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/civilian/bar)
+/obj/structure/table/woodentable,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/book/manual/wiki/security_space_law,
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
 "bCE" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -45063,6 +45265,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	name = "HoP Office";
+	sortType = "HoP Office"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
@@ -45091,6 +45298,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "bCH" = (
@@ -45107,7 +45317,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "bCI" = (
@@ -45210,8 +45423,15 @@
 	},
 /area/station/civilian/chapel/mass_driver)
 "bCP" = (
-/turf/simulated/floor/carpet,
-/area/station/civilian/bar)
+/obj/item/device/radio/intercom{
+	dir = 0;
+	name = "Station Intercom (General)";
+	pixel_y = 27
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/locker)
 "bCQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -45254,14 +45474,19 @@
 /turf/simulated/floor,
 /area/station/civilian/janitor)
 "bCT" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/media/jukebox/bar,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/obj/machinery/camera{
+	c_tag = "Bar West";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/bar)
 "bCU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -45348,24 +45573,26 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
 "bDd" = (
-/obj/structure/table/woodentable,
-/obj/item/ashtray/glass,
-/obj/item/weapon/lighter/zippo{
-	pixel_x = -5;
-	pixel_y = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 32
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/turf/simulated/floor/carpet,
-/area/station/civilian/bar)
+/obj/structure/disposalpipe/sortjunction{
+	dir = 2;
+	icon_state = "pipe-j2s";
+	name = "QM Office";
+	sortType = "RnD Break Room"
+	},
+/turf/simulated/floor,
+/area/station/cargo/office)
 "bDe" = (
 /obj/structure/object_wall/pod{
 	icon_state = "2,2"
@@ -45373,16 +45600,9 @@
 /turf/environment/space/shuttle,
 /area/shuttle/escape_pod2/station)
 "bDf" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
-	},
-/obj/structure/table,
-/obj/machinery/computer/stockexchange,
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "brown"
-	},
-/area/station/cargo/office)
+/obj/machinery/smartfridge,
+/turf/simulated/wall,
+/area/station/civilian/kitchen)
 "bDg" = (
 /obj/item/weapon/reagent_containers/glass/beaker/cryoxadone{
 	pixel_x = 7;
@@ -45444,16 +45664,18 @@
 	},
 /area/station/medical/cryo)
 "bDk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/disposal,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
+/area/station/civilian/locker)
 "bDl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -45472,54 +45694,69 @@
 	},
 /area/station/medical/medbreak)
 "bDm" = (
-/obj/structure/table,
-/obj/item/device/destTagger,
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "brown"
+/obj/item/weapon/book/manual/hydroponics_beekeeping,
+/obj/item/device/eftpos{
+	eftpos_name = "Botany EFTPOS scanner"
 	},
-/area/station/cargo/office)
+/obj/item/weapon/paper/hydroponics,
+/obj/machinery/light_switch{
+	pixel_x = -23
+	},
+/obj/structure/table/glass,
+/obj/item/weapon/book/manual/wiki/hydroponics,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/station/civilian/hydroponics)
 "bDn" = (
 /turf/simulated/wall,
 /area/station/civilian/theatre)
 "bDo" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access = list(12)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor,
+/area/station/cargo/storage)
+"bDp" = (
+/obj/machinery/power/port_gen/pacman/scrap,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/station/cargo/recycleroffice)
+"bDq" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
-"bDp" = (
-/turf/simulated/wall,
-/area/station/civilian/cold_room)
-"bDq" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/sortjunction/wildcard{
+/area/station/civilian/hydroponics)
+"bDr" = (
+/obj/machinery/washing_machine,
+/obj/structure/window/reinforced{
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "browncorner"
+	dir = 8;
+	icon_state = "barber"
 	},
-/area/station/hallway/secondary/entry)
-"bDr" = (
-/obj/machinery/door/airlock{
-	name = "Honk Office";
-	req_access = list(46)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/civilian/theatre)
+/area/station/civilian/locker)
 "bDs" = (
 /obj/structure/stool,
 /obj/item/device/radio/intercom{
@@ -45549,10 +45786,8 @@
 /turf/simulated/floor/carpet/blue,
 /area/station/civilian/dormitories/dormthree)
 "bDv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
-/area/station/security/vacantoffice)
+/turf/simulated/floor,
+/area/station/civilian/bar)
 "bDw" = (
 /obj/machinery/status_display,
 /turf/simulated/wall,
@@ -45755,8 +45990,14 @@
 /turf/simulated/floor/carpet/green,
 /area/station/medical/patients_rooms)
 "bDO" = (
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "barber"
+	},
+/area/station/civilian/locker)
 "bDP" = (
 /obj/machinery/camera{
 	c_tag = "Central Hallway South-West";
@@ -45816,12 +46057,16 @@
 	},
 /area/station/medical/storage)
 "bDU" = (
-/obj/structure/table/woodentable,
-/obj/item/clothing/head/santahat,
-/obj/item/clothing/suit/santa,
-/obj/item/weapon/storage/backpack/santabag,
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
+/obj/structure/closet/wardrobe/black,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "vault"
+	},
+/area/station/civilian/locker)
 "bDV" = (
 /turf/simulated/wall,
 /area/station/medical/patients_rooms)
@@ -45843,33 +46088,17 @@
 	},
 /area/station/cargo/miningoffice)
 "bDY" = (
-/obj/machinery/door_control{
-	id = "bar";
-	name = "Privacy shutter";
-	pixel_x = 8;
-	pixel_y = -24;
-	req_access = list(25,1)
-	},
-/obj/machinery/computer/arcade,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
-	},
-/area/station/civilian/bar)
-"bDZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/stool/bed/chair/office/dark{
+	dir = 1
 	},
 /turf/simulated/floor,
-/area/station/civilian/locker)
+/area/station/cargo/storage)
+"bDZ" = (
+/turf/simulated/floor/carpet/blue,
+/area/station/civilian/bar)
 "bEa" = (
 /obj/structure/table/woodentable,
+/obj/item/device/camera,
 /obj/item/weapon/storage/photo_album{
 	pixel_y = -10
 	},
@@ -45879,7 +46108,6 @@
 /obj/machinery/telescience_jammer{
 	radius = 2
 	},
-/obj/item/device/camera,
 /turf/simulated/floor/carpet/blue,
 /area/station/bridge/captain_quarters)
 "bEb" = (
@@ -45976,36 +46204,44 @@
 	},
 /area/station/maintenance/science)
 "bEk" = (
-/obj/structure/stool,
-/obj/effect/landmark/start/shaft_miner,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor{
-	icon_state = "bar"
+	dir = 1;
+	icon_state = "asteroid"
 	},
-/area/station/cargo/miningoffice)
+/turf/simulated/floor{
+	icon_state = "siding8"
+	},
+/area/station/civilian/kitchen)
 "bEl" = (
-/obj/structure/stool,
-/obj/effect/landmark/start/shaft_miner,
-/turf/simulated/floor{
-	icon_state = "bar"
+/obj/structure/rack,
+/obj/item/weapon/stock_parts/cell{
+	maxcharge = 2000
 	},
-/area/station/cargo/miningoffice)
+/obj/item/weapon/storage/belt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "bEm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/structure/table/woodentable,
+/obj/item/device/flashlight/lamp,
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
+"bEn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
-"bEn" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Bar Maintenance";
-	req_one_access = list(12,25,28)
-	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "bEo" = (
@@ -46015,23 +46251,22 @@
 	},
 /area/station/rnd/hor)
 "bEp" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/kitchenspike,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	dir = 1;
+	icon_state = "brown"
 	},
-/area/station/civilian/cold_room)
+/area/station/cargo/storage)
 "bEq" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/machinery/icecream_vat,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
-/area/station/civilian/cold_room)
+/area/station/hallway/secondary/entry)
 "bEr" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -46056,16 +46291,18 @@
 /turf/simulated/floor/carpet/green,
 /area/station/medical/psych)
 "bEu" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -30
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/glass{
+	name = "Diner"
 	},
-/obj/structure/dresser,
-/obj/structure/mirror{
-	pixel_y = 26
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
+/area/station/civilian/bar)
 "bEv" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -46090,18 +46327,15 @@
 	},
 /area/station/bridge)
 "bEx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/structure/closet/wardrobe/xenos,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/structure/closet/crate,
 /turf/simulated/floor{
-	icon_state = "floorgrime"
+	dir = 8;
+	icon_state = "vault"
 	},
-/area/station/cargo/storage)
+/area/station/civilian/locker)
 "bEy" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -46154,19 +46388,10 @@
 	},
 /area/station/bridge)
 "bED" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/turf/simulated/floor{
+	icon_state = "bar"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/carpet/purple,
-/area/station/civilian/theatre)
+/area/station/cargo/miningbreaktime)
 "bEE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -46174,16 +46399,14 @@
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "bEF" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/structure/kitchenspike,
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
 	},
-/turf/simulated/floor/carpet/purple,
-/area/station/civilian/theatre)
+/area/station/civilian/kitchen)
 "bEG" = (
 /obj/structure/sink{
 	dir = 8;
@@ -46201,19 +46424,12 @@
 	},
 /area/station/rnd/lab)
 "bEI" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=1";
-	freq = 1400;
-	location = "Hydroponics"
-	},
-/obj/structure/plasticflaps{
-	opacity = 1
+/obj/machinery/door/airlock/maintenance{
+	name = "Hydroponics Maintenance";
+	req_access = list(35)
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "bot"
-	},
+/turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
 "bEJ" = (
 /obj/machinery/space_heater,
@@ -46232,26 +46448,23 @@
 	},
 /area/station/hallway/primary/central)
 "bEL" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance{
-	name = "Hydroponics Maintenance";
-	req_one_access = list(35,28)
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
 	},
-/turf/simulated/floor/plating,
-/area/station/civilian/hydroponics)
+/obj/structure/closet/lawcloset,
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
 "bEM" = (
-/obj/machinery/camera{
-	c_tag = "Bar South";
-	dir = 1
-	},
-/obj/structure/stool/bed/chair/comfy/black{
-	dir = 8
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+	icon_state = "green"
 	},
-/area/station/civilian/bar)
+/area/station/civilian/hydroponics)
 "bEN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -46277,15 +46490,17 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/aft)
 "bEO" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/lipstick/purple{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/machinery/door/window/westright{
+	name = "Kitchen Maintenance";
+	req_access = list(28)
 	},
-/obj/item/weapon/lipstick/jade,
-/obj/item/toy/sound_button,
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
+/area/station/civilian/kitchen)
 "bEP" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/execution)
@@ -46326,47 +46541,46 @@
 	},
 /area/station/medical/medbreak)
 "bES" = (
-/obj/structure/closet/secure_closet/personal,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
+"bET" = (
+/obj/machinery/door/airlock/glass{
+	name = "Hydroponics";
+	req_access = list(35)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/station/civilian/hydroponics)
+"bEU" = (
+/obj/structure/stool,
+/obj/machinery/camera{
+	c_tag = "Locker Room"
+	},
+/turf/simulated/floor,
+/area/station/civilian/locker)
+"bEV" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
-/area/station/civilian/locker)
-"bET" = (
-/obj/machinery/door_control{
-	id = "bar";
-	name = "Privacy shutter";
-	pixel_x = 8;
-	pixel_y = 24
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/bar)
-"bEU" = (
-/obj/structure/table/woodentable/fancy/black,
-/obj/item/trash/candle/red,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
-	},
-/area/station/civilian/bar)
-"bEV" = (
-/obj/machinery/door/airlock{
-	name = "Kitchen Cold Room";
-	req_access = list(28)
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/station/civilian/cold_room)
+/turf/simulated/floor/plating,
+/area/station/cargo/storage)
 "bEW" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
@@ -46401,12 +46615,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "bFa" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/door/poddoor/shutters{
+	id = "qm_warehouse";
+	name = "Warehouse Shutters"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
+/area/station/cargo/storage)
 "bFb" = (
 /obj/structure/stool/bed/chair/metal/blue,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -46592,29 +46811,35 @@
 	},
 /area/station/medical/patients_rooms)
 "bFr" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Delivery Office";
-	req_access = list(50)
-	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Hydroponics";
+	req_access = list(35)
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor,
-/area/station/cargo/office)
+/area/station/civilian/hydroponics)
 "bFs" = (
+/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken4"
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Bay";
+	req_one_access = list(31,48,67)
 	},
-/area/station/civilian/theatre)
+/turf/simulated/floor,
+/area/station/cargo/storage)
 "bFt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -46659,16 +46884,6 @@
 "bFy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 8;
-	name = "Bar";
-	sortType = "Bar"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -46826,20 +47041,9 @@
 	},
 /area/station/rnd/hallway)
 "bFO" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor,
+/area/station/cargo/office)
 "bFP" = (
 /obj/random/scrap/safe_even,
 /turf/simulated/floor/plating,
@@ -47069,24 +47273,16 @@
 	},
 /area/station/bridge)
 "bGl" = (
-/obj/machinery/door/firedoor,
-/obj/structure/table/reinforced,
-/obj/item/weapon/paper_bin,
-/obj/machinery/door/window/westright{
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/alarm{
 	dir = 4;
-	name = "Cargo Delivery Door";
-	req_access = list(50)
+	pixel_x = -23
 	},
-/obj/machinery/status_display{
-	layer = 3.3;
-	pixel_y = -30;
-	supply_display = 1
-	},
-/obj/item/weapon/pen,
-/turf/simulated/floor{
-	icon_state = "bot"
-	},
-/area/station/cargo/office)
+/turf/simulated/floor/carpet,
+/area/station/civilian/bar)
 "bGm" = (
 /obj/structure/stool/bed/chair/wood/normal{
 	dir = 1
@@ -47206,11 +47402,19 @@
 	},
 /area/station/civilian/barbershop)
 "bGt" = (
-/obj/structure/stool/bed/chair/comfy/brown{
-	dir = 4
+/obj/machinery/door_control{
+	id = "qm_warehouse";
+	name = "Warehouse Door Control";
+	pixel_x = -1;
+	pixel_y = 24;
+	req_access = list(31)
 	},
-/turf/simulated/floor/wood,
-/area/station/civilian/bar)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "bGu" = (
 /obj/structure/rack,
 /obj/item/weapon/tank/oxygen,
@@ -47218,18 +47422,22 @@
 /turf/simulated/floor/plating,
 /area/station/bridge/teleporter)
 "bGv" = (
-/obj/structure/closet/crate,
-/obj/item/toy/prize/honk,
-/obj/item/weapon/coin/bananium,
-/obj/item/weapon/coin/bananium{
-	pixel_x = -3
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/stool,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/obj/item/weapon/coin/bananium{
-	pixel_x = 7;
-	pixel_y = 5
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/recycler,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/cargo/recycleroffice)
 "bGw" = (
 /obj/machinery/disposal,
 /obj/machinery/light{
@@ -47351,15 +47559,16 @@
 	},
 /area/station/rnd/robotics)
 "bGI" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "delivery"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/area/station/cargo/storage)
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "bGJ" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor{
@@ -47446,24 +47655,13 @@
 	},
 /area/station/medical/patient_a)
 "bGQ" = (
-/obj/machinery/door/airlock{
-	name = "Honk Office";
-	req_access = list(46)
+/obj/structure/table,
+/obj/item/weapon/storage/box,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/civilian/theatre)
+/area/station/cargo/recycleroffice)
 "bGR" = (
 /obj/machinery/camera{
 	c_tag = "Patient's Room";
@@ -47759,15 +47957,12 @@
 	},
 /area/station/civilian/library)
 "bHw" = (
-/obj/structure/closet/crate,
-/obj/random/tools/tool,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "delivery"
-	},
-/area/station/cargo/storage)
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "bHx" = (
 /obj/structure/table/reinforced,
 /obj/item/device/transfer_valve{
@@ -47805,6 +48000,10 @@
 	},
 /area/station/medical/storage)
 "bHz" = (
+/obj/item/device/camera{
+	pixel_x = 8;
+	pixel_y = 7
+	},
 /obj/structure/table/woodentable,
 /obj/item/device/taperecorder{
 	pixel_x = -8;
@@ -47813,7 +48012,6 @@
 /obj/machinery/newscaster{
 	pixel_y = -28
 	},
-/obj/item/device/camera,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -47828,24 +48026,14 @@
 /turf/simulated/floor/carpet/black,
 /area/station/security/iaa_office)
 "bHB" = (
-/obj/machinery/door/airlock/mining{
-	name = "Mining Equpment";
-	req_access = list(48)
-	},
-/obj/machinery/door/firedoor,
+/turf/simulated/wall,
+/area/station/cargo/miningbreaktime)
+"bHC" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
-/area/station/cargo/miningoffice)
-"bHC" = (
-/obj/structure/dryer{
-	dir = 4;
-	pixel_x = -6
-	},
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/station/civilian/cold_room)
+/area/station/cargo/storage)
 "bHD" = (
 /obj/machinery/light/small,
 /obj/machinery/light_switch{
@@ -47863,26 +48051,16 @@
 	},
 /area/station/hallway/primary/starboard)
 "bHF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/cable{
 	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
+/area/station/civilian/bar)
 "bHG" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -47912,20 +48090,41 @@
 	},
 /area/station/bridge/hop_office)
 "bHI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/structure/table,
+/obj/item/weapon/hand_labeler,
+/obj/item/weapon/stamp{
+	name = "cargo rubber stamp";
+	pixel_x = -3;
+	pixel_y = 3;
+	stamp_message = "Cargo"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/item/weapon/hand_labeler,
+/obj/structure/sign/poster{
+	official = 1;
+	pixel_x = 32
 	},
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	dir = 4;
+	icon_state = "brown"
 	},
-/area/station/civilian/cold_room)
+/area/station/cargo/storage)
 "bHJ" = (
-/obj/item/weapon/flora/random,
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/station/cargo/recycleroffice)
 "bHK" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -47982,14 +48181,16 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "bHO" = (
-/obj/structure/sink{
+/obj/item/device/radio/intercom{
 	dir = 4;
-	pixel_x = 12
+	name = "Station Intercom (General)";
+	pixel_x = 27
 	},
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	dir = 4;
+	icon_state = "brown"
 	},
-/area/station/civilian/cold_room)
+/area/station/cargo/qm)
 "bHP" = (
 /obj/effect/landmark/start/medical_intern,
 /turf/simulated/floor{
@@ -48055,14 +48256,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "bHU" = (
-/obj/structure/stool/bed/chair/comfy/brown{
-	dir = 8
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
 	},
-/obj/structure/sign/poster/official/love_ian{
-	pixel_x = 32
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
 	},
-/turf/simulated/floor/wood,
-/area/station/civilian/bar)
+/area/station/civilian/kitchen)
 "bHV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -48291,7 +48493,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/area/station/hallway/secondary/entry)
 "bIo" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -48311,17 +48513,20 @@
 	},
 /area/station/civilian/dormitories)
 "bIp" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 30
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/machinery/door_control{
-	id = "bar-m";
-	name = "Maintenance Shutters";
-	pixel_x = -8;
-	pixel_y = 24
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/civilian/bar)
 "bIq" = (
 /obj/item/weapon/storage/fancy/donut_box,
@@ -48533,24 +48738,34 @@
 	},
 /area/station/medical/hallway)
 "bIJ" = (
-/obj/structure/kitchenspike,
-/obj/machinery/camera{
-	c_tag = "Kitchen Cold Room"
-	},
-/obj/machinery/alarm{
-	pixel_y = 23
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	dir = 1;
+	icon_state = "brown"
 	},
-/area/station/civilian/cold_room)
+/area/station/cargo/storage)
 "bIK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
+/obj/structure/table,
+/obj/machinery/requests_console{
+	department = "Cargo Bay";
+	departmentType = 2;
+	pixel_x = 30
 	},
-/area/station/civilian/cold_room)
+/obj/machinery/cell_charger,
+/obj/item/clothing/head/soft,
+/obj/item/clothing/head/soft,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "bIL" = (
 /obj/machinery/vending/robotics,
 /obj/machinery/camera{
@@ -48564,14 +48779,15 @@
 	},
 /area/station/rnd/robotics)
 "bIM" = (
-/obj/machinery/chem_master/condimaster{
-	name = "CondiMaster Neo";
-	pixel_x = -5
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	icon_state = "floorgrime"
 	},
-/area/station/civilian/cold_room)
+/area/station/cargo/storage)
 "bIN" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -48713,19 +48929,32 @@
 	},
 /area/station/rnd/brainstorm_center)
 "bIY" = (
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
+/obj/machinery/hydroponics/constructable,
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
 	},
-/area/station/civilian/cold_room)
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/hydroponics)
 "bIZ" = (
 /turf/simulated/wall,
 /area/station/maintenance/engineering)
 "bJa" = (
-/obj/machinery/gibber,
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/area/station/civilian/cold_room)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/cargo/storage)
 "bJb" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -48986,7 +49215,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/area/station/hallway/secondary/entry)
 "bJA" = (
 /obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor{
@@ -49017,7 +49246,6 @@
 /turf/simulated/floor/carpet/blue,
 /area/station/civilian/dormitories/dormthree)
 "bJF" = (
-/obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/carpet{
 	icon_state = "carpetsymbol"
 	},
@@ -49027,7 +49255,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -49056,20 +49283,27 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/area/station/hallway/secondary/entry)
 "bJJ" = (
 /turf/simulated/wall/r_wall,
 /area/station/rnd/telesci)
 "bJK" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/item/weapon/shard{
-	icon_state = "small"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "bJL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -49100,18 +49334,12 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/area/station/maintenance/cargo)
 "bJO" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/closet/theatrecloset,
-/turf/simulated/floor/carpet/purple,
-/area/station/civilian/theatre)
+/obj/item/weapon/razor,
+/obj/structure/table/glass,
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "bJP" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall,
@@ -49148,19 +49376,15 @@
 	},
 /area/station/civilian/gym)
 "bJT" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Disposal Access";
-	req_access = list(12)
-	},
-/obj/machinery/door/firedoor,
+/obj/machinery/hologram/holopad,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/turf/simulated/floor,
+/area/station/cargo/qm)
 "bJU" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -49176,30 +49400,22 @@
 	},
 /area/station/medical/medbreak)
 "bJW" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Disposal Access";
+	req_access = list(12)
+	},
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bJX" = (
-/obj/structure/closet/crate/freezer,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "warning"
-	},
-/area/station/civilian/cold_room)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/station/cargo/qm)
 "bJY" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
@@ -49279,18 +49495,12 @@
 	},
 /area/station/medical/hallway)
 "bKh" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
+/obj/structure/closet/secure_closet/cargotech,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "warning"
+	dir = 4;
+	icon_state = "brown"
 	},
-/area/station/civilian/cold_room)
+/area/station/cargo/storage)
 "bKi" = (
 /obj/structure/stool,
 /turf/simulated/floor{
@@ -50308,7 +50518,6 @@
 	},
 /area/station/civilian/dormitories)
 "bMd" = (
-/obj/effect/decal/cleanable/cobweb2,
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
@@ -51645,25 +51854,26 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "bOy" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/area/station/hallway/secondary/entry)
+/obj/machinery/vending/hydronutrients,
+/turf/simulated/floor,
+/area/station/civilian/hydroponics)
 "bOz" = (
 /turf/simulated/floor/engine,
 /area/station/rnd/telesci)
 "bOA" = (
-/obj/machinery/light{
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "browncorner"
-	},
-/area/station/hallway/secondary/entry)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics)
 "bOB" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -52740,11 +52950,27 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/starboard)
 "bQB" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	icon_state = "browncorner"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/area/station/hallway/secondary/entry)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/port)
 "bQC" = (
 /obj/structure/stool,
 /turf/simulated/floor/carpet/green,
@@ -53051,21 +53277,25 @@
 /turf/simulated/floor/carpet/green,
 /area/station/civilian/dormitories/dormone)
 "bRk" = (
-/obj/machinery/light_switch{
-	pixel_y = 25
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
 	},
-/obj/structure/closet/lawcloset,
-/turf/simulated/floor/wood,
-/area/station/security/vacantoffice)
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/civilian/bar)
 "bRm" = (
 /turf/simulated/wall/r_wall,
 /area/station/rnd/storage)
 "bRn" = (
-/turf/simulated/floor{
-	dir = 9;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "bRo" = (
 /obj/structure/barricade/wooden,
 /turf/simulated/floor/plating,
@@ -53130,11 +53360,12 @@
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "bRC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor{
-	icon_state = "bar"
+	dir = 5;
+	icon_state = "vault"
 	},
-/area/station/cargo/miningoffice)
+/area/station/civilian/bar)
 "bRE" = (
 /obj/machinery/power/smes,
 /obj/structure/cable{
@@ -53847,7 +54078,7 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "browncorner"
+	icon_state = "greencorner"
 	},
 /area/station/hallway/secondary/entry)
 "bTq" = (
@@ -54011,14 +54242,9 @@
 /turf/simulated/floor/plating,
 /area/station/rnd/mixing)
 "bTT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor{
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
+/obj/structure/stool/bed/chair/office/dark,
+/turf/simulated/floor,
+/area/station/cargo/miningoffice)
 "bTU" = (
 /obj/machinery/sparker{
 	id = "Xenobio";
@@ -54952,6 +55178,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "neutral"
@@ -55560,25 +55790,7 @@
 	},
 /area/station/maintenance/engineering)
 "bYp" = (
-/obj/structure/closet/crate{
-	name = "TEG crate"
-	},
-/obj/item/weapon/circuitboard/teg,
-/obj/item/weapon/circuitboard/circulator,
-/obj/item/weapon/circuitboard/circulator,
-/obj/item/weapon/stock_parts/capacitor,
-/obj/item/weapon/stock_parts/capacitor,
-/obj/item/weapon/stock_parts/capacitor,
-/obj/item/weapon/stock_parts/console_screen,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/matter_bin,
-/obj/item/weapon/stock_parts/matter_bin,
-/obj/item/stack/cable_coil,
+/obj/structure/closet/crate,
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
@@ -55699,6 +55911,7 @@
 /area/station/civilian/library)
 "bYL" = (
 /obj/structure/closet/cabinet,
+/obj/item/device/camera,
 /obj/item/clothing/under/suit_jacket/red,
 /obj/item/device/eftpos{
 	eftpos_name = "Library EFTPOS scanner"
@@ -55712,10 +55925,6 @@
 /obj/item/clothing/suit/wcoat,
 /obj/item/clothing/head/beret/black,
 /obj/effect/decal/cleanable/cobweb,
-/obj/item/device/camera,
-/obj/item/device/lens/posterization,
-/obj/item/device/lens/sepia,
-/obj/item/device/lens/grayscale,
 /turf/simulated/floor{
 	icon_state = "cult"
 	},
@@ -57302,11 +57511,11 @@
 /area/station/security/armoury)
 "ceV" = (
 /obj/structure/table/woodentable,
+/obj/item/device/camera,
 /obj/machinery/newscaster{
 	pixel_x = -28;
 	pixel_y = 1
 	},
-/obj/item/device/camera/oldcamera,
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken7"
 	},
@@ -58950,8 +59159,9 @@
 	},
 /area/station/rnd/brainstorm_center)
 "cjM" = (
+/obj/machinery/light,
 /turf/simulated/floor{
-	icon_state = "whitecorner"
+	icon_state = "browncorner"
 	},
 /area/station/hallway/primary/port)
 "cjN" = (
@@ -60515,29 +60725,19 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "coa" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 4;
-	name = "Hydroponics";
-	sortType = "Hydroponics"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/port)
+/area/station/civilian/kitchen)
 "coc" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -60726,21 +60926,12 @@
 	},
 /area/station/aisat)
 "cox" = (
-/obj/structure/grille,
 /obj/machinery/door/firedoor,
-/obj/structure/window/reinforced/polarized{
-	dir = 8;
-	id = "kitchen"
-	},
-/obj/structure/window/reinforced/polarized{
-	id = "kitchen"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 1;
-	id = "kitchen"
-	},
-/turf/simulated/floor/plating,
-/area/station/civilian/kitchen)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/station/cargo/office)
 "coz" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 8
@@ -60947,14 +61138,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
@@ -61294,21 +61485,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 4;
-	name = "Kitchen";
-	sortType = "Kitchen"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/port)
@@ -61338,14 +61522,16 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	name = "Kitchen";
+	sortType = "Kitchen"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/port)
@@ -61640,16 +61826,8 @@
 	},
 /area/station/aisat)
 "cqt" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor{
-	icon_state = "whitecorner"
+	icon_state = "browncorner"
 	},
 /area/station/hallway/primary/port)
 "cqu" = (
@@ -62026,11 +62204,11 @@
 	},
 /area/station/bridge/hop_office)
 "cri" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/vending/coffee,
+/turf/simulated/floor{
+	icon_state = "dark"
 	},
-/turf/simulated/floor,
-/area/station/cargo/office)
+/area/station/civilian/bar)
 "crn" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/bluegrid{
@@ -62379,12 +62557,17 @@
 	},
 /area/station/tcommsat/chamber)
 "crY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/simulated/floor,
-/area/station/cargo/office)
+/obj/structure/window/reinforced,
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/kitchen)
 "csa" = (
 /obj/structure/rack,
 /obj/item/weapon/circuitboard/crew{
@@ -63312,16 +63495,32 @@
 	},
 /area/station/bridge/hop_office)
 "cux" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/random/vending/cola,
+/turf/simulated/floor{
+	icon_state = "brown"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
+/area/station/cargo/miningbreaktime)
+"cuz" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "cuB" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -65942,8 +66141,6 @@
 /obj/item/weapon/gun/syringe,
 /obj/item/weapon/medical/teleporter,
 /obj/item/weapon/medical/teleporter,
-/obj/item/device/lens/rentgene,
-/obj/item/device/camera,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -67865,12 +68062,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/stool/bed/chair/wood/normal{
-	dir = 4
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
 	},
-/obj/effect/landmark/start/clown,
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "cIu" = (
 /obj/structure/table/woodentable,
 /obj/effect/decal/cleanable/cobweb2,
@@ -69268,14 +69465,20 @@
 	},
 /area/station/hallway/secondary/exit)
 "cTO" = (
-/obj/structure/stool/bed/chair/office/dark{
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "brown"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/area/station/cargo/office)
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics)
 "cUb" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -69287,10 +69490,14 @@
 	},
 /area/station/security/brig)
 "cUv" = (
-/obj/item/weapon/bedsheet/rainbow,
-/obj/structure/stool/bed,
-/turf/simulated/floor/wood,
-/area/station/maintenance/cargo)
+/obj/structure/table,
+/obj/machinery/light_switch{
+	pixel_x = -23
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/bar)
 "cVb" = (
 /obj/structure/table/glass,
 /obj/item/device/healthanalyzer{
@@ -69415,11 +69622,13 @@
 /turf/simulated/floor,
 /area/station/engineering/engine)
 "dbM" = (
-/obj/structure/window/reinforced{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/station/civilian/bar)
+/turf/simulated/floor{
+	icon_state = "floorgrime"
+	},
+/area/station/cargo/storage)
 "ddb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
@@ -69485,6 +69694,15 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/break_room)
+"deW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor,
+/area/station/cargo/office)
 "dgb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -69625,11 +69843,16 @@
 	},
 /area/station/engineering/drone_fabrication)
 "dra" = (
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "green"
+/obj/structure/table,
+/obj/item/device/destTagger,
+/obj/machinery/camera{
+	c_tag = "Cargo mail";
+	dir = 1
 	},
-/area/station/hallway/primary/port)
+/turf/simulated/floor{
+	icon_state = "brown"
+	},
+/area/station/cargo/office)
 "drb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -69764,14 +69987,13 @@
 	},
 /area/station/medical/reception)
 "dxv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/kitchen_machine/grill,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor,
-/area/station/cargo/office)
+/area/station/civilian/kitchen)
 "dyb" = (
 /obj/structure/sink{
 	dir = 8;
@@ -69787,12 +70009,16 @@
 	},
 /area/station/civilian/garden)
 "dyy" = (
-/obj/structure/table/reinforced,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/station/civilian/bar)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor,
+/area/station/cargo/qm)
 "dzb" = (
 /obj/machinery/light{
 	dir = 4
@@ -69861,20 +70087,13 @@
 	},
 /area/station/hallway/secondary/exit)
 "dDJ" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Cargo Bay Maintenance";
-	req_access = list(31)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/floor{
+	icon_state = "bot"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/area/station/cargo/storage)
 "dEb" = (
 /obj/machinery/door/airlock/external{
 	dock_tag = "arrival_ferry";
@@ -69919,6 +70138,26 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"dIG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "dIT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -70038,7 +70277,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/area/station/maintenance/cargo)
 "dQH" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -70081,12 +70320,16 @@
 	},
 /area/station/rnd/hallway)
 "dSI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood,
-/area/station/civilian/bar)
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "dUb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -70214,16 +70457,13 @@
 	},
 /area/station/civilian/library)
 "ebk" = (
-/obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2"
+/obj/machinery/door/airlock/glass{
+	name = "Hydroponics";
+	req_access = list(35)
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor,
-/area/station/cargo/office)
+/area/station/civilian/hydroponics)
 "ecb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
@@ -70292,16 +70532,9 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/meeting_room)
 "eho" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor,
-/area/station/civilian/hydroponics)
+/area/station/cargo/office)
 "ehX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -70623,19 +70856,22 @@
 	},
 /area/station/medical/genetics)
 "eFk" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "asteroid"
 	},
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/cargo/office)
+/turf/simulated/floor{
+	icon_state = "siding8"
+	},
+/area/station/civilian/kitchen)
 "eGb" = (
 /obj/item/stack/medical/ointment{
 	pixel_y = 4
@@ -70659,24 +70895,15 @@
 	},
 /area/station/medical/reception)
 "eHa" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/glass{
-	name = "Kitchen";
-	req_access = list(28)
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=8";
+	freq = 1400;
+	location = "QM #3"
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "bot"
 	},
-/area/station/civilian/kitchen)
+/area/station/cargo/storage)
 "eHO" = (
 /obj/machinery/light{
 	dir = 4
@@ -70715,14 +70942,14 @@
 	},
 /area/station/medical/reception)
 "eKs" = (
-/obj/machinery/door/firedoor,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/port)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "eMb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -70857,12 +71084,16 @@
 	},
 /area/station/engineering/break_room)
 "eTT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor{
-	icon_state = "floorgrime"
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/area/station/cargo/storage)
+/obj/item/weapon/shard{
+	icon_state = "small"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "eUb" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -70881,20 +71112,17 @@
 /turf/simulated/floor/plating,
 /area/station/medical/cmo)
 "eUl" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/table,
+/obj/item/weapon/folder/yellow,
+/obj/item/weapon/stamp{
+	name = "recycler's rubber stamp";
+	stamp_message = "Recycler"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/cargo/recycleroffice)
 "eVb" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel";
@@ -70914,11 +71142,13 @@
 	},
 /area/station/bridge/hop_office)
 "eVv" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor{
-	icon_state = "floorgrime"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
-/area/station/cargo/storage)
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/cargo/recycleroffice)
 "eVy" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
@@ -70957,12 +71187,12 @@
 /turf/simulated/floor,
 /area/station/construction)
 "eXg" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/item/toy/cards,
+/turf/simulated/floor{
+	icon_state = "grimy"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/civilian/bar)
 "eXz" = (
 /obj/structure/stool/bed/chair/comfy/black{
 	dir = 1
@@ -70975,14 +71205,13 @@
 "eZb" = (
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/area/station/hallway/secondary/entry)
 "eZS" = (
-/obj/machinery/camera{
-	c_tag = "Cargo Office South";
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/seed_extractor,
 /turf/simulated/floor,
-/area/station/cargo/office)
+/area/station/civilian/hydroponics)
 "fab" = (
 /obj/machinery/door/airlock/external{
 	dock_tag = "arrival_admin";
@@ -71001,16 +71230,36 @@
 	},
 /area/station/hallway/secondary/exit)
 "fcK" = (
-/obj/structure/reagent_dispensers/beerkeg,
-/turf/simulated/floor/wood,
-/area/station/civilian/bar)
-"fec" = (
-/obj/machinery/autolathe,
-/turf/simulated/floor{
-	dir = 10;
-	icon_state = "brown"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/area/station/cargo/office)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "asteroid"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "siding2"
+	},
+/area/station/civilian/kitchen)
+"fec" = (
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 28
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry)
 "ffD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -71054,24 +71303,25 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "fkD" = (
-/obj/item/weapon/hand_labeler,
-/obj/item/weapon/packageWrap,
-/obj/structure/table/glass,
-/obj/item/weapon/book/manual/wiki/hydroponics,
-/obj/item/device/eftpos{
-	eftpos_name = "Botany EFTPOS scanner"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/obj/machinery/light_switch{
-	pixel_y = 24
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "green"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/station/civilian/hydroponics)
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "flb" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -71096,11 +71346,14 @@
 	},
 /area/station/security/brig)
 "fmh" = (
-/obj/machinery/seed_extractor,
+/obj/structure/table,
+/obj/item/weapon/wrapping_paper,
+/obj/item/weapon/wrapping_paper,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "arrival"
 	},
-/area/station/civilian/hydroponics)
+/area/station/cargo/office)
 "fmS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -71268,9 +71521,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/plating{
-	icon_state = "platebotc"
-	},
+/turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
 "fvU" = (
 /obj/structure/disposalpipe/segment{
@@ -71308,9 +71559,7 @@
 	tag_exterior_door = "recycler_outer";
 	tag_interior_door = "recycler_inner"
 	},
-/turf/simulated/floor/plating{
-	icon_state = "platebotc"
-	},
+/turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
 "fxg" = (
 /obj/structure/cable{
@@ -71367,36 +71616,24 @@
 /turf/simulated/floor/plating/airless,
 /area/station/cargo/recycler)
 "fDb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
+"fDx" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-y"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
+	icon_state = "dark"
 	},
-/area/station/cargo/storage)
-"fDx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/cargo/recycleroffice)
 "fDS" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -71417,16 +71654,14 @@
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "fDT" = (
-/obj/machinery/power/apc{
-	name = "Port Hall APC";
-	pixel_y = -26
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "greencorner"
+	icon_state = "floorgrime"
 	},
-/area/station/hallway/primary/port)
+/area/station/cargo/storage)
 "fEm" = (
 /obj/machinery/camera{
 	c_tag = "Prison Maintenance";
@@ -71656,11 +71891,10 @@
 /area/station/civilian/library)
 "fQb" = (
 /obj/item/clothing/mask/breath,
-/obj/structure/reagent_dispensers/aqueous_foam_tank,
 /obj/item/weapon/tank/oxygen,
 /obj/item/clothing/mask/breath,
 /turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/area/station/hallway/secondary/entry)
 "fRb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood{
@@ -71756,13 +71990,11 @@
 	},
 /area/station/medical/morgue)
 "fVd" = (
-/obj/structure/stool/bed/chair/comfy/black{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken5"
-	},
-/area/station/maintenance/cargo)
+/turf/simulated/floor,
+/area/station/civilian/hydroponics)
 "fWb" = (
 /obj/structure/stool/bed/chair/office/light{
 	dir = 4
@@ -71795,19 +72027,26 @@
 /turf/simulated/floor,
 /area/station/engineering/engine)
 "fXb" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/item/weapon/storage/box,
+/obj/structure/table,
+/obj/item/weapon/storage/box,
+/obj/item/weapon/storage/box,
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -28
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/turf/simulated/floor,
+/area/station/cargo/office)
 "fXV" = (
-/obj/structure/stool/bed/chair/comfy/black,
-/turf/simulated/floor/carpet/black,
-/area/station/security/vacantoffice)
+/obj/machinery/newscaster{
+	pixel_x = 27;
+	pixel_y = 1
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "fYb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -71856,16 +72095,14 @@
 /turf/simulated/floor/grass,
 /area/station/medical/genetics)
 "gdb" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/table/woodentable,
+/obj/item/device/flashlight/lamp/green,
+/obj/structure/sign/poster{
+	official = 1;
+	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor{
-	icon_state = "bot"
-	},
-/area/station/cargo/storage)
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
 "geb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -71883,6 +72120,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"geo" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/recycleroffice)
 "gfm" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
@@ -71900,14 +72152,11 @@
 	},
 /area/station/engineering/drone_fabrication)
 "ggb" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/cargo/storage)
+/area/station/cargo/office)
 "ghb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -71927,9 +72176,15 @@
 	},
 /area/station/engineering/break_room)
 "gib" = (
-/obj/structure/closet/secure_closet/recycler,
-/obj/machinery/status_display{
-	pixel_y = 32
+/obj/structure/table,
+/obj/structure/sign/poster{
+	official = 1;
+	pixel_x = -32
+	},
+/obj/item/device/flashlight,
+/obj/item/weapon/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -71952,11 +72207,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "brown"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/station/cargo/office)
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "greenchecker"
+	},
+/area/station/civilian/hydroponics)
 "glT" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -72140,29 +72398,28 @@
 	},
 /area/station/engineering/engine)
 "gvg" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
-"gvk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 5
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/cargo/miningbreaktime)
+"gvk" = (
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Hydroponics APC";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor{
+	icon_state = "green"
+	},
+/area/station/civilian/hydroponics)
 "gwb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -72297,9 +72554,18 @@
 	},
 /area/station/maintenance/incinerator)
 "gGO" = (
-/obj/structure/sign/warning/docking,
-/turf/simulated/wall,
-/area/station/maintenance/disposal)
+/obj/structure/table,
+/obj/item/weapon/paper_bin,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25
+	},
+/obj/item/weapon/packageWrap,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/station/cargo/recycleroffice)
 "gGP" = (
 /obj/machinery/vending/engivend,
 /turf/simulated/floor{
@@ -72347,23 +72613,34 @@
 	icon_state = "delivery"
 	},
 /area/station/rnd/robotics)
-"gKG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+"gKC" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/station/civilian/bar)
+"gKG" = (
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "green"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/area/station/civilian/hydroponics)
+/obj/structure/disposalpipe/sortjunction{
+	dir = 4;
+	name = "Private Office";
+	sortType = "Private Office"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "gKX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -72374,10 +72651,17 @@
 	},
 /area/station/hallway/secondary/entry)
 "gLt" = (
-/obj/machinery/light_switch{
-	pixel_x = -23
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -72441,13 +72725,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "gNe" = (
-/obj/item/weapon/flora/pottedplant/minitree,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "green"
+/obj/structure/stool/bed/chair{
+	dir = 4
 	},
-/area/station/civilian/hydroponics)
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "gOF" = (
 /obj/structure/transit_tube{
 	icon_state = "N-S"
@@ -72485,12 +72767,19 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
 "gQi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+/obj/machinery/requests_console{
+	department = "Cargo Bay";
+	departmentType = 2;
+	pixel_x = -30
 	},
-/area/station/civilian/kitchen)
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "brown"
+	},
+/area/station/cargo/qm)
 "gRb" = (
 /obj/structure/closet/secure_closet/security,
 /turf/simulated/floor{
@@ -72524,6 +72813,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
+"gSy" = (
+/obj/structure/table,
+/obj/item/weapon/folder/yellow,
+/obj/item/weapon/clipboard,
+/obj/item/weapon/stamp/qm,
+/turf/simulated/floor,
+/area/station/cargo/qm)
 "gSN" = (
 /obj/machinery/door/poddoor{
 	id = "disvent";
@@ -72532,15 +72828,14 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/maintenance/incinerator)
 "gSX" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/cargo/office)
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "greenchecker"
+	},
+/area/station/civilian/hydroponics)
 "gTb" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/structure/extinguisher_cabinet{
@@ -72622,20 +72917,15 @@
 	},
 /area/station/maintenance/eva)
 "gWo" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
+/obj/machinery/camera{
+	c_tag = "Quartermaster's Office";
 	dir = 8
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/civilian/kitchen)
+/area/station/cargo/qm)
 "gWp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -72646,10 +72936,26 @@
 	},
 /area/station/hallway/primary/central)
 "gWz" = (
-/obj/item/weapon/flora/pottedplant{
-	icon_state = "plant-21"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/turf/simulated/floor/wood,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "gWR" = (
 /obj/machinery/computer/atmos_alert,
@@ -72673,16 +72979,12 @@
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
 "gXB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(12)
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "gYb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -72693,23 +72995,31 @@
 	},
 /area/station/medical/hallway)
 "gYf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "floorgrime"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/cargo/storage)
 "gYZ" = (
-/obj/structure/rack,
-/obj/item/weapon/storage/toolbox/electrical,
-/obj/item/device/multitool,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/station/cargo/recycleroffice)
 "gZb" = (
 /obj/structure/object_wall/mining{
 	icon_state = "1-3"
@@ -72717,20 +73027,13 @@
 /turf/environment/space,
 /area/shuttle/mining/station)
 "haq" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/civilian/kitchen)
+/turf/simulated/floor,
+/area/station/cargo/office)
 "haA" = (
 /obj/machinery/field_generator{
 	anchored = 1;
@@ -72841,19 +73144,12 @@
 /turf/environment/space,
 /area/shuttle/mining/station)
 "hho" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
+/turf/simulated/floor,
+/area/station/cargo/office)
 "hib" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -72919,20 +73215,19 @@
 	},
 /area/station/engineering/engine)
 "hmR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "hnb" = (
@@ -72944,12 +73239,11 @@
 	},
 /area/shuttle/mining/station)
 "hne" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
-/area/station/cargo/storage)
+/area/station/cargo/miningoffice)
 "hob" = (
 /obj/machinery/door/airlock/external{
 	name = "Arrival Airlock"
@@ -73026,15 +73320,14 @@
 	},
 /area/station/hallway/secondary/exit)
 "hvE" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/newscaster{
+	pixel_x = 30
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/station/civilian/bar)
 "hwb" = (
 /obj/structure/rack,
 /obj/item/weapon/tank/oxygen,
@@ -73126,11 +73419,21 @@
 	},
 /area/station/medical/reception)
 "hBN" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "hFb" = (
@@ -73142,6 +73445,13 @@
 	icon_state = "dark"
 	},
 /area/station/medical/morgue)
+"hFc" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
 "hFo" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -73196,17 +73506,17 @@
 	},
 /area/station/maintenance/chapel)
 "hHe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/cargo/storage)
 "hHi" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -73276,12 +73586,19 @@
 	},
 /area/station/maintenance/eva)
 "hJt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
-/turf/simulated/wall,
-/area/station/cargo/office)
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "vault"
+	},
+/area/station/civilian/hydroponics)
 "hKb" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -73414,18 +73731,11 @@
 	},
 /area/station/hallway/secondary/arrival)
 "hSt" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/firealarm{
+/turf/simulated/floor{
 	dir = 8;
-	pixel_x = -24
+	icon_state = "cautioncorner"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/hallway/primary/port)
 "hTt" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 9
@@ -73612,14 +73922,13 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "ice" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/closet/crate,
+/obj/item/toy/prize/honk,
+/obj/item/weapon/coin/bananium,
+/obj/item/weapon/coin/bananium,
+/obj/item/weapon/coin/bananium,
 /turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/maintenance/engineering)
 "icl" = (
 /obj/machinery/airlock_sensor{
 	id_tag = "atmospherics_sensor";
@@ -73772,9 +74081,9 @@
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/eva)
 "ikq" = (
-/obj/structure/disposalpipe/segment,
+/obj/item/latexballon,
 /turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/storage/emergency2)
 "ilb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -73797,19 +74106,18 @@
 /turf/simulated/wall,
 /area/station/hallway/secondary/mine_sci_shuttle)
 "iob" = (
+/obj/item/weapon/table_parts/wood,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "loadingarea"
-	},
-/area/station/cargo/storage)
+/obj/item/weapon/crowbar/red,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "ipb" = (
+/obj/machinery/camera{
+	c_tag = "Port Hallway 3";
+	dir = 1
+	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "greencorner"
+	icon_state = "browncorner"
 	},
 /area/station/hallway/primary/port)
 "iqb" = (
@@ -73829,14 +74137,19 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/incinerator)
 "iry" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/area/station/cargo/storage)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/cargo/miningbreaktime)
 "irW" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -73850,14 +74163,19 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "isb" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/door_control{
+	id = "qm_warehouse";
+	name = "Warehouse Door Control";
+	pixel_x = 28;
+	req_access = list(31)
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "greencorner"
+	icon_state = "floorgrime"
 	},
-/area/station/hallway/primary/port)
+/area/station/cargo/storage)
 "itb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -73876,9 +74194,15 @@
 	},
 /area/station/medical/reception)
 "itt" = (
-/obj/item/weapon/table_parts/wood/fancy,
-/obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/wood,
+/obj/structure/disposalpipe/tagger/partial{
+	dir = 1;
+	name = "Sorting Office";
+	sort_tag = "Sorting Office"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "iuc" = (
 /obj/structure/disposalpipe/segment,
@@ -73910,32 +74234,40 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
 "ivb" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/camera{
-	c_tag = "Hydroponics";
-	dir = 4
+/obj/machinery/vending/dinnerware,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "cafeteria"
 	},
-/area/station/civilian/hydroponics)
+/area/station/civilian/kitchen)
 "ivL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/airlock/mining{
+	name = "Recycler office";
+	req_access = list(67)
 	},
+/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor,
-/area/station/cargo/office)
+/area/station/cargo/storage)
 "iwb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
@@ -73990,12 +74322,16 @@
 /turf/simulated/floor,
 /area/station/engineering/break_room)
 "iyb" = (
-/obj/machinery/hydroponics/constructable,
-/obj/item/weapon/reagent_containers/glass/bucket,
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	id_tag = "arrival_dock_inner";
+	locked = 1;
+	name = "Arrival Dock External Access";
+	req_one_access = list(13,45,1)
 	},
-/area/station/civilian/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "iyR" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -74032,34 +74368,25 @@
 	},
 /area/station/hallway/primary/central)
 "iAL" = (
-/obj/item/weapon/reagent_containers/spray/plantbgone{
-	pixel_y = 3
-	},
-/obj/item/weapon/reagent_containers/spray/plantbgone{
-	pixel_y = 3
-	},
-/obj/item/weapon/reagent_containers/spray/plantbgone{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/weapon/reagent_containers/spray/plantbgone{
-	pixel_x = 13;
-	pixel_y = 5
-	},
-/obj/structure/table/glass,
-/obj/item/weapon/book/manual/hydroponics_beekeeping,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "green"
+	icon_state = "neutral"
 	},
-/area/station/civilian/hydroponics)
+/area/station/civilian/locker)
 "iAY" = (
-/obj/effect/decal/cleanable/generic,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/reagent_dispensers/beerkeg,
+/obj/machinery/newscaster{
+	pixel_x = 30
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/bar)
 "iBb" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -74103,7 +74430,8 @@
 "iDb" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	icon_state = "browncorner"
+	dir = 4;
+	icon_state = "arrival"
 	},
 /area/station/hallway/secondary/entry)
 "iDo" = (
@@ -74190,13 +74518,20 @@
 /turf/environment/space,
 /area/space)
 "iIo" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "asteroid"
+	},
+/turf/simulated/floor{
+	icon_state = "siding8"
+	},
+/area/station/civilian/kitchen)
 "iJb" = (
 /obj/machinery/embedded_controller/radio/airlock_controller{
 	id_tag = "toxin_test_airlock";
@@ -74211,12 +74546,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "iJB" = (
-/obj/structure/table/reinforced,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "darkred"
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -23
 	},
-/area/station/civilian/bar)
+/turf/simulated/floor{
+	icon_state = "arrival"
+	},
+/area/station/hallway/secondary/entry)
 "iKb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -74331,18 +74668,21 @@
 /area/station/bridge)
 "iRH" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/cargo/storage)
+/area/station/cargo/office)
 "iSb" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -74357,17 +74697,9 @@
 	},
 /area/station/hallway/primary/central)
 "iSz" = (
-/obj/machinery/hologram/holopad,
-/obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
+/obj/effect/landmark/start/botanist,
 /turf/simulated/floor,
-/area/station/cargo/office)
+/area/station/civilian/hydroponics)
 "iTb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -74494,19 +74826,11 @@
 	},
 /area/station/hallway/primary/central)
 "iZg" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "bot"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/cargo/storage)
 "jab" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -74537,14 +74861,13 @@
 /turf/simulated/floor,
 /area/station/construction)
 "jaX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/stool/bed/chair/comfy/black{
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "brown"
+	icon_state = "dark"
 	},
-/area/station/cargo/storage)
+/area/station/civilian/bar)
 "jbb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -74635,7 +74958,6 @@
 /obj/item/weapon/folder,
 /obj/item/weapon/pen,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/device/lens/nude,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "jhb" = (
@@ -74658,21 +74980,18 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "jjN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/maintenance/engineering)
 "jkb" = (
 /obj/structure/rack,
 /obj/item/weapon/reagent_containers/spray/extinguisher,
 /obj/item/clothing/mask/gas/coloured,
 /turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/area/station/hallway/secondary/entry)
 "jkp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -74718,9 +75037,9 @@
 	},
 /area/station/maintenance/disposal)
 "jmV" = (
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor,
-/area/station/civilian/hydroponics)
+/obj/item/clothing/suit/nerdshirt,
+/turf/simulated/floor/plating,
+/area/station/storage/emergency2)
 "jmW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -74746,9 +75065,6 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
@@ -74790,13 +75106,21 @@
 	},
 /area/station/civilian/chapel/mass_driver)
 "jpM" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 5
+/obj/structure/table/reinforced,
+/obj/structure/condiment_shelf{
+	pixel_y = 32
 	},
-/turf/simulated/floor/plating,
-/area/station/cargo/recycleroffice)
+/obj/item/weapon/reagent_containers/food/condiment/sugar,
+/obj/item/weapon/reagent_containers/food/condiment/enzyme,
+/obj/item/weapon/reagent_containers/food/condiment/rice,
+/obj/item/weapon/reagent_containers/food/condiment/saltshaker,
+/obj/item/weapon/reagent_containers/food/condiment/peppermill,
+/obj/item/weapon/reagent_containers/food/condiment/ketchup,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "jqb" = (
 /obj/item/weapon/reagent_containers/syringe,
 /obj/item/weapon/reagent_containers/pill/methylphenidate,
@@ -75062,9 +75386,20 @@
 /turf/simulated/floor/carpet,
 /area/station/civilian/library)
 "jFb" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/obj/structure/table/woodentable,
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/item/weapon/reagent_containers/food/condiment/saltshaker,
+/obj/item/weapon/reagent_containers/food/condiment/peppermill{
+	pixel_x = 3
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/station/civilian/bar)
 "jFK" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Break Room";
@@ -75167,11 +75502,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "jMR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor{
-	icon_state = "browncorner"
-	},
-/area/station/cargo/office)
+/obj/effect/landmark/start/botanist,
+/turf/simulated/floor/grass,
+/area/station/civilian/kitchen)
 "jNb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor,
@@ -75183,13 +75516,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/bridge)
 "jOv" = (
-/obj/structure/stool/bed/chair/office/dark{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "brown"
-	},
-/area/station/cargo/office)
+/obj/structure/stool,
+/turf/simulated/floor/grass,
+/area/station/civilian/kitchen)
 "jOD" = (
 /obj/machinery/the_singularitygen,
 /turf/simulated/floor/plating/airless{
@@ -75252,12 +75581,16 @@
 	},
 /area/station/medical/reception)
 "jQu" = (
-/obj/structure/closet/secure_closet/freezer/kitchen,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/station/civilian/kitchen)
+/turf/simulated/floor,
+/area/station/cargo/storage)
 "jRb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -75463,13 +75796,24 @@
 /turf/simulated/floor,
 /area/station/engineering/break_room)
 "kdV" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/table,
+/obj/machinery/chem_dispenser/soda{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/station/security/vacantoffice)
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/door_control{
+	id = "Bar";
+	name = "Bar Shutter Control";
+	pixel_x = -28;
+	pixel_y = 5;
+	req_access = list(25)
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/bar)
 "keb" = (
 /obj/item/weapon/hand_labeler,
 /obj/structure/table/glass,
@@ -75513,25 +75857,22 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "keS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/structure/disposaloutlet{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/station/security/vacantoffice)
-"kgz" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/cargo/office)
+"kgz" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/item/weapon/flora/floorleaf,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/station/civilian/bar)
 "khw" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -75540,19 +75881,12 @@
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "khG" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/disposalpipe/segment,
+/obj/effect/landmark/start/bartender,
+/turf/simulated/floor{
+	icon_state = "grimy"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/area/station/civilian/bar)
 "kif" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -75692,17 +76026,16 @@
 	},
 /area/station/medical/genetics)
 "kpu" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light_switch{
+	pixel_x = -23
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/structure/stool/bed/chair/metal/yellow{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/turf/simulated/floor{
+	icon_state = "bar"
+	},
+/area/station/cargo/miningbreaktime)
 "kqb" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -75714,17 +76047,14 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "krG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
+	dir = 1;
+	icon_state = "greenchecker"
 	},
-/area/station/cargo/office)
+/area/station/civilian/hydroponics)
 "krJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -75753,10 +76083,16 @@
 /turf/simulated/floor/plating,
 /area/station/bridge/teleporter)
 "kss" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/landmark/start/botanist,
-/turf/simulated/floor,
-/area/station/civilian/hydroponics)
+/obj/structure/sign/poster{
+	official = 1;
+	pixel_x = 32
+	},
+/turf/simulated/floor{
+	icon_state = "brown"
+	},
+/area/station/cargo/office)
 "ksR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -75861,15 +76197,11 @@
 /turf/simulated/wall/r_wall,
 /area/station/hallway/primary/central)
 "kyH" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -28
-	},
-/obj/machinery/light{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/landmark/start/botanist,
 /turf/simulated/floor,
-/area/station/cargo/office)
+/area/station/civilian/hydroponics)
 "kzb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -75969,41 +76301,62 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "kED" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/cargo/storage)
-"kFb" = (
-/obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/cargo/recycleroffice)
-"kFe" = (
-/obj/effect/landmark/start/botanist,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "green"
-	},
-/area/station/civilian/hydroponics)
-"kFh" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access = list(12)
+	name = "Honk Maintenance";
+	req_access = list(46)
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/barricade/wooden{
-	layer = 2.8;
-	name = "doorway barricade"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/civilian/theatre)
+"kFb" = (
+/obj/structure/disposalpipe/trunk,
+/obj/machinery/disposal/deliveryChute{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/office)
+"kFe" = (
+/obj/structure/table,
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/stamp{
+	name = "cargo rubber stamp";
+	pixel_x = -3;
+	pixel_y = 3;
+	stamp_message = "Cargo"
+	},
+/obj/item/weapon/hand_labeler,
+/obj/item/weapon/hand_labeler,
+/turf/simulated/floor{
+	icon_state = "brown"
+	},
+/area/station/cargo/office)
+"kFh" = (
+/obj/structure/sign/poster{
+	dir = 6;
+	official = 1;
+	pixel_x = 32
+	},
+/obj/structure/stool/bed/chair/comfy/black{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/bar)
 "kFw" = (
 /obj/machinery/atmospherics/components/unary/portables_connector,
 /obj/machinery/portable_atmospherics/canister,
@@ -76066,12 +76419,13 @@
 	},
 /area/station/engineering/break_room)
 "kLo" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/weapon/reagent_containers/glass/bucket,
+/obj/structure/closet/crate,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "floorgrime"
 	},
-/area/station/civilian/hydroponics)
+/area/station/cargo/storage)
 "kMb" = (
 /turf/simulated/floor/plating{
 	icon_state = "platingdmg1"
@@ -76118,18 +76472,21 @@
 /area/station/civilian/chapel/mass_driver)
 "kQm" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "kRb" = (
 /turf/simulated/floor{
 	dir = 6;
@@ -76214,8 +76571,12 @@
 	},
 /area/station/civilian/chapel)
 "kYI" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "greencorner"
+	},
 /area/station/hallway/secondary/entry)
 "kYJ" = (
 /obj/item/device/radio/intercom{
@@ -76232,22 +76593,42 @@
 /turf/simulated/floor/engine,
 /area/station/rnd/xenobiology)
 "lab" = (
+/obj/structure/table,
+/obj/item/weapon/stamp{
+	name = "cargo rubber stamp";
+	stamp_message = "Cargo"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
+	},
+/area/station/cargo/miningoffice)
+"lac" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo Bay Maintenance";
+	req_access = list(31)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/cargo/storage)
+"lar" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
-"lac" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/landmark/start/cargo_technician,
-/turf/simulated/floor,
-/area/station/cargo/office)
-"lar" = (
-/obj/structure/sign/warning/moving_parts,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/wall,
-/area/station/cargo/office)
+/area/station/cargo/storage)
 "lay" = (
 /obj/machinery/light{
 	dir = 1
@@ -76267,14 +76648,14 @@
 	},
 /area/station/hallway/primary/central)
 "lcb" = (
-/obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/simulated/floor{
-	icon_state = "brown"
+	icon_state = "browncorner"
 	},
-/area/station/cargo/storage)
+/area/station/hallway/primary/port)
 "lcB" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
@@ -76393,6 +76774,15 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"ljD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/station/civilian/hydroponics)
 "ljQ" = (
 /obj/structure/stool/bed/chair/metal/yellow,
 /turf/simulated/floor,
@@ -76419,11 +76809,14 @@
 	},
 /area/station/hallway/primary/central)
 "lkl" = (
-/obj/machinery/light,
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/area/station/civilian/locker)
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "llb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -76459,14 +76852,23 @@
 /turf/simulated/floor/plating,
 /area/station/storage/emergency2)
 "lqO" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/area/station/cargo/recycleroffice)
+/turf/simulated/floor/plating,
+/area/station/cargo/storage)
 "lru" = (
 /obj/random/foods/food_trash,
 /turf/simulated/floor/plating{
@@ -76474,17 +76876,14 @@
 	},
 /area/station/maintenance/engineering)
 "lrT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/turf/simulated/floor{
+	icon_state = "brown"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/cargo/miningbreaktime)
 "lsD" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -76521,15 +76920,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "lup" = (
-/obj/machinery/kitchen_machine/candymaker,
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Office";
+	req_access = list(50)
 	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/station/cargo/office)
 "lvb" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
@@ -76563,16 +76961,24 @@
 /turf/simulated/wall/r_wall,
 /area/station/bridge)
 "lwo" = (
-/obj/machinery/hologram/holopad,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/cargo/office)
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/grass,
+/turf/simulated/floor{
+	icon_state = "siding8"
+	},
+/area/station/civilian/kitchen)
 "lwE" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/civilian/hydroponics)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/cargo/qm)
 "lxb" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -76623,25 +77029,17 @@
 /turf/simulated/floor,
 /area/station/civilian/fitness)
 "lzm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/station/cargo/office)
+/obj/structure/window/reinforced,
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics)
 "lAb" = (
 /obj/structure/morgue,
 /obj/machinery/camera{
@@ -76703,28 +77101,27 @@
 /area/station/maintenance/medbay)
 "lDp" = (
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/civilian/kitchen)
 "lDy" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/stool,
+/obj/item/device/radio/intercom{
+	dir = 0;
+	name = "Station Intercom (General)";
+	pixel_x = -27
 	},
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/obj/effect/landmark/start/shaft_miner,
+/turf/simulated/floor{
+	icon_state = "bar"
+	},
+/area/station/cargo/miningbreaktime)
 "lEb" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -76771,12 +77168,11 @@
 	},
 /area/station/civilian/chapel)
 "lFQ" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/light,
+/obj/structure/closet/crate/medical,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "floorgrime"
 	},
-/area/station/civilian/hydroponics)
+/area/station/cargo/storage)
 "lGb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -76812,16 +77208,12 @@
 	},
 /area/station/medical/reception)
 "lJr" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
 	},
 /turf/simulated/floor,
-/area/station/civilian/hydroponics)
+/area/station/cargo/office)
 "lJF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -76857,12 +77249,24 @@
 /obj/machinery/field_generator,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
-"lLb" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	icon_state = "browncorner"
+"lKJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/area/station/cargo/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
+"lLb" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/cargo/miningoffice)
 "lLD" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -76900,18 +77304,9 @@
 	},
 /area/station/medical/cmo)
 "lMr" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -28
-	},
-/obj/structure/table,
-/obj/item/clothing/under/lawyer/oldman,
-/obj/item/clothing/under/suit_jacket/really_black{
-	pixel_x = -2
-	},
-/obj/item/clothing/under/suit_jacket/female{
-	pixel_x = 3;
-	pixel_y = 1
+/obj/machinery/washing_machine,
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -76934,20 +77329,18 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "lNB" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/cargo/qm)
+/turf/simulated/floor/plating{
+	icon_state = "platebotc"
+	},
+/area/station/maintenance/cargo)
 "lOb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -77143,15 +77536,11 @@
 	},
 /area/station/hallway/secondary/arrival)
 "mal" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "packageSort2"
+/obj/structure/stool/bed/chair/office/dark{
+	dir = 1
 	},
-/obj/machinery/light,
-/turf/simulated/floor/plating{
-	dir = 1;
-	icon_state = "warnplate"
-	},
+/obj/effect/landmark/start/cargo_technician,
+/turf/simulated/floor,
 /area/station/cargo/office)
 "mbb" = (
 /obj/structure/table/glass,
@@ -77238,6 +77627,12 @@
 	icon_state = "white"
 	},
 /area/station/medical/hallway)
+"mgB" = (
+/obj/effect/decal/cleanable/cobweb2,
+/obj/structure/table/woodentable/fancy,
+/obj/item/weapon/flora/pottedplant/smallcactus,
+/turf/simulated/floor/wood,
+/area/station/civilian/chapel)
 "mhb" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'VACUUM'";
@@ -77426,27 +77821,20 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 4;
-	name = "Locker Room";
-	sortType = "Locker Room"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "msI" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/structure/dresser,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "barber"
+	dir = 5;
+	icon_state = "vault"
 	},
-/area/station/civilian/locker)
+/area/station/civilian/bar)
 "mtb" = (
 /obj/structure/bookcase{
 	name = "bookcase (Religious)"
@@ -77463,19 +77851,30 @@
 /area/station/maintenance/engineering)
 "mtS" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "warningcorner"
 	},
-/area/station/cargo/recycleroffice)
+/area/station/cargo/storage)
 "mub" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -77520,26 +77919,34 @@
 	},
 /area/station/engineering/atmos)
 "myC" = (
-/obj/item/weapon/book/manual/wiki/supply_crates,
-/obj/structure/table,
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "brown"
+	icon_state = "dark"
 	},
-/area/station/cargo/storage)
+/area/station/civilian/hydroponics)
 "myS" = (
-/obj/structure/sign/warning/docking,
-/turf/simulated/wall,
-/area/station/cargo/storage)
-"mzF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/hologram/holopad,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -23
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/hydroponics)
+"mzF" = (
+/obj/structure/window/reinforced,
+/obj/structure/dresser,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "barber"
+	},
 /area/station/civilian/locker)
 "mBb" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
@@ -77549,6 +77956,12 @@
 	icon_state = "platebotc"
 	},
 /area/station/maintenance/medbay)
+"mBp" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "Stairs_wide"
+	},
+/area/station/civilian/bar)
 "mCb" = (
 /obj/structure/sign/departments/science{
 	icon_state = "xenobio3"
@@ -77728,32 +78141,26 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "mNg" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/maintenance/engineering)
 "mNC" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/table,
+/obj/item/weapon/paper_bin,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "brown"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/area/station/cargo/miningoffice)
 "mOb" = (
 /obj/structure/grille{
 	destroyed = 1
@@ -77768,13 +78175,18 @@
 	},
 /area/station/medical/genetics)
 "mPD" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Locker Restrooms APC";
+	pixel_x = -27;
+	pixel_y = 2
 	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "mPK" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -77803,18 +78215,23 @@
 	},
 /area/station/engineering/singularity)
 "mTP" = (
-/obj/machinery/alarm{
-	pixel_y = 28
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/cargo/recycleroffice)
+/turf/simulated/floor,
+/area/station/cargo/storage)
 "mUb" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"mUB" = (
+/obj/item/device/radio/intercom{
+	pixel_y = -28
+	},
+/turf/simulated/floor{
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/secondary/entry)
 "mUK" = (
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
@@ -77910,6 +78327,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"naK" = (
+/obj/machinery/camera{
+	c_tag = "Vacant Office";
+	dir = 4
+	},
+/obj/structure/filingcabinet/chestdrawer/black,
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
 "nbb" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -77927,18 +78352,20 @@
 	},
 /area/station/engineering/break_room)
 "ncT" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/table/reinforced,
+/obj/item/ashtray/plastic,
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	dir = 4;
+	icon_state = "shutter0";
+	id = "Bar";
+	name = "Bar Shutters";
+	opacity = 0
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/turf/simulated/floor{
+	icon_state = "grimy"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/civilian/bar)
 "ndb" = (
 /obj/machinery/mass_driver{
 	dir = 1;
@@ -77970,15 +78397,24 @@
 	},
 /area/station/medical/genetics_cloning)
 "neo" = (
-/obj/machinery/camera{
-	c_tag = "Bar North"
+/obj/machinery/alarm{
+	pixel_y = 26
 	},
-/obj/structure/stool/bar,
-/obj/structure/window/reinforced{
-	dir = 4
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken7"
 	},
-/turf/simulated/floor/wood,
-/area/station/civilian/bar)
+/area/station/security/vacantoffice)
+"neA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor{
+	icon_state = "Stairs_wide"
+	},
+/area/station/civilian/hydroponics)
 "nfb" = (
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
@@ -78000,6 +78436,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"ngy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/landmark{
+	name = "blobstart"
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/station/cargo/recycleroffice)
 "ngQ" = (
 /turf/simulated/floor{
 	dir = 6;
@@ -78101,13 +78547,12 @@
 /turf/simulated/floor/plating,
 /area/station/civilian/playroom)
 "npd" = (
-/obj/machinery/status_display{
-	pixel_y = -32
-	},
+/obj/machinery/kitchen_machine/candymaker,
 /turf/simulated/floor{
-	icon_state = "whitecorner"
+	dir = 5;
+	icon_state = "cafeteria"
 	},
-/area/station/hallway/primary/port)
+/area/station/civilian/kitchen)
 "npv" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -78130,14 +78575,16 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "nqm" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Delivery Office";
-	req_access = list(50)
+/obj/structure/closet/secure_closet/hydroponics,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/cargo/office)
+/turf/simulated/floor{
+	icon_state = "green"
+	},
+/area/station/civilian/hydroponics)
 "nrb" = (
 /obj/structure/rack,
 /obj/item/weapon/airlock_electronics,
@@ -78245,16 +78692,13 @@
 "nws" = (
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/turf/simulated/floor{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/civilian/bar)
 "nxV" = (
 /obj/machinery/shield_capacitor,
 /turf/simulated/floor/plating,
@@ -78309,20 +78753,12 @@
 	},
 /area/station/medical/reception)
 "nAY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "nBb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -78351,11 +78787,21 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/incinerator)
 "nCQ" = (
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood,
-/area/station/civilian/bar)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "nDb" = (
 /obj/structure/window/reinforced,
 /obj/structure/stool/bed/roller,
@@ -78383,12 +78829,6 @@
 	},
 /area/station/engineering/break_room)
 "nFb" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -78397,17 +78837,33 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=CHW";
+	location = "Bar"
+	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "nGb" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/power/apc{
+	cell_type = 2500;
+	dir = 8;
+	name = "Mining breaktime room APC";
+	pixel_x = -27
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor{
-	icon_state = "brown"
+	icon_state = "bar"
 	},
-/area/station/cargo/storage)
+/area/station/cargo/miningbreaktime)
 "nHb" = (
 /obj/structure/rack,
 /obj/item/weapon/storage/briefcase/inflatable{
@@ -78435,9 +78891,14 @@
 /turf/simulated/floor/wood,
 /area/station/maintenance/engineering)
 "nJb" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 5
+	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/wall,
-/area/station/maintenance/cargo)
+/turf/simulated/floor/plating,
+/area/station/cargo/recycler)
 "nLb" = (
 /obj/structure/table/woodentable,
 /obj/random/misc/book,
@@ -78448,14 +78909,21 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "nLZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
-/turf/simulated/floor,
-/area/station/cargo/office)
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "greenchecker"
+	},
+/area/station/civilian/hydroponics)
 "nMb" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Construction Area Maintenance";
@@ -78481,14 +78949,11 @@
 	},
 /area/station/hallway/primary/central)
 "nMw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "loadingarea"
-	},
-/area/station/cargo/storage)
+/obj/structure/stool/bed,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/bedsheet/clown,
+/turf/simulated/floor/wood,
+/area/station/maintenance/cargo)
 "nNb" = (
 /obj/machinery/door/airlock/security{
 	name = "Security Checkpoint";
@@ -78503,13 +78968,11 @@
 	},
 /area/station/medical/reception)
 "nNV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "green"
-	},
-/area/station/civilian/hydroponics)
+/obj/structure/table/woodentable,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/hand_labeler,
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
 "nOb" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -78546,27 +79009,35 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "nQR" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized{
-	dir = 4;
-	id = "privateoffice"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/window/reinforced/polarized{
-	dir = 1;
-	id = "privateoffice"
+/turf/simulated/floor{
+	icon_state = "bar"
 	},
-/obj/structure/window/reinforced/polarized{
-	id = "privateoffice"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/security/vacantoffice)
+/area/station/cargo/miningbreaktime)
 "nSy" = (
-/obj/effect/decal/cleanable/vomit{
-	icon_state = "vomit_4"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	icon_state = "loadingareadirty2"
+	},
+/area/station/cargo/storage)
 "nSP" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 6
@@ -78671,19 +79142,14 @@
 /area/station/medical/hallway)
 "nZG" = (
 /obj/structure/table,
-/obj/item/weapon/storage/belt/utility,
-/obj/item/weapon/storage/belt/utility,
-/obj/item/weapon/storage/belt/utility,
-/obj/item/weapon/storage/firstaid/regular,
-/obj/machinery/computer/guestpass{
-	dir = 8;
-	pixel_x = 28
-	},
+/obj/item/toy/cards,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/weapon/book/manual/wiki/supply_crates,
 /turf/simulated/floor{
-	dir = 6;
+	dir = 1;
 	icon_state = "brown"
 	},
-/area/station/cargo/office)
+/area/station/cargo/storage)
 "oab" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -78727,18 +79193,11 @@
 	},
 /area/station/engineering/engine)
 "oaE" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 30
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/station/cargo/office)
+/obj/structure/flora/ausbushes/grassybush,
+/obj/machinery/light,
+/obj/structure/chicken_feeder,
+/turf/simulated/floor/grass,
+/area/station/civilian/kitchen)
 "oaO" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -78761,6 +79220,19 @@
 	icon_state = "platebotc"
 	},
 /area/station/maintenance/engineering)
+"obL" = (
+/obj/structure/sign/poster{
+	official = 1;
+	pixel_x = 32
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	icon_state = "bar"
+	},
+/area/station/cargo/miningbreaktime)
 "ocr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor,
@@ -78801,54 +79273,48 @@
 /turf/simulated/wall,
 /area/station/hallway/secondary/arrival)
 "odV" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Cargo Bay Maintenance";
-	req_access = list(31)
+/obj/structure/stool/bed/chair/wood/normal{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/cargo/storage)
+/obj/effect/landmark/start/clown,
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "oek" = (
 /obj/item/weapon/weldingtool,
 /turf/simulated/floor/plating/airless,
 /area/space)
 "ofi" = (
-/obj/item/weapon/flora/pottedplant/large,
-/turf/simulated/floor{
-	dir = 9;
-	icon_state = "brown"
+/obj/machinery/light{
+	dir = 8
 	},
-/area/station/cargo/office)
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "greenchecker"
+	},
+/area/station/civilian/hydroponics)
 "ofm" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	icon_state = "bar"
+	},
+/area/station/cargo/miningbreaktime)
+"ofu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/cargo/storage)
-"ofu" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "ofy" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/four,
@@ -78947,11 +79413,9 @@
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/incinerator)
 "onu" = (
-/obj/structure/stool/bed/chair/metal,
-/obj/machinery/alarm{
-	pixel_y = 26
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
 	},
-/turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "oob" = (
 /obj/machinery/power/rad_collector{
@@ -78963,17 +79427,17 @@
 	},
 /area/station/engineering/engine)
 "ooW" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "qm_warehouse";
-	name = "Warehouse Shutters"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor{
-	icon_state = "floorgrime"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/area/station/cargo/storage)
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/station/civilian/theatre)
 "opc" = (
 /obj/machinery/the_singularitygen/tesla,
 /turf/simulated/floor/plating/airless{
@@ -78982,19 +79446,23 @@
 	},
 /area/space)
 "opR" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/station/civilian/hydroponics)
+/area/station/maintenance/cargo)
 "orb" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -79021,12 +79489,16 @@
 	},
 /area/station/civilian/chapel/altar)
 "osT" = (
-/obj/structure/bookcase{
-	name = "Forbidden Knowledge"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/item/weapon/book/manual/nuclear,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "floorgrime"
+	},
+/area/station/cargo/storage)
 "osZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -79069,26 +79541,23 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "owK" = (
-/obj/machinery/door/window/eastleft{
-	req_access = list(25)
-	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/vending/cigarette,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
 	},
 /turf/simulated/floor{
-	icon_state = "delivery"
+	icon_state = "dark"
 	},
 /area/station/civilian/bar)
 "owL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/obj/structure/closet,
+/obj/item/clothing/under/boxing/green,
+/obj/item/clothing/shoes/boxing,
+/obj/item/clothing/mask/luchador,
+/obj/item/clothing/gloves/green,
+/obj/effect/decal/cleanable/cobweb,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "oxb" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
@@ -79117,9 +79586,23 @@
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/singularity)
 "oyg" = (
-/obj/structure/flora/ausbushes/lavendergrass,
-/turf/simulated/floor/grass,
-/area/station/civilian/hydroponics)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/cargo/office)
+"oyv" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/cargo/storage)
 "oyN" = (
 /turf/simulated/floor{
 	dir = 5;
@@ -79202,35 +79685,30 @@
 	},
 /area/station/medical/cmo)
 "oEO" = (
-/obj/machinery/camera{
-	c_tag = "Hydroponics Lobby";
-	dir = 1
-	},
-/obj/machinery/newscaster{
-	pixel_y = -30
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor{
-	dir = 6;
-	icon_state = "green"
+	icon_state = "dark"
 	},
-/area/station/civilian/hydroponics)
+/area/station/civilian/bar)
 "oGL" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/westleft{
-	dir = 4;
-	name = "Kitchen";
-	req_access = list(28)
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/clipboard,
+/obj/item/weapon/pen/red,
+/obj/structure/table,
+/obj/item/weapon/stamp/denied{
+	pixel_x = 3;
+	pixel_y = -3
 	},
-/obj/machinery/door/window/westleft{
-	name = "Hydroponics";
-	req_access = list(35)
+/obj/item/weapon/stamp/approve{
+	pixel_x = -3;
+	pixel_y = 3
 	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
+/turf/simulated/floor,
+/area/station/cargo/office)
 "oHi" = (
 /obj/machinery/vending/donut,
 /turf/simulated/floor{
@@ -79314,13 +79792,9 @@
 /turf/simulated/floor,
 /area/station/civilian/garden)
 "oMQ" = (
-/obj/machinery/smartfridge,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor,
+/area/station/cargo/storage)
 "oOd" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -79332,12 +79806,11 @@
 	},
 /area/station/engineering/atmos)
 "oQM" = (
-/obj/structure/rack,
-/obj/item/weapon/reagent_containers/spray/extinguisher,
-/obj/item/weapon/storage/belt/utility,
-/obj/item/clothing/mask/gas/coloured,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/cargo/office)
 "oRb" = (
 /obj/structure/closet/secure_closet/injection,
 /turf/simulated/floor{
@@ -79353,68 +79826,62 @@
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/mass_driver)
 "oRm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
-"oTJ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
-"oUI" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/flour,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"oTd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
+"oTJ" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/closet/theatrecloset,
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken7"
+	},
+/area/station/civilian/theatre)
+"oUI" = (
+/obj/effect/landmark/start/recycler,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/station/cargo/recycleroffice)
 "oXb" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/light{
-	dir = 8
+/obj/structure/plasticflaps/mining,
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "packageSort2"
 	},
-/obj/machinery/requests_console/hydroponics{
-	pixel_x = -30
+/turf/simulated/floor/plating{
+	dir = 1;
+	icon_state = "warnplate"
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/civilian/hydroponics)
+/area/station/cargo/office)
 "oXG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/civilian/bar)
+/obj/structure/table/woodentable,
+/obj/item/weapon/folder,
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
 "oXR" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -79528,12 +79995,19 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/maintenance/incinerator)
 "pgZ" = (
-/obj/structure/sink/puddle,
-/obj/structure/flora/ausbushes/reedbush{
-	pixel_y = 6
+/obj/structure/disposalpipe/sortjunction/flipped{
+	dir = 8;
+	name = "Cargo Bay";
+	sortType = "Cargo Bay"
 	},
-/turf/simulated/floor/grass,
-/area/station/civilian/hydroponics)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/cargo/office)
 "pht" = (
 /obj/machinery/light_switch{
 	pixel_x = 27
@@ -79542,16 +80016,13 @@
 /turf/simulated/floor,
 /area/station/construction)
 "phy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/item/device/radio/intercom{
+	pixel_y = -28
 	},
 /turf/simulated/floor{
-	dir = 1;
 	icon_state = "neutralcorner"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/primary/port)
 "pib" = (
 /obj/item/seeds/tomatoseed,
 /turf/simulated/floor/plating,
@@ -79571,24 +80042,30 @@
 	},
 /area/station/maintenance/atmos)
 "pjk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table/woodentable,
+/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,
+/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/ale,
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken6"
 	},
-/obj/machinery/light,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor{
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
+/area/station/maintenance/cargo)
 "pkf" = (
 /turf/simulated/floor{
 	icon_state = "wood_stairs2"
 	},
 /area/station/civilian/chapel)
+"plA" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/station/cargo/office)
 "plH" = (
 /obj/structure/table/woodentable,
 /obj/machinery/newscaster{
@@ -79662,20 +80139,29 @@
 /turf/simulated/wall/r_wall,
 /area/station/aisat/ai_chamber)
 "psV" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
-"puN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
 	dir = 5;
-	icon_state = "brown"
+	icon_state = "vault"
 	},
-/area/station/cargo/office)
+/area/station/civilian/bar)
+"puN" = (
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics)
 "pvb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -79690,13 +80176,30 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "pvI" = (
-/obj/structure/flora/junglebush/large,
-/turf/simulated/floor/grass,
-/area/station/civilian/hydroponics)
-"pwb" = (
-/obj/structure/sign/warning/mail_delivery,
-/turf/simulated/wall,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor,
 /area/station/cargo/office)
+"pwb" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	name = "Hydroponics Desk";
+	req_access = list(35)
+	},
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
+/area/station/civilian/hydroponics)
 "pwt" = (
 /obj/machinery/power/emitter{
 	anchored = 1;
@@ -79717,19 +80220,13 @@
 	},
 /area/station/engineering/singularity)
 "pwX" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/door/airlock{
+	name = "Honk Office";
+	req_access = list(46)
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/civilian/bar)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "pxb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -79741,6 +80238,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
@@ -79781,41 +80282,36 @@
 	},
 /area/station/medical/cmo)
 "pAb" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/stool/bed/chair/comfy/black,
+/obj/machinery/camera{
+	c_tag = "Bar East";
+	dir = 8
 	},
-/turf/simulated/floor/plating{
-	icon_state = "platingdmg3"
+/turf/simulated/floor{
+	icon_state = "dark"
 	},
-/area/station/maintenance/cargo)
+/area/station/civilian/bar)
 "pAe" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/incinerator)
 "pAG" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/disposalpipe/sortjunction{
+/turf/simulated/floor{
 	dir = 8;
-	name = "Bar Backroom";
-	sortType = "Bar Backroom"
+	icon_state = "Stairs2_wide"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/civilian/bar)
 "pAV" = (
 /turf/simulated/floor{
 	icon_state = "yellow"
@@ -79916,28 +80412,34 @@
 	},
 /area/station/maintenance/incinerator)
 "pEt" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/status_display{
-	pixel_x = -32
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/civilian/hydroponics)
-"pGd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor,
-/area/station/cargo/storage)
-"pIL" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 30
+/area/station/cargo/miningoffice)
+"pGd" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/stool/bed/chair/comfy/black,
-/turf/simulated/floor/carpet,
-/area/station/civilian/bar)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "brown"
+	},
+/area/station/cargo/miningoffice)
+"pIL" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "pKb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -79968,13 +80470,22 @@
 	},
 /area/station/civilian/chapel/mass_driver)
 "pNN" = (
-/obj/structure/rack,
-/obj/item/device/flashlight,
-/obj/item/weapon/wrench,
-/obj/item/device/t_scanner,
-/obj/item/weapon/wirecutters,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/obj/machinery/camera{
+	c_tag = "Cargo Bay Storage";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	icon_state = "floorgrime"
+	},
+/area/station/cargo/storage)
 "pOb" = (
 /obj/structure/sign/barber{
 	buildable_sign = 0;
@@ -80021,19 +80532,14 @@
 	},
 /area/station/medical/chemistry)
 "pRn" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
+	dir = 1;
+	icon_state = "green"
 	},
-/area/station/cargo/office)
+/area/station/civilian/hydroponics)
 "pSU" = (
 /turf/simulated/floor/carpet,
 /area/station/tcommsat/computer)
@@ -80112,12 +80618,13 @@
 	},
 /area/station/cargo/office)
 "pVE" = (
-/obj/item/weapon/reagent_containers/food/drinks/bottle/beer,
-/obj/effect/decal/cleanable/vomit{
-	icon_state = "vomit_4"
+/obj/item/stack/sheet/cardboard,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
+/turf/simulated/floor{
+	icon_state = "floorgrime"
 	},
-/turf/simulated/floor/wood,
-/area/station/maintenance/cargo)
+/area/station/cargo/storage)
 "pXY" = (
 /obj/structure/window/reinforced,
 /obj/item/weapon/flora/random,
@@ -80148,14 +80655,17 @@
 	},
 /area/station/hallway/secondary/exit)
 "qab" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/grass,
-/area/station/civilian/hydroponics)
+/turf/simulated/floor,
+/area/station/cargo/office)
 "qau" = (
 /turf/simulated/floor/plating/airless{
 	dir = 9;
@@ -80163,19 +80673,16 @@
 	},
 /area/station/engineering/singularity)
 "qaV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/maintenance/engineering)
 "qcd" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
@@ -80202,9 +80709,13 @@
 	},
 /area/station/bridge/hop_office)
 "qex" = (
-/obj/structure/flora/junglebush,
-/turf/simulated/floor/grass,
-/area/station/civilian/hydroponics)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "bar"
+	},
+/area/station/cargo/miningbreaktime)
 "qgb" = (
 /obj/structure/stool/bed/chair/office/light,
 /obj/effect/landmark/start/chief_engineer,
@@ -80321,9 +80832,12 @@
 	},
 /area/station/medical/chemistry)
 "qla" = (
-/obj/structure/sign/warning/moving_parts,
-/turf/simulated/wall,
-/area/station/maintenance/cargo)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
 "qlb" = (
 /obj/item/device/assembly/timer{
 	pixel_x = -3;
@@ -80404,25 +80918,25 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "qoN" = (
-/obj/machinery/light,
-/obj/structure/closet,
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "barber"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/area/station/civilian/locker)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/bar)
 "qoQ" = (
 /obj/machinery/light/small,
 /obj/machinery/light/small,
 /turf/simulated/floor/engine,
 /area/station/rnd/xenobiology)
 "qoS" = (
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	dir = 1;
-	icon_state = "brown"
+	icon_state = "greenchecker"
 	},
-/area/station/cargo/office)
+/area/station/civilian/hydroponics)
 "qoW" = (
 /obj/structure/rack,
 /obj/item/weapon/reagent_containers/spray/extinguisher,
@@ -80485,11 +80999,11 @@
 /turf/simulated/floor/plating,
 /area/station/medical/chemistry)
 "qsv" = (
-/obj/structure/table/woodentable,
+/obj/machinery/vending/coffee,
 /turf/simulated/floor{
-	icon_state = "brown"
+	icon_state = "bar"
 	},
-/area/station/cargo/storage)
+/area/station/cargo/miningbreaktime)
 "qsw" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -80502,11 +81016,12 @@
 	},
 /area/space)
 "qtj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/structure/table,
+/obj/machinery/reagentgrinder,
+/turf/simulated/floor{
+	icon_state = "cafeteria"
 	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
+/area/station/civilian/kitchen)
 "qub" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -80722,20 +81237,15 @@
 	},
 /area/station/civilian/fitness)
 "qJL" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/filingcabinet,
+/obj/machinery/light_switch{
+	pixel_x = 27
 	},
-/obj/machinery/door_control{
-	id = "qm_warehouse";
-	name = "Warehouse Door Control";
-	pixel_y = 32;
-	req_access = list(31)
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "brown"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/area/station/cargo/miningoffice)
 "qKo" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -80755,18 +81265,17 @@
 	},
 /area/station/engineering/singularity)
 "qLl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/tools/tool,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 1;
+	icon_state = "pipe-c"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor{
-	icon_state = "bot"
-	},
-/area/station/cargo/storage)
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "qLs" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -80802,6 +81311,16 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/arrival)
+"qNN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/carpet,
+/area/station/civilian/bar)
 "qPb" = (
 /turf/simulated/floor{
 	dir = 6;
@@ -80862,22 +81381,17 @@
 "qSg" = (
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/maintenance/engineering)
 "qTb" = (
 /obj/machinery/light_switch{
 	pixel_y = -26
@@ -80887,15 +81401,11 @@
 	},
 /area/station/storage/tools)
 "qTO" = (
-/obj/machinery/power/apc{
-	pixel_y = -26
-	},
-/obj/structure/cable,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/recycler,
 /turf/simulated/floor{
-	dir = 4;
 	icon_state = "dark"
 	},
 /area/station/cargo/recycleroffice)
@@ -80921,10 +81431,16 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "qUJ" = (
+/obj/machinery/camera{
+	c_tag = "Arrival Dock's South 2";
+	dir = 8
+	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "greencorner"
+	},
 /area/station/hallway/secondary/entry)
 "qVb" = (
 /obj/random/meds/chemical_bottle,
@@ -80980,22 +81496,31 @@
 	},
 /area/station/civilian/library)
 "qXi" = (
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -22
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'LANDFILL'";
+	icon_state = "space";
+	layer = 4;
+	name = "LANDFILL";
+	pixel_x = 32
+	},
+/obj/machinery/conveyor_switch/oneway{
+	id = "packageSort2"
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "barber"
+	icon_state = "brown"
 	},
-/area/station/civilian/locker)
+/area/station/cargo/office)
 "qYi" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 20
+/obj/machinery/door/airlock{
+	name = "Bar Backroom";
+	req_access = list(25)
 	},
-/turf/simulated/wall,
-/area/station/cargo/storage)
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/station/civilian/bar)
 "qZb" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyerOut";
@@ -81025,11 +81550,18 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "rbB" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	icon_state = "brown"
+/obj/machinery/door/airlock/glass{
+	name = "Hydroponics";
+	req_access = list(35)
 	},
-/area/station/cargo/office)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor,
+/area/station/civilian/hydroponics)
 "rcb" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
@@ -81041,10 +81573,23 @@
 	},
 /area/station/engineering/engine)
 "rck" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "rda" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 5
@@ -81120,19 +81665,29 @@
 	},
 /area/station/medical/virology)
 "rhj" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/airlock/mining{
+	name = "Recycler's workplace";
+	req_access = list(67)
+	},
+/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/turf/simulated/floor{
+	icon_state = "dark"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/cargo/recycleroffice)
 "rib" = (
 /obj/structure/table/glass,
 /obj/item/weapon/virusdish/random,
@@ -81194,14 +81749,12 @@
 	},
 /area/station/medical/virology)
 "rku" = (
-/obj/machinery/door/morgue{
-	dir = 4;
-	name = "Reading Bay"
+/obj/machinery/light/small,
+/obj/structure/closet/crate,
+/turf/simulated/floor{
+	icon_state = "floorgrime"
 	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken"
-	},
-/area/station/maintenance/cargo)
+/area/station/cargo/storage)
 "rlb" = (
 /obj/structure/sink{
 	pixel_x = 6;
@@ -81222,22 +81775,12 @@
 	},
 /area/station/medical/virology)
 "rlZ" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/civilian/kitchen)
 "rmb" = (
 /obj/structure/closet/l3closet/virology,
 /obj/item/clothing/mask/gas/coloured,
@@ -81277,31 +81820,23 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "rnx" = (
-/obj/structure/closet/crate{
-	desc = "It's a storage unit for kitchen clothes and equipment.";
-	name = "Kitchen Crate"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/clothing/head/chefhat,
-/obj/item/clothing/under/rank/chef,
-/obj/item/weapon/storage/box/mousetraps,
-/obj/item/weapon/storage/box/mousetraps,
-/obj/item/clothing/under/waiter,
-/obj/item/clothing/under/waiter,
-/obj/item/clothing/under/sundress,
-/obj/item/device/eftpos{
-	eftpos_name = "Kitchen EFTPOS scanner"
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Cold Room APC";
-	pixel_x = -28
-	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
+	d1 = 2;
 	d2 = 4;
-	icon_state = "0-4"
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor,
-/area/station/civilian/cold_room)
+/area/station/cargo/storage)
 "rnU" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/main)
@@ -81638,15 +82173,10 @@
 	},
 /area/station/medical/virology)
 "rFw" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/civilian/hydroponics)
+/obj/item/clothing/head/soft/grey,
+/obj/structure/table/glass,
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "rHb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -81655,7 +82185,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
@@ -81682,6 +82211,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"rJK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "rKb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -81710,14 +82253,9 @@
 /turf/simulated/floor,
 /area/station/engineering/engine)
 "rLZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "bot"
-	},
-/area/station/cargo/storage)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall,
+/area/station/cargo/recycler)
 "rMb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -81890,22 +82428,14 @@
 	},
 /area/station/medical/virology)
 "rXf" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "rYb" = (
 /obj/item/weapon/reagent_containers/spray/cleaner,
 /obj/item/weapon/reagent_containers/syringe/antiviral,
@@ -81969,13 +82499,19 @@
 	},
 /area/station/medical/virology)
 "sbs" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "brown"
+/obj/structure/table,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/beer,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -32
 	},
-/area/station/cargo/storage)
+/obj/machinery/newscaster{
+	layer = 3.3;
+	pixel_y = 32
+	},
+/turf/simulated/floor{
+	icon_state = "bar"
+	},
+/area/station/cargo/miningbreaktime)
 "scb" = (
 /turf/simulated/floor{
 	dir = 6;
@@ -82060,14 +82596,20 @@
 	},
 /area/station/medical/virology)
 "shv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/stool,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/obj/effect/landmark/start/shaft_miner,
+/turf/simulated/floor{
+	icon_state = "bar"
+	},
+/area/station/cargo/miningbreaktime)
 "sib" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -82177,11 +82719,24 @@
 	},
 /area/station/civilian/chapel/altar)
 "slP" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	icon_state = "browncorner"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/station/cargo/office)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	icon_state = "floorgrime"
+	},
+/area/station/cargo/storage)
 "slU" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -82236,17 +82791,17 @@
 	},
 /area/station/medical/virology)
 "sox" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/tools/tool,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/simulated/floor{
-	icon_state = "bot"
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/area/station/cargo/storage)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/cargo/office)
 "spb" = (
 /obj/structure/sink{
 	dir = 4;
@@ -82258,12 +82813,15 @@
 	},
 /area/station/medical/virology)
 "spt" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/closet/crate,
+/obj/item/weapon/screwdriver,
+/obj/item/weapon/crowbar,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/maintenance/engineering)
 "spF" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/disposalpipe/segment{
@@ -82287,18 +82845,19 @@
 	},
 /area/station/medical/virology)
 "sqt" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Recycler Office";
-	dir = 0
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/station/cargo/recycleroffice)
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "srb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -82568,18 +83127,17 @@
 	},
 /area/station/medical/hallway)
 "sJr" = (
-/obj/structure/table/woodentable,
-/obj/item/device/flashlight/lamp/green{
-	on = 0;
-	pixel_x = -3;
-	pixel_y = 8
+/obj/structure/table,
+/obj/item/weapon/dice/d20{
+	layer = 5
 	},
-/obj/item/clothing/suit/superman,
-/obj/structure/mirror{
-	pixel_x = 28
+/obj/machinery/light,
+/obj/item/device/violin,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
 	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
+/area/station/civilian/bar)
 "sKb" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -82638,13 +83196,13 @@
 	},
 /area/station/medical/virology)
 "sMn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor{
+/obj/machinery/conveyor{
 	dir = 4;
-	icon_state = "browncorner"
+	id = "stationscrap"
 	},
-/area/station/cargo/office)
+/obj/random/misc/all,
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
 "sNb" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor{
@@ -82653,19 +83211,14 @@
 	},
 /area/station/medical/virology)
 "sNO" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
+/obj/structure/table/woodentable,
+/obj/structure/mirror{
+	pixel_y = 30
 	},
-/obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/cargo/recycleroffice)
+/obj/item/clothing/suit/batman,
+/obj/item/clothing/head/batman_helmet,
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "sOb" = (
 /obj/structure/stool/bed/chair/office/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -82836,21 +83389,26 @@
 	},
 /area/station/medical/virology)
 "sVF" = (
-/obj/effect/landmark/start/recycler,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/area/station/cargo/recycleroffice)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warningcorner"
+	},
+/area/station/cargo/storage)
 "sWb" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -82858,19 +83416,16 @@
 	},
 /area/station/medical/surgery2)
 "sWE" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
-/area/station/cargo/office)
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "sWV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -82943,14 +83498,14 @@
 	},
 /area/station/tcommsat/chamber)
 "tbS" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/landmark{
+	name = "lightsout"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/station/civilian/locker)
 "tcb" = (
 /obj/item/weapon/storage/box/beakers{
 	pixel_x = 2;
@@ -83016,15 +83571,19 @@
 	},
 /area/station/civilian/gym)
 "tgJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/chips,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "thb" = (
@@ -83086,22 +83645,18 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "tlY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/lattice,
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1379;
+	master_tag = "arrival_dock_airlock";
+	name = "exterior access button";
+	pixel_x = 20;
+	pixel_y = 20;
+	req_one_access = list(13,45,1)
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor,
-/area/station/cargo/office)
+/turf/environment/space,
+/area/space)
 "tmb" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -83165,19 +83720,16 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "tpw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "packageExternal"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "greencorner"
+/obj/structure/plasticflaps{
+	opacity = 1
 	},
-/area/station/hallway/primary/port)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor,
+/area/station/cargo/office)
 "tso" = (
 /obj/structure/transit_tube{
 	icon_state = "D-NE"
@@ -83224,6 +83776,15 @@
 	icon_state = "warnplate"
 	},
 /area/station/engineering/singularity)
+"tAl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/cargo/storage)
 "tCO" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -83243,21 +83804,43 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
-"tEw" = (
-/obj/effect/decal/remains/robot,
+"tDh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/maintenance/engineering)
+"tEw" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "whitecorner"
+	},
+/area/station/hallway/secondary/entry)
 "tFz" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/maintenance/engineering)
 "tFA" = (
 /obj/structure/stool/bed/chair/pew/left,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -83314,13 +83897,15 @@
 	},
 /area/station/engineering/engine)
 "tHV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
 	},
 /turf/simulated/floor{
-	icon_state = "floorgrime"
+	dir = 5;
+	icon_state = "cafeteria"
 	},
-/area/station/cargo/storage)
+/area/station/civilian/kitchen)
 "tIb" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -83367,19 +83952,25 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "tKI" = (
-/obj/structure/closet/crate,
-/obj/item/clothing/mask/luchador,
-/obj/item/clothing/gloves/wrestling,
-/obj/item/clothing/shoes/boxing/gray,
-/obj/item/clothing/under/boxing/green,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "tMk" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
 	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
+/area/station/civilian/bar)
 "tMB" = (
 /turf/simulated/floor{
 	icon_state = "stairs_middle"
@@ -83413,13 +84004,10 @@
 /turf/simulated/floor/grass,
 /area/station/hallway/secondary/exit)
 "tRI" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/floor{
+	icon_state = "brown"
 	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
+/area/station/cargo/miningbreaktime)
 "tSb" = (
 /obj/structure/window/reinforced{
 	dir = 5
@@ -83502,23 +84090,11 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "udR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/machinery/vending/boozeomat,
+/turf/simulated/floor{
+	icon_state = "grimy"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/area/station/civilian/bar)
 "ueb" = (
 /obj/structure/window/reinforced{
 	dir = 5
@@ -83532,11 +84108,14 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "uek" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/cargo/office)
 "uey" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 6
@@ -83593,21 +84172,23 @@
 	},
 /area/station/medical/genetics)
 "uhJ" = (
-/obj/structure/closet,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
+/obj/structure/dresser,
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "ujL" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/item/weapon/storage/fancy/donut_box,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/area/station/civilian/bar)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "uml" = (
 /obj/structure/stool/bed/chair/pew/right,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -83660,16 +84241,14 @@
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "uof" = (
-/obj/item/weapon/reagent_containers/food/condiment/peppermill,
-/obj/item/weapon/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/structure/table/woodentable/fancy/black,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+/obj/structure/sign/poster{
+	pixel_x = 32
 	},
-/area/station/civilian/bar)
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
 "uoD" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -83680,17 +84259,13 @@
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "uqD" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/cargo/office)
+/turf/simulated/floor{
+	icon_state = "Stairs2_wide"
+	},
+/area/station/civilian/hydroponics)
 "urb" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -83702,9 +84277,16 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "usn" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/cargo/storage)
 "usq" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -83756,29 +84338,22 @@
 	},
 /area/station/hallway/secondary/exit)
 "uwT" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
+/obj/structure/stool/bed/chair/metal/yellow,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	dir = 1;
+	icon_state = "brown"
 	},
-/area/station/civilian/kitchen)
+/area/station/cargo/office)
 "uBz" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	icon_state = "yellow"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/hallway/secondary/entry)
 "uCp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -83798,25 +84373,29 @@
 	},
 /area/station/hallway/secondary/entry)
 "uDc" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "barber"
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
 	},
+/turf/simulated/floor,
 /area/station/civilian/locker)
 "uEB" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/hallway/primary/starboard)
 "uEX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg1"
 	},
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/area/station/maintenance/cargo)
 "uFT" = (
 /obj/machinery/atmospherics/components/unary/tank/oxygen{
 	dir = 8
@@ -83842,22 +84421,15 @@
 	},
 /area/station/civilian/toilet)
 "uIm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/maintenance/engineering)
 "uIq" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -83898,29 +84470,33 @@
 	},
 /area/station/civilian/chapel/mass_driver)
 "uMv" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/disposal,
+/obj/machinery/door_control{
+	id = "kitchen";
+	name = "Kitchen Shutters Control";
+	pixel_y = 24;
+	req_access = list(28)
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/cargo/office)
+/area/station/civilian/kitchen)
 "uOD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = 32
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/bar)
 "uPw" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Showers"
@@ -84003,25 +84579,52 @@
 	},
 /area/station/engineering/atmos)
 "vdm" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
-"vhl" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced/polarized{
-	dir = 8;
-	id = "privateoffice"
-	},
-/obj/structure/window/reinforced/polarized{
-	dir = 1;
-	id = "privateoffice"
-	},
-/obj/structure/window/reinforced/polarized{
-	id = "privateoffice"
+/obj/machinery/door/airlock/glass{
+	name = "Diner"
 	},
 /obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/civilian/bar)
+"vhl" = (
+/obj/structure/stool,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/start/shaft_miner,
+/turf/simulated/floor{
+	icon_state = "bar"
+	},
+/area/station/cargo/miningbreaktime)
+"vhI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
-/area/station/security/vacantoffice)
+/area/station/maintenance/cargo)
 "vls" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/toolcloset,
@@ -84040,6 +84643,16 @@
 /obj/item/stack/rods,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"vnh" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/kitchen/utensil/spoon,
+/obj/item/weapon/kitchen/utensil/fork{
+	pixel_x = 8
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/bar)
 "vnz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -84051,18 +84664,17 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"vru" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/table/woodentable/fancy,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/holywater,
+/turf/simulated/floor/wood,
+/area/station/civilian/chapel)
 "vsv" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/southright{
-	name = "Bar Door";
-	req_one_access = list(25)
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/civilian/bar)
+/obj/effect/decal/cleanable/generic,
+/obj/machinery/atmospherics/components/binary/pump/on,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "vvH" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
@@ -84100,11 +84712,22 @@
 	},
 /area/station/engineering/engine)
 "vBO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "vCd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -84117,9 +84740,27 @@
 	},
 /area/station/civilian/toilet)
 "vDF" = (
-/obj/item/clothing/under/rainbow,
-/turf/simulated/floor/wood,
-/area/station/maintenance/cargo)
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/obj/effect/landmark/start/recycler,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/station/cargo/recycleroffice)
 "vFP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -84138,17 +84779,16 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "vGq" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/computer/cargo/request{
+	dir = 4
 	},
-/obj/structure/window/reinforced,
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/status_display{
+	layer = 3.3;
+	pixel_x = -32;
+	supply_display = 1
 	},
-/turf/simulated/floor/plating,
-/area/station/civilian/hydroponics)
+/turf/simulated/floor,
+/area/station/cargo/office)
 "vJB" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -84188,12 +84828,15 @@
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "vTP" = (
-/obj/structure/stool,
-/obj/effect/landmark/start/botanist,
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/structure/stool/bed/chair/metal/yellow{
+	dir = 1
 	},
-/area/station/civilian/hydroponics)
+/obj/effect/landmark/start/cargo_technician,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "arrival"
+	},
+/area/station/cargo/office)
 "vVm" = (
 /obj/random/vending/snack,
 /turf/simulated/floor{
@@ -84202,11 +84845,10 @@
 	},
 /area/station/engineering/break_room)
 "vWv" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -84215,40 +84857,45 @@
 	},
 /area/station/hallway/secondary/entry)
 "vWx" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
-"vWz" = (
-/obj/machinery/door/firedoor,
-/obj/structure/table/reinforced,
-/obj/item/weapon/bell,
 /turf/simulated/floor{
 	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "vault"
 	},
-/area/station/civilian/bar)
-"vWU" = (
+/area/station/cargo/recycleroffice)
+"vWz" = (
+/obj/machinery/door/airlock/mining{
+	name = "Recycler office";
+	req_access = list(67)
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 10;
-	icon_state = "green"
+	dir = 5;
+	icon_state = "vault"
 	},
-/area/station/hallway/primary/port)
+/area/station/cargo/recycleroffice)
+"vWU" = (
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "packageExternal"
+	},
+/obj/machinery/door/window{
+	layer = 3;
+	name = "Delivery Office";
+	req_access = list(50)
+	},
+/turf/simulated/floor,
+/area/station/cargo/office)
 "vXW" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/components/unary/portables_connector,
@@ -84295,22 +84942,19 @@
 	},
 /area/station/engineering/engine)
 "wfg" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/hand_labeler,
-/turf/simulated/floor/wood,
-/area/station/security/vacantoffice)
-"wfm" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/status_display{
-	pixel_y = 32
-	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "brown"
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
-/area/station/cargo/storage)
+/area/station/civilian/bar)
+"wfm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken5"
+	},
+/area/station/civilian/bar)
 "wfH" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -84364,18 +85008,12 @@
 	},
 /area/station/civilian/fitness)
 "wht" = (
-/obj/machinery/door_control{
-	id = "qm_warehouse";
-	name = "Warehouse Door Control";
-	pixel_x = 28;
-	req_access = list(31)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
-/area/station/cargo/storage)
+/turf/simulated/floor/carpet/purple,
+/area/station/civilian/theatre)
 "wjJ" = (
 /obj/machinery/door/firedoor,
 /obj/item/device/radio/intercom{
@@ -84388,11 +85026,17 @@
 	},
 /area/station/civilian/chapel/mass_driver)
 "wld" = (
-/obj/machinery/biogenerator,
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/item/weapon/folder/yellow,
+/obj/item/weapon/pen{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/area/station/civilian/hydroponics)
+/obj/structure/table,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "arrival"
+	},
+/area/station/cargo/office)
 "wlF" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engine Room";
@@ -84435,9 +85079,11 @@
 	},
 /area/station/civilian/chapel)
 "wnx" = (
-/obj/structure/sign/warning/moving_parts,
-/turf/simulated/wall,
-/area/station/maintenance/disposal)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
 "woc" = (
 /turf/simulated/floor{
 	dir = 5;
@@ -84445,22 +85091,14 @@
 	},
 /area/station/civilian/chapel/mass_driver)
 "wol" = (
-/obj/machinery/door/airlock/glass{
-	name = "Private Room"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	icon_state = "shutter0";
-	id = "bar";
-	name = "Bar Shutters";
-	opacity = 0
-	},
+/obj/machinery/light/small,
 /turf/simulated/floor{
-	dir = 4;
 	icon_state = "dark"
 	},
-/area/station/civilian/bar)
+/area/station/cargo/recycleroffice)
 "wow" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Break Room";
@@ -84473,15 +85111,20 @@
 /turf/simulated/floor,
 /area/station/engineering/break_room)
 "woS" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	icon_state = "shutter0";
+	id = "kitchen";
+	name = "Kitchen Shutters";
+	opacity = 0
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/eastleft{
+	name = "Kitchen";
+	req_access = list(28)
 	},
+/obj/item/weapon/bell,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -84518,15 +85161,21 @@
 	},
 /area/station/engineering/engine)
 "wuI" = (
-/obj/item/weapon/cigbutt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/obj/effect/decal/cleanable/dirt,
+/obj/random/tools/tool,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
+/area/station/cargo/storage)
 "wwg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
@@ -84560,14 +85209,15 @@
 /turf/simulated/floor/carpet,
 /area/station/civilian/chapel)
 "wAe" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/table/woodentable,
+/obj/item/clothing/head/santahat,
+/obj/item/clothing/suit/santa,
+/obj/item/weapon/storage/backpack/santabag,
+/obj/structure/mirror{
+	pixel_y = 30
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "wAu" = (
 /obj/structure/stool/bed/chair/metal/black{
 	dir = 1
@@ -84577,17 +85227,23 @@
 	},
 /area/station/civilian/chapel/mass_driver)
 "wEg" = (
-/obj/machinery/vending/hydronutrients,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "delivery"
+	},
+/area/station/cargo/storage)
+"wEL" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/station/civilian/hydroponics)
-"wEL" = (
-/obj/structure/closet/crate,
-/obj/item/weapon/screwdriver,
-/obj/item/weapon/crowbar,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
 "wER" = (
 /obj/structure/stool/bed/chair/comfy/brown{
 	dir = 1
@@ -84600,50 +85256,28 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "wET" = (
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/grille,
-/turf/simulated/floor/plating,
-/area/station/cargo/office)
-"wFQ" = (
-/obj/structure/window/reinforced,
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/civilian/hydroponics)
-"wFY" = (
-/obj/structure/closet/crate/hydroponics,
-/obj/item/weapon/reagent_containers/glass/bucket,
-/obj/item/weapon/screwdriver,
-/obj/item/weapon/shovel/spade,
-/obj/item/weapon/wrench,
-/obj/item/weapon/minihoe{
-	pixel_x = 3
-	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Hydroponics APC";
-	pixel_x = -28
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "arrivalcorner"
 	},
-/area/station/civilian/hydroponics)
+/area/station/hallway/secondary/entry)
+"wFQ" = (
+/obj/machinery/conveyor_switch/oneway{
+	convdir = -1;
+	id = "packageExternal"
+	},
+/turf/simulated/floor,
+/area/station/cargo/office)
+"wFY" = (
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "packageSort1"
+	},
+/obj/structure/plasticflaps,
+/turf/simulated/floor/plating{
+	dir = 4;
+	icon_state = "warnplate"
+	},
+/area/station/cargo/office)
 "wHd" = (
 /turf/simulated/floor{
 	icon_state = "warning"
@@ -84674,6 +85308,25 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
+"wHO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	icon_state = "bar"
+	},
+/area/station/cargo/miningbreaktime)
 "wII" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
@@ -84705,16 +85358,13 @@
 	},
 /area/station/bridge/hop_office)
 "wJm" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "green"
-	},
-/area/station/civilian/hydroponics)
+/obj/structure/table,
+/obj/random/tools/tech_supply,
+/obj/random/tools/tech_supply,
+/obj/random/tools/tech_supply,
+/obj/random/tools/tech_supply,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "wLi" = (
 /turf/simulated/wall,
 /area/station/civilian/chapel/mass_driver)
@@ -84758,13 +85408,26 @@
 	},
 /area/station/civilian/chapel/mass_driver)
 "wQY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
+/obj/item/weapon/reagent_containers/spray/plantbgone{
+	pixel_y = 3
 	},
-/area/station/cargo/office)
+/obj/item/weapon/reagent_containers/spray/plantbgone{
+	pixel_y = 3
+	},
+/obj/item/weapon/reagent_containers/spray/plantbgone{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/weapon/reagent_containers/spray/plantbgone{
+	pixel_x = 13;
+	pixel_y = 5
+	},
+/obj/structure/table/glass,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "green"
+	},
+/area/station/civilian/hydroponics)
 "wYU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -84786,9 +85449,11 @@
 	},
 /area/station/civilian/toilet)
 "wZc" = (
-/obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/cargo/miningoffice)
 "xat" = (
 /obj/structure/stool/bed/chair/pew/right,
 /obj/effect/decal/cleanable/dirt,
@@ -84813,20 +85478,35 @@
 	},
 /area/station/engineering/atmos)
 "xeC" = (
-/obj/structure/stool/bed/chair/office/dark{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	icon_state = "grimy"
 	},
-/turf/simulated/floor/wood,
-/area/station/security/vacantoffice)
+/area/station/civilian/bar)
+"xgc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/station/cargo/office)
 "xiQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "arrival"
 	},
-/area/station/civilian/kitchen)
+/area/station/hallway/secondary/entry)
+"xkK" = (
+/obj/structure/table/woodentable,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/item/ashtray/glass,
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
 "xoA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
@@ -84845,14 +85525,11 @@
 	},
 /area/station/engineering/engine)
 "xoX" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
 "xqb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -84884,6 +85561,24 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
+"xuq" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/hydroponics)
+"xvY" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/stool/bar,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/bar)
 "xwj" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -84891,11 +85586,17 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "xwm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/camera{
+	c_tag = "Recycler workplace";
+	dir = 8
 	},
-/turf/simulated/floor,
-/area/station/civilian/hydroponics)
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/cargo/recycleroffice)
 "xwC" = (
 /obj/machinery/newscaster{
 	pixel_x = -32
@@ -84944,11 +85645,13 @@
 	},
 /area/space)
 "xDN" = (
-/obj/structure/stool/bed/chair/wood/normal{
-	dir = 4
+/obj/machinery/door/airlock/mining{
+	name = "Mining Equpment";
+	req_access = list(48)
 	},
-/turf/simulated/floor/wood,
-/area/station/maintenance/cargo)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor,
+/area/station/cargo/miningoffice)
 "xFm" = (
 /obj/structure/closet/wardrobe/engineering_yellow,
 /turf/simulated/floor{
@@ -84957,17 +85660,10 @@
 	},
 /area/station/engineering/engine)
 "xGD" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc/mediumcell{
-	dir = 8;
-	name = "Delivery Office APC";
-	pixel_x = -28
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
-/area/station/cargo/office)
+/area/station/civilian/hydroponics)
 "xGY" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -85002,29 +85698,25 @@
 	},
 /area/station/civilian/chapel)
 "xIW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=8";
+	freq = 1400;
+	location = "QM #2"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/machinery/bot/mulebot{
+	home_destination = "QM #2";
+	suffix = "#2"
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "green"
+	icon_state = "bot"
 	},
-/area/station/civilian/hydroponics)
+/area/station/cargo/storage)
 "xLk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
+/turf/simulated/floor/carpet/purple,
+/area/station/civilian/theatre)
 "xLM" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -85088,33 +85780,36 @@
 	},
 /area/station/engineering/engine)
 "xQr" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	name = "Cargo Bay APC";
-	pixel_y = -26
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/cable,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /obj/structure/cable{
-	d1 = 1;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "1-8"
+	icon_state = "4-8"
 	},
-/turf/simulated/floor{
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
+/turf/simulated/floor,
+/area/station/civilian/bar)
 "xRb" = (
-/obj/machinery/hydroponics/constructable,
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -30
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "packageSort1"
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/machinery/light{
+	dir = 8
 	},
-/area/station/civilian/hydroponics)
+/turf/simulated/floor/plating{
+	dir = 4;
+	icon_state = "warnplate"
+	},
+/area/station/cargo/office)
 "xRo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -85125,11 +85820,22 @@
 	},
 /area/station/engineering/engine)
 "xRx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor,
-/area/station/cargo/qm)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/status_display{
+	supply_display = 1;
+	pixel_x = -32
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "xTO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -85173,6 +85879,10 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating/airless,
 /area/station/cargo/recycler)
 "xZb" = (
@@ -85180,27 +85890,42 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/trunk{
-	dir = 1
+	dir = 8
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/cargo/recycler)
 "yab" = (
-/obj/structure/grille,
-/obj/structure/sign/warning/securearea{
-	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/lattice,
-/turf/environment/space,
-/area/space)
+/turf/simulated/floor{
+	icon_state = "floorgrime"
+	},
+/area/station/cargo/storage)
 "yaV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
 /turf/simulated/floor,
-/area/station/civilian/hydroponics)
+/area/station/cargo/office)
 "ybN" = (
-/obj/structure/sign/warning/moving_parts,
-/turf/simulated/wall,
-/area/station/cargo/recycleroffice)
+/obj/structure/closet/secure_closet/freezer/fridge,
+/obj/machinery/light_switch{
+	pixel_x = -23
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "ycW" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -85228,14 +85953,19 @@
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "ydn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/maintenance/engineering)
 "yji" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -91580,16 +92310,16 @@ aaa
 aaa
 aaa
 aaa
+btD
+btD
+btD
+btD
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+btD
+btD
+btD
+btD
+aag
 aaa
 aaa
 aaa
@@ -91836,17 +92566,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
 btD
 btD
 btD
 btD
-aaa
 btD
 btD
 btD
 btD
-aag
+btD
+btD
+btD
 aaa
 aaa
 aaa
@@ -92092,7 +92822,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 btD
 btD
 btD
@@ -92104,7 +92833,8 @@ btD
 btD
 btD
 btD
-aaa
+btD
+btD
 aaa
 aaa
 aaa
@@ -92339,16 +93069,15 @@ aaa
 aaa
 aaa
 aaa
+bgj
+bgj
+bgj
+bgj
+bgj
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 btD
 btD
 btD
@@ -92362,7 +93091,8 @@ btD
 btD
 btD
 btD
-aaa
+btD
+btD
 aaa
 aaa
 aaa
@@ -93115,7 +93845,7 @@ bgj
 bgj
 bgj
 bgj
-aaa
+hVb
 aaa
 aaa
 aaa
@@ -93372,10 +94102,10 @@ bgj
 bgj
 bgj
 bgj
-hVb
-aaa
-aaa
-aaa
+apo
+aEb
+aEb
+aEb
 btD
 btD
 btD
@@ -93629,10 +94359,10 @@ bgj
 bgj
 bgj
 bgj
-apo
-aEb
-aEb
-aEb
+evb
+boX
+aro
+fab
 btD
 btD
 btD
@@ -93887,7 +94617,7 @@ bgj
 bgj
 bgj
 evb
-boX
+aro
 aro
 fab
 btD
@@ -94143,10 +94873,10 @@ bgj
 bgj
 bgj
 bgj
-evb
-aro
-aro
-fab
+apT
+baY
+baY
+apT
 btD
 btD
 btD
@@ -94401,9 +95131,9 @@ bgj
 bgj
 bgj
 apT
-baY
-baY
-apT
+uDb
+urb
+icb
 btD
 btD
 btD
@@ -94416,7 +95146,7 @@ btD
 btD
 btD
 btD
-btD
+tQb
 btD
 btD
 aaa
@@ -94660,7 +95390,7 @@ bgj
 apT
 uDb
 urb
-icb
+aEb
 btD
 btD
 btD
@@ -94673,7 +95403,7 @@ btD
 btD
 btD
 btD
-tQb
+btD
 btD
 btD
 aaa
@@ -94909,24 +95639,24 @@ avy
 avy
 avy
 apT
+aah
 bgj
 bgj
 bgj
-bgj
-bgj
+aah
 apT
-uDb
-urb
-aEb
+cMC
+dBb
+bdz
 btD
 btD
 btD
 btD
 btD
 btD
-btD
-btD
-btD
+aaa
+aaa
+aaa
 btD
 btD
 btD
@@ -95172,9 +95902,9 @@ evb
 aEb
 aaa
 apT
-cMC
-dBb
-bdz
+uDb
+urb
+apT
 btD
 btD
 btD
@@ -95432,7 +96162,7 @@ apT
 dCb
 aml
 apT
-btD
+aaa
 btD
 btD
 btD
@@ -95446,7 +96176,7 @@ btD
 btD
 btD
 btD
-btD
+aaa
 aaa
 aaa
 aaa
@@ -95932,11 +96662,11 @@ aEb
 aGj
 apT
 bWw
-bTo
-bTo
-bTo
+csh
+csh
+csh
 bie
-phy
+jyQ
 jyQ
 cVW
 bvc
@@ -95947,7 +96677,7 @@ bwx
 aYh
 aEb
 aaa
-btD
+aaa
 btD
 btD
 btD
@@ -95959,7 +96689,7 @@ btD
 btD
 btD
 btD
-btD
+aaa
 aaa
 aaa
 aaa
@@ -96189,33 +96919,33 @@ aEb
 aGp
 apT
 wwg
-xLk
-atE
-atE
-bkQ
-qtj
-atE
-qUJ
-bhj
 bvg
-bhj
+bfZ
+bvg
+bkQ
+bvg
+bvg
+qUJ
+bmq
+bvg
+bvg
 bfZ
 aMb
-bhj
+bhg
 aEb
 aaa
 aaa
-btD
-btD
-btD
-btD
 aaa
 aaa
 aaa
-btD
-btD
-btD
-btD
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -96433,33 +97163,33 @@ bvZ
 bdA
 bhc
 bkn
-gKX
+bEq
 bDc
-gKX
+bEq
 bJG
-gKX
-gKX
-gKX
-csh
-lUd
-bOy
+bEq
+bEq
+bEq
+bTo
+blX
+bTo
 vWv
-csh
+bTo
 baI
 kYI
-bQB
-bQB
+aNi
+aNi
 bDq
-bis
+bOA
 bOA
 bgP
-bhd
-bHe
-bHe
-bio
+aNi
+aNi
+aNi
+aNi
 bIn
-bio
-bio
+apT
+apT
 aaa
 aaa
 aaa
@@ -96688,35 +97418,35 @@ apT
 bbd
 aFz
 aJT
-bis
+wET
 iDb
-bOA
+bcw
 aNw
 bis
 baq
 bis
 biV
 bkB
-bis
+fec
 iDb
 bmq
-bis
+bvg
 bTp
 bbT
 ajb
-bis
-bHe
-bll
-bHe
-bHe
-bHe
-bHe
+aNi
+wEL
+ayy
+ayy
+xuq
+ayy
+myS
 hJt
 bvL
-bio
+aNi
 bJI
 fQb
-bgp
+aEb
 aaa
 aaa
 aaa
@@ -96945,35 +97675,35 @@ apT
 bsU
 bbe
 coZ
-bis
-aon
-eFk
-wET
-aEs
-bHe
-bHe
-bHe
-bHe
-bHe
-bHe
-bHe
+bit
+aMZ
+aMZ
+aMZ
+awO
+aMZ
+aMZ
+aMZ
+aMZ
+aMZ
+aMZ
+aNi
 pwb
-aDh
+bxC
 bFr
-aDh
-bGl
-bHe
-blq
-bpe
-bom
-bpe
-bpe
-bll
+aNi
+aNi
+tIJ
+sfk
+sfk
+sfk
+sfk
+sfk
+gni
 bvM
-bio
+aNi
 bJI
 eZb
-bgp
+aEb
 aaa
 aaa
 aaa
@@ -97202,35 +97932,35 @@ aEb
 bsr
 aEl
 aJW
-ajb
-uMv
+xiQ
+aMZ
 apE
-bsG
-bfh
-bHe
+aCa
+aWw
+ybN
 bfi
-biW
+aMZ
 bkJ
 avD
 awZ
-fec
+cTO
 bBv
 ofi
 glx
 bDm
 cTO
-bHe
-bHe
-bHe
-lar
-bpM
-bsG
-buX
-bvN
-bio
+nHV
+aVg
+aVg
+aVg
+fVd
+aVg
+aZs
+aWy
+aNi
 bJI
 jkb
-bio
+apT
 aaa
 aaa
 aaa
@@ -97459,32 +98189,32 @@ aEb
 btB
 bbd
 xrW
-bis
-apk
-bkW
-bkW
-biU
-baB
+bit
+aXW
+bzc
 bgF
-bkW
-bkW
-bkW
-bkW
-pUQ
-aCd
+lDp
+baB
+aWw
+bxH
+bEk
+iIo
+eFk
+rbB
+bEM
 buD
 nLZ
-bkW
-bkW
-bkW
+ljD
+bET
+neA
 xGD
 kyH
 eZS
-bpU
-bkW
-buY
-mal
-bio
+bmd
+aVg
+aZs
+ayy
+aNi
 bJz
 bio
 bio
@@ -97718,8 +98448,8 @@ bbd
 nFb
 bit
 bnB
-brg
-brg
+aDQ
+aWw
 bkz
 baQ
 bgJ
@@ -97727,22 +98457,22 @@ crY
 blz
 lwo
 bpV
-rbB
+cTO
 nqm
 qoS
 gSX
-mcG
+nHV
 ebk
 uqD
-sWE
+aVg
 iSz
-mcG
-bpV
-slP
-bvb
-bvN
-bio
-bJI
+bmn
+bOy
+aVg
+aZs
+ayy
+aNi
+lKJ
 bio
 bip
 iMb
@@ -97973,10 +98703,10 @@ aEb
 btw
 bbd
 xrW
-bis
-apk
-bkW
-bkW
+bit
+aMZ
+uMv
+bwz
 dxv
 aGQ
 bgK
@@ -97984,22 +98714,22 @@ bjA
 blD
 jMR
 oaE
-nZG
-bBv
-puN
+aNi
+bmp
+qoS
 krG
 wQY
 lzm
 pRn
-sMn
-tlY
-bkW
+aVg
+aVg
+aVg
 bpY
-bsH
-bHe
-bvM
-bio
-bJI
+aVg
+aZs
+bIY
+aNi
+lKJ
 bcB
 biq
 bio
@@ -98230,42 +98960,42 @@ aEb
 btx
 bbd
 xrW
-bis
-aIY
-bkW
-bkW
-bkW
-bbp
-buD
-cri
-bkW
+bit
+aMZ
+ivb
+aWw
+auw
+coa
+qtj
+aMZ
+fcK
 jOv
-qlZ
-qlZ
-qlZ
-aHK
-aPV
-qlZ
-aYD
-qlZ
-buD
-ivL
-lac
-bpZ
-bsK
-bHe
+bwQ
+aNi
+gvk
+qoS
+qoS
+bks
+puN
+aMT
+aVh
+aVh
+aVh
+aVh
+aVh
+hTE
 bvQ
+bEI
+lKJ
 bio
-bJI
-wnx
 bir
 bXq
 bnf
 jxb
 bgp
 bgp
-bWt
-bWt
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -98487,32 +99217,32 @@ aEb
 btv
 bbd
 xrW
-bis
+bit
 aXW
 aOo
-aWx
-bgN
-bHe
+slc
+auK
+coa
 bja
-bjT
+aMZ
 blZ
 bDf
-lNB
-axc
-aCg
-aLW
-aPW
-aVN
-aZI
-qlZ
+aMZ
+aMZ
+aMZ
+aMZ
+aMZ
+aMZ
+aMZ
+aMZ
 amz
-asc
-boo
+ayy
+myC
 boo
 bsL
-bHe
+bvL
 brf
-bio
+bpZ
 bJN
 bJP
 bsn
@@ -98521,8 +99251,8 @@ jnb
 jyb
 jYb
 bgp
-aah
-bWt
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -98744,32 +99474,32 @@ apT
 bty
 bbd
 xrW
-aEL
-aWW
-aWW
-aWW
-aWW
-aWW
-aWW
-aWW
-aWW
-aWW
-qlZ
-axI
-aCz
+bit
+bnB
+npd
+aWw
+rlZ
+byV
+aWw
+tHV
+bzx
+aWw
+aDT
+aMZ
+bEF
 aOb
 aQq
 aVO
 aZM
-qlZ
-aok
-atX
-aFg
-aFg
-aFg
-aFg
-bwW
-bio
+aMZ
+aNi
+aNi
+aNi
+aNi
+aNi
+aNi
+aNi
+aNi
 dQb
 bio
 bio
@@ -98777,10 +99507,10 @@ bio
 aqP
 bio
 bio
-gGO
-aah
-bWt
-bWt
+bio
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -99001,44 +99731,44 @@ apT
 btA
 bbd
 bbr
-bhj
-aWW
-aHg
-aWB
-bhe
+bit
+aMZ
+apr
+aWw
+aWw
 bbN
 bjG
-bmD
-bmJ
-bmK
-qlZ
+bjG
+gLt
+aFO
+aWw
 axK
 aCI
 aOH
-xRx
+aCI
 aVP
 aZN
-qlZ
+bdu
 bRn
 oRm
-bmz
+aSM
 bqy
 brC
 bvj
 bxN
-dDJ
-kpu
+aSM
+dQb
 aBW
 bhR
 bio
 aqV
 bio
-aah
-aah
-aah
-aah
-bWt
-bWt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -99258,48 +99988,48 @@ apT
 bup
 ahw
 aYm
-bhj
-vhl
-aHM
-aZw
-aZw
-bcy
+bit
+aMZ
+jpM
+aWw
+aWw
+dIG
 fXV
 blJ
 blY
-aZw
-qlZ
-aCa
+aWw
+bHU
+aMZ
 aCJ
 aOI
 aRi
-aWO
-aZQ
-qlZ
-xoX
+bzk
+bEO
+aEr
+bEW
 rXf
 bmA
 iob
 brF
 nMw
 pjk
+aSM
+dQb
+qAF
+qcd
 bio
-uek
-bhO
-mNC
-bJT
 bJW
 bio
-aah
-aah
-aah
-aah
-aah
-bWt
-bWt
-bWt
-bWt
-bWt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -99515,48 +100245,48 @@ apT
 aWu
 bbd
 xrW
-bhj
-nQR
-aIr
-aZw
+iJB
+aMZ
+aBd
+woS
 bqN
 bcy
-bhg
-bkr
-gXz
-aZw
-qlZ
-qlZ
-qlZ
-qlZ
-qlZ
-qlZ
-qlZ
-qlZ
-wfm
-udR
-iRH
-hvE
-khG
-tbS
-xQr
-bio
-bio
-bio
-bio
-bio
-bio
-gGO
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-bWt
+aMZ
+aMZ
+aMZ
+aMZ
+bCd
+aMZ
+aMZ
+aMZ
+aMZ
+aMZ
+aMZ
+aMZ
+aSM
+avg
+aSM
+aSM
+aSM
+aSM
+aSM
+aSM
+ujL
+pIL
+wNf
+wNf
+eKs
+aSM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -99772,48 +100502,48 @@ apT
 buZ
 bbd
 xrW
-bhj
-aWW
+tEw
+vdm
 aID
-aZw
-brk
+aID
+aID
 bcK
 bhq
-kdV
+aGn
 blO
 kdV
-bBa
+bmw
 bCT
-bBw
-aFg
-aRp
-aWV
+cUv
+udR
+aGn
+bGl
 aXz
-aFg
-myC
+asa
+aGn
 avg
-ofm
-vBO
-brG
-pGd
+uEX
+auv
 bxb
-alk
-aMc
-byG
-bzq
-bcM
+bxb
+bxb
+bxb
+bvb
+aCn
+wJm
+moP
+gNe
+aSM
 aaa
-aah
-rxx
-rxx
-rxx
-rxx
-rxx
-rxx
-rxx
-rxx
-aah
-bWt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -100029,48 +100759,48 @@ apT
 bvT
 bbd
 bdB
-bhf
+atE
 apt
 bwc
 bDv
-keS
-bhr
+bDv
+xQr
 bhr
 bku
 xeC
-bmW
-aSM
-qAF
-nLo
-aFg
-bxz
+xeC
+khG
+xeC
+xeC
+buX
+bbq
 aWX
-baK
-aFg
+qNN
+wfm
 qYi
-aFg
+atT
 bnp
 brb
-brG
-pGd
-ofm
-bFS
-bxC
-byS
-bzs
-bcM
-bcM
-bCt
-rxx
-rxx
-rxx
-rxx
-rxx
-rxx
-rxx
-rxx
-aah
-bWt
+eTT
+onu
+aSM
+aSM
+aSM
+aSM
+aSM
+aWx
+aWx
+aSM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -100285,49 +101015,49 @@ beZ
 apT
 btx
 bbd
-xrW
+gKG
 aHc
-aWW
+bEu
 bRk
 aMl
 aPP
 aRY
 wfg
-bcF
+arZ
 bil
-blV
-aSM
+bmw
+bmw
 bmw
 eXg
-aFg
-bsy
+iAY
+aGn
 bxv
-bBm
-bxz
-bxz
-aLT
-ofm
-vBO
+bhf
+boc
+byR
+bEW
+bEW
+hBN
 bGI
-uEX
+sCd
 bHw
-bFS
+aSM
 bxk
-byT
-byT
-bBk
-byT
-bBk
-rxx
-rxx
-rxx
-rxx
-rxx
-rxx
-rxx
-rxx
+aSM
 aah
-bWt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -100543,48 +101273,48 @@ apT
 bsY
 bbd
 xrW
-bmb
-aSP
-aSP
-aSP
-aSP
-aSP
-aSP
-aSP
-aSP
-aSM
-aSM
+bit
+aGn
+cri
+owK
+aGn
+pAG
+mBp
+aGn
+bvJ
+aOD
+bba
 ncT
 aEM
-aFg
-aSa
-aXJ
-bcf
-bxz
-bxz
-aLT
-ofm
+aGn
+aGn
+bDn
+bDn
+bDn
+bDn
+bDn
+bDn
 vBO
-bsC
-pGd
-kTw
-bFS
+bqg
+vsv
+aUs
+iyb
 bxx
-byW
-bAe
-bBl
-bBV
-bCw
-rxx
-rxx
-rxx
-rxx
-rxx
-rxx
-rxx
-rxx
-aah
-bWt
+bjT
+tlY
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -100801,47 +101531,47 @@ apT
 bbv
 cEp
 bhh
-aSP
-aIZ
-aQX
-aXY
-beJ
-qXi
-lMr
-aSP
-bEW
-bEW
-qAF
-bEW
-aFg
+aGn
+aGn
+aGn
+aGn
+awg
+bzi
+dWf
+bHL
+gTX
+bHL
+gTX
+bHL
+bHF
 aSc
-aXJ
-bxz
-bxz
-bxz
-aLT
-ofm
-vBO
-sox
-pGd
-rLZ
-bFS
-bxz
-bFS
-bAh
-bcM
-bcM
-bcM
-rxx
-rxx
-rxx
-rxx
-rxx
-rxx
-rxx
-rxx
+bDn
+aQY
+bxB
+xwj
+uhJ
+bDn
+ofu
+brd
+brd
+brd
+brd
+brd
+brd
 aah
-bWt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -101058,47 +101788,47 @@ aYR
 bbd
 xrW
 bhi
-aSP
+aGn
 aJs
-aQX
+bDZ
 aYb
 beJ
-arB
+tMk
 qoN
-aSP
+psV
 bBw
-ixO
-qAF
-bEW
-aPD
-bxz
-aXJ
-bxz
-bxz
-bxz
+psV
+aTp
+dWf
+aDx
+sJr
+bDn
+sNO
+bGm
+xLk
 aLT
-ofm
-vBO
-bsC
-tHV
-qLl
-bFS
-bxC
-byX
-bAk
-bBl
-bCh
-bCw
-rxx
-rxx
-rxx
-rxx
-rxx
-rxx
-rxx
-rxx
-aah
-bWt
+bDn
+ofu
+brd
+bfB
+bDX
+bGc
+bop
+brd
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -101317,45 +102047,45 @@ bbg
 bhj
 aqg
 aMo
-aQX
-aYf
+buB
+aGn
 beW
-uDc
+bzi
 msI
-aSP
-aSM
-mPD
-qAF
-vdm
-aFg
-bcf
-bEx
-bba
-eTT
+bAu
+bRC
+bzi
+gKC
+bzi
+hlV
+azc
+bDn
+bDQ
+bEf
 wht
 ooW
 kED
 rck
-gdb
-eVv
-kTw
-bFS
+brd
+bfH
+wZc
+awS
 byo
-bzd
-bzd
-bBt
-bzd
-bBt
-rxx
-rxx
-rxx
-rxx
-rxx
-rxx
-rxx
-rxx
-aah
-bWt
+brd
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -101572,47 +102302,47 @@ aYU
 bbd
 aCe
 ala
-aqe
+aGn
 bwC
 bDZ
-mzF
+aGn
 uOD
-gXB
-tRI
-bky
-wNf
-wNf
+lLD
 nws
-aSM
-aFg
-aFg
-aFg
-aFg
-aFg
-aFg
-aFg
-qJL
-vBO
+bky
+nws
+bIp
+nws
+lLD
+oEO
+dWf
+pwX
+bxQ
+bEg
+bEc
+bDn
+bDn
+gWz
 brG
 pGd
-ofm
-bFS
-byq
-bze
-bAl
-bcM
-bcM
-bCt
-rxx
-rxx
-rxx
-rxx
-rxx
-rxx
-rxx
-rxx
-aah
-bWt
+aET
+bmb
+bot
+bzg
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aag
 aaa
 aaa
@@ -101829,47 +102559,47 @@ aFG
 bbw
 msb
 bmT
-boc
-bwD
-bEm
-beY
-beY
-beY
-tMk
-aSM
-sCd
-bEW
-psV
-wNf
-hBN
-bEW
-bEW
-bEW
-aFg
-uhJ
-bFS
-ofm
-vBO
-ggb
-iIo
+aGn
+aGn
+aGn
+aGn
+bwf
+bzi
+tze
+vnh
+eXz
+aDx
+dWf
+jaX
+dWf
+bzi
+bDn
+bDR
+bEs
+bFR
+bDn
+owL
+ofu
+brd
+aFc
 hne
 lLb
 aMg
 bzg
-aFg
-myS
-aah
-aah
-rxx
-rxx
-rxx
-rxx
-rxx
-rxx
-rxx
-rxx
-aah
-bWt
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -102085,48 +102815,48 @@ aWz
 aFG
 aUO
 bdG
-bhj
-aqg
-bxs
+mUB
+aSM
+qcd
 aRm
-biv
-bfb
-biv
-aSP
-aSM
+aGn
+xvY
+hvE
+bvI
+bxD
 kFh
-aSM
+hlV
 pAb
 jFb
 aQm
 kgz
-wAe
+bDn
 wAe
 odV
 oTJ
-gvg
-fDb
+bDn
+bEW
 ofu
-bkR
-owL
-hne
+brd
+aYl
+pEt
 bTT
-aFg
-bzj
-aFg
-aah
-aah
-aah
-rxx
-rxx
-rxx
-rxx
-rxx
-rxx
-rxx
-rxx
-aah
-bWt
+boK
+bzg
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -102342,48 +103072,48 @@ aWA
 afW
 bbC
 aKb
-bhj
-aSP
+uBz
+bom
 bzv
-aUs
-aZr
-bfg
-biP
-aSP
-xDN
-bcD
-aSM
-onu
 bEW
-bDk
-spt
-aSM
+aGn
+aGn
+aGn
+aGn
+aGn
+aGn
+bhe
+aGn
+aGn
+aGn
+aGn
+bDn
+bDn
+bDn
+bDn
+bDn
+vhI
+opR
 brd
-brd
-brd
-brd
-brd
-brd
-jaX
-shv
-ofm
+qJL
+aqe
 lab
-aFg
-aFg
-aFg
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-bWt
+mNC
+brd
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -102599,48 +103329,48 @@ aWC
 aFG
 bbD
 aJS
-bfZ
-aSP
+ayz
+aSM
 bzP
-aZK
-aZK
-aZK
+bEn
+bRn
+fDb
 lkl
-aSP
+bnp
 itt
 aOY
-aSM
-bBw
-sCd
-bDk
-eXg
-eXg
+aYf
+dSI
+dSI
+dSI
+dSI
+fkD
+nCQ
+tKI
+bsI
+sWE
+avP
 brd
-bfB
-bDX
-bGc
-bop
 brd
-bks
-shv
-ofm
-lcb
-myS
-aah
-aah
-aah
-aah
-bWt
-bWt
-bWt
-bWt
-bWt
-bWt
-bWt
-bWt
-bWt
-bWt
-bWt
+brd
+xDN
+brd
+brd
+brd
+brd
+brd
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -102857,40 +103587,40 @@ aFG
 bck
 qEb
 beb
-aSP
+aSM
 bBp
 bES
-aVt
-aVt
-aVt
-aSP
-cUv
-vDF
+bcE
+aVf
+lNB
 aSM
-oQM
-sCd
-bDk
-wZc
+aSM
+bwW
+aFg
+aFg
+aFg
+aPD
+aFg
+rJK
 bEW
-brd
-bfH
-bRC
-awg
-boq
+bEW
+ixO
+bEW
+bEW
 bHB
 sbs
 lDy
-ofm
+bED
 nGb
-bcM
-bWt
-bWt
-bWt
-bWt
-bWt
-aah
-aah
-aah
+kpu
+bHB
+cux
+bHB
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -103113,41 +103843,41 @@ bii
 clm
 bdf
 aTd
-eKs
-aNi
-aNi
-aNi
-aNi
-aNi
-aNi
-aNi
-aNi
-aNi
-aNi
-aNi
-bBw
+bgb
+bHe
+bll
+bHe
+bHe
+bHe
+bHe
+bHe
+keS
+aAX
+aRp
+aWV
+bsK
 gYf
-wAe
+aFg
 hmR
-bcE
-bgu
-bEk
+aSM
+aSM
+aSM
 ayX
-bot
-brd
+aSM
+bHB
 bsD
 shv
-ofm
+nQR
 auO
-bcM
+byq
+aTH
+tRI
+gvg
 aaa
 aaa
 aaa
-aah
-aah
-aah
-aah
-aah
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -103369,46 +104099,46 @@ cnZ
 cnZ
 bik
 bbI
-bdX
-fDT
-aNi
-ata
-aVf
+bdM
+cqt
+bHe
+blq
+bpe
 wFY
 xRb
-ivb
-pEt
+bpe
+bHe
 oXb
-aVf
-aFH
-aNi
-aSM
-aSM
-aSM
+bwW
+bcf
+bwL
+fDT
+baK
+aFg
 tgJ
-brd
-aFc
+uru
+aSM
 bEl
-ayz
+aRm
 boB
-brd
+bHB
 bsO
-shv
+vhl
 ofm
-aDw
-bcM
+ofm
+ofm
+obL
+ata
+gvg
 aaa
 aaa
 aaa
 aaa
 aaa
-aah
-aah
-aah
-aah
-aaa
-aaa
-aaa
+bWt
+bWt
+bWt
+bWt
 aaa
 aaa
 aaa
@@ -103626,47 +104356,47 @@ aFL
 aFL
 aFL
 bbJ
-bdM
-ipb
-aqD
-wEg
-tIJ
-wJm
-sfk
-sfk
-sfk
-sfk
-gni
-rFw
-aNi
+bQB
+aEh
+bHe
+bHe
+bHe
+bHe
+bpM
+bsG
+bvs
+bvN
+bwW
+bsy
+gYf
 osT
-fVd
+bBm
+aFg
+aDI
+nLo
 aSM
-bDk
-brd
-aYl
-bEl
-bcw
-boK
-brd
+aFH
+bEW
+boB
+bHB
 bmE
-shv
-ofm
+wHO
+qex
 qsv
-bcM
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+buG
+bHB
+lrT
+bHB
+bWt
+bWt
+bWt
+bWt
+bWt
+bWt
 aah
 aah
-aah
-aah
-aaa
-aaa
-aaa
+bWt
+bWt
 aaa
 aaa
 aaa
@@ -103884,47 +104614,47 @@ aWF
 aNF
 bdv
 bes
-ipb
-arh
+lcb
+bHe
 fmh
-nHV
+fXb
 lJr
-xwm
-aVg
-aVg
-aVg
-aZs
-ayy
-aNi
-gWz
+bpU
+bkW
+pUQ
+bvN
+bwW
+bmU
+bxz
+aXJ
 pVE
-aSM
-bDk
-brd
-brd
-brd
-brd
-brd
-brd
-bls
+aFg
+lac
+aFg
+aFg
+aFg
+aFg
+aFg
+bHB
+bHB
 bnI
 iry
 aKF
-aFg
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bHB
+bHB
+bHB
+bHB
 aah
 aah
 aah
 aah
 aah
-aaa
-aaa
+aah
+aah
+aah
+aah
+bWt
+bWt
 aaa
 aaa
 aaa
@@ -104141,55 +104871,55 @@ aWG
 aHQ
 bdv
 bdM
-ipb
-ari
+cqt
+aDh
 wld
-nHV
-eho
-ayy
-iyb
-ayy
-ayy
-aZs
+bkW
+bkW
+oQM
+bkW
+qXi
+bvN
+bwW
 aFJ
-aNi
-aSM
+bxz
+aXJ
 rku
-aSM
-bDk
-bEW
-kGX
-bEJ
-jhk
-jsD
-bNk
+aFg
+cuz
+auL
+xRx
+bxg
+azA
+bhp
+bwy
 buu
 bvq
-bvV
-bNk
-bNk
-aaa
-aaa
-aaa
+byG
+bzq
+bcM
+aah
+aah
+rxx
+rxx
+rxx
+rxx
+rxx
+rxx
+rxx
+rxx
+aah
+aah
+aah
+bWt
+aah
+aah
 aaa
 aaa
 aaa
 aaa
 aaa
 aah
-aah
-aah
-aah
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -104398,56 +105128,56 @@ aWG
 aNF
 bdo
 bdY
-isb
+bnt
 avT
 vTP
-nHV
+bkW
 eho
-aVg
-aVg
-lwE
-aVg
-aZs
+deW
+dra
+bHe
+oXb
+bwW
 lFQ
-aNi
-uru
-bEW
-sCd
-bDk
-sCd
-kGX
-qPE
-hOV
-lpD
-bNk
-buA
-bvs
-bxd
-bNk
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bxz
+bls
+bxz
+bpt
+bod
+aSa
+bxz
+tAl
+bFS
+bFS
+aqD
+baK
+bvw
+byS
+bzs
+bcM
+bcM
+bCt
+rxx
+rxx
+rxx
+rxx
+rxx
+rxx
+rxx
+rxx
+aah
+aah
+aah
+bWt
 aah
 aah
 aah
 aah
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aah
+aah
+aah
+aah
+aah
 aah
 aah
 aaa
@@ -104655,47 +105385,47 @@ aWH
 aFL
 bbK
 bdZ
-ipb
-vGq
+cqt
+aDh
 atZ
-gNe
-xIW
-aVh
+bkW
+bkW
+uek
 kFe
-asT
-aVh
-hTE
+bHe
+kFb
+lar
 kLo
-aNi
+bmY
 pNN
-bEW
+isb
 bFa
-bDk
-bEW
-kGX
-kGX
-qiM
-kGX
-bNk
-buB
+bEp
+wEg
+bsC
+atX
+aAR
+aSa
+bgN
+bFS
 bvu
-bwA
-bNk
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+byT
+byT
+bBk
+byT
+bBk
+rxx
+rxx
+rxx
+rxx
+rxx
+rxx
+rxx
+rxx
 aah
 aah
 aah
-aah
-aaa
+bWt
 aaa
 aaa
 aaa
@@ -104913,46 +105643,46 @@ aYX
 cki
 bdZ
 ipb
-bod
-aNK
+bHe
+bHe
 wFQ
-gKG
-aVg
-jmV
-nNV
-opR
-aQc
-bmU
-aNi
-aNi
-bEW
-bEW
-gYf
-wAe
-wAe
-hSt
+bkW
+uek
+pUQ
+bHe
+bHe
+bwW
+aFg
+aFg
+aFg
+aFg
+aFg
+bGt
+bFS
+dbM
+bxz
 iZg
-hHe
-bNk
-buV
+bFS
+bvV
+bFS
 sVF
-byv
-bNk
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+byW
+bAe
+bBl
+bBV
+bCw
+rxx
+rxx
+rxx
+rxx
+rxx
+rxx
+rxx
+rxx
 aah
 aah
-aaa
-aaa
+bWt
+bWt
 aaa
 aaa
 aaa
@@ -105168,47 +105898,47 @@ aVm
 aWK
 aYY
 bdv
-coa
-tpw
+cpJ
+cqt
 tpw
 vWU
 awq
-aEJ
+bkW
 yaV
 kss
 aEK
-aAB
+brg
 aNv
-qex
+lJr
 aMQ
-bEI
-bEW
-aSM
-aSM
-aSM
-bEW
-moP
+aFg
+bxs
+alk
+aMc
+iZg
+bfh
+aSa
 wuI
-bDk
-bNk
-buA
-mtS
-kFb
-bNk
-aBd
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bFS
+iZg
+bxz
+slP
+bFS
+bAh
+bcM
+bcM
+bcM
+rxx
+rxx
+rxx
+rxx
+rxx
+rxx
+rxx
+rxx
 aah
-aah
-aaa
+bWt
+bWt
 aaa
 aaa
 aaa
@@ -105427,44 +106157,44 @@ aFL
 alz
 bdZ
 cjM
-aOD
-dra
-aNi
-fkD
-iAL
-aVh
-oEO
-aNi
+bHe
+bHe
+bHe
+aCd
+bHe
+bHe
+bHe
+axI
 oyg
-aFf
+bkW
 byP
-bEL
-bEW
-aSM
-bGv
-aSM
-bEW
-aSM
-qcd
-bDk
-bNk
-bsS
+aFg
+bmD
+bDY
+bFS
+iZg
+aDz
+bxz
+iZg
+bxz
+wuI
+oMQ
 bvw
-bvV
-bNk
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+byX
+bAk
+bBl
+bCh
+bCw
+rxx
+rxx
+rxx
+rxx
+rxx
+rxx
+rxx
+rxx
 aah
-aah
+bWt
 aaa
 aaa
 aaa
@@ -105683,45 +106413,45 @@ ckE
 aNF
 bdv
 bdZ
-bmY
-aMZ
-aMZ
-aMZ
-aMZ
-haq
-oMQ
+cqt
+buY
+aBN
+bwB
+bkW
+vGq
+bHe
 oGL
-aMZ
+aVG
 pgZ
-aNv
+mcG
 byQ
-bDp
-bDp
-bDp
-bDp
-bDp
-bDp
-bDp
-qcd
-bDk
-bNk
+bEV
+nZG
+aSa
+bcD
+aAR
+kTw
+oyv
+bvV
+bxz
+dDJ
 mTP
-mtS
-lqO
-bNk
-bNk
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+nSy
+bzd
+bzd
+bBt
+bzd
+bBt
+rxx
+rxx
+rxx
+rxx
+rxx
+rxx
+rxx
+rxx
 aah
-aah
+bWt
 aaa
 aaa
 aaa
@@ -105940,46 +106670,46 @@ aWP
 ajt
 bbO
 bep
-cjM
-aMZ
+cqt
+byv
 uwT
-aDI
-gLt
-jQu
-aWw
-aWw
-haq
+bkW
+bkW
+biU
+ave
+mal
+bkW
 pvI
 aMX
 aOJ
-bDp
+aNK
 bEp
 bHC
 bIM
-bJX
+bHC
 rnx
-bDp
+bDo
 usn
-tgJ
-bNk
-bsT
+jQu
+boq
+jQu
 mtS
-lqO
-bxB
-jpM
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bze
+bAl
+bcM
+bcM
+bCt
+rxx
+rxx
+rxx
+rxx
+rxx
+rxx
+rxx
+rxx
 aah
-aah
-aah
+bWt
+aaa
 aaa
 aaa
 aaa
@@ -106198,45 +106928,45 @@ aNF
 bdv
 cpJ
 cqt
-eHa
+apk
 aum
 bFO
-woS
-aAN
-aAN
+bkW
+aCg
+buY
 aAN
 bms
 aAG
 aFl
 aYC
-bDp
+bFs
 bIJ
-bzx
-bIK
+ajV
+yab
 ajV
 atK
 atk
-wNf
 bmR
-bNk
+bmR
+bsZ
 bsZ
 bvA
 bvX
-bxD
-jpM
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aFg
+aFg
 aah
 aah
+rxx
+rxx
+rxx
+rxx
+rxx
+rxx
+rxx
+rxx
 aah
+bWt
+aaa
 aaa
 aaa
 aaa
@@ -106457,11 +107187,11 @@ cpL
 bns
 cox
 auq
-bbq
-hho
-aWw
-slc
-aWw
+mcG
+xgc
+aCg
+byv
+bwD
 haq
 qab
 aFn
@@ -106469,32 +107199,32 @@ aYv
 bEV
 bIK
 bHI
-bIY
+bKh
 bKh
 asp
-avr
-wZc
-bDk
-bNk
-btH
-lqO
+aFg
+bmz
+xIW
+eHa
+aEJ
+aFg
 bwa
-bxH
-jpM
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aFg
 aah
 aah
 aah
+rxx
+rxx
+rxx
+rxx
+rxx
+rxx
+rxx
+rxx
 aah
+bWt
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -106711,36 +107441,32 @@ aWR
 npb
 bKb
 bdZ
-cjM
-awu
-auw
-xiQ
+cqt
+sox
+aNk
+bkW
 hho
-aAR
+mcG
 lup
-aDT
-aMZ
+bDd
+plA
 aAf
 aLK
 aYy
-bDp
-bEq
-bHO
+aFg
+aFg
+aFg
 bJa
-bDp
-bDp
-bDp
-bEW
-fDx
-bNk
-bNk
-sqt
-sNO
-bNk
-bNk
-aaa
-aaa
-aaa
+hHe
+ivL
+aFg
+aFg
+aFg
+aFg
+aFg
+aFg
+lqO
+aFg
 aah
 aah
 aah
@@ -106748,9 +107474,13 @@ aah
 aah
 aah
 aah
-yab
-agn
-agn
+aah
+aah
+aah
+aah
+aah
+bWt
+aFf
 agn
 agn
 agn
@@ -106968,30 +107698,30 @@ aWT
 aOz
 bdK
 bdZ
-cjM
-awu
-auK
-aWw
-nAY
-aAX
-aMZ
-aMZ
-aMZ
-aNi
-aNi
-aNi
-bDp
-bDp
-bDp
+cqt
+byv
+bzm
+ggb
+bkW
+bkW
+bbp
+iRH
+aIZ
+bwA
+buW
+buA
+aFg
+ikq
+bNk
 bDp
 bDp
 gYZ
-bEW
-bEW
-bDk
-bNk
+aon
+geo
+bsT
+buV
 gib
-bvB
+btN
 qTO
 bNk
 bNk
@@ -107001,12 +107731,12 @@ bNk
 bNk
 bNk
 bNk
-aaa
-aah
-aaa
-aaa
-aah
-aaa
+bWt
+bWt
+bWt
+bWt
+bWt
+bWt
 aaa
 aah
 aaa
@@ -107225,29 +107955,29 @@ aWU
 aZh
 bbP
 cpb
-cjM
-awu
-auL
-slc
-hho
-azA
-aMZ
-aFO
-aTp
-bwJ
-owK
-byR
-bEW
-bEW
-tEw
-bEW
-aSM
-aSM
-bEW
-moP
-fDx
+cqt
+aEs
+qlZ
+qlZ
+aHK
+aPV
+qlZ
+aYD
+qlZ
+bHe
+bHe
+bHe
+aFg
+jmV
 bNk
-btN
+auN
+ngy
+vDF
+bHJ
+vWz
+fDx
+bwJ
+bGv
 bvC
 bwb
 aLV
@@ -107484,29 +108214,29 @@ bdo
 bet
 bnt
 awu
-auN
+axc
 gQi
-aNl
-aBN
-aMZ
-blX
-buW
-bwL
-dSI
-bBq
+aLW
+aPW
+aVN
+aZI
+qlZ
+bEJ
+jhk
+jsD
+kGX
 ikq
-ikq
-ikq
+bNk
 eUl
-oUI
+asc
 oUI
 vWx
-oUI
-pAG
-bNk
-bNk
+bsS
+btH
+eVv
+xwm
 bvE
-kNq
+wol
 bNk
 fob
 fqb
@@ -107739,38 +108469,38 @@ aWT
 aZi
 bdv
 bdZ
-cjM
+cqt
 aoS
 aBi
-aWw
-aWw
+aCz
+gSy
 aBY
-aMZ
+dyy
 blK
-fcK
-bwQ
-bsI
-aGn
-bDn
-bDn
-bDn
+qlZ
+qPE
+hOV
+lpD
+kGX
+kGX
+bNk
 bGQ
-bDn
-bDn
-bDn
-bDn
-rlZ
-fXb
-qSg
+gGO
+bec
+bvm
+bNk
+bNk
+bNk
+bNk
 rhj
-bvH
+kNq
 bNk
 bNk
 bNk
 bNk
 bNk
 bNk
-ybN
+bNk
 bNk
 fCb
 bZZ
@@ -107996,38 +108726,38 @@ aXc
 aZg
 bdv
 bdZ
-cjM
-aMZ
+cqt
+lwE
 auP
-aWw
+bJX
 aQn
-aMZ
-aMZ
+bJX
+bJT
 beo
-aGn
-aGn
-aGn
-aGn
-bDn
-bEu
-bEs
-bED
-bDO
-xwj
-bHJ
-bDn
+qlZ
+kGX
+qiM
+kGX
+kGX
+chX
+bNk
+bNk
+bNk
+bkR
+bNk
+bIZ
 ice
-bEW
+bIZ
 bqM
+pxb
 bvH
-bvH
-aSM
-bxQ
+rLZ
+bzf
 qla
-xYb
-bZZ
-bZZ
-bZZ
+bzf
+bzf
+bzf
+bzf
 xYb
 bZZ
 bZZ
@@ -108253,38 +108983,38 @@ aOz
 aOz
 bdN
 bdZ
-npd
-aMZ
-aMZ
-awO
+cqt
+qlZ
+bdX
+bHO
 gWo
-aMZ
-aET
-bmx
-aTH
-bmd
+aWB
+aWO
+aZQ
+qlZ
+bQl
 btW
-aZe
-bDn
-bDQ
-bEf
-bEF
-bFs
+aYE
+aYE
+aYE
+aYE
+aYE
+bqY
 cIs
-apr
-bDn
-bec
-bqg
-buG
-bvI
-byO
-bwz
-byV
-bzc
-bzf
-bzf
-bzf
-bzf
+bYw
+bIZ
+bIZ
+bIZ
+ceY
+xqb
+bTa
+cap
+bZZ
+bZZ
+sMn
+bZZ
+bZZ
+bZZ
 xZb
 bZZ
 bZZ
@@ -108511,33 +109241,33 @@ aHy
 bdO
 beH
 bgr
-aGn
-ave
-awS
-awS
-vsv
-avN
-bmx
-avN
-avN
-bvm
-bzk
-bDn
-bDR
-bEg
-bEc
-bDn
-sJr
-bEO
-bDn
-uBz
-ikq
+qlZ
+qlZ
+qlZ
+qlZ
+qlZ
+qlZ
+qlZ
+qlZ
+bQl
+bJc
+aSP
+aSP
+aSP
+aSP
+aSP
+aSP
+aSP
+bJc
+bQl
+bQl
+bIZ
 mNg
-iAY
-aMT
-aSM
-aSM
-aSM
+xqb
+bTa
+cap
+bZZ
+bZZ
 cbS
 bZZ
 cbS
@@ -108766,30 +109496,30 @@ aCq
 aCq
 aCq
 bdQ
-aKd
-bgE
+aXY
+bAY
 ayv
-dyy
-awS
-awS
-pwX
-aWy
+ciS
+ciS
+ciS
+ciS
+ciS
 bmx
-avN
-avN
+aYE
+aYE
 bwd
-avN
+aSP
 bDr
 bDO
-bEs
-bFR
-bDn
-bDn
-bDn
-bDn
-aSM
-aSM
-lDp
+bhd
+avr
+aQX
+gXB
+bjN
+aYE
+qLl
+bqa
+cfq
 ydn
 jjN
 nJb
@@ -109024,32 +109754,32 @@ bac
 aCq
 bdP
 aKd
-bgE
-aGn
-vWz
-ujL
-aNk
-aGn
-aEr
+hSt
+aWW
+aWW
+aWW
+aWW
+aWW
+aWW
 boS
-iJB
-bmn
-bwf
-bzm
-bDn
-bDU
-bGm
+aWW
+aWW
+aWW
+aSP
+lMr
+arB
+beF
 bJO
-bDn
-wEL
-lrT
-wAe
-wAe
-wAe
+aQX
+aSP
+aSP
+aSP
+bsH
+sqt
 uIm
-wNf
-kQm
-aSM
+aAF
+bIZ
+cap
 cap
 cap
 cap
@@ -109281,30 +110011,30 @@ aUZ
 aXU
 bdR
 aKd
-bgE
-azc
-dWf
-avN
-dWf
-avN
-gTX
+izb
+aWW
+aHg
+bhO
+naK
+oXG
+bBa
 brh
-gTX
-bHL
-gTX
-bAu
-bDn
-bDn
-bDn
-bDn
-bDn
-aSM
-bDk
-bdu
-sCd
+hFc
+gdb
+nNV
+aSP
+asT
+arB
+mzF
+rFw
+aQX
+mPD
+azO
+aSP
+spt
 bfn
-aSM
-bEW
+biW
+biW
 qaV
 tFz
 pvb
@@ -109538,33 +110268,33 @@ aPr
 aCq
 bdj
 aKd
-izb
-arZ
-avM
-nCQ
-avN
-dWf
+bgE
+aWW
+aHM
+aZw
+aZw
+aZw
 aEz
 brw
-aAF
-lLD
+aZw
+axC
 aUu
-bhp
-bzi
-bDY
-aGn
-bET
-bGt
-aGn
-bDk
-bEW
-bEW
-tKI
-aSM
-bBw
-nSy
-usn
-xqb
+aSP
+aIY
+aQX
+aQX
+aQX
+aQX
+avM
+arh
+aSP
+bxd
+bZy
+bQl
+bQl
+bQl
+bQl
+tDh
 bxl
 bHa
 cbf
@@ -109796,22 +110526,22 @@ baf
 bea
 aKd
 bys
-aGn
-bCd
-aEh
-dWf
-atT
+aWW
+aIr
+aZw
+aQc
+aZw
 aFQ
 brx
-bwy
-oXG
-dWf
-bzi
-dWf
-avN
-wol
-aEh
-bxg
+aZw
+aZw
+ari
+aSP
+bEU
+beY
+beY
+aQX
+aQX
 ate
 bDk
 bFW
@@ -109821,7 +110551,7 @@ bFW
 bFW
 bFW
 bFW
-xqb
+bSi
 bQl
 bHa
 cbf
@@ -110053,24 +110783,24 @@ bci
 byj
 bfx
 bgE
-aGn
+aWW
 neo
-dbM
-avN
-dWf
+aZw
+aZw
+biP
 aFS
 brz
-aDx
-dWf
-bzi
-dWf
+wnx
+aZw
+bcF
+aSP
 avN
-bEU
-aGn
-bIp
-bHU
-aGn
-tgJ
+bfb
+biv
+aQX
+aQX
+uDc
+aSP
 bFW
 bGn
 bGw
@@ -110079,7 +110809,7 @@ bHK
 bIO
 bFW
 pxb
-bQl
+nAY
 cap
 ciO
 caq
@@ -110309,25 +111039,25 @@ bbk
 bbQ
 aYd
 aQC
-bgE
-aQY
-dWf
-avN
-dWf
-auv
+phy
+aWW
+aDw
+aZw
+bEm
+brk
 aNn
 aGk
-hlV
+xoX
 bxf
-dWf
-avN
-dWf
-bEM
-aGn
-aGn
-aGn
-aGn
-bDk
+bEL
+aSP
+bEx
+aZr
+bfg
+bDU
+bBq
+bgu
+aok
 bFW
 bGo
 bGx
@@ -110336,7 +111066,7 @@ bHV
 bIP
 bFW
 aMh
-bQl
+bTa
 cap
 cap
 cap
@@ -110567,24 +111297,24 @@ aCq
 aYk
 aKj
 bgb
-aGn
-avP
+aWW
+bmJ
 axC
-azO
-aGn
+gXz
+aNl
 baX
 beG
 bmy
-aGn
+axC
+bmW
+aSP
 bCP
-aCn
-bCP
-dWf
-bEn
-lrT
-wAe
-wAe
-gvk
+aZK
+aZK
+aZK
+tbS
+bJK
+aQX
 bFW
 bGq
 bGy
@@ -110593,10 +111323,10 @@ bIl
 bIQ
 bFW
 aMj
-cfq
-cfq
+qSg
+rHb
 byU
-bps
+oTd
 aGM
 aHU
 bIZ
@@ -110824,24 +111554,24 @@ aCq
 byk
 aOX
 beb
-aGn
-tze
+aWW
+bmK
 uof
-eXz
-aGn
+xkK
+aAB
 bhH
-beF
-bhv
+aZw
+aZw
 bCD
-pIL
-bDd
-bAY
-bvJ
-aSM
-bDk
-bEW
+blV
+aSP
+aVt
+aVt
+aVt
+aZe
+bzj
 bJK
-asa
+aQX
 bFW
 bGr
 bGC
@@ -111081,24 +111811,24 @@ aCq
 byl
 aFE
 iEb
-aGn
-aDz
-aDQ
-aVG
-aGn
+aWW
+aWW
+aWW
+aWW
+aWW
 aRj
-bau
+aWW
 bhv
-aGn
-aGn
-aGn
-aGn
-aGn
-aSM
-bDo
-aSM
-aSM
-aSM
+byO
+aWW
+aSP
+aSP
+aSP
+aSP
+aSP
+aSP
+bkr
+iAL
 bFW
 bGs
 bFW
@@ -111113,7 +111843,7 @@ rCb
 bIZ
 bIZ
 bBx
-bCE
+bvB
 ckS
 bQl
 bRv
@@ -111343,18 +112073,18 @@ bjv
 bmC
 bht
 aNA
-aKx
+aEL
 bav
-bpt
-bwB
-bmp
-bmp
-bmp
+aMM
+bgZ
+bht
+bht
+bht
 bmZ
 btQ
 bFy
 sVa
-aMM
+kQm
 aMM
 bgZ
 bmS
@@ -111602,15 +112332,15 @@ blR
 blR
 bjU
 blR
-bqa
+blR
 bAv
 blR
 blR
 blR
 blR
 bhJ
-bHF
-cux
+bjQ
+blR
 boW
 cro
 aXb
@@ -131380,7 +132110,7 @@ aUL
 qFO
 koU
 aIU
-aIU
+vru
 bQn
 asO
 bjr
@@ -133436,7 +134166,7 @@ aKv
 aKv
 bHn
 aKv
-aIU
+mgB
 bQn
 azS
 bao

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -5259,6 +5259,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/machinery/camera{
+	c_tag = "Arrival Dock's South 1";
+	dir = 1
+	},
 /turf/simulated/floor{
 	icon_state = "greencorner"
 	},
@@ -11982,20 +11986,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"auv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
 "auw" = (
 /obj/machinery/deepfryer,
 /turf/simulated/floor{
@@ -17180,10 +17170,17 @@
 	},
 /area/station/security/main)
 "aEz" = (
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Vacant Office APC";
+	pixel_x = -26
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
+	},
 /obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
@@ -17504,6 +17501,9 @@
 /obj/item/weapon/pickaxe/drill,
 /obj/machinery/alarm{
 	pixel_y = 26
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -17830,14 +17830,9 @@
 	},
 /area/station/rnd/storage)
 "aFJ" = (
-/obj/structure/rack,
-/obj/item/weapon/module/power_control,
-/obj/item/weapon/stock_parts/cell{
-	maxcharge = 2000
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/structure/closet/crate/internals,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
@@ -17914,6 +17909,7 @@
 "aFS" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/paper_bin,
+/obj/item/weapon/folder,
 /turf/simulated/floor/carpet/black,
 /area/station/security/vacantoffice)
 "aFT" = (
@@ -21356,7 +21352,6 @@
 /obj/structure/table,
 /obj/item/weapon/folder/yellow,
 /obj/item/weapon/packageWrap,
-/obj/machinery/light,
 /turf/simulated/floor{
 	icon_state = "brown"
 	},
@@ -21401,6 +21396,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/effect/spawner/lootdrop/maintenance/three,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "aMk" = (
@@ -21989,12 +21985,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/computer/guestpass{
 	dir = 8;
 	pixel_x = -28
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/cargo/office)
@@ -22863,10 +22860,7 @@
 "aOY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2"
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "aOZ" = (
@@ -24105,15 +24099,9 @@
 	},
 /area/station/rnd/hor)
 "aRp" = (
-/obj/structure/rack,
-/obj/item/stack/sheet/cardboard,
-/obj/item/stack/rods{
-	amount = 50
-	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
-/area/station/cargo/storage)
+/obj/effect/spawner/lootdrop/maintenance/three,
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "aRq" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -28007,13 +27995,16 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "aYf" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
@@ -30425,7 +30416,14 @@
 	},
 /area/station/gateway)
 "bcf" = (
-/obj/structure/closet/crate,
+/obj/structure/rack,
+/obj/item/stack/sheet/cardboard,
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
@@ -30717,14 +30715,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "bcF" = (
-/obj/structure/closet{
-	name = "Evidence Closet"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/item/device/camera,
-/obj/item/device/taperecorder,
-/obj/item/weapon/storage/box/evidence,
-/turf/simulated/floor/wood,
-/area/station/security/vacantoffice)
+/obj/effect/decal/cleanable/cobweb2,
+/obj/item/weapon/bucket_sensor,
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/station/maintenance/cargo)
 "bcG" = (
 /obj/machinery/vending/wallmed1{
 	name = "Emergency NanoMed";
@@ -32925,9 +32924,6 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -35506,17 +35502,22 @@
 	},
 /area/station/rnd/hallway)
 "bls" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "floorgrime"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/station/cargo/storage)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "blt" = (
 /obj/effect/spawner/lootdrop/maintenance/four,
 /obj/structure/closet/cabinet,
@@ -35584,6 +35585,10 @@
 	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/cargo/office)
@@ -36411,7 +36416,13 @@
 	},
 /area/station/hallway/secondary/entry)
 "bmU" = (
-/obj/structure/closet/crate/internals,
+/obj/structure/closet/crate/freezer,
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
@@ -36446,6 +36457,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
+/obj/structure/closet/crate,
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
@@ -37426,15 +37438,23 @@
 	},
 /area/station/tcommsat/computer)
 "boS" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Private Maintenance";
-	req_access = list(12)
+/obj/structure/sign/warning/smoking{
+	pixel_x = 32
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/item/weapon/cigbutt{
+	pixel_y = 9
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
+/obj/item/weapon/cigbutt{
+	pixel_x = -9;
+	pixel_y = -9
+	},
+/obj/item/weapon/cigbutt{
+	pixel_x = 7;
+	pixel_y = -11
+	},
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/station/security/vacantoffice)
 "boT" = (
 /turf/simulated/floor{
@@ -38511,6 +38531,7 @@
 /obj/item/weapon/wrench,
 /obj/item/device/t_scanner,
 /obj/item/weapon/wirecutters,
+/obj/effect/spawner/lootdrop/maintenance/three,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "bqN" = (
@@ -38669,9 +38690,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	name = "Bar";
+	sortType = "Bar"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
@@ -38904,6 +38926,9 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
@@ -39452,9 +39477,9 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
 "bsy" = (
-/obj/structure/closet/crate/freezer,
-/obj/machinery/alarm{
-	pixel_y = 23
+/obj/structure/closet/crate,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
@@ -40902,20 +40927,6 @@
 	temperature = 80
 	},
 /area/station/tcommsat/chamber)
-"bvb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
 "bvc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
@@ -42111,6 +42122,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "bxc" = (
@@ -42491,7 +42503,7 @@
 /obj/machinery/door/window/westleft{
 	name = "Hydroponics";
 	req_access = list(35);
-	dir = 0
+	dir = 2
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -43381,9 +43393,7 @@
 	},
 /area/station/medical/hallway)
 "bzm" = (
-/obj/structure/stool/bed/chair/metal/yellow{
-	dir = 4
-	},
+/obj/structure/stool/bed/chair/metal/yellow,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
@@ -44340,19 +44350,17 @@
 	},
 /area/station/medical/hallway)
 "bBa" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Vacant Office APC";
-	pixel_x = -26
-	},
-/obj/structure/table/woodentable,
-/obj/item/weapon/book/manual/wiki/security_space_law,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood,
-/area/station/security/vacantoffice)
+/obj/item/trash/pistachios,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "bBb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -44477,14 +44485,19 @@
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "bBm" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "floorgrime"
+/obj/structure/sign/warning/smoking{
+	pixel_x = -32
 	},
-/area/station/cargo/storage)
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "bBn" = (
 /obj/machinery/door_control{
 	id = "bridge blast";
@@ -45636,6 +45649,9 @@
 	},
 /obj/structure/table/glass,
 /obj/item/weapon/book/manual/wiki/hydroponics,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "green"
@@ -48119,9 +48135,9 @@
 /area/station/maintenance/engineering)
 "bHO" = (
 /obj/item/device/radio/intercom{
-	dir = 4;
+	freerange = 1;
 	name = "Station Intercom (General)";
-	pixel_x = 28
+	pixel_x = 27
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -49256,19 +49272,6 @@
 	icon_state = "bluecorner"
 	},
 /area/station/hallway/primary/central)
-"bJN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
 "bJO" = (
 /obj/item/weapon/razor,
 /obj/structure/table/glass,
@@ -54007,14 +54010,9 @@
 	},
 /area/station/hallway/secondary/entry)
 "bTp" = (
-/obj/machinery/camera{
-	c_tag = "Arrival Dock's South 1";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "greencorner"
-	},
-/area/station/hallway/secondary/entry)
+/obj/structure/stool/bed/chair/metal/black,
+/turf/simulated/floor/plating,
+/area/station/security/vacantoffice)
 "bTq" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -71302,6 +71300,12 @@
 /obj/machinery/atmospherics/components/binary/pump/on,
 /turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
+"fnd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/security/vacantoffice)
 "fng" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -72806,6 +72810,12 @@
 	icon_state = "vault"
 	},
 /area/station/civilian/bar)
+"gUl" = (
+/obj/structure/sign/poster/contraband/rip_badger{
+	pixel_x = 32
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "gUO" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -73373,11 +73383,15 @@
 	},
 /area/station/medical/morgue)
 "hFc" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/machinery/door/airlock/maintenance{
+	name = "Private Maintenance";
+	req_access = list(12)
 	},
-/turf/simulated/floor/wood,
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/station/security/vacantoffice)
 "hFo" = (
 /obj/structure/sign/warning/securearea{
@@ -74900,6 +74914,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/effect/spawner/lootdrop/maintenance/four,
 /turf/simulated/floor/plating,
 /area/station/storage/emergency2)
 "jib" = (
@@ -76346,6 +76361,9 @@
 /obj/structure/closet/crate,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
@@ -76547,9 +76565,6 @@
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "lar" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall,
 /area/station/cargo/storage)
@@ -76843,6 +76858,12 @@
 /obj/structure/stool,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"lue" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "lup" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Office";
@@ -77092,7 +77113,18 @@
 	},
 /area/station/civilian/chapel)
 "lFQ" = (
-/obj/structure/closet/crate/medical,
+/obj/structure/rack,
+/obj/item/weapon/module/power_control,
+/obj/item/weapon/stock_parts/cell{
+	maxcharge = 2000
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
@@ -77674,6 +77706,7 @@
 	},
 /area/station/engineering/drone_fabrication)
 "moP" = (
+/obj/effect/spawner/lootdrop/maintenance/seven,
 /turf/simulated/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -77856,6 +77889,9 @@
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -23
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -78324,6 +78360,12 @@
 /obj/machinery/alarm{
 	pixel_y = 26
 	},
+/obj/structure/closet{
+	name = "Evidence Closet"
+	},
+/obj/item/device/camera,
+/obj/item/device/taperecorder,
+/obj/item/weapon/storage/box/evidence,
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken7"
 	},
@@ -79207,14 +79249,9 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "ofi" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "greenchecker"
-	},
-/area/station/civilian/hydroponics)
+/obj/effect/decal/cleanable/spiderling_remains,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "ofm" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -79479,6 +79516,7 @@
 /obj/item/clothing/mask/luchador,
 /obj/item/clothing/gloves/green,
 /obj/effect/decal/cleanable/cobweb,
+/obj/effect/spawner/lootdrop/maintenance/three,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "oxb" = (
@@ -79801,8 +79839,10 @@
 	},
 /area/station/cargo/office)
 "oXG" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/folder,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal,
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
 "oXR" = (
@@ -79969,6 +80009,7 @@
 /obj/item/weapon/reagent_containers/food/drinks/drinkingglass,
 /obj/item/weapon/reagent_containers/food/drinks/drinkingglass,
 /obj/item/weapon/reagent_containers/food/drinks/bottle/ale,
+/obj/effect/spawner/lootdrop/gloves,
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken6"
 	},
@@ -80541,9 +80582,11 @@
 	},
 /area/station/cargo/office)
 "pVE" = (
-/obj/item/stack/sheet/cardboard,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate,
+/obj/structure/closet/crate/medical,
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
@@ -80695,6 +80738,15 @@
 	icon_state = "platebot"
 	},
 /area/station/maintenance/incinerator)
+"qhx" = (
+/obj/structure/table,
+/obj/item/weapon/storage/fancy/cigarettes/dromedaryco{
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/box/matches,
+/turf/simulated/floor/plating,
+/area/station/security/vacantoffice)
 "qib" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -81354,10 +81406,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "qUJ" = (
-/obj/machinery/camera{
-	c_tag = "Arrival Dock's South 2";
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -81670,8 +81718,10 @@
 	},
 /area/station/medical/virology)
 "rku" = (
-/obj/machinery/light/small,
+/obj/item/stack/sheet/cardboard,
+/obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
+/obj/machinery/light/small,
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
@@ -81939,6 +81989,15 @@
 	icon_state = "vault"
 	},
 /area/station/medical/virology)
+"ryS" = (
+/obj/machinery/camera{
+	c_tag = "Arrival Dock's South 2";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "greencorner"
+	},
+/area/station/hallway/secondary/entry)
 "rzb" = (
 /obj/structure/table/glass,
 /obj/machinery/camera{
@@ -82248,6 +82307,9 @@
 	},
 /obj/structure/sign/poster/random{
 	pixel_y = 32
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
@@ -84120,6 +84182,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "uml" = (
@@ -84313,9 +84378,6 @@
 	},
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -85440,6 +85502,7 @@
 	pixel_x = 24
 	},
 /obj/item/ashtray/glass,
+/obj/item/weapon/book/manual/wiki/security_space_law,
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
 "xoA" = (
@@ -85497,14 +85560,10 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "xuq" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/civilian/hydroponics)
+/obj/effect/decal/cleanable/generic,
+/obj/effect/decal/cleanable/ash,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "xvY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -85603,6 +85662,13 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/engine)
+"xFE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
 "xGD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -93016,11 +93082,11 @@ aaa
 aaa
 aaa
 aaa
-bgj
-bgj
-bgj
-bgj
-bgj
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -95586,11 +95652,11 @@ avy
 avy
 avy
 apT
-aah
 bgj
 bgj
 bgj
-aah
+bgj
+bgj
 apT
 cMC
 dBb
@@ -95843,11 +95909,11 @@ bZz
 aEb
 aah
 apT
-aaa
+aah
 icb
 evb
 aEb
-aaa
+aah
 apT
 uDb
 urb
@@ -96873,8 +96939,8 @@ bkQ
 bvg
 bvg
 qUJ
+ryS
 bmq
-bvg
 bvg
 bfZ
 aMb
@@ -97378,14 +97444,14 @@ fec
 iDb
 bmq
 bvg
-bTp
+bvg
 bbT
 ajb
 aNi
 wEL
 ayy
 ayy
-xuq
+ayy
 ayy
 myS
 hJt
@@ -97892,7 +97958,7 @@ avD
 awZ
 cTO
 bBv
-ofi
+qoS
 glx
 bDm
 cTO
@@ -99183,14 +99249,14 @@ aMZ
 aMZ
 aMZ
 amz
-ayy
 myC
+ayy
 boo
 bsL
 bvL
 brf
 bpZ
-bJN
+dQb
 bJP
 bsn
 bXs
@@ -99447,7 +99513,7 @@ aNi
 aNi
 aNi
 aNi
-dQb
+lKJ
 bio
 bio
 bio
@@ -99961,7 +100027,7 @@ brF
 nMw
 pjk
 aSM
-dQb
+lKJ
 qAF
 qcd
 bio
@@ -100470,12 +100536,12 @@ asa
 aGn
 avg
 uEX
-auv
+vhI
 bxb
 bxb
 bxb
 bxb
-bvb
+opR
 aCn
 wJm
 moP
@@ -103288,8 +103354,8 @@ itt
 aOY
 aYf
 dSI
-dSI
-dSI
+bBa
+bBm
 dSI
 fkD
 nCQ
@@ -103542,18 +103608,18 @@ aVf
 lNB
 aSM
 aSM
-bwW
-aFg
-aFg
-aFg
-aPD
-aFg
-rJK
+aSM
+bcF
+gUl
 bEW
+sCd
+sCd
+rJK
+xuq
 bEW
 ixO
-bEW
-bEW
+ofi
+sCd
 bHB
 sbs
 lDy
@@ -103799,11 +103865,11 @@ bHe
 bHe
 bHe
 keS
+lar
 aAX
-aRp
-aWV
-bsK
-gYf
+aFg
+aFg
+aPD
 aFg
 hmR
 aSM
@@ -104056,11 +104122,11 @@ xRb
 bpe
 bHe
 oXb
-bwW
+aFg
 bcf
-bwL
-fDT
-baK
+aWV
+bsK
+gYf
 aFg
 tgJ
 uru
@@ -104313,11 +104379,11 @@ bpM
 bsG
 bvs
 bvN
-bwW
+aFg
 bsy
-gYf
-osT
-bBm
+bwL
+fDT
+baK
 aFg
 aDI
 nLo
@@ -104570,10 +104636,10 @@ bpU
 bkW
 pUQ
 bvN
-bwW
+aFg
 bmU
-bxz
-aXJ
+gYf
+osT
 pVE
 aFg
 lac
@@ -104827,7 +104893,7 @@ oQM
 bkW
 qXi
 bvN
-bwW
+aFg
 aFJ
 bxz
 aXJ
@@ -105084,10 +105150,10 @@ deW
 dra
 bHe
 oXb
-bwW
+aFg
 lFQ
 bxz
-bls
+aXJ
 bxz
 bpt
 bod
@@ -105598,8 +105664,8 @@ uek
 pUQ
 bHe
 bHe
-bwW
 aFg
+bwW
 aFg
 aFg
 aFg
@@ -108939,7 +109005,7 @@ aWB
 aWO
 aZQ
 qlZ
-bQl
+aRp
 btW
 aYE
 aYE
@@ -109451,8 +109517,8 @@ ciS
 ciS
 ciS
 ciS
+ciS
 bmx
-aYE
 aYE
 bwd
 aSP
@@ -109709,9 +109775,9 @@ aWW
 aWW
 aWW
 boS
-aWW
-aWW
-aWW
+fnd
+bTp
+qhx
 aSP
 lMr
 arB
@@ -109964,11 +110030,11 @@ aHg
 bhO
 naK
 oXG
-bBa
-brh
+aWW
+aWW
 hFc
-gdb
-nNV
+aWW
+aWW
 aSP
 asT
 arB
@@ -110220,12 +110286,12 @@ aWW
 aHM
 aZw
 aZw
-aZw
+brh
 aEz
 brw
-aZw
-axC
-aUu
+xFE
+gdb
+nNV
 aSP
 aIY
 aQX
@@ -110481,8 +110547,8 @@ aZw
 aFQ
 brx
 aZw
-aZw
-ari
+axC
+aUu
 aSP
 bEU
 beY
@@ -110739,7 +110805,7 @@ aFS
 brz
 wnx
 aZw
-bcF
+ari
 aSP
 avN
 bfb
@@ -111260,8 +111326,8 @@ aZK
 aZK
 aZK
 tbS
-bJK
-aQX
+bls
+lue
 bFW
 bGq
 bGy

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -6531,16 +6531,6 @@
 /obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor,
 /area/station/storage/primary)
-"ala" = (
-/obj/machinery/power/apc{
-	name = "Arrival Shuttle Hallway APC";
-	pixel_y = -24
-	},
-/obj/structure/cable,
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "alb" = (
 /obj/machinery/door_timer/cell_3,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -16033,28 +16023,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/station/cargo/office)
-"aCe" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "aCf" = (
 /obj/effect/landmark{
 	name = "Holodeck Base"
@@ -102301,8 +102269,8 @@ bhj
 aWv
 aYU
 bbd
-aCe
-ala
+bdB
+bhj
 aGn
 bwC
 bDZ

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -14353,7 +14353,7 @@
 /area/station/maintenance/dormitory)
 "azc" = (
 /obj/machinery/computer/arcade,
-/obj/structure/sign/poster{
+/obj/structure/sign/poster/contraband{
 	pixel_y = -32
 	},
 /turf/simulated/floor{
@@ -23331,13 +23331,12 @@
 	},
 /area/station/storage/tools)
 "aPP" = (
-/obj/structure/sign/poster{
-	official = 1;
-	pixel_x = 30
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/structure/sign/poster/contraband{
+	pixel_x = 32
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -24135,10 +24134,10 @@
 /turf/simulated/wall,
 /area/station/hallway/secondary/exit)
 "aRo" = (
-/obj/structure/lamarr,
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/displaycase/labcage,
 /turf/simulated/floor{
 	icon_state = "whitebot"
 	},
@@ -42594,9 +42593,6 @@
 	},
 /area/station/rnd/chargebay)
 "bxN" = (
-/obj/structure/sign/poster{
-	pixel_y = -32
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/flashlight/seclite,
 /turf/simulated/floor/wood,
@@ -48099,8 +48095,7 @@
 	stamp_message = "Cargo"
 	},
 /obj/item/weapon/hand_labeler,
-/obj/structure/sign/poster{
-	official = 1;
+/obj/structure/sign/poster/contraband{
 	pixel_x = 32
 	},
 /turf/simulated/floor{
@@ -72177,14 +72172,13 @@
 /area/station/engineering/break_room)
 "gib" = (
 /obj/structure/table,
-/obj/structure/sign/poster{
-	official = 1;
-	pixel_x = -32
-	},
 /obj/item/device/flashlight,
 /obj/item/weapon/stock_parts/cell/high{
 	charge = 100;
 	maxcharge = 15000
+	},
+/obj/structure/sign/poster/contraband{
+	pixel_x = -32
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -76085,8 +76079,7 @@
 "kss" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/sign/poster{
-	official = 1;
+/obj/structure/sign/poster/contraband{
 	pixel_x = 32
 	},
 /turf/simulated/floor{
@@ -76345,13 +76338,11 @@
 	},
 /area/station/cargo/office)
 "kFh" = (
-/obj/structure/sign/poster{
-	dir = 6;
-	official = 1;
-	pixel_x = 32
-	},
 /obj/structure/stool/bed/chair/comfy/black{
 	dir = 1
+	},
+/obj/structure/sign/poster/contraband{
+	pixel_x = 32
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -79221,14 +79212,13 @@
 	},
 /area/station/maintenance/engineering)
 "obL" = (
-/obj/structure/sign/poster{
-	official = 1;
-	pixel_x = 32
-	},
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/sign/poster/contraband{
+	pixel_x = 32
+	},
 /turf/simulated/floor{
 	icon_state = "bar"
 	},
@@ -82318,6 +82308,18 @@
 /obj/structure/sign/warning/biohazard,
 /turf/simulated/wall/r_wall,
 /area/station/security/execution)
+"rQR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/sign/poster/contraband{
+	pixel_y = 32
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "rRb" = (
 /obj/structure/stool/bed/chair/office/light{
 	dir = 8
@@ -99757,7 +99759,7 @@ brC
 bvj
 bxN
 aSM
-dQb
+rQR
 aBW
 bhR
 bio

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -14339,7 +14339,7 @@
 /area/station/maintenance/dormitory)
 "azc" = (
 /obj/machinery/computer/arcade,
-/obj/structure/sign/poster/contraband{
+/obj/structure/sign/poster/random{
 	pixel_y = -32
 	},
 /turf/simulated/floor{
@@ -23296,7 +23296,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/structure/sign/poster/contraband{
+/obj/structure/sign/poster/random{
 	pixel_x = 32
 	},
 /turf/simulated/floor{
@@ -48034,11 +48034,11 @@
 	stamp_message = "Cargo"
 	},
 /obj/item/weapon/hand_labeler,
-/obj/structure/sign/poster/contraband{
-	pixel_x = 32
-	},
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/structure/sign/poster/random{
+	pixel_x = 32
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -72026,7 +72026,7 @@
 "gdb" = (
 /obj/structure/table/woodentable,
 /obj/item/device/flashlight/lamp/green,
-/obj/structure/sign/poster/contraband{
+/obj/structure/sign/poster/random{
 	pixel_x = -32
 	},
 /turf/simulated/floor/wood,
@@ -72110,7 +72110,7 @@
 	charge = 100;
 	maxcharge = 15000
 	},
-/obj/structure/sign/poster/contraband{
+/obj/structure/sign/poster/random{
 	pixel_x = -32
 	},
 /turf/simulated/floor{
@@ -76012,7 +76012,7 @@
 "kss" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/sign/poster/contraband{
+/obj/structure/sign/poster/random{
 	pixel_x = 32
 	},
 /turf/simulated/floor{
@@ -76274,7 +76274,7 @@
 /obj/structure/stool/bed/chair/comfy/black{
 	dir = 1
 	},
-/obj/structure/sign/poster/contraband{
+/obj/structure/sign/poster/random{
 	pixel_x = 32
 	},
 /turf/simulated/floor{
@@ -79149,7 +79149,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/sign/poster/contraband{
+/obj/structure/sign/poster/random{
 	pixel_x = 32
 	},
 /turf/simulated/floor{
@@ -82246,7 +82246,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/sign/poster/contraband{
+/obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
 /turf/simulated/floor/plating,
@@ -84177,7 +84177,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/sign/poster{
+/obj/structure/sign/poster/random{
 	pixel_x = 32
 	},
 /turf/simulated/floor/wood,

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -59239,15 +59239,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
-"cki" = (
-/obj/machinery/camera{
-	c_tag = "Port Hallway 3"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/port)
 "ckl" = (
 /obj/machinery/optable,
 /turf/simulated/floor{
@@ -105596,7 +105587,7 @@ aJk
 aVl
 aWI
 aYX
-cki
+bdv
 bdZ
 ipb
 bHe


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Бар на боксе возвращается в отбытие - 
Частичный откат того самого ремапа Юлиана, который перенес бар из отбытия и поменял его местами с карго. Старые проблемы с трубами убраны, как и некоторые другие. Оставлены внешние трубы которые делал Юлиан, есть так же несколько небольших изменений, который в прочем не бросаются в глаза. 

Я не предлагаю полноценно заменить текущий вариант на этот. 

![SSBoxStationBarvotbitieremap](https://user-images.githubusercontent.com/61697643/197338664-9d740b0d-4da5-4630-bc85-16517771e94e.png)

![SSBoxStationBarvotbitieremapbarcrupno](https://user-images.githubusercontent.com/61697643/197338665-a8fb093c-4b87-4a6b-8865-967ec6cbe6e3.png)

## Почему и что этот ПР улучшит

Особенно ничего, игроки немного поиграют, вспомнят молодость. Затем я верну все как было с несколькими фиксами текущих мелких проблем. Оставлять это на долгий срок я бы не хотел

## Авторство

Enerty

## Чеинжлог

:cl: Enerty
 - map: Бар на Boxstation вернулся в отбытие.