### PR TITLE
Deconstruct closet

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -185,7 +185,7 @@
 				new /obj/item/stack/sheet/metal(loc)
 				user.visible_message("[user] cut apart [src] with [WT].",
 				                     "<span class='notice'>You cut apart [src] with [WT].</span>")
-				qdel(src)
+				deconstruct(TRUE)
 				return TRUE
 			else
 				src.welded = !src.welded

--- a/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
@@ -48,7 +48,7 @@
 					addtimer(CALLBACK(src, /atom.proc/update_icon), 10)
 				return
 			..()
-			
+
 	else if (istype(O, /obj/item/weapon/fireaxe) && localopened)
 		if(!fireaxe)
 			user.drop_from_inventory(O, src)


### PR DESCRIPTION
## Описание изменений
Вещи перестанут испаряться при испарении ящика. К примеру, если ящик с топором разварить, то последний испарится. Без понятия, что это может сломать помимо, но кудел там смотрится слегка странно по мне.
closes #10014
## Почему и что этот ПР улучшит
Багфиксы
## Авторство

## Чеинжлог
:cl: Chip11-n
- bugfix: При полной разварке некоторых особых ящиков, вещи не будут испаряться.