### PR TITLE
Mech syringe gun

### DIFF
--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -409,7 +409,7 @@
 	accessible_reagents = list("inaprovaline","anti_toxin", "alkysine", "arithrazine", "bicaridine", "citalopram", "dermaline",
 	"dexalin", "dexalinp", "ethylredoxrazine", "hyperzine", "hyronalin", "imidazoline", "kelotane", "leporazine", "methylphenidate",
 	"oxycodone", "paracetamol", "paroxetine", "peridaxon", "rezadone", "ryetalyn", "spaceacillin", "sterilizine", "synaptizine",
-	"tramadol", "tricordrazine", "doctorsdelight", "metatrombine", "dextromethorphan")
+	"tramadol", "tricordrazine", "doctorsdelight", "metatrombine")
 	known_reagents = list("inaprovaline"="Inaprovaline","anti_toxin"="Anti-Toxin (Dylovene)")
 	processed_reagents = new
 	create_reagents(max_volume)

--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -409,7 +409,7 @@
 	accessible_reagents = list("inaprovaline","anti_toxin", "alkysine", "arithrazine", "bicaridine", "citalopram", "dermaline",
 	"dexalin", "dexalinp", "ethylredoxrazine", "hyperzine", "hyronalin", "imidazoline", "kelotane", "leporazine", "methylphenidate",
 	"oxycodone", "paracetamol", "paroxetine", "peridaxon", "rezadone", "ryetalyn", "spaceacillin", "sterilizine", "synaptizine",
-	"tramadol", "tricordrazine", "doctorsdelight")
+	"tramadol", "tricordrazine", "doctorsdelight", "metatrombine", "dextromethorphan")
 	known_reagents = list("inaprovaline"="Inaprovaline","anti_toxin"="Anti-Toxin (Dylovene)")
 	processed_reagents = new
 	create_reagents(max_volume)


### PR DESCRIPTION
## Описание изменений
Метатромбин можно синтезировать для шприцемёта
closes #9973
## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
:cl: Chip11-n
- bugfix: Метатромбин для шприцемёта меха.