### PR TITLE
Ауризин лечит перма глухоту при полном восстановлении ушей

### DIFF
--- a/code/modules/reagents/reagent_types/Chemistry-Medicine.dm
+++ b/code/modules/reagents/reagent_types/Chemistry-Medicine.dm
@@ -469,6 +469,8 @@
 	..()
 	M.ear_damage = max(M.ear_damage - 1, 0)
 	M.ear_deaf = max(M.ear_deaf - 3, 0)
+	if(M.ear_damage <= 0 && M.ear_deaf <= 0)
+		M.sdisabilities &= ~DEAF
 
 /datum/reagent/peridaxon
 	name = "Peridaxon"

--- a/code/modules/surgery/ribcage.dm
+++ b/code/modules/surgery/ribcage.dm
@@ -763,3 +763,4 @@
 	qdel(tool)
 	target.ear_damage = 0
 	target.ear_deaf = 0
+	target.sdisabilities &= ~DEAF


### PR DESCRIPTION
## Описание изменений
Ауризин лечит перма глухоту при полном восстановлении ушей (перма глухота там в некоторых местах нагладывается с шансом, ага)
Ну ещё ИПЦ при фиксе ушек через операцию лечатся от глухоты, круто.
## Почему и что этот ПР улучшит
Теперь нельзя намертво оглохнуть, что лечится военными преступлениями.
fix https://github.com/TauCetiStation/TauCetiClassic/issues/9948
fix https://github.com/TauCetiStation/TauCetiClassic/issues/10229
## Авторство
Winter Schock - Felicia Ruin
## Чеинжлог
🆑 
- tweak: Перма глухоту от громких звуков (флешки, колокол и тд) можно вылечить Ауризином и, для ИПЦ, операцией.