### PR TITLE
Магическое зеркало не накладывало реколор при смене цвета кожи

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -152,6 +152,7 @@
 			if(new_tone)
 				H.s_tone = max(min(round(new_tone), 220), 1)
 				H.s_tone =  -H.s_tone + 35
+			H.apply_recolor()
 			H.update_hair()
 			H.update_body()
 			H.check_dna(H)


### PR DESCRIPTION
## Описание изменений
Теперь смена цвета кожи через зеркало работает, сколько до этого просто не накладывался реколор
## Почему и что этот ПР улучшит
Теперь зеркало работает лучше
fix https://github.com/TauCetiStation/TauCetiClassic/issues/10163
## Авторство
Winter Schock - Felicia Ruin
## Чеинжлог
:cl: Winter Schock
- bugfix: Магическое зеркало меняет цвет кожи 