### PR TITLE
Фотоальбом теперь имеет в руках вид книги

### DIFF
--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -251,7 +251,7 @@
 	name = "Photo album"
 	icon = 'icons/obj/items.dmi'
 	icon_state = "album"
-	item_state = "briefcase"
+	item_state = "book8"
 	can_hold = list(/obj/item/weapon/photo)
 	max_storage_space = DEFAULT_BOX_STORAGE
 


### PR DESCRIPTION
## Описание изменений
Теперь фотоальбом выглядит как коричневая книжка в руках, а не чумудан.
fix https://github.com/TauCetiStation/TauCetiClassic/issues/10161
## Почему и что этот ПР улучшит
Теперь более логично будет выглядить
## Авторство
Winter Schock - Felicia Ruin
## Чеинжлог
:cl: Winter Schock
- bugfix: Фотоальбом в руках выглядит как книга.