### PR TITLE
Активация ловушек при стартовом ивенте "airlock_joke"

### DIFF
--- a/code/defines/obj/weapon.dm
+++ b/code/defines/obj/weapon.dm
@@ -128,6 +128,10 @@
 
 		icon_state = "beartrap[armed]"
 
+/obj/item/weapon/legcuffs/beartrap/armed
+	icon_state = "beartrap1"
+	armed = 1
+
 /obj/item/weapon/legcuffs/bola
 	name = "bola"
 	desc = "A restraining device designed to be thrown at the target. Upon connecting with said target, it will wrap around their legs, making it difficult for them to move quickly."

--- a/code/modules/events/roundstart_events/misc_events.dm
+++ b/code/modules/events/roundstart_events/misc_events.dm
@@ -133,7 +133,7 @@ var/global/list/sec_closets_list = list()
 			log_game("RoundStart Event: [account1.owner_name] and [account2.owner_name] salaries has been swapped.")
 
 /datum/event/feature/airlock_joke/start()
-	var/list/possible_types = list(/obj/item/weapon/bananapeel, /obj/item/device/assembly/mousetrap, /obj/item/weapon/legcuffs/beartrap, /obj/effect/decal/cleanable/blood/oil)
+	var/list/possible_types = list(/obj/item/weapon/bananapeel, /obj/item/device/assembly/mousetrap/armed, /obj/item/weapon/legcuffs/beartrap/armed, /obj/effect/decal/cleanable/blood/oil)
 	for(var/obj/machinery/door/airlock/A as anything in airlock_list)
 		if(!is_station_level(A.z))
 			continue


### PR DESCRIPTION
## Описание изменений
Капканы и мышеловки активны при ивенте с "шуткой" со спавном всякого под дверьми
## Почему и что этот ПР улучшит
FUN
fix https://github.com/TauCetiStation/TauCetiClassic/issues/9531
## Авторство
Winter Shock - Felicia Ruin
## Чеинжлог
:cl: Winter Schock
- bugfix: Мышеловки и капканы активны во время стартового ивента с шутками под аерлоками