### PR TITLE
Фикс звука тряпки и ведра при поднятии установке их на стол

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -434,7 +434,7 @@
 // apparently called whenever an item is removed from a slot, container, or anything else.
 /obj/item/proc/dropped(mob/user)
 	SHOULD_CALL_PARENT(TRUE)
-	if(isturf(loc) && (user.loc != loc))
+	if(user?.loc != loc && isturf(loc))
 		playsound(user, dropped_sound, VOL_EFFECTS_MASTER)
 	SEND_SIGNAL(src, COMSIG_ITEM_DROPPED, user)
 	flags &= ~IN_INVENTORY

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -433,6 +433,7 @@
 
 // apparently called whenever an item is removed from a slot, container, or anything else.
 /obj/item/proc/dropped(mob/user)
+	SHOULD_CALL_PARENT(TRUE)
 	playsound(user, dropped_sound, VOL_EFFECTS_MASTER)
 	SHOULD_CALL_PARENT(TRUE)
 	SEND_SIGNAL(src, COMSIG_ITEM_DROPPED, user)
@@ -444,6 +445,7 @@
 
 // called just as an item is picked up (loc is not yet changed)
 /obj/item/proc/pickup(mob/user)
+	SHOULD_CALL_PARENT(TRUE)
 	playsound(user, pickup_sound, VOL_EFFECTS_MASTER)
 	SHOULD_CALL_PARENT(TRUE)
 	if(SEND_SIGNAL(src, COMSIG_ITEM_PICKUP, user) & COMPONENT_ITEM_NO_PICKUP)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -446,8 +446,7 @@
 // called just as an item is picked up (loc is not yet changed)
 /obj/item/proc/pickup(mob/user)
 	SHOULD_CALL_PARENT(TRUE)
-	if(isturf(loc) && (user.loc != loc))
-		playsound(user, pickup_sound, VOL_EFFECTS_MASTER)
+	playsound(user, pickup_sound, VOL_EFFECTS_MASTER)
 	if(SEND_SIGNAL(src, COMSIG_ITEM_PICKUP, user) & COMPONENT_ITEM_NO_PICKUP)
 		return FALSE
 	return TRUE

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -434,8 +434,8 @@
 // apparently called whenever an item is removed from a slot, container, or anything else.
 /obj/item/proc/dropped(mob/user)
 	SHOULD_CALL_PARENT(TRUE)
-	playsound(user, dropped_sound, VOL_EFFECTS_MASTER)
-	SHOULD_CALL_PARENT(TRUE)
+	if(isturf(loc) && (user.loc != loc))
+		playsound(user, dropped_sound, VOL_EFFECTS_MASTER)
 	SEND_SIGNAL(src, COMSIG_ITEM_DROPPED, user)
 	flags &= ~IN_INVENTORY
 	if(flags & DROPDEL)
@@ -446,8 +446,8 @@
 // called just as an item is picked up (loc is not yet changed)
 /obj/item/proc/pickup(mob/user)
 	SHOULD_CALL_PARENT(TRUE)
-	playsound(user, pickup_sound, VOL_EFFECTS_MASTER)
-	SHOULD_CALL_PARENT(TRUE)
+	if(isturf(loc) && (user.loc != loc))
+		playsound(user, pickup_sound, VOL_EFFECTS_MASTER)
 	if(SEND_SIGNAL(src, COMSIG_ITEM_PICKUP, user) & COMPONENT_ITEM_NO_PICKUP)
 		return FALSE
 	return TRUE

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -447,8 +447,8 @@
 /obj/item/proc/pickup(mob/user)
 	SHOULD_CALL_PARENT(TRUE)
 	if(SEND_SIGNAL(src, COMSIG_ITEM_PICKUP, user) & COMPONENT_ITEM_NO_PICKUP)
-		playsound(user, pickup_sound, VOL_EFFECTS_MASTER)
 		return FALSE
+	playsound(user, pickup_sound, VOL_EFFECTS_MASTER)
 	return TRUE
 
 // called when this item is removed from a storage item, which is passed on as S. The loc variable is already set to the new destination before this is called.

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -446,8 +446,8 @@
 // called just as an item is picked up (loc is not yet changed)
 /obj/item/proc/pickup(mob/user)
 	SHOULD_CALL_PARENT(TRUE)
-	playsound(user, pickup_sound, VOL_EFFECTS_MASTER)
 	if(SEND_SIGNAL(src, COMSIG_ITEM_PICKUP, user) & COMPONENT_ITEM_NO_PICKUP)
+		playsound(user, pickup_sound, VOL_EFFECTS_MASTER)
 		return FALSE
 	return TRUE
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -434,7 +434,7 @@
 // apparently called whenever an item is removed from a slot, container, or anything else.
 /obj/item/proc/dropped(mob/user)
 	SHOULD_CALL_PARENT(TRUE)
-	if(user?.loc != loc && isturf(loc))
+	if(user && user.loc != loc && isturf(loc))
 		playsound(user, dropped_sound, VOL_EFFECTS_MASTER)
 	SEND_SIGNAL(src, COMSIG_ITEM_DROPPED, user)
 	flags &= ~IN_INVENTORY

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -11,6 +11,8 @@
 	var/burning = null
 	var/list/hitsound = list()
 	var/usesound = null
+	var/pickup_sound = null
+	var/dropped_sound = null
 	var/wet = 0
 	var/can_embed = 1
 	var/slot_flags = 0		//This is used to determine on which slots an item can fit.
@@ -431,6 +433,7 @@
 
 // apparently called whenever an item is removed from a slot, container, or anything else.
 /obj/item/proc/dropped(mob/user)
+	playsound(user, dropped_sound, VOL_EFFECTS_MASTER)
 	SHOULD_CALL_PARENT(TRUE)
 	SEND_SIGNAL(src, COMSIG_ITEM_DROPPED, user)
 	flags &= ~IN_INVENTORY
@@ -441,6 +444,7 @@
 
 // called just as an item is picked up (loc is not yet changed)
 /obj/item/proc/pickup(mob/user)
+	playsound(user, pickup_sound, VOL_EFFECTS_MASTER)
 	SHOULD_CALL_PARENT(TRUE)
 	if(SEND_SIGNAL(src, COMSIG_ITEM_PICKUP, user) & COMPONENT_ITEM_NO_PICKUP)
 		return FALSE

--- a/code/modules/detectivework/footprints_and_rag.dm
+++ b/code/modules/detectivework/footprints_and_rag.dm
@@ -22,6 +22,8 @@
 	possible_transfer_amounts = list(5)
 	volume = 5
 	can_be_placed_into = null
+	pickup_sound = null
+	dropped_sound = null
 
 /obj/item/weapon/reagent_containers/glass/rag/attack_self(mob/user)
 	return

--- a/code/modules/reagents/reagent_containers/food/drinks/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/drinkingglass.dm
@@ -22,8 +22,6 @@
 
 /obj/item/weapon/reagent_containers/food/drinks/drinkingglass/dropped(mob/user)
 	. = ..()
-	if(isturf(loc) && (user.loc != loc))
-		playsound(user, 'sound/items/glass_containers/bottle_put-empty.ogg', VOL_EFFECTS_MASTER)
 
 /obj/item/weapon/reagent_containers/food/drinks/drinkingglass/on_reagent_change()
 	/*if(reagents.reagent_list.len > 1 )

--- a/code/modules/reagents/reagent_containers/food/drinks/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/drinkingglass.dm
@@ -4,6 +4,8 @@
 	icon_state = "glass_empty"
 	amount_per_transfer_from_this = 5
 	volume = 25
+	pickup_sound = 'sound/items/glass_containers/bottle_take-empty.ogg'
+	dropped_sound = 'sound/items/glass_containers/bottle_put-empty.ogg'
 
 /obj/item/weapon/reagent_containers/food/drinks/drinkingglass/afterattack(atom/target, mob/user, proximity, params)
 	. = ..()
@@ -17,10 +19,6 @@
 	new /obj/item/weapon/shard(loc)
 	reagents.standard_splash(loc)
 	qdel(src)
-
-/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/pickup(mob/living/user)
-	. = ..()
-	playsound(user, 'sound/items/glass_containers/bottle_take-empty.ogg', VOL_EFFECTS_MASTER)
 
 /obj/item/weapon/reagent_containers/food/drinks/drinkingglass/dropped(mob/user)
 	. = ..()

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -14,6 +14,8 @@
 	flags = OPENCONTAINER
 	action_button_name = "Switch Lid"
 	var/label_text = ""
+	pickup_sound = 'sound/items/glass_containers/bottle_take-empty.ogg'
+	dropped_sound = 'sound/items/glass_containers/bottle_put-empty.ogg'
 
 	//var/list/
 	can_be_placed_into = list(
@@ -65,12 +67,12 @@
 
 /obj/item/weapon/reagent_containers/glass/pickup(mob/living/user)
 	. = ..()
-	playsound(user, 'sound/items/glass_containers/bottle_take-empty.ogg', VOL_EFFECTS_MASTER)
+	playsound(user, pickup_sound, VOL_EFFECTS_MASTER)
 
 /obj/item/weapon/reagent_containers/glass/dropped(mob/user)
 	. = ..()
 	if(isturf(loc) && (user.loc != loc))
-		playsound(user, 'sound/items/glass_containers/bottle_put-empty.ogg', VOL_EFFECTS_MASTER)
+		playsound(user, dropped_sound, VOL_EFFECTS_MASTER)
 
 /obj/item/weapon/reagent_containers/glass/afterattack(atom/target, mob/user, proximity, params)
 
@@ -309,6 +311,8 @@
 	slot_flags = SLOT_FLAGS_HEAD
 	armor = list(melee = 10, bullet = 5, laser = 5,energy = 3, bomb = 5, bio = 0, rad = 0)
 	force = 5
+	pickup_sound = null
+	dropped_sound = null
 
 /obj/item/weapon/reagent_containers/glass/bucket/attackby(obj/item/I, mob/user, params)
 	if(isprox(I))

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -65,15 +65,6 @@
 		flags |= OPENCONTAINER
 	update_icon()
 
-/obj/item/weapon/reagent_containers/glass/pickup(mob/living/user)
-	. = ..()
-	playsound(user, pickup_sound, VOL_EFFECTS_MASTER)
-
-/obj/item/weapon/reagent_containers/glass/dropped(mob/user)
-	. = ..()
-	if(isturf(loc) && (user.loc != loc))
-		playsound(user, dropped_sound, VOL_EFFECTS_MASTER)
-
 /obj/item/weapon/reagent_containers/glass/afterattack(atom/target, mob/user, proximity, params)
 
 	if (!is_open_container() || !proximity)

--- a/code/modules/research/xenoarchaeology/tools/tools_wave_scanner.dm
+++ b/code/modules/research/xenoarchaeology/tools/tools_wave_scanner.dm
@@ -153,6 +153,7 @@
 	throwforce = 0 // we shall not abuse
 	throw_range = 0
 	slot_flags = null
+	dropped_sound = 'sound/items/buttonswitch.ogg'
 	var/nearest_artifact_id = "unknown"
 	var/nearest_artifact_distance = -1
 	var/last_scan_time = 0
@@ -174,9 +175,7 @@
 	..()
 	if(wavescanner)
 		wavescanner.remove_processor()
-		playsound(src, 'sound/items/buttonswitch.ogg', VOL_EFFECTS_MASTER)
 	else
-		playsound(src, 'sound/items/buttonswitch.ogg', VOL_EFFECTS_MASTER)
 		qdel(src)
 
 /obj/item/device/searcher/afterattack(atom/target, mob/user, proximity, params)


### PR DESCRIPTION
## Описание изменений
Я по звукам не секу впринципе, но теперь ведро и тряпочка не шумят стекло при поднимании и поставлении их на стол
Ну а ещё общая переменная для звука поднятия и опускания штук айтемам (да знаю всёравно попросили-бы)
## Почему и что этот ПР улучшит
Теперь нежные уши игроков не будут сталкиваться со звуком стекла у тканевой тряпки
close https://github.com/TauCetiStation/TauCetiClassic/issues/10031
## Авторство
Winter Schock - Felicia Ruin
## Чеинжлог
:cl: Winter Schock
- bugfix: ведро и тряпка не издают звуки стекла при поднятии и опускании вещей