### PR TITLE
уменьшает стан от разгерм

### DIFF
--- a/code/modules/atmospheric/ZAS/Airflow.dm
+++ b/code/modules/atmospheric/ZAS/Airflow.dm
@@ -176,7 +176,7 @@ Contains helper procs for airflow, handled in /connection_group.
 		var/obj/item/I = A
 		weak_amt = I.w_class
 	else
-		weak_amt = rand(1, 5)
+		weak_amt = rand(1, 3)
 	Stun(weak_amt * 0.5)
 	Weaken(weak_amt)
 	..()

--- a/code/modules/atmospheric/ZAS/Airflow.dm
+++ b/code/modules/atmospheric/ZAS/Airflow.dm
@@ -18,8 +18,7 @@ Contains helper procs for airflow, handled in /connection_group.
 		return FALSE
 	if(!lying)
 		to_chat(src, "<span class='warning'>The sudden rush of air knocks you over!</span>")
-	Stun(2)
-	Weaken(5)
+	Weaken(1)
 	COOLDOWN_START(src, last_airflow_stun, vsc.airflow_stun_cooldown)
 
 /mob/living/silicon/airflow_stun()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
уменьшает стан из-за внезапного перемещения воздуха до одной секунды, было пять.
уменьшает стан из-за аирфлов хита до 1-3 секунд, было 1-5.
## Почему и что этот ПР улучшит
Жизнь игрокам.
Стан от разгермы не будет значить 100% смерть, ведь при удачных обстоятельствах эта хуйня станит на 10 секунд, а из-за смешной системы болеурона, кукла падает в болекрит из-за разгермы за 20-25 секунд, а чтобы покинуть место с низким давлением нужно найти лом, открыть ломом створку (что занимает без скиллов секунд 5), снова упасть в стан и наконец то таки уйти. 
Сложив это всё можно понять, что кукла не может пережить разгерму, не залутав зараньше лом и болеутоляющие, что позволят кое-как покинуть место разгерметизации.
Ну и антаги с адреналином или боевыми ботинками абьюзят данную механику, делая клик ломом + сваркой по полу можно ввести в кнок на 10-15 секунд целую кучу людей.
## Авторство

## Чеинжлог
:cl: Simbaka
- balance: Резкий порыв воздуха оглушает на намного меньшее время.