### PR TITLE
Update atmos_control.dm

### DIFF
--- a/code/game/machinery/computer/atmos_control.dm
+++ b/code/game/machinery/computer/atmos_control.dm
@@ -172,7 +172,7 @@ Toxins: <span class='dl[phoron_dangerlevel]'>[phoron_percent]</span>%<br>
 					var/list/thresholds = list("lower bound", "low warning", "high warning", "upper bound")
 					var/newval = input("Enter [thresholds[threshold]] for [env]", "Alarm triggers", selected[threshold]) as num|null
 
-					if (isnull(newval) || ..() || (current.locked && issilicon(usr)))
+					if (isnull(newval) || !..() || (current.locked && issilicon(usr)))
 						return FALSE
 
 					if (newval < 0)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Фикс Central Atmospherics Computer, теперь установка порогов тревог(содержание газов, температура, давление) работает как и должна.
## Почему и что этот ПР улучшит
Меньше багов
## Авторство

## Чеинжлог
:cl:
 - bugfix: Через центральную консоль управления атмосом теперь можно менять пороги тревог.