### PR TITLE
Divided divine power for shielding aura

### DIFF
--- a/code/modules/religion/religion.dm
+++ b/code/modules/religion/religion.dm
@@ -398,6 +398,17 @@
 /datum/religion/proc/affect_divine_power_rite(datum/religion_rites/R)
 	R.divine_power = calc_divine_power(R.needed_aspects, initial(R.divine_power))
 
+/**
+ * Returns a list with the difference between the needed aspects for rite and those in religion.
+ * Return format: "Aspect name" = difference
+ */
+/datum/religion/proc/get_aspect_diffs(list/rite_aspects)
+	var/list/diffs = list()
+	for(var/need_aspect in rite_aspects)
+		var/datum/aspect/aspect = aspects[need_aspect]
+		diffs[aspect.name] = aspect.power - rite_aspects[need_aspect]
+	return diffs
+
 // Give our gods all needed spells which in /list/spells
 /datum/religion/proc/give_god_spells(mob/G)
 	for(var/spell in god_spells)

--- a/code/modules/religion/rites/instant/instant.dm
+++ b/code/modules/religion/rites/instant/instant.dm
@@ -497,7 +497,7 @@
 
 	var/obj/effect/effect/forcefield/rune/R = new
 	var/list/diffs = get_aspect_diffs()
-	H.AddComponent(/datum/component/forcefield, "power aura", 30 * diffs[ASPECT_CHAOS], 1 MINUTE / diffs[ASPECT_RESCUE], 2.5 MINUTE / diffs[ASPECT_RESCUE], R, FALSE, TRUE)
+	H.AddComponent(/datum/component/forcefield, "power aura", 30 * sqrt(diffs[ASPECT_CHAOS]), 1 MINUTE / sqrt(diffs[ASPECT_RESCUE]), 2.5 MINUTE / sqrt(diffs[ASPECT_RESCUE]), R, FALSE, TRUE)
 	SEND_SIGNAL(H, COMSIG_FORCEFIELD_PROTECT, H)
 
 	return TRUE
@@ -507,7 +507,7 @@
 	for(var/need_aspect in needed_aspects)
 		var/datum/aspect/aspect = religion.aspects[need_aspect]
 		to_chat(world,"[aspect], [religion.aspects[need_aspect]], [religion.aspects[needed_aspects[need_aspect]]]")
-		diffs += list("[aspect.name]" = aspect.power - need_aspect + 1)
+		diffs += list("[aspect.name]" = aspect.power - needed_aspects[need_aspect] + 1)
 	return diffs
 
 /datum/religion_rites/instant/cult/upgrade_tome

--- a/code/modules/religion/rites/instant/instant.dm
+++ b/code/modules/religion/rites/instant/instant.dm
@@ -4,6 +4,13 @@
 /datum/religion_rites/instant/chaplain
 	religion_type = /datum/religion/chaplain
 
+/datum/religion_rites/instant/cult/proc/get_aspect_diffs()
+	var/list/diffs = list()
+	for(var/need_aspect in needed_aspects)
+		var/datum/aspect/aspect = religion.aspects[need_aspect]
+		diffs[aspect.name] = aspect.power - needed_aspects[need_aspect] + 1
+	return diffs
+
 /datum/religion_rites/instant/cult/sacrifice
 	name = "Жертвоприношение"
 	desc = "Душа для древнего бога."
@@ -501,14 +508,6 @@
 	SEND_SIGNAL(H, COMSIG_FORCEFIELD_PROTECT, H)
 
 	return TRUE
-
-/datum/religion_rites/instant/cult/proc/get_aspect_diffs()
-	var/list/diffs = list()
-	for(var/need_aspect in needed_aspects)
-		var/datum/aspect/aspect = religion.aspects[need_aspect]
-		to_chat(world,"[aspect], [religion.aspects[need_aspect]], [religion.aspects[needed_aspects[need_aspect]]]")
-		diffs += list("[aspect.name]" = aspect.power - needed_aspects[need_aspect] + 1)
-	return diffs
 
 /datum/religion_rites/instant/cult/upgrade_tome
 	name = "Улучшение Тома"

--- a/code/modules/religion/rites/instant/instant.dm
+++ b/code/modules/religion/rites/instant/instant.dm
@@ -4,13 +4,6 @@
 /datum/religion_rites/instant/chaplain
 	religion_type = /datum/religion/chaplain
 
-/datum/religion_rites/instant/cult/proc/get_aspect_diffs()
-	var/list/diffs = list()
-	for(var/need_aspect in needed_aspects)
-		var/datum/aspect/aspect = religion.aspects[need_aspect]
-		diffs[aspect.name] = aspect.power - needed_aspects[need_aspect] + 1
-	return diffs
-
 /datum/religion_rites/instant/cult/sacrifice
 	name = "Жертвоприношение"
 	desc = "Душа для древнего бога."
@@ -504,7 +497,10 @@
 
 	var/obj/effect/effect/forcefield/rune/R = new
 	var/list/diffs = get_aspect_diffs()
-	H.AddComponent(/datum/component/forcefield, "power aura", 30 * sqrt(diffs[ASPECT_CHAOS]), 1 MINUTE / sqrt(diffs[ASPECT_RESCUE]), 2.5 MINUTE / sqrt(diffs[ASPECT_RESCUE]), R, FALSE, TRUE)
+	var/shield_health = 30 * sqrt(diffs[ASPECT_CHAOS] + 1)
+	var/reactivation_time = 1 MINUTE / sqrt(diffs[ASPECT_RESCUE] + 1)
+	var/recharge_time = 2.5 MINUTE / sqrt(diffs[ASPECT_RESCUE] + 1)
+	H.AddComponent(/datum/component/forcefield, "power aura", shield_health, reactivation_time, recharge_time, R, FALSE, TRUE)
 	SEND_SIGNAL(H, COMSIG_FORCEFIELD_PROTECT, H)
 
 	return TRUE

--- a/code/modules/religion/rites/instant/instant.dm
+++ b/code/modules/religion/rites/instant/instant.dm
@@ -496,7 +496,7 @@
 	H.take_overall_damage(10, 20)
 
 	var/obj/effect/effect/forcefield/rune/R = new
-	var/list/diffs = get_aspect_diffs()
+	var/list/diffs = religion.get_aspect_diffs(needed_aspects)
 	var/shield_health = 30 * sqrt(diffs[ASPECT_CHAOS] + 1)
 	var/reactivation_time = 1 MINUTE / sqrt(diffs[ASPECT_RESCUE] + 1)
 	var/recharge_time = 2.5 MINUTE / sqrt(diffs[ASPECT_RESCUE] + 1)

--- a/code/modules/religion/rites/instant/instant.dm
+++ b/code/modules/religion/rites/instant/instant.dm
@@ -451,7 +451,7 @@
 
 /datum/religion_rites/instant/cult/give_forcearmor
 	name = "Создание Силовой Ауры"
-	desc = "Окружает человека на алтаре силовой аурой, которая может блокировать урон."
+	desc = "Окружает человека на алтаре силовой аурой, которая может блокировать урон. Аспект Хаоса повышает силу щита, а аспект Салютуса - скорость восстановления."
 	ritual_length = (15 SECONDS)
 	invoke_msg = "Защитись же!!"
 	favor_cost = 300
@@ -496,10 +496,19 @@
 	H.take_overall_damage(10, 20)
 
 	var/obj/effect/effect/forcefield/rune/R = new
-	H.AddComponent(/datum/component/forcefield, "power aura", 30 * divine_power, 1 MINUTE, 2.5 MINUTE, R, FALSE, TRUE)
+	var/list/diffs = get_aspect_diffs()
+	H.AddComponent(/datum/component/forcefield, "power aura", 30 * diffs[ASPECT_CHAOS], 1 MINUTE / diffs[ASPECT_RESCUE], 2.5 MINUTE / diffs[ASPECT_RESCUE], R, FALSE, TRUE)
 	SEND_SIGNAL(H, COMSIG_FORCEFIELD_PROTECT, H)
 
 	return TRUE
+
+/datum/religion_rites/instant/cult/proc/get_aspect_diffs()
+	var/list/diffs = list()
+	for(var/need_aspect in needed_aspects)
+		var/datum/aspect/aspect = religion.aspects[need_aspect]
+		to_chat(world,"[aspect], [religion.aspects[need_aspect]], [religion.aspects[needed_aspects[need_aspect]]]")
+		diffs += list("[aspect.name]" = aspect.power - need_aspect + 1)
+	return diffs
 
 /datum/religion_rites/instant/cult/upgrade_tome
 	name = "Улучшение Тома"

--- a/code/modules/religion/rites_type/rites.dm
+++ b/code/modules/religion/rites_type/rites.dm
@@ -155,14 +155,3 @@
 	pre_start(user, AOG)
 	start(user, AOG)
 	return TRUE
-
-/**
- * Returns a list with the difference between the needed aspects for rite and those in religion.
- * Return format: "Aspect name" = difference
- */
-/datum/religion_rites/proc/get_aspect_diffs()
-	var/list/diffs = list()
-	for(var/need_aspect in needed_aspects)
-		var/datum/aspect/aspect = religion.aspects[need_aspect]
-		diffs[aspect.name] = aspect.power - needed_aspects[need_aspect]
-	return diffs

--- a/code/modules/religion/rites_type/rites.dm
+++ b/code/modules/religion/rites_type/rites.dm
@@ -155,3 +155,14 @@
 	pre_start(user, AOG)
 	start(user, AOG)
 	return TRUE
+
+/**
+ * Returns a list with the difference between the needed aspects for rite and those in religion.
+ * Return format: "Aspect name" = difference
+ */
+/datum/religion_rites/proc/get_aspect_diffs()
+	var/list/diffs = list()
+	for(var/need_aspect in needed_aspects)
+		var/datum/aspect/aspect = religion.aspects[need_aspect]
+		diffs[aspect.name] = aspect.power - needed_aspects[need_aspect]
+	return diffs


### PR DESCRIPTION
## Описание изменений
1) Щит-аура теперь имеет особую градацию от аспектов. Так, хаос влияет на живучесть щита, а салютус на скорость перезарядки и восстановления.
2) Сила аспекта берётся в корень, в итоге сильно понижая эффективность на большой циферке аспекта. Кто-то достигал 600 ХП (сам не видел, но в теории даже 100 много, учитывая что им доступны те же опции брони, что и экипажу поверх щита)
3) Заготовка-прок для получения разницы в "нужных-имеющихся" аспектах в виде листа `get_aspect_diffs()`
## Почему и что этот ПР улучшит
Баланс, полагаю.
## Авторство

## Чеинжлог
:cl: Chip11-n
- balance: Усиление от аспектов теперь по другому работает для силовой ауры культа.