### PR TITLE
New cult members-oriented objectives

### DIFF
--- a/code/game/gamemodes/factions/cult.dm
+++ b/code/game/gamemodes/factions/cult.dm
@@ -41,7 +41,7 @@
 		return FALSE
 
 	var/list/possibles_objectives = subtypesof(/datum/objective/cult) + /datum/objective/target/sacrifice
-	for(var/i in 1 to rand(2, 3))
+	for(var/i in 1 to rand(3, 4))
 		AppendObjective(pick_n_take(possibles_objectives))
 	return TRUE
 

--- a/code/game/gamemodes/objectives/cult/cult_objectives.dm
+++ b/code/game/gamemodes/objectives/cult/cult_objectives.dm
@@ -75,7 +75,7 @@
 	var/convertees_needed
 	var/datum/job/job
 
-/datum/objective/cult/New()
+/datum/objective/cult/job_convert/New()
 	var/list/possible_jobs = list()
 	for(var/I in get_all_jobs())
 		if(I in list("Security Officer", "Security Cadet", "Head of Security", "Captain", "Forensic Technician", "Detective", "Warden", "Head of Personnel", "AI", "Cyborg", "Internal Affairs Agent"))
@@ -84,7 +84,7 @@
 		if(J.current_positions > 1)
 			possible_jobs += I
 	job = SSjob.GetJob(pick(possible_jobs))
-	convertees_needed = rand(CEIL(job.current_positions / 2), 1)
+	convertees_needed = rand(1, CEIL(job.current_positions / 2))
 	explanation_text = "Культ нуждается в [convertees_needed] [pluralize_russian(convertees_needed, "последователе", "последователях", "последователях")], являющихся [job.title]."
 	..()
 

--- a/code/game/gamemodes/objectives/cult/cult_objectives.dm
+++ b/code/game/gamemodes/objectives/cult/cult_objectives.dm
@@ -1,28 +1,28 @@
 /datum/objective/cult
 
-/datum/objective/cult/escape
+/datum/objective/cult/recruit
 	var/acolytes_needed
 
-/datum/objective/cult/escape/New()
-	acolytes_needed = round(player_list.len * 0.04)
+/datum/objective/cult/recruit/New()
+	acolytes_needed = round(player_list.len * 0.08)
 	explanation_text = "Убедитесь, что хотя бы [acolytes_needed] [pluralize_russian(acolytes_needed, "культист", "культиста", "культистов")] улетят живыми на шаттле, чтобы продолжить исследования на других станциях."
 	..()
 
-/datum/objective/cult/escape/check_completion()
+/datum/objective/cult/recruit/check_completion()
 	var/datum/faction/cult/C = faction
 	if(istype(C) && C.get_cultists_out() >= acolytes_needed)
 		return OBJECTIVE_WIN
 	return OBJECTIVE_LOSS
 
-/datum/objective/cult/recruit
+/datum/objective/cult/convert
 	var/acolytes_needed
 
-/datum/objective/cult/recruit/New()
+/datum/objective/cult/convert/New()
 	acolytes_needed = max(5, round(player_list.len * 0.3))
 	explanation_text = "Заполучите [acolytes_needed] [pluralize_russian(acolytes_needed, "человека", "человека", "человек")] в подчинение культа, живыми или мёртвыми."
 	..()
 
-/datum/objective/cult/recruit/check_completion()
+/datum/objective/cult/convert/check_completion()
 	var/datum/faction/cult/C = faction
 	if(istype(C) && C.members.len >= acolytes_needed)
 		return OBJECTIVE_WIN

--- a/code/game/gamemodes/objectives/cult/cult_objectives.dm
+++ b/code/game/gamemodes/objectives/cult/cult_objectives.dm
@@ -76,16 +76,15 @@
 	var/datum/job/job
 
 /datum/objective/cult/job_convert/New()
+	var/list/all_jobs = list() + engineering_positions + medical_positions + science_positions + civilian_positions - command_positions
 	var/list/possible_jobs = list()
-	for(var/I in get_all_jobs())
-		if(I in list("Security Officer", "Security Cadet", "Head of Security", "Captain", "Forensic Technician", "Detective", "Warden", "Head of Personnel", "AI", "Cyborg", "Internal Affairs Agent"))
-			continue
+	for(var/I in all_jobs)
 		var/datum/job/J = SSjob.GetJob(I)
 		if(J.current_positions > 1)
 			possible_jobs += I
 	job = SSjob.GetJob(pick(possible_jobs))
 	convertees_needed = rand(1, CEIL(job.current_positions / 2))
-	explanation_text = "Культ нуждается в [convertees_needed] [pluralize_russian(convertees_needed, "последователе", "последователях", "последователях")], являющихся [job.title]."
+	explanation_text = "Культ нуждается в [convertees_needed] [pluralize_russian(convertees_needed, "последователе, являющемся", "последователях, являющихся", "последователях, являющихся")] [job.title]."
 	..()
 
 /datum/objective/cult/job_convert/check_completion()

--- a/code/game/gamemodes/objectives/cult/cult_objectives.dm
+++ b/code/game/gamemodes/objectives/cult/cult_objectives.dm
@@ -4,7 +4,7 @@
 	var/acolytes_needed
 
 /datum/objective/cult/escape/New()
-	acolytes_needed = max(5, round(player_list.len * 0.04))
+	acolytes_needed = round(player_list.len * 0.04)
 	explanation_text = "Убедитесь, что хотя бы [acolytes_needed] [pluralize_russian(acolytes_needed, "культист", "культиста", "культистов")] улетят живыми на шаттле, чтобы продолжить исследования на других станциях."
 	..()
 

--- a/code/game/gamemodes/objectives/cult/cult_objectives.dm
+++ b/code/game/gamemodes/objectives/cult/cult_objectives.dm
@@ -1,17 +1,51 @@
 /datum/objective/cult
 
+/datum/objective/cult/escape
+	var/acolytes_needed
+
+/datum/objective/cult/escape/New()
+	acolytes_needed = max(5, round(player_list.len * 0.04))
+	explanation_text = "Убедитесь, что хотя бы [acolytes_needed] [pluralize_russian(acolytes_needed, "культист", "культиста", "культистов")] улетят живыми на шаттле, чтобы продолжить исследования на других станциях."
+	..()
+
+/datum/objective/cult/escape/check_completion()
+	var/datum/faction/cult/C = faction
+	if(istype(C) && C.get_cultists_out() >= acolytes_needed)
+		return OBJECTIVE_WIN
+	return OBJECTIVE_LOSS
+
 /datum/objective/cult/recruit
 	var/acolytes_needed
 
 /datum/objective/cult/recruit/New()
-	acolytes_needed = max(5, round(player_list.len * 0.18))
-	explanation_text = "Убедитесь, что хотя бы [acolytes_needed] [pluralize_russian(acolytes_needed, "культист", "культиста", "культистов")] улетят на шаттле, чтобы продолжить исследования на других станциях."
+	acolytes_needed = max(5, round(player_list.len * 0.3))
+	explanation_text = "Заполучите [acolytes_needed] [pluralize_russian(acolytes_needed, "человека", "человека", "человек")] в подчинение культа, живыми или мёртвыми."
 	..()
 
 /datum/objective/cult/recruit/check_completion()
 	var/datum/faction/cult/C = faction
-	if(istype(C) && C.get_cultists_out() >= acolytes_needed)
+	if(istype(C) && C.members.len >= acolytes_needed)
 		return OBJECTIVE_WIN
+	return OBJECTIVE_LOSS
+
+/datum/objective/cult/survive
+	var/acolytes_needed
+
+/datum/objective/cult/survive/New()
+	acolytes_needed = max(5, round(player_list.len * 0.15))
+	explanation_text = "Должно дожить не менее [acolytes_needed] [pluralize_russian(acolytes_needed, "последователя", "последователей", "последователей")] до конца этой смены."
+	..()
+
+/datum/objective/cult/survive/check_completion()
+	var/datum/faction/cult/C = faction
+	if(istype(C))
+		var/alive = 0
+		for(var/datum/role/I in C.members)
+			var/mob/M = I.antag.current
+			if(M.stat != DEAD)
+				alive++
+		if(alive >= acolytes_needed)
+			return OBJECTIVE_WIN
 	return OBJECTIVE_LOSS
 
 /datum/objective/cult/summon_narsie

--- a/code/game/gamemodes/objectives/cult/cult_objectives.dm
+++ b/code/game/gamemodes/objectives/cult/cult_objectives.dm
@@ -70,3 +70,31 @@
 	if(istype(C) && C.religion.captured_areas.len - C.religion.area_types.len >= need_capture)
 		return OBJECTIVE_WIN
 	return OBJECTIVE_LOSS
+
+/datum/objective/cult/job_convert
+	var/convertees_needed
+	var/datum/job/job
+
+/datum/objective/cult/New()
+	var/list/possible_jobs = list()
+	for(var/I in get_all_jobs())
+		if(I in list("Security Officer", "Security Cadet", "Head of Security", "Captain", "Forensic Technician", "Detective", "Warden", "Head of Personnel", "AI", "Cyborg", "Internal Affairs Agent"))
+			continue
+		var/datum/job/J = SSjob.GetJob(I)
+		if(J.current_positions > 1)
+			possible_jobs += I
+	job = SSjob.GetJob(pick(possible_jobs))
+	convertees_needed = rand(CEIL(job.current_positions / 2), 1)
+	explanation_text = "Культ нуждается в [convertees_needed] [pluralize_russian(convertees_needed, "последователе", "последователях", "последователях")], являющихся [job.title]."
+	..()
+
+/datum/objective/cult/job_convert/check_completion()
+	var/datum/faction/cult/C = faction
+	if(istype(C))
+		var/convertees = 0
+		for(var/datum/role/R in C.members)
+			if(R.antag.current.mind.assigned_job == job)
+				convertees++
+		if(convertees >= convertees_needed)
+			return OBJECTIVE_WIN
+	return OBJECTIVE_LOSS


### PR DESCRIPTION
## Описание изменений
У культа теперь три задания которые так или иначе связаны с количеством культистов:
Формула: всего игроков на сервере * множитель задания.
1) Нужно что бы несколько человек сбежало на шаттле. Множитель 0.08 (при 70 примерно 6-о). Я когда делал хало, этого не продумал. Я видел всего 1 успешный культ без вызова нарси, который захватил шаттл, и улетел на нём, и это был раунд с гуляющим фороном. Тут либо устраивать откровенное мессиво, либо ничего не делать.
2) Нужно что бы выжили культисты. Множитель 0.15 (при 70 примерно 11 человек). Учитывая, что под конец раунда у сильного культа в живых ~14-20.
3) Нужно вербовать. Множитель 0.3 (при 70 примерно 21). Не важно, живые или нет, главное получить количество культяк.
4) Задание на конверт определённых должностей. На должности должно быть больше 1 человека с начала раунда, то-есть главы и какие-то психологи отпадают - это на случай случайной смерти одного из игроков. Также, роль не может быть из брига. 
## Почему и что этот ПР улучшит
Люди может(!) быть начнут играть по другому. По аналогии с тем же тритором и его задачами или на побег или выживание смотрится не так уж плохо. Изменений колоссальных не будет, но это всё же новое в игре, что так или иначе повлияет на игру.
В случае с выживаемостью люди будут стремиться именно дожить до конца раунда, а не улететь. В случае конверта будут стремиться (по идее) конвертить всех и вся. Ну, а побег это просто мем, 12 человек без полного доминирования шаттла не сбегут на нём - аналог хиджака.
С конвертом должностей всё и так понятно, должно быть забавно.
## Авторство

## Чеинжлог
:cl:
- add: У культа появились новые задания.