### PR TITLE
из 3 граба теперь можно выбраться

### DIFF
--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -256,7 +256,6 @@
 				qdel(src)
 				return PROCESS_KILL
 			BP.add_autopsy_data("Strangled", 0, BRUISE) //if 0, then unknow
-		affecting.Stun(1)
 		if(isliving(affecting))
 			var/mob/living/L = affecting
 			L.adjustOxyLoss(1)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
убрал постоянное прибавление stun'a схваченному в 3 граб
## Почему и что этот ПР улучшит
fix #10206
## Авторство

## Чеинжлог
:cl: Simbaka
- fix: Из красного захвата было невозможно выбраться.