### PR TITLE
Норм фича бросания хуманов в хуманов со станом последних

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -1,3 +1,5 @@
+#define SIZE_DIFFERENCE(A, B) (A.w_class - B.w_class)
+
 /mob/living/carbon/human/getHalLoss()
 	if(species.flags[NO_PAIN])
 		return 0
@@ -12,6 +14,28 @@
 	if(species.flags[NO_PAIN])
 		return
 	..()
+
+/mob/living/carbon/human/hitby(atom/movable/AM, datum/thrownthing/throwingdatum)
+	. = ..()
+	var/size_diff_calculate = SIZE_DIFFERENCE(AM, src)
+	//should be non-negative
+	if(size_diff_calculate < 0)
+		return
+	var/weight_diff_coef = 1 + sqrt(size_diff_calculate)
+	if(weight_diff_coef)
+		if(isSlipImmune())
+			adjustHalLoss(15 * weight_diff_coef)	//thicc landing
+		else
+			AdjustWeakened(3 * weight_diff_coef)	//3 seconds is default slip
+		visible_message("<span class='warning'>[AM] falls at [src].</span>",
+						"<span class='warning'>[AM] falls at you!</span>",
+						"<span class='notice'>You hear something heavy fall.</span>")
+
+/mob/living/carbon/human/proc/isSlipImmune()
+	if(istype(shoes, /obj/item/clothing/shoes) && shoes.flags & NOSLIP)
+		return TRUE
+	if(istype(wear_suit, /obj/item/clothing/suit/space/rig) && wear_suit.flags & NOSLIP)
+		return TRUE
 
 /mob/living/carbon/human/bullet_act(obj/item/projectile/P, def_zone)
 	def_zone = check_zone(def_zone)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Почти как на ТГ! (стоило бы посмотреть как там, перед тем как самому закодить, но ладно уже).
Второй/третий граб на куклу, включённый режим броска, расстояние до цели ~2 тайла = швыряние тела в оппонента с станом по формуле (1 + корень из разницы в размерах) умноженное на 3 секунды лёгкого стана (можно ползать) или на 15 болеурона (если ты нюкер в комбат бутсах или парень с магнитными ботиночками).

Сделал меньше хардкода чем могло быть, в расчёте, что можно будет кидаться квиной чужих и получать 8 секунд стана или почти удар дубинки, а нельзя. *pepesad.
Щас ещё заметил что не ограничил метание мобами, то есть можно метать и объекты (те что не прикручены). Например грушу, хотя не уверен что знаю как. Ну и корову, карпа, возвышенного шадоулинга и монстров с шахты в теории тоже можно будет метнуть со станом.
## Почему и что этот ПР улучшит
Геймплей. Меньше желающих подходить в мили с дубинками к тому, кто держит человека в захвате.
## Авторство
идея с ТГ
## Чеинжлог
- add: Теперь метание здоровых объектов станит или накладывает болеурон людям.