### PR TITLE
Фикс бага - возможности посмотреть и достать предметы из lockbox

### DIFF
--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -51,6 +51,18 @@
 	else
 		to_chat(user, "<span class='warning'>Its locked!</span>")
 
+/obj/item/weapon/storage/lockbox/attack_hand(mob/user)
+	if ((src.loc == user) && (src.locked == 1))
+		to_chat(user, "<span class='warning'>[src] is locked and cannot be opened!</span>")
+	else if ((src.loc == user) && (!src.locked))
+		open(user)
+	else
+		..()
+		for(var/mob/M in range(1))
+			if (M.s_active == src)
+				close(M)
+	add_fingerprint(user)
+
 /obj/item/weapon/storage/lockbox/emag_act(mob/user)
 	if(broken)
 		return FALSE
@@ -64,7 +76,7 @@
 /obj/item/weapon/storage/lockbox/try_open(mob/user)
 	if(locked && !broken)
 		if(user.in_interaction_vicinity(src))
-			to_chat(user, "<span class='warning'>Its locked!</span>")
+			to_chat(user, "<span class='warning'>[src] is locked and cannot be opened!</span>")
 		return FALSE
 	else
 		return ..()

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -24,9 +24,7 @@
 			if(locked)
 				icon_state = icon_locked
 				to_chat(user, "<span class='warning'>You lock the [src]!</span>")
-				for(var/mob/M in range(1)) // close the content window for all mobs, when lock lockbox
-					if (M.s_active == src)
-						close(M)
+				close_all() // close the content window for all mobs, when lock lockbox
 				return
 			else
 				icon_state = icon_closed
@@ -61,9 +59,6 @@
 		open(user)
 	else
 		..()
-		for(var/mob/M in range(1))
-			if (M.s_active == src)
-				close(M)
 	add_fingerprint(user)
 
 /obj/item/weapon/storage/lockbox/emag_act(mob/user)

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -24,6 +24,9 @@
 			if(locked)
 				icon_state = icon_locked
 				to_chat(user, "<span class='warning'>You lock the [src]!</span>")
+				for(var/mob/M in range(1)) // close the content window for all mobs, when lock lockbox
+					if (M.s_active == src)
+						close(M)
 				return
 			else
 				icon_state = icon_closed

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -52,9 +52,9 @@
 		to_chat(user, "<span class='warning'>Its locked!</span>")
 
 /obj/item/weapon/storage/lockbox/attack_hand(mob/user)
-	if ((src.loc == user) && (src.locked == 1))
+	if ((loc == user) && locked)
 		to_chat(user, "<span class='warning'>[src] is locked and cannot be opened!</span>")
-	else if ((src.loc == user) && (!src.locked))
+	else if ((loc == user) && !locked)
 		open(user)
 	else
 		..()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
fix #10359

Определена функция attack_hand() для /obj/item/weapon/storage/lockbox  (закрывающиеся картой ящички с антисингулярностью, имплантами лояльности, образцами вирусов, медалями). Функция взята с закрывающегося на кодовый замок кейса /obj/item/weapon/storage/secure/briefcase. 

Ранее вызывалась родительская функция /obj/item/weapon/storage/attack_hand(), просто открывающая ящичек.

## Почему и что этот ПР улучшит
багфикс
## Авторство

## Чеинжлог
:cl: Karras Bring
- bugfix: теперь нельзя посмотреть в lockbox и взять предметы без разблокировки картой
