### PR TITLE
БыстроДуши и точка

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -15188,7 +15188,7 @@
 	},
 /area/station/security/lobby)
 "aAx" = (
-/obj/machinery/shower{
+/obj/machinery/shower/free{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -15768,7 +15768,7 @@
 	},
 /area/station/rnd/xenobiology)
 "aBG" = (
-/obj/machinery/shower{
+/obj/machinery/shower/free{
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -40513,9 +40513,6 @@
 	},
 /area/station/cargo/office)
 "buE" = (
-/obj/machinery/shower{
-	dir = 4
-	},
 /obj/structure/drain{
 	drainage = 2
 	},
@@ -40523,6 +40520,9 @@
 	icon_state = "left";
 	name = "Cloning Cell";
 	req_access = list(5)
+	},
+/obj/machinery/shower/free{
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 5;

--- a/maps/centcom/centcom.dmm
+++ b/maps/centcom/centcom.dmm
@@ -609,9 +609,6 @@
 /turf/unsimulated/wall/fakeglass,
 /area/centcom/evac)
 "abo" = (
-/obj/machinery/shower{
-	dir = 8
-	},
 /obj/structure/drain{
 	drainage = 2
 	},
@@ -619,6 +616,9 @@
 /obj/machinery/door/window{
 	dir = 8;
 	name = "Shower cabin"
+	},
+/obj/machinery/shower/free{
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "freezerfloor"
@@ -4895,9 +4895,6 @@
 	},
 /area/centcom/specops)
 "ame" = (
-/obj/machinery/shower{
-	dir = 1
-	},
 /obj/machinery/door/window{
 	dir = 1;
 	name = "Shower cabin"
@@ -4907,6 +4904,9 @@
 	},
 /obj/item/weapon/reagent_containers/food/snacks/soap/syndie,
 /obj/structure/curtain/open/shower/security,
+/obj/machinery/shower/free{
+	dir = 1
+	},
 /turf/unsimulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -5635,9 +5635,6 @@
 	},
 /area/custom/syndicate_mothership)
 "anE" = (
-/obj/machinery/shower{
-	dir = 1
-	},
 /obj/structure/curtain/open/shower/security,
 /obj/machinery/door/window{
 	dir = 1;
@@ -5645,6 +5642,9 @@
 	},
 /obj/structure/drain{
 	drainage = 2
+	},
+/obj/machinery/shower/free{
+	dir = 1
 	},
 /turf/unsimulated/floor{
 	icon_state = "freezerfloor"
@@ -6587,28 +6587,28 @@
 	},
 /area/velocity)
 "apU" = (
-/obj/machinery/shower{
-	pixel_y = 20
-	},
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/structure/window/reinforced{
 	dir = 8
+	},
+/obj/machinery/shower/free{
+	pixel_y = 20
 	},
 /turf/unsimulated/floor{
 	icon_state = "freezerfloor"
 	},
 /area/velocity)
 "apV" = (
-/obj/machinery/shower{
-	pixel_y = 20
-	},
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/structure/window/reinforced{
 	dir = 4
+	},
+/obj/machinery/shower/free{
+	pixel_y = 20
 	},
 /turf/unsimulated/floor{
 	icon_state = "freezerfloor"
@@ -17106,11 +17106,11 @@
 /turf/unsimulated/floor,
 /area/centcom/living)
 "aMA" = (
-/obj/machinery/shower{
-	dir = 8
-	},
 /obj/machinery/porta_turret/stationary{
 	lethal = 0
+	},
+/obj/machinery/shower/free{
+	dir = 8
 	},
 /turf/unsimulated/floor{
 	icon_state = "freezerfloor"
@@ -24444,7 +24444,7 @@
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
 	},
-/obj/machinery/shower{
+/obj/machinery/shower/free{
 	dir = 4
 	},
 /turf/unsimulated/floor{
@@ -26892,7 +26892,7 @@
 /area/custom/syndicate_mothership/elite_squad)
 "iab" = (
 /obj/structure/window/reinforced,
-/obj/machinery/shower{
+/obj/machinery/shower/free{
 	dir = 4
 	},
 /turf/unsimulated/floor{
@@ -26901,7 +26901,7 @@
 /area/centcom/living)
 "ibb" = (
 /obj/structure/window/reinforced,
-/obj/machinery/shower{
+/obj/machinery/shower/free{
 	dir = 8
 	},
 /turf/unsimulated/floor{

--- a/maps/falcon/falcon.dmm
+++ b/maps/falcon/falcon.dmm
@@ -19177,11 +19177,11 @@
 /area/station/civilian/bar)
 "jMj" = (
 /obj/machinery/clonepod,
-/obj/machinery/shower{
-	dir = 8
-	},
 /obj/structure/drain{
 	drainage = 2
+	},
+/obj/machinery/shower/free{
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 5;

--- a/maps/prometheus/prometheus.dmm
+++ b/maps/prometheus/prometheus.dmm
@@ -22925,7 +22925,7 @@
 	},
 /area/station/medical/reception)
 "fnH" = (
-/obj/machinery/shower{
+/obj/machinery/shower/free{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -44057,13 +44057,13 @@
 /obj/structure/drain{
 	drainage = 2
 	},
-/obj/machinery/shower{
-	dir = 8
-	},
 /obj/item/device/radio/intercom{
 	frequency = 1485;
 	name = "Station Intercom (Medbay)";
 	pixel_y = -32
+	},
+/obj/machinery/shower/free{
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 5;


### PR DESCRIPTION
## Описание изменений
Быстро раскидал бесплатные души по тюрьмам и клонилкам всех станций, а также полностью заменил все души на цк слое на бесплатные.

## Почему и что этот ПР улучшит
Закрыть гештальт Дехаки

## Авторство
AndreyGysev и никто никто никто кто помогал в дискорде

## Чеинжлог
:cl:
 - tweak: Позаменял множество душей по станциям и цк слою на бесплатные версии.