### PR TITLE
test subject pack osobka 1

### DIFF
--- a/code/datums/qualities/quirkieish.dm
+++ b/code/datums/qualities/quirkieish.dm
@@ -204,3 +204,15 @@
 		LAZYREMOVE(H.mind.skills.available_skillsets, s)
 	H.mind.skills.add_available_skillset(/datum/skillset/jack_of_all_trades)
 	H.mind.skills.maximize_active_skills()
+
+
+/datum/quality/quirkieish/slime_person
+	name = "Slimeperson"
+	desc = "Ты един со слизнями."
+	requirement = "Подопытный."
+
+/datum/quality/quirkieish/slime_person/satisfies_requirements(mob/living/carbon/human/H, latespawn)
+	return H.mind.role_alt_title == "Test Subject"
+
+/datum/quality/quirkieish/slime_person/add_effect(mob/living/carbon/human/H, latespawn)
+	H.set_species(SLIME)


### PR DESCRIPTION
## Описание изменений

открывающая в паке особок для Подопытных (и именно подопытных).

идея особок для подопытных в том чтобы сделать подопытных смешными и со своим характером,.

думаю особки для Подопытных могут нести особо дебильный и разрушительный в отношении игрока характер так как:
- у подопытных нет важной роли в игре
- очень легко НЕ выбрать роль подопытного (а значит и заигнорить особку)

Надеюсь что в будущем на подопытных будут тестировать лимиты дебильности особок, но пока-что эта, довольно скучная.

!!! нужно чтобы кто-то затестил у меня лапки помогите !!!

## Почему и что этот ПР улучшит

больше контента для особок == интереснее прожимать лутбокс

