### PR TITLE
Накачанные ноги больше не уменьшают замедление

### DIFF
--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -75,8 +75,6 @@
 			bp_tally += 1.6
 		else if(BP.status & ORGAN_BROKEN)
 			bp_tally += 6
-		else if(BP.pumped)
-			bp_weight_negation += BP.pumped * 0.02
 
 	tally += bp_tally / moving_bodyparts.len
 	weight_negation += bp_weight_negation / moving_bodyparts.len


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Накачанные ноги больше не уменьшают замедление ото всякой одежды.
То есть, от прокликивания велотренажера меняется только спрайт ног и не более.
## Почему и что этот ПР улучшит
close #10299
Будет невозможно накачать ноги и бегать без штрафов к скорости в почти любом риге или каком-нибудь хазард сьюте.
## Авторство

## Чеинжлог
:cl: Simbaka
- balance: Накачанные ноги больше не уменьшают замедление от различных скафандров, неудобной одежды и так далее.