### PR TITLE
Eminence swap minds fix

### DIFF
--- a/code/game/gamemodes/modes_gameplays/cult/eminence.dm
+++ b/code/game/gamemodes/modes_gameplays/cult/eminence.dm
@@ -45,6 +45,7 @@
 
 /mob/camera/eminence/Login()
 	..()
+	sync_mind()
 	var/datum/religion/cult/R = global.cult_religion
 	if(R.eminence && R.eminence != src)
 		R.remove_member(src)

--- a/code/modules/religion/rites/instant/instant.dm
+++ b/code/modules/religion/rites/instant/instant.dm
@@ -397,12 +397,12 @@
 	if(!..())
 		return FALSE
 
-	if(AOG.buckled_mob.get_species() == HOMUNCULUS)
-		to_chat(user, "<span class='warning'>Тело гомункула слишком слабо.</span>")
+	if(!isliving(AOG.buckled_mob))
+		to_chat(user, "<span class='warning'>На алтаре должно лежать живое существо.</span>")
 		return FALSE
 
-	if(!isliving(AOG.buckled_mob))
-		to_chat(user, "<span class='warning'>На алтаре должно лежать существо.</span>")
+	if(AOG.buckled_mob.get_species() == HOMUNCULUS)
+		to_chat(user, "<span class='warning'>Тело гомункула слишком слабо.</span>")
 		return FALSE
 
 	return TRUE


### PR DESCRIPTION

## Описание изменений
- sync_mind() синхронизирует маенд и клиент при логине от эминенса. В этом была проблема выброса игрока при маендсвапе в лобби (или только проблема найденная мной на тесте). closes #10385
- Чисто логическая ошибка в постановке порядка условий. Появляется рантайм при попытке маендсвапа без человека на алтаре (проверяет расу гомункула, не проверив, "человек ли?")
## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
