### PR TITLE
taser light rebalance

### DIFF
--- a/code/game/machinery/bots/ed209bot.dm
+++ b/code/game/machinery/bots/ed209bot.dm
@@ -298,7 +298,7 @@
 			if(emagged == 2)
 				projectile = /obj/item/projectile/beam
 			else
-				projectile = /obj/item/projectile/energy/electrode
+				projectile = /obj/item/projectile/beam/stun
 		else if(lasertag_color == "blue")
 			if(emagged == 2)
 				projectile = /obj/item/projectile/beam/lasertag/omni

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -20,6 +20,12 @@
 	damage_type = HALLOSS
 	//Damage will be handled on the MOB side, to prevent window shattering.
 
+/obj/item/projectile/energy/electrode/Bump()
+	var/dist_crossed = get_dist(get_turf(src), starting)
+	if(dist_crossed > 1)
+		agony -= dist_crossed * 20
+	return ..()
+
 /obj/item/projectile/energy/declone
 	name = "declone"
 	icon_state = "declone"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Боль, причиняемая электродом, уменьшается с каждой клеткой. 
При выстреле накладывается:
- вплотную - тоже что и было
- 1 клетка дистанции - тоже что и было
- 2 клетки - чуть сильнее удара дубинки
- 3 клетки - удар дубинки
- 4 клетки - выстрел луча тазера
- 5 клеток - половина выстрела луча
- 6 клеток - 0 эффекта

Не смог сделать по какой-то загадочной причине чтобы электрод летел только ограниченное кол-во времени или клеток, сделал так.
Этот ПР повлияет на текущую ситуацию с офицерами, которые по моим наблюдениям, сосут по всем фронтам, если опытных игроков нет, в худшую сторону. Однако же это не отменяет то, что тазер плохо забаланшен по сравнению с другим оружием и альтернативным (вообще основным) режимом стрельбы. Удаление тазера и/или замена его глоком никому не нравится, потому балансим как можем.
ЕД-шка теперь стреляет стан-лучом, а не электродами. Получается ходящая турель.
## Почему и что этот ПР улучшит
Баланс тазера. Концепт из "переключай всегда в электрод" превращается в "стан-лучи для дальнего боя, электрод для ближнего". Стан-луч имеет шансы всякие промахов и тд, электрод вплотную даёт больше импакта. Стан-ту-вин немного понерфлен.
## Авторство

## Чеинжлог
:cl: Deahaka
- balance: Электрод уменьшает накладываемую боль с расстоянием.