### PR TITLE
deletes quirks incomptabile with species on specie acquisition

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1439,6 +1439,10 @@
 
 	species.on_gain(src)
 
+	for(var/datum/quirk/Q in roundstart_quirks)
+		if(SSquirks.quirk_blacklist_species[Q.name] && (species.name in SSquirks.quirk_blacklist_species[Q.name]))
+			qdel(Q)
+
 	regenerate_icons()
 	full_prosthetic = null
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

при смене расы куклы все квирки несовместимые с новой расой слетают.

в теории не должно позволить быть жирным големом, подменой, и т.д. ...

## Почему и что этот ПР улучшит

fixes #10475 
