### PR TITLE
Hunter pounce

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/humanoid/caste/hunter.dm
@@ -91,7 +91,7 @@
 	if(isliving(hit_atom))
 		var/mob/living/L = hit_atom
 		var/obj/item/weapon/shield/shield = L.is_in_hands(/obj/item/weapon/shield)
-		if(shield && check_shield_dir(hit_atom) && prob(shield.Get_shield_chance() + 20))
+		if(shield && check_shield_dir(hit_atom))
 			L.visible_message("<span class='danger'>[src] smashed into [L]'s [shield]!</span>", "<span class='userdanger'>[src] pounces on your [shield]!</span>")
 			Stun(2)
 			Weaken(2)
@@ -106,14 +106,14 @@
 			sleep(2)  // Runtime prevention (infinite bump() calls on hulks)
 			step_towards(src, L)
 			toggle_leap(FALSE)
-			pounce_cooldown = TRUE
-			VARSET_IN(src, pounce_cooldown, FALSE, pounce_cooldown_time)
 			playsound(src, pick(SOUNDIN_HUNTER_LEAP), VOL_EFFECTS_MASTER, vary = FALSE)
 	else if(hit_atom.density)
 		visible_message("<span class='danger'>[src] smashes into [hit_atom]!</span>", "<span class='alertalien'>You smashes into [hit_atom]!</span>")
 		Stun(2)
 		Weaken(2)
 
+	pounce_cooldown = TRUE
+	VARSET_IN(src, pounce_cooldown, FALSE, pounce_cooldown_time)
 	update_canmove()
 
 #undef MAX_ALIEN_LEAP_DIST
@@ -138,8 +138,7 @@
 			return TRUE
 		else if(M.dir == WEST && (dir in list(EAST, NORTH)))
 			return TRUE
-		return FALSE
-	else if(istype(M.r_hand, /obj/item/weapon/shield))
+	if(istype(M.r_hand, /obj/item/weapon/shield))
 		if(M.dir == NORTH && (dir in list(SOUTH, WEST)))
 			return TRUE
 		else if(M.dir == SOUTH && (dir in list(NORTH, EAST)))
@@ -148,7 +147,6 @@
 			return TRUE
 		else if(M.dir == WEST && (dir in list(EAST, SOUTH)))
 			return TRUE
-		return FALSE
 	return FALSE
 
 /mob/living/carbon/xenomorph/humanoid/hunter/proc/toggle_invisible()

--- a/code/modules/mob/living/carbon/xenomorph/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/xenomorph/humanoid/humanoid.dm
@@ -13,7 +13,7 @@
 	var/leap_on_click = 0
 	heal_rate = 3
 	var/pounce_cooldown = 0
-	var/pounce_cooldown_time = 15 SECONDS
+	var/pounce_cooldown_time = 10 SECONDS
 
 	var/neurotoxin_on_click = 0
 	var/neurotoxin_delay = 60


### PR DESCRIPTION

## Описание изменений
- Теперь после прыжка охотник не сможет прыгать снова и снова на свою жертву до момента, пока она не упадёт. До этого, пока ты не повалил свою жертву на пол, прыжок не уходил на КД.
- Два щита в руке защищают как два, а не один.
- Для балансировки, КД снижен с 15 до 10 секунд
- 
Из спорного:
- Убраны случайные станы сквозь щит. Стан там 5 секунд, а это граб, другой коридор, лицехват, гнездо.
## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
:cl: 
- balance: Стезя охотника стала сложнее