### PR TITLE
твики видения снов

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -107,7 +107,7 @@
 		human_owner.SetConfused(human_owner.confused * 0.997)
 		human_owner.SetDrunkenness(human_owner.drunkenness * 0.997)
 
-	if(prob(20))
+	if(prob(50))
 		if(carbon_owner)
 			carbon_owner.handle_dreams()
 		if(prob(10) && owner.health)

--- a/code/modules/flufftext/Dreaming.dm
+++ b/code/modules/flufftext/Dreaming.dm
@@ -44,7 +44,7 @@ var/global/list/nightmares = list(
 	return TRUE
 
 /mob/living/carbon/proc/dream_sequence(segments)
-	if(stat != UNCONSCIOUS || paralysis <= 0)
+	if(stat != UNCONSCIOUS)
 		dreaming = NOT_DREAMING
 		return
 
@@ -62,7 +62,7 @@ var/global/list/nightmares = list(
 		dreaming = NOT_DREAMING
 
 /mob/living/carbon/proc/handle_dreams()
-	if(client && !dreaming && prob(10))
+	if(client && !dreaming && prob(50))
 		dream()
 
 /mob/living/carbon/var/dreaming = NOT_DREAMING

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -304,10 +304,9 @@
 			heardword = copytext(heardword,2)
 		if(copytext(heardword,-1) in punctuation)
 			heardword = copytext(heardword,1,-1)
-		heard = "<span class = 'game_say'>...You hear something about...[heardword]</span>"
-
+		heard = "<span class='notice italic'>... [heardword] ...</span>"
 	else
-		heard = "<span class = 'game_say'>...<i>You almost hear someone talking</i>...</span>"
+		return
 
 	to_chat(src, heard)
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
теперь для того чтобы видеть сны не обязательно получить по голове, нужно именно просто заснуть (Sleep в IC или баллон с газом)
повысил шанс на отображение слов снов, теперь они чаще вылазиют
выпилил строчку "You can almost hear someone talking...", изменил строчку с услышанным случайным словом на похожую как в случае снов
## Почему и что этот ПР улучшит
меньше перемешанного русского с английским текстом, выглядит всё органичнее и прикольнее
## Авторство
я
## Чеинжлог
:cl:
- rscadd: Изменения в выведении текста, когда космонавт спит.