### PR TITLE
Уменьшение кол-ва игроков необходимых для Воксо-нюки

### DIFF
--- a/code/game/gamemodes/modes_declares/mixed/nukeheist.dm
+++ b/code/game/gamemodes/modes_declares/mixed/nukeheist.dm
@@ -4,5 +4,5 @@
 	probability = 80
 	factions_allowed = list(/datum/faction/nuclear/crossfire)
 
-	minimum_player_count = 50
-	minimum_players_bundles = 50
+	minimum_player_count = 25
+	minimum_players_bundles = 35


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Нюковоксы уже [изменены ](https://github.com/TauCetiStation/TauCetiClassic/pull/10008) и не требуют заполнения антагами в начале раунда. Кол-во реди можно понизить, но у нюки, кажется, низкая планка в 20 человек. Сделал как у алиенов.
## Почему и что этот ПР улучшит
#closes #10490
Нюковоксов теперь можно запустить на фул сервере без спама в чат "жмите реди".
## Авторство

## Чеинжлог
:cl: Deahaka
- tweak: Требуемое число игроков для старта режима Crossfire уменьшено.