### PR TITLE
Нерф нерфа алиенов

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/xenomorph/humanoid/humanoid.dm
@@ -16,7 +16,7 @@
 	var/pounce_cooldown_time = 10 SECONDS
 
 	var/neurotoxin_on_click = 0
-	var/neurotoxin_delay = 60
+	var/neurotoxin_delay = 40
 	var/neurotoxin_next_shot = 0
 	var/last_neurotoxin = 0
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Кд на выстрел нейротоксином 4 секунды (было 6) 
## Почему и что этот ПР улучшит
После "нерфа" страж тупо не может 1 на 1 вынести даже челика в риотке. Ты его станишь, ждёшь пока пройдёт кд, ломаешь броню, он встаёт и убивает тебя. Теперь же страж сможет норм убивать челика, но всё ещё не будет турелью. 
## Авторство

## Чеинжлог
:cl:
- balance: Теперь кд на плевки Стражей 4 секунды. 