### PR TITLE
переносит данные сенсоров из офиса рд в теленауку

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -27655,7 +27655,6 @@
 	network = list("SS13","Research")
 	},
 /obj/machinery/computer/skills,
-/obj/item/weapon/paper/space_structures,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -40588,6 +40587,7 @@
 /obj/machinery/computer/telescience{
 	dir = 8
 	},
+/obj/item/weapon/paper/space_structures,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "warning"

--- a/maps/falcon/falcon.dmm
+++ b/maps/falcon/falcon.dmm
@@ -3252,6 +3252,7 @@
 /obj/machinery/alarm{
 	pixel_y = 21
 	},
+/obj/item/weapon/paper/space_structures,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "warndark"
@@ -29564,7 +29565,6 @@
 /area/station/hallway/primary/central)
 "tAD" = (
 /obj/structure/table/reinforced,
-/obj/item/weapon/paper/space_structures,
 /obj/machinery/keycard_auth{
 	pixel_x = -28
 	},

--- a/maps/gamma/gamma.dmm
+++ b/maps/gamma/gamma.dmm
@@ -46112,6 +46112,7 @@
 /area/station/security/hos)
 "nxW" = (
 /obj/machinery/computer/telescience,
+/obj/item/weapon/paper/space_structures,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -66936,7 +66937,6 @@
 /area/station/maintenance/science)
 "ugH" = (
 /obj/structure/table,
-/obj/item/weapon/paper/space_structures,
 /obj/machinery/computer/skills,
 /turf/simulated/floor{
 	dir = 5;

--- a/maps/prometheus/prometheus.dmm
+++ b/maps/prometheus/prometheus.dmm
@@ -33687,7 +33687,6 @@
 "hDM" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/item/weapon/paper/monitorkey,
-/obj/item/weapon/paper/space_structures,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "darkpurple"
@@ -70335,6 +70334,7 @@
 /area/station/maintenance/engineering)
 "qSO" = (
 /obj/machinery/computer/telescience,
+/obj/item/weapon/paper/space_structures,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "darkpurple"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
переносит данные сенсоров из офиса рд в теленауку
## Почему и что этот ПР улучшит
resolve #7781
## Авторство

## Чеинжлог
:cl: Simbaka
- tweak: Бумажка с координатами дереликтов теперь лежит в теленауке.