### PR TITLE
Для открытия склада в инженерном отсеке теперь нужен доступ инженера

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -71739,6 +71739,9 @@
 /area/station/medical/cmo)
 "fSs" = (
 /obj/machinery/door/firedoor,
+/obj/structure/sign/warning/securearea{
+	pixel_y = 32
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "yellow"
@@ -76404,8 +76407,12 @@
 	},
 /area/station/cargo/storage)
 "lcB" = (
-/obj/structure/sign/warning/securearea{
-	pixel_y = 32
+/obj/machinery/door_control{
+	desc = "A remote control-switch for secure storage.";
+	id = "Secure Storage";
+	name = "Engineering Secure Storage";
+	pixel_y = 28;
+	req_access = list(10)
 	},
 /turf/simulated/floor{
 	dir = 4;

--- a/maps/prometheus/prometheus.dmm
+++ b/maps/prometheus/prometheus.dmm
@@ -67492,7 +67492,7 @@
 	id = "Secure Storage";
 	name = "Engineering Secure Storage";
 	pixel_y = 28;
-	req_access = list(56)
+	req_access = list(10)
 	},
 /turf/simulated/floor{
 	dir = 5;


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Кнопка, открывающая инженерный склад на прометее теперь требует доступ в инженерный отсек, а не в офис СЕ.
Добавил такую же кнопку на бох стейшен.
## Почему и что этот ПР улучшит
Инженерам не нужно будет отключать питание для открытия склада.
## Авторство

## Чеинжлог 
:cl: Simbaka
- map: Добавлена ещё одна кнопка для открытия инженерного склада на карте boxstation.
- tweak: Чтобы открыть инженерный склад с помощью этой кнопки, теперь достаточно иметь доступ инженера.