### PR TITLE
Бафф адреналина у генок

### DIFF
--- a/code/game/gamemodes/modes_gameplays/changeling/powers/epinephrine.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/epinephrine.dm
@@ -1,8 +1,8 @@
 /obj/effect/proc_holder/changeling/epinephrine
-	name = "Epinephrine Overdose"
+	name = "Adrenaline Overdose"
 	desc = "We evolve additional sacs of adrenaline throughout our body."
-	helptext = "Removes all stuns instantly and adds a short-term reduction in further stuns. Can be used while unconscious. Continued use poisons the body."
-	chemical_cost = 30
+	helptext = "Removes all stuns instantly and adds a short-term reduction in further stuns. Can be used while unconscious. Every use poisons the body."
+	chemical_cost = 35
 	genomecost = 2
 	req_human = 1
 	req_stat = UNCONSCIOUS
@@ -18,7 +18,8 @@
 	user.SetParalysis(0)
 	user.SetStunned(0)
 	user.SetWeakened(0)
-	user.reagents.add_reagent("synaptizine", 0.5)
+	user.reagents.add_reagent("stimulants", 5)
+	user.reagents.add_reagent("toxin", 2)
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		H.setHalLoss(0)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Теперь при прожатии адреналина генокрад получает в кровь 5 единиц стимуляторов и 2 токсина. Раньше он просто получал 0.5 юнитов синаптизина. Цена повышена на 5 химикатов, чтоб чувак не мог встать и начать месить всех блейдом. 
## Почему и что этот ПР улучшит
Сейчас адреналин это юзлес хуйня, которую берут раз в три года. Даже меньше чем молот. Генокрад сможет убежать от офицериков. Сейчас единственное применение адреналина - встать после флешки. 
## Авторство

## Чеинжлог
:cl: 
- balance: Теперь адреналин генокрадов вводит им адреналин, а не синаптизин. 
