### PR TITLE
под щупальцами скреллов теперь не видно вещей за ушами

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -24,6 +24,9 @@
 	if(wear_mask)
 		skipface |= wear_mask.flags_inv & HIDEFACE
 
+	if(get_species() == SKRELL && h_style != "Bald")
+		skipears = TRUE
+
 	var/obj/item/organ/external/head/MyHead = bodyparts_by_name[BP_HEAD]
 	if(!istype(MyHead) || MyHead.is_stump)
 		skipface = TRUE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
тайтл
## Почему и что этот ПР улучшит
невероятная фича + контентус
## Авторство
я
## Чеинжлог
:cl:
- rscadd: Под щупальцами скреллов не видно, что они прячут за ушами.