### PR TITLE
Магнитная держалка удерживает пласталь

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -25,7 +25,8 @@
 		/obj/item/weapon/tank,
 		/obj/item/weapon/circuitboard,
 		/obj/item/weapon/light/tube,
-		/obj/item/weapon/light/bulb
+		/obj/item/weapon/light/bulb,
+		/obj/item/stack/sheet/plasteel
 		)
 
 	//Item currently being held.


### PR DESCRIPTION
## Описание изменений
Роботы могут держать пласталь магнитной держалкой.
## Почему и что этот ПР улучшит
Роботы смогут строить бронестены. Добавлено по просьбам трудящихся. Fixes #10235
## Чеинжлог
:cl:
 - tweak: Роботы могут держать пласталь магнитной держалкой.