### PR TITLE
OCD small equip changes

### DIFF
--- a/code/game/gamemodes/modes_gameplays/families/outfit.dm
+++ b/code/game/gamemodes/modes_gameplays/families/outfit.dm
@@ -2,7 +2,7 @@
 	startswith = list(/obj/item/weapon/melee/baton = 1, /obj/item/weapon/grenade/flashbang = 2, /obj/item/weapon/handcuffs = 3, /obj/item/weapon/shield/riot/tele = 1)
 
 /obj/item/weapon/storage/belt/security/tactical/cops
-	startswith = list(/obj/item/weapon/melee/baton = 1, /obj/item/weapon/grenade/flashbang = 2, /obj/item/weapon/handcuffs = 3, /obj/item/ammo_box/magazine/m556 = 3)
+	startswith = list(/obj/item/weapon/melee/baton = 1, /obj/item/weapon/grenade/flashbang = 2, /obj/item/weapon/handcuffs = 2, /obj/item/ammo_box/magazine/m556 = 3, /obj/item/weapon/shield/riot/tele = 1)
 
 /datum/outfit/families_police/beatcop
 	name = "Families: Офицер"
@@ -10,13 +10,13 @@
 	uniform = /obj/item/clothing/under/rank/security/beatcop
 	back = /obj/item/weapon/storage/backpack/satchel/sec/cops
 	shoes = /obj/item/clothing/shoes/boots/police
-	glasses = /obj/item/clothing/glasses/sunglasses
+	glasses = /obj/item/clothing/glasses/sunglasses/hud/sechud
 	l_ear = /obj/item/device/radio/headset/headset_sec/alt
 	head = /obj/item/clothing/head/spacepolice
 	mask = /obj/item/clothing/mask/gas/sechailer/police
 	belt = /obj/item/weapon/storage/belt/security/cops
-	r_pocket = /obj/item/device/flashlight
-	l_pocket = /obj/item/device/flash
+	r_pocket = /obj/item/device/flashlight/seclite
+	l_pocket = /obj/item/weapon/storage/firstaid/small_firstaid_kit/civilian
 	id = /obj/item/weapon/card/id/space_police
 	r_hand = /obj/item/weapon/gun/energy/taser
 
@@ -63,7 +63,7 @@
 	name = "Families: Инспектор"
 	suit = /obj/item/clothing/suit/armor/laserproof/police
 	head = /obj/item/clothing/head/helmet/laserproof/police
-	glasses = /obj/item/clothing/glasses/sunglasses/big
+	shoes = /obj/item/clothing/shoes/boots/combat
 	gloves = /obj/item/clothing/gloves/combat/police
 	suit_store = /obj/item/weapon/gun/projectile/automatic
 	backpack_contents = list(
@@ -76,6 +76,7 @@
 	name = "Families: Боец ВСНТ"
 	suit = /obj/item/clothing/suit/storage/flak/police/fullbody/heavy
 	head = /obj/item/clothing/head/helmet/police/elite
+	shoes = /obj/item/clothing/shoes/boots/combat
 	belt = /obj/item/weapon/storage/belt/security/tactical/cops
 	gloves = /obj/item/clothing/gloves/combat/police
 	back = /obj/item/weapon/storage/backpack/satchel/sec/cops


### PR DESCRIPTION
## Описание изменений
Считаю большинство вещей недосмотром или просто багом
- У ОБОПа были санглассы, а не секхуды. В итоге у некоторых офицеров внезапно пропадали худы. Последних не жалко, но ситуация странная.
- Были обычные фонарики, а не офицерские.
- Флешка заменена на обычную цивильную аптечку (боевую не дам - жирно).
- У инспекторов и ВСНТ появились комбат буты. Нечего им на мыле подскальзываться с матебой в руках. ВСНТ это уже прямое наказание режима в моём видении.
- У ВСНТ появился телескопик-щит по цене одних наручей
## Почему и что этот ПР улучшит
Чуть менее смешная экипировка ОБОПа
## Авторство

## Чеинжлог
:cl: 
- tweak: Слегка изменена экипировка ОБОПа