### PR TITLE
DS equip small changes

### DIFF
--- a/code/datums/outfits/misc/shitspawn.dm
+++ b/code/datums/outfits/misc/shitspawn.dm
@@ -185,7 +185,6 @@
 
 	l_ear = /obj/item/device/radio/headset/deathsquad
 	uniform = /obj/item/clothing/under/color/green
-	suit_store = /obj/item/weapon/tank/oxygen
 	shoes = /obj/item/clothing/shoes/boots/swat
 	suit = /obj/item/clothing/suit/armor/swat
 	gloves = /obj/item/clothing/gloves/combat
@@ -202,12 +201,11 @@
 		/obj/item/device/flashlight/seclite,
 		/obj/item/weapon/plastique,
 		/obj/item/clothing/accessory/storage/black_vest,
-		/obj/item/weapon/tank/oxygen,
 	)
 
 	l_pocket = /obj/item/weapon/melee/energy/sword
 	r_pocket = /obj/item/weapon/shield/energy
-	suit_store = /obj/item/weapon/tank/emergency_oxygen
+	suit_store = /obj/item/weapon/tank/oxygen
 	belt = /obj/item/weapon/gun/projectile/revolver/mateba
 
 	r_hand = /obj/item/weapon/gun/energy/pulse_rifle
@@ -222,14 +220,13 @@
 	backpack_contents = list(
 		/obj/item/ammo_box/a357,
 		/obj/item/ammo_box/a357,
-		/obj/item/weapon/storage/firstaid/regular,
+		/obj/item/weapon/storage/firstaid/tactical,
 		/obj/item/weapon/storage/box/flashbangs,
-		/obj/item/device/flashlight,
+		/obj/item/device/flashlight/seclite,
 		/obj/item/weapon/pinpointer,
 		/obj/item/weapon/disk/nuclear,
 		/obj/item/weapon/plastique,
 		/obj/item/clothing/accessory/storage/black_vest,
-		/obj/item/weapon/tank/oxygen,
 		/obj/item/weapon/melee/energy/sword,
 	)
 

--- a/code/datums/outfits/misc/shitspawn.dm
+++ b/code/datums/outfits/misc/shitspawn.dm
@@ -185,6 +185,7 @@
 
 	l_ear = /obj/item/device/radio/headset/deathsquad
 	uniform = /obj/item/clothing/under/color/green
+	suit_store = /obj/item/weapon/tank/oxygen
 	shoes = /obj/item/clothing/shoes/boots/swat
 	suit = /obj/item/clothing/suit/armor/swat
 	gloves = /obj/item/clothing/gloves/combat
@@ -194,16 +195,18 @@
 	back = /obj/item/weapon/storage/backpack/security
 
 	backpack_contents = list(
-		/obj/item/weapon/storage/box,
 		/obj/item/ammo_box/a357,
-		/obj/item/weapon/storage/firstaid/regular,
+		/obj/item/ammo_box/a357,
+		/obj/item/weapon/storage/firstaid/tactical,
 		/obj/item/weapon/storage/box/flashbangs,
-		/obj/item/device/flashlight,
+		/obj/item/device/flashlight/seclite,
 		/obj/item/weapon/plastique,
+		/obj/item/clothing/accessory/storage/black_vest,
+		/obj/item/weapon/tank/oxygen,
 	)
 
 	l_pocket = /obj/item/weapon/melee/energy/sword
-	r_pocket = /obj/item/weapon/grenade/flashbang
+	r_pocket = /obj/item/weapon/shield/energy
 	suit_store = /obj/item/weapon/tank/emergency_oxygen
 	belt = /obj/item/weapon/gun/projectile/revolver/mateba
 
@@ -213,17 +216,21 @@
 
 /datum/outfit/death_squad/leader
 	name = "NanoTrasen: death squad leader"
-	
+
 	uniform = /obj/item/clothing/under/rank/centcom_officer
 
 	backpack_contents = list(
-		/obj/item/weapon/storage/box,
+		/obj/item/ammo_box/a357,
 		/obj/item/ammo_box/a357,
 		/obj/item/weapon/storage/firstaid/regular,
 		/obj/item/weapon/storage/box/flashbangs,
 		/obj/item/device/flashlight,
 		/obj/item/weapon/pinpointer,
 		/obj/item/weapon/disk/nuclear,
+		/obj/item/weapon/plastique,
+		/obj/item/clothing/accessory/storage/black_vest,
+		/obj/item/weapon/tank/oxygen,
+		/obj/item/weapon/melee/energy/sword,
 	)
 
 /datum/outfit/syndicate_commando

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -193,6 +193,7 @@
 	pierce_protection = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
 	slowdown = 0.5
 	armor = list(melee = 80, bullet = 70, laser = 70,energy = 70, bomb = 70, bio = 0, rad = 0)
+	allowed = list(/obj/item/weapon/gun/energy,/obj/item/weapon/gun/projectile,/obj/item/ammo_box/magazine,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/clothing/head/helmet, /obj/item/weapon/tank)
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL
 	cold_protection = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE


### PR DESCRIPTION
## Описание изменений
Правильно называли их дедсадовцами. Аптечка обычная, фонарик обычный, у лидера нет сифора, обойма только одна, а воздух им и вовсе не нужен, оказывается. А emergency box не нуждался в наполнении для них.
Так они не будут выглядит хотя бы настолько смешными.
Добавлено:
- Боевая аптека
- Обойма на матебу
- Офицерский фонарик
- Баллон с кислородом
- Разгрузка
- Лидеру доп. меч и отсутствующий сифор
- Щит


- Удалена пустая коробка
## Почему и что этот ПР улучшит
Было
![image](https://user-images.githubusercontent.com/50750952/208489323-86123dc9-eb54-47d7-9149-fb84b2a72d57.png)

Стало
![image](https://user-images.githubusercontent.com/50750952/208489444-de466856-fb3c-4e86-b2c4-dc5cdcc1996b.png)

## Авторство

## Чеинжлог
Щитспавн штука, думаю, не нужно.