### PR TITLE
Nearsight no more in life()

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -201,3 +201,9 @@
 
 // atom traits
 #define TRAIT_XENO_FUR "xeno_fur"
+
+// trait sources
+#define EYE_DAMAGE "eye_damage"
+#define EYE_DAMAGE_TEMPORARY "eye_damage_temporary"
+#define GENETIC_MUTATION "genetic"
+#define QUIRK "quirk"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -204,6 +204,6 @@
 
 // trait sources
 #define EYE_DAMAGE "eye_damage"
-#define EYE_DAMAGE_TEMPORARY "eye_damage_temporary"
-#define GENETIC_MUTATION "genetic"
-#define QUIRK "quirk"
+#define EYE_DAMAGE_TEMPORARY_TRAIT "eye_damage_temporary"
+#define GENETIC_MUTATION_TRAIT "genetic"
+#define QUIRK_TRAIT "quirk"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -203,7 +203,7 @@
 #define TRAIT_XENO_FUR "xeno_fur"
 
 // trait sources
-#define EYE_DAMAGE "eye_damage"
+#define EYE_DAMAGE_TRAIT "eye_damage"
 #define EYE_DAMAGE_TEMPORARY_TRAIT "eye_damage_temporary"
 #define GENETIC_MUTATION_TRAIT "genetic"
 #define QUIRK_TRAIT "quirk"

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -103,6 +103,7 @@
 
 /datum/quirk/nearsighted/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
+	H.become_nearsighted(QUIRK)
 	var/obj/item/clothing/glasses/regular/G = new
 	if(!H.equip_to_slot_if_possible(G, SLOT_GLASSES, null, TRUE))
 		H.put_in_hands(G)

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -103,7 +103,7 @@
 
 /datum/quirk/nearsighted/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
-	H.become_nearsighted(QUIRK)
+	H.become_nearsighted(QUIRK_TRAIT)
 	var/obj/item/clothing/glasses/regular/G = new
 	if(!H.equip_to_slot_if_possible(G, SLOT_GLASSES, null, TRUE))
 		H.put_in_hands(G)

--- a/code/game/dna/genes/disabilities.dm
+++ b/code/game/dna/genes/disabilities.dm
@@ -152,8 +152,8 @@
 
 /datum/dna/gene/disability/nearsighted/activate(mob/M, connected, flags)
 	. = ..()
-	M.become_nearsighted(GENETIC_MUTATION)
+	M.become_nearsighted(GENETIC_MUTATION_TRAIT)
 
 /datum/dna/gene/disability/nearsighted/deactivate(mob/M, connected, flags)
 	. = ..()
-	M.cure_nearsighted(GENETIC_MUTATION)
+	M.cure_nearsighted(GENETIC_MUTATION_TRAIT)

--- a/code/game/dna/genes/disabilities.dm
+++ b/code/game/dna/genes/disabilities.dm
@@ -149,3 +149,11 @@
 
 /datum/dna/gene/disability/nearsighted/New()
 	block=GLASSESBLOCK
+
+/datum/dna/gene/disability/nearsighted/activate(mob/M, connected, flags)
+	. = ..()
+	M.become_nearsighted(GENETIC_MUTATION)
+
+/datum/dna/gene/disability/nearsighted/deactivate(mob/M, connected, flags)
+	. = ..()
+	M.cure_nearsighted(GENETIC_MUTATION)

--- a/code/game/gamemodes/modes_gameplays/changeling/powers/stings.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/stings.dm
@@ -245,8 +245,8 @@
 	if(sting_fail(user,target))
 		return FALSE
 	to_chat(target, "<span class='danger'>Your eyes burn horrifically!</span>")
-	target.become_nearsighted(EYE_DAMAGE_TEMPORARY)
-	addtimer(CALLBACK(target, /mob.proc/cure_nearsighted, EYE_DAMAGE_TEMPORARY), 30 SECONDS, TIMER_STOPPABLE)
+	target.become_nearsighted(EYE_DAMAGE_TEMPORARY_TRAIT)
+	addtimer(CALLBACK(target, /mob.proc/cure_nearsighted, EYE_DAMAGE_TEMPORARY_TRAIT), 30 SECONDS, TIMER_STOPPABLE)
 	target.eye_blind = 20
 	target.blurEyes(40)
 	feedback_add_details("changeling_powers","BS")

--- a/code/game/gamemodes/modes_gameplays/changeling/powers/stings.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/stings.dm
@@ -245,8 +245,8 @@
 	if(sting_fail(user,target))
 		return FALSE
 	to_chat(target, "<span class='danger'>Your eyes burn horrifically!</span>")
-	target.disabilities |= NEARSIGHTED
-	spawn(300)	target.disabilities &= ~NEARSIGHTED
+	target.become_nearsighted(EYE_DAMAGE_TEMPORARY)
+	addtimer(CALLBACK(target, /mob.proc/cure_nearsighted, EYE_DAMAGE_TEMPORARY), 30 SECONDS, TIMER_STOPPABLE)
 	target.eye_blind = 20
 	target.blurEyes(40)
 	feedback_add_details("changeling_powers","BS")

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -344,7 +344,7 @@
 				if(occupant.sdisabilities & BLIND)
 					dat += text("<font color='red'>Cataracts detected.</font><BR>")
 					storedinfo += text("<font color='red'>Cataracts detected.</font><BR>")
-				if(occupant.sdisabilities & NEARSIGHTED)
+				if(HAS_TRAIT(occupant, TRAIT_NEARSIGHT))
 					dat += text("<font color='red'>Retinal misalignment detected.</font><BR>")
 					storedinfo += text("<font color='red'>Retinal misalignment detected.</font><BR>")
 		else

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -487,9 +487,8 @@
 				to_chat(user, "<span class='danger'>You go blind!</span>")
 				user.eye_blind = 5
 				user.adjustBlurriness(5)
-				user.disabilities |= NEARSIGHTED
-				spawn(100)
-					user.disabilities &= ~NEARSIGHTED
+				user.become_nearsighted(EYE_DAMAGE_TEMPORARY)
+				addtimer(CALLBACK(user, /mob.proc/cure_nearsighted, EYE_DAMAGE_TEMPORARY), 20 SECONDS, TIMER_STOPPABLE)
 	return
 
 

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -487,8 +487,8 @@
 				to_chat(user, "<span class='danger'>You go blind!</span>")
 				user.eye_blind = 5
 				user.adjustBlurriness(5)
-				user.become_nearsighted(EYE_DAMAGE_TEMPORARY)
-				addtimer(CALLBACK(user, /mob.proc/cure_nearsighted, EYE_DAMAGE_TEMPORARY), 10 SECONDS, TIMER_STOPPABLE)
+				user.become_nearsighted(EYE_DAMAGE_TEMPORARY_TRAIT)
+				addtimer(CALLBACK(user, /mob.proc/cure_nearsighted, EYE_DAMAGE_TEMPORARY_TRAIT), 10 SECONDS, TIMER_STOPPABLE)
 	return
 
 

--- a/code/game/objects/items/weapons/tools.dm
+++ b/code/game/objects/items/weapons/tools.dm
@@ -487,8 +487,8 @@
 				to_chat(user, "<span class='danger'>You go blind!</span>")
 				user.eye_blind = 5
 				user.adjustBlurriness(5)
-				user.become_nearsighted(EYE_DAMAGE_TEMPORARY)
-				addtimer(CALLBACK(user, /mob.proc/cure_nearsighted, EYE_DAMAGE_TEMPORARY), 20 SECONDS, TIMER_STOPPABLE)
+				user.become_nearsighted(EYE_DAMAGE_TEMPORARY_TRAIT)
+				addtimer(CALLBACK(user, /mob.proc/cure_nearsighted, EYE_DAMAGE_TEMPORARY_TRAIT), 20 SECONDS, TIMER_STOPPABLE)
 	return
 
 

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -281,9 +281,8 @@
 		if(M.glasses == src)
 			M.eye_blind = 3
 			M.blurEyes(15)
-			M.disabilities |= NEARSIGHTED
-			spawn(100)
-				M.disabilities &= ~NEARSIGHTED
+			M.become_nearsighted(EYE_DAMAGE_TEMPORARY)
+			addtimer(CALLBACK(M, /mob.proc/cure_nearsighted, EYE_DAMAGE_TEMPORARY), 5 SECONDS, TIMER_STOPPABLE)
 	..()
 
 /obj/item/clothing/glasses/thermal/syndi	//These are now a traitor item, concealed as mesons.	-Pete
@@ -385,7 +384,7 @@
 /obj/item/clothing/glasses/sunglasses/noir/verb/toggle_noir()
 	set name = "Toggle Noir"
 	set category = "Object"
-	
+
 	if(usr.incapacitated())
 		return
 	active = !active

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -38,6 +38,18 @@
 			H.update_inv_glasses()
 			H.update_sight()
 
+/obj/item/clothing/glasses/equipped(mob/user, slot)
+	. = ..()
+	if(slot == SLOT_GLASSES)
+		if(prescription)
+			user.clear_fullscreen("nearsighted")
+
+/obj/item/clothing/glasses/dropped(mob/user)
+	. = ..()
+	if(!prescription)
+		if(HAS_TRAIT(src, TRAIT_NEARSIGHT))
+			user.overlay_fullscreen("nearsighted", /atom/movable/screen/fullscreen/impaired, 1)
+
 /obj/item/clothing/glasses/meson
 	name = "optical meson scanner"
 	desc = "Used for seeing walls, floors, and stuff through anything."
@@ -281,8 +293,8 @@
 		if(M.glasses == src)
 			M.eye_blind = 3
 			M.blurEyes(15)
-			M.become_nearsighted(EYE_DAMAGE_TEMPORARY)
-			addtimer(CALLBACK(M, /mob.proc/cure_nearsighted, EYE_DAMAGE_TEMPORARY), 5 SECONDS, TIMER_STOPPABLE)
+			M.become_nearsighted(EYE_DAMAGE_TEMPORARY_TRAIT)
+			addtimer(CALLBACK(M, /mob.proc/cure_nearsighted, EYE_DAMAGE_TEMPORARY_TRAIT), 5 SECONDS, TIMER_STOPPABLE)
 	..()
 
 /obj/item/clothing/glasses/thermal/syndi	//These are now a traitor item, concealed as mesons.	-Pete

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -46,8 +46,8 @@
 
 /obj/item/clothing/glasses/dropped(mob/user)
 	. = ..()
-	if(!prescription)
-		if(HAS_TRAIT(src, TRAIT_NEARSIGHT))
+	if(prescription)
+		if(HAS_TRAIT(user, TRAIT_NEARSIGHT))
 			user.overlay_fullscreen("nearsighted", /atom/movable/screen/fullscreen/impaired, 1)
 
 /obj/item/clothing/glasses/meson

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -293,8 +293,8 @@
 		if(M.glasses == src)
 			M.eye_blind = 3
 			M.blurEyes(15)
-			M.become_nearsighted(EYE_DAMAGE_TEMPORARY)
-			addtimer(CALLBACK(M, /mob.proc/cure_nearsighted, EYE_DAMAGE_TEMPORARY), 10 SECONDS, TIMER_STOPPABLE)
+			M.become_nearsighted(EYE_DAMAGE_TEMPORARY_TRAIT)
+			addtimer(CALLBACK(M, /mob.proc/cure_nearsighted, EYE_DAMAGE_TEMPORARY_TRAIT), 10 SECONDS, TIMER_STOPPABLE)
 	..()
 
 /obj/item/clothing/glasses/thermal/syndi	//These are now a traitor item, concealed as mesons.	-Pete

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -154,10 +154,6 @@
 		update_inv_gloves()
 	else if (W == glasses)
 		glasses = null
-		var/obj/item/clothing/glasses/G = W
-		if(G.prescription)
-			if(HAS_TRAIT(src, TRAIT_NEARSIGHT))
-				overlay_fullscreen("nearsighted", /atom/movable/screen/fullscreen/impaired, 1)
 		update_inv_glasses()
 	else if (W == head)
 		head = null
@@ -317,9 +313,6 @@
 			update_inv_ears()
 		if(SLOT_GLASSES)
 			src.glasses = W
-			var/obj/item/clothing/glasses/G = W
-			if(G.prescription)
-				clear_fullscreen("nearsighted")
 			W.equipped(src, slot)
 			update_inv_glasses()
 		if(SLOT_GLOVES)

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -154,6 +154,10 @@
 		update_inv_gloves()
 	else if (W == glasses)
 		glasses = null
+		var/obj/item/clothing/glasses/G = W
+		if(G.prescription)
+			if(HAS_TRAIT(src, TRAIT_NEARSIGHT))
+				overlay_fullscreen("nearsighted", /atom/movable/screen/fullscreen/impaired, 1)
 		update_inv_glasses()
 	else if (W == head)
 		head = null
@@ -313,6 +317,9 @@
 			update_inv_ears()
 		if(SLOT_GLASSES)
 			src.glasses = W
+			var/obj/item/clothing/glasses/G = W
+			if(G.prescription)
+				clear_fullscreen("nearsighted")
 			W.equipped(src, slot)
 			update_inv_glasses()
 		if(SLOT_GLOVES)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1002,17 +1002,19 @@ var/global/list/tourette_bad_words = list("ГОВНО","ЖОПА","ЕБАЛ","Б
 		nutrition_icon.icon_state = "[fullness_icon][CEILING(full_perc, 20)]"
 
 	//OH cmon...
-	var/nearsighted = 0
 	var/impaired    = 0
-
+/*
+	var/nearsighted = 0
 	if(disabilities & NEARSIGHTED || HAS_TRAIT(src, TRAIT_NEARSIGHT))
-		nearsighted = 1
-
-	if(glasses)
-		var/obj/item/clothing/glasses/G = glasses
-		if(G.prescription)
-			nearsighted = 0
-
+		if(glasses)
+			var/obj/item/clothing/glasses/G = glasses
+			if(G.prescription)
+				clear_fullscreen("nearsighted")
+	if(nearsighted)
+		overlay_fullscreen("nearsighted", /atom/movable/screen/fullscreen/impaired, 1)
+	else
+		clear_fullscreen("nearsighted")
+*/
 	if(istype(head, /obj/item/clothing/head/welding) || istype(head, /obj/item/clothing/head/helmet/space/unathi))
 		var/obj/item/clothing/head/welding/O = head
 		if(!O.up && tinted_weldhelh)
@@ -1025,16 +1027,12 @@ var/global/list/tourette_bad_words = list("ГОВНО","ЖОПА","ЕБАЛ","Б
 		var/obj/item/clothing/glasses/welding/O = glasses
 		if(!O.up && tinted_weldhelh)
 			impaired = max(impaired, 2)
-
-	if(eye_blurry)
-		update_eye_blur()
-	else
-		update_eye_blur()
+/*
 	if(nearsighted)
 		overlay_fullscreen("nearsighted", /atom/movable/screen/fullscreen/impaired, 1)
 	else
 		clear_fullscreen("nearsighted")
-
+*/
 	if(impaired)
 		overlay_fullscreen("impaired", /atom/movable/screen/fullscreen/impaired, impaired)
 	else

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1003,18 +1003,6 @@ var/global/list/tourette_bad_words = list("ГОВНО","ЖОПА","ЕБАЛ","Б
 
 	//OH cmon...
 	var/impaired    = 0
-/*
-	var/nearsighted = 0
-	if(disabilities & NEARSIGHTED || HAS_TRAIT(src, TRAIT_NEARSIGHT))
-		if(glasses)
-			var/obj/item/clothing/glasses/G = glasses
-			if(G.prescription)
-				clear_fullscreen("nearsighted")
-	if(nearsighted)
-		overlay_fullscreen("nearsighted", /atom/movable/screen/fullscreen/impaired, 1)
-	else
-		clear_fullscreen("nearsighted")
-*/
 	if(istype(head, /obj/item/clothing/head/welding) || istype(head, /obj/item/clothing/head/helmet/space/unathi))
 		var/obj/item/clothing/head/welding/O = head
 		if(!O.up && tinted_weldhelh)
@@ -1027,12 +1015,7 @@ var/global/list/tourette_bad_words = list("ГОВНО","ЖОПА","ЕБАЛ","Б
 		var/obj/item/clothing/glasses/welding/O = glasses
 		if(!O.up && tinted_weldhelh)
 			impaired = max(impaired, 2)
-/*
-	if(nearsighted)
-		overlay_fullscreen("nearsighted", /atom/movable/screen/fullscreen/impaired, 1)
-	else
-		clear_fullscreen("nearsighted")
-*/
+
 	if(impaired)
 		overlay_fullscreen("impaired", /atom/movable/screen/fullscreen/impaired, impaired)
 	else

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1015,11 +1015,12 @@ var/global/list/tourette_bad_words = list("ГОВНО","ЖОПА","ЕБАЛ","Б
 		var/obj/item/clothing/glasses/welding/O = glasses
 		if(!O.up && tinted_weldhelh)
 			impaired = max(impaired, 2)
-
 	if(impaired)
 		overlay_fullscreen("impaired", /atom/movable/screen/fullscreen/impaired, impaired)
 	else
 		clear_fullscreen("impaired")
+
+	update_eye_blur()
 
 	if(!machine)
 		var/isRemoteObserve = 0

--- a/code/modules/mob/living/carbon/human/zombie.dm
+++ b/code/modules/mob/living/carbon/human/zombie.dm
@@ -166,7 +166,7 @@
 	//zombie have NO_PAIN and can't adjust/sets halloss
 	H.setHalLoss(0)
 	//remove all blind-blur effects
-	H.cure_nearsighted(list(EYE_DAMAGE, GENETIC_MUTATION, EYE_DAMAGE_TEMPORARY))
+	H.cure_nearsighted(list(EYE_DAMAGE, GENETIC_MUTATION_TRAIT, EYE_DAMAGE_TEMPORARY_TRAIT))
 	H.sdisabilities &= ~BLIND
 	H.blinded = FALSE
 	H.setBlurriness(0)

--- a/code/modules/mob/living/carbon/human/zombie.dm
+++ b/code/modules/mob/living/carbon/human/zombie.dm
@@ -166,7 +166,7 @@
 	//zombie have NO_PAIN and can't adjust/sets halloss
 	H.setHalLoss(0)
 	//remove all blind-blur effects
-	H.cure_nearsighted(list(EYE_DAMAGE, GENETIC_MUTATION_TRAIT, EYE_DAMAGE_TEMPORARY_TRAIT))
+	H.cure_nearsighted(list(EYE_DAMAGE_TRAIT, GENETIC_MUTATION_TRAIT, EYE_DAMAGE_TEMPORARY_TRAIT))
 	H.sdisabilities &= ~BLIND
 	H.blinded = FALSE
 	H.setBlurriness(0)

--- a/code/modules/mob/living/carbon/human/zombie.dm
+++ b/code/modules/mob/living/carbon/human/zombie.dm
@@ -166,7 +166,7 @@
 	//zombie have NO_PAIN and can't adjust/sets halloss
 	H.setHalLoss(0)
 	//remove all blind-blur effects
-	H.disabilities &= ~NEARSIGHTED
+	H.cure_nearsighted(list(EYE_DAMAGE, GENETIC_MUTATION, EYE_DAMAGE_TEMPORARY))
 	H.sdisabilities &= ~BLIND
 	H.blinded = FALSE
 	H.setBlurriness(0)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -96,14 +96,12 @@
 		else
 			clear_alert("blind")
 			clear_fullscreen("blind", 0)
-			if(!ishuman(src))
-				if(disabilities & NEARSIGHTED)
+/*			if(!ishuman(src))
+				if(HAS_TRAIT(occupant, TRAIT_NEARSIGHT))
 					overlay_fullscreen("impaired", /atom/movable/screen/fullscreen/impaired, 1)
 				else
 					clear_fullscreen("impaired")
-
-					update_eye_blur()
-
+*/
 		if(machine)
 			if (!(machine.check_eye(src)))
 				reset_view(null)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -96,12 +96,6 @@
 		else
 			clear_alert("blind")
 			clear_fullscreen("blind", 0)
-/*			if(!ishuman(src))
-				if(HAS_TRAIT(occupant, TRAIT_NEARSIGHT))
-					overlay_fullscreen("impaired", /atom/movable/screen/fullscreen/impaired, 1)
-				else
-					clear_fullscreen("impaired")
-*/
 		if(machine)
 			if (!(machine.check_eye(src)))
 				reset_view(null)

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -31,6 +31,16 @@
 		overlay_fullscreen("nearsighted", /atom/movable/screen/fullscreen/impaired, 1)
 	ADD_TRAIT(src, TRAIT_NEARSIGHT, source)
 
+/mob/living/carbon/human/become_nearsighted(source)
+	if(glasses)
+		var/obj/item/clothing/glasses/G = glasses
+		if(G.prescription)
+			ADD_TRAIT(src, TRAIT_NEARSIGHT, source)
+			return
+	if(!HAS_TRAIT(src, TRAIT_NEARSIGHT))
+		overlay_fullscreen("nearsighted", /atom/movable/screen/fullscreen/impaired, 1)
+	ADD_TRAIT(src, TRAIT_NEARSIGHT, source)
+
 /* STUN */
 // placeholders
 /mob/proc/IsStun()

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -21,6 +21,15 @@
 /mob/living/proc/has_quirk(quirktype)
 	return roundstart_quirks[quirktype]
 
+/mob/proc/cure_nearsighted(source)
+	REMOVE_TRAIT(src, TRAIT_NEARSIGHT, source)
+	if(!HAS_TRAIT(src, TRAIT_NEARSIGHT))
+		clear_fullscreen("nearsighted")
+
+/mob/proc/become_nearsighted(source)
+	if(!HAS_TRAIT(src, TRAIT_NEARSIGHT))
+		overlay_fullscreen("nearsighted", /atom/movable/screen/fullscreen/impaired, 1)
+	ADD_TRAIT(src, TRAIT_NEARSIGHT, source)
 
 /* STUN */
 // placeholders

--- a/code/modules/reagents/reagent_types/Chemistry-Drinks.dm
+++ b/code/modules/reagents/reagent_types/Chemistry-Drinks.dm
@@ -76,7 +76,7 @@
 			//nothing
 		if(21 to INFINITY)
 			if(prob(data["ticks"] - 10))
-				M.cure_nearsighted(EYE_DAMAGE)
+				M.cure_nearsighted(EYE_DAMAGE_TRAIT)
 	data["ticks"]++
 
 /datum/reagent/consumable/drink/berryjuice

--- a/code/modules/reagents/reagent_types/Chemistry-Drinks.dm
+++ b/code/modules/reagents/reagent_types/Chemistry-Drinks.dm
@@ -76,7 +76,7 @@
 			//nothing
 		if(21 to INFINITY)
 			if(prob(data["ticks"] - 10))
-				M.disabilities &= ~NEARSIGHTED
+				M.cure_nearsighted(EYE_DAMAGE)
 	data["ticks"]++
 
 /datum/reagent/consumable/drink/berryjuice

--- a/code/modules/religion/rites/instant/instant.dm
+++ b/code/modules/religion/rites/instant/instant.dm
@@ -576,7 +576,7 @@
 		C.blurEyes(blindless_modifier)
 		C.eye_blind += blindless_modifier / 2
 		if(prob(5))
-			C.become_nearsighted(GENETIC_MUTATION)
+			C.become_nearsighted(GENETIC_MUTATION_TRAIT)
 			if(prob(10))
 				C.sdisabilities |= BLIND
 		C.show_message("<span class='userdanger'>Внезапно вы видите красную вспышку, которая ослепила вас.</span>", SHOWMSG_VISUAL)

--- a/code/modules/religion/rites/instant/instant.dm
+++ b/code/modules/religion/rites/instant/instant.dm
@@ -576,7 +576,7 @@
 		C.blurEyes(blindless_modifier)
 		C.eye_blind += blindless_modifier / 2
 		if(prob(5))
-			C.disabilities |= NEARSIGHTED
+			C.become_nearsighted(GENETIC_MUTATION)
 			if(prob(10))
 				C.sdisabilities |= BLIND
 		C.show_message("<span class='userdanger'>Внезапно вы видите красную вспышку, которая ослепила вас.</span>", SHOWMSG_VISUAL)

--- a/code/modules/surgery/eye.dm
+++ b/code/modules/surgery/eye.dm
@@ -131,7 +131,7 @@
 	user.visible_message("<span class='notice'>[user] cauterizes the incision around [target]'s eyes with \the [tool].</span>", \
 	"<span class='notice'>You cauterize the incision around [target]'s eyes with \the [tool].</span>")
 	if (target.op_stage.eyes == 3)
-		target.disabilities &= ~NEARSIGHTED
+		target.cure_nearsighted(list(EYE_DAMAGE, EYE_DAMAGE_TEMPORARY))
 		target.sdisabilities &= ~BLIND
 		eyes.damage = 0
 	target.op_stage.eyes = 0
@@ -259,7 +259,7 @@
 	user.visible_message("<span class='notice'>[user] locks [target]'s camera panels with \the [tool].</span>",
 	"<span class='notice'>You lock [target]'s camera panels with \the [tool].</span>")
 	if (target.op_stage.eyes == 2)
-		target.disabilities &= ~NEARSIGHTED
+		target.cure_nearsighted(EYE_DAMAGE)
 		target.sdisabilities &= ~BLIND
 		eyes.damage = 0
 	target.op_stage.eyes = 0

--- a/code/modules/surgery/eye.dm
+++ b/code/modules/surgery/eye.dm
@@ -131,7 +131,7 @@
 	user.visible_message("<span class='notice'>[user] cauterizes the incision around [target]'s eyes with \the [tool].</span>", \
 	"<span class='notice'>You cauterize the incision around [target]'s eyes with \the [tool].</span>")
 	if (target.op_stage.eyes == 3)
-		target.cure_nearsighted(list(EYE_DAMAGE, EYE_DAMAGE_TEMPORARY))
+		target.cure_nearsighted(list(EYE_DAMAGE, EYE_DAMAGE_TEMPORARY_TRAIT))
 		target.sdisabilities &= ~BLIND
 		eyes.damage = 0
 	target.op_stage.eyes = 0

--- a/code/modules/surgery/eye.dm
+++ b/code/modules/surgery/eye.dm
@@ -131,7 +131,7 @@
 	user.visible_message("<span class='notice'>[user] cauterizes the incision around [target]'s eyes with \the [tool].</span>", \
 	"<span class='notice'>You cauterize the incision around [target]'s eyes with \the [tool].</span>")
 	if (target.op_stage.eyes == 3)
-		target.cure_nearsighted(list(EYE_DAMAGE, EYE_DAMAGE_TEMPORARY_TRAIT))
+		target.cure_nearsighted(list(EYE_DAMAGE_TRAIT, EYE_DAMAGE_TEMPORARY_TRAIT))
 		target.sdisabilities &= ~BLIND
 		eyes.damage = 0
 	target.op_stage.eyes = 0
@@ -259,7 +259,7 @@
 	user.visible_message("<span class='notice'>[user] locks [target]'s camera panels with \the [tool].</span>",
 	"<span class='notice'>You lock [target]'s camera panels with \the [tool].</span>")
 	if (target.op_stage.eyes == 2)
-		target.cure_nearsighted(EYE_DAMAGE)
+		target.cure_nearsighted(EYE_DAMAGE_TRAIT)
 		target.sdisabilities &= ~BLIND
 		eyes.damage = 0
 	target.op_stage.eyes = 0


### PR DESCRIPTION
## Описание изменений
Мои потуги уменьшить то мессиво в процессинге у зрения и соответственно у лайфа моба.
1) Перевод NEARSIGHT с процессинга на триггеры при наступлении самой близорукости. 
Было: Включается переменная у моба, потом моб каждый свой тик проверяет и выставляет близорукость как фуллскрин
Стало: Сразу проком, который и выставляет фулскрин объект.

2) Было:` if(blurry) update_blurry() else update_blurry()`. И это в лайфе. Пытался его вообще убрать, но что-то пошло не так и блюр оверлей не убирался.

## Почему и что этот ПР улучшит
Потуги в оптимизацию
## Авторство

## Чеинжлог
