### PR TITLE
Poll time

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -655,7 +655,7 @@
 /proc/requestCandidate(mob/M, time_passed, candidates, Question, Ignore_Role, poll_time)
 	M.playsound_local(null, 'sound/misc/notice2.ogg', VOL_EFFECTS_MASTER, vary = FALSE, frequency = null, ignore_environment = TRUE)//Alerting them to their consideration
 	window_flash(M.client)
-	var/ans = tgui_alert(M, Question, "Please answer in [poll_time * 0.1] seconds!", list("Yes", "No", "Not This Round"))
+	var/ans = tgui_alert(M, Question, "Please answer in [poll_time * 0.1] seconds!", list("Yes", "No", "Not This Round"), poll_time)
 	switch(ans)
 		if("Yes")
 			to_chat(M, "<span class='notice'>Choice registered: Yes.</span>")


### PR DESCRIPTION
Фича на один параметр.
## Описание изменений
Позволяет окошку поллов самим исчезать по пршествию определённого времени, а не "Sorry you were too late..."
Также поможет избежать ситуации, когда отошёл на минут 5, а тебе накидали 20ку окон о создании гомункула. Да и в целом, так красивее.

Применяется ко всем pollGhostCandidates() - гомункулы, блобы, блоббернауты, сюрвайворы, синди-боргам, лярвам и т.д.

Не убирал проверку чуть ниже на время.
## Почему и что этот ПР улучшит
![image](https://user-images.githubusercontent.com/50750952/209967196-2abb9610-bdc1-4ee7-bde2-be7a1d1cb2ab.png)

![image](https://user-images.githubusercontent.com/50750952/209968272-3a1a3537-6111-4a29-b66e-777debe2278b.png)

## Авторство

## Чеинжлог
:cl: 
- tweak: При поиске кадидатов из призраков, таймеры будут появляться вместе с окошками.