### PR TITLE
Ремап Гейта. Ребаланс нюки

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -24915,10 +24915,6 @@
 	dir = 1;
 	pixel_y = 32
 	},
-/obj/machinery/recharger/wallcharger{
-	pixel_x = -24;
-	pixel_y = -6
-	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "vault"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
До
![0101010102](https://user-images.githubusercontent.com/96499407/210035872-768f61bc-1305-4ecf-9c30-1fee86c5216b.png)
После
![0101010101](https://user-images.githubusercontent.com/96499407/210035877-2e322ad5-e3b9-4501-a45b-430c7094f495.png)
## Почему и что этот ПР улучшит
Баланс. Вторженцы с гейта больше не смогут заряжаться, отсиживаясь в гейтвее.
Кажется, он был там для экспедиций, но я почему-то уверен что ним для этого никто не пользовался. Цитата автора прошлого ремапа (Гейм Админ): "Если админес построят дереликт, но мне каажется экспедиции не нуждаются в зарядниках".
## Авторство

## Чеинжлог
:cl: Deahaka
- map: Удалён зарядник в Гейтвее.