### PR TITLE
мыши теперь не могут показывать пальцем и спамить экзамином

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -36,6 +36,8 @@ var/global/list/image/ghost_sightless_images = list() //this is a list of images
 
 	var/obj/item/device/multitool/adminMulti = null //Wew, personal multiotool for ghosts!
 
+	show_examine_log = FALSE
+
 /mob/dead/observer/atom_init()
 	invisibility = INVISIBILITY_OBSERVER
 

--- a/code/modules/mob/living/parasite/meme.dm
+++ b/code/modules/mob/living/parasite/meme.dm
@@ -19,6 +19,7 @@ var/global/const/MAXIMUM_MEME_POINTS = 750
 
 /mob/living/parasite
 	var/mob/living/carbon/host // the host that this parasite occupies
+	show_examine_log = FALSE
 
 /mob/living/parasite/Login()
 	..()

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -40,7 +40,6 @@
 	has_arm = TRUE
 	has_leg = TRUE
 
-	can_point = FALSE
 	show_examine_log = FALSE
 
 /mob/living/simple_animal/mouse/Life()

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -40,6 +40,9 @@
 	has_arm = TRUE
 	has_leg = TRUE
 
+	can_point = FALSE
+	show_examine_log = FALSE
+
 /mob/living/simple_animal/mouse/Life()
 	..()
 	if(stat == CONSCIOUS && prob(speak_chance))

--- a/code/modules/mob/living/simple_animal/hulk.dm
+++ b/code/modules/mob/living/simple_animal/hulk.dm
@@ -45,6 +45,8 @@
 	has_arm = TRUE
 	has_leg = TRUE
 
+	can_point = TRUE
+
 /mob/living/simple_animal/hulk/atom_init()
 	attack_sound = SOUNDIN_PUNCH_HEAVY
 	. = ..()
@@ -247,7 +249,7 @@
 
 	if(!. || moving_diagonally)
 		return .
-	
+
 	var/turf/T = loc
 
 	if(isturf(T) && !(T.flags & NOSTEPSOUND) && !lying)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -60,6 +60,8 @@
 	var/has_arm = FALSE
 	var/has_leg = FALSE
 
+	can_point = FALSE
+
 	///What kind of footstep this mob should have. Null if it shouldn't have any.
 	var/footstep_type
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -336,7 +336,7 @@
 		return FALSE
 
 	if(!can_point)
-		return
+		return FALSE
 	// Removes an ability to point to the object which is out of our sight.
 	// Mostly for cases when we have mesons, thermals etc. equipped.
 	if(client && !(A in view(client.view, src)))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -316,7 +316,7 @@
 	A.examine(src)
 	SEND_SIGNAL(A, COMSIG_PARENT_POST_EXAMINE, src)
 	SEND_SIGNAL(src, COMSIG_PARENT_POST_EXAMINATE, A)
-	if(isobserver(src))
+	if(!show_examine_log)
 		return
 	var/mob/living/carbon/human/H = src
 	if(ishuman(src))
@@ -335,6 +335,8 @@
 	if(istype(A, /obj/effect/decal/point))
 		return FALSE
 
+	if(!can_point)
+		return
 	// Removes an ability to point to the object which is out of our sight.
 	// Mostly for cases when we have mesons, thermals etc. equipped.
 	if(client && !(A in view(client.view, src)))

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -235,3 +235,6 @@
 
 	// Used for statistics of death
 	var/last_phrase
+
+	var/can_point = TRUE
+	var/show_examine_log = TRUE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
тайтл
## Почему и что этот ПР улучшит
мыши - существа незаметные, маленькие, ничтожные, но суки падлы за них заходят, флудят поинт ту и надоедают всячески. экзамин за компанию убрал
fixes #10559
## Авторство
я
## Чеинжлог
:cl:
- tweak: Мыши больше не могут показывать пальцем.
