### PR TITLE
Quantity of roles in families

### DIFF
--- a/code/game/gamemodes/factions/cops.dm
+++ b/code/game/gamemodes/factions/cops.dm
@@ -36,7 +36,7 @@
 	AppendObjective(/datum/objective/gang/destroy_gangs)
 
 /datum/faction/cops/proc/send_syndicate()
-	create_spawners(/datum/spawner/dealer, 2)
+	create_spawners(/datum/spawner/dealer, 3)
 
 /datum/faction/cops/proc/announce_gang_locations()
 	var/list/readable_gang_names = list()

--- a/code/game/gamemodes/modes_gameplays/families/cops_handler.dm
+++ b/code/game/gamemodes/modes_gameplays/families/cops_handler.dm
@@ -48,27 +48,27 @@
 	var/cops_to_send
 	switch(wanted_level)
 		if(1)
-			team_size = 5
+			team_size = 3
 			cops_to_send = /datum/spawner/cop/beatcop
 			var/datum/announcement/centcomm/gang/cops_1/announce = new
 			announce.play()
 		if(2)
-			team_size = 6
+			team_size = 4
 			cops_to_send = /datum/spawner/cop/armored
 			var/datum/announcement/centcomm/gang/cops_2/announce = new
 			announce.play()
 		if(3)
-			team_size = 7
+			team_size = 5
 			cops_to_send = /datum/spawner/cop/swat
 			var/datum/announcement/centcomm/gang/cops_3/announce = new
 			announce.play()
 		if(4)
-			team_size = 8
+			team_size = 5
 			cops_to_send = /datum/spawner/cop/fbi
 			var/datum/announcement/centcomm/gang/cops_4/announce = new
 			announce.play()
 		if(5)
-			team_size = 9
+			team_size = 8
 			cops_to_send = /datum/spawner/cop/military
 			var/datum/announcement/centcomm/gang/cops_5/announce = new
 			announce.play()

--- a/code/game/gamemodes/roles/families.dm
+++ b/code/game/gamemodes/roles/families.dm
@@ -105,8 +105,8 @@
 
 /datum/role/traitor/dealer/OnPostSetup(laterole)
 	var/mob/living/carbon/human/H = antag.current
-	notify_ghosts("New gun dealer!", source = H, action = NOTIFY_ORBIT, header = "Gun Dealer")
 	H.equipOutfit(/datum/outfit/families_traitor)
+	notify_ghosts("New gun dealer!", source = H, action = NOTIFY_ORBIT, header = "Gun Dealer")
 	. = ..()
 
 /datum/role/traitor/dealer/forgeObjectives()


### PR DESCRIPTION

## Описание изменений
- ОБОПа будет меньше. Как пример, сегодня в раунде ОБОП, при свободных 4 спавнерах на момент прилёта их шаттла, 
победили. Их в целом по моему мнению многовато. 11 СБ + 5 с чем-то злых ОБОПовцев на ~10-15 бандосов, у которых оружия толком нет.
- Торгашей будет трое.  Они чаще забавные, чем нет. Каждой банде по личному барыге!
- Переместил оповещение гостам о торгаше после экипировки. Голые мужики в оповещениях выглядят забавно.

Для меня раунд в бандах складывается таким образом:
1) Оповещение о бандах, СБ собирает оружие, при первых действиях банд хватают и садят тех на минут 50 или пожизненное. 
2) Прилетают торгаши, если они робастные, удачливые и налутали броню с оружием у СБ, начинается резня с их стороны. Если нет, то подыхают довольно быстро. Но в это время банды что-то пытаются делать. В любом случае, это интересная со стороны экшона часть раунда.
3) Прилетает ОБОП и ловит всех бандосов.

Весёлая статистика:
![image](https://user-images.githubusercontent.com/50750952/210267533-5dfe3ac2-c53d-4345-bb30-0cc754eaa27e.png)

## Почему и что этот ПР улучшит
Сделать банды как режим более активным, а вступление в банду менее... бьющим палкой по хребту.
## Авторство

## Чеинжлог
:cl: 
- balance: ОБОПа стало меньше, а торговцев оружия чуть больше.