### PR TITLE
Микротвик бросания хуманов в связи с последними апдейтами

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -23,7 +23,7 @@
 	if(size_diff_calculate < 0)
 		return
 	var/weight_diff_coef = 1 + sqrt(size_diff_calculate)
-	if(shoes?.flags & NOSLIP || wear_suit?.flags & NOSLIP)
+	if(shoes?.flags & AIR_FLOW_PROTECT || wear_suit?.flags & AIR_FLOW_PROTECT)
 		adjustHalLoss(15 * weight_diff_coef)	//thicc landing
 	else
 		AdjustWeakened(2 * weight_diff_coef)	//4 seconds is default slip


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
https://github.com/TauCetiStation/TauCetiClassic/pull/10432 добавил то, что должно защищать от опрокидывания. Меняю https://github.com/TauCetiStation/TauCetiClassic/pull/10396 , чтобы магбуты защищали от стана.
## Почему и что этот ПР улучшит
Улучшение https://github.com/TauCetiStation/TauCetiClassic/pull/10396 , изначальная задумка которого не предполагала защиту ничем, кроме магбутов.
## Авторство

## Чеинжлог
:cl: Deahaka
- tweak: Магнитные ботинки защищают от опрокидывания броском больших мобов.