### PR TITLE
Fixes #9816

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -95,8 +95,6 @@
 	if(movement_disabled && usr.ckey != movement_disabled_exception)
 		to_chat(usr, "<span class='warning'>Передвижение отключено администрацией.</span>")//This is to identify lag problems
 		return FALSE
-	if (!(mover && isturf(mover.loc)))
-		return TRUE
 
 	var/list/second_check = list()
 	var/turf/mover_loc = mover.loc

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -441,24 +441,25 @@
 	return
 
 /obj/machinery/disposal/deliveryChute/Bumped(atom/movable/AM) //Go straight into the chute
-	if(istype(AM, /obj/item/projectile) || istype(AM, /obj/effect))	return
+	if(istype(AM, /obj/item/projectile) || istype(AM, /obj/effect))
+		return
 	switch(dir)
 		if(NORTH)
-			if(AM.loc.y != src.loc.y+1) return
+			if(AM.loc.y != src.loc.y+1)
+				return
 		if(EAST)
-			if(AM.loc.x != src.loc.x+1) return
+			if(AM.loc.x != src.loc.x+1)
+				return
 		if(SOUTH)
-			if(AM.loc.y != src.loc.y-1) return
+			if(AM.loc.y != src.loc.y-1)
+				return
 		if(WEST)
-			if(AM.loc.x != src.loc.x-1) return
+			if(AM.loc.x != src.loc.x-1)
+				return
 
-	if(istype(AM, /obj))
-		var/obj/O = AM
-		O.loc = src
-	else if(istype(AM, /mob))
-		var/mob/M = AM
-		M.loc = src
-	flush()
+	if(istype(AM, /obj) || istype(AM, /mob)) // istype(AM) ?
+		AM.forceMove(src)
+		flush()
 
 /obj/machinery/disposal/deliveryChute/flush()
 	flushing = 1


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Суть проблемы в том, что мы первым шагом диагонального движения помещаемся в ``deliveryChute``, но Bump/Bumped не возвращают никакого кода, ``/Move`` не знает что мы уже обработали движение, и пытается обработать второй шаг из диагонального движения. Только уже мобу из трубы.

А теперь самое смешное - какой-то древний код без комментариев и с потерянной историей, который даёт инстапасс без валидации для подобного движения:

![Снимок экрана от 2023-01-06 15-37-59](https://user-images.githubusercontent.com/4064061/211017044-dfbe3b2c-2bef-43dd-83c1-83e5c1a67adf.png)

Я не могу сходу представить, для чего это исключение сделали, и в каких вообще ситуациях подобное могло произойти до ввода диагонального движения. Предлагаю залить в тм и посмотреть, что сломается.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
