### PR TITLE
нерф щита магуса

### DIFF
--- a/code/game/gamemodes/modes_gameplays/wizard/spellbook.dm
+++ b/code/game/gamemodes/modes_gameplays/wizard/spellbook.dm
@@ -390,6 +390,13 @@
 		new /obj/item/clothing/head/helmet/space/rig/wizard(get_turf(user))//To complete the outfit
 		new /obj/item/clothing/gloves/combat/wizard(get_turf(user))//To complete the outfit COMPLETELY
 
+/datum/spellbook_entry/item/tiara
+	name = "Тиара защиты"
+	desc = "Дорогостоящая корона из драгоценного металла, инкрустированная магическими кристаллами. Излучает защитную ауру, используя силу РаЗуМа!"
+	item_path = /obj/item/clothing/head/wizard/amp/shielded
+	log_name = "TZ"
+	category = "Оборона"
+
 /datum/spellbook_entry/item/contract
 	name = "Контракт ученичества"
 	desc = "Магический контракт, что связывает учителя и ученика."

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -130,30 +130,6 @@ LINEN BINS
 	desc = "A special fabric enchanted with magic so you can have an enchanted night.  It even glows!"
 	icon_state = "sheetwiz"
 
-/obj/item/weapon/bedsheet/wiz/atom_init()
-	. = ..()
-
-	var/obj/effect/effect/forcefield/F = new
-	AddComponent(/datum/component/forcefield, "wizard field", 20, 3 SECONDS, 5 SECONDS, F, TRUE, TRUE)
-
-/obj/item/weapon/bedsheet/wiz/proc/activate(mob/living/user)
-	if(iswizard(user) || iswizardapprentice(user))
-		SEND_SIGNAL(src, COMSIG_FORCEFIELD_PROTECT, user)
-
-/obj/item/weapon/bedsheet/wiz/proc/deactivate(mob/living/user)
-	SEND_SIGNAL(src, COMSIG_FORCEFIELD_UNPROTECT, user)
-
-/obj/item/weapon/bedsheet/wiz/equipped(mob/living/user, slot)
-	. = ..()
-
-	if(slot == SLOT_BACK)
-		activate(user)
-
-/obj/item/weapon/bedsheet/wiz/dropped(mob/living/user)
-	. = ..()
-	if(slot_equipped == SLOT_BACK)
-		deactivate(user)
-
 /obj/item/weapon/bedsheet/gar
 	name = "gar bedsheet"
 	desc = "A surprisingly soft gar bedsheet."

--- a/code/modules/clothing/suits/wiz_robe.dm
+++ b/code/modules/clothing/suits/wiz_robe.dm
@@ -130,6 +130,34 @@
 	desc = "A crown-of-thorns psychic amplifier. Kind of looks like a tiara having sex with an industrial robot."
 	icon_state = "amp"
 
+/obj/item/clothing/head/wizard/amp/shielded
+	name = "tiara of protection"
+	desc = "A crown-of-thorns psychic amplifier. Kind of looks like a tiara having sex with an industrial robot. This one emanates protection aura."
+
+/obj/item/clothing/head/wizard/amp/shielded/atom_init()
+	. = ..()
+
+	var/obj/effect/effect/forcefield/F = new
+	AddComponent(/datum/component/forcefield, "wizard field", 20, 3 SECONDS, 5 SECONDS, F, TRUE, TRUE)
+
+/obj/item/clothing/head/wizard/amp/shielded/proc/activate(mob/living/user)
+	if(iswizard(user) || iswizardapprentice(user))
+		SEND_SIGNAL(src, COMSIG_FORCEFIELD_PROTECT, user)
+
+/obj/item/clothing/head/wizard/amp/shielded/proc/deactivate(mob/living/user)
+	SEND_SIGNAL(src, COMSIG_FORCEFIELD_UNPROTECT, user)
+
+/obj/item/clothing/head/wizard/amp/shielded/equipped(mob/living/user, slot)
+	. = ..()
+
+	if(slot == SLOT_HEAD)
+		activate(user)
+
+/obj/item/clothing/head/wizard/amp/shielded/dropped(mob/living/user)
+	. = ..()
+	if(slot_equipped == SLOT_HEAD)
+		deactivate(user)
+
 /obj/item/clothing/head/wizard/cap
 	name = "gentlemans cap"
 	desc = "A checkered gray flat cap woven together with the rarest of threads."


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
магическое одеяло больше не даёт магу щит, его даёт покупаемая в книжке за один магический рубль корона защиты
## Почему и что этот ПР улучшит
кто придумал давать магу бесплатный щит просто сумасшедший. учитывая и так огромную мобильность чародея, он практически становится неуязвимым, а если наденет скафандр - то вообще никак его не завалить и не застанить. поэтому делаем вот такой вот ему выбор, либо защита от всякого говна раундстартом, либо щит
## Авторство
я
## Чеинжлог
:cl:
- rscdel: Одеялко мага больше не даёт ему щит...
- rscadd: ...зато щит даёт корона защиты, покупаемая в книге!
