### PR TITLE
No to handcuffing nests

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/alien_nests.dm
@@ -15,6 +15,8 @@
 	var/mob/living/L = buckled_mob
 	add_fingerprint(user)
 	if(L != user)
+		if(user.lying)
+			return
 		L.visible_message(
 			"<span class='notice'>[user.name] pulls [L.name] free from the sticky nest!</span>",
 			"<span class='notice'>[user.name] pulls you free from the gelatinous resin.</span>",

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -386,8 +386,6 @@
 		return TRUE
 	if (istype(wear_suit, /obj/item/clothing/suit/straight_jacket))
 		return TRUE
-	if (istype(buckled, /obj/structure/stool/bed/nest))
-		return TRUE
 	return 0
 
 /mob/living/carbon/human/resist()


### PR DESCRIPTION

## Описание изменений
Несты заковывали людей  `/human/restrained()` > Люди считались недееспособными `/living/incapasitated()` > Прогрессбар ругался `if(user.incapacitated(NONE))` > Из нестов не могли выбраться closes #10288
<details>

![image](https://user-images.githubusercontent.com/50750952/212548777-623158fb-623c-4a8c-ad0f-631d1bd5e93b.png)

</details>

## Почему и что этот ПР улучшит
Что бы можно было сказать, что баги фиксятся
<details>

![image](https://user-images.githubusercontent.com/50750952/212548715-66edb362-2e4f-4086-ab84-7850042ffcd2.png)

</details>

## Авторство

## Чеинжлог
:cl: 
- bugfix: Чужие разучились приклеивать людей к гнёздам суперклеем