### PR TITLE
Fix xeno eggs

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/effects/aliens.dm
+++ b/code/modules/mob/living/carbon/xenomorph/effects/aliens.dm
@@ -306,8 +306,15 @@
 /obj/structure/alien/egg/atom_init()
 	. = ..()
 	START_PROCESSING(SSobj, src)
-	timer = addtimer(CALLBACK(src, .proc/Grow), rand(MIN_GROWTH_TIME, MAX_GROWTH_TIME), TIMER_STOPPABLE)
-	proximity_monitor = new(src, status == GROWN ? 1 : null)
+	if(status == GROWN)
+		Grow()
+	else
+		timer = addtimer(CALLBACK(src, .proc/Grow), rand(MIN_GROWTH_TIME, MAX_GROWTH_TIME), TIMER_STOPPABLE)
+
+/obj/structure/alien/egg/Destroy()
+	if(timer)
+		deltimer(timer)
+	return ..()
 
 /obj/structure/alien/egg/attack_paw(mob/user)
 	if(isxeno(user))
@@ -338,20 +345,24 @@
 /obj/structure/alien/egg/proc/Grow()
 	icon_state = "egg"
 	status = GROWN
-	new /obj/item/clothing/mask/facehugger(src)
+	proximity_monitor = new(src, 1)
+
+/obj/structure/alien/egg/proc/spawn_hugger(kill_fh = TRUE)
+	var/obj/item/clothing/mask/facehugger/FH = new (get_turf(src))
+	status = BURST
+	if(kill_fh)
+		FH.Die()
 
 /obj/structure/alien/egg/proc/Burst(kill_fh = TRUE)
+	if(status == BURST || status == BURSTING)
+		return
 	STOP_PROCESSING(SSobj, src)
 	deltimer(timer)
-	if(status == GROWN || status == GROWING)
-		icon_state = "egg_hatched"
-		flick("egg_opening", src)
-		status = BURSTING
-		spawn(15)
-			status = BURST
-			var/obj/item/clothing/mask/facehugger/FH = new /obj/item/clothing/mask/facehugger(get_turf(src))
-			if(kill_fh)
-				FH.Die()
+	QDEL_NULL(proximity_monitor)
+	icon_state = "egg_hatched"
+	flick("egg_opening", src)
+	status = BURSTING
+	timer = addtimer(CALLBACK(src, .proc/spawn_hugger, kill_fh), 15, TIMER_STOPPABLE)
 
 /obj/structure/alien/egg/attack_ghost(mob/dead/observer/user)
 	if(facehuggers_control_type != FACEHUGGERS_PLAYABLE)
@@ -396,17 +407,17 @@
 	if(exposed_temperature > 290)
 		take_damage(25, BURN, FIRE, FALSE)
 
-/obj/structure/alien/egg/proc/spawn_hugger()
-	new /obj/item/clothing/mask/facehugger(get_turf(src))
-	status = BURST
+/obj/structure/alien/egg/HasProximity(mob/living/carbon/C)
+	if (!((ishuman(C) || ismonkey(C)) && C.is_facehuggable()))
+		return
+	if(istype(C.wear_mask, /obj/item/clothing/mask/facehugger))
+		return
 
-/obj/structure/alien/egg/HasProximity(atom/movable/AM)
-	if ((ishuman(AM) || ismonkey(AM)) && status == GROWN)
-		icon_state = "egg_hatched"
-		flick("egg_opening", src)
-		status = BURSTING
-		addtimer(CALLBACK(src, .proc/spawn_hugger), 15)
-		QDEL_NULL(proximity_monitor)
+	Burst(FALSE)
+
+// for shitspawn
+/obj/structure/alien/egg/grown
+	status = GROWN
 
 #undef BURST
 #undef BURSTING

--- a/code/modules/mob/living/carbon/xenomorph/effects/aliens.dm
+++ b/code/modules/mob/living/carbon/xenomorph/effects/aliens.dm
@@ -358,11 +358,12 @@
 		return
 	STOP_PROCESSING(SSobj, src)
 	deltimer(timer)
+	timer = null
 	QDEL_NULL(proximity_monitor)
 	icon_state = "egg_hatched"
 	flick("egg_opening", src)
 	status = BURSTING
-	timer = addtimer(CALLBACK(src, .proc/spawn_hugger, kill_fh), 15, TIMER_STOPPABLE)
+	addtimer(CALLBACK(src, .proc/spawn_hugger, kill_fh), 15)
 
 /obj/structure/alien/egg/attack_ghost(mob/dead/observer/user)
 	if(facehuggers_control_type != FACEHUGGERS_PLAYABLE)

--- a/code/modules/mob/living/carbon/xenomorph/special/facehugger/facehugger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/special/facehugger/facehugger.dm
@@ -193,10 +193,10 @@
 
 /obj/item/clothing/mask/facehugger/Crossed(atom/movable/AM)
 	..()
-	return HasProximity(AM)
+	HasProximity(AM)
 
 /obj/item/clothing/mask/facehugger/HasProximity(mob/living/carbon/C)
-	if(!current_hugger && istype(loc, /turf)) //not in hands
+	if(istype(C) && !current_hugger && istype(loc, /turf)) //not in hands
 		return Attach(C)
 
 /obj/item/clothing/mask/facehugger/on_found(mob/finder)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Починил яйца ксеноморфов (что они не раскрывались при приближении), добавил проверку на заражение. В самих лицехватах сделал пораньше проверку на моба.

## Почему и что этот ПР улучшит
-баг
+меньше срабатываний яиц

## Авторство

## Чеинжлог
