### PR TITLE
Небольшой твик по запросу поваров и ботаников.

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -11594,22 +11594,11 @@
 /turf/environment/space,
 /area/shuttle/mining/station)
 "atK" = (
-/obj/structure/closet/wardrobe/white,
-/obj/item/device/eftpos{
-	eftpos_name = "Kitchen EFTPOS scanner"
-	},
-/obj/item/weapon/storage/box/mousetraps,
-/obj/item/weapon/storage/box/mousetraps,
-/obj/item/clothing/under/sundress,
-/obj/item/clothing/under/waiter,
-/obj/item/clothing/under/waiter,
-/obj/item/clothing/under/rank/chef,
-/obj/item/clothing/head/chefhat,
+/obj/machinery/vending/hydroseeds,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "dark"
 	},
-/area/station/civilian/kitchen)
+/area/station/civilian/hydroponics)
 "atL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/firealarm{
@@ -11798,22 +11787,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "atZ" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/civilian/hydroponics)
 "aua" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -23523,16 +23507,13 @@
 	},
 /area/station/civilian/garden)
 "aQc" = (
-/obj/structure/closet/secure_closet/bar,
-/obj/item/weapon/gun/projectile/revolver/doublebarrel,
-/obj/item/weapon/storage/firstaid/regular,
-/obj/item/weapon/paper{
-	info = "This permit signifies that the Bartender is permitted to posess this firearm in the bar, and ONLY the bar. Failure to adhere to this permit will result in confiscation of the weapon and possibly arrest.";
-	name = "Shotgun permit"
+/obj/structure/table,
+/obj/item/weapon/book/manual/wiki/chefs_recipes,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
 	},
-/obj/item/clothing/suit/armor/vest,
-/turf/environment/space,
-/area/station/civilian/bar)
+/area/station/civilian/kitchen)
 "aQd" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/simulated/floor{
@@ -41953,14 +41934,16 @@
 	},
 /area/station/medical/sleeper)
 "bwQ" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/station/civilian/cold_room)
+/turf/simulated/floor,
+/area/station/civilian/hydroponics)
 "bwR" = (
 /obj/structure/closet/crate/freezer,
 /turf/simulated/floor,
@@ -49331,18 +49314,6 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/hallway)
-"bKh" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/station/civilian/hydroponics)
 "bKi" = (
 /obj/structure/stool,
 /turf/simulated/floor{
@@ -69672,11 +69643,11 @@
 	},
 /area/station/engineering/drone_fabrication)
 "dra" = (
-/obj/machinery/vending/hydroseeds,
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/area/station/civilian/hydroponics)
+/turf/simulated/floor/wood,
+/area/station/civilian/bar)
 "drb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -70340,18 +70311,12 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/meeting_room)
 "eho" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/turf/simulated/floor{
+	icon_state = "dark"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
 /area/station/civilian/hydroponics)
 "ehX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -71066,13 +71031,15 @@
 	},
 /area/station/hallway/secondary/exit)
 "fcK" = (
-/obj/structure/table,
-/obj/item/weapon/book/manual/wiki/chefs_recipes,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
-/area/station/civilian/kitchen)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/simulated/floor/wood,
+/area/station/civilian/bar)
 "fec" = (
 /obj/machinery/autolathe,
 /turf/simulated/floor{
@@ -72418,15 +72385,19 @@
 	},
 /area/station/rnd/robotics)
 "gKG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/light/small{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/reagent_dispensers/beerkeg,
-/turf/simulated/floor/wood,
-/area/station/civilian/bar)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/civilian/hydroponics)
 "gKX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -72437,13 +72408,22 @@
 	},
 /area/station/hallway/secondary/entry)
 "gLt" = (
-/obj/machinery/light{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/station/civilian/hydroponics)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "gMb" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -73897,14 +73877,16 @@
 /turf/simulated/floor,
 /area/station/cargo/storage)
 "ipb" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/closet/secure_closet/bar,
+/obj/item/weapon/gun/projectile/revolver/doublebarrel,
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/paper{
+	info = "This permit signifies that the Bartender is permitted to posess this firearm in the bar, and ONLY the bar. Failure to adhere to this permit will result in confiscation of the weapon and possibly arrest.";
+	name = "Shotgun permit"
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/civilian/hydroponics)
+/obj/item/clothing/suit/armor/vest,
+/turf/environment/space,
+/area/station/civilian/bar)
 "iqb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced{
@@ -75345,11 +75327,22 @@
 	},
 /area/station/medical/reception)
 "jQu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/structure/closet/wardrobe/white,
+/obj/item/device/eftpos{
+	eftpos_name = "Kitchen EFTPOS scanner"
 	},
-/turf/simulated/floor/wood,
-/area/station/civilian/bar)
+/obj/item/weapon/storage/box/mousetraps,
+/obj/item/weapon/storage/box/mousetraps,
+/obj/item/clothing/under/sundress,
+/obj/item/clothing/under/waiter,
+/obj/item/clothing/under/waiter,
+/obj/item/clothing/under/rank/chef,
+/obj/item/clothing/head/chefhat,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "jRb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -76924,6 +76917,15 @@
 	icon_state = "vault"
 	},
 /area/station/civilian/chapel)
+"lFQ" = (
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
+	},
+/area/station/civilian/cold_room)
 "lGb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -79402,16 +79404,23 @@
 	},
 /area/station/civilian/hydroponics)
 "oGL" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/westleft{
+	dir = 4;
+	name = "Kitchen";
+	req_access = list(28)
 	},
-/turf/simulated/floor,
-/area/station/civilian/hydroponics)
+/obj/machinery/reagentgrinder,
+/obj/machinery/door/window/westright{
+	name = "Kitchen";
+	req_access = list(28)
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "oHi" = (
 /obj/machinery/vending/donut,
 /turf/simulated/floor{
@@ -81503,23 +81512,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "rnx" = (
-/obj/structure/table/reinforced,
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/window/westleft{
-	dir = 4;
-	name = "Kitchen";
-	req_access = list(28)
-	},
-/obj/machinery/reagentgrinder,
-/obj/machinery/door/window/westright{
-	name = "Kitchen";
-	req_access = list(28)
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics)
 "rnU" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/main)
@@ -103687,7 +103687,7 @@ xRb
 ivb
 pEt
 oXb
-gLt
+eho
 aFH
 aNi
 aSM
@@ -104450,10 +104450,10 @@ aHQ
 bdv
 bdM
 aOD
-ipb
+rnx
 wld
 nHV
-eho
+gKG
 ayy
 iyb
 ayy
@@ -104708,9 +104708,9 @@ bdo
 bdY
 isb
 ari
-dra
+atK
 nHV
-eho
+gKG
 aVg
 aVg
 lwE
@@ -105224,7 +105224,7 @@ aOD
 bod
 aNK
 wFQ
-eho
+gKG
 aVg
 jmV
 nNV
@@ -105480,12 +105480,12 @@ coa
 tpw
 awq
 vWU
-oGL
+bwQ
 aEJ
 yaV
 kss
 aEK
-bKh
+atZ
 aNv
 qex
 aMQ
@@ -105995,7 +105995,7 @@ bmY
 aMZ
 aMZ
 aMZ
-rnx
+oGL
 vGq
 oMQ
 haq
@@ -106255,7 +106255,7 @@ aDI
 aWw
 aWw
 aWw
-atK
+jQu
 haq
 pvI
 aMX
@@ -106767,7 +106767,7 @@ cox
 auL
 bbq
 hho
-fcK
+aQc
 slc
 aWw
 haq
@@ -106777,7 +106777,7 @@ aYv
 bEV
 bIK
 bHI
-bwQ
+lFQ
 asp
 avr
 bEW
@@ -107039,7 +107039,7 @@ bDp
 bDp
 aSM
 usn
-atZ
+gLt
 bNk
 bNk
 sqt
@@ -107543,7 +107543,7 @@ aMZ
 aFO
 aTp
 bwJ
-aQc
+ipb
 owK
 byR
 bEW
@@ -107800,7 +107800,7 @@ aMZ
 blX
 buW
 bwL
-jQu
+dra
 dSI
 bBq
 ikq
@@ -108057,7 +108057,7 @@ aMZ
 blK
 aEh
 aEh
-gKG
+fcK
 bsI
 bDn
 bDn

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -5927,8 +5927,9 @@
 /turf/simulated/wall/r_wall,
 /area/station/security/processing)
 "ake" = (
-/obj/structure/table/woodentable/poker,
-/obj/item/toy/cards,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
 /turf/simulated/floor,
 /area/station/civilian/playroom)
 "akf" = (
@@ -6146,8 +6147,8 @@
 "akt" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "escapecorner";
+	dir = 4
 	},
 /area/station/hallway/primary/port)
 "aku" = (
@@ -9010,7 +9011,8 @@
 	icon_state = "shutter0";
 	opacity = 0;
 	name = "Kitchen Shutters";
-	id = "kitchen2"
+	id = "kitchen2";
+	density = 0
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
@@ -13012,11 +13014,6 @@
 	},
 /area/station/rnd/xenobiology)
 "awq" = (
-/obj/machinery/door/airlock/glass{
-	name = "Hydroponics";
-	req_access = list(35)
-	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -13025,8 +13022,11 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/civilian/hydroponics)
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "greencorner"
+	},
+/area/station/hallway/primary/port)
 "awr" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -13084,7 +13084,8 @@
 	icon_state = "shutter0";
 	opacity = 0;
 	name = "Kitchen Shutters";
-	id = "kitchen2"
+	id = "kitchen2";
+	density = 0
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
@@ -14084,7 +14085,8 @@
 	icon_state = "shutter0";
 	opacity = 0;
 	name = "Kitchen Shutters";
-	id = "kitchen1"
+	id = "kitchen1";
+	density = 0
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/bar)
@@ -17378,7 +17380,10 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "green"
+	},
 /area/station/civilian/hydroponics)
 "aEK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -22007,7 +22012,8 @@
 	icon_state = "shutter0";
 	opacity = 0;
 	name = "Kitchen Shutters";
-	id = "kitchen1"
+	id = "kitchen1";
+	density = 0
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -22258,11 +22264,15 @@
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
 "aNK" = (
-/obj/item/weapon/flora/pottedplant/minitree,
-/turf/simulated/floor{
-	dir = 9;
-	icon_state = "green"
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
 "aNL" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -22898,10 +22908,14 @@
 /turf/simulated/floor/plating,
 /area/station/medical/hallway)
 "aOP" = (
-/obj/effect/decal/cleanable/blood/oil,
-/obj/machinery/space_heater,
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
+/obj/structure/table,
+/obj/item/weapon/flora/deskleaf{
+	pixel_y = 7
+	},
+/turf/simulated/floor{
+	icon_state = "redchecker"
+	},
+/area/station/hallway/primary/port)
 "aOQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -23565,7 +23579,15 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/obj/machinery/door/airlock/glass{
+	name = "Hydroponics";
+	req_access = list(35)
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "whitegreenfull"
+	},
 /area/station/civilian/hydroponics)
 "aQd" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
@@ -23575,7 +23597,6 @@
 	},
 /area/station/medical/cryo)
 "aQe" = (
-/obj/structure/stool,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -23613,10 +23634,10 @@
 /obj/machinery/camera{
 	c_tag = "Playroom"
 	},
-/obj/structure/stool,
 /obj/machinery/light_switch{
 	pixel_x = 27
 	},
+/obj/structure/closet/lasertag/blue,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "neutral"
@@ -24088,19 +24109,30 @@
 /turf/simulated/floor/plating,
 /area/station/civilian/bar)
 "aQZ" = (
-/obj/structure/closet/lasertag/blue,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Play Room APC";
+	pixel_x = -24
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/disposal,
 /turf/simulated/floor{
-	dir = 9;
+	dir = 8;
 	icon_state = "neutral"
 	},
 /area/station/civilian/playroom)
 "aRa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -24125,8 +24157,7 @@
 	},
 /area/station/medical/sleeper)
 "aRd" = (
-/obj/structure/table/woodentable/poker,
-/obj/item/weapon/storage/fancy/crayons,
+/obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutral"
@@ -24855,27 +24886,23 @@
 	},
 /area/station/storage/primary)
 "aSx" = (
-/obj/structure/closet/lasertag/red,
+/obj/machinery/vending/junkfood,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutral"
 	},
 /area/station/civilian/playroom)
 "aSy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/camera{
+	c_tag = "Port Hallway 2"
 	},
-/turf/simulated/floor,
-/area/station/civilian/playroom)
-"aSz" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/hologram/holopad,
-/turf/simulated/floor,
-/area/station/civilian/playroom)
+/obj/structure/stool/bed/chair/metal/red{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "redchecker"
+	},
+/area/station/hallway/primary/port)
 "aSA" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -24887,10 +24914,11 @@
 	},
 /area/station/civilian/chapel)
 "aSB" = (
-/obj/item/device/paicard,
-/obj/structure/table/woodentable/poker,
-/turf/simulated/floor,
-/area/station/civilian/playroom)
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "greencorner"
+	},
+/area/station/hallway/primary/port)
 "aSC" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -24951,12 +24979,11 @@
 	},
 /area/station/gateway)
 "aSG" = (
-/obj/item/weapon/dice/d20,
-/obj/structure/table/woodentable/poker,
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutral"
@@ -25663,18 +25690,9 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/chapel/office)
 "aTQ" = (
-/obj/item/weapon/flora/random,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Play Room APC";
-	pixel_x = -24
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
+/obj/machinery/vending/donut,
 /turf/simulated/floor{
-	dir = 8;
+	dir = 10;
 	icon_state = "neutral"
 	},
 /area/station/civilian/playroom)
@@ -25688,36 +25706,44 @@
 	},
 /area/station/hallway/primary/central)
 "aTS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor,
-/area/station/civilian/playroom)
-"aTT" = (
-/obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2"
-	},
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/civilian/playroom)
 "aTU" = (
-/obj/structure/stool,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/structure/table/glass,
+/obj/item/weapon/book/manual/wiki/hydroponics,
+/obj/item/weapon/book/manual/hydroponics_beekeeping,
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/packageWrap,
+/obj/item/device/eftpos{
+	eftpos_name = "Botany EFTPOS scanner"
 	},
-/obj/structure/disposalpipe/segment{
+/obj/item/device/tagger/shop,
+/obj/item/weapon/reagent_containers/spray/plantbgone{
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/item/weapon/reagent_containers/spray/plantbgone{
+	pixel_x = 13;
+	pixel_y = 5
+	},
+/obj/item/weapon/reagent_containers/spray/plantbgone{
+	pixel_y = 3
+	},
+/obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/civilian/playroom)
+/obj/machinery/light_switch{
+	pixel_y = 24
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "green"
+	},
+/area/station/civilian/hydroponics)
 "aTV" = (
 /obj/machinery/embedded_controller/radio/airlock_controller{
 	id_tag = "chapel_airlock";
@@ -25732,13 +25758,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "aTW" = (
-/obj/structure/stool,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/closet/lasertag/red,
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/station/civilian/playroom)
 "aTX" = (
@@ -26496,13 +26518,6 @@
 	icon_state = "neutral"
 	},
 /area/station/storage/primary)
-"aVs" = (
-/obj/structure/closet/secure_closet/personal,
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutral"
-	},
-/area/station/civilian/playroom)
 "aVt" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/structure/window/reinforced{
@@ -26526,15 +26541,23 @@
 /turf/simulated/floor,
 /area/station/civilian/playroom)
 "aVw" = (
-/turf/simulated/floor,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/station/civilian/playroom)
 "aVx" = (
-/obj/machinery/vending/donut,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutral"
+	icon_state = "redchecker"
 	},
-/area/station/civilian/playroom)
+/area/station/hallway/primary/port)
 "aVy" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Science Maintenance";
@@ -27441,12 +27464,16 @@
 	},
 /area/station/storage/primary)
 "aWR" = (
-/obj/structure/closet/secure_closet/personal,
-/turf/simulated/floor{
-	dir = 10;
-	icon_state = "neutral"
+/obj/structure/table,
+/obj/item/ashtray/glass,
+/obj/item/clothing/mask/cigarette{
+	pixel_y = 2;
+	pixel_x = -3
 	},
-/area/station/civilian/playroom)
+/turf/simulated/floor{
+	icon_state = "redchecker"
+	},
+/area/station/hallway/primary/port)
 "aWS" = (
 /obj/structure/table,
 /obj/item/weapon/paper_bin,
@@ -27544,12 +27571,13 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aXc" = (
-/obj/machinery/vending/junkfood,
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "neutral"
+/obj/structure/stool/bed/chair/metal/red{
+	dir = 8
 	},
-/area/station/civilian/playroom)
+/turf/simulated/floor{
+	icon_state = "redchecker"
+	},
+/area/station/hallway/primary/port)
 "aXd" = (
 /obj/structure/stool/bed/chair/comfy/black,
 /obj/machinery/firealarm{
@@ -28736,17 +28764,13 @@
 /turf/simulated/floor/plating,
 /area/station/civilian/playroom)
 "aZg" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
+/obj/structure/stool/bed/chair/metal/red{
 	dir = 1
 	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
+/turf/simulated/floor{
+	icon_state = "redchecker"
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/civilian/playroom)
+/area/station/hallway/primary/port)
 "aZh" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -28756,14 +28780,10 @@
 /turf/simulated/floor,
 /area/station/civilian/playroom)
 "aZi" = (
-/obj/structure/window/reinforced{
-	dir = 1
+/turf/simulated/floor{
+	icon_state = "redchecker"
 	},
-/obj/structure/window/reinforced,
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/civilian/playroom)
+/area/station/hallway/primary/port)
 "aZj" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -30296,8 +30316,8 @@
 "bbP" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "escape";
+	dir = 1
 	},
 /area/station/hallway/primary/port)
 "bbQ" = (
@@ -31346,15 +31366,9 @@
 	},
 /area/station/medical/sleeper)
 "bdK" = (
-/obj/machinery/camera{
-	c_tag = "Port Hallway 2"
-	},
-/obj/structure/sign/directions/holodeck{
-	pixel_y = 32
-	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "escape";
+	dir = 1
 	},
 /area/station/hallway/primary/port)
 "bdL" = (
@@ -31385,8 +31399,8 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "yellowcorner"
+	icon_state = "escapecorner";
+	dir = 1
 	},
 /area/station/hallway/primary/port)
 "bdO" = (
@@ -31417,6 +31431,7 @@
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
+/obj/machinery/vending/junkfood,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "bluecorner"
@@ -31431,6 +31446,7 @@
 /obj/machinery/alarm{
 	pixel_y = 26
 	},
+/obj/machinery/vending/donut,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "yellowcorner"
@@ -31442,6 +31458,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/disposal,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "blue"
@@ -32934,7 +32951,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor{
-	icon_state = "whitecorner"
+	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/port)
 "bgs" = (
@@ -36955,7 +36972,6 @@
 	dir = 4
 	},
 /obj/structure/sign/departments/botany,
-/obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
 "boe" = (
@@ -49304,14 +49320,23 @@
 /turf/simulated/floor/carpet/green,
 /area/station/medical/patients_rooms)
 "bKb" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/item/weapon/flora/pottedplant/minitree,
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
+	dir = 1;
+	icon_state = "green"
 	},
-/area/station/hallway/primary/port)
+/area/station/civilian/hydroponics)
 "bKc" = (
 /turf/simulated/wall,
 /area/station/medical/patient_b)
@@ -60815,7 +60840,8 @@
 	icon_state = "shutter0";
 	opacity = 0;
 	name = "Kitchen Shutters";
-	id = "kitchen2"
+	id = "kitchen2";
+	density = 0
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
@@ -70774,8 +70800,7 @@
 	req_access = list(28)
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "white"
 	},
 /area/station/civilian/kitchen)
 "eHO" = (
@@ -71167,24 +71192,10 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "fkD" = (
-/obj/item/weapon/packageWrap,
-/obj/structure/table/glass,
-/obj/item/weapon/book/manual/wiki/hydroponics,
-/obj/item/device/eftpos{
-	eftpos_name = "Botany EFTPOS scanner"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_y = 24
-	},
-/obj/item/device/tagger/shop,
 /turf/simulated/floor{
-	dir = 5;
 	icon_state = "green"
 	},
-/area/station/civilian/hydroponics)
+/area/station/hallway/primary/port)
 "flb" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -74165,29 +74176,6 @@
 	icon_state = "bluecorner"
 	},
 /area/station/hallway/primary/central)
-"iAL" = (
-/obj/item/weapon/reagent_containers/spray/plantbgone{
-	pixel_y = 3
-	},
-/obj/item/weapon/reagent_containers/spray/plantbgone{
-	pixel_y = 3
-	},
-/obj/item/weapon/reagent_containers/spray/plantbgone{
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/item/weapon/reagent_containers/spray/plantbgone{
-	pixel_x = 13;
-	pixel_y = 5
-	},
-/obj/structure/table/glass,
-/obj/item/weapon/book/manual/hydroponics_beekeeping,
-/obj/item/weapon/packageWrap,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "green"
-	},
-/area/station/civilian/hydroponics)
 "iAY" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/disposalpipe/segment{
@@ -79650,15 +79638,12 @@
 	},
 /area/station/civilian/bar)
 "oXR" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "neutral"
+	icon_state = "escape";
+	dir = 1
 	},
-/area/station/civilian/playroom)
+/area/station/hallway/primary/port)
 "oYb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -79990,12 +79975,6 @@
 /obj/machinery/door/window/southright{
 	name = "Bar Door";
 	req_one_access = list(25)
-	},
-/obj/machinery/door/poddoor/shutters{
-	icon_state = "shutter0";
-	opacity = 0;
-	name = "Kitchen Shutters";
-	id = "kitchen1"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -83435,16 +83414,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "tpw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/sign/directions/holodeck{
+	pixel_y = 32
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/stool/bed/chair/metal/red{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor{
-	icon_state = "greencorner"
+	icon_state = "redchecker"
 	},
 /area/station/hallway/primary/port)
 "tso" = (
@@ -83888,7 +83868,8 @@
 	icon_state = "shutter0";
 	opacity = 0;
 	name = "Kitchen Shutters";
-	id = "kitchen1"
+	id = "kitchen1";
+	density = 0
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -84370,12 +84351,6 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/door/poddoor/shutters{
-	icon_state = "shutter0";
-	opacity = 0;
-	name = "Kitchen Shutters";
-	id = "kitchen1"
-	},
 /turf/simulated/floor/plating,
 /area/station/civilian/bar)
 "vvH" = (
@@ -84577,7 +84552,8 @@
 	icon_state = "shutter0";
 	opacity = 0;
 	name = "Kitchen Shutters";
-	id = "kitchen1"
+	id = "kitchen1";
+	density = 0
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -84594,10 +84570,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
-	dir = 1;
+	dir = 10;
 	icon_state = "green"
 	},
-/area/station/civilian/hydroponics)
+/area/station/hallway/primary/port)
 "vXW" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/components/unary/portables_connector,
@@ -84970,11 +84946,10 @@
 /turf/simulated/floor/plating,
 /area/station/cargo/office)
 "wFQ" = (
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "greencorner"
-	},
-/area/station/civilian/hydroponics)
+/obj/machinery/space_heater,
+/obj/machinery/space_heater,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "wFY" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/weapon/reagent_containers/glass/bucket,
@@ -105027,7 +105002,7 @@ aWH
 aFL
 bbK
 bdZ
-aOD
+fkD
 avT
 vTP
 gNe
@@ -105284,11 +105259,11 @@ aWI
 aYX
 cki
 bdZ
-aOD
+aSB
 bod
 aNK
-wFQ
-gKG
+bmU
+bKb
 aVg
 jmV
 nNV
@@ -105541,7 +105516,7 @@ aWK
 aYY
 bdv
 coa
-tpw
+awq
 awq
 vWU
 aQc
@@ -105798,11 +105773,11 @@ aWN
 aFL
 alz
 bdZ
-aOD
-aNi
+cjM
+cjM
 fkD
-iAL
-aVh
+aNi
+aTU
 aVh
 aVh
 oEO
@@ -107078,10 +107053,10 @@ aOz
 aQZ
 aSx
 aTQ
-aVs
-aWR
 npb
-bKb
+aWR
+aZg
+bdK
 bdZ
 cjM
 awu
@@ -107333,11 +107308,11 @@ aNf
 aOA
 aPS
 aRa
-aSy
-aTS
 aVu
 aWT
 aOz
+tpw
+aZi
 bdK
 bdZ
 cjM
@@ -107589,12 +107564,12 @@ aLN
 aNj
 aOB
 aPU
-aRb
-aSz
-aTT
+aTS
 aRb
 aWU
 aZh
+aVx
+aVx
 bbP
 cpb
 cjM
@@ -107847,12 +107822,12 @@ aNp
 aOz
 aQe
 ake
-aSB
-aTU
 aVv
 aWY
 aZf
-bdo
+aSy
+aZi
+oXR
 bet
 bnt
 awu
@@ -108107,9 +108082,9 @@ aRd
 aSG
 aTW
 aVw
-aWT
+aOP
 aZi
-bdv
+bdK
 bdZ
 cjM
 aoS
@@ -108362,11 +108337,11 @@ aOz
 aOz
 aOz
 aOz
-oXR
-aVx
+aOz
+aOz
 aXc
-aZg
-bdv
+aZi
+bdK
 bdZ
 cjM
 aMZ
@@ -108616,13 +108591,13 @@ alZ
 iqb
 aKY
 alZ
-aOP
+awE
+alZ
+wFQ
 azj
-aOz
-aOz
-aOz
-aOz
-aOz
+agO
+agO
+agO
 bdN
 bdZ
 npd

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -5836,11 +5836,10 @@
 	},
 /area/station/security/main)
 "ajV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -11243,10 +11242,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "ata" = (
-/obj/machinery/vending/hydroseeds,
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -11594,13 +11594,22 @@
 /turf/environment/space,
 /area/shuttle/mining/station)
 "atK" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/structure/closet/wardrobe/white,
+/obj/item/device/eftpos{
+	eftpos_name = "Kitchen EFTPOS scanner"
 	},
-/turf/simulated/floor,
-/area/station/civilian/cold_room)
+/obj/item/weapon/storage/box/mousetraps,
+/obj/item/weapon/storage/box/mousetraps,
+/obj/item/clothing/under/sundress,
+/obj/item/clothing/under/waiter,
+/obj/item/clothing/under/waiter,
+/obj/item/clothing/under/rank/chef,
+/obj/item/clothing/head/chefhat,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "atL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/firealarm{
@@ -11789,12 +11798,22 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "atZ" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/station/civilian/hydroponics)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "aua" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -12338,6 +12357,11 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/weapon/reagent_containers/food/snacks/pie,
+/obj/machinery/door_control{
+	pixel_x = -25;
+	name = "Kitchen Shutters";
+	id = "kitchen"
+	},
 /turf/simulated/floor{
 	icon_state = "cafeteria"
 	},
@@ -14623,8 +14647,10 @@
 	},
 /area/station/civilian/dormitories)
 "azA" = (
-/obj/structure/table,
-/obj/item/weapon/reagent_containers/food/snacks/mint,
+/obj/machinery/light_switch{
+	pixel_y = -28
+	},
+/obj/structure/closet/secure_closet/freezer/fridge,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -14975,7 +15001,6 @@
 /turf/simulated/floor/plating,
 /area/station/storage/tech/north)
 "aAf" = (
-/obj/structure/closet/secure_closet/hydroponics,
 /obj/machinery/vending/wallmed1{
 	pixel_y = 30
 	},
@@ -15403,16 +15428,15 @@
 /turf/simulated/floor/plating,
 /area/station/security/lobby)
 "aAX" = (
-/obj/structure/table,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/item/weapon/book/manual/wiki/chefs_recipes,
 /obj/machinery/camera{
 	c_tag = "Kitchen";
 	dir = 1
 	},
+/obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/simulated/floor{
 	icon_state = "cafeteria"
 	},
@@ -15993,7 +16017,7 @@
 "aBY" = (
 /obj/structure/table,
 /obj/machinery/light,
-/obj/machinery/reagentgrinder,
+/obj/item/weapon/reagent_containers/food/snacks/mint,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -17320,15 +17344,13 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "green"
-	},
+/turf/simulated/floor,
 /area/station/civilian/hydroponics)
 "aEK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/structure/closet/secure_closet/hydroponics,
 /turf/simulated/floor{
 	icon_state = "green"
 	},
@@ -17924,7 +17946,7 @@
 	pixel_x = -12
 	},
 /obj/structure/sign/monkey_painting{
-	pixel_y = 32
+	pixel_y = 25
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -21177,7 +21199,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/closet/secure_closet/hydroponics,
 /turf/simulated/floor/grass,
 /area/station/civilian/hydroponics)
 "aLL" = (
@@ -21947,6 +21968,13 @@
 	name = "Kitchen";
 	req_access = list(28)
 	},
+/obj/machinery/door/poddoor/shutters{
+	dir = 4;
+	icon_state = "shutter0";
+	opacity = 0;
+	name = "Kitchen Shutters";
+	id = "kitchen"
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -22196,15 +22224,11 @@
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
 "aNK" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/item/weapon/flora/pottedplant/minitree,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "green"
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
 "aNL" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -22744,7 +22768,6 @@
 	c_tag = "Hydroponics Pasture";
 	dir = 1
 	},
-/obj/structure/chicken_feeder,
 /turf/simulated/floor/grass,
 /area/station/civilian/hydroponics)
 "aOK" = (
@@ -23500,16 +23523,16 @@
 	},
 /area/station/civilian/garden)
 "aQc" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/closet/secure_closet/bar,
+/obj/item/weapon/gun/projectile/revolver/doublebarrel,
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/paper{
+	info = "This permit signifies that the Bartender is permitted to posess this firearm in the bar, and ONLY the bar. Failure to adhere to this permit will result in confiscation of the weapon and possibly arrest.";
+	name = "Shotgun permit"
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/civilian/hydroponics)
+/obj/item/clothing/suit/armor/vest,
+/turf/environment/space,
+/area/station/civilian/bar)
 "aQd" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/simulated/floor{
@@ -26340,6 +26363,7 @@
 	dir = 8;
 	pixel_x = -12
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -28300,11 +28324,11 @@
 	},
 /area/station/hallway/secondary/entry)
 "aYy" = (
-/obj/structure/closet/secure_closet/hydroponics,
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/structure/chicken_feeder,
 /turf/simulated/floor/grass,
 /area/station/civilian/hydroponics)
 "aYz" = (
@@ -36897,6 +36921,7 @@
 	dir = 4
 	},
 /obj/structure/sign/departments/botany,
+/obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
 "boe" = (
@@ -40744,7 +40769,6 @@
 	},
 /area/station/cargo/recycleroffice)
 "buW" = (
-/obj/effect/landmark/start/bartender,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
@@ -41874,11 +41898,10 @@
 	},
 /area/station/hallway/primary/central)
 "bwL" = (
+/obj/effect/landmark/start/bartender,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/bar)
@@ -41930,22 +41953,14 @@
 	},
 /area/station/medical/sleeper)
 "bwQ" = (
-/obj/structure/closet/secure_closet/bar,
-/obj/item/weapon/gun/projectile/revolver/doublebarrel,
-/obj/item/weapon/paper{
-	info = "This permit signifies that the Bartender is permitted to posess this firearm in the bar, and ONLY the bar. Failure to adhere to this permit will result in confiscation of the weapon and possibly arrest.";
-	name = "Shotgun permit"
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/item/clothing/suit/armor/vest,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/turf/simulated/floor{
+	icon_state = "showroomfloor"
 	},
-/obj/item/weapon/storage/firstaid/regular,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/bar)
+/area/station/civilian/cold_room)
 "bwR" = (
 /obj/structure/closet/crate/freezer,
 /turf/simulated/floor,
@@ -43395,10 +43410,7 @@
 	pixel_x = -1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
@@ -47875,6 +47887,13 @@
 	dir = 4;
 	pixel_x = -6
 	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -47948,9 +47967,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -49220,14 +49237,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bJX" = (
-/obj/structure/closet/crate/freezer,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/firealarm{
+/obj/machinery/power/apc{
 	dir = 8;
-	pixel_x = -24
+	name = "Cold Room APC";
+	pixel_x = -28
 	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/closet/crate/freezer,
+/obj/machinery/light/small,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "warning"
@@ -49312,18 +49332,17 @@
 	},
 /area/station/medical/hallway)
 "bKh" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/obj/machinery/light/small{
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "warning"
-	},
-/area/station/civilian/cold_room)
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics)
 "bKi" = (
 /obj/structure/stool,
 /turf/simulated/floor{
@@ -69653,11 +69672,11 @@
 	},
 /area/station/engineering/drone_fabrication)
 "dra" = (
+/obj/machinery/vending/hydroseeds,
 /turf/simulated/floor{
-	dir = 6;
-	icon_state = "green"
+	icon_state = "dark"
 	},
-/area/station/hallway/primary/port)
+/area/station/civilian/hydroponics)
 "drb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -70328,6 +70347,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/civilian/hydroponics)
@@ -71044,9 +71066,13 @@
 	},
 /area/station/hallway/secondary/exit)
 "fcK" = (
-/obj/structure/reagent_dispensers/beerkeg,
-/turf/simulated/floor/wood,
-/area/station/civilian/bar)
+/obj/structure/table,
+/obj/item/weapon/book/manual/wiki/chefs_recipes,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "fec" = (
 /obj/machinery/autolathe,
 /turf/simulated/floor{
@@ -71466,7 +71492,6 @@
 	},
 /obj/structure/cable,
 /turf/simulated/floor{
-	dir = 8;
 	icon_state = "greencorner"
 	},
 /area/station/hallway/primary/port)
@@ -72393,22 +72418,15 @@
 	},
 /area/station/rnd/robotics)
 "gKG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "green"
-	},
-/area/station/civilian/hydroponics)
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/simulated/floor/wood,
+/area/station/civilian/bar)
 "gKX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -72419,15 +72437,13 @@
 	},
 /area/station/hallway/secondary/entry)
 "gLt" = (
-/obj/machinery/light_switch{
-	pixel_x = -23
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/closet/secure_closet/freezer/fridge,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "dark"
 	},
-/area/station/civilian/kitchen)
+/area/station/civilian/hydroponics)
 "gMb" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -72486,8 +72502,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "gNe" = (
-/obj/item/weapon/flora/pottedplant/minitree,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "green"
@@ -73883,11 +73897,14 @@
 /turf/simulated/floor,
 /area/station/cargo/storage)
 "ipb" = (
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "greencorner"
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/area/station/hallway/primary/port)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics)
 "iqb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced{
@@ -73930,7 +73947,6 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 8;
 	icon_state = "greencorner"
 	},
 /area/station/hallway/primary/port)
@@ -75329,12 +75345,11 @@
 	},
 /area/station/medical/reception)
 "jQu" = (
-/obj/structure/closet/secure_closet/freezer/kitchen,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/area/station/civilian/kitchen)
+/turf/simulated/floor/wood,
+/area/station/civilian/bar)
 "jRb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -76178,6 +76193,7 @@
 "kLo" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/item/weapon/reagent_containers/glass/bucket,
+/obj/machinery/light,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -76908,13 +76924,6 @@
 	icon_state = "vault"
 	},
 /area/station/civilian/chapel)
-"lFQ" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/light,
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/civilian/hydroponics)
 "lGb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -76957,6 +76966,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/civilian/hydroponics)
@@ -78683,6 +78695,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/hydroponics,
 /turf/simulated/floor{
 	icon_state = "green"
 	},
@@ -79159,15 +79172,13 @@
 "opR" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
 "orb" = (
@@ -79384,28 +79395,23 @@
 /obj/machinery/newscaster{
 	pixel_y = -30
 	},
+/obj/structure/closet/secure_closet/hydroponics,
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "green"
 	},
 /area/station/civilian/hydroponics)
 "oGL" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/westleft{
-	dir = 4;
-	name = "Kitchen";
-	req_access = list(28)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/door/window/westleft{
-	name = "Hydroponics";
-	req_access = list(35)
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
+/turf/simulated/floor,
+/area/station/civilian/hydroponics)
 "oHi" = (
 /obj/machinery/vending/donut,
 /turf/simulated/floor{
@@ -79562,9 +79568,6 @@
 /area/station/maintenance/cargo)
 "oXb" = (
 /obj/machinery/hydroponics/constructable,
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/machinery/requests_console/hydroponics{
 	pixel_x = -30
 	},
@@ -81500,31 +81503,23 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "rnx" = (
-/obj/structure/closet/crate{
-	desc = "It's a storage unit for kitchen clothes and equipment.";
-	name = "Kitchen Crate"
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/westleft{
+	dir = 4;
+	name = "Kitchen";
+	req_access = list(28)
 	},
-/obj/item/clothing/head/chefhat,
-/obj/item/clothing/under/rank/chef,
-/obj/item/weapon/storage/box/mousetraps,
-/obj/item/weapon/storage/box/mousetraps,
-/obj/item/clothing/under/waiter,
-/obj/item/clothing/under/waiter,
-/obj/item/clothing/under/sundress,
-/obj/item/device/eftpos{
-	eftpos_name = "Kitchen EFTPOS scanner"
+/obj/machinery/reagentgrinder,
+/obj/machinery/door/window/westright{
+	name = "Kitchen";
+	req_access = list(28)
 	},
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Cold Room APC";
-	pixel_x = -28
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
 	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor,
-/area/station/civilian/cold_room)
+/area/station/civilian/kitchen)
 "rnU" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/main)
@@ -83384,7 +83379,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 8;
 	icon_state = "greencorner"
 	},
 /area/station/hallway/primary/port)
@@ -83824,6 +83818,13 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/item/weapon/storage/fancy/donut_box,
+/obj/machinery/door/poddoor/shutters{
+	dir = 4;
+	icon_state = "shutter0";
+	opacity = 0;
+	name = "Kitchen Shutters";
+	id = "kitchen"
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -84379,17 +84380,22 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "vGq" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/structure/grille,
+/obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/door/window/westleft{
+	name = "Hydroponics";
+	req_access = list(35)
 	},
-/turf/simulated/floor/plating,
-/area/station/civilian/hydroponics)
+/obj/machinery/door/window/westright{
+	name = "Kitchen";
+	req_access = list(28);
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "vIi" = (
 /obj/structure/closet/crate/freezer,
 /obj/random/foods/drink_can,
@@ -84502,6 +84508,13 @@
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
 /obj/item/weapon/bell,
+/obj/machinery/door/poddoor/shutters{
+	dir = 4;
+	icon_state = "shutter0";
+	opacity = 0;
+	name = "Kitchen Shutters";
+	id = "kitchen"
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -84517,10 +84530,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
-	dir = 10;
+	dir = 1;
 	icon_state = "green"
 	},
-/area/station/hallway/primary/port)
+/area/station/civilian/hydroponics)
 "vXW" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/components/unary/portables_connector,
@@ -84893,16 +84906,10 @@
 /turf/simulated/floor/plating,
 /area/station/cargo/office)
 "wFQ" = (
-/obj/structure/window/reinforced,
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "greencorner"
 	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
 "wFY" = (
 /obj/structure/closet/crate/hydroponics,
@@ -84921,6 +84928,10 @@
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -84991,6 +85002,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -85307,8 +85321,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -103674,7 +103687,7 @@ xRb
 ivb
 pEt
 oXb
-aVf
+gLt
 aFH
 aNi
 aSM
@@ -103922,7 +103935,7 @@ aFL
 aFL
 bbJ
 bdM
-ipb
+aOD
 aqD
 wEg
 tIJ
@@ -104179,7 +104192,7 @@ aWF
 aNF
 bdv
 bes
-ipb
+aOD
 arh
 fmh
 nHV
@@ -104436,8 +104449,8 @@ aWG
 aHQ
 bdv
 bdM
+aOD
 ipb
-ari
 wld
 nHV
 eho
@@ -104694,8 +104707,8 @@ aNF
 bdo
 bdY
 isb
-avT
-vTP
+ari
+dra
 nHV
 eho
 aVg
@@ -104703,7 +104716,7 @@ aVg
 lwE
 aVg
 aZs
-lFQ
+ayy
 aNi
 uru
 bEW
@@ -104950,9 +104963,9 @@ aWH
 aFL
 bbK
 bdZ
-ipb
-vGq
-atZ
+aOD
+avT
+vTP
 gNe
 xIW
 aVh
@@ -105207,16 +105220,16 @@ aWI
 aYX
 cki
 bdZ
-ipb
+aOD
 bod
 aNK
 wFQ
-gKG
+eho
 aVg
 jmV
 nNV
 opR
-aQc
+aAB
 bmU
 aNi
 aNi
@@ -105465,14 +105478,14 @@ aYY
 bdv
 coa
 tpw
-tpw
-vWU
 awq
+vWU
+oGL
 aEJ
 yaV
 kss
 aEK
-aAB
+bKh
 aNv
 qex
 aMQ
@@ -105721,12 +105734,12 @@ aWN
 aFL
 alz
 bdZ
-cjM
 aOD
-dra
 aNi
 fkD
 iAL
+aVh
+aVh
 aVh
 oEO
 aNi
@@ -105739,8 +105752,8 @@ aSM
 bGv
 aSM
 bEW
-aSM
-qcd
+bEW
+bEW
 bDk
 bNk
 bsS
@@ -105982,10 +105995,10 @@ bmY
 aMZ
 aMZ
 aMZ
-aMZ
-haq
+rnx
+vGq
 oMQ
-oGL
+haq
 aMZ
 pgZ
 aNv
@@ -105996,8 +106009,8 @@ bDp
 bDp
 bDp
 bDp
-bDp
 qcd
+bEW
 bDk
 bNk
 mTP
@@ -106239,10 +106252,10 @@ cjM
 aMZ
 uwT
 aDI
-gLt
-jQu
 aWw
 aWw
+aWw
+atK
 haq
 pvI
 aMX
@@ -106252,10 +106265,10 @@ bEp
 bHC
 bIM
 bJX
-rnx
 bDp
-usn
-tgJ
+qcd
+bEW
+bDk
 bNk
 bsT
 mtS
@@ -106507,10 +106520,10 @@ aYC
 bDp
 bIJ
 bzx
-bIK
+bIY
 ajV
-atK
 atk
+wNf
 wNf
 bmR
 bNk
@@ -106751,10 +106764,10 @@ akt
 cpL
 bns
 cox
-auq
+auL
 bbq
 hho
-aWw
+fcK
 slc
 aWw
 haq
@@ -106764,10 +106777,10 @@ aYv
 bEV
 bIK
 bHI
-bIY
-bKh
+bwQ
 asp
 avr
+bEW
 wZc
 bDk
 bNk
@@ -107008,7 +107021,7 @@ bKb
 bdZ
 cjM
 awu
-auw
+auq
 xiQ
 hho
 aAR
@@ -107024,9 +107037,9 @@ bHO
 bJa
 bDp
 bDp
-bDp
-bEW
-fDx
+aSM
+usn
+atZ
 bNk
 bNk
 sqt
@@ -107265,7 +107278,7 @@ bdK
 bdZ
 cjM
 awu
-auK
+auw
 aWw
 nAY
 aAX
@@ -107522,7 +107535,7 @@ bbP
 cpb
 cjM
 awu
-auL
+auK
 slc
 hho
 azA
@@ -107530,9 +107543,9 @@ aMZ
 aFO
 aTp
 bwJ
+aQc
 owK
 byR
-bEW
 bEW
 tEw
 bEW
@@ -107787,9 +107800,9 @@ aMZ
 blX
 buW
 bwL
+jQu
 dSI
 bBq
-ikq
 ikq
 ikq
 eUl
@@ -108042,10 +108055,10 @@ aWw
 aBY
 aMZ
 blK
-fcK
-bwQ
+aEh
+aEh
+gKG
 bsI
-aGn
 bDn
 bDn
 bDn

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -12031,14 +12031,17 @@
 "auw" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/window/westleft{
-	name = "Hydroponics";
-	req_access = list(35)
-	},
 /obj/machinery/door/window/westright{
 	name = "Kitchen";
-	req_access = list(28);
-	dir = 4
+	req_access = list(28)
+	},
+/obj/machinery/door/window/westleft{
+	dir = 4;
+	name = "Kitchen";
+	req_access = list(28)
+	},
+/obj/machinery/reagentgrinder{
+	pixel_y = 4
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -48644,10 +48647,7 @@
 	},
 /area/station/rnd/robotics)
 "bIM" = (
-/obj/machinery/chem_master/condimaster{
-	name = "CondiMaster Neo";
-	pixel_x = -5
-	},
+/obj/structure/closet/secure_closet/freezer/meat,
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -73943,18 +73943,10 @@
 /turf/simulated/floor,
 /area/station/cargo/storage)
 "ipb" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/westright{
-	name = "Kitchen";
-	req_access = list(28)
+/obj/machinery/chem_master/condimaster{
+	name = "CondiMaster Neo";
+	pixel_x = -5
 	},
-/obj/machinery/door/window/westleft{
-	dir = 4;
-	name = "Kitchen";
-	req_access = list(28)
-	},
-/obj/machinery/reagentgrinder,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -84461,7 +84453,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "vGq" = (
-/obj/structure/closet/secure_closet/freezer/meat,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -106068,7 +106059,7 @@ bmY
 aMZ
 aMZ
 aMZ
-ipb
+haq
 auw
 oMQ
 haq
@@ -106325,7 +106316,7 @@ cjM
 aMZ
 uwT
 aDI
-aWw
+ipb
 aWw
 aWw
 aDT

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -11594,10 +11594,15 @@
 /turf/environment/space,
 /area/shuttle/mining/station)
 "atK" = (
-/obj/machinery/vending/hydroseeds,
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/turf/simulated/floor,
 /area/station/civilian/hydroponics)
 "atL" = (
 /obj/machinery/door/firedoor,
@@ -11787,17 +11792,16 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "atZ" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/closet/secure_closet/bar,
+/obj/item/weapon/gun/projectile/revolver/doublebarrel,
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/paper{
+	info = "This permit signifies that the Bartender is permitted to posess this firearm in the bar, and ONLY the bar. Failure to adhere to this permit will result in confiscation of the weapon and possibly arrest.";
+	name = "Shotgun permit"
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/station/civilian/hydroponics)
+/obj/item/clothing/suit/armor/vest,
+/turf/environment/space,
+/area/station/civilian/bar)
 "aua" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -23507,13 +23511,15 @@
 	},
 /area/station/civilian/garden)
 "aQc" = (
-/obj/structure/table,
-/obj/item/weapon/book/manual/wiki/chefs_recipes,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
 	},
-/area/station/civilian/kitchen)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/hydroponics)
 "aQd" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
 /turf/simulated/floor{
@@ -26340,11 +26346,9 @@
 	},
 /area/station/medical/cryo)
 "aVf" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -41934,16 +41938,15 @@
 	},
 /area/station/medical/sleeper)
 "bwQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
-/turf/simulated/floor,
-/area/station/civilian/hydroponics)
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/simulated/floor/wood,
+/area/station/civilian/bar)
 "bwR" = (
 /obj/structure/closet/crate/freezer,
 /turf/simulated/floor,
@@ -49314,6 +49317,23 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/hallway)
+"bKh" = (
+/obj/structure/closet/wardrobe/white,
+/obj/item/device/eftpos{
+	eftpos_name = "Kitchen EFTPOS scanner"
+	},
+/obj/item/weapon/storage/box/mousetraps,
+/obj/item/weapon/storage/box/mousetraps,
+/obj/item/clothing/under/sundress,
+/obj/item/clothing/under/waiter,
+/obj/item/clothing/under/waiter,
+/obj/item/clothing/under/rank/chef,
+/obj/item/clothing/head/chefhat,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "bKi" = (
 /obj/structure/stool,
 /turf/simulated/floor{
@@ -70311,12 +70331,18 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/meeting_room)
 "eho" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor,
 /area/station/civilian/hydroponics)
 "ehX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -70691,10 +70717,6 @@
 /area/station/cargo/storage)
 "eHa" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/glass{
-	name = "Kitchen";
-	req_access = list(28)
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -70702,6 +70724,10 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock{
+	name = "Kitchen";
+	req_access = list(28)
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -71031,15 +71057,17 @@
 	},
 /area/station/hallway/secondary/exit)
 "fcK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/light/small{
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/reagent_dispensers/beerkeg,
-/turf/simulated/floor/wood,
-/area/station/civilian/bar)
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics)
 "fec" = (
 /obj/machinery/autolathe,
 /turf/simulated/floor{
@@ -72385,19 +72413,23 @@
 	},
 /area/station/rnd/robotics)
 "gKG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/westleft{
+	dir = 4;
+	name = "Kitchen";
+	req_access = list(28)
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/reagentgrinder,
+/obj/machinery/door/window/westright{
+	name = "Kitchen";
+	req_access = list(28)
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
 	},
-/turf/simulated/floor,
-/area/station/civilian/hydroponics)
+/area/station/civilian/kitchen)
 "gKX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -72408,22 +72440,11 @@
 	},
 /area/station/hallway/secondary/entry)
 "gLt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/vending/hydroseeds,
+/turf/simulated/floor{
+	icon_state = "dark"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/civilian/hydroponics)
 "gMb" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -73877,16 +73898,13 @@
 /turf/simulated/floor,
 /area/station/cargo/storage)
 "ipb" = (
-/obj/structure/closet/secure_closet/bar,
-/obj/item/weapon/gun/projectile/revolver/doublebarrel,
-/obj/item/weapon/storage/firstaid/regular,
-/obj/item/weapon/paper{
-	info = "This permit signifies that the Bartender is permitted to posess this firearm in the bar, and ONLY the bar. Failure to adhere to this permit will result in confiscation of the weapon and possibly arrest.";
-	name = "Shotgun permit"
+/obj/structure/table,
+/obj/item/weapon/book/manual/wiki/chefs_recipes,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
 	},
-/obj/item/clothing/suit/armor/vest,
-/turf/environment/space,
-/area/station/civilian/bar)
+/area/station/civilian/kitchen)
 "iqb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced{
@@ -75327,17 +75345,17 @@
 	},
 /area/station/medical/reception)
 "jQu" = (
-/obj/structure/closet/wardrobe/white,
-/obj/item/device/eftpos{
-	eftpos_name = "Kitchen EFTPOS scanner"
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/westleft{
+	name = "Hydroponics";
+	req_access = list(35)
 	},
-/obj/item/weapon/storage/box/mousetraps,
-/obj/item/weapon/storage/box/mousetraps,
-/obj/item/clothing/under/sundress,
-/obj/item/clothing/under/waiter,
-/obj/item/clothing/under/waiter,
-/obj/item/clothing/under/rank/chef,
-/obj/item/clothing/head/chefhat,
+/obj/machinery/door/window/westright{
+	name = "Kitchen";
+	req_access = list(28);
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -76917,15 +76935,6 @@
 	icon_state = "vault"
 	},
 /area/station/civilian/chapel)
-"lFQ" = (
-/obj/structure/closet/secure_closet/freezer/meat,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
-/area/station/civilian/cold_room)
 "lGb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -79404,23 +79413,14 @@
 	},
 /area/station/civilian/hydroponics)
 "oGL" = (
-/obj/structure/table/reinforced,
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/window/westleft{
-	dir = 4;
-	name = "Kitchen";
-	req_access = list(28)
-	},
-/obj/machinery/reagentgrinder,
-/obj/machinery/door/window/westright{
-	name = "Kitchen";
-	req_access = list(28)
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics)
 "oHi" = (
 /obj/machinery/vending/donut,
 /turf/simulated/floor{
@@ -81512,14 +81512,22 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "rnx" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/station/civilian/hydroponics)
+/area/station/maintenance/cargo)
 "rnU" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/main)
@@ -84380,22 +84388,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "vGq" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/westleft{
-	name = "Hydroponics";
-	req_access = list(35)
-	},
-/obj/machinery/door/window/westright{
-	name = "Kitchen";
-	req_access = list(28);
-	dir = 4
+/obj/structure/closet/secure_closet/freezer/meat,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "showroomfloor"
 	},
-/area/station/civilian/kitchen)
+/area/station/civilian/cold_room)
 "vIi" = (
 /obj/structure/closet/crate/freezer,
 /obj/random/foods/drink_can,
@@ -103681,13 +103681,13 @@ bdX
 fDT
 aNi
 ata
-aVf
+aQc
 wFY
 xRb
 ivb
 pEt
 oXb
-eho
+aVf
 aFH
 aNi
 aSM
@@ -104450,10 +104450,10 @@ aHQ
 bdv
 bdM
 aOD
-rnx
+oGL
 wld
 nHV
-gKG
+eho
 ayy
 iyb
 ayy
@@ -104708,9 +104708,9 @@ bdo
 bdY
 isb
 ari
-atK
+gLt
 nHV
-gKG
+eho
 aVg
 aVg
 lwE
@@ -105224,7 +105224,7 @@ aOD
 bod
 aNK
 wFQ
-gKG
+eho
 aVg
 jmV
 nNV
@@ -105480,12 +105480,12 @@ coa
 tpw
 awq
 vWU
-bwQ
+atK
 aEJ
 yaV
 kss
 aEK
-atZ
+fcK
 aNv
 qex
 aMQ
@@ -105995,8 +105995,8 @@ bmY
 aMZ
 aMZ
 aMZ
-oGL
-vGq
+gKG
+jQu
 oMQ
 haq
 aMZ
@@ -106255,7 +106255,7 @@ aDI
 aWw
 aWw
 aWw
-jQu
+bKh
 haq
 pvI
 aMX
@@ -106767,7 +106767,7 @@ cox
 auL
 bbq
 hho
-aQc
+ipb
 slc
 aWw
 haq
@@ -106777,7 +106777,7 @@ aYv
 bEV
 bIK
 bHI
-lFQ
+vGq
 asp
 avr
 bEW
@@ -107039,7 +107039,7 @@ bDp
 bDp
 aSM
 usn
-gLt
+rnx
 bNk
 bNk
 sqt
@@ -107543,7 +107543,7 @@ aMZ
 aFO
 aTp
 bwJ
-ipb
+atZ
 owK
 byR
 bEW
@@ -108057,7 +108057,7 @@ aMZ
 blK
 aEh
 aEh
-fcK
+bwQ
 bsI
 bDn
 bDn

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -9005,6 +9005,13 @@
 /obj/structure/window/reinforced/polarized{
 	id = "kitchen"
 	},
+/obj/machinery/door/poddoor/shutters{
+	dir = 1;
+	icon_state = "shutter0";
+	opacity = 0;
+	name = "Kitchen Shutters";
+	id = "kitchen2"
+	},
 /turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
 "aoT" = (
@@ -12170,10 +12177,10 @@
 	},
 /area/station/maintenance/eva)
 "auN" = (
+/obj/machinery/kitchen_machine/grill,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/kitchen_machine/oven,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -12191,7 +12198,8 @@
 	},
 /obj/machinery/windowtint{
 	id = "kitchen";
-	pixel_x = 24
+	pixel_x = 24;
+	pixel_y = 5
 	},
 /obj/structure/condiment_shelf{
 	pixel_y = 32
@@ -12201,7 +12209,17 @@
 /obj/item/weapon/reagent_containers/food/condiment/peppermill,
 /obj/item/weapon/reagent_containers/food/condiment/rice,
 /obj/item/weapon/reagent_containers/food/condiment/ketchup,
-/obj/machinery/vending/dinnerware,
+/obj/structure/table,
+/obj/machinery/kitchen_machine/microwave{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/machinery/door_control{
+	pixel_x = 24;
+	name = "Kitchen Shutters";
+	id = "kitchen";
+	pixel_y = -5
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -12346,13 +12364,16 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/food/snacks/pie,
 /obj/machinery/door_control{
-	pixel_x = -25;
-	name = "Kitchen Shutters";
+	pixel_x = -24;
+	name = "Kitchen Serving Shutters";
 	id = "kitchen"
 	},
+/obj/machinery/chem_dispenser/soda{
+	pixel_y = 4
+	},
 /turf/simulated/floor{
+	dir = 5;
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/bar)
@@ -13054,6 +13075,13 @@
 /obj/structure/window/reinforced/polarized{
 	dir = 1;
 	id = "kitchen"
+	},
+/obj/machinery/door/poddoor/shutters{
+	dir = 1;
+	icon_state = "shutter0";
+	opacity = 0;
+	name = "Kitchen Shutters";
+	id = "kitchen2"
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
@@ -14644,10 +14672,14 @@
 	},
 /area/station/civilian/dormitories)
 "azA" = (
+/obj/machinery/camera{
+	c_tag = "Kitchen";
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/freezer/kitchen,
 /obj/machinery/light_switch{
 	pixel_y = -28
 	},
-/obj/structure/closet/secure_closet/freezer/fridge,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -15371,17 +15403,6 @@
 	icon_state = "floorgrime"
 	},
 /area/station/storage/tech/north)
-"aAR" = (
-/obj/structure/table,
-/obj/item/weapon/kitchen/rollingpin,
-/obj/item/weapon/reagent_containers/glass/beaker{
-	pixel_x = 5
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
 "aAS" = (
 /turf/simulated/floor/plating{
 	icon_state = "platingdmg1"
@@ -15431,16 +15452,17 @@
 /turf/simulated/floor/plating,
 /area/station/security/lobby)
 "aAX" = (
+/obj/structure/table,
+/obj/item/weapon/kitchen/rollingpin,
+/obj/item/weapon/reagent_containers/glass/beaker{
+	pixel_x = 5
+	},
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/machinery/camera{
-	c_tag = "Kitchen";
-	dir = 1
-	},
-/obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/simulated/floor{
+	dir = 5;
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/kitchen)
@@ -15870,18 +15892,15 @@
 	},
 /area/station/civilian/dormitories)
 "aBN" = (
-/obj/structure/table,
+/obj/machinery/light_switch{
+	pixel_y = -28
+	},
+/obj/structure/closet/secure_closet/freezer/fridge,
 /obj/machinery/power/apc{
 	name = "Kitchen APC";
 	pixel_y = -26
 	},
 /obj/structure/cable,
-/obj/item/weapon/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/weapon/packageWrap,
-/obj/item/device/tagger/shop,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -16023,9 +16042,13 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "aBY" = (
-/obj/machinery/light,
 /obj/structure/table,
-/obj/item/weapon/reagent_containers/food/snacks/mint,
+/obj/item/weapon/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/packageWrap,
+/obj/item/device/tagger/shop,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -16877,7 +16900,7 @@
 /obj/machinery/newscaster{
 	pixel_x = -30
 	},
-/obj/machinery/deepfryer,
+/obj/machinery/vending/dinnerware,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -17477,18 +17500,18 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "aET" = (
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/light,
+/obj/structure/table,
+/obj/item/weapon/reagent_containers/food/snacks/mint,
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -28
 	},
-/obj/machinery/light_switch{
-	pixel_x = -30
-	},
-/obj/machinery/vending/boozeomat,
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "cafeteria"
 	},
-/area/station/civilian/bar)
+/area/station/civilian/kitchen)
 "aEU" = (
 /obj/machinery/optable,
 /obj/effect/decal/cleanable/vomit,
@@ -23645,10 +23668,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "aQn" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -28
-	},
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = 12
@@ -27203,7 +27222,13 @@
 	},
 /area/station/cargo/office)
 "aWy" = (
-/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/media/jukebox/bar,
+/obj/machinery/light_switch{
+	pixel_x = -30
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -40231,7 +40256,7 @@
 /area/station/maintenance/escape)
 "btW" = (
 /obj/structure/window/reinforced,
-/obj/machinery/media/jukebox/bar,
+/obj/machinery/vending/boozeomat,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -60785,6 +60810,13 @@
 	dir = 1;
 	id = "kitchen"
 	},
+/obj/machinery/door/poddoor/shutters{
+	dir = 1;
+	icon_state = "shutter0";
+	opacity = 0;
+	name = "Kitchen Shutters";
+	id = "kitchen2"
+	},
 /turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
 "coz" = (
@@ -69675,21 +69707,12 @@
 	},
 /area/station/engineering/drone_fabrication)
 "dra" = (
-/obj/structure/closet/wardrobe/white,
-/obj/item/weapon/storage/box/mousetraps,
-/obj/item/weapon/storage/box/mousetraps,
-/obj/item/device/eftpos{
-	eftpos_name = "Kitchen EFTPOS scanner"
-	},
-/obj/item/clothing/under/waiter,
-/obj/item/clothing/under/waiter,
-/obj/item/clothing/under/rank/chef,
-/obj/item/clothing/head/chefhat,
+/obj/machinery/deepfryer,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
 	},
-/area/station/civilian/bar)
+/area/station/civilian/kitchen)
 "drb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -69848,6 +69871,7 @@
 /area/station/civilian/garden)
 "dyy" = (
 /obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/food/snacks/pie,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -76717,10 +76741,16 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/machinery/chem_dispenser/soda{
-	pixel_y = 4
+/obj/structure/closet/wardrobe/white,
+/obj/item/device/eftpos{
+	eftpos_name = "Kitchen EFTPOS scanner"
 	},
+/obj/item/weapon/storage/box/mousetraps,
+/obj/item/weapon/storage/box/mousetraps,
+/obj/item/clothing/under/waiter,
+/obj/item/clothing/under/waiter,
+/obj/item/clothing/under/rank/chef,
+/obj/item/clothing/head/chefhat,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -106807,10 +106837,10 @@ akt
 cpL
 bns
 cox
-auL
+dra
 bbq
 aBi
-bwQ
+aWw
 aWw
 aWw
 aAf
@@ -107064,10 +107094,10 @@ bKb
 bdZ
 cjM
 awu
-auK
+auL
 xiQ
 hho
-aAR
+bwQ
 lup
 atZ
 oGL
@@ -107321,7 +107351,7 @@ bdK
 bdZ
 cjM
 awu
-auq
+auK
 aWw
 nAY
 aAX
@@ -108092,7 +108122,7 @@ bdv
 bdZ
 cjM
 aoS
-auL
+auK
 aWw
 aWw
 aBY
@@ -108352,7 +108382,7 @@ aMZ
 auP
 aWw
 aQn
-aMZ
+aET
 aMZ
 beo
 aGn
@@ -108610,7 +108640,7 @@ aMZ
 awO
 gWo
 aMZ
-aET
+aMZ
 bmx
 aTH
 bmd
@@ -108865,7 +108895,7 @@ bgr
 aGn
 ave
 awS
-dra
+awS
 vsv
 aWy
 bmx

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -12220,7 +12220,7 @@
 /obj/machinery/door_control{
 	pixel_x = 24;
 	name = "Kitchen Shutters";
-	id = "kitchen";
+	id = "kitchen2";
 	pixel_y = -5
 	},
 /turf/simulated/floor{
@@ -12370,7 +12370,7 @@
 /obj/machinery/door_control{
 	pixel_x = -24;
 	name = "Kitchen Serving Shutters";
-	id = "kitchen"
+	id = "kitchen1"
 	},
 /obj/machinery/chem_dispenser/soda{
 	pixel_y = 4
@@ -14084,7 +14084,7 @@
 	icon_state = "shutter0";
 	opacity = 0;
 	name = "Kitchen Shutters";
-	id = "kitchen"
+	id = "kitchen1"
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/bar)
@@ -22007,7 +22007,7 @@
 	icon_state = "shutter0";
 	opacity = 0;
 	name = "Kitchen Shutters";
-	id = "kitchen"
+	id = "kitchen1"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -79995,7 +79995,7 @@
 	icon_state = "shutter0";
 	opacity = 0;
 	name = "Kitchen Shutters";
-	id = "kitchen"
+	id = "kitchen1"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -83888,7 +83888,7 @@
 	icon_state = "shutter0";
 	opacity = 0;
 	name = "Kitchen Shutters";
-	id = "kitchen"
+	id = "kitchen1"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -84374,7 +84374,7 @@
 	icon_state = "shutter0";
 	opacity = 0;
 	name = "Kitchen Shutters";
-	id = "kitchen"
+	id = "kitchen1"
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/bar)
@@ -84577,7 +84577,7 @@
 	icon_state = "shutter0";
 	opacity = 0;
 	name = "Kitchen Shutters";
-	id = "kitchen"
+	id = "kitchen1"
 	},
 /turf/simulated/floor{
 	dir = 5;

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -11594,16 +11594,16 @@
 /turf/environment/space,
 /area/shuttle/mining/station)
 "atK" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/closet/secure_closet/bar,
+/obj/item/weapon/gun/projectile/revolver/doublebarrel,
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/paper{
+	info = "This permit signifies that the Bartender is permitted to posess this firearm in the bar, and ONLY the bar. Failure to adhere to this permit will result in confiscation of the weapon and possibly arrest.";
+	name = "Shotgun permit"
 	},
-/turf/simulated/floor,
-/area/station/civilian/hydroponics)
+/obj/item/clothing/suit/armor/vest,
+/turf/simulated/floor/wood,
+/area/station/civilian/bar)
 "atL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/firealarm{
@@ -11792,16 +11792,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "atZ" = (
-/obj/structure/closet/secure_closet/bar,
-/obj/item/weapon/gun/projectile/revolver/doublebarrel,
-/obj/item/weapon/storage/firstaid/regular,
-/obj/item/weapon/paper{
-	info = "This permit signifies that the Bartender is permitted to posess this firearm in the bar, and ONLY the bar. Failure to adhere to this permit will result in confiscation of the weapon and possibly arrest.";
-	name = "Shotgun permit"
+/obj/machinery/kitchen_machine/candymaker,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
 	},
-/obj/item/clothing/suit/armor/vest,
-/turf/environment/space,
-/area/station/civilian/bar)
+/area/station/civilian/kitchen)
 "aua" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -11931,16 +11927,16 @@
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/auxsolarstarboard)
 "aum" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -12026,7 +12022,17 @@
 	},
 /area/station/civilian/bar)
 "auw" = (
-/obj/machinery/deepfryer,
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/westleft{
+	name = "Hydroponics";
+	req_access = list(35)
+	},
+/obj/machinery/door/window/westright{
+	name = "Kitchen";
+	req_access = list(28);
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -12164,14 +12170,10 @@
 	},
 /area/station/maintenance/eva)
 "auN" = (
-/obj/structure/table,
-/obj/machinery/kitchen_machine/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/kitchen_machine/oven,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -12187,7 +12189,6 @@
 /obj/item/weapon/reagent_containers/food/condiment/enzyme{
 	pixel_x = 10
 	},
-/obj/structure/table,
 /obj/machinery/windowtint{
 	id = "kitchen";
 	pixel_x = 24
@@ -12200,6 +12201,7 @@
 /obj/item/weapon/reagent_containers/food/condiment/peppermill,
 /obj/item/weapon/reagent_containers/food/condiment/rice,
 /obj/item/weapon/reagent_containers/food/condiment/ketchup,
+/obj/machinery/vending/dinnerware,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -14046,6 +14048,13 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/machinery/door/poddoor/shutters{
+	dir = 1;
+	icon_state = "shutter0";
+	opacity = 0;
+	name = "Kitchen Shutters";
+	id = "kitchen"
+	},
 /turf/simulated/floor/plating,
 /area/station/civilian/bar)
 "ayw" = (
@@ -14989,11 +14998,17 @@
 /turf/simulated/floor/plating,
 /area/station/storage/tech/north)
 "aAf" = (
-/obj/machinery/vending/wallmed1{
-	pixel_y = 30
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/simulated/floor/grass,
-/area/station/civilian/hydroponics)
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/civilian/kitchen)
 "aAg" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -15527,10 +15542,15 @@
 /turf/simulated/floor/beach/water/waterpool,
 /area/station/civilian/gym)
 "aBi" = (
-/obj/structure/table,
-/obj/machinery/chem_dispenser/soda{
-	pixel_y = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/landmark/start/chef,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -16003,8 +16023,8 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "aBY" = (
-/obj/structure/table,
 /obj/machinery/light,
+/obj/structure/table,
 /obj/item/weapon/reagent_containers/food/snacks/mint,
 /turf/simulated/floor{
 	dir = 5;
@@ -16854,10 +16874,10 @@
 	},
 /area/station/ai_monitored/eva)
 "aDI" = (
-/obj/machinery/vending/dinnerware,
 /obj/machinery/newscaster{
 	pixel_x = -30
 	},
+/obj/machinery/deepfryer,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -23511,14 +23531,15 @@
 	},
 /area/station/civilian/garden)
 "aQc" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
-	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/turf/simulated/floor,
 /area/station/civilian/hydroponics)
 "aQd" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer,
@@ -41938,15 +41959,13 @@
 	},
 /area/station/medical/sleeper)
 "bwQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/structure/table,
+/obj/item/weapon/book/manual/wiki/chefs_recipes,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/beerkeg,
-/turf/simulated/floor/wood,
-/area/station/civilian/bar)
+/area/station/civilian/kitchen)
 "bwR" = (
 /obj/structure/closet/crate/freezer,
 /turf/simulated/floor,
@@ -49318,22 +49337,15 @@
 	},
 /area/station/medical/hallway)
 "bKh" = (
-/obj/structure/closet/wardrobe/white,
-/obj/item/device/eftpos{
-	eftpos_name = "Kitchen EFTPOS scanner"
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
 	},
-/obj/item/weapon/storage/box/mousetraps,
-/obj/item/weapon/storage/box/mousetraps,
-/obj/item/clothing/under/sundress,
-/obj/item/clothing/under/waiter,
-/obj/item/clothing/under/waiter,
-/obj/item/clothing/under/rank/chef,
-/obj/item/clothing/head/chefhat,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "dark"
 	},
-/area/station/civilian/kitchen)
+/area/station/civilian/hydroponics)
 "bKi" = (
 /obj/structure/stool,
 /turf/simulated/floor{
@@ -69663,10 +69675,20 @@
 	},
 /area/station/engineering/drone_fabrication)
 "dra" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/structure/closet/wardrobe/white,
+/obj/item/weapon/storage/box/mousetraps,
+/obj/item/weapon/storage/box/mousetraps,
+/obj/item/device/eftpos{
+	eftpos_name = "Kitchen EFTPOS scanner"
 	},
-/turf/simulated/floor/wood,
+/obj/item/clothing/under/waiter,
+/obj/item/clothing/under/waiter,
+/obj/item/clothing/under/rank/chef,
+/obj/item/clothing/head/chefhat,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
 /area/station/civilian/bar)
 "drb" = (
 /obj/structure/disposalpipe/segment{
@@ -70331,18 +70353,16 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/meeting_room)
 "eho" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
 "ehX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -71057,17 +71077,22 @@
 	},
 /area/station/hallway/secondary/exit)
 "fcK" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/station/civilian/hydroponics)
+/area/station/maintenance/cargo)
 "fec" = (
 /obj/machinery/autolathe,
 /turf/simulated/floor{
@@ -72413,23 +72438,19 @@
 	},
 /area/station/rnd/robotics)
 "gKG" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/westleft{
-	dir = 4;
-	name = "Kitchen";
-	req_access = list(28)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/reagentgrinder,
-/obj/machinery/door/window/westright{
-	name = "Kitchen";
-	req_access = list(28)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/station/civilian/kitchen)
+/turf/simulated/floor,
+/area/station/civilian/hydroponics)
 "gKX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -73898,8 +73919,18 @@
 /turf/simulated/floor,
 /area/station/cargo/storage)
 "ipb" = (
-/obj/structure/table,
-/obj/item/weapon/book/manual/wiki/chefs_recipes,
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/westright{
+	name = "Kitchen";
+	req_access = list(28)
+	},
+/obj/machinery/door/window/westleft{
+	dir = 4;
+	name = "Kitchen";
+	req_access = list(28)
+	},
+/obj/machinery/reagentgrinder,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -75345,22 +75376,11 @@
 	},
 /area/station/medical/reception)
 "jQu" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/westleft{
-	name = "Hydroponics";
-	req_access = list(35)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/obj/machinery/door/window/westright{
-	name = "Kitchen";
-	req_access = list(28);
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
+/turf/simulated/floor/wood,
+/area/station/civilian/bar)
 "jRb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -76694,9 +76714,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "lup" = (
-/obj/machinery/kitchen_machine/candymaker,
 /obj/machinery/light{
 	dir = 4
+	},
+/obj/structure/table,
+/obj/machinery/chem_dispenser/soda{
+	pixel_y = 4
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -76935,6 +76958,15 @@
 	icon_state = "vault"
 	},
 /area/station/civilian/chapel)
+"lFQ" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics)
 "lGb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -79416,11 +79448,14 @@
 /obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/station/civilian/hydroponics)
+/area/station/civilian/kitchen)
 "oHi" = (
 /obj/machinery/vending/donut,
 /turf/simulated/floor{
@@ -79720,6 +79755,9 @@
 /obj/structure/flora/ausbushes/reedbush{
 	pixel_y = 6
 	},
+/obj/machinery/vending/wallmed1{
+	pixel_y = 30
+	},
 /turf/simulated/floor/grass,
 /area/station/civilian/hydroponics)
 "pht" = (
@@ -79925,18 +79963,22 @@
 	},
 /area/station/engineering/singularity)
 "pwX" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/southright{
+	name = "Bar Door";
+	req_one_access = list(25)
 	},
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/door/poddoor/shutters{
+	icon_state = "shutter0";
+	opacity = 0;
+	name = "Kitchen Shutters";
+	id = "kitchen"
 	},
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
 	},
-/turf/simulated/floor/plating,
 /area/station/civilian/bar)
 "pxb" = (
 /obj/structure/cable{
@@ -81512,22 +81554,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "rnx" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/light/small{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/obj/structure/reagent_dispensers/beerkeg,
+/turf/simulated/floor/wood,
+/area/station/civilian/bar)
 "rnU" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/main)
@@ -83987,15 +84022,15 @@
 	},
 /area/station/hallway/secondary/exit)
 "uwT" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
 /obj/machinery/firealarm{
 	pixel_y = 24
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -84302,16 +84337,24 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "vsv" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/window/southright{
-	name = "Bar Door";
-	req_one_access = list(25)
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+/obj/structure/window/reinforced{
+	dir = 4
 	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/poddoor/shutters{
+	icon_state = "shutter0";
+	opacity = 0;
+	name = "Kitchen Shutters";
+	id = "kitchen"
+	},
+/turf/simulated/floor/plating,
 /area/station/civilian/bar)
 "vvH" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -103681,7 +103724,7 @@ bdX
 fDT
 aNi
 ata
-aQc
+bKh
 wFY
 xRb
 ivb
@@ -104450,10 +104493,10 @@ aHQ
 bdv
 bdM
 aOD
-oGL
+lFQ
 wld
 nHV
-eho
+gKG
 ayy
 iyb
 ayy
@@ -104710,7 +104753,7 @@ isb
 ari
 gLt
 nHV
-eho
+gKG
 aVg
 aVg
 lwE
@@ -105224,7 +105267,7 @@ aOD
 bod
 aNK
 wFQ
-eho
+gKG
 aVg
 jmV
 nNV
@@ -105480,12 +105523,12 @@ coa
 tpw
 awq
 vWU
-atK
+aQc
 aEJ
 yaV
 kss
 aEK
-fcK
+eho
 aNv
 qex
 aMQ
@@ -105995,8 +106038,8 @@ bmY
 aMZ
 aMZ
 aMZ
-gKG
-jQu
+ipb
+auw
 oMQ
 haq
 aMZ
@@ -106255,8 +106298,8 @@ aDI
 aWw
 aWw
 aWw
-bKh
-haq
+aDT
+gWo
 pvI
 aMX
 aOJ
@@ -106766,11 +106809,11 @@ bns
 cox
 auL
 bbq
-hho
-ipb
-slc
+aBi
+bwQ
 aWw
-haq
+aWw
+aAf
 qab
 aFn
 aYv
@@ -107021,14 +107064,14 @@ bKb
 bdZ
 cjM
 awu
-auq
+auK
 xiQ
 hho
 aAR
 lup
-aDT
-aMZ
-aAf
+atZ
+oGL
+aNv
 aLK
 aYy
 bDp
@@ -107039,7 +107082,7 @@ bDp
 bDp
 aSM
 usn
-rnx
+fcK
 bNk
 bNk
 sqt
@@ -107278,7 +107321,7 @@ bdK
 bdZ
 cjM
 awu
-auw
+auq
 aWw
 nAY
 aAX
@@ -107535,7 +107578,7 @@ bbP
 cpb
 cjM
 awu
-auK
+auq
 slc
 hho
 azA
@@ -107543,7 +107586,7 @@ aMZ
 aFO
 aTp
 bwJ
-atZ
+atK
 owK
 byR
 bEW
@@ -107800,7 +107843,7 @@ aMZ
 blX
 buW
 bwL
-dra
+jQu
 dSI
 bBq
 ikq
@@ -108049,7 +108092,7 @@ bdv
 bdZ
 cjM
 aoS
-aBi
+auL
 aWw
 aWw
 aBY
@@ -108057,7 +108100,7 @@ aMZ
 blK
 aEh
 aEh
-bwQ
+rnx
 bsI
 bDn
 bDn
@@ -108822,9 +108865,9 @@ bgr
 aGn
 ave
 awS
-awS
+dra
 vsv
-avN
+aWy
 bmx
 avN
 avN
@@ -109081,7 +109124,7 @@ dyy
 awS
 awS
 pwX
-aWy
+avN
 bmx
 avN
 avN


### PR DESCRIPTION
## Описание изменений
![image](https://user-images.githubusercontent.com/21008918/215816658-f522845f-b763-43fd-acdf-0310a4486671.png)
1.Убран карманчик у ботаники.
2.Перенесены ящики ботаников внутрь ботаники.
3.Убрана лампочка с трея.
4.Убрана лампочка с трея.
5.Разделены рабочие зоны для двух поваров.
6.Урезана ненужно большая морозилка.
7.Перенесён шкаф с одеждой из морозилки на кухню.
8.Добавлены шаттерсы в зоне для раздачи еды.
9.Диспенсер перенесён к выдаче, чтобы подавать напитки.
10.Добавлены шаттерсы кухонному окну.
11.Убрана стенка 2х2, потому расширена каморка бармена.
12.Заменена стеклянная дверь на кухне на непрозрачную чтобы не уничтожать смысл электрохромного стекла рядом...

Upd. Вернул нишу ботаников. Ввернул нишу кафешки.
![image](https://user-images.githubusercontent.com/21008918/215976029-cb70b94e-015b-4734-8b16-8335dbad427f.png)

## Почему и что этот ПР улучшит
Фиксы по запросам общественности. Quality of Life.
1.
![image](https://user-images.githubusercontent.com/21008918/215803823-9c04ad83-6fdc-479e-bf57-12e1eb585e7d.png)
2.
![image](https://user-images.githubusercontent.com/21008918/215803899-d4530315-3fb1-46f0-bef0-d6eddd1ee8bf.png)
3. Людям мешала видеть огоньки трея.
4. Людям мешала видеть огоньки трея.
5. Чтобы два повара не готовили говно когда не заметили что один из них положил в устройство свою еду. Удобство парной готовки.
6. Морозилка и так большая, а когда я убрал ящик с одеждой на кухню там оказалось ещё пустее.
7. Шкаф в морозилке это говно как шкафы ботаников в саду.
8. Чтобы закрывать кухню как раньше.
9. Чтобы подавать напитки.
10. Чтобы не вламывались.
11. Бесит.
12. Логично.

## Авторство
AndreyGysev и все все все, кто помогал в дискорде.

## Чеинжлог
:cl: 
 - map: небольшие изменения на кухне и ботанике бокса.