### PR TITLE
3 новых сигнала шока

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -316,6 +316,14 @@
 #define COMSIG_MOB_SWAP_HANDS "mob_swap_hands"
 	#define COMPONENT_BLOCK_SWAP 1
 
+
+///sent by stuff like stunbatons and tasers: ()
+#define COMSIG_MOB_MINOR_SHOCK "mob_minor_shock"
+///sent by adbuctor baton: ()
+#define COMSIG_MOB_ABDUCTION_SHOCK "mob_abduction_shock"
+///sent by defib act: ()
+#define COMSIG_MOB_DEFIB_SHOCK "mob_defib_shock"
+
 /// from /datum/action/changeling/transform/sting_action(): (mob/living/carbon/human/user)
 #define COMSIG_CHANGELING_TRANSFORM "changeling_transform"
 /// from /mob/living/carbon/proc/finish_monkeyize()

--- a/code/game/gamemodes/modes_gameplays/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/modes_gameplays/abduction/abduction_gear.dm
@@ -454,7 +454,7 @@
 	L.Stun(7)
 	L.Weaken(7)
 	L.apply_effect(STUTTER, 7)
-
+	SEND_SIGNAL(L, COMSIG_MOB_ABDUCTION_SHOCK)
 	L.visible_message("<span class='danger'>[user] has stunned [L] with [src]!</span>", \
 							"<span class='userdanger'>[user] has stunned you with [src]!</span>")
 	playsound(src, 'sound/weapons/Egloves.ogg', VOL_EFFECTS_MASTER)

--- a/code/game/objects/items/weapons/defibrillator.dm
+++ b/code/game/objects/items/weapons/defibrillator.dm
@@ -319,6 +319,7 @@
 
 	if(user.a_intent == INTENT_HARM)
 		do_electrocute(M, user, def_zone)
+		SEND_SIGNAL(M, COMSIG_MOB_DEFIB_SHOCK)
 	else
 		try_revive(M, user)
 

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -92,7 +92,7 @@
 		else
 			discharge()
 		H.visible_message("<span class='danger'>[M] has been attacked with the [src] by [user]!</span>")
-
+		SEND_SIGNAL(H, COMSIG_MOB_MINOR_SHOCK)
 		if(!(user.a_intent == INTENT_HARM))
 			H.log_combat(user, "stunned (attempt) with [name]")
 

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -181,6 +181,10 @@
 	. = ..()
 	proj_act_sound = null
 
+/obj/item/projectile/beam/stun/on_hit(atom/target, def_zone = BP_CHEST, blocked = 0)
+	. = ..()
+	SEND_SIGNAL(target, COMSIG_MOB_MINOR_SHOCK)
+
 /obj/item/projectile/beam/cult_laser
 	name = "beam"
 	icon_state = "emitter"

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -20,6 +20,10 @@
 	damage_type = HALLOSS
 	//Damage will be handled on the MOB side, to prevent window shattering.
 
+/obj/item/projectile/energy/electrode/on_hit(atom/target, def_zone = BP_CHEST, blocked = 0)
+	. = ..()
+	SEND_SIGNAL(target, COMSIG_MOB_MINOR_SHOCK)
+
 /obj/item/projectile/energy/declone
 	name = "declone"
 	icon_state = "declone"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Порт с ТГ. Там один сигнал на все COMSIG_LIVING_MINOR_SHOCK, а я подумал что можно и разделить, всё же они не много общего имеют между собой.

Добавление сигналов на атаку абдуктора станпалкой, луч тазера, электрод, станбатон, неудачный залп деффибрилятора. Можно будет наложить дополнительные эффекты на эти действия.

Не уверен надо ли дополнительно проверять у выстрелов что таргет является мобом. Думаю, оно и в таком виде нормально, но на ТГ проверяется.
## Почему и что этот ПР улучшит
дорога к нанитам
## Авторство

## Чеинжлог
