### PR TITLE
Добавление дефайнов для айди серверов и консолей РнД

### DIFF
--- a/code/__DEFINES/research.dm
+++ b/code/__DEFINES/research.dm
@@ -8,3 +8,12 @@
 
 // Is used in calculating reliability increase per prototype created.
 #define RND_RELIABILITY_EXPONENT 0.75
+
+#define DEFAULT_CENTCOM_SERVER_ID -1
+#define DEFAULT_SCIENCE_SERVER_ID 1
+#define DEFAULT_ROBOTICS_SERVER_ID 2
+#define DEFAULT_MINING_SERVER_ID 3
+
+#define DEFAULT_SCIENCE_CONSOLE_ID 1
+#define DEFAULT_ROBOTICS_CONSOLE_ID 2
+#define DEFAULT_MINING_CONSOLE_ID 3

--- a/code/modules/research/experiment.dm
+++ b/code/modules/research/experiment.dm
@@ -14,9 +14,9 @@
 	)
 
 
-	//Determines maximum amount of points that can be earned by certain methods. 
+	//Determines maximum amount of points that can be earned by certain methods.
 	//Total points that can be earned equal highest score multiplied by this number
-	var/cap_coeff = 2 
+	var/cap_coeff = 2
 
 	var/list/tech_points = list(
 		"materials" = 200,
@@ -247,8 +247,8 @@
 
 /obj/item/device/radio/beacon/interaction_watcher/proc/research_interaction(inter_type, score, new_score_coeff=800, repeat_score_coeff=160)
 	var/calculated_research_points = -1
-	for(var/obj/machinery/computer/rdconsole/RD in RDcomputer_list)
-		if(RD.id == 1)
+	for(var/obj/machinery/computer/rdconsole/RD as anything in global.RDcomputer_list)
+		if(RD.id == DEFAULT_SCIENCE_CONSOLE_ID)
 			var/saved_interaction_score = RD.files.experiments.saved_best_score[inter_type]
 			var/saved_earned_points = max(RD.files.experiments.earned_score[inter_type], 1)
 

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -55,7 +55,7 @@ cause a ton of data to be lost, an admin can go send it back.
 	allowed_checks = ALLOWED_CHECK_NONE
 
 	required_skills = list(/datum/skill/research = SKILL_LEVEL_TRAINED)
-
+ADD_TO_GLOBAL_LIST(/obj/machinery/computer/rdconsole, RDcomputer_list)
 /obj/machinery/computer/rdconsole/proc/CallMaterialName(ID)
 	var/datum/reagent/temp_reagent
 	var/return_name = null
@@ -114,12 +114,10 @@ cause a ton of data to be lost, an admin can go send it back.
 
 /obj/machinery/computer/rdconsole/atom_init()
 	. = ..()
-	RDcomputer_list += src
 	files = new /datum/research(src) //Setup the research data holder.
 	SyncRDevices()
 
 /obj/machinery/computer/rdconsole/Destroy()
-	RDcomputer_list -= src
 	if(linked_destroy)
 		linked_destroy.linked_console = null
 		linked_destroy = null
@@ -672,7 +670,7 @@ cause a ton of data to be lost, an admin can go send it back.
 
 /obj/machinery/computer/rdconsole/robotics
 	name = "Robotics R&D Console"
-	id = 2
+	id = DEFAULT_ROBOTICS_CONSOLE_ID
 	req_access = list(29)
 	can_research = FALSE
 	required_skills = list(/datum/skill/research = SKILL_LEVEL_TRAINED)
@@ -685,12 +683,12 @@ cause a ton of data to be lost, an admin can go send it back.
 
 /obj/machinery/computer/rdconsole/core
 	name = "Core R&D Console"
-	id = 1
+	id = DEFAULT_SCIENCE_CONSOLE_ID
 	can_research = TRUE
 
 /obj/machinery/computer/rdconsole/mining
 	name = "Mining R&D Console"
-	id = 3
+	id = DEFAULT_MINING_CONSOLE_ID
 	req_access = list(48)
 	can_research = FALSE
 	required_skills = list(/datum/skill/research = SKILL_LEVEL_NOVICE)

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -128,7 +128,7 @@
 
 /obj/machinery/r_n_d/server/centcom
 	name = "Centcom Central R&D Database"
-	server_id = -1
+	server_id = DEFAULT_CENTCOM_SERVER_ID
 
 /obj/machinery/r_n_d/server/centcom/atom_init()
 	. = ..()
@@ -136,7 +136,7 @@
 	var/list/server_ids = list()
 	for(var/obj/machinery/r_n_d/server/S in rnd_server_list)
 		switch(S.server_id)
-			if(-1)
+			if(DEFAULT_CENTCOM_SERVER_ID)
 				continue
 			if(0)
 				no_id_servers += S
@@ -190,7 +190,7 @@
 				break
 		if(href_list["access"])
 			screen = 1
-			for(var/obj/machinery/computer/rdconsole/C in computer_list)
+			for(var/obj/machinery/computer/rdconsole/C as anything in global.RDcomputer_list)
 				if(C.sync)
 					consoles += C
 		else if(href_list["data"])
@@ -250,7 +250,7 @@
 		if(1) //Access rights menu
 			dat += "[temp_server.name] Access Rights<BR><BR>"
 			dat += "Consoles with Upload Access<BR>"
-			for(var/obj/machinery/computer/rdconsole/C in consoles)
+			for(var/obj/machinery/computer/rdconsole/C as anything in global.RDcomputer_list)
 				var/turf/console_turf = get_turf(C)
 				dat += "* <A href='?src=\ref[src];upload_toggle=[C.id]'>[console_turf.loc]" //FYI, these are all numeric ids, eventually.
 				if(C.id in temp_server.id_with_upload)
@@ -258,7 +258,7 @@
 				else
 					dat += "Add</A><BR>"
 			dat += "Consoles with Download Access<BR>"
-			for(var/obj/machinery/computer/rdconsole/C in consoles)
+			for(var/obj/machinery/computer/rdconsole/C as anything in global.RDcomputer_list)
 				var/turf/console_turf = get_turf(C)
 				dat += "* <A href='?src=\ref[src];download_toggle=[C.id]'>[console_turf.loc]"
 				if(C.id in temp_server.id_with_download)
@@ -310,17 +310,17 @@
 	name = "Robotics R&D Server"
 	id_with_upload_string = "1;2"
 	id_with_download_string = "1;2"
-	server_id = 2
+	server_id = DEFAULT_ROBOTICS_SERVER_ID
 
 
 /obj/machinery/r_n_d/server/core
 	name = "Core R&D Server"
 	id_with_upload_string = "1"
 	id_with_download_string = "1"
-	server_id = 1
+	server_id = DEFAULT_SCIENCE_SERVER_ID
 
 /obj/machinery/r_n_d/server/mining
 	name = "Mining R&D Server"
 	id_with_upload_string = "1;3"
 	id_with_download_string = "1;3"
-	server_id = 3
+	server_id = DEFAULT_MINING_SERVER_ID


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Изменил цифровые обозначения консолей и серверов на дефайны. Заменил заполнение консолей в глобальный список на дефайновое. Поставил в циклах с поиском РД консолей `as anything`
## Почему и что этот ПР улучшит
Улучшение читаемости кода, дорога к нанитам
## Авторство

## Чеинжлог
