### PR TITLE
Добавление трейта для препятствия разрыва артерий

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -168,9 +168,6 @@
 #define TRAIT_CULT_EYES           "cult_eyes"
 #define TRAIT_CULT_HALO           "cult_halo"
 #define TRAIT_HEALS_FROM_PYLONS   "heals_from_pylons"
-
-
-
 #define TRAIT_HEMOCOAGULATION     "hemocoagulation"
 
 /*

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -169,6 +169,10 @@
 #define TRAIT_CULT_HALO           "cult_halo"
 #define TRAIT_HEALS_FROM_PYLONS   "heals_from_pylons"
 
+
+
+#define TRAIT_HEMOCOAGULATION     "hemocoagulation"
+
 /*
  * Used for movables that need to be updated, via COMSIG_ENTER_AREA and COMSIG_EXIT_AREA, when transitioning areas.
  * Use [/atom/movable/proc/become_area_sensitive(trait_source)] to properly enable it. How you remove it isn't as important.

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -1457,6 +1457,8 @@
 /datum/species/zombie/on_gain(mob/living/carbon/human/H)
 	..()
 
+	ADD_TRAIT(H, TRAIT_HEMOCOAGULATION, GENERIC_TRAIT)
+
 	H.remove_status_flags(CANSTUN|CANPARALYSE) //CANWEAKEN
 
 	H.drop_l_hand()
@@ -1468,6 +1470,8 @@
 	add_zombie(H)
 
 /datum/species/zombie/on_loose(mob/living/carbon/human/H, new_species)
+	REMOVE_TRAIT(H, TRAIT_HEMOCOAGULATION, GENERIC_TRAIT)
+
 	H.add_status_flags(MOB_STATUS_FLAGS_DEFAULT)
 
 	if(istype(H.l_hand, /obj/item/weapon/melee/zombie_hand))

--- a/code/modules/organs/external/flesh.dm
+++ b/code/modules/organs/external/flesh.dm
@@ -589,7 +589,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	return BP.species.blood_datum.color
 
 /datum/bodypart_controller/proc/sever_artery()
-	if(HAS_TRAIT(BP.owner, TRAIT_HEMOCOAGULATION, NANITE_TRAIT))
+	if(HAS_TRAIT(BP.owner, TRAIT_HEMOCOAGULATION))
 		return FALSE
 	if(!(BP.status & ORGAN_ARTERY_CUT) && BP.owner.organs_by_name[O_HEART])
 		BP.status |= ORGAN_ARTERY_CUT

--- a/code/modules/organs/external/flesh.dm
+++ b/code/modules/organs/external/flesh.dm
@@ -589,7 +589,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	return BP.species.blood_datum.color
 
 /datum/bodypart_controller/proc/sever_artery()
-	if(iszombie(BP.owner))
+	if(HAS_TRAIT(BP.owner, TRAIT_HEMOCOAGULATION, NANITE_TRAIT))
 		return FALSE
 	if(!(BP.status & ORGAN_ARTERY_CUT) && BP.owner.organs_by_name[O_HEART])
 		BP.status |= ORGAN_ARTERY_CUT


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
в #10284 делал iszombie проверку, теперь сделал добавление зомбям нового трейта при получении расы и его проверку в органах
## Почему и что этот ПР улучшит
Улучшение кода, дорога к нанитам.
## Авторство

## Чеинжлог
