### PR TITLE
Нанитовое дополнение кода исследований

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -30,10 +30,11 @@ cause a ton of data to be lost, an admin can go send it back.
 	icon_state = "rdcomp"
 	light_color = "#a97faa"
 	circuit = /obj/item/weapon/circuitboard/rdconsole
+	var/research_datum_type = /datum/research
+	var/list/blacklisted_techs_list = list()
 	var/datum/research/files							//Stores all the collected research data.
 	var/obj/item/weapon/disk/tech_disk/t_disk = null	//Stores the technology disk.
 	var/obj/item/weapon/disk/design_disk/d_disk = null	//Stores the design disk.
-	var/research_datum_type = /datum/research
 
 	var/obj/machinery/r_n_d/destructive_analyzer/linked_destroy = null	//Linked Destructive Analyzer
 	var/obj/machinery/r_n_d/protolathe/linked_lathe = null				//Linked Protolathe
@@ -120,7 +121,7 @@ ADD_TO_GLOBAL_LIST(/obj/machinery/computer/rdconsole, RDcomputer_list)
 	SyncRDevices()
 
 /obj/machinery/computer/rdconsole/proc/create_research_files()
-	files = new research_datum_type(src)
+	files = new research_datum_type(src, blacklisted_tech = blacklisted_techs_list)
 
 /obj/machinery/computer/rdconsole/Destroy()
 	if(linked_destroy)
@@ -676,8 +677,8 @@ ADD_TO_GLOBAL_LIST(/obj/machinery/computer/rdconsole, RDcomputer_list)
 /obj/machinery/computer/rdconsole/robotics
 	name = "Robotics R&D Console"
 	id = DEFAULT_ROBOTICS_CONSOLE_ID
+	research_datum_type = /datum/research/robotics
 	req_access = list(29)
-	can_research = FALSE
 	required_skills = list(/datum/skill/research = SKILL_LEVEL_TRAINED)
 
 /obj/machinery/computer/rdconsole/robotics/atom_init()
@@ -690,12 +691,14 @@ ADD_TO_GLOBAL_LIST(/obj/machinery/computer/rdconsole, RDcomputer_list)
 	name = "Core R&D Console"
 	id = DEFAULT_SCIENCE_CONSOLE_ID
 	can_research = TRUE
+	blacklisted_techs_list = list(RESEARCH_ROBOTICS)
 
 /obj/machinery/computer/rdconsole/mining
 	name = "Mining R&D Console"
 	id = DEFAULT_MINING_CONSOLE_ID
 	req_access = list(48)
 	can_research = FALSE
+	blacklisted_techs_list = list(RESEARCH_ROBOTICS)
 	required_skills = list(/datum/skill/research = SKILL_LEVEL_NOVICE)
 
 /obj/machinery/computer/rdconsole/mining/atom_init()

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -33,6 +33,7 @@ cause a ton of data to be lost, an admin can go send it back.
 	var/datum/research/files							//Stores all the collected research data.
 	var/obj/item/weapon/disk/tech_disk/t_disk = null	//Stores the technology disk.
 	var/obj/item/weapon/disk/design_disk/d_disk = null	//Stores the design disk.
+	var/research_datum_type = /datum/research
 
 	var/obj/machinery/r_n_d/destructive_analyzer/linked_destroy = null	//Linked Destructive Analyzer
 	var/obj/machinery/r_n_d/protolathe/linked_lathe = null				//Linked Protolathe
@@ -115,8 +116,12 @@ cause a ton of data to be lost, an admin can go send it back.
 /obj/machinery/computer/rdconsole/atom_init()
 	. = ..()
 	RDcomputer_list += src
-	files = new /datum/research(src) //Setup the research data holder.
+	//Setup the research data holder.
+	create_research_files()
 	SyncRDevices()
+
+/obj/machinery/computer/rdconsole/proc/create_research_files()
+	files = new research_datum_type(src)
 
 /obj/machinery/computer/rdconsole/Destroy()
 	RDcomputer_list -= src
@@ -298,7 +303,7 @@ cause a ton of data to be lost, an admin can go send it back.
 		if(choice == "Continue")
 			screen = "working"
 			qdel(files)
-			files = new /datum/research(src)
+			create_research_files()
 			spawn(20)
 				screen = "main"
 				nanomanager.update_uis(src)

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -65,17 +65,12 @@ The tech datums are the actual "tech trees" that you improve through researching
 			design_reliabilities[d.id] = 10
 			design_created_prototypes[d.id] = 0
 
-	for(var/T in subtypesof(/datum/tech))
-		var/datum/tech/Tech_Tree = new T
-		tech_trees[Tech_Tree.id] = Tech_Tree
-		all_technologies[Tech_Tree.id] = list()
+	generate_trees()
 
 	for(var/T in subtypesof(/datum/technology))
 		var/datum/technology/Tech = new T
 		if(all_technologies[Tech.tech_type])
 			all_technologies[Tech.tech_type][Tech.id] = Tech
-		else
-			WARNING("Unknown tech_type '[Tech.tech_type]' in technology '[Tech.name]'")
 
 	for(var/tech_tree_id in tech_trees)
 		var/datum/tech/Tech_Tree = tech_trees[tech_tree_id]
@@ -89,6 +84,12 @@ The tech datums are the actual "tech trees" that you improve through researching
 	experiments = new /datum/experiment_data()
 	// This is a science station. Most tech is already at least somewhat known.
 	experiments.init_known_tech()
+
+/datum/research/proc/generate_trees()
+	for(var/T in subtypesof(/datum/tech))
+		var/datum/tech/Tech_Tree = new T
+		tech_trees[Tech_Tree.id] = Tech_Tree
+		all_technologies[Tech_Tree.id] = list()
 
 /datum/research/proc/IsResearched(datum/technology/T)
 	return !!researched_tech[T.id]
@@ -185,16 +186,23 @@ The tech datums are the actual "tech trees" that you improve through researching
 	T.avg_reliability = GetAverageDesignReliability(T)
 
 /datum/research/proc/download_from(datum/research/O)
+	var/list/our_tech_trees = list()
 
 	for(var/tech_tree_id in O.tech_trees)
 		var/datum/tech/Tech_Tree = O.tech_trees[tech_tree_id]
 		var/datum/tech/Our_Tech_Tree = tech_trees[tech_tree_id]
 
-		if(Tech_Tree.shown)
-			Our_Tech_Tree.shown = Tech_Tree.shown
+		if(Our_Tech_Tree)
+			our_tech_trees[Our_Tech_Tree.id] = Our_Tech_Tree
+			if(Tech_Tree.shown)
+				Our_Tech_Tree.shown = Tech_Tree.shown
 
 	for(var/tech_id in O.researched_tech)
 		var/datum/technology/T = O.researched_tech[tech_id]
+		if(T)
+			//is my files have that tech tree?
+			if(isnull(our_tech_trees[T.tech_type]))
+				continue
 		UnlockTechology(T, force = TRUE)
 
 		for(var/D in T.unlocks_designs)

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -54,7 +54,7 @@ The tech datums are the actual "tech trees" that you improve through researching
 
 	var/research_points = 0
 
-/datum/research/New()
+/datum/research/New(list/blacklisted_tech)
 	for(var/D in subtypesof(/datum/design))
 		var/datum/design/d = new D(src)
 		design_by_id[d.id] = d
@@ -64,9 +64,7 @@ The tech datums are the actual "tech trees" that you improve through researching
 		else
 			design_reliabilities[d.id] = 10
 			design_created_prototypes[d.id] = 0
-
-	generate_trees()
-
+	generate_trees(blacklisted_tech)
 	for(var/T in subtypesof(/datum/technology))
 		var/datum/technology/Tech = new T
 		if(all_technologies[Tech.tech_type])
@@ -84,12 +82,6 @@ The tech datums are the actual "tech trees" that you improve through researching
 	experiments = new /datum/experiment_data()
 	// This is a science station. Most tech is already at least somewhat known.
 	experiments.init_known_tech()
-
-/datum/research/proc/generate_trees()
-	for(var/T in subtypesof(/datum/tech))
-		var/datum/tech/Tech_Tree = new T
-		tech_trees[Tech_Tree.id] = Tech_Tree
-		all_technologies[Tech_Tree.id] = list()
 
 /datum/research/proc/IsResearched(datum/technology/T)
 	return !!researched_tech[T.id]
@@ -155,7 +147,8 @@ The tech datums are the actual "tech trees" that you improve through researching
 	researched_tech[T.id] = T
 	if(!force)
 		research_points -= T.cost
-	tech_trees[T.tech_type].level += 1
+	if(tech_trees[T.tech_type])
+		tech_trees[T.tech_type].level += 1
 
 	for(var/t in T.unlocks_designs)
 		var/datum/design/D = design_by_id[t]
@@ -280,6 +273,19 @@ The tech datums are the actual "tech trees" that you improve through researching
 			if(item_tech == T.item_tech_req)
 				T.shown = TRUE
 				return
+
+/datum/research/proc/generate_trees(list/blacklisted_tech)
+	for(var/T in subtypesof(/datum/tech))
+		var/datum/tech/Tech_Tree = new T
+		if(Tech_Tree.id in blacklisted_tech)
+			continue
+		tech_trees[Tech_Tree.id] = Tech_Tree
+		all_technologies[Tech_Tree.id] = list()
+
+/datum/research/robotics/generate_trees()
+	var/datum/tech/Tech_Tree = new /datum/tech/robotics
+	tech_trees[Tech_Tree.id] = Tech_Tree
+	all_technologies[Tech_Tree.id] = list()
 
 /***************************************************************
 **						Technology Datums					  **

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -13,6 +13,8 @@
 	var/heat_gen = 100
 	var/heating_power = 40000
 	var/delay = 10
+	var/research_datum_type = /datum/research
+	var/list/blacklisted_techs_list = list()
 	req_access = list(access_rd) //Only the R&D can change server settings.
 
 /obj/machinery/r_n_d/server/atom_init()
@@ -39,7 +41,7 @@
 /obj/machinery/r_n_d/server/atom_init()
 	. = ..()
 	if(!files)
-		files = new /datum/research(src)
+		files = new research_datum_type(src, blacklisted_tech = blacklisted_techs_list)
 	var/list/temp_list
 	if(!id_with_upload.len)
 		temp_list = list()
@@ -311,16 +313,18 @@
 	id_with_upload_string = "1;2"
 	id_with_download_string = "1;2"
 	server_id = DEFAULT_ROBOTICS_SERVER_ID
-
+	research_datum_type = /datum/research/robotics
 
 /obj/machinery/r_n_d/server/core
 	name = "Core R&D Server"
 	id_with_upload_string = "1"
 	id_with_download_string = "1"
 	server_id = DEFAULT_SCIENCE_SERVER_ID
+	blacklisted_techs_list = list(RESEARCH_ROBOTICS)
 
 /obj/machinery/r_n_d/server/mining
 	name = "Mining R&D Server"
 	id_with_upload_string = "1;3"
 	id_with_download_string = "1;3"
 	server_id = DEFAULT_MINING_SERVER_ID
+	blacklisted_techs_list = list(RESEARCH_ROBOTICS)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Перенёс создание датумов исследований и древ исследований в проки, чтобы их можно было переопределять в дочерних типах. Убран ворнинг, который предупреждает во время загрузки что какой-то какая-то технология не была занесена в ассоциативный список с древами `all_technologies` текущего датума исследований (если мы захотим не давать какое-нибудь древо нашему датуму, то технологии этого древа вызовут эти ворнинги, но корректно не запишутся в `all_technologies`)

Немного дополнен `download_from()` который не предполагает что источник загрузки и текущий датум исследований  могут иметь разные древа исследований. Теперь он проверяет нашлось ли вообще это древо у текущего датума исследований `(Our_Tech_Tree`). Создан ассоциативный список для проверки в другом цикле технологий, которые мы должны перенести из источника в наш датум, а которые должны пропустить.

Создан новый датум исследований роботехники, отличие которого в том, что он имеет только одно дерево для исследований. Добавлен роботехнической консоли и серверу.

Удалено дерево исследований роботехники на РнД и шахтёрской консоли путём создания не очень красивых но рабочих переменных blacklisted_tech у консолей и серверов.

Удалён запрет роботехнической консоли исследовать технологии.

Я тестировал синхронизации и другие манипуляции с серверами (конкретно удаление и восстановление) и всё работало как и должно.
## Почему и что этот ПР улучшит
Это ПР в ветку нанитов.
Меньше хардкода в исследованиях по технологиям. Добавление возможности роботехникам иметь независимые (от заблокированной им консоли учёных) исследований. Усиление акцента на работу роботехника с ригами и их модулями.
## Авторство

## Чеинжлог
