### PR TITLE
Admin funny button. Peaceful Mode

### DIFF
--- a/code/_globalvars/station.dm
+++ b/code/_globalvars/station.dm
@@ -10,3 +10,5 @@ var/global/datum/moduletypes/mods = new()
 
 // Reference list for disposal sort junctions. Filled up by sorting junction's New()
 var/global/list/tagger_locations = list()
+
+var/global/DEATH_EXPLOSION = FALSE

--- a/code/modules/admin/secrets.dm
+++ b/code/modules/admin/secrets.dm
@@ -118,6 +118,7 @@
 					<A href='?src=\ref[src];secretsfun=sec_classic1'>Remove firesuits, grilles, and pods</A><BR>
 					<A href='?src=\ref[src];secretsfun=drop_asteroid'>Drop asteroid</A><BR>
 					<A href='?src=\ref[src];secretsfun=global_sound_speed'>Set global sound speed modifier</A><BR>
+					<A href='?src=\ref[src];secretsfun=death_explosion'>Toggle Death Explosion Mode</A><BR>
 					"}
 
 	var/datum/browser/popup = new(usr, "secrets", "<div align='center'>Admin Secrets</div>", 500, 812)
@@ -529,6 +530,15 @@
 			message_admins("[key_name_admin(usr)] has modified global sound speed to [playsound_frequency_admin]")
 			feedback_inc("admin_secrets_fun_used",1)
 			feedback_add_details("admin_secrets_fun_used","Global Sound Frequency")
+
+		if("death_explosion")
+			global.DEATH_EXPLOSION = !global.DEATH_EXPLOSION
+			if(global.DEATH_EXPLOSION)
+				to_chat(world, "<span class='warning'>Peaceful mode activated!</span>")
+			else
+				to_chat(usr, "<span class='notice'>Violence mode activated.</span>")
+			feedback_inc("admin_secrets_fun_used",1)
+			feedback_add_details("admin_secrets_fun_used","DeathEx")
 		else
 			to_chat(world, "oof, this is ["secretsfun"] not worked")
 	if(usr)

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -85,6 +85,8 @@
 	..(gibbed)
 
 	SSStatistics.add_death_stat(src)
+	if(global.DEATH_EXPLOSION)
+		explosion(get_turf(src), 1, 2, 4, 7, FALSE)
 
 // Called right after we will lost our head
 /mob/living/carbon/human/proc/handle_decapitation(obj/item/organ/external/head/BP)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Добавление кнопки в OOC Events панельке секретов администрации "Toggle Death Explosion Mode". Исходя из названия думаю понятно что она включает взрыв после смерти (только для хуманов).
## Почему и что этот ПР улучшит
Больше приколов для админов и игроков. Можно включать в эксту, когда эскалация конфликта до смерти оппонента врядли была бы уместна.
## Авторство

## Чеинжлог
:cl: Deahaka
- add[link]: Новая кнопка в меню секретов администраторов.