### PR TITLE
Не ставьте консоль исследований на дереликте без смены ей ID

### DIFF
--- a/maps/RandomZLevels/zresearchlabs.dmm
+++ b/maps/RandomZLevels/zresearchlabs.dmm
@@ -2827,7 +2827,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/computer/rdconsole/core,
+/obj/machinery/computer/rdconsole/core{
+	id = 0
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "bot"

--- a/maps/templates/space_structures/abandoned_lab.dmm
+++ b/maps/templates/space_structures/abandoned_lab.dmm
@@ -773,7 +773,9 @@
 /turf/simulated/floor/plating/airless/catwalk,
 /area/space_structures/derelict_lab)
 "cs" = (
-/obj/machinery/computer/rdconsole/core,
+/obj/machinery/computer/rdconsole/core{
+	id = 0
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Поменял РД-консолям на дереликтах ID. Теперь не конфликтуют с станционными.
## Почему и что этот ПР улучшит
Абсолютно точно необходимо к https://github.com/TauCetiStation/TauCetiClassic/pull/10695 в данный момент
## Авторство

## Чеинжлог
