### PR TITLE
Усиление охраны. Развиваем мышцы.

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -28,6 +28,11 @@
 	*/
 	restricted_species = list(SKRELL, UNATHI, TAJARAN, DIONA, VOX, IPC)
 
+/datum/job/hos/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	for(var/obj/item/organ/external/BP in H.bodyparts)
+		if(BP.max_pumped > 0)
+			BP.adjust_pumped(BP.max_pumped)
+			BP.update_sprite()
 
 /datum/job/warden
 	title = "Warden"
@@ -53,6 +58,11 @@
 	*/
 	restricted_species = list(TAJARAN, DIONA, VOX, IPC)
 
+/datum/job/warden/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	for(var/obj/item/organ/external/BP in H.bodyparts)
+		if(BP.max_pumped > 0)
+			BP.adjust_pumped(BP.max_pumped)
+			BP.update_sprite()
 
 /datum/job/detective
 	title = "Detective"
@@ -103,6 +113,11 @@
 	*/
 	restricted_species = list(DIONA, TAJARAN, VOX, IPC)
 
+/datum/job/officer/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	for(var/obj/item/organ/external/BP in H.bodyparts)
+		if(BP.max_pumped > 0)
+			BP.adjust_pumped(BP.max_pumped)
+			BP.update_sprite()
 
 /datum/job/forensic
 	title = "Forensic Technician"
@@ -152,3 +167,9 @@
 		~Luduk
 	*/
 	restricted_species = list(DIONA, TAJARAN, VOX, IPC)
+
+/datum/job/cadet/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	for(var/obj/item/organ/external/BP in H.bodyparts)
+		if(BP.max_pumped > 0)
+			BP.adjust_pumped(BP.max_pumped)
+			BP.update_sprite()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Балансобаф, направленный на небольшое усиление СБ, не трогая каждого антагониста по отдельности. Кадетам, Офицерам, Вардену и ГСБ теперь наращивают мышцы на велосити. Накачанные части тела в общей суме дают: +-20% защиты органам, уменьшают замедление при передвижении в тяжёлых костюмах, увеличенный урон в ближнем бою.
## Почему и что этот ПР улучшит
боланс. Охрана сейчас переживает не лучшие времена и в дальнейшем я не вижу как с текущим балансом у неё забрать ваншот-гранатомёт, пробивные дубинки и электрод в тазере.
## Авторство
Идею придумал coiscin
## Чеинжлог
:cl: Deahaka
- balance: Служба Безопасности подкачалась.