### PR TITLE
shieldwallgen & shieldwall upd

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -17,6 +17,8 @@
 
 #define iswallturf(A) (istype(A, /turf/simulated/wall))
 
+#define isshieldwall(A) (istype(A, /obj/machinery/shieldwall))
+
 // HUMAN
 
 #define ishuman(A) (istype(A, /mob/living/carbon/human))

--- a/code/_onclick/adjacent.dm
+++ b/code/_onclick/adjacent.dm
@@ -105,6 +105,8 @@ Quick adjacency (to turf):
 	for(var/obj/O in src)
 		if( !O.density || O == target_atom || O.throwpass) continue // throwpass is used for anything you can click through
 
+		if(isshieldwall(O))
+			return FALSE
 		if( O.flags&ON_BORDER) // windows have throwpass but are on border, check them first
 			if( O.dir & target_dir || O.dir&(O.dir-1) ) // full tile windows are just diagonals mechanically
 				var/obj/structure/window/W = target_atom

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -217,6 +217,7 @@
 	req_access = list(access_research)
 	flags = CONDUCT
 	use_power = NO_POWER_USE
+	unacidable  = 1
 	var/active = FALSE
 	var/power = 0
 	var/state = 0

--- a/code/game/machinery/shieldgen.dm
+++ b/code/game/machinery/shieldgen.dm
@@ -217,7 +217,6 @@
 	req_access = list(access_research)
 	flags = CONDUCT
 	use_power = NO_POWER_USE
-	unacidable  = 1
 	var/active = FALSE
 	var/power = 0
 	var/state = 0

--- a/code/modules/mob/living/carbon/xenomorph/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/humanoid/alien_powers.dm
@@ -13,14 +13,14 @@
 		return FALSE
 	return TRUE
 
-/mob/living/carbon/xenomorph/humanoid/proc/corrosive_acid(O in oview(1)) //If they right click to corrode, an error will flash if its an invalid target./N
+/mob/living/carbon/xenomorph/humanoid/proc/corrosive_acid(atom/O as obj | turf in oview(1)) //If they right click to corrode, an error will flash if its an invalid target./N
 	set name = "Corrossive Acid (100)"
 	set desc = "Drench an object in acid, destroying it over time."
 	set category = "Alien"
 
 	if(powerc(100))
 		if(O in oview(1))
-			if(!usr.Adjacent(O))
+			if(!O.Adjacent(usr))
 				return
 			else
 				// OBJ CHECK

--- a/code/modules/mob/living/carbon/xenomorph/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/xenomorph/humanoid/alien_powers.dm
@@ -20,25 +20,28 @@
 
 	if(powerc(100))
 		if(O in oview(1))
-			// OBJ CHECK
-			if(isobj(O))
-				var/obj/I = O
-				if(I.unacidable)	//So the aliens don't destroy energy fields/singularies/other aliens/etc with their acid.
-					to_chat(src, "<span class='warning'>You cannot dissolve this object.</span>")
-					return
-			// TURF CHECK
-			else if(istype(O, /turf/simulated))
-				var/turf/T = O
-				// R WALL
-				if(istype(T, /turf/simulated/wall/r_wall))
-					to_chat(src, "<span class='warning'>You cannot dissolve this object.</span>")
-					return
-				// R FLOOR
-				if(istype(T, /turf/simulated/floor/engine))
-					to_chat(src, "<span class='warning'>You cannot dissolve this object.</span>")
-					return
-			else// Not a type we can acid.
+			if(!usr.Adjacent(O))
 				return
+			else
+				// OBJ CHECK
+				if(isobj(O))
+					var/obj/I = O
+					if(I.unacidable)	//So the aliens don't destroy energy fields/singularies/other aliens/etc with their acid.
+						to_chat(src, "<span class='warning'>You cannot dissolve this object.</span>")
+						return
+				// TURF CHECK
+				else if(istype(O, /turf/simulated))
+					var/turf/T = O
+					// R WALL
+					if(istype(T, /turf/simulated/wall/r_wall))
+						to_chat(src, "<span class='warning'>You cannot dissolve this object.</span>")
+						return
+					// R FLOOR
+					if(istype(T, /turf/simulated/floor/engine))
+						to_chat(src, "<span class='warning'>You cannot dissolve this object.</span>")
+						return
+				else// Not a type we can acid.
+					return
 
 			adjustToxLoss(-100)
 			new /obj/effect/alien/acid(get_turf(O), O)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Теперь, все что находится под стеной энергетического щита, не может атаковано, по тому же принципу что и с полнотайловым стеклом.

Генератор энергетического щита теперь нельзя расплавить. 
## Почему и что этот ПР улучшит
Щит будет защищать то что под ним, а не просто блокировать проход и не позволять прострелить себя.

Генератор энергетического щита не будут плавить и сбегать при любой возможности.
## Авторство

## Чеинжлог
:cl:
- tweak: Поле энергетического щита блокирует взаимодействия с вещами в нем.
- tweak: Генератор энергетического щита больше нельзя расплавить кислотой.