### PR TITLE
Скилы на столы

### DIFF
--- a/code/game/objects/items/weapons/table_rack_parts.dm
+++ b/code/game/objects/items/weapons/table_rack_parts.dm
@@ -129,11 +129,10 @@
 
 /obj/item/weapon/rack_parts/attack_self(mob/user)
 	var/turf/simulated/T = get_turf(user)
-	if(handle_fumbling(user, src, SKILL_TASK_AVERAGE, list(/datum/skill/engineering = SKILL_LEVEL_NOVICE)))
-		if(T.CanPass(null, T))
-			var/obj/structure/rack/R = new /obj/structure/rack( T )
-			to_chat(user, "<span class='notice'>You assemble [src].</span>")
-			R.add_fingerprint(user)
-			qdel(src)
-		else
-			to_chat(user, "<span class='warning'>You can't put it here!</span>")
+	if(T.CanPass(null, T))
+		var/obj/structure/rack/R = new /obj/structure/rack( T )
+		to_chat(user, "<span class='notice'>You assemble [src].</span>")
+		R.add_fingerprint(user)
+		qdel(src)
+	else
+		to_chat(user, "<span class='warning'>You can't put it here!</span>")

--- a/code/game/objects/items/weapons/table_rack_parts.dm
+++ b/code/game/objects/items/weapons/table_rack_parts.dm
@@ -46,16 +46,16 @@
 	..()
 
 /obj/item/weapon/table_parts/attack_self(mob/user)
+	if(!handle_fumbling(user, src, SKILL_TASK_AVERAGE, list(/datum/skill/engineering = SKILL_LEVEL_NOVICE)))
+		return
 	var/turf/simulated/T = get_turf(user)
-	if(handle_fumbling(user, src, SKILL_TASK_AVERAGE, list(/datum/skill/engineering = SKILL_LEVEL_NOVICE)))
-		if(T && T.CanPass(null, T))
-			var/obj/structure/table/R = new table_type( T )
-			to_chat(user, "<span class='notice'>You assemble [src].</span>")
-			R.add_fingerprint(user)
-			qdel(src)
-		else
-			to_chat(user, "<span class='warning'>You can't put it here!</span>")
-
+	if(!T || !T.CanPass(null, T))
+		to_chat(user, "<span class='warning'>You can't put it here!</span>")
+		return
+	var/obj/structure/table/R = new table_type( T )
+	to_chat(user, "<span class='notice'>You assemble [src].</span>")
+	R.add_fingerprint(user)
+	qdel(src)
 
 /*
  * Reinforced Table Parts

--- a/code/game/objects/items/weapons/table_rack_parts.dm
+++ b/code/game/objects/items/weapons/table_rack_parts.dm
@@ -47,13 +47,14 @@
 
 /obj/item/weapon/table_parts/attack_self(mob/user)
 	var/turf/simulated/T = get_turf(user)
-	if (T.CanPass(null, T))
-		var/obj/structure/table/R = new table_type( T )
-		to_chat(user, "<span class='notice'>You assemble [src].</span>")
-		R.add_fingerprint(user)
-		qdel(src)
-	else
-		to_chat(user, "<span class='warning'>You can't put it here!</span>")
+	if(handle_fumbling(user, src, SKILL_TASK_AVERAGE, list(/datum/skill/engineering = SKILL_LEVEL_NOVICE)))
+		if(T && T.CanPass(null, T))
+			var/obj/structure/table/R = new table_type( T )
+			to_chat(user, "<span class='notice'>You assemble [src].</span>")
+			R.add_fingerprint(user)
+			qdel(src)
+		else
+			to_chat(user, "<span class='warning'>You can't put it here!</span>")
 
 
 /*
@@ -128,10 +129,11 @@
 
 /obj/item/weapon/rack_parts/attack_self(mob/user)
 	var/turf/simulated/T = get_turf(user)
-	if(T.CanPass(null, T))
-		var/obj/structure/rack/R = new /obj/structure/rack( T )
-		to_chat(user, "<span class='notice'>You assemble [src].</span>")
-		R.add_fingerprint(user)
-		qdel(src)
-	else
-		to_chat(user, "<span class='warning'>You can't put it here!</span>")
+	if(handle_fumbling(user, src, SKILL_TASK_AVERAGE, list(/datum/skill/engineering = SKILL_LEVEL_NOVICE)))
+		if(T.CanPass(null, T))
+			var/obj/structure/rack/R = new /obj/structure/rack( T )
+			to_chat(user, "<span class='notice'>You assemble [src].</span>")
+			R.add_fingerprint(user)
+			qdel(src)
+		else
+			to_chat(user, "<span class='warning'>You can't put it here!</span>")


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Офицеры разбирают столы как надо, с задержкой, но почему они должны их ставить без? Нерфим.
Теперь у них и других анскилов задержка такая же, как и при разборке стола. 
## Почему и что этот ПР улучшит
Чуть меньше неприятных моментов, когда разобрал укреплённый стол, а офицер его в момент поставил назад.
## Авторство

## Чеинжлог
:cl: Deahaka
- tweak: Добавлено требование навыков для установки стола.