### PR TITLE
Кнопка Do Not Revive

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -171,7 +171,7 @@
 	var/datum/mind/clonemind = locate(R.mind)
 	if(!istype(clonemind, /datum/mind)) //not a mind
 		return FALSE
-	if(clonemind.current && clonemind.current.stat != DEAD) //mind is associated with a non-dead body
+	if(clonemind.current && (clonemind.current.stat != DEAD || clonemind.current.client?.no_resurrect)) //mind is associated with a non-dead body
 		return FALSE
 	if(clonemind.active) //somebody is using that mind
 		if(ckey(clonemind.key) != R.ckey )

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -112,7 +112,7 @@
 		//They must return in the body
 		else if(isobserver(M))
 			var/mob/dead/observer/O = M
-			if(!O.can_reenter_corpse)
+			if(!O.can_reenter_corpse || O.client?.no_resurrect)
 				continue
 
 		if(M.ckey == find_key)

--- a/code/game/objects/items/weapons/defibrillator.dm
+++ b/code/game/objects/items/weapons/defibrillator.dm
@@ -381,7 +381,7 @@
 		playsound(src, 'sound/items/surgery/defib_failed.ogg', VOL_EFFECTS_MASTER, null, FALSE)
 		return
 
-	if(H.stat == DEAD && (world.time - H.timeofdeath) >= DEFIB_TIME_LIMIT)
+	if(H.stat == DEAD && ((world.time - H.timeofdeath) >= DEFIB_TIME_LIMIT) || H.client?.no_resurrect)
 		make_announcement("buzzes, \"Defibrillation failed - Severe neurological decay makes recovery of patient impossible. Further attempts futile.\"")
 		playsound(src, 'sound/items/surgery/defib_failed.ogg', VOL_EFFECTS_MASTER, null, FALSE)
 		return

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -123,3 +123,5 @@
 
 	/// Messages currently seen by this client
 	var/list/seen_messages
+
+	var/no_resurrect = FALSE

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -104,6 +104,13 @@
 	to_chat(src, "You will receive requests for \"[role]\" again")
 	feedback_add_details("admin_verb","TBeSpecialIgnore") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/client/verb/toggle_no_revieve()
+	set name = "Toggle No Revieve"
+	set category = "Preferences"
+	no_resurrect = !no_resurrect
+	to_chat(src, "[no_resurrect ? "You can not resurrect." : "You can resurrect again."]")
+	feedback_add_details("admin_verb","DNR") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
 /client/verb/change_ui()
 	set name = "Change UI"
 	set category = "Preferences"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -2186,7 +2186,7 @@
 	if(species.flags[NO_BLOOD])
 		return
 
-	if(world.time - timeofdeath >= DEFIB_TIME_LIMIT)
+	if(world.time - timeofdeath >= DEFIB_TIME_LIMIT || client?.no_resurrect)
 		to_chat(user, "<span class='notice'>It seems [src] is far too gone to be reanimated... Your efforts are futile.</span>")
 		return
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Попытка реализовать кнопку для тех, кто желает не возвращать куклу в раунд, если она умерла. Rest in Peace, не всех можно спасти.
## Почему и что этот ПР улучшит
closes #9359
## Авторство
Симбака придумал
## Чеинжлог
:cl: Deahaka
- add: В вкладку Preferences добавлена кнопка "Toggle No Revieve", которая предотвращает реанимацию и клонирование.