### PR TITLE
Фотки во флаффе

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -194,7 +194,7 @@
 		if(P.crumpled)
 			to_chat(usr, "Paper too crumpled for anything.")
 			return
-		if(tgui_alert(user, "Would you like to hold up \the [P] to the camera?", "Let camera see your text!", list("Yes!", "No!")) != "Yes!")
+		if(tgui_alert(user, "Would you like to hold up \the [P] to the camera?", "Let AI see your text!", list("Yes!", "No!")) != "Yes!")
 			return
 		to_chat(user, "You hold \the [P] up to the camera...")
 		for(var/mob/living/silicon/ai/O as anything in ai_list)
@@ -210,27 +210,6 @@
 				var/mob/living/L = locate(M) // M is a \ref. weird
 				to_chat(L, "You can see [user] holding \the [P] to the camera you're watching...")
 				P.show_content(L)
-	else if(istype(W, /obj/item/weapon/photo))
-		user.SetNextMove(CLICK_CD_INTERACT)
-		if(show_paper_cooldown > world.time)
-			return
-		show_paper_cooldown = world.time + 5 SECONDS
-		var/obj/item/weapon/photo/P = W
-		if(tgui_alert(user, "Would you like to hold up \the [P] to the camera?", "Let camera see your photo!", list("Yes!", "No!")) != "Yes!")
-			return
-		to_chat(user, "You hold \the [P] up to the camera...")
-		for(var/mob/living/silicon/ai/O as anything in ai_list)
-			if(!O.client || O.stat == DEAD)
-				continue
-			to_chat(O, "<b><a href='byond://?src=\ref[O];track2=\ref[O];track=\ref[user];trackname=[user.name]'>[user.name]</a></b> holds \the [P] up to one of your cameras...")
-			P.show(O)
-		for(var/obj/machinery/computer/security/S in computer_list) // show the paper to all people watching this camera. except ghosts, fuck ghosts
-			if(S.active_camera != src)
-				continue
-			for(var/M in S.concurrent_users)
-				var/mob/living/L = locate(M) // M is a \ref. weird
-				to_chat(L, "You can see [user] holding \the [P] to the camera you're watching...")
-				P.show(L)
 
 	else if (istype(W, /obj/item/device/camera_bug))
 		if(!can_use())

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -194,7 +194,7 @@
 		if(P.crumpled)
 			to_chat(usr, "Paper too crumpled for anything.")
 			return
-		if(tgui_alert(user, "Would you like to hold up \the [P] to the camera?", "Let AI see your text!", list("Yes!", "No!")) != "Yes!")
+		if(tgui_alert(user, "Would you like to hold up \the [P] to the camera?", "Let camera see your text!", list("Yes!", "No!")) != "Yes!")
 			return
 		to_chat(user, "You hold \the [P] up to the camera...")
 		for(var/mob/living/silicon/ai/O as anything in ai_list)
@@ -210,6 +210,27 @@
 				var/mob/living/L = locate(M) // M is a \ref. weird
 				to_chat(L, "You can see [user] holding \the [P] to the camera you're watching...")
 				P.show_content(L)
+	else if(istype(W, /obj/item/weapon/photo))
+		user.SetNextMove(CLICK_CD_INTERACT)
+		if(show_paper_cooldown > world.time)
+			return
+		show_paper_cooldown = world.time + 5 SECONDS
+		var/obj/item/weapon/photo/P = W
+		if(tgui_alert(user, "Would you like to hold up \the [P] to the camera?", "Let camera see your photo!", list("Yes!", "No!")) != "Yes!")
+			return
+		to_chat(user, "You hold \the [P] up to the camera...")
+		for(var/mob/living/silicon/ai/O as anything in ai_list)
+			if(!O.client || O.stat == DEAD)
+				continue
+			to_chat(O, "<b><a href='byond://?src=\ref[O];track2=\ref[O];track=\ref[user];trackname=[user.name]'>[user.name]</a></b> holds \the [P] up to one of your cameras...")
+			P.show(O)
+		for(var/obj/machinery/computer/security/S in computer_list) // show the paper to all people watching this camera. except ghosts, fuck ghosts
+			if(S.active_camera != src)
+				continue
+			for(var/M in S.concurrent_users)
+				var/mob/living/L = locate(M) // M is a \ref. weird
+				to_chat(L, "You can see [user] holding \the [P] to the camera you're watching...")
+				P.show(L)
 
 	else if (istype(W, /obj/item/device/camera_bug))
 		if(!can_use())

--- a/code/modules/fluff/customitems.dm
+++ b/code/modules/fluff/customitems.dm
@@ -14,6 +14,9 @@
 /obj/item/weapon/lighter/zippo/custom
 	name = "Custom zippo"
 
+/obj/item/weapon/photo/custom
+	name = "Custom photo"
+
 /obj/item/clothing/head/custom
 	name = "Custom hat"
 	body_parts_covered = 0
@@ -229,6 +232,23 @@
 				zippo.icon_on = "[custom_item_info.icon_state]_on"
 				zippo.icon_off = custom_item_info.icon_state
 				item = zippo
+			if("photo")
+				var/obj/item/weapon/photo/custom/Photo = new /obj/item/weapon/photo/custom()
+				var/icon/photo_itself = new(custom_item_info.icon, custom_item_info.icon_state)
+				var/icon/small_img = new(custom_item_info.icon, custom_item_info.icon_state)
+				var/icon/tiny_img = new(custom_item_info.icon, custom_item_info.icon_state)
+				var/icon/ic = icon('icons/obj/items.dmi',"photo")
+				var/icon/pc = icon('icons/obj/bureaucracy.dmi', "photo")
+				small_img.Scale(8, 8)
+				tiny_img.Scale(4, 4)
+				ic.Blend(small_img,ICON_OVERLAY, 13, 13)
+				pc.Blend(tiny_img,ICON_OVERLAY, 12, 19)
+
+				Photo.icon = ic
+				Photo.tiny = pc
+				Photo.img = photo_itself
+
+				item = Photo
 			if("hat")
 				item = new /obj/item/clothing/head/custom()
 			if("uniform")
@@ -260,10 +280,14 @@
 		item.desc = custom_item_info.desc
 		if(custom_item_info.sprite_author)
 			item.desc = "[item.desc]<br><small><span style='color:#00BFFF;'><i>sprite author:</i> [custom_item_info.sprite_author]</span></small>"
-		item.icon = custom_item_info.icon
-		item.icon_custom = custom_item_info.icon
-		item.icon_state = custom_item_info.icon_state
-		item.item_state = custom_item_info.icon_state
+		if(!item.icon)
+			item.icon = custom_item_info.icon
+		if(!item.icon_custom)
+			item.icon_custom = custom_item_info.icon
+		if(!item.icon_state)
+			item.icon_state = custom_item_info.icon_state
+		if(!item.item_state)
+			item.item_state = custom_item_info.icon_state
 
 		switch(custom_item_info.hair_flags)
 			if(FLUFF_HAIR_HIDE_HEAD)

--- a/code/modules/fluff/customitems.dm
+++ b/code/modules/fluff/customitems.dm
@@ -221,6 +221,11 @@
 		if(custom_item_info.status != "accepted")
 			continue
 
+		var/item_icon = custom_item_info.icon
+		var/item_icon_custom = custom_item_info.icon
+		var/item_iconstate = custom_item_info.icon_state
+		var/item_itemstate = custom_item_info.icon_state
+
 		//item spawning
 		var/obj/item/item = null
 
@@ -244,7 +249,9 @@
 				ic.Blend(small_img, ICON_OVERLAY, 13, 13)
 				pc.Blend(tiny_img, ICON_OVERLAY, 12, 19)
 
-				Photo.icon = ic
+				item_icon = ic
+				item_icon_custom = null
+				item_itemstate = "paper"
 				Photo.tiny = pc
 				Photo.img = photo_itself
 
@@ -280,14 +287,11 @@
 		item.desc = custom_item_info.desc
 		if(custom_item_info.sprite_author)
 			item.desc = "[item.desc]<br><small><span style='color:#00BFFF;'><i>sprite author:</i> [custom_item_info.sprite_author]</span></small>"
-		if(!item.icon)
-			item.icon = custom_item_info.icon
-		if(!item.icon_custom)
-			item.icon_custom = custom_item_info.icon
-		if(!item.icon_state)
-			item.icon_state = custom_item_info.icon_state
-		if(!item.item_state)
-			item.item_state = custom_item_info.icon_state
+
+		item.icon = item_icon
+		item.icon_custom = item_icon_custom
+		item.icon_state = item_iconstate
+		item.item_state = item_itemstate
 
 		switch(custom_item_info.hair_flags)
 			if(FLUFF_HAIR_HIDE_HEAD)

--- a/code/modules/fluff/customitems.dm
+++ b/code/modules/fluff/customitems.dm
@@ -241,8 +241,8 @@
 				var/icon/pc = icon('icons/obj/bureaucracy.dmi', "photo")
 				small_img.Scale(8, 8)
 				tiny_img.Scale(4, 4)
-				ic.Blend(small_img,ICON_OVERLAY, 13, 13)
-				pc.Blend(tiny_img,ICON_OVERLAY, 12, 19)
+				ic.Blend(small_img, ICON_OVERLAY, 13, 13)
+				pc.Blend(tiny_img, ICON_OVERLAY, 12, 19)
 
 				Photo.icon = ic
 				Photo.tiny = pc

--- a/code/modules/fluff/fluffmenu.dm
+++ b/code/modules/fluff/fluffmenu.dm
@@ -36,12 +36,15 @@ var/global/list/editing_item_oldname_list = list()
 	preview_icon.Scale(150, 70)
 	if(editing_item.icon && editing_item.icon_state)
 		var/icon/I = new(editing_item.icon,icon_state = editing_item.icon_state,dir = SOUTH)
+		I.Scale(32, 32)
 		preview_icon.Blend(I, ICON_OVERLAY, 13, 22)
 
 		I = new(editing_item.icon,icon_state = editing_item.icon_state,dir = NORTH)
+		I.Scale(32, 32)
 		preview_icon.Blend(I, ICON_OVERLAY, 109, 19)
 
 		I = new(editing_item.icon,icon_state = editing_item.icon_state,dir = WEST)
+		I.Scale(32, 32)
 		preview_icon.Blend(I, ICON_OVERLAY, 60, 18)
 
 		if("[editing_item.icon_state]_mob" in icon_states(editing_item.icon))
@@ -51,12 +54,15 @@ var/global/list/editing_item_oldname_list = list()
 			preview_icon_mob.Scale(150, 70)
 
 			I = new(editing_item.icon,icon_state = mob_icon_state,dir = SOUTH)
+			I.Scale(32, 32)
 			preview_icon_mob.Blend(I, ICON_OVERLAY, 13, 22)
 
 			I = new(editing_item.icon,icon_state = mob_icon_state,dir = NORTH)
+			I.Scale(32, 32)
 			preview_icon_mob.Blend(I, ICON_OVERLAY, 109, 19)
 
 			I = new(editing_item.icon,icon_state = mob_icon_state,dir = WEST)
+			I.Scale(32, 32)
 			preview_icon_mob.Blend(I, ICON_OVERLAY, 60, 18)
 
 	user << browse_rsc(preview_icon, "itempreviewicon.png")
@@ -218,7 +224,7 @@ var/global/list/editing_item_oldname_list = list()
 		return
 
 	if(href_list["change_type"])
-		var/new_type = sanitize(input("Select item type", "Text")  as null|anything in list("normal", "small", "lighter", "hat", "uniform", "suit", "mask", "glasses", "gloves", "shoes", "accessory", "labcoat"))
+		var/new_type = sanitize(input("Select item type", "Text")  as null|anything in list("normal", "small", "lighter", "photo", "hat", "uniform", "suit", "mask", "glasses", "gloves", "shoes", "accessory", "labcoat"))
 		if(!editing_item || !new_type)
 			return
 		editing_item.item_type = new_type
@@ -329,7 +335,11 @@ var/global/list/editing_item_oldname_list = list()
 		if(icon_states.len > 6)
 			to_chat(user, "This icon has too many states")
 			return
-		if(I.Width() != 32 || I.Height() != 32)
+		if(editing_item.item_type == "photo")
+			if(I.Width() > 128 || I.Height() > 128)
+				to_chat(user, "This icon has incorrect size")
+				return
+		else if(I.Width() != 32 || I.Height() != 32)
 			to_chat(user, "This icon has incorrect size")
 			return
 		editing_item.icon = new_item_icon

--- a/code/modules/fluff/fluffmenu.dm
+++ b/code/modules/fluff/fluffmenu.dm
@@ -228,6 +228,8 @@ var/global/list/editing_item_oldname_list = list()
 		if(!editing_item || !new_type)
 			return
 		editing_item.item_type = new_type
+		editing_item.icon = null
+		editing_item.icon_state = null
 		edit_custom_item_panel(src, user)
 		return
 

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -91,7 +91,7 @@
 /obj/item/weapon/photo/proc/show(mob/user)
 	user << browse_rsc(img, "tmp_photo.png")
 
-	var/datum/browser/popup = new(user, "window=book [name]", "[sanitize(name)]", 224, (scribble ? 400 : 224), ntheme = CSS_THEME_LIGHT)
+	var/datum/browser/popup = new(user, "window=book [name]", "[sanitize(name)]", 224, (scribble ? 400 : 236), ntheme = CSS_THEME_LIGHT)
 	popup.set_content("<div style='overflow:hidden;text-align:center;'> <img src='tmp_photo.png' width = '192' style='-ms-interpolation-mode:nearest-neighbor'>[scribble ? "<br>Written on the back:<br><i>[scribble]</i>" : null]</div>")
 	popup.open()
 


### PR DESCRIPTION
## Описание изменений
Добавлена возможность добавлять фотографии во флафф слот.

Можно добавить иконку до 128х128 пикселей размером.
![image](https://user-images.githubusercontent.com/21008918/218269184-c0978d7a-ae3d-492e-a9e5-7d6b0da0a8cb.png)
![image](https://user-images.githubusercontent.com/21008918/218269189-97711178-6695-4891-b1ed-3350b590dbfd.png)

Из мелкого изменения - пофиксил размер окна фотографий на 12 пикселей высоты. Теперь фотография открывается без скролбара. (Когда делали фотки вообще ни о чём не думали? Это литералли изменить одно число, лол, вот это низкие стандарты раньше были, писец.)

## Почему и что этот ПР улучшит
Больше возможностей, теперь не будет кринж-медальонов на фуллтайл с лицом Трисс.

## Авторство
AndreyGysev и все все все, кто помогал в дискорде.

## Чеинжлог
 :cl:
 - rscadd: Добавлена возможность сделать флафф-фотографию.