### PR TITLE
Remapik Dokov

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -5189,13 +5189,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "ajb" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "browncorner"
-	},
-/area/station/hallway/secondary/arrival)
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "ajc" = (
 /obj/structure/stool/bed/roller,
 /obj/machinery/iv_drip,
@@ -5705,7 +5701,8 @@
 "ajR" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	icon_state = "redcorner"
+	dir = 6;
+	icon_state = "escape"
 	},
 /area/station/hallway/secondary/exit)
 "ajS" = (
@@ -7051,7 +7048,7 @@
 	},
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
 /area/station/security/checkpoint)
 "alT" = (
@@ -9346,12 +9343,14 @@
 /turf/simulated/floor/plating,
 /area/station/civilian/barbershop)
 "apN" = (
-/obj/structure/sign/warning/securearea{
-	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA"
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1
 	},
-/turf/simulated/wall,
-/area/station/hallway/secondary/exit)
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/plating{
+	icon_state = "platebotc"
+	},
+/area/station/hallway/secondary/arrival)
 "apO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -10012,7 +10011,6 @@
 /area/station/rnd/xenobiology)
 "arb" = (
 /obj/structure/grille,
-/obj/item/weapon/shard,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -10546,8 +10544,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "asb" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -10837,9 +10835,6 @@
 /area/station/maintenance/dormitory)
 "asB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -16838,14 +16833,20 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/security/checkpoint)
 "aEl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	id_tag = "arrival_hallway_outer";
+	locked = 1;
+	name = "Arrival Hallway External Access";
+	req_one_access = list(13,45,1)
 	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
 "aEm" = (
 /obj/item/weapon/hemostat,
@@ -17904,7 +17905,6 @@
 	},
 /area/station/civilian/gym)
 "aGp" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
 	name = "Arrival Access"
 	},
@@ -18310,6 +18310,9 @@
 /obj/structure/table/woodentable,
 /obj/item/device/camera_film,
 /obj/item/device/camera_film,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
 /obj/item/device/camera/polar,
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
@@ -18885,9 +18888,6 @@
 /area/station/medical/hallway)
 "aIr" = (
 /obj/machinery/photocopier,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
 "aIs" = (
@@ -19269,6 +19269,10 @@
 "aIZ" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/fancy/crayons,
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = 32
+	},
 /turf/simulated/floor,
 /area/station/civilian/locker)
 "aJa" = (
@@ -19721,13 +19725,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/arrival)
@@ -19756,14 +19758,14 @@
 	},
 /area/station/maintenance/atmos)
 "aJW" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/arrival)
@@ -19796,7 +19798,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
 	name = "Arrival Access"
 	},
@@ -20660,13 +20661,15 @@
 "aLB" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
+	dir = 10;
+	icon_state = "escape"
 	},
 /area/station/hallway/secondary/exit)
 "aLC" = (
 /obj/machinery/door/firedoor,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "escape"
+	},
 /area/station/hallway/secondary/exit)
 "aLD" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -23375,8 +23378,9 @@
 /area/station/rnd/hallway)
 "aQJ" = (
 /obj/random/vending/snack,
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/machinery/camera{
+	c_tag = "Escape Hall North";
+	pixel_x = 22
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -23405,7 +23409,9 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/security/checkpoint)
 "aQN" = (
 /obj/structure/stool,
@@ -23437,7 +23443,7 @@
 	},
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
 /area/station/security/checkpoint)
 "aQQ" = (
@@ -24074,7 +24080,7 @@
 /obj/machinery/computer/skills,
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
 /area/station/security/checkpoint)
 "aRY" = (
@@ -24091,7 +24097,9 @@
 	name = "Shutters Control";
 	pixel_x = -28
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/security/checkpoint)
 "aSb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -24979,7 +24987,7 @@
 /obj/item/weapon/pen,
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
 /area/station/security/checkpoint)
 "aTF" = (
@@ -24997,13 +25005,10 @@
 	},
 /area/station/rnd/scibreak)
 "aTG" = (
-/obj/machinery/status_display{
-	pixel_x = 32
-	},
 /obj/structure/filingcabinet,
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
 /area/station/security/checkpoint)
 "aTH" = (
@@ -25626,7 +25631,7 @@
 	},
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
 /area/station/security/checkpoint)
 "aUQ" = (
@@ -26618,7 +26623,6 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/mine_sci_shuttle)
 "aWv" = (
-/obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	icon_state = "escape"
 	},
@@ -26652,12 +26656,12 @@
 "aWz" = (
 /turf/simulated/floor{
 	dir = 10;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
 /area/station/security/checkpoint)
 "aWA" = (
 /turf/simulated/floor{
-	icon_state = "red"
+	icon_state = "darkred"
 	},
 /area/station/security/checkpoint)
 "aWB" = (
@@ -26681,7 +26685,7 @@
 	},
 /turf/simulated/floor{
 	dir = 6;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
 /area/station/security/checkpoint)
 "aWD" = (
@@ -28422,9 +28426,25 @@
 	},
 /area/station/cargo/recycleroffice)
 "aZN" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/cargo/office)
+/obj/structure/sign/mark{
+	icon_state = "ylf";
+	pixel_y = 8
+	},
+/obj/structure/sign/mark{
+	icon_state = "ylf";
+	pixel_x = 8;
+	pixel_y = 8
+	},
+/obj/structure/sign/mark{
+	icon_state = "ylf";
+	pixel_x = 16;
+	pixel_y = 8
+	},
+/obj/structure/sign/directions/dock_tablo/arrival{
+	pixel_y = -4
+	},
+/turf/simulated/wall,
+/area/station/hallway/secondary/entry)
 "aZO" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Research Director";
@@ -29141,7 +29161,6 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/hologram/holopad,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "bbh" = (
@@ -29276,12 +29295,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/station/hallway/secondary/arrival)
 "bbs" = (
@@ -29330,11 +29343,14 @@
 	dir = 1;
 	pixel_y = 28
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/sign/directions/supply{
 	buildable_sign = 0;
 	dir = 8;
 	pixel_y = 36
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Arrival Access"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -29973,9 +29989,12 @@
 	c_tag = "Security Checkpoint";
 	network = list("SS13","Security")
 	},
+/obj/machinery/status_display{
+	pixel_x = 32
+	},
 /turf/simulated/floor{
 	dir = 5;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
 /area/station/security/checkpoint)
 "bcD" = (
@@ -30457,7 +30476,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "bdC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -30503,9 +30522,6 @@
 	},
 /area/station/maintenance/engineering)
 "bdG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -30515,6 +30531,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -31351,17 +31370,19 @@
 /turf/simulated/floor,
 /area/station/civilian/locker)
 "beZ" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 5
 	},
-/obj/structure/stool/bed/chair/metal/red{
-	dir = 1
+/obj/machinery/door/firedoor,
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK"
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/hallway/secondary/exit)
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/arrival)
 "bfa" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -32535,34 +32556,36 @@
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "bhg" = (
 /turf/simulated/floor/carpet/black,
 /area/station/security/vacantoffice)
 "bhh" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Arrival Access"
 	},
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
 "bhi" = (
-/obj/machinery/camera{
-	c_tag = "Arrival East";
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/status_display{
-	pixel_y = -32
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/station/hallway/secondary/entry)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/arrival)
 "bhj" = (
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
@@ -34620,6 +34643,9 @@
 	},
 /area/station/rnd/hallway)
 "bls" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
 /turf/simulated/floor{
 	icon_state = "whiteblue"
 	},
@@ -35022,10 +35048,14 @@
 /obj/structure/sign/departments/lawyer{
 	pixel_y = -32
 	},
+/obj/machinery/camera{
+	c_tag = "Arrival East";
+	dir = 1
+	},
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "bmc" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -35408,7 +35438,7 @@
 	},
 /turf/simulated/floor{
 	dir = 1;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
 /area/station/security/checkpoint)
 "bmQ" = (
@@ -35565,6 +35595,9 @@
 /area/station/civilian/chapel/altar)
 "bne" = (
 /obj/machinery/vending/coffee,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "brown"
@@ -37442,15 +37475,9 @@
 /turf/simulated/floor/plating,
 /area/station/medical/morgue)
 "bqI" = (
-/obj/machinery/camera{
-	c_tag = "Escape Hall North";
-	dir = 1;
-	pixel_x = 22
-	},
-/turf/simulated/floor{
-	icon_state = "escape"
-	},
-/area/station/hallway/secondary/exit)
+/obj/machinery/atmospherics/pipe/manifold4w/visible,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/arrival)
 "bqJ" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 1;
@@ -37990,7 +38017,7 @@
 /obj/structure/closet/wardrobe/red,
 /turf/simulated/floor{
 	dir = 9;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
 /area/station/security/checkpoint)
 "brP" = (
@@ -38564,7 +38591,6 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "bsU" = (
@@ -38860,7 +38886,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "btw" = (
 /obj/structure/stool,
 /obj/effect/landmark/start/shaft_miner,
@@ -38877,10 +38903,14 @@
 /obj/structure/stool/bed/chair/comfy/black{
 	dir = 8
 	},
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = 22
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "bty" = (
 /obj/structure/grille{
 	destroyed = 1
@@ -39073,7 +39103,7 @@
 	},
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
 /area/station/security/checkpoint)
 "btQ" = (
@@ -39146,11 +39176,9 @@
 	},
 /area/station/medical/hallway)
 "btV" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 1
+/turf/simulated/floor{
+	icon_state = "dark"
 	},
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
 "btW" = (
 /obj/structure/window/reinforced,
@@ -39243,7 +39271,9 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/security/checkpoint)
 "buh" = (
 /obj/machinery/hologram/holopad,
@@ -39279,7 +39309,7 @@
 	},
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
 /area/station/security/checkpoint)
 "bul" = (
@@ -39422,7 +39452,9 @@
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/security/checkpoint)
 "buz" = (
 /turf/simulated/floor{
@@ -39546,13 +39578,15 @@
 	},
 /area/station/cargo/qm)
 "buO" = (
-/obj/item/weapon/flora/random,
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/item/weapon/flora/pottedplant{
+	icon_state = "plant-6"
+	},
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
 /area/station/security/checkpoint)
 "buQ" = (
@@ -39645,14 +39679,10 @@
 /obj/structure/stool/bed/chair/comfy/black{
 	dir = 4
 	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 22
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "bva" = (
 /obj/machinery/telecomms/server/presets/command,
 /obj/machinery/camera{
@@ -39819,7 +39849,7 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
 /area/station/security/checkpoint)
 "bvv" = (
@@ -39971,7 +40001,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "escape"
+	dir = 8;
+	icon_state = "escapecorner"
 	},
 /area/station/hallway/secondary/exit)
 "bvL" = (
@@ -40006,9 +40037,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor{
-	icon_state = "escape"
-	},
+/turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "bvP" = (
 /turf/simulated/floor/plating/airless,
@@ -40034,17 +40063,18 @@
 /area/station/bridge/hop_office)
 "bvT" = (
 /obj/structure/table/woodentable/fancy/black,
-/obj/item/weapon/flora/deskleaf{
-	pixel_y = 7
+/obj/item/ashtray/glass,
+/obj/item/weapon/lighter/zippo{
+	pixel_x = -5;
+	pixel_y = 5
 	},
-/obj/machinery/status_display{
-	layer = 4;
+/obj/machinery/newscaster{
 	pixel_y = 32
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "bvV" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/disposalpipe/segment{
@@ -40053,13 +40083,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "bvW" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -40824,7 +40853,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/station/cargo/office)
+/area/space)
 "bxn" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -42969,7 +42998,6 @@
 	},
 /area/station/civilian/gym)
 "bBj" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/cigbutt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
@@ -44035,11 +44063,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "bDi" = (
-/obj/machinery/power/apc{
-	name = "Arrival Hallway APC";
-	pixel_y = -24
-	},
-/obj/structure/cable,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
@@ -46235,7 +46259,7 @@
 	},
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
 /area/station/security/checkpoint)
 "bHv" = (
@@ -47509,7 +47533,7 @@
 	},
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
 /area/station/security/checkpoint)
 "bJL" = (
@@ -47580,10 +47604,30 @@
 	},
 /area/station/civilian/gym)
 "bJT" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/environment/space,
-/area/space)
+/obj/machinery/embedded_controller/radio/airlock_controller{
+	id_tag = "arrival_hallway_airlock";
+	pixel_x = 25;
+	req_one_access = list(13,45,1);
+	tag_airpump = "arrival_hallway_pump";
+	tag_chamber_sensor = "arrival_hallway_sensor";
+	tag_exterior_door = "arrival_hallway_outer";
+	tag_interior_door = "arrival_hallway_inner"
+	},
+/obj/machinery/airlock_sensor{
+	id_tag = "arrival_hallway_sensor";
+	pixel_x = 25;
+	pixel_y = 12
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
+	dir = 8;
+	frequency = 1379;
+	id_tag = "arrival_hallway_pump";
+	name = "Arrival Hallway Large Air Vent"
+	},
+/turf/simulated/floor/plating{
+	icon_state = "platebotc"
+	},
+/area/station/hallway/secondary/arrival)
 "bJU" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -51079,9 +51123,20 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/starboard)
 "bQB" = (
-/obj/structure/lattice,
-/turf/environment/space,
-/area/station/cargo/office)
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	name = "Arrival Hallway APC";
+	pixel_y = 24;
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/arrival)
 "bQC" = (
 /obj/structure/stool,
 /turf/simulated/floor/carpet/green,
@@ -51398,15 +51453,16 @@
 /turf/simulated/wall/r_wall,
 /area/station/rnd/storage)
 "bRn" = (
-/obj/machinery/door/airlock/glass{
-	name = "Arrival Access"
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = 32
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "bRo" = (
 /obj/structure/barricade/wooden,
 /turf/simulated/floor/plating,
@@ -53293,7 +53349,6 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "bWy" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -54911,14 +54966,11 @@
 	},
 /area/station/civilian/library)
 "cbS" = (
-/obj/machinery/door/airlock/glass{
-	name = "Arrival Access"
+/obj/machinery/light/small{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "cbT" = (
 /obj/machinery/door/window/northright{
 	dir = 8;
@@ -57540,12 +57592,8 @@
 	},
 /area/station/engineering/drone_fabrication)
 "cks" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	id_tag = "arrival_dock_outer";
-	locked = 1;
-	name = "Arrival Dock External Access";
-	req_one_access = list(13,45,1)
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
@@ -59501,7 +59549,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 10
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -65045,10 +65093,6 @@
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/auxport)
 "cEp" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -65056,6 +65100,16 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Arrival Access"
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
@@ -67739,7 +67793,9 @@
 "dbf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/security/checkpoint)
 "dbs" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
@@ -67908,6 +67964,11 @@
 	icon_state = "warnplate"
 	},
 /area/station/engineering/engine)
+"dlJ" = (
+/turf/simulated/floor{
+	icon_state = "escapecorner"
+	},
+/area/station/hallway/secondary/exit)
 "dmb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -68218,11 +68279,13 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "dBT" = (
-/obj/machinery/light,
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance{
+	name = "Labor Shuttle";
+	req_access = list(1)
 	},
-/area/station/hallway/secondary/entry)
+/turf/simulated/floor/plating,
+/area/station/security/processing)
 "dCb" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -68319,7 +68382,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/security/checkpoint)
 "dMb" = (
 /obj/structure/window/reinforced{
@@ -69543,6 +69608,9 @@
 /area/station/security/prison)
 "fgl" = (
 /obj/machinery/iv_drip,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
 /turf/simulated/floor{
 	icon_state = "whiteblue"
 	},
@@ -69791,14 +69859,15 @@
 	},
 /area/station/medical/hallway)
 "fxb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "white"
+	icon_state = "warning"
 	},
-/area/station/hallway/secondary/exit)
+/area/station/hallway/secondary/arrival)
 "fxg" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -69935,12 +70004,15 @@
 	},
 /area/station/hallway/primary/port)
 "fEm" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/firealarm{
 	dir = 4;
-	icon_state = "pipe-c"
+	pixel_x = 24
 	},
-/turf/simulated/floor/plating,
-/area/station/cargo/office)
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "escape"
+	},
+/area/station/hallway/secondary/exit)
 "fEy" = (
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -70363,11 +70435,13 @@
 /turf/simulated/floor/grass,
 /area/station/medical/genetics)
 "gdb" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 27
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "geb" = (
 /obj/structure/cable{
@@ -71040,6 +71114,26 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/kitchen)
+"gQm" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_x = -32
+	},
+/obj/machinery/camera{
+	c_tag = "Arrival Hallway East";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/hallway/secondary/arrival)
 "gRb" = (
 /obj/structure/closet/secure_closet/security,
 /turf/simulated/floor{
@@ -74209,7 +74303,6 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
 "kdV" = (
@@ -74283,7 +74376,15 @@
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
 "kfK" = (
-/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	id_tag = "arrival_hallway_inner";
+	locked = 1;
+	name = "Arrival Hallway External Access";
+	req_one_access = list(13,45,1)
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
 "kgz" = (
@@ -75377,10 +75478,8 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/arrival)
@@ -76040,13 +76139,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "mcG" = (
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
+/obj/machinery/status_display,
+/turf/simulated/wall,
 /area/station/hallway/secondary/arrival)
 "mdb" = (
 /obj/structure/table,
@@ -76309,9 +76403,6 @@
 /turf/simulated/floor/carpet,
 /area/station/civilian/library)
 "msb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -76324,6 +76415,9 @@
 	dir = 4;
 	name = "Locker Room";
 	sortType = "Locker Room"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
@@ -76895,12 +76989,11 @@
 	},
 /area/station/rnd/xenobiology)
 "nfY" = (
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = 32
-	},
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = 28
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -77293,18 +77386,12 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/machinery/hologram/holopad,
 /obj/effect/landmark{
 	name = "Observer-Start"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/arrival)
@@ -78197,6 +78284,16 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/kitchen)
+"oHb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor,
+/area/station/hallway/secondary/arrival)
 "oHi" = (
 /obj/machinery/vending/donut,
 /turf/simulated/floor{
@@ -78755,14 +78852,14 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "pvb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "white"
+	icon_state = "neutralcorner"
 	},
-/area/station/hallway/secondary/exit)
+/area/station/hallway/secondary/entry)
 "pvq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -79016,6 +79113,10 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/hydroponics)
+"pFf" = (
+/obj/item/weapon/shard,
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "pFO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -80485,9 +80586,6 @@
 	},
 /area/station/medical/virology)
 "roq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -80499,12 +80597,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/glass{
-	name = "Arrival Access"
-	},
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "rpb" = (
 /obj/structure/stool,
 /turf/simulated/floor{
@@ -81007,21 +81102,15 @@
 	},
 /area/station/medical/virology)
 "rRu" = (
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	id_tag = "arrival_dock_airlock";
-	pixel_x = 25;
-	req_one_access = list(13,45,1);
-	tag_airpump = "arrival_dock_pump";
-	tag_chamber_sensor = "arrival_dock_sensor";
-	tag_exterior_door = "arrival_dock_outer";
-	tag_interior_door = "arrival_dock_inner"
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
+	dir = 8;
+	frequency = 1379;
+	id_tag = "arrival_hallway_pump";
+	name = "Arrival Hallway Large Air Vent"
 	},
-/obj/machinery/airlock_sensor{
-	id_tag = "arrival_dock_sensor";
-	pixel_x = 25;
-	pixel_y = 12
+/turf/simulated/floor/plating{
+	icon_state = "platebotc"
 	},
-/turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
 "rRE" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -81306,16 +81395,14 @@
 	},
 /area/station/medical/virology)
 "set" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
-	dir = 8;
-	frequency = 1379;
-	id_tag = "arrival_dock_pump";
-	name = "Arrival Dock Large Air Vent"
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
 	},
-/turf/simulated/floor/plating{
-	icon_state = "platebotc"
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
 	},
-/area/station/hallway/secondary/arrival)
+/area/station/hallway/secondary/entry)
 "sfb" = (
 /obj/structure/table/glass,
 /obj/machinery/alarm{
@@ -81845,18 +81932,8 @@
 	},
 /area/station/medical/virology)
 "sEe" = (
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1379;
-	master_tag = "arrival_dock_airlock";
-	name = "interior access button";
-	pixel_y = -20;
-	req_one_access = list(13,45,1)
-	},
-/obj/machinery/camera{
-	c_tag = "Arrival Hallway West";
-	dir = 1;
-	pixel_x = 20
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
@@ -82451,6 +82528,14 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/civilian/toilet)
+"tla" = (
+/obj/machinery/camera{
+	c_tag = "Prison Maintenance";
+	dir = 8;
+	network = list("SS13","Security")
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "tlE" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -82554,6 +82639,15 @@
 	icon_state = "warnplate"
 	},
 /area/station/engineering/engine)
+"txE" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/station/maintenance/auxsolarport)
 "txK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -82903,11 +82997,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=CHW";
 	location = "Bar"
@@ -83033,6 +83122,23 @@
 	icon_state = "vault"
 	},
 /area/station/civilian/chapel)
+"umB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "umE" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -83123,8 +83229,13 @@
 /area/station/hallway/secondary/exit)
 "usG" = (
 /obj/item/weapon/flora/pottedplant/orientaltree,
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/camera{
+	c_tag = "Arrival Dock's South 2";
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -83165,6 +83276,10 @@
 "uvb" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/handcuffs,
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -83206,7 +83321,7 @@
 	},
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
 /area/station/security/checkpoint)
 "uCp" = (
@@ -83303,14 +83418,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "uIo" = (
-/obj/machinery/camera{
-	c_tag = "Arrival Dock's South 2";
-	dir = 8
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
+	name = "KEEP CLEAR: DOCKING AREA"
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "warning"
-	},
+/turf/simulated/wall/r_wall,
 /area/station/hallway/secondary/arrival)
 "uIq" = (
 /obj/structure/cable{
@@ -83339,7 +83451,7 @@
 	},
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
 /area/station/security/checkpoint)
 "uIC" = (
@@ -83365,7 +83477,6 @@
 /turf/simulated/floor/plating,
 /area/station/cargo/office)
 "uMW" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
 	name = "Arrival Access"
 	},
@@ -83428,16 +83539,19 @@
 	},
 /area/station/rnd/hallway)
 "uTe" = (
-/obj/machinery/door/airlock/external{
+/obj/machinery/access_button{
+	command = "cycle_interior";
 	frequency = 1379;
-	id_tag = "arrival_dock_inner";
-	locked = 1;
-	name = "Arrival Dock External Access";
+	master_tag = "arrival_hallway_airlock";
+	name = "interior access button";
+	pixel_x = 26;
+	pixel_y = -20;
 	req_one_access = list(13,45,1)
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/components/binary/pump/on,
-/turf/simulated/floor/plating,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/hallway/secondary/arrival)
 "uTg" = (
 /obj/machinery/conveyor{
@@ -84490,9 +84604,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -84501,8 +84612,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "xwj" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -84895,19 +85009,18 @@
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "ydn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/area/station/hallway/secondary/arrival)
+"yfa" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/escape)
+/area/station/hallway/secondary/arrival)
 "yji" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -88888,7 +89001,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aag
 aaa
 aaa
 aaa
@@ -89433,7 +89546,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aag
 aaa
 aaa
 aaa
@@ -89690,7 +89803,7 @@ aaa
 aaa
 aaa
 aaa
-aag
+aaa
 aaa
 aaa
 aaa
@@ -89947,16 +90060,16 @@ aaa
 aaa
 aaa
 aaa
+btD
+btD
+btD
+btD
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+btD
+btD
+btD
+btD
+aag
 aaa
 aaa
 aaa
@@ -90203,17 +90316,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
 btD
 btD
 btD
 btD
-aaa
 btD
 btD
 btD
 btD
-aag
+btD
+btD
+btD
 aaa
 aaa
 aaa
@@ -90459,7 +90572,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 btD
 btD
 btD
@@ -90471,7 +90583,8 @@ btD
 btD
 btD
 btD
-aaa
+btD
+btD
 aaa
 aaa
 aaa
@@ -90715,7 +90828,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
 btD
 btD
 btD
@@ -90729,7 +90841,8 @@ btD
 btD
 btD
 btD
-aaa
+btD
+btD
 aaa
 aaa
 aaa
@@ -91739,10 +91852,10 @@ bgj
 bgj
 bgj
 bgj
-aaa
-aaa
-aaa
-aaa
+uIo
+iur
+iur
+iur
 btD
 btD
 btD
@@ -91996,10 +92109,10 @@ bgj
 bgj
 bgj
 bgj
-bdz
-iur
-iur
-iur
+evb
+boX
+bsx
+fab
 btD
 btD
 btD
@@ -92253,8 +92366,8 @@ bgj
 bgj
 bgj
 bgj
-odL
-boX
+evb
+bsx
 bsx
 fab
 btD
@@ -92511,9 +92624,9 @@ bgj
 bgj
 bgj
 odL
-bsx
-bsx
-fab
+baY
+baY
+odL
 btD
 btD
 btD
@@ -92768,8 +92881,8 @@ bgj
 bgj
 bgj
 odL
-baY
-baY
+hSb
+cgz
 odL
 btD
 btD
@@ -92783,7 +92896,7 @@ btD
 btD
 btD
 btD
-btD
+tQb
 btD
 btD
 aaa
@@ -93007,9 +93120,9 @@ aXZ
 aXZ
 aXZ
 aah
-aah
-aah
-aDy
+aaa
+aaa
+beZ
 bAk
 aYh
 aDy
@@ -93025,8 +93138,8 @@ bgj
 bgj
 bgj
 odL
-hSb
-cgz
+bAk
+aYh
 icb
 btD
 btD
@@ -93040,7 +93153,7 @@ btD
 btD
 btD
 btD
-tQb
+btD
 btD
 btD
 aaa
@@ -93264,8 +93377,8 @@ aXZ
 aXZ
 aaa
 aah
-aah
-bJT
+aaa
+aaa
 aDy
 bAk
 aYh
@@ -93291,9 +93404,9 @@ btD
 btD
 btD
 btD
-btD
-btD
-btD
+aaa
+aaa
+aaa
 btD
 btD
 btD
@@ -93520,7 +93633,7 @@ aXZ
 aXZ
 aXZ
 aaa
-aaa
+aah
 aah
 aah
 aDy
@@ -93799,7 +93912,7 @@ odL
 dCb
 aml
 qYH
-btD
+aaa
 btD
 btD
 btD
@@ -93813,7 +93926,7 @@ btD
 btD
 btD
 btD
-btD
+aaa
 aaa
 aaa
 aaa
@@ -94056,7 +94169,7 @@ ffq
 bwe
 aYh
 iur
-aah
+aaa
 btD
 btD
 btD
@@ -94313,8 +94426,8 @@ tck
 bwx
 aYh
 iur
-aah
-btD
+aaa
+aaa
 btD
 btD
 btD
@@ -94326,7 +94439,7 @@ btD
 btD
 btD
 btD
-btD
+aaa
 aaa
 aaa
 aaa
@@ -94553,12 +94666,12 @@ aXZ
 aXZ
 aDy
 ofu
-aMb
+fxb
 hVG
 aMb
 aMb
 bJI
-uIo
+aMb
 aFB
 aIm
 aFB
@@ -94567,22 +94680,22 @@ bJI
 aMb
 aMb
 hVG
-aMb
+fxb
 dvb
 odL
-aah
-aah
-btD
-btD
-btD
-btD
 aaa
 aaa
 aaa
-btD
-btD
-btD
-btD
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -94815,10 +94928,11 @@ odL
 odL
 odL
 odL
-odL
+mcG
 aGU
 epm
 nSy
+mcG
 odL
 odL
 odL
@@ -94826,9 +94940,8 @@ odL
 odL
 odL
 odL
-odL
-aah
-aah
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -95067,26 +95180,26 @@ aaa
 aaa
 aaa
 aah
+aaa
+aaa
 aah
-aah
-aah
-aah
-aah
+aaa
+aaa
 odL
 uMW
 aJZ
 aGp
 odL
+aah
 aaa
 aaa
-aaa
-aaa
+aah
 aaa
 aaa
 aah
 aah
 aah
-aaa
+aah
 aaa
 aaa
 aaa
@@ -95324,26 +95437,26 @@ aaa
 aaa
 aaa
 aah
+aaa
+aaa
 aah
-aah
-aah
-aah
-aah
+aaa
+aaa
 odL
 aGU
 epm
 nSy
 odL
-aaa
-aaa
-aaa
+aah
 aaa
 aaa
 aah
-aah
-aah
+aaa
+aaa
 aah
 aaa
+aaa
+aah
 aaa
 aaa
 aaa
@@ -95587,20 +95700,20 @@ bWt
 bWt
 bWt
 odL
-mcG
+buT
 aIm
 gmF
 odL
 odL
 odL
 odL
+odL
 aah
 aah
 aah
-aah
-aah
-bJT
 aaa
+aaa
+aah
 aaa
 aaa
 aaa
@@ -95847,10 +95960,12 @@ odL
 rSU
 bvW
 bDi
+gQm
 odL
 aHe
-btV
+apN
 odL
+cju
 cju
 aah
 aah
@@ -95859,10 +95974,8 @@ aah
 aah
 aah
 aah
-aaa
-aaa
-aaa
-aaa
+aah
+aah
 aah
 aah
 aah
@@ -96106,25 +96219,25 @@ lwr
 bjT
 uTe
 kfK
-bsx
+bqI
 cks
+aEl
 rGM
 cju
 aah
+aaa
+aaa
+aah
+aah
+aaa
+aaa
 aah
 aah
 aah
-aah
-aah
-aah
-aah
-aah
-aah
-bQB
-fEm
-aZN
-aZN
-aZN
+fBb
+bbN
+bbN
+bbN
 bxm
 bHe
 bHe
@@ -96358,23 +96471,23 @@ aGy
 aGy
 aGy
 aTy
-buT
+ydn
 aJT
 sEe
+btV
 odL
-set
 rRu
+bJT
 odL
 cju
 cju
 aah
+aaa
+aaa
 aah
 aah
-aah
-aah
-aah
-aah
-aah
+aaa
+aaa
 aah
 aah
 jjN
@@ -96615,8 +96728,8 @@ aGy
 aGy
 aGy
 iur
-buT
-aJT
+yfa
+oHb
 qSg
 aon
 bHe
@@ -96872,9 +96985,9 @@ aGy
 aGy
 aGy
 bsr
-aEl
+buT
 aJW
-ajb
+bis
 uMv
 apE
 bsG
@@ -97130,7 +97243,7 @@ aGy
 aGy
 iur
 buT
-aJT
+bbr
 bis
 apk
 bkW
@@ -97901,7 +98014,7 @@ aGy
 aGy
 bsr
 buT
-aYm
+bbr
 bis
 aIY
 bkW
@@ -98158,7 +98271,7 @@ aGy
 aGy
 iur
 buT
-aYm
+bbr
 bis
 aXW
 aOo
@@ -98414,8 +98527,8 @@ aGy
 aGy
 aGy
 aTy
-buT
-aYm
+ydn
+bbr
 aEL
 aWW
 aWW
@@ -98671,10 +98784,10 @@ aGy
 aGy
 aGy
 qRb
-aGU
+hIf
 bbr
-nSy
-vhl
+qSg
+aWW
 aHg
 aWB
 bhe
@@ -98928,10 +99041,10 @@ aGy
 aGy
 aGy
 odL
-buT
-aYm
+bQB
+bhi
 qSg
-nQR
+vhl
 aHM
 aZw
 aZw
@@ -99183,12 +99296,12 @@ aRn
 aRn
 aRn
 aRn
-apT
-apT
+odL
+odL
 bRn
 roq
-cbS
-aWW
+qSg
+nQR
 aIr
 aZw
 bqN
@@ -99440,11 +99553,11 @@ baR
 bqh
 apy
 uvb
-apT
+odL
 buZ
-bbd
+buT
 xrW
-bhj
+sEe
 aWW
 aID
 aZw
@@ -99697,9 +99810,9 @@ baU
 bqr
 brV
 aYZ
-apT
+odL
 bvT
-bbd
+buT
 bdB
 bhf
 apt
@@ -99953,12 +100066,12 @@ brW
 bou
 bqG
 brW
-beZ
-apT
+aYZ
+odL
 btx
-bbd
-xrW
-dBT
+buT
+aYm
+gmF
 aWW
 bRk
 aMl
@@ -100211,10 +100324,10 @@ boz
 bqW
 fPk
 aYg
-apT
+odL
 btv
-bbd
-xrW
+buT
+aYm
 bmb
 aSP
 aSP
@@ -100468,7 +100581,7 @@ aRn
 aRn
 tPb
 aRn
-apT
+aZN
 apT
 bbv
 cEp
@@ -100697,7 +100810,7 @@ asL
 atJ
 auz
 inL
-hib
+era
 hib
 inL
 inL
@@ -100719,8 +100832,8 @@ bvK
 aLB
 ciQ
 hXd
-brf
 aFF
+brf
 aTB
 brU
 urb
@@ -100728,8 +100841,8 @@ aTv
 aWv
 aYR
 bbd
-xrW
-bhi
+umB
+bhj
 aSP
 aJs
 aQX
@@ -100957,7 +101070,7 @@ inL
 aWq
 aXO
 aXT
-fgF
+inL
 bne
 iPK
 bbF
@@ -100976,8 +101089,8 @@ bvO
 aLC
 aly
 pRu
+btF
 atE
-gth
 gth
 boh
 bss
@@ -101229,12 +101342,12 @@ aVq
 aVq
 aVq
 aVq
-aJL
+dlJ
 ajR
 cwT
-pRu
-btF
-btF
+bfZ
+bhj
+pvb
 gdb
 bud
 bhj
@@ -101475,7 +101588,7 @@ aWu
 bGM
 aFh
 bJH
-aVq
+dlJ
 bqf
 tIb
 tIb
@@ -101485,7 +101598,7 @@ cFO
 tIb
 tIb
 bqf
-tIb
+fEm
 brl
 aFG
 aFG
@@ -101732,7 +101845,7 @@ baT
 aUV
 aVq
 bET
-bqI
+aJL
 aRn
 bnj
 otU
@@ -102014,7 +102127,7 @@ aWA
 afW
 bbC
 aKb
-bhj
+set
 aSP
 bzv
 aUs
@@ -102239,7 +102352,7 @@ hnb
 auB
 bjC
 inL
-inL
+fgF
 inL
 inL
 inL
@@ -102251,10 +102364,10 @@ aRn
 fub
 aRn
 aMW
-cnZ
-ydn
-cnZ
+bbf
+xGz
 bpf
+pFf
 xYb
 cnZ
 cnZ
@@ -102514,7 +102627,7 @@ bBj
 cnZ
 arb
 cnZ
-cnZ
+ajb
 aFG
 aFG
 aQQ
@@ -102756,7 +102869,7 @@ bWt
 aah
 aaa
 aaa
-apN
+aRn
 aqJ
 bvC
 aiw
@@ -102775,11 +102888,11 @@ brq
 brq
 bbn
 iac
+bbf
+bbf
+bbf
 cnZ
-bbf
-bbf
-bbf
-bbf
+bBj
 cnZ
 wVh
 clm
@@ -103272,7 +103385,7 @@ aah
 aaa
 aRn
 apm
-fxb
+atI
 asB
 axU
 aRn
@@ -103529,8 +103642,8 @@ aah
 aah
 aRn
 bIO
-asb
-pvb
+atI
+asB
 bnE
 aRn
 aBv
@@ -103782,12 +103895,12 @@ aaa
 aaa
 aaa
 aaa
-bJT
+aah
 aah
 aRn
 fDb
 atI
-atI
+asb
 fgl
 aRn
 aBu
@@ -109175,7 +109288,7 @@ aDh
 aDh
 ahJ
 amu
-amu
+txE
 acO
 bup
 bkn
@@ -109695,8 +109808,8 @@ sAj
 aKY
 aKY
 agO
-alZ
-alZ
+cbS
+tla
 alZ
 alZ
 cfP
@@ -109948,7 +110061,7 @@ agI
 akG
 amC
 alm
-cFL
+alZ
 atc
 cfP
 adW
@@ -110204,8 +110317,8 @@ acb
 acA
 alc
 alU
-alm
-cFL
+dBT
+alZ
 alZ
 aru
 adW
@@ -110462,8 +110575,8 @@ acB
 acK
 adb
 alm
-alZ
-alZ
+cFL
+cFL
 aru
 adW
 dFe

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -617,14 +617,14 @@
 	},
 /area/station/security/main)
 "abj" = (
-/obj/machinery/power/tracker,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/plating/airless/catwalk,
-/area/station/solar/auxport)
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
+/area/station/cargo/recycleroffice)
 "abk" = (
 /obj/structure/stool/bed/chair/office/dark,
 /obj/structure/disposalpipe/segment,
@@ -1268,13 +1268,21 @@
 	},
 /area/station/security/brig)
 "acj" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = 29
 	},
-/turf/simulated/floor/plating/airless/catwalk,
-/area/station/solar/auxport)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal)
 "ack" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -1487,8 +1495,12 @@
 	},
 /area/station/security/execution)
 "acE" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 8
+	},
 /turf/simulated/floor/plating,
-/area/station/security/processing)
+/area/station/maintenance/auxsolarport)
 "acF" = (
 /obj/machinery/door_control{
 	id = "Armoury0";
@@ -1503,12 +1515,13 @@
 	},
 /area/station/security/armoury)
 "acG" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 5
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/weapon/storage/fancy/crayons,
+/turf/simulated/floor{
+	icon_state = "floorgrime"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/auxsolarport)
+/area/station/cargo/storage)
 "acH" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -1522,14 +1535,16 @@
 	},
 /area/station/security/main)
 "acJ" = (
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Labor Camp Shuttle Airlock";
-	req_access = list(2)
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Bay";
+	req_one_access = list(31,48,67)
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/security/processing)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/cargo/storage)
 "acK" = (
 /obj/machinery/door_control{
 	id = "laborexit";
@@ -1569,13 +1584,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/incinerator)
 "acO" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 5
-	},
-/turf/simulated/floor/plating,
-/area/station/security/processing)
+/turf/simulated/wall/r_wall,
+/area/station/maintenance/auxsolarport)
 "acP" = (
 /obj/structure/stool/bed/chair/metal/black{
 	dir = 8
@@ -1962,23 +1972,9 @@
 	},
 /area/station/security/armoury)
 "ady" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/airless/catwalk,
-/area/station/solar/auxport)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
 "adz" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -2392,19 +2388,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/main)
-"aee" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/plating/airless/catwalk,
-/area/station/solar/auxport)
 "aef" = (
 /turf/simulated/wall,
 /area/station/maintenance/dormitory)
@@ -2744,20 +2727,6 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
-"aeN" = (
-/obj/machinery/power/solar{
-	id = "auxsolareast";
-	name = "Port Auxiliary Solar Array"
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 1
-	},
-/turf/simulated/floor/airless{
-	icon_state = "solarpanel"
-	},
-/area/station/solar/auxport)
 "aeO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -2873,32 +2842,12 @@
 	icon_state = "warning"
 	},
 /area/station/security/armoury)
-"aeX" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating/airless/catwalk,
-/area/station/solar/auxport)
 "aeY" = (
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "redfull"
 	},
 /area/station/security/main)
-"aeZ" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/plating/airless/catwalk,
-/area/station/solar/auxport)
 "afa" = (
 /obj/structure/window/reinforced,
 /obj/structure/closet/wardrobe/red,
@@ -3234,23 +3183,17 @@
 	},
 /area/station/security/armoury)
 "afB" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/item/device/radio/intercom{
+	dir = 0;
+	name = "Station Intercom (General)";
+	pixel_x = 27
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "browncorner"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating/airless/catwalk,
-/area/station/solar/auxport)
+/area/station/cargo/storage)
 "afC" = (
 /obj/machinery/door/airlock/glass{
 	name = "Holodeck Door"
@@ -3359,16 +3302,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/brig)
-"afM" = (
-/obj/machinery/power/solar{
-	id = "auxsolareast";
-	name = "Port Auxiliary Solar Array"
-	},
-/obj/structure/cable,
-/turf/simulated/floor/airless{
-	icon_state = "solarpanel"
-	},
-/area/station/solar/auxport)
 "afN" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -4266,16 +4199,13 @@
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/auxstarboard)
 "ahw" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/stool/bed/chair/comfy/brown{
+	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "brown"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/cargo/storage)
 "ahx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -4466,14 +4396,11 @@
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "ahJ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Labor Camp Shuttle Airlock";
-	req_access = list(2)
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/security/processing)
+/area/station/maintenance/auxsolarport)
 "ahK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -4870,16 +4797,14 @@
 	},
 /area/station/security/main)
 "ait" = (
-/obj/structure/rack,
+/obj/structure/table,
+/obj/item/weapon/storage/toolbox/emergency,
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/item/weapon/airlock_electronics,
-/obj/item/weapon/module/power_control,
-/obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor{
-	dir = 9;
+	dir = 8;
 	icon_state = "yellow"
 	},
 /area/station/storage/tools)
@@ -4908,15 +4833,22 @@
 /turf/environment/space/shuttle,
 /area/shuttle/escape_pod3/station)
 "aiw" = (
-/obj/machinery/vending/cigarette,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_x = -32;
+	pixel_y = 32
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "whiteblue"
 	},
-/area/station/hallway/secondary/arrival)
+/area/station/hallway/secondary/exit)
 "aix" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/drinks/flask/barflask,
@@ -5082,19 +5014,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/arrival)
+/turf/simulated/wall,
+/area/station/cargo/storage)
 "aiL" = (
 /obj/structure/object_wall/pod{
 	icon_state = "2,0"
@@ -5274,7 +5195,7 @@
 /turf/simulated/floor{
 	icon_state = "browncorner"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "ajc" = (
 /obj/structure/stool/bed/roller,
 /obj/machinery/iv_drip,
@@ -5744,9 +5665,12 @@
 	},
 /area/station/security/main)
 "ajN" = (
-/obj/structure/cable,
-/turf/simulated/floor/plating/airless/catwalk,
-/area/station/solar/auxport)
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/station/cargo/office)
 "ajO" = (
 /obj/machinery/computer/prisoner{
 	dir = 8
@@ -5780,11 +5704,8 @@
 /area/station/security/brig)
 "ajR" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Escape Hall"
-	},
 /turf/simulated/floor{
-	icon_state = "neutralcorner"
+	icon_state = "redcorner"
 	},
 /area/station/hallway/secondary/exit)
 "ajS" = (
@@ -6207,21 +6128,16 @@
 	},
 /area/station/medical/virology)
 "akz" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -6255,12 +6171,16 @@
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/auxstarboard)
 "akD" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/structure/closet/emcloset,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/turf/simulated/floor/plating/airless/catwalk,
-/area/station/solar/auxport)
+/obj/item/clothing/mask/gas/coloured,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "akE" = (
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/auxport)
@@ -6494,19 +6414,12 @@
 	},
 /area/station/security/brig)
 "akV" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 4
+	dir = 5
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
+/obj/structure/flora/ausbushes/grassybush,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/grass,
 /area/station/hallway/secondary/exit)
 "akW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -6670,12 +6583,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/brig)
-"alk" = (
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "all" = (
 /obj/machinery/camera{
 	c_tag = "Brig West";
@@ -6800,19 +6707,56 @@
 	},
 /area/station/security/brig)
 "alv" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance{
-	name = "Labor Shuttle";
-	req_access = list(1)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/station/security/processing)
+/area/station/maintenance/cargo)
 "alw" = (
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "escape"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/station/hallway/secondary/exit)
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/embedded_controller/radio/airlock_controller{
+	id_tag = "solar_tool_airlock";
+	pixel_x = 28;
+	pixel_y = 4;
+	req_access = list(13);
+	tag_airpump = "solar_tool_pump";
+	tag_chamber_sensor = "solar_tool_sensor";
+	tag_exterior_door = "solar_tool_outer";
+	tag_interior_door = "solar_tool_inner"
+	},
+/obj/machinery/airlock_sensor{
+	id_tag = "solar_tool_sensor";
+	layer = 3.3;
+	pixel_x = 28;
+	pixel_y = -8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
+	frequency = 1379;
+	id_tag = "solar_tool_pump";
+	name = "Solar Tool Large Air Vent"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/auxsolarport)
 "alx" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
@@ -6828,16 +6772,10 @@
 	},
 /area/station/medical/virology)
 "aly" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/machinery/door/airlock/glass{
+	name = "Escape Hall"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "white"
-	},
+/turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "alz" = (
 /obj/structure/sign/nanotrasen{
@@ -7104,6 +7042,13 @@
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "alS" = (
+/obj/machinery/computer/security{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -27
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "red"
@@ -7145,17 +7090,6 @@
 /area/station/maintenance/dormitory)
 "alW" = (
 /obj/machinery/door_timer/cell_4,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "red"
@@ -7216,20 +7150,20 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "amc" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	id_tag = "solar_tool_outer";
-	locked = 1;
-	name = "Engineering External Access";
-	req_access = list(10,13)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/auxsolarport)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
+	},
+/area/station/cargo/office)
 "amd" = (
 /obj/machinery/power/apc/smallcell{
 	dir = 8;
@@ -7348,14 +7282,10 @@
 /area/station/security/brig)
 "aml" = (
 /obj/machinery/light,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "warning"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "amm" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -7388,37 +7318,21 @@
 	},
 /area/station/security/detectives_office)
 "amp" = (
+/obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	id_tag = "solar_tool_airlock";
-	pixel_x = 28;
-	pixel_y = 4;
-	req_access = list(13);
-	tag_airpump = "solar_tool_pump";
-	tag_chamber_sensor = "solar_tool_sensor";
-	tag_exterior_door = "solar_tool_outer";
-	tag_interior_door = "solar_tool_inner"
-	},
-/obj/machinery/airlock_sensor{
-	id_tag = "solar_tool_sensor";
-	layer = 3.3;
-	pixel_x = 28;
-	pixel_y = -8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
+/obj/machinery/door/airlock/external{
 	frequency = 1379;
-	id_tag = "solar_tool_pump";
-	name = "Solar Tool Large Air Vent"
+	id_tag = "recycler_inner";
+	locked = 1;
+	name = "Recycler External Access";
+	req_access = list(67)
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/auxsolarport)
+/area/station/cargo/recycleroffice)
 "amq" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -7474,14 +7388,13 @@
 	},
 /area/station/security/prison)
 "amu" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 5
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/sign/warning/docking,
 /turf/simulated/floor/plating,
-/area/station/security/processing)
+/area/station/maintenance/auxsolarport)
 "amv" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -7519,16 +7432,6 @@
 	icon_state = "warning"
 	},
 /area/station/engineering/engine)
-"amz" = (
-/obj/machinery/alarm{
-	pixel_y = 28
-	},
-/obj/structure/closet/secure_closet/cargotech,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "brown"
-	},
-/area/station/cargo/office)
 "amA" = (
 /obj/machinery/door_control{
 	desc = "A remote control switch for the brig foyer.";
@@ -7674,22 +7577,9 @@
 	},
 /area/station/security/prison)
 "amO" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2";
-	pixel_y = 1
-	},
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1379;
-	master_tag = "solar_tool_airlock";
-	name = "exterior access button";
-	pixel_x = -25;
-	pixel_y = -25;
-	req_access = list(13)
-	},
-/turf/simulated/floor/plating/airless/catwalk,
-/area/station/solar/auxport)
+/obj/structure/scrap_beacon,
+/turf/simulated/floor/airless/ceiling,
+/area/station/cargo/recycler)
 "amP" = (
 /obj/machinery/door_control{
 	desc = "A remote control switch for the brig foyer.";
@@ -7959,21 +7849,6 @@
 "ani" = (
 /turf/simulated/wall,
 /area/station/security/prison)
-"anj" = (
-/obj/structure/table/glass,
-/obj/item/weapon/medical/teleporter{
-	pixel_x = -5;
-	pixel_y = 7
-	},
-/obj/item/weapon/storage/firstaid/toxin{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "whiteblue"
-	},
-/area/station/hallway/secondary/exit)
 "ank" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -8131,23 +8006,15 @@
 /turf/simulated/floor/carpet/red,
 /area/station/security/detectives_office)
 "anx" = (
-/obj/machinery/power/solar_control{
-	id = "auxsolareast";
-	name = "Fore Port Solar Control"
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/light_switch{
+	pixel_y = 28
 	},
-/obj/structure/sign/warning/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_y = 32
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/auxsolarport)
+/obj/machinery/vending/theater,
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "any" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -8642,25 +8509,31 @@
 /turf/simulated/floor,
 /area/station/security/lobby)
 "aok" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Bay";
-	req_one_access = list(31,48,67)
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
+	dir = 4;
+	frequency = 1379;
+	id_tag = "arrival_dock_pump";
+	name = "Arrival Dock Large Air Vent"
 	},
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/turf/simulated/floor/plating{
+	icon_state = "platebotc"
+	},
+/area/station/maintenance/cargo)
 "aol" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Escape Maintenance APC";
+	pixel_x = 28
 	},
-/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/auxsolarport)
+/area/station/maintenance/escape)
 "aom" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -8889,22 +8762,20 @@
 	},
 /area/station/security/prison)
 "aoK" = (
+/obj/machinery/hologram/holopad,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	id_tag = "solar_tool_inner";
-	locked = 1;
-	name = "Engineering External Access";
-	req_access = list(13)
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/auxsolarport)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor,
+/area/station/cargo/qm)
 "aoL" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -9054,42 +8925,22 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "aoX" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	icon_state = "browncorner"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 8
-	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1379;
-	master_tag = "solar_tool_airlock";
-	name = "interior access button";
-	pixel_x = 25;
-	pixel_y = 25;
-	req_access = list(13)
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/auxsolarport)
+/area/station/cargo/office)
 "aoY" = (
 /obj/structure/table,
 /obj/item/weapon/dice/d20,
 /turf/simulated/floor,
 /area/station/security/prison)
 "aoZ" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8
-	},
+/obj/item/weapon/table_parts,
+/obj/item/weapon/storage/box/lights/mixed,
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
-/area/station/maintenance/auxsolarport)
+/area/station/maintenance/engineering)
 "apa" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -9206,33 +9057,25 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "apm" = (
-/obj/machinery/power/smes,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/computer/crew,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "whiteblue"
 	},
-/obj/machinery/light/small,
-/turf/simulated/floor/plating,
-/area/station/maintenance/auxsolarport)
+/area/station/hallway/secondary/exit)
 "apn" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/components/binary/pump/on{
+/obj/structure/table/glass,
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/auxsolarport)
-"apo" = (
-/turf/simulated/wall/r_wall,
-/area/station/hallway/secondary/entry)
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/obj/item/weapon/folder/white,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "whiteblue"
+	},
+/area/station/hallway/secondary/exit)
 "app" = (
 /turf/simulated/floor/plating/airless{
 	dir = 4;
@@ -9249,17 +9092,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/prison)
-"apr" = (
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	name = "Honk Office APC";
-	pixel_y = -30
-	},
-/obj/structure/table/woodentable,
-/obj/item/clothing/suit/batman,
-/obj/item/clothing/head/batman_helmet,
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "aps" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -9307,12 +9139,11 @@
 	},
 /area/station/security/prison)
 "apw" = (
-/obj/structure/sign/warning/securearea{
-	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA"
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6
 	},
-/turf/simulated/wall,
-/area/station/hallway/secondary/exit)
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "apx" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
@@ -9503,28 +9334,24 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "apM" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
+/obj/structure/window/reinforced{
+	dir = 8
 	},
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced,
 /turf/simulated/floor/plating,
-/area/station/maintenance/auxsolarport)
+/area/station/civilian/barbershop)
 "apN" = (
-/obj/machinery/camera{
-	c_tag = "Fore Port Solar Control";
-	dir = 4;
-	network = list("SS13","Engineering")
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
+	name = "KEEP CLEAR: DOCKING AREA"
 	},
-/obj/structure/stool{
-	pixel_y = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/auxsolarport)
+/turf/simulated/wall,
+/area/station/hallway/secondary/exit)
 "apO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -9630,7 +9457,7 @@
 /area/station/rnd/test_area)
 "aqb" = (
 /obj/structure/stool/bed/chair/metal{
-	dir = 8
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
@@ -10029,16 +9856,24 @@
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "aqJ" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/newscaster{
+	pixel_x = -28;
+	pixel_y = 1
 	},
-/obj/machinery/power/apc{
-	name = "Fore Port Solar APC";
-	pixel_y = -28
+/obj/structure/table/glass,
+/obj/item/device/radio/off{
+	pixel_x = -6;
+	pixel_y = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/auxsolarport)
+/obj/item/device/radio/off{
+	pixel_x = 6;
+	pixel_y = 1
+	},
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "whiteblue"
+	},
+/area/station/hallway/secondary/exit)
 "aqK" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
@@ -10079,32 +9914,12 @@
 	},
 /turf/environment/space,
 /area/shuttle/mining/station)
-"aqN" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "aqO" = (
 /obj/structure/object_wall/mining{
 	icon_state = "1-2"
 	},
 /turf/environment/space,
 /area/shuttle/mining/station)
-"aqP" = (
-/obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/alarm{
-	pixel_y = 23
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
 "aqQ" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating,
@@ -10138,25 +9953,6 @@
 	icon_state = "whitehall"
 	},
 /area/station/medical/surgery2)
-"aqV" = (
-/obj/machinery/light_switch{
-	pixel_y = -25
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 29
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
 "aqW" = (
 /obj/structure/stool/bed/chair/metal{
 	dir = 4
@@ -10215,12 +10011,12 @@
 	},
 /area/station/rnd/xenobiology)
 "arb" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/grille,
+/obj/item/weapon/shard,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "arc" = (
@@ -10337,8 +10133,26 @@
 	},
 /area/station/security/prison)
 "aro" = (
+/obj/machinery/airlock_sensor{
+	id_tag = "arrival_dock_sensor";
+	pixel_x = 25;
+	pixel_y = 12
+	},
+/obj/machinery/embedded_controller/radio/airlock_controller{
+	id_tag = "arrival_dock_airlock";
+	pixel_x = 25;
+	req_one_access = list(13,45,1);
+	tag_airpump = "arrival_dock_pump";
+	tag_chamber_sensor = "arrival_dock_sensor";
+	tag_exterior_door = "arrival_dock_outer";
+	tag_interior_door = "arrival_dock_inner"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
+/area/station/maintenance/cargo)
 "arp" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
@@ -10732,15 +10546,25 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "asb" = (
-/obj/structure/stool/bed/roller,
-/obj/machinery/iv_drip,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor{
-	icon_state = "whiteblue"
+	dir = 4;
+	icon_state = "white"
 	},
 /area/station/hallway/secondary/exit)
 "asc" = (
+/obj/structure/table,
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/packageWrap,
 /turf/simulated/floor{
-	dir = 4;
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
@@ -10805,6 +10629,9 @@
 /area/station/security/prison)
 "asi" = (
 /obj/effect/decal/cleanable/generic,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "asj" = (
@@ -11009,14 +10836,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "asB" = (
-/obj/effect/decal/cleanable/cobweb2,
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/turf/simulated/floor/plating{
-	icon_state = "platingdmg3"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/area/station/maintenance/escape)
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "white"
+	},
+/area/station/hallway/secondary/exit)
 "asC" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -11047,13 +10877,6 @@
 	icon_state = "redfull"
 	},
 /area/station/security/prison)
-"asD" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 5
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
 "asE" = (
 /obj/structure/table/woodentable/poker,
 /obj/item/weapon/game_kit/random{
@@ -11065,6 +10888,10 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "asG" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "warning"
@@ -11261,17 +11088,18 @@
 	},
 /area/station/maintenance/eva)
 "atd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/escape)
+/area/station/maintenance/cargo)
 "ate" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -11549,6 +11377,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "atE" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "atF" = (
@@ -11584,8 +11417,11 @@
 /turf/environment/space,
 /area/shuttle/mining/station)
 "atI" = (
-/turf/simulated/wall/r_wall,
-/area/station/maintenance/auxsolarport)
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "white"
+	},
+/area/station/hallway/secondary/exit)
 "atJ" = (
 /obj/structure/object_wall/mining{
 	icon_state = "4-2";
@@ -11601,16 +11437,6 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/cold_room)
-"atL" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/hallway/secondary/entry)
 "atM" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -11855,24 +11681,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "auf" = (
-/obj/structure/table/glass,
-/obj/item/weapon/storage/firstaid/o2,
-/obj/item/device/radio/off{
-	pixel_x = -6;
-	pixel_y = 4
-	},
-/obj/item/device/radio/off{
-	pixel_x = 6;
-	pixel_y = 1
-	},
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "whiteblue"
-	},
-/area/station/hallway/secondary/exit)
+/obj/item/weapon/flora/random,
+/turf/simulated/floor,
+/area/station/hallway/secondary/mine_sci_shuttle)
 "aug" = (
 /obj/structure/barricade/wooden,
 /turf/simulated/floor/plating,
@@ -12060,16 +11871,11 @@
 /turf/environment/space,
 /area/shuttle/mining/station)
 "auC" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warningcorner"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/escape)
+/area/station/cargo/storage)
 "auD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -12171,10 +11977,19 @@
 	},
 /area/station/civilian/kitchen)
 "auO" = (
-/obj/item/weapon/flora/random,
-/turf/simulated/floor{
-	icon_state = "brown"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/machinery/door_control{
+	id = "qm_warehouse";
+	name = "Warehouse Door Control";
+	pixel_y = 24;
+	req_access = list(31)
+	},
+/turf/simulated/floor,
 /area/station/cargo/storage)
 "auP" = (
 /obj/item/weapon/reagent_containers/food/condiment/enzyme{
@@ -12352,11 +12167,12 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "avg" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/table,
-/obj/item/weapon/storage/fancy/crayons,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
 /turf/simulated/floor{
-	icon_state = "floorgrime"
+	icon_state = "brown"
 	},
 /area/station/cargo/storage)
 "avh" = (
@@ -12889,15 +12705,6 @@
 	icon_state = "warnwhite"
 	},
 /area/station/rnd/xenobiology)
-"awg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "bar"
-	},
-/area/station/cargo/miningoffice)
 "awh" = (
 /turf/simulated/floor/engine{
 	name = "Holodeck Projector Floor"
@@ -13044,11 +12851,13 @@
 /turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
 "awv" = (
-/obj/random/vending/cola,
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/area/station/hallway/secondary/arrival)
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "aww" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/plating,
@@ -13350,14 +13159,20 @@
 /turf/simulated/wall,
 /area/station/security/range)
 "axc" = (
-/obj/machinery/computer/cargo{
-	dir = 1
+/obj/structure/rack,
+/obj/item/weapon/pickaxe/drill{
+	pixel_y = 4
+	},
+/obj/item/weapon/pickaxe/drill,
+/obj/item/weapon/pickaxe/drill,
+/obj/machinery/alarm{
+	pixel_y = 26
 	},
 /turf/simulated/floor{
-	dir = 9;
+	dir = 1;
 	icon_state = "brown"
 	},
-/area/station/cargo/qm)
+/area/station/cargo/miningoffice)
 "axd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -13686,17 +13501,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/eva)
-"axK" = (
-/obj/machinery/computer/security/mining,
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 24
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "brown"
-	},
-/area/station/cargo/qm)
 "axL" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
@@ -13753,9 +13557,9 @@
 	},
 /area/station/maintenance/eva)
 "axU" = (
+/obj/structure/stool/bed/roller,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "bluecorner"
+	icon_state = "whiteblue"
 	},
 /area/station/hallway/secondary/exit)
 "axV" = (
@@ -14069,19 +13873,6 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/hydroponics)
-"ayz" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "bar"
-	},
-/area/station/cargo/miningoffice)
 "ayA" = (
 /obj/structure/closet/athletic_mixed,
 /obj/item/clothing/under/pants/black_sport,
@@ -14191,19 +13982,6 @@
 	icon_state = "wooden-2"
 	},
 /area/station/civilian/gym)
-"ayJ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/airlock/maintenance{
-	req_access = list(12)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/escape)
 "ayK" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -14295,9 +14073,6 @@
 /turf/simulated/floor/plating,
 /area/station/storage/tech/north)
 "ayV" = (
-/obj/structure/stool/bed/chair/metal/red{
-	dir = 8
-	},
 /obj/machinery/camera{
 	c_tag = "Escape Security Room";
 	dir = 8;
@@ -14317,18 +14092,18 @@
 /turf/simulated/floor,
 /area/station/rnd/misc_lab)
 "ayX" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/structure/closet/crate,
+/obj/random/tools/tech_supply,
+/obj/random/tools/tech_supply,
+/obj/item/weapon/rack_parts,
+/obj/item/weapon/rack_parts,
+/obj/item/weapon/rack_parts,
+/obj/item/weapon/rack_parts,
+/obj/item/weapon/rack_parts,
 /turf/simulated/floor{
-	icon_state = "bar"
+	icon_state = "floorgrime"
 	},
-/area/station/cargo/miningoffice)
+/area/station/cargo/storage)
 "ayY" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -14440,11 +14215,20 @@
 	},
 /area/station/rnd/xenobiology)
 "azh" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "bluecorner"
+/obj/machinery/atmospherics/components/binary/pump/on,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/station/hallway/secondary/exit)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "azi" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -14551,16 +14335,14 @@
 	},
 /area/station/civilian/gym)
 "azs" = (
-/obj/machinery/vending/coffee,
-/obj/machinery/power/apc{
-	name = "Arrival Hallway APC";
-	pixel_y = -24
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
 	},
-/obj/structure/cable,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "escape"
 	},
-/area/station/hallway/secondary/arrival)
+/area/station/hallway/secondary/exit)
 "azt" = (
 /obj/machinery/requests_console/science{
 	pixel_y = -32
@@ -14571,13 +14353,13 @@
 	},
 /area/station/rnd/xenobiology)
 "azu" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "stationscrap"
 	},
-/obj/item/trash/chips,
-/obj/item/clothing/head/ushanka,
+/obj/item/stack/sheet/refined_scrap,
 /turf/simulated/floor/plating/airless,
-/area/station/maintenance/escape)
+/area/station/cargo/recycler)
 "azv" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas/coloured,
@@ -15651,11 +15433,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
-"aBw" = (
-/obj/structure/stool/bed/chair/metal,
-/obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/plating,
-/area/station/maintenance/escape)
 "aBx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15976,10 +15753,6 @@
 	icon_state = "warning"
 	},
 /area/station/ai_monitored/eva)
-"aBW" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
 "aBX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -16038,6 +15811,7 @@
 	req_access = list(50)
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/cargo/office)
 "aCe" = (
@@ -16296,15 +16070,20 @@
 /turf/simulated/floor,
 /area/station/cargo/qm)
 "aCJ" = (
-/obj/machinery/atm{
-	pixel_x = 32
+/obj/machinery/disposal,
+/obj/machinery/light{
+	dir = 8
 	},
-/mob/living/simple_animal/walle,
+/obj/structure/sign/poster/official/soft_cap_pop_art{
+	pixel_x = -32
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
+	icon_state = "purplechecker"
 	},
-/area/station/cargo/qm)
+/area/station/civilian/barbershop)
 "aCK" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -16388,14 +16167,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "aCR" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/table/woodentable,
+/obj/item/weapon/lipstick/purple{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "warning"
-	},
-/area/station/hallway/secondary/entry)
+/obj/item/weapon/lipstick/jade,
+/obj/item/toy/sound_button,
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "aCS" = (
 /turf/simulated/floor/plating{
 	icon_state = "panelscorched"
@@ -16438,12 +16218,6 @@
 	icon_state = "vault"
 	},
 /area/station/medical/hallway)
-"aCX" = (
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "browncorner"
-	},
-/area/station/hallway/secondary/arrival)
 "aCY" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
@@ -16533,19 +16307,11 @@
 /area/station/maintenance/chapel)
 "aDh" = (
 /obj/structure/grille,
-/obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
-	dir = 4
+	dir = 5
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/station/cargo/office)
+/area/station/maintenance/auxsolarport)
 "aDi" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -16721,14 +16487,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/civilian/chapel)
-"aDw" = (
-/obj/structure/stool/bed/chair/comfy/brown{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "aDx" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -16746,7 +16504,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "aDz" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -17006,13 +16764,11 @@
 /turf/simulated/wall,
 /area/station/civilian/toilet)
 "aEb" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 5
+/obj/structure/table/woodentable,
+/turf/simulated/floor{
+	icon_state = "brown"
 	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
+/area/station/cargo/storage)
 "aEc" = (
 /obj/item/weapon/coin/iron,
 /turf/simulated/floor/plating,
@@ -17077,17 +16833,20 @@
 	},
 /area/station/security/main)
 "aEk" = (
-/obj/machinery/hologram/holopad,
-/obj/item/device/radio/beacon,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/stool/bed/chair/office/dark{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor,
-/area/station/hallway/secondary/arrival)
+/area/station/security/checkpoint)
 "aEl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "aEm" = (
 /obj/item/weapon/hemostat,
 /obj/structure/table/glass,
@@ -17145,18 +16904,6 @@
 	icon_state = "darkred"
 	},
 /area/station/civilian/bar)
-"aEs" = (
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/station/cargo/office)
 "aEt" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 8
@@ -17340,7 +17087,7 @@
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "aEM" = (
 /obj/machinery/power/apc{
 	name = "Port Maintenance APC";
@@ -17531,21 +17278,6 @@
 	icon_state = "vault"
 	},
 /area/station/gateway)
-"aFc" = (
-/obj/structure/rack,
-/obj/item/weapon/pickaxe/drill{
-	pixel_y = 4
-	},
-/obj/item/weapon/pickaxe/drill,
-/obj/item/weapon/pickaxe/drill,
-/obj/machinery/alarm{
-	pixel_y = 26
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "brown"
-	},
-/area/station/cargo/miningoffice)
 "aFd" = (
 /obj/machinery/gateway{
 	dir = 4
@@ -17581,9 +17313,14 @@
 /turf/simulated/wall,
 /area/station/cargo/storage)
 "aFh" = (
-/turf/simulated/floor{
-	icon_state = "whiteblue"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "aFi" = (
 /obj/machinery/light{
@@ -17801,15 +17538,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"aFz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "aFA" = (
 /obj/effect/spawner/lootdrop/maintenance/two,
 /obj/structure/closet/secure_closet/personal,
@@ -17895,10 +17623,10 @@
 /turf/simulated/wall,
 /area/station/storage/primary)
 "aFM" = (
-/obj/item/weapon/flora/random,
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/item/weapon/flora/random,
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -18137,15 +17865,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/civilian/toilet)
-"aGj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "aGk" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -18185,18 +17904,14 @@
 	},
 /area/station/civilian/gym)
 "aGp" = (
-/obj/machinery/door/airlock/external{
-	name = "Arrival Airlock"
-	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/door/airlock/glass{
+	name = "Arrival Access"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
 	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "aGq" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -18445,18 +18160,6 @@
 	icon_state = "warningcorner"
 	},
 /area/station/maintenance/science)
-"aGM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
 "aGN" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
@@ -18483,6 +18186,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/cargo/office)
 "aGR" = (
@@ -18490,15 +18194,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "aGS" = (
-/obj/machinery/camera{
-	c_tag = "Escape Medical Checkpoint";
-	network = list("SS13","Medical")
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "whiteblue"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/station/hallway/secondary/exit)
+/turf/simulated/floor,
+/area/station/hallway/secondary/mine_sci_shuttle)
 "aGT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -18530,39 +18236,6 @@
 "aGW" = (
 /turf/simulated/wall,
 /area/station/storage/tools)
-"aGX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/arrival)
-"aGY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/arrival)
 "aGZ" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -18598,14 +18271,21 @@
 	},
 /area/station/maintenance/science)
 "aHc" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/area/station/hallway/secondary/entry)
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/auxsolarport)
 "aHd" = (
 /obj/structure/rack,
 /obj/item/weapon/reagent_containers/spray/extinguisher,
@@ -18614,14 +18294,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "aHe" = (
-/obj/item/stack/tile/wood{
-	amount = 3
-	},
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/escape)
+/area/station/hallway/secondary/arrival)
 "aHf" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor{
@@ -18633,9 +18310,6 @@
 /obj/structure/table/woodentable,
 /obj/item/device/camera_film,
 /obj/item/device/camera_film,
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/item/device/camera/polar,
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
@@ -18774,15 +18448,6 @@
 	icon_state = "white"
 	},
 /area/station/medical/storage)
-"aHw" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 5
-	},
-/obj/structure/sign/directions/dock_tablo/tablo2,
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
 "aHx" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -18845,9 +18510,19 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aHC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/arrival)
+/area/station/hallway/secondary/exit)
 "aHD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -18884,11 +18559,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "aHH" = (
-/obj/item/weapon/flora/random,
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken5"
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/station/maintenance/escape)
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "aHI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
@@ -18997,14 +18678,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "aHU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "aHV" = (
@@ -19057,17 +18732,8 @@
 	},
 /area/station/medical/genetics)
 "aIb" = (
-/obj/structure/table,
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 20
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/stack/rods{
-	amount = 50
-	},
+/obj/structure/closet/toolcloset,
+/obj/item/clothing/suit/storage/hazardvest,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "yellow"
@@ -19084,7 +18750,6 @@
 	icon_state = "0-2";
 	pixel_y = 1
 	},
-/obj/structure/closet/toolcloset,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "yellow"
@@ -19141,26 +18806,15 @@
 /turf/simulated/wall,
 /area/station/maintenance/chapel)
 "aIk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/effect/landmark/start/cargo_technician,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/arrival)
+/turf/simulated/floor,
+/area/station/cargo/office)
 "aIl" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -19180,39 +18834,14 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "aIm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
+/turf/simulated/floor,
 /area/station/hallway/secondary/arrival)
-"aIn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/escape)
 "aIo" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -19256,6 +18885,9 @@
 /area/station/medical/hallway)
 "aIr" = (
 /obj/machinery/photocopier,
+/obj/machinery/newscaster{
+	pixel_y = 32
+	},
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
 "aIs" = (
@@ -19993,29 +19625,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"aJJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/arrival)
 "aJK" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 10
 	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "aJL" = (
 /turf/simulated/floor{
 	icon_state = "escape"
@@ -20073,21 +19696,9 @@
 	},
 /area/station/civilian/toilet)
 "aJR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/station/maintenance/escape)
+/obj/mecha/working/ripley,
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
 "aJS" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -20107,17 +19718,10 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "aJT" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=CHW";
-	location = "Bar"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable{
@@ -20126,7 +19730,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "aJU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -20156,16 +19760,13 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "aJX" = (
 /obj/effect/decal/cleanable/blood/oil,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -20189,27 +19790,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "aJZ" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Arrival Access"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Arrival Hallway East";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
+/turf/simulated/floor,
 /area/station/hallway/secondary/arrival)
 "aKa" = (
 /obj/item/seeds/berryseed,
@@ -20498,14 +20089,12 @@
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
 "aKF" = (
-/obj/structure/stool/bed/chair/comfy/brown{
-	dir = 8
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
+/turf/simulated/floor/plating/airless/catwalk,
+/area/station/solar/auxport)
 "aKG" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -20722,11 +20311,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "aKZ" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/weapon/storage/box/lights/mixed,
+/obj/structure/closet/toolcloset,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "yellow"
@@ -21073,9 +20658,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "aLB" = (
-/obj/machinery/door/airlock/glass{
-	name = "Escape Hall"
-	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	dir = 8;
@@ -21084,9 +20666,6 @@
 /area/station/hallway/secondary/exit)
 "aLC" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Escape Hall"
-	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "aLD" = (
@@ -21340,19 +20919,11 @@
 	},
 /area/station/rnd/brainstorm_center)
 "aMb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "warning"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "aMc" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -21401,17 +20972,16 @@
 	},
 /area/station/ai_monitored/eva)
 "aMg" = (
-/obj/item/device/radio/intercom{
-	dir = 0;
-	name = "Station Intercom (General)";
-	pixel_x = 27
+/obj/machinery/door/airlock{
+	name = "Honk Office";
+	req_access = list(46)
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "browncorner"
+	icon_state = "dark"
 	},
-/area/station/cargo/storage)
+/area/station/civilian/theatre)
 "aMh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -21491,21 +21061,6 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/locker)
-"aMp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/item/stack/tile/carpet/orange,
-/turf/simulated/floor/plating,
-/area/station/maintenance/escape)
 "aMq" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -21782,45 +21337,27 @@
 	},
 /area/station/hallway/primary/central)
 "aMT" = (
-/obj/structure/sign/warning/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_y = -32
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/plating{
-	icon_state = "platebotc"
-	},
-/area/station/maintenance/cargo)
-"aMU" = (
-/obj/structure/table/glass,
-/obj/item/weapon/storage/firstaid/regular{
-	pixel_x = -2;
-	pixel_y = 4
-	},
-/obj/item/weapon/reagent_containers/syringe{
-	pixel_x = -4
-	},
-/obj/item/weapon/reagent_containers/syringe{
-	pixel_x = -2;
-	pixel_y = 3
-	},
-/obj/item/weapon/reagent_containers/syringe{
-	pixel_y = 6
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "whiteblue"
+	dir = 4;
+	icon_state = "dark"
 	},
-/area/station/hallway/secondary/exit)
+/area/station/cargo/recycleroffice)
+"aMU" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/obj/machinery/light,
+/turf/simulated/floor,
+/area/station/hallway/secondary/mine_sci_shuttle)
 "aMV" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/reagent_dispensers/fueltank,
@@ -21837,18 +21374,11 @@
 /turf/simulated/floor/grass,
 /area/station/civilian/hydroponics)
 "aMY" = (
-/obj/machinery/light{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/rack,
-/obj/item/clothing/gloves/fyellow,
-/obj/item/clothing/suit/storage/hazardvest,
-/obj/item/device/multitool,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "yellow"
-	},
-/area/station/storage/tools)
+/turf/simulated/floor/plating,
+/area/space)
 "aMZ" = (
 /turf/simulated/wall,
 /area/station/civilian/kitchen)
@@ -21858,13 +21388,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "aNb" = (
-/obj/structure/closet/toolcloset,
-/obj/machinery/camera{
-	c_tag = "Auxiliary Tool Storage"
-	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "yellow"
+	dir = 4;
+	icon_state = "yellowcorner"
 	},
 /area/station/storage/tools)
 "aNc" = (
@@ -22055,14 +21581,6 @@
 "aNv" = (
 /turf/simulated/floor/grass,
 /area/station/civilian/hydroponics)
-"aNw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "browncorner"
-	},
-/area/station/hallway/secondary/entry)
 "aNx" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -22149,12 +21667,6 @@
 	icon_state = "whitecorner"
 	},
 /area/station/rnd/hallway)
-"aNE" = (
-/obj/item/weapon/table_parts,
-/obj/item/weapon/storage/box/lights/mixed,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
 "aNF" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -22175,7 +21687,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "aNH" = (
 /obj/item/weapon/table_parts,
 /obj/item/trash/cheesie,
@@ -22541,16 +22053,10 @@
 	},
 /area/station/cargo/office)
 "aOp" = (
-/obj/structure/table/glass,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/pen,
-/obj/item/weapon/folder/white,
-/obj/item/weapon/reagent_containers/food/drinks/britcup{
-	pixel_x = -4
-	},
+/obj/machinery/vending/cigarette,
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "whiteblue"
+	dir = 1;
+	icon_state = "brown"
 	},
 /area/station/hallway/secondary/exit)
 "aOq" = (
@@ -22611,8 +22117,10 @@
 /turf/simulated/floor,
 /area/station/storage/tools)
 "aOx" = (
-/obj/structure/table,
-/obj/item/weapon/storage/toolbox/emergency,
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 27
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "yellow"
@@ -22724,21 +22232,6 @@
 	icon_state = "floorgrime"
 	},
 /area/station/cargo/storage)
-"aOI" = (
-/obj/machinery/camera{
-	c_tag = "Quartermaster's Office";
-	dir = 8
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/item/weapon/flora/pottedplant/ficus,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/station/cargo/qm)
 "aOJ" = (
 /obj/machinery/camera{
 	c_tag = "Hydroponics Pasture";
@@ -23316,28 +22809,38 @@
 /turf/simulated/floor,
 /area/station/civilian/janitor)
 "aPJ" = (
-/obj/structure/reagent_dispensers/peppertank{
-	pixel_y = 30
+/obj/machinery/firealarm{
+	pixel_y = 28
 	},
-/obj/structure/closet/wardrobe/red,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "red"
-	},
-/area/station/security/checkpoint)
-"aPK" = (
-/obj/structure/stool/bed/chair/office/light{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
 	},
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "white"
+	icon_state = "darkredcorners"
 	},
 /area/station/hallway/secondary/exit)
+"aPK" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/camera{
+	c_tag = "Mining Shuttle";
+	dir = 8;
+	pixel_y = -18
+	},
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
+/area/station/hallway/secondary/mine_sci_shuttle)
 "aPL" = (
-/obj/structure/reagent_dispensers/fueltank,
+/obj/structure/rack,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
+	},
+/obj/item/weapon/module/power_control{
+	pixel_y = -5
+	},
+/obj/item/weapon/airlock_electronics{
+	pixel_y = 5
 	},
 /turf/simulated/floor{
 	dir = 10;
@@ -23350,13 +22853,8 @@
 	icon_state = "yellow"
 	},
 /area/station/storage/tools)
-"aPN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "aPO" = (
+/obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor{
 	icon_state = "yellow"
 	},
@@ -23381,7 +22879,9 @@
 	},
 /area/station/storage/tools)
 "aPR" = (
-/obj/item/weapon/flora/random,
+/obj/structure/rack,
+/obj/item/clothing/gloves/fyellow,
+/obj/item/device/multitool,
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "yellow"
@@ -23412,25 +22912,26 @@
 	},
 /area/station/civilian/playroom)
 "aPV" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/power/solar{
+	id = "auxsolareast";
+	name = "Port Auxiliary Solar Array"
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/cable,
+/turf/simulated/floor/airless{
+	icon_state = "solarpanel"
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/station/cargo/qm)
+/area/station/solar/auxport)
 "aPW" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/item/weapon/flora/pottedplant/tropicalfern,
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "brown"
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 30
 	},
-/area/station/cargo/qm)
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "loadingarea"
+	},
+/area/station/cargo/storage)
 "aPX" = (
 /obj/machinery/shower{
 	dir = 8
@@ -23649,11 +23150,11 @@
 	},
 /area/station/rnd/hor)
 "aQq" = (
-/obj/structure/stool/bed/chair/office/dark{
-	dir = 1
+/obj/machinery/vending/barbervend,
+/turf/simulated/floor{
+	icon_state = "purplechecker"
 	},
-/turf/simulated/floor,
-/area/station/cargo/qm)
+/area/station/civilian/barbershop)
 "aQr" = (
 /turf/simulated/floor{
 	dir = 9;
@@ -23873,9 +23374,13 @@
 	},
 /area/station/rnd/hallway)
 "aQJ" = (
+/obj/random/vending/snack,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "white"
+	dir = 1;
+	icon_state = "brown"
 	},
 /area/station/hallway/secondary/exit)
 "aQK" = (
@@ -23894,6 +23399,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor,
 /area/station/security/checkpoint)
@@ -23921,9 +23431,9 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -23949,12 +23459,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
-"aQR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
 "aQS" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -24129,14 +23633,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "aRi" = (
-/obj/structure/sign/poster/official/the_owl{
-	pixel_x = 32
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/station/cargo/qm)
+/turf/simulated/floor,
+/area/station/cargo/office)
 "aRj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -24547,14 +24054,9 @@
 	},
 /area/station/rnd/scibreak)
 "aRV" = (
-/obj/machinery/camera{
-	c_tag = "Mining Shuttle";
-	pixel_x = 18
-	},
-/turf/simulated/floor{
-	icon_state = "delivery"
-	},
-/area/station/hallway/secondary/mine_sci_shuttle)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/station/cargo/office)
 "aRW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -24584,21 +24086,13 @@
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
 "aRZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door_control{
+	id = "Security_private";
+	name = "Shutters Control";
+	pixel_x = -28
+	},
 /turf/simulated/floor,
 /area/station/security/checkpoint)
-"aSa" = (
-/obj/machinery/camera{
-	c_tag = "Cargo Bay Storage";
-	dir = 0
-	},
-/obj/structure/rack,
-/obj/random/science/circuit,
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
-/area/station/cargo/storage)
 "aSb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -24625,12 +24119,13 @@
 /turf/simulated/wall/r_wall,
 /area/station/rnd/hallway)
 "aSf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/simulated/floor{
+/obj/machinery/conveyor{
 	dir = 4;
-	icon_state = "white"
+	id = "stationscrap"
 	},
-/area/station/hallway/secondary/exit)
+/obj/machinery/recycler,
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
 "aSg" = (
 /obj/machinery/vending/assist,
 /obj/machinery/requests_console/tool_storage{
@@ -24921,11 +24416,13 @@
 	},
 /area/station/gateway)
 "aSI" = (
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "warning"
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(12)
 	},
-/area/station/hallway/secondary/entry)
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "aSJ" = (
 /obj/machinery/camera{
 	c_tag = "Bridge West Entrance";
@@ -25503,9 +25000,7 @@
 /obj/machinery/status_display{
 	pixel_x = 32
 	},
-/obj/machinery/computer/card{
-	dir = 8
-	},
+/obj/structure/filingcabinet,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "red"
@@ -25536,13 +25031,7 @@
 	},
 /area/station/rnd/robotics)
 "aTJ" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "whiteblue"
-	},
+/turf/environment/space,
 /area/station/hallway/secondary/exit)
 "aTK" = (
 /obj/structure/table,
@@ -25920,9 +25409,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/light_switch{
-	pixel_x = -27
-	},
+/obj/machinery/light_switch,
 /turf/simulated/floor,
 /area/station/rnd/misc_lab)
 "aUu" = (
@@ -26134,10 +25621,9 @@
 	},
 /area/station/hallway/secondary/entry)
 "aUP" = (
-/obj/machinery/recharger{
-	pixel_y = 4
+/obj/machinery/computer/card{
+	dir = 4
 	},
-/obj/structure/table/reinforced,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "red"
@@ -26229,15 +25715,9 @@
 	},
 /area/station/medical/medbreak)
 "aUV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "white"
+	dir = 1;
+	icon_state = "browncorner"
 	},
 /area/station/hallway/secondary/exit)
 "aUW" = (
@@ -26404,18 +25884,14 @@
 /turf/simulated/floor,
 /area/station/storage/primary)
 "aVn" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
+/area/station/maintenance/auxsolarport)
 "aVo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -26664,53 +26140,42 @@
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "aVN" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/status_display{
+	layer = 3.3;
+	pixel_y = -32;
+	supply_display = 1
 	},
 /turf/simulated/floor{
-	dir = 8;
+	dir = 10;
+	icon_state = "warning"
+	},
+/area/station/cargo/storage)
+"aVO" = (
+/obj/structure/closet/crate,
+/obj/random/misc/all,
+/obj/random/misc/all,
+/turf/simulated/floor{
+	icon_state = "floorgrime"
+	},
+/area/station/cargo/storage)
+"aVP" = (
+/obj/machinery/newscaster{
+	pixel_y = -30
+	},
+/obj/machinery/light,
+/obj/structure/table,
+/obj/item/weapon/cartridge/quartermaster,
+/obj/item/weapon/cartridge/quartermaster{
+	pixel_x = 6;
+	pixel_y = 5
+	},
+/obj/item/weapon/cartridge/quartermaster{
+	pixel_x = -4;
+	pixel_y = 7
+	},
+/turf/simulated/floor{
 	icon_state = "brown"
 	},
-/area/station/cargo/qm)
-"aVO" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/cargo/qm)
-"aVP" = (
-/obj/machinery/hologram/holopad,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor,
 /area/station/cargo/qm)
 "aVQ" = (
 /obj/structure/window/reinforced{
@@ -27139,14 +26604,19 @@
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "aWu" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/door/airlock/mining{
+	req_one_access = list(65,48)
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/station/hallway/secondary/entry)
+/turf/simulated/floor,
+/area/station/hallway/secondary/mine_sci_shuttle)
 "aWv" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -27180,28 +26650,12 @@
 	},
 /area/station/civilian/bar)
 "aWz" = (
-/obj/item/weapon/crowbar,
-/obj/item/device/flash,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Security Checkpoint";
-	dir = 1;
-	network = list("SS13","Security")
-	},
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "red"
 	},
 /area/station/security/checkpoint)
 "aWA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /turf/simulated/floor{
 	icon_state = "red"
 	},
@@ -27218,15 +26672,12 @@
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
 "aWC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
 	},
 /obj/machinery/light_switch{
-	pixel_x = 27
-	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
+	pixel_y = -27
 	},
 /turf/simulated/floor{
 	dir = 6;
@@ -27339,22 +26790,12 @@
 	},
 /area/station/storage/primary)
 "aWO" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Quartermaster APC";
-	pixel_x = 27;
-	pixel_y = 2
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 4;
+	dir = 6;
 	icon_state = "brown"
 	},
 /area/station/cargo/qm)
@@ -27417,32 +26858,15 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/playroom)
-"aWV" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
-/area/station/cargo/storage)
 "aWW" = (
 /turf/simulated/wall,
 /area/station/security/vacantoffice)
 "aWX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/stool/bed/chair/comfy/brown{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
-/area/station/cargo/storage)
+/turf/simulated/floor/wood,
+/area/station/civilian/bar)
 "aWY" = (
 /obj/machinery/light,
 /turf/simulated/floor{
@@ -27569,9 +26993,7 @@
 	name = "Station Intercom (Medbay)";
 	pixel_y = -28
 	},
-/obj/machinery/light_switch{
-	pixel_x = -27
-	},
+/obj/machinery/light_switch,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -27749,17 +27171,6 @@
 	icon_state = "barber"
 	},
 /area/station/medical/cmo)
-"aXz" = (
-/obj/machinery/door_control{
-	id = "qm_warehouse";
-	name = "Warehouse Door Control";
-	pixel_x = -24;
-	req_access = list(31)
-	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
-/area/station/cargo/storage)
 "aXA" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -27840,22 +27251,12 @@
 	},
 /area/station/civilian/chapel/office)
 "aXJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/closet/crate,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/random/misc/all,
-/obj/random/tools/tech_supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	icon_state = "floorgrime"
+	icon_state = "brown"
 	},
-/area/station/cargo/storage)
+/area/station/cargo/miningoffice)
 "aXK" = (
 /obj/structure/stool/bed/chair/metal/black{
 	dir = 1
@@ -27922,37 +27323,25 @@
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "aXR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/sign/directions/dock_tablo{
+	pixel_y = -4
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/structure/sign/mark{
+	icon_state = "fup";
+	pixel_y = -2;
+	pixel_x = -8
 	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "warning"
+/obj/structure/sign/mark{
+	icon_state = "fup";
+	pixel_y = -8;
+	pixel_x = -8
 	},
-/area/station/hallway/secondary/mine_sci_shuttle)
+/turf/simulated/wall,
+/area/station/security/checkpoint)
 "aXS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light/small,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "warning"
-	},
-/area/station/hallway/secondary/mine_sci_shuttle)
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "aXT" = (
 /obj/machinery/computer/mine_sci_shuttle{
 	dir = 4
@@ -28098,14 +27487,10 @@
 	},
 /area/station/hallway/secondary/exit)
 "aYh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "warning"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "aYi" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -28149,12 +27534,11 @@
 	},
 /area/station/hallway/primary/port)
 "aYl" = (
-/obj/machinery/mineral/equipment_vendor,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "brown"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/station/cargo/miningoffice)
+/turf/simulated/floor,
+/area/station/cargo/office)
 "aYm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -28166,17 +27550,12 @@
 	dir = 4
 	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "aYn" = (
 /obj/machinery/door/airlock/external{
 	dock_tag = "pod2"
@@ -28184,24 +27563,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "aYo" = (
-/obj/structure/table/woodentable,
-/obj/item/device/flashlight/lamp/green{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/item/ashtray/bronze,
-/obj/item/weapon/lighter/zippo{
-	pixel_x = -5;
-	pixel_y = 5
-	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 31
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/hallway/secondary/exit)
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "aYp" = (
 /obj/structure/sign/warning/pods{
 	pixel_x = 32
@@ -28293,12 +27657,9 @@
 	},
 /area/station/aisat)
 "aYx" = (
-/obj/structure/closet/emcloset,
-/turf/simulated/floor{
-	dir = 9;
-	icon_state = "warndark"
-	},
-/area/station/hallway/secondary/entry)
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "aYy" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/machinery/alarm{
@@ -28324,9 +27685,8 @@
 /obj/structure/window/reinforced{
 	dir = 5
 	},
-/obj/structure/sign/warning/airlock,
 /turf/simulated/floor/plating,
-/area/station/hallway/secondary/exit)
+/area/station/hallway/secondary/arrival)
 "aYB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -28345,12 +27705,6 @@
 /obj/effect/landmark/start/botanist,
 /turf/simulated/floor/grass,
 /area/station/civilian/hydroponics)
-"aYD" = (
-/obj/item/device/flashlight/lamp/fir,
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
-/area/station/cargo/storage)
 "aYE" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -28417,26 +27771,18 @@
 /turf/simulated/floor/whitegreed,
 /area/station/bridge/ai_upload)
 "aYL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/camera{
-	c_tag = "Arrival Hallway West";
-	dir = 1;
-	pixel_x = 20
+	c_tag = "Bar South";
+	dir = 1
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/stool/bed/chair/comfy/black{
+	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "dark"
 	},
-/area/station/hallway/secondary/arrival)
+/area/station/civilian/bar)
 "aYM" = (
 /obj/machinery/camera{
 	c_tag = "Containment Cell 6";
@@ -28503,13 +27849,6 @@
 	icon_state = "Stairs_wide"
 	},
 /area/station/hallway/secondary/entry)
-"aYS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor{
-	icon_state = "whiteblue"
-	},
-/area/station/hallway/secondary/exit)
 "aYT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -29025,12 +28364,11 @@
 	},
 /area/station/aisat)
 "aZI" = (
-/obj/machinery/light_switch{
-	pixel_x = -27
+/obj/machinery/computer/cargo{
+	dir = 1
 	},
-/obj/structure/closet/secure_closet/quartermaster,
 /turf/simulated/floor{
-	dir = 10;
+	dir = 9;
 	icon_state = "brown"
 	},
 /area/station/cargo/qm)
@@ -29064,45 +28402,29 @@
 /turf/simulated/floor/carpet,
 /area/station/tcommsat/computer)
 "aZM" = (
-/obj/structure/table,
-/obj/item/device/megaphone{
-	pixel_x = 6;
-	pixel_y = 8
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
+	dir = 4;
+	frequency = 1379;
+	id_tag = "recycler_pump";
+	name = "Recycler Large Air Vent"
 	},
-/obj/item/device/eftpos{
-	eftpos_name = "Quartermaster EFTPOS scanner"
+/obj/machinery/embedded_controller/radio/airlock_controller{
+	id_tag = "recycler_airlock";
+	pixel_x = -25;
+	req_access = list(67);
+	tag_airpump = "recycler_pump";
+	tag_chamber_sensor = "recycler_sensor";
+	tag_exterior_door = "recycler_outer";
+	tag_interior_door = "recycler_inner"
 	},
-/obj/item/weapon/coin/silver{
-	pixel_x = -10;
-	pixel_y = 3
+/turf/simulated/floor/plating{
+	icon_state = "platebotc"
 	},
-/obj/item/weapon/coin/silver{
-	pixel_x = -8;
-	pixel_y = -2
-	},
-/turf/simulated/floor{
-	icon_state = "brown"
-	},
-/area/station/cargo/qm)
+/area/station/cargo/recycleroffice)
 "aZN" = (
-/obj/machinery/newscaster{
-	pixel_y = -30
-	},
-/obj/machinery/light,
-/obj/structure/table,
-/obj/item/weapon/cartridge/quartermaster,
-/obj/item/weapon/cartridge/quartermaster{
-	pixel_x = 6;
-	pixel_y = 5
-	},
-/obj/item/weapon/cartridge/quartermaster{
-	pixel_x = -4;
-	pixel_y = 7
-	},
-/turf/simulated/floor{
-	icon_state = "brown"
-	},
-/area/station/cargo/qm)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/station/cargo/office)
 "aZO" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Research Director";
@@ -29155,15 +28477,9 @@
 	},
 /area/station/aisat/teleport)
 "aZQ" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "brown"
-	},
-/area/station/cargo/qm)
+/obj/effect/decal/cleanable/spiderling_remains,
+/turf/simulated/floor/airless/ceiling,
+/area/station/cargo/recycler)
 "aZR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -29408,20 +28724,12 @@
 	},
 /area/station/bridge/nuke_storage)
 "baq" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Arrival Dock's North";
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "browncorner"
-	},
-/area/station/hallway/secondary/entry)
+/obj/machinery/disposal/deliveryChute,
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
 "bar" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Bridge";
@@ -29609,12 +28917,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
-"baI" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "baJ" = (
 /obj/machinery/light_switch{
 	pixel_y = 25
@@ -29629,12 +28931,10 @@
 	},
 /area/station/civilian/chapel/mass_driver)
 "baK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/conveyor{
+	id = "QMLoad"
 	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
+/turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "baL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -29645,19 +28945,6 @@
 	icon_state = "warning"
 	},
 /area/station/gateway)
-"baM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -23
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "baN" = (
 /obj/structure/flora/junglebush/b,
 /obj/machinery/camera{
@@ -29783,23 +29070,25 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "baZ" = (
 /mob/living/simple_animal/fox/Renault,
 /turf/simulated/floor/carpet/blue2,
 /area/station/bridge/captain_quarters)
 "bba" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/machinery/door/airlock/maintenance{
+	name = "Disposal Access";
+	req_access = list(12)
 	},
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
-/area/station/cargo/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal)
 "bbb" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -29832,13 +29121,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
-"bbe" = (
-/obj/structure/disposalpipe/junction,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "bbf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -29854,6 +29136,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "bbh" = (
@@ -29988,17 +29276,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/hologram/holopad,
-/obj/effect/landmark{
-	name = "Observer-Start"
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "bbs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 5
@@ -30017,16 +29302,18 @@
 	},
 /area/station/tcommsat/computer)
 "bbt" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "bbu" = (
 /obj/structure/stool/bed/chair/comfy/black{
@@ -30132,16 +29419,18 @@
 	},
 /area/station/medical/storage)
 "bbF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/medical/glass{
-	name = "Escape Medical Checkpoint";
-	req_access = list(5)
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor{
-	icon_state = "whitebluefull"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "bbG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -30210,17 +29499,9 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/starboard)
 "bbN" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "Coworking APC";
-	pixel_x = -26
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/wood,
-/area/station/security/vacantoffice)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/space)
 "bbO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -30271,17 +29552,6 @@
 	icon_state = "white"
 	},
 /area/station/rnd/lab)
-"bbT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "browncorner"
-	},
-/area/station/hallway/secondary/entry)
 "bbU" = (
 /obj/machinery/power/apc{
 	name = "Science Break Room APC";
@@ -30358,6 +29628,11 @@
 "bbZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -30440,13 +29715,11 @@
 	},
 /area/station/gateway)
 "bcf" = (
-/obj/structure/closet/crate,
-/obj/random/misc/all,
-/obj/random/misc/all,
-/turf/simulated/floor{
-	icon_state = "floorgrime"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/station/cargo/storage)
+/turf/simulated/wall,
+/area/station/cargo/recycleroffice)
 "bcg" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/power/apc{
@@ -30532,13 +29805,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "bcn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/stool/bed/chair/metal{
-	dir = 4
+/obj/structure/stool/bed/chair/office/dark{
+	dir = 1
 	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/exit)
+/area/station/cargo/qm)
 "bco" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -30551,6 +29822,11 @@
 "bcp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	icon_state = "stairs_middle"
 	},
@@ -30617,11 +29893,14 @@
 	},
 /area/station/rnd/xenobiology)
 "bcw" = (
-/obj/structure/stool/bed/chair/office/dark,
-/turf/simulated/floor{
-	icon_state = "bar"
+/obj/machinery/sleeper{
+	dir = 8
 	},
-/area/station/cargo/miningoffice)
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "whiteblue"
+	},
+/area/station/hallway/secondary/exit)
 "bcx" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -30637,13 +29916,15 @@
 	},
 /area/station/tcommsat/chamber)
 "bcy" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=8";
+	freq = 1400;
+	location = "QM #3"
 	},
-/turf/simulated/floor/carpet/black,
-/area/station/security/vacantoffice)
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
+/area/station/cargo/storage)
 "bcz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -30688,27 +29969,24 @@
 	},
 /area/station/maintenance/disposal)
 "bcC" = (
-/obj/structure/closet/emcloset,
-/turf/simulated/floor/plating,
-/area/station/maintenance/escape)
+/obj/machinery/camera{
+	c_tag = "Security Checkpoint";
+	network = list("SS13","Security")
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "red"
+	},
+/area/station/security/checkpoint)
 "bcD" = (
 /obj/item/stack/sheet/wood,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/station/maintenance/cargo)
 "bcE" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Mining Equipment Maintenance";
-	req_access = list(48)
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/cargo/miningoffice)
+/obj/structure/closet/emcloset,
+/turf/simulated/floor,
+/area/station/cargo/storage)
 "bcF" = (
 /obj/structure/closet{
 	name = "Evidence Closet"
@@ -30757,14 +30035,11 @@
 /turf/environment/space,
 /area/shuttle/escape_pod1/station)
 "bcK" = (
-/obj/machinery/hologram/holopad,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/turf/simulated/floor/carpet/black,
-/area/station/security/vacantoffice)
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "bcL" = (
 /obj/structure/window/reinforced{
 	dir = 5
@@ -30905,15 +30180,23 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "bcY" = (
-/obj/random/vending/snack,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/station/hallway/secondary/arrival)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/station/cargo/office)
 "bcZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -31083,14 +30366,14 @@
 	},
 /area/station/civilian/chapel)
 "bds" = (
-/obj/structure/grille,
-/obj/item/weapon/shard,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/disposaloutlet{
+	dir = 4
 	},
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/station/maintenance/escape)
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
 "bdt" = (
 /obj/structure/closet,
 /obj/item/clothing/shoes/boxing/gray,
@@ -31148,28 +30431,14 @@
 	name = "KEEP CLEAR: DOCKING AREA"
 	},
 /turf/simulated/wall,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "bdA" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 4;
+	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
+/turf/simulated/wall,
+/area/station/cargo/office)
 "bdB" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -31390,10 +30659,16 @@
 	},
 /area/station/hallway/primary/port)
 "bdS" = (
-/turf/simulated/floor/plating{
-	icon_state = "platingdmg1"
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/area/station/maintenance/escape)
+/obj/machinery/power/apc{
+	name = "Fore Port Solar APC";
+	pixel_y = -28
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/auxsolarport)
 "bdT" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/paper_bin,
@@ -31501,16 +30776,20 @@
 	},
 /area/station/hallway/primary/port)
 "bec" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/item/clothing/mask/gas/coloured,
-/obj/structure/disposalpipe/segment{
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/cargo/recycleroffice)
 "bed" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor{
@@ -31518,19 +30797,10 @@
 	},
 /area/station/maintenance/incinerator)
 "bee" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/station/maintenance/escape)
+/area/station/maintenance/eva)
 "bef" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -32127,12 +31397,21 @@
 	},
 /area/station/rnd/hallway)
 "bfd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "blue"
+/obj/structure/stool/bed/chair/metal{
+	dir = 4
 	},
+/obj/machinery/newscaster{
+	pixel_x = -28;
+	pixel_y = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "bfe" = (
 /obj/machinery/door/airlock/glass{
@@ -32265,10 +31544,11 @@
 /turf/simulated/floor/plating/airless,
 /area/space)
 "bfn" = (
-/obj/structure/grille,
-/obj/item/weapon/shard,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/obj/item/device/flashlight/lamp/fir,
+/turf/simulated/floor{
+	icon_state = "floorgrime"
+	},
+/area/station/cargo/storage)
 "bfo" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -32401,26 +31681,33 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "bfz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/turf/simulated/floor/plating,
-/area/station/maintenance/escape)
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "packageSort1"
+	},
+/obj/structure/plasticflaps/mining,
+/turf/simulated/floor/plating{
+	dir = 4;
+	icon_state = "warnplate"
+	},
+/area/station/cargo/office)
 "bfA" = (
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
 "bfB" = (
-/obj/structure/closet/secure_closet/miner,
-/obj/item/device/radio/intercom{
-	dir = 0;
-	name = "Station Intercom (General)";
-	pixel_x = -27
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor{
-	dir = 9;
-	icon_state = "brown"
+/obj/machinery/power/apc/mediumcell{
+	dir = 8;
+	name = "Delivery Office APC";
+	pixel_x = -28
 	},
-/area/station/cargo/miningoffice)
+/turf/simulated/floor,
+/area/station/cargo/office)
 "bfC" = (
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
@@ -32469,15 +31756,6 @@
 	icon_state = "white"
 	},
 /area/station/rnd/hallway)
-"bfH" = (
-/obj/machinery/camera{
-	c_tag = "Mining office"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "brown"
-	},
-/area/station/cargo/miningoffice)
 "bfI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -32902,15 +32180,15 @@
 /area/station/medical/morgue)
 "bgu" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "brown"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/area/station/cargo/miningoffice)
+/turf/simulated/floor/carpet/purple,
+/area/station/civilian/theatre)
 "bgv" = (
 /obj/machinery/ai_status_display{
 	pixel_y = 32
@@ -33001,10 +32279,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/bridge/meeting_room)
-"bgD" = (
-/obj/machinery/atmospherics/components/binary/pump/on,
-/turf/simulated/floor/plating,
-/area/station/maintenance/escape)
 "bgE" = (
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
@@ -33050,6 +32324,7 @@
 "bgK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "brown"
@@ -33112,33 +32387,26 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
-"bgP" = (
-/obj/machinery/camera{
-	c_tag = "Arrival Dock's South 2";
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "bgQ" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/flora/deskferntrim,
 /turf/simulated/floor/carpet/blue2,
 /area/station/bridge/captain_quarters)
 "bgR" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 1
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	id_tag = "recycler_outer";
+	locked = 1;
+	name = "Recycler External Access";
+	req_access = list(67)
 	},
-/obj/machinery/portable_atmospherics/powered/pump,
-/turf/simulated/floor/plating{
-	icon_state = "platebotc"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/station/maintenance/escape)
+/turf/simulated/floor/plating,
+/area/station/cargo/recycleroffice)
 "bgS" = (
 /obj/machinery/door/window{
 	base_state = "right";
@@ -33252,24 +32520,6 @@
 	icon_state = "white"
 	},
 /area/station/medical/morgue)
-"bhc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
-"bhd" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 25
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "bhe" = (
 /obj/machinery/camera{
 	c_tag = "Coworking";
@@ -33381,13 +32631,20 @@
 	},
 /area/station/civilian/bar)
 "bhq" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/simulated/floor/carpet/black,
-/area/station/security/vacantoffice)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door_control{
+	id = "qm_warehouse";
+	name = "Warehouse Door Control";
+	pixel_y = 24;
+	req_access = list(31)
+	},
+/turf/simulated/floor,
+/area/station/cargo/storage)
 "bhr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/carpet/black,
@@ -33775,16 +33032,6 @@
 	icon_state = "dark"
 	},
 /area/station/tcommsat/computer)
-"bie" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "bif" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -33824,12 +33071,6 @@
 	icon_state = "dark"
 	},
 /area/station/bridge/ai_upload)
-"bii" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/plating{
-	icon_state = "platebotc"
-	},
-/area/station/maintenance/escape)
 "bij" = (
 /obj/machinery/telecomms/bus/preset_four,
 /obj/machinery/camera{
@@ -33917,14 +33158,15 @@
 /turf/simulated/floor{
 	icon_state = "browncorner"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "bit" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	icon_state = "browncorner"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "biu" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -34059,13 +33301,6 @@
 	icon_state = "floor"
 	},
 /area/shuttle/escape_pod1/station)
-"biI" = (
-/obj/machinery/camera{
-	c_tag = "Ferry shuttle South";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "biJ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -34179,14 +33414,20 @@
 	},
 /area/station/cargo/office)
 "biV" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/structure/grille,
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "browncorner"
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/area/station/hallway/secondary/entry)
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/cargo/qm)
 "biW" = (
 /obj/item/weapon/stamp/denied{
 	pixel_x = 4;
@@ -34412,6 +33653,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/cargo/office)
 "bjB" = (
@@ -34431,13 +33673,6 @@
 	},
 /turf/environment/space,
 /area/shuttle/mining/station)
-"bjD" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/weapon/weldingtool,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
 "bjE" = (
 /obj/structure/window/reinforced/shuttle/mining{
 	icon_state = "3-9"
@@ -34452,14 +33687,25 @@
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "bjG" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/door/airlock/mining{
+	name = "Recycler office";
+	req_access = list(67)
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/station/security/vacantoffice)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
+/area/station/cargo/recycleroffice)
 "bjH" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet/black,
@@ -34487,13 +33733,12 @@
 	},
 /area/station/civilian/chapel/mass_driver)
 "bjL" = (
-/obj/structure/stool/bed/roller,
-/obj/machinery/iv_drip,
-/obj/machinery/light,
-/turf/simulated/floor{
-	icon_state = "whiteblue"
+/obj/effect/decal/cleanable/generic,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/station/hallway/secondary/exit)
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "bjM" = (
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "2-7"
@@ -34563,15 +33808,11 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "bjT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
+	icon_state = "neutralcorner"
 	},
-/area/station/cargo/office)
+/area/station/hallway/secondary/arrival)
 "bjU" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -34642,16 +33883,10 @@
 	icon_state = "vault"
 	},
 /area/station/bridge/nuke_storage)
-"bka" = (
-/obj/structure/sign/warning/securearea{
-	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA"
-	},
-/turf/simulated/wall,
-/area/space)
 "bkb" = (
+/obj/structure/sign/warning/docking,
 /turf/simulated/wall,
-/area/space)
+/area/station/cargo/storage)
 "bkc" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -34765,15 +34000,9 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/meeting_room)
 "bkn" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
+/obj/effect/decal/cleanable/generic,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "bko" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/incinerator)
@@ -34810,19 +34039,12 @@
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
 "bks" = (
-/obj/machinery/camera{
-	c_tag = "Cargo Bay East";
-	pixel_x = 22
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "stationscrap"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/item/weapon/flora/random,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
 "bkt" = (
 /obj/structure/rack,
 /obj/item/weapon/reagent_containers/spray/extinguisher{
@@ -34877,6 +34099,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
@@ -34891,14 +34117,17 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "bkB" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 25
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	icon_state = "browncorner"
+	icon_state = "bot"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/cargo/storage)
 "bkC" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -35067,30 +34296,10 @@
 	icon_state = "platingdmg2"
 	},
 /area/station/construction/assembly_line)
-"bkQ" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "bkR" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "browncorner"
-	},
-/area/station/cargo/storage)
+/obj/random/foods/food_trash,
+/turf/simulated/floor/airless/ceiling,
+/area/station/cargo/recycler)
 "bkS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
@@ -35330,12 +34539,6 @@
 	icon_state = "white"
 	},
 /area/station/rnd/hallway)
-"bll" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/station/cargo/office)
 "blm" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -35391,13 +34594,6 @@
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/station/bridge/captain_quarters)
-"blq" = (
-/obj/machinery/disposal/deliveryChute,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/cargo/office)
 "blr" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -35424,15 +34620,10 @@
 	},
 /area/station/rnd/hallway)
 "bls" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/vending/cigarette,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "brown"
+	icon_state = "whiteblue"
 	},
-/area/station/cargo/storage)
+/area/station/hallway/secondary/exit)
 "blt" = (
 /obj/effect/spawner/lootdrop/maintenance/four,
 /obj/structure/closet/cabinet,
@@ -35498,6 +34689,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/cargo/office)
 "blA" = (
@@ -35536,6 +34730,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/cargo/office)
@@ -35714,15 +34912,10 @@
 /turf/simulated/floor/carpet,
 /area/station/civilian/chapel)
 "blO" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken4"
-	},
-/area/station/security/vacantoffice)
+/obj/structure/stool/bed/chair/metal,
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "blP" = (
 /obj/structure/window/reinforced{
 	dir = 5
@@ -35809,24 +35002,9 @@
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
 "blZ" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Cargo Office North";
-	dir = 8
-	},
-/obj/structure/table,
-/obj/item/weapon/folder/brown,
-/obj/item/device/eftpos{
-	eftpos_name = "Cargo Bay EFTPOS scanner"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/station/cargo/office)
+/obj/item/weapon/scrap_lump,
+/turf/simulated/floor/airless/ceiling,
+/area/station/cargo/recycler)
 "bma" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/flora/pottedplant/crystal{
@@ -35841,7 +35019,6 @@
 	},
 /area/station/tcommsat/chamber)
 "bmb" = (
-/obj/machinery/light,
 /obj/structure/sign/departments/lawyer{
 	pixel_y = -32
 	},
@@ -36023,18 +35200,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
-"bmq" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 28
-	},
-/turf/simulated/floor{
-	icon_state = "browncorner"
-	},
-/area/station/hallway/secondary/entry)
 "bmr" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Chemistry Lab";
@@ -36120,44 +35285,6 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/bar)
-"bmz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
-"bmA" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/cargo/storage)
 "bmB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -36270,19 +35397,25 @@
 	},
 /area/station/civilian/chapel/altar)
 "bmP" = (
-/obj/structure/stool/bed/chair/comfy/black{
-	dir = 1
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Checkpoint APC";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "red"
 	},
-/area/station/hallway/secondary/exit)
+/area/station/security/checkpoint)
 "bmQ" = (
-/obj/item/clothing/gloves/rainbow,
-/obj/item/clothing/head/soft/rainbow,
-/obj/item/clothing/shoes/rainbow,
-/obj/item/clothing/suit/poncho/rainbow,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "bmR" = (
 /obj/structure/disposalpipe/segment{
@@ -36431,34 +35564,24 @@
 	},
 /area/station/civilian/chapel/altar)
 "bne" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
+/obj/machinery/vending/coffee,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "brown"
 	},
-/turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "bnf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
 /obj/structure/stool,
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bng" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/camera{
-	c_tag = "Escape Hall North";
-	dir = 8;
-	pixel_y = -10
+/obj/structure/dryer{
+	pixel_y = 20
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "escape"
+	icon_state = "freezerfloor"
 	},
-/area/station/hallway/secondary/exit)
+/area/station/civilian/fitness)
 "bnh" = (
 /obj/machinery/computer/med_data,
 /turf/simulated/floor{
@@ -36628,6 +35751,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/cargo/office)
 "bnC" = (
@@ -36650,15 +35774,16 @@
 	},
 /area/station/bridge)
 "bnE" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
+/obj/machinery/camera{
+	c_tag = "Escape Medical Checkpoint";
+	network = list("SS13","Medical");
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/structure/stool/bed/roller,
+/turf/simulated/floor{
+	icon_state = "whiteblue"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/escape)
+/area/station/hallway/secondary/exit)
 "bnF" = (
 /obj/item/device/radio/intercom/pod{
 	dir = 4;
@@ -36681,36 +35806,16 @@
 	},
 /area/station/hallway/primary/central)
 "bnH" = (
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_x = -32;
-	pixel_y = 32
-	},
-/obj/item/weapon/flora/random,
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -30
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "whiteblue"
-	},
-/area/station/hallway/secondary/exit)
-"bnI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 9
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal)
 "bnJ" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 4
@@ -36828,11 +35933,6 @@
 	icon_state = "vault"
 	},
 /area/station/bridge/nuke_storage)
-"bnX" = (
-/obj/structure/grille,
-/obj/item/weapon/shard,
-/turf/simulated/floor/plating,
-/area/station/maintenance/escape)
 "bnY" = (
 /obj/structure/rack,
 /obj/item/weapon/tank/jetpack/oxygen,
@@ -36944,6 +36044,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "boi" = (
@@ -36952,6 +36057,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "boj" = (
@@ -36991,17 +36101,6 @@
 /obj/item/clothing/under/patient_gown,
 /turf/simulated/floor,
 /area/station/medical/surgery)
-"bom" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "packageSort1"
-	},
-/obj/structure/plasticflaps/mining,
-/turf/simulated/floor/plating{
-	dir = 4;
-	icon_state = "warnplate"
-	},
-/area/station/cargo/office)
 "bon" = (
 /obj/machinery/dna_scannernew,
 /obj/machinery/alarm{
@@ -37032,19 +36131,34 @@
 	},
 /area/station/cargo/office)
 "bop" = (
-/obj/item/weapon/flora/random,
-/turf/simulated/floor{
-	dir = 10;
-	icon_state = "brown"
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/area/station/cargo/miningoffice)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/cargo/office)
 "boq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor{
-	icon_state = "brown"
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1379;
+	master_tag = "arrival_dock_airlock";
+	name = "interior access button";
+	pixel_x = -20;
+	pixel_y = -20;
+	req_one_access = list(13,45,1)
 	},
-/area/station/cargo/miningoffice)
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "bor" = (
 /obj/structure/object_wall/pod{
 	icon_state = "3,0"
@@ -37057,11 +36171,17 @@
 	},
 /area/station/construction/assembly_line)
 "bot" = (
-/obj/machinery/vending/assist,
-/turf/simulated/floor{
-	icon_state = "brown"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/area/station/cargo/miningoffice)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "blue"
+	},
+/area/station/hallway/secondary/exit)
 "bou" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger{
@@ -37148,9 +36268,6 @@
 	pixel_y = 4
 	},
 /obj/item/device/flash,
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor{
 	icon_state = "warndark"
 	},
@@ -37160,20 +36277,6 @@
 /obj/machinery/kitchen_machine/microwave,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
-"boB" = (
-/obj/structure/table,
-/obj/item/weapon/folder/brown,
-/obj/item/weapon/packageWrap,
-/obj/machinery/light,
-/obj/structure/cable,
-/obj/machinery/power/apc{
-	name = "Mining Office APC";
-	pixel_y = -30
-	},
-/turf/simulated/floor{
-	icon_state = "brown"
-	},
-/area/station/cargo/miningoffice)
 "boC" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -37268,12 +36371,6 @@
 	icon_state = "white"
 	},
 /area/station/medical/hallway)
-"boK" = (
-/obj/structure/table,
-/turf/simulated/floor{
-	icon_state = "brown"
-	},
-/area/station/cargo/miningoffice)
 "boL" = (
 /obj/structure/stool/bed/chair/office/light{
 	dir = 8
@@ -37408,7 +36505,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "boY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 9
@@ -37472,29 +36569,10 @@
 	icon_state = "warning"
 	},
 /area/station/rnd/telesci)
-"bpe" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "packageSort1"
-	},
-/turf/simulated/floor/plating{
-	dir = 4;
-	icon_state = "warnplate"
-	},
-/area/station/cargo/office)
 "bpf" = (
-/obj/random/vending/cola,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 30
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/hallway/secondary/exit)
-"bpg" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
@@ -37522,16 +36600,14 @@
 	},
 /area/station/rnd/telesci)
 "bpj" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "escapecorner"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/station/hallway/secondary/exit)
-"bpk" = (
-/turf/simulated/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/station/maintenance/escape)
+/obj/machinery/atmospherics/components/binary/pump/on,
+/turf/simulated/floor/plating,
+/area/station/cargo/recycleroffice)
 "bpl" = (
 /obj/structure/table,
 /obj/item/weapon/paper_bin,
@@ -37820,10 +36896,11 @@
 	},
 /area/station/cargo/office)
 "bpN" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/station/maintenance/escape)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/hallway/secondary/exit)
 "bpO" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -37952,25 +37029,13 @@
 	},
 /area/station/medical/surgery)
 "bpY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
-/area/station/cargo/office)
-"bpZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/effect/landmark/start/cargo_technician,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/cargo/office)
+/turf/simulated/floor/plating,
+/area/station/storage/emergency2)
 "bqa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -38015,15 +37080,14 @@
 	},
 /area/station/rnd/hallway)
 "bqd" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/item/weapon/shard{
-	icon_state = "medium"
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "warning"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/escape)
+/area/station/hallway/secondary/arrival)
 "bqe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -38155,14 +37219,10 @@
 	},
 /area/station/hallway/secondary/exit)
 "bqs" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -28
-	},
-/obj/structure/reagent_dispensers/water_cooler,
+/obj/item/weapon/flora/random,
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "escape"
+	dir = 4;
+	icon_state = "bluecorner"
 	},
 /area/station/hallway/secondary/exit)
 "bqt" = (
@@ -38217,10 +37277,25 @@
 	},
 /area/station/bridge)
 "bqy" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/obj/machinery/door/airlock/mining{
+	name = "Recycler office";
+	req_access = list(67)
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
+/area/station/cargo/recycleroffice)
 "bqz" = (
 /obj/item/stack/cable_coil/red,
 /obj/item/stack/cable_coil/red{
@@ -38367,13 +37442,13 @@
 /turf/simulated/floor/plating,
 /area/station/medical/morgue)
 "bqI" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
+/obj/machinery/camera{
+	c_tag = "Escape Hall North";
+	dir = 1;
+	pixel_x = 22
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "escape"
 	},
 /area/station/hallway/secondary/exit)
 "bqJ" = (
@@ -38406,32 +37481,6 @@
 	},
 /turf/environment/space/shuttle,
 /area/shuttle/escape_pod1/station)
-"bqM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/item/weapon/shard{
-	icon_state = "small"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
 "bqN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -38441,20 +37490,15 @@
 	},
 /area/station/security/vacantoffice)
 "bqO" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
-	},
 /obj/structure/table/glass,
-/obj/item/weapon/storage/box/cups{
-	pixel_y = 4
+/obj/item/weapon/book/manual/wiki/security_space_law,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -25
 	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "escape"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "warningline"
 	},
 /area/station/hallway/secondary/exit)
 "bqP" = (
@@ -38513,12 +37557,23 @@
 	},
 /area/station/rnd/robotics)
 "bqU" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+/obj/structure/grille,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/recycleroffice)
 "bqV" = (
 /obj/structure/object_wall/pod{
 	icon_state = "3,0"
@@ -38625,17 +37680,24 @@
 	},
 /area/station/bridge/nuke_storage)
 "brf" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Entry Hallway APC";
+	pixel_x = -24
 	},
-/obj/machinery/disposal/deliveryChute{
-	dir = 8
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor/plating,
-/area/station/cargo/office)
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "brg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/cargo/office)
 "brh" = (
@@ -38679,35 +37741,15 @@
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
 "brl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "escape"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "brm" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
 	dir = 10;
-	icon_state = "escape"
-	},
-/area/station/hallway/secondary/exit)
-"brn" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 4;
 	icon_state = "escape"
 	},
 /area/station/hallway/secondary/exit)
@@ -38732,26 +37774,12 @@
 /turf/environment/space,
 /area/shuttle/mining/station)
 "brq" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
@@ -38906,16 +37934,8 @@
 	},
 /area/station/rnd/robotics)
 "brI" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "escape"
-	},
-/area/station/hallway/secondary/exit)
+/turf/simulated/floor/airless/ceiling,
+/area/station/cargo/recycler)
 "brJ" = (
 /obj/structure/table,
 /obj/item/weapon/pen,
@@ -38928,20 +37948,6 @@
 /obj/item/weapon/packageWrap,
 /turf/simulated/floor,
 /area/station/bridge/hop_office)
-"brK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 25
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/escape)
 "brL" = (
 /obj/machinery/computer/rdservercontrol,
 /turf/simulated/floor{
@@ -38973,21 +37979,20 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "brO" = (
-/obj/structure/cable,
-/obj/item/weapon/flora/random,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Escape Hallway APC";
-	pixel_x = 24
-	},
+/obj/structure/closet/wardrobe/red,
 /turf/simulated/floor{
-	dir = 6;
-	icon_state = "escape"
+	dir = 9;
+	icon_state = "red"
 	},
-/area/station/hallway/secondary/exit)
+/area/station/security/checkpoint)
 "brP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -39277,14 +38282,22 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "bsr" = (
-/obj/machinery/vending/cigarette,
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 5
 	},
-/area/station/hallway/secondary/entry)
+/obj/structure/sign/directions/dock_tablo/arrival,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/arrival)
 "bss" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "bst" = (
@@ -39405,21 +38418,14 @@
 	},
 /area/station/cargo/storage)
 "bsD" = (
-/obj/structure/table/woodentable,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/door_control{
+	id = "bar";
+	name = "Privacy shutter";
+	pixel_x = 8;
+	pixel_y = 24
 	},
-/obj/item/weapon/storage/fancy/cigarettes{
-	pixel_x = -4
-	},
-/obj/item/weapon/lighter/random{
-	pixel_x = 5
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
+/turf/simulated/floor/wood,
+/area/station/civilian/bar)
 "bsE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -39452,13 +38458,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
-"bsH" = (
-/obj/structure/table,
-/obj/item/device/tagger,
-/turf/simulated/floor{
-	icon_state = "brown"
-	},
-/area/station/cargo/office)
 "bsI" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -39472,20 +38471,6 @@
 	},
 /turf/environment/space/shuttle,
 /area/shuttle/escape_pod1/station)
-"bsK" = (
-/obj/structure/table,
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/packageWrap,
-/turf/simulated/floor{
-	icon_state = "brown"
-	},
-/area/station/cargo/office)
 "bsL" = (
 /obj/structure/table,
 /obj/item/weapon/stamp{
@@ -39513,19 +38498,19 @@
 	},
 /area/station/bridge/nuke_storage)
 "bsO" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 20
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/vending/coffee,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "brown"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/area/station/cargo/storage)
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "bsP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -39575,37 +38560,27 @@
 	},
 /area/station/aisat)
 "bsS" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
+/obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plating,
-/area/station/cargo/recycleroffice)
-"bsT" = (
-/obj/structure/dispenser/oxygen,
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/cargo/recycleroffice)
+/area/station/maintenance/escape)
 "bsU" = (
-/obj/structure/disposalpipe/trunk,
-/obj/machinery/disposal,
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = 32
+/obj/structure/table,
+/obj/item/weapon/folder/brown,
+/obj/item/weapon/packageWrap,
+/obj/machinery/light,
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	name = "Mining Office APC";
+	pixel_y = -30
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "brown"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/cargo/miningoffice)
 "bsV" = (
 /obj/random/vending/snack,
 /turf/simulated/floor{
@@ -39633,28 +38608,29 @@
 /turf/simulated/floor/plating,
 /area/station/bridge/hop_office)
 "bsX" = (
-/obj/structure/stool/bed/chair/comfy/black{
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/hallway/secondary/entry)
+/turf/simulated/floor,
+/area/station/cargo/storage)
 "bsY" = (
-/obj/random/vending/cola,
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "packageSort2"
 	},
-/area/station/hallway/secondary/entry)
+/turf/simulated/floor/plating{
+	dir = 1;
+	icon_state = "warnplate"
+	},
+/area/station/cargo/office)
 "bsZ" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/firealarm{
-	pixel_y = 28
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/cargo/recycleroffice)
+/turf/simulated/floor/plating/airless/catwalk,
+/area/station/solar/auxport)
 "bta" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -39806,12 +38782,15 @@
 	},
 /area/station/medical/sleeper)
 "btk" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/area/station/hallway/secondary/entry)
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "darkred"
+	},
+/area/station/hallway/secondary/exit)
 "btl" = (
 /obj/item/weapon/storage/secure/briefcase,
 /obj/structure/table/glass,
@@ -39822,14 +38801,10 @@
 /area/station/bridge)
 "btm" = (
 /obj/item/weapon/flora/random,
-/obj/machinery/alarm{
-	pixel_y = 23
-	},
 /turf/simulated/floor{
-	dir = 9;
-	icon_state = "red"
+	icon_state = "brown"
 	},
-/area/station/security/checkpoint)
+/area/station/cargo/storage)
 "btn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
@@ -39849,21 +38824,11 @@
 	},
 /area/station/bridge)
 "btq" = (
-/obj/structure/closet/secure_closet/security,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Checkpoint APC";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "red"
+	dir = 8;
+	icon_state = "warningcorner"
 	},
-/area/station/security/checkpoint)
+/area/station/hallway/secondary/arrival)
 "btr" = (
 /turf/simulated/floor,
 /area/station/rnd/robotics)
@@ -39897,16 +38862,17 @@
 	},
 /area/station/hallway/secondary/entry)
 "btw" = (
-/obj/item/ashtray/glass,
-/obj/item/weapon/lighter/zippo{
-	pixel_x = -5;
-	pixel_y = 5
+/obj/structure/stool,
+/obj/effect/landmark/start/shaft_miner,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/table/woodentable/fancy/black,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "bar"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/cargo/miningoffice)
 "btx" = (
 /obj/structure/stool/bed/chair/comfy/black{
 	dir = 8
@@ -39916,14 +38882,14 @@
 	},
 /area/station/hallway/secondary/entry)
 "bty" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/structure/grille{
+	destroyed = 1
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg1"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/maintenance/engineering)
 "btz" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -39953,26 +38919,12 @@
 	},
 /area/station/tcommsat/computer)
 "btA" = (
-/obj/machinery/camera{
-	c_tag = "Cargo Hallway"
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "stationscrap"
 	},
-/obj/machinery/computer/arcade,
-/obj/machinery/alarm{
-	pixel_y = 23
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/hallway/secondary/entry)
-"btB" = (
-/obj/random/vending/snack,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/hallway/secondary/entry)
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
 "btC" = (
 /obj/machinery/telecomms/server/presets/common,
 /obj/machinery/light/small{
@@ -39997,38 +38949,27 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "btF" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "red"
-	},
+/turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "btG" = (
-/obj/structure/table/reinforced,
-/obj/item/device/radio/off{
-	pixel_x = -6;
-	pixel_y = 4
+/obj/structure/closet/secure_closet/cargotech,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "red"
+	icon_state = "brown"
 	},
-/area/station/security/checkpoint)
-"btH" = (
-/obj/structure/closet/emcloset,
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/cargo/recycleroffice)
+/area/station/cargo/office)
 "btI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door_control{
-	id = "Security_private";
-	name = "Shutters Control";
-	pixel_x = -28
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor,
-/area/station/security/checkpoint)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal)
 "btJ" = (
 /obj/item/weapon/storage/firstaid/regular,
 /obj/structure/cable{
@@ -40097,11 +39038,16 @@
 	},
 /area/station/hallway/primary/central)
 "btN" = (
-/obj/structure/closet/secure_closet/recycler,
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/machinery/camera{
+	c_tag = "Cargo Bay Storage";
+	dir = 0
 	},
-/area/station/cargo/recycleroffice)
+/obj/structure/rack,
+/obj/random/science/circuit,
+/turf/simulated/floor{
+	icon_state = "floorgrime"
+	},
+/area/station/cargo/storage)
 "btO" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -40119,7 +39065,12 @@
 	},
 /area/station/hallway/primary/central)
 "btP" = (
-/obj/structure/filingcabinet,
+/obj/machinery/requests_console/security{
+	pixel_x = 32
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "red"
@@ -40195,9 +39146,12 @@
 	},
 /area/station/medical/hallway)
 "btV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 1
+	},
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
-/area/station/maintenance/escape)
+/area/station/hallway/secondary/arrival)
 "btW" = (
 /obj/structure/window/reinforced,
 /obj/machinery/media/jukebox/bar,
@@ -40285,11 +39239,10 @@
 	},
 /area/station/rnd/lab)
 "bug" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/stool/bed/chair/office/dark{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor,
 /area/station/security/checkpoint)
 "buh" = (
@@ -40317,14 +39270,12 @@
 	},
 /area/station/medical/genetics_cloning)
 "buk" = (
-/obj/machinery/requests_console/security{
-	pixel_x = 32
-	},
-/obj/machinery/computer/security{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -40364,20 +39315,11 @@
 	},
 /area/station/rnd/lab)
 "bup" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Entry Hallway APC";
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
 	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/hallway/secondary/entry)
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "buq" = (
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access";
@@ -40418,20 +39360,15 @@
 /turf/simulated/floor,
 /area/station/rnd/robotics)
 "buu" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/hologram/holopad,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/station/cargo/recycleroffice)
+/turf/simulated/floor,
+/area/station/cargo/office)
 "buv" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/plasteel{
@@ -40485,8 +39422,6 @@
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/security/checkpoint)
 "buz" = (
@@ -40504,15 +39439,18 @@
 	},
 /area/station/cargo/recycleroffice)
 "buB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/machinery/firealarm{
-	pixel_y = 28
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 30
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	dir = 4;
 	icon_state = "dark"
 	},
-/area/station/cargo/recycleroffice)
+/area/station/hallway/secondary/exit)
 "buC" = (
 /obj/machinery/light{
 	dir = 8
@@ -40552,20 +39490,16 @@
 /turf/environment/space/shuttle,
 /area/shuttle/escape_pod1/station)
 "buG" = (
-/obj/machinery/atmospherics/components/binary/pump/on,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/table/glass,
+/obj/item/weapon/storage/firstaid/toxin{
+	pixel_x = 2;
+	pixel_y = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "whiteblue"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/hallway/secondary/exit)
 "buH" = (
 /turf/simulated/floor{
 	dir = 9;
@@ -40603,50 +39537,24 @@
 	icon_state = "vault"
 	},
 /area/station/civilian/chapel)
-"buM" = (
-/obj/structure/closet/emcloset,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "bot"
-	},
-/area/station/hallway/secondary/arrival)
 "buN" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/status_display{
-	layer = 4;
-	pixel_y = 32
-	},
-/obj/item/weapon/flora/pottedplant/orientaltree,
+/obj/machinery/light_switch,
+/obj/structure/closet/secure_closet/quartermaster,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutral"
+	dir = 10;
+	icon_state = "brown"
 	},
-/area/station/hallway/secondary/arrival)
+/area/station/cargo/qm)
 "buO" = (
-/obj/machinery/computer/secure_data{
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
+/obj/item/weapon/flora/random,
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "red"
 	},
 /area/station/security/checkpoint)
-"buP" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/machinery/alarm{
-	pixel_y = 26
-	},
-/turf/simulated/floor{
-	icon_state = "delivery"
-	},
-/area/station/hallway/secondary/mine_sci_shuttle)
 "buQ" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -40689,24 +39597,15 @@
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/altar)
 "buS" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 5
-	},
-/obj/structure/sign/directions/dock_tablo/arrival,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
-/area/station/hallway/secondary/arrival)
+/area/station/maintenance/disposal)
 "buT" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Arrival Access"
-	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "buU" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -40727,44 +39626,20 @@
 	icon_state = "dark"
 	},
 /area/station/tcommsat/computer)
-"buV" = (
-/obj/structure/table,
-/obj/item/weapon/folder/brown,
-/obj/item/weapon/stamp{
-	name = "recycler's rubber stamp";
-	stamp_message = "Recycler"
-	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 20
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/cargo/recycleroffice)
 "buW" = (
 /obj/effect/landmark/start/bartender,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood,
 /area/station/civilian/bar)
-"buX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 10;
-	icon_state = "brown"
-	},
-/area/station/cargo/office)
 "buY" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "brown"
+/obj/machinery/disposal/deliveryChute{
+	dir = 8
 	},
+/turf/simulated/floor/plating,
 /area/station/cargo/office)
 "buZ" = (
 /obj/structure/stool/bed/chair/comfy/black{
@@ -40793,35 +39668,20 @@
 	temperature = 80
 	},
 /area/station/tcommsat/chamber)
-"bvb" = (
-/obj/structure/sign/warning/securearea{
-	desc = "A warning sign which reads 'LANDFILL'";
-	icon_state = "space";
-	layer = 4;
-	name = "LANDFILL";
-	pixel_x = 32
-	},
-/obj/machinery/conveyor_switch/oneway{
-	id = "packageSort2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "brown"
-	},
-/area/station/cargo/office)
 "bvc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = 20
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/vending/coffee,
 /turf/simulated/floor{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "brown"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/cargo/storage)
 "bvd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -40833,35 +39693,22 @@
 	},
 /area/station/civilian/chapel)
 "bve" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/firealarm{
-	pixel_y = 28
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "darkredcorners"
+	dir = 8;
+	icon_state = "brown"
 	},
-/area/station/hallway/secondary/exit)
-"bvf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "darkred"
-	},
-/area/station/hallway/secondary/exit)
+/area/station/cargo/storage)
 "bvg" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "neutralcorner"
+	icon_state = "dark"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/cargo/recycleroffice)
 "bvh" = (
 /obj/machinery/light_switch{
 	pixel_y = -25
@@ -40877,17 +39724,14 @@
 	},
 /area/station/hallway/primary/central)
 "bvj" = (
-/obj/structure/table,
-/obj/machinery/cell_charger{
-	pixel_y = 5
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -25
+/obj/machinery/door_control{
+	id = "qm_warehouse";
+	name = "Warehouse Door Control";
+	pixel_x = -24;
+	req_access = list(31)
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "brown"
+	icon_state = "floorgrime"
 	},
 /area/station/cargo/storage)
 "bvk" = (
@@ -40942,25 +39786,16 @@
 /turf/simulated/floor/carpet/blue2,
 /area/station/bridge/hop_office)
 "bvq" = (
-/obj/machinery/door/airlock/mining{
-	name = "Recycler office";
-	req_access = list(67)
-	},
 /obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/cargo/recycleroffice)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "bvr" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -40974,21 +39809,6 @@
 	icon_state = "darkredcorners"
 	},
 /area/station/hallway/secondary/exit)
-"bvs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/cargo/recycleroffice)
 "bvt" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -40996,45 +39816,18 @@
 	},
 /area/station/medical/hallway)
 "bvu" = (
-/obj/effect/landmark/start/recycler,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/structure/table/reinforced,
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "red"
 	},
-/area/station/cargo/recycleroffice)
+/area/station/security/checkpoint)
 "bvv" = (
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whiteblue"
 	},
 /area/station/medical/storage)
-"bvw" = (
-/obj/machinery/door/airlock/mining{
-	name = "Recycler office";
-	req_access = list(67)
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/cargo/recycleroffice)
 "bvx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
@@ -41077,20 +39870,10 @@
 	},
 /area/station/medical/genetics_cloning)
 "bvA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/cargo/recycleroffice)
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor,
+/area/station/cargo/storage)
 "bvB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41106,26 +39889,19 @@
 	},
 /area/station/cargo/recycleroffice)
 "bvC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/table/glass,
+/obj/item/weapon/reagent_containers/food/drinks/britcup{
+	pixel_x = -4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/item/weapon/medical/teleporter{
+	pixel_x = 5;
+	pixel_y = 6
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "whiteblue"
 	},
-/area/station/cargo/recycleroffice)
+/area/station/hallway/secondary/exit)
 "bvD" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -41142,24 +39918,9 @@
 /turf/simulated/floor/plating,
 /area/station/medical/genetics)
 "bvE" = (
-/obj/machinery/door/airlock/mining{
-	name = "Recycler's workplace";
-	req_access = list(67)
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/cargo/recycleroffice)
+/obj/machinery/floodlight,
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
 "bvF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41175,18 +39936,23 @@
 	},
 /area/station/medical/genetics_cloning)
 "bvH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/turf/simulated/floor{
+	icon_state = "floorgrime"
+	},
+/area/station/cargo/storage)
 "bvI" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 8;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
+	},
+/area/station/cargo/office)
 "bvJ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -41209,30 +39975,25 @@
 	},
 /area/station/hallway/secondary/exit)
 "bvL" = (
-/obj/structure/disposaloutlet{
-	dir = 4
-	},
-/obj/structure/disposalpipe/trunk{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/station/cargo/office)
+/turf/simulated/floor{
+	icon_state = "floorgrime"
+	},
+/area/station/cargo/storage)
 "bvM" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "packageSort2"
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/structure/plasticflaps/mining,
-/turf/simulated/floor/plating{
-	dir = 1;
-	icon_state = "warnplate"
-	},
-/area/station/cargo/office)
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
 "bvN" = (
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "packageSort2"
 	},
+/obj/machinery/light,
 /turf/simulated/floor/plating{
 	dir = 1;
 	icon_state = "warnplate"
@@ -41253,12 +40014,10 @@
 /turf/simulated/floor/plating/airless,
 /area/station/maintenance/chapel)
 "bvQ" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "packageSort2"
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken5"
 	},
-/turf/simulated/floor/plating,
-/area/station/cargo/office)
+/area/station/maintenance/escape)
 "bvR" = (
 /turf/simulated/wall,
 /area/station/medical/genetics_cloning)
@@ -41286,67 +40045,35 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/secondary/entry)
-"bvU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/arrival)
 "bvV" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/simple/visible,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/cargo/recycleroffice)
+/area/station/maintenance/cargo)
 "bvW" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Arrival Access"
-	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/arrival)
+"bvX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
-"bvX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -41362,55 +40089,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
-"bvZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
-"bwa" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/cargo/recycleroffice)
 "bwb" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	id_tag = "engin_inner";
+	locked = 1;
+	name = "Engineering External Access";
+	req_one_access = list(13,45,1)
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/cargo/recycleroffice)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "bwc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -41434,14 +40126,11 @@
 	},
 /area/station/civilian/bar)
 "bwe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
+/turf/simulated/floor,
+/area/station/hallway/secondary/arrival)
 "bwf" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
@@ -41682,25 +40371,11 @@
 	},
 /area/station/aisat)
 "bwv" = (
-/obj/structure/sign/mark{
-	icon_state = "ylf";
-	pixel_y = 8
+/obj/machinery/light/small{
+	dir = 1
 	},
-/obj/structure/sign/mark{
-	icon_state = "ylf";
-	pixel_x = 8;
-	pixel_y = 8
-	},
-/obj/structure/sign/mark{
-	icon_state = "ylf";
-	pixel_x = 16;
-	pixel_y = 8
-	},
-/obj/structure/sign/directions/dock_tablo/arrival{
-	pixel_y = -4
-	},
-/turf/simulated/wall,
-/area/station/hallway/secondary/entry)
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "bww" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -41715,19 +40390,11 @@
 	},
 /area/station/aisat)
 "bwx" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
+/turf/simulated/floor,
+/area/station/hallway/secondary/arrival)
 "bwy" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -41741,28 +40408,29 @@
 	},
 /area/station/civilian/bar)
 "bwz" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	id_tag = "arrival_dock_inner";
-	locked = 1;
-	name = "Arrival Dock External Access";
-	req_one_access = list(13,45,1)
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/cargo/storage)
 "bwA" = (
-/obj/machinery/power/port_gen/pacman/scrap,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "dark"
+	icon_state = "brown"
 	},
-/area/station/cargo/recycleroffice)
+/area/station/cargo/storage)
 "bwB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
@@ -41998,12 +40666,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/genetics_cloning)
-"bwW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/station/cargo/storage)
 "bwX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -42054,14 +40716,10 @@
 	},
 /area/station/aisat)
 "bxb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "browncorner"
-	},
-/area/station/cargo/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor,
+/area/station/hallway/secondary/arrival)
 "bxc" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -42072,18 +40730,11 @@
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
 "bxd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/power/port_gen/pacman/scrap,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/cargo/recycleroffice)
+/turf/simulated/floor,
+/area/station/cargo/storage)
 "bxe" = (
 /obj/machinery/camera{
 	c_tag = "Teleporter"
@@ -42115,25 +40766,11 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/bar)
 "bxh" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor{
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "brown"
 	},
-/area/station/hallway/secondary/arrival)
+/area/station/cargo/storage)
 "bxi" = (
 /turf/simulated/wall,
 /area/station/medical/hallway)
@@ -42168,18 +40805,26 @@
 	},
 /area/station/cargo/storage)
 "bxl" = (
-/obj/structure/closet/crate,
-/obj/item/device/multitool,
-/obj/item/device/multitool,
-/obj/item/device/assembly/prox_sensor,
-/obj/item/device/flashlight,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
+/area/station/maintenance/escape)
 "bxm" = (
-/obj/structure/rack,
-/obj/item/weapon/storage/toolbox/mechanical,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
+/area/station/cargo/office)
 "bxn" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -42316,31 +40961,40 @@
 	},
 /area/station/rnd/hallway)
 "bxB" = (
-/obj/structure/table,
-/obj/item/device/flashlight,
-/obj/item/weapon/stock_parts/cell/high{
-	charge = 100;
-	maxcharge = 15000
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "brown"
 	},
-/area/station/cargo/recycleroffice)
+/area/station/cargo/storage)
 "bxC" = (
 /turf/simulated/floor{
 	icon_state = "warningcorner"
 	},
 /area/station/cargo/storage)
 "bxD" = (
-/obj/structure/stool,
-/obj/effect/landmark/start/recycler,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	id_tag = "engin_outer";
+	locked = 1;
+	name = "Engineering External Access";
+	req_one_access = list(13,45,1)
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/cargo/recycleroffice)
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "bxE" = (
 /obj/structure/table,
 /obj/structure/window/reinforced{
@@ -42389,14 +41043,6 @@
 	icon_state = "bot"
 	},
 /area/station/rnd/robotics)
-"bxH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/cargo/recycleroffice)
 "bxI" = (
 /obj/machinery/light_switch{
 	pixel_x = 27
@@ -42435,19 +41081,20 @@
 	},
 /area/station/rnd/chargebay)
 "bxN" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/table,
-/obj/item/weapon/book/manual/wiki/supply_crates{
-	pixel_x = -4;
-	pixel_y = 7
-	},
-/turf/simulated/floor{
-	dir = 10;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/station/cargo/recycleroffice)
 "bxO" = (
 /obj/machinery/access_button{
 	command = "cycle_exterior";
@@ -42466,20 +41113,6 @@
 	icon_state = "gcircuit"
 	},
 /area/station/rnd/chargebay)
-"bxQ" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
-	dir = 4;
-	frequency = 1379;
-	id_tag = "arrival_dock_pump";
-	name = "Arrival Dock Large Air Vent"
-	},
-/turf/simulated/floor/plating{
-	icon_state = "platebotc"
-	},
-/area/station/maintenance/cargo)
 "bxR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -42780,11 +41413,22 @@
 	},
 /area/station/medical/hallway)
 "byq" = (
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "warningcorner"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/station/cargo/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/cargo/recycleroffice)
 "byr" = (
 /obj/item/device/radio/intercom{
 	frequency = 1485;
@@ -42941,10 +41585,6 @@
 	},
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
-"byG" = (
-/obj/structure/closet/emcloset,
-/turf/simulated/floor,
-/area/station/cargo/storage)
 "byH" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/cable{
@@ -43048,21 +41688,16 @@
 	},
 /area/station/bridge/hop_office)
 "byO" = (
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1379;
-	master_tag = "arrival_dock_airlock";
-	name = "interior access button";
-	pixel_x = -20;
-	pixel_y = -20;
-	req_one_access = list(13,45,1)
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
@@ -43111,37 +41746,19 @@
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "byU" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
+/area/station/maintenance/disposal)
 "byV" = (
-/obj/machinery/airlock_sensor{
-	id_tag = "arrival_dock_sensor";
-	pixel_x = 25;
-	pixel_y = 12
+/obj/item/weapon/flora/random,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "brown"
 	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	id_tag = "arrival_dock_airlock";
-	pixel_x = 25;
-	req_one_access = list(13,45,1);
-	tag_airpump = "arrival_dock_pump";
-	tag_chamber_sensor = "arrival_dock_sensor";
-	tag_exterior_door = "arrival_dock_outer";
-	tag_interior_door = "arrival_dock_inner"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/cargo/miningoffice)
 "byW" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "QMLoad2"
@@ -43152,14 +41769,11 @@
 	},
 /area/station/cargo/storage)
 "byX" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "QMLoad"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "warning"
+	icon_state = "dark"
 	},
-/area/station/cargo/storage)
+/area/station/hallway/secondary/exit)
 "byY" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -43204,33 +41818,33 @@
 	icon_state = "white"
 	},
 /area/station/medical/surgery)
-"bzc" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	id_tag = "arrival_dock_outer";
-	locked = 1;
-	name = "Arrival Dock External Access";
-	req_one_access = list(13,45,1)
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
 "bzd" = (
-/obj/machinery/conveyor{
-	id = "QMLoad"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/turf/simulated/floor/plating,
-/area/station/cargo/storage)
-"bze" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor{
-	dir = 8;
+	dir = 1;
 	icon_state = "warning"
 	},
-/area/station/cargo/storage)
+/area/station/hallway/secondary/mine_sci_shuttle)
+"bze" = (
+/obj/machinery/camera{
+	c_tag = "Mining office"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "brown"
+	},
+/area/station/cargo/miningoffice)
 "bzf" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating/airless,
-/area/station/cargo/recycler)
+/obj/structure/sign/warning/moving_parts,
+/turf/simulated/wall,
+/area/station/maintenance/cargo)
 "bzg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -43258,17 +41872,6 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/bar)
-"bzj" = (
-/obj/structure/disposaloutlet{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "delivery"
-	},
-/area/station/cargo/storage)
 "bzk" = (
 /obj/machinery/light,
 /turf/simulated/floor{
@@ -43320,11 +41923,23 @@
 	},
 /area/station/medical/hallway)
 "bzq" = (
-/obj/structure/closet/emcloset,
-/turf/simulated/floor{
-	icon_state = "warning"
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/area/station/cargo/storage)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/airless/catwalk,
+/area/station/solar/auxport)
 "bzr" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -43821,23 +42436,24 @@
 	},
 /area/station/bridge)
 "bAk" = (
-/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
-	dir = 6;
+	dir = 1;
 	icon_state = "warning"
 	},
-/area/station/cargo/storage)
+/area/station/hallway/secondary/arrival)
 "bAl" = (
-/obj/machinery/status_display{
-	layer = 3.3;
-	pixel_y = -32;
-	supply_display = 1
+/obj/structure/table,
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/obj/item/stack/rods{
+	amount = 50
 	},
 /turf/simulated/floor{
-	dir = 10;
-	icon_state = "warning"
+	dir = 9;
+	icon_state = "yellow"
 	},
-/area/station/cargo/storage)
+/area/station/storage/tools)
 "bAm" = (
 /obj/structure/closet/l3closet/general,
 /obj/machinery/firealarm{
@@ -43929,18 +42545,13 @@
 	},
 /area/station/medical/sleeper)
 "bAu" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/machinery/power/apc{
-	name = "Bar APC";
-	pixel_y = -30
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/civilian/bar)
+/obj/structure/closet/crate,
+/obj/item/device/multitool,
+/obj/item/device/multitool,
+/obj/item/device/assembly/prox_sensor,
+/obj/item/device/flashlight,
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "bAv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -44358,15 +42969,9 @@
 	},
 /area/station/civilian/gym)
 "bBj" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/weapon/cigbutt,
+/turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "bBk" = (
 /obj/machinery/door/poddoor{
@@ -44388,12 +42993,6 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/station/cargo/storage)
-"bBm" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
 /area/station/cargo/storage)
 "bBn" = (
 /obj/machinery/door_control{
@@ -45375,16 +43974,10 @@
 	},
 /area/station/security/main)
 "bDc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/plating,
+/area/station/cargo/recycleroffice)
 "bDd" = (
 /obj/structure/table/woodentable,
 /obj/item/ashtray/glass,
@@ -45404,16 +43997,16 @@
 /turf/environment/space/shuttle,
 /area/shuttle/escape_pod2/station)
 "bDf" = (
-/obj/machinery/newscaster{
-	pixel_x = 32
+/obj/structure/closet/emcloset,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/table,
-/obj/machinery/computer/stockexchange,
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "brown"
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = 28
 	},
-/area/station/cargo/office)
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "bDg" = (
 /obj/item/weapon/reagent_containers/glass/beaker/cryoxadone{
 	pixel_x = 7;
@@ -45442,25 +44035,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "bDi" = (
-/obj/structure/sign/mark{
-	icon_state = "ylf";
-	pixel_x = 8;
-	pixel_y = 8
+/obj/machinery/power/apc{
+	name = "Arrival Hallway APC";
+	pixel_y = -24
 	},
-/obj/structure/sign/mark{
-	icon_state = "ylf";
-	pixel_x = 16;
-	pixel_y = 8
+/obj/structure/cable,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
 	},
-/obj/structure/sign/mark{
-	icon_state = "ylf";
-	pixel_y = 8
-	},
-/obj/structure/sign/directions/dock_tablo{
-	pixel_y = -4
-	},
-/turf/simulated/wall,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "bDj" = (
 /obj/item/weapon/defibrillator/loaded,
 /obj/machinery/recharger/wallcharger{
@@ -45503,54 +44086,50 @@
 	},
 /area/station/medical/medbreak)
 "bDm" = (
-/obj/structure/table,
-/obj/item/device/tagger,
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "brown"
+/obj/structure/disposalpipe/sortjunction{
+	dir = 1;
+	name = "OnlineShop";
+	sortType = "OnlineShop"
 	},
+/turf/simulated/wall,
 /area/station/cargo/office)
 "bDn" = (
 /turf/simulated/wall,
 /area/station/civilian/theatre)
 "bDo" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access = list(12)
+/obj/item/weapon/reagent_containers/blood/AMinus{
+	pixel_x = -7;
+	pixel_y = -3
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/item/weapon/reagent_containers/blood/APlus{
+	pixel_x = -5;
+	pixel_y = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/item/weapon/reagent_containers/blood/BPlus{
+	pixel_x = 5;
+	pixel_y = 3
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/obj/item/weapon/reagent_containers/blood/OMinus{
+	pixel_x = -5;
+	pixel_y = -1
+	},
+/obj/structure/table/glass,
+/obj/item/weapon/reagent_containers/blood/empty{
+	pixel_x = 1;
+	pixel_y = -4
+	},
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "whiteblue"
+	},
+/area/station/hallway/secondary/exit)
 "bDp" = (
 /turf/simulated/wall,
 /area/station/civilian/cold_room)
-"bDq" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/sortjunction/wildcard{
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "browncorner"
-	},
-/area/station/hallway/secondary/entry)
 "bDr" = (
-/obj/machinery/door/airlock{
-	name = "Honk Office";
-	req_access = list(46)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/civilian/theatre)
+/obj/structure/sign/warning/moving_parts,
+/turf/simulated/wall,
+/area/station/cargo/recycler)
 "bDs" = (
 /obj/structure/stool,
 /obj/item/device/radio/intercom{
@@ -45802,28 +44381,22 @@
 	},
 /area/station/hallway/primary/central)
 "bDQ" = (
-/obj/structure/table/woodentable,
-/obj/machinery/camera{
-	c_tag = "Theater Backroom"
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "packageSort1"
 	},
-/obj/item/weapon/paper{
-	info = "Wherah is BANANAS?";
-	info_links = "Clown Memo"
+/turf/simulated/floor/plating{
+	dir = 4;
+	icon_state = "warnplate"
 	},
-/obj/item/toy/prize/honk,
-/obj/item/weapon/reagent_containers/spray/watergun,
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
+/area/station/cargo/office)
 "bDR" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/mineral/equipment_vendor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "brown"
 	},
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
-/obj/machinery/vending/theater,
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
+/area/station/cargo/miningoffice)
 "bDS" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -45866,27 +44439,6 @@
 	icon_state = "cafeteria"
 	},
 /area/station/medical/medbreak)
-"bDX" = (
-/obj/structure/closet/secure_closet/miner,
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "brown"
-	},
-/area/station/cargo/miningoffice)
-"bDY" = (
-/obj/machinery/door_control{
-	id = "bar";
-	name = "Privacy shutter";
-	pixel_x = 8;
-	pixel_y = -24;
-	req_access = list(25,1)
-	},
-/obj/machinery/computer/arcade,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
-	},
-/area/station/civilian/bar)
 "bDZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -45917,13 +44469,19 @@
 /turf/simulated/wall/r_wall,
 /area/station/rnd/server)
 "bEc" = (
-/obj/structure/closet/theatrecloset,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/carpet/purple,
-/area/station/civilian/theatre)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "bEd" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -45949,11 +44507,12 @@
 /turf/simulated/floor/carpet/purple,
 /area/station/civilian/theatre)
 "bEg" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	icon_state = "floorgrime"
 	},
-/turf/simulated/floor/carpet/purple,
-/area/station/civilian/theatre)
+/area/station/cargo/storage)
 "bEh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
@@ -46007,17 +44566,12 @@
 	},
 /area/station/maintenance/science)
 "bEk" = (
-/obj/structure/stool,
-/obj/effect/landmark/start/shaft_miner,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/disposal/deliveryChute,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/turf/simulated/floor{
-	icon_state = "bar"
-	},
-/area/station/cargo/miningoffice)
+/turf/simulated/floor/plating,
+/area/station/cargo/office)
 "bEl" = (
 /obj/structure/stool,
 /obj/effect/landmark/start/shaft_miner,
@@ -46120,19 +44674,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/bridge)
-"bEx" = (
-/obj/structure/closet/crate,
-/obj/random/tools/tech_supply,
-/obj/random/tools/tech_supply,
-/obj/item/weapon/rack_parts,
-/obj/item/weapon/rack_parts,
-/obj/item/weapon/rack_parts,
-/obj/item/weapon/rack_parts,
-/obj/item/weapon/rack_parts,
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
-/area/station/cargo/storage)
 "bEy" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -46205,16 +44746,13 @@
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "bEF" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/turf/simulated/floor{
+	icon_state = "floorgrime"
 	},
-/turf/simulated/floor/carpet/purple,
-/area/station/civilian/theatre)
+/area/station/cargo/storage)
 "bEG" = (
 /obj/structure/sink{
 	dir = 8;
@@ -46247,9 +44785,14 @@
 	},
 /area/station/civilian/hydroponics)
 "bEJ" = (
-/obj/machinery/space_heater,
-/turf/simulated/floor/plating,
-/area/station/storage/emergency2)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "browncorner"
+	},
+/area/station/cargo/storage)
 "bEK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -46270,19 +44813,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
-"bEM" = (
-/obj/machinery/camera{
-	c_tag = "Bar South";
-	dir = 1
-	},
-/obj/structure/stool/bed/chair/comfy/black{
-	dir = 8
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/civilian/bar)
 "bEN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -46308,15 +44838,17 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/aft)
 "bEO" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/lipstick/purple{
-	pixel_x = 3;
-	pixel_y = 3
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/item/weapon/lipstick/jade,
-/obj/item/toy/sound_button,
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
+/area/station/cargo/recycleroffice)
 "bEP" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/execution)
@@ -46370,14 +44902,14 @@
 	},
 /area/station/civilian/locker)
 "bET" = (
-/obj/machinery/door_control{
-	id = "bar";
-	name = "Privacy shutter";
-	pixel_x = 8;
-	pixel_y = 24
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/station/civilian/bar)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "bEU" = (
 /obj/structure/table/woodentable/fancy/black,
 /obj/item/trash/candle/red,
@@ -46545,9 +45077,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/machinery/light_switch{
-	pixel_x = -27
-	},
+/obj/machinery/light_switch,
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -46622,30 +45152,6 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/patients_rooms)
-"bFr" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Delivery Office";
-	req_access = list(50)
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/cargo/office)
-"bFs" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/wood{
-	icon_state = "wood-broken4"
-	},
-/area/station/civilian/theatre)
 "bFt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -46661,16 +45167,6 @@
 	icon_state = "floor"
 	},
 /area/shuttle/escape_pod2/station)
-"bFv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/maintenance/escape)
 "bFw" = (
 /turf/simulated/floor{
 	dir = 6;
@@ -46888,10 +45384,17 @@
 	},
 /area/station/rnd/hallway)
 "bFR" = (
-/obj/structure/closet/theatrecloset,
-/obj/item/device/guitar/electric,
-/turf/simulated/floor/carpet/purple,
-/area/station/civilian/theatre)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "bFS" = (
 /turf/simulated/floor,
 /area/station/cargo/storage)
@@ -46982,16 +45485,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "bGc" = (
-/obj/structure/closet/secure_closet/miner,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "brown"
-	},
-/area/station/cargo/miningoffice)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall,
+/area/station/maintenance/cargo)
 "bGd" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor{
@@ -47098,28 +45594,6 @@
 	icon_state = "darkred"
 	},
 /area/station/bridge)
-"bGl" = (
-/obj/machinery/door/firedoor,
-/obj/structure/table/reinforced,
-/obj/item/weapon/paper_bin,
-/obj/machinery/door/window/westright{
-	dir = 4;
-	name = "Cargo Delivery Door";
-	req_access = list(50)
-	},
-/obj/machinery/status_display{
-	layer = 3.3;
-	pixel_y = -30;
-	supply_display = 1
-	},
-/obj/item/weapon/pen,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "bot"
-	},
-/area/station/cargo/office)
 "bGm" = (
 /obj/structure/stool/bed/chair/wood/normal{
 	dir = 1
@@ -47146,23 +45620,6 @@
 	icon_state = "purplechecker"
 	},
 /area/station/civilian/barbershop)
-"bGo" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Barbershop APC";
-	pixel_y = 27
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "purplechecker"
-	},
-/area/station/civilian/barbershop)
 "bGp" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -47171,6 +45628,12 @@
 	},
 /area/station/rnd/robotics)
 "bGq" = (
+/obj/structure/closet/secure_closet/brig,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/hallway/secondary/exit)
+"bGr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -47189,25 +45652,6 @@
 	c_tag = "Barbershop"
 	},
 /obj/machinery/color_mixer,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "purplechecker"
-	},
-/area/station/civilian/barbershop)
-"bGr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -47239,11 +45683,18 @@
 	},
 /area/station/civilian/barbershop)
 "bGt" = (
-/obj/structure/stool/bed/chair/comfy/brown{
-	dir = 4
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/wood,
-/area/station/civilian/bar)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/airless/catwalk,
+/area/station/solar/auxport)
 "bGu" = (
 /obj/structure/rack,
 /obj/item/weapon/tank/oxygen,
@@ -47251,33 +45702,33 @@
 /turf/simulated/floor/plating,
 /area/station/bridge/teleporter)
 "bGv" = (
-/obj/structure/closet/crate,
-/obj/item/toy/prize/honk,
-/obj/item/weapon/coin/bananium,
-/obj/item/weapon/coin/bananium{
-	pixel_x = -3
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/item/weapon/coin/bananium{
-	pixel_x = 7;
-	pixel_y = 5
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
-"bGw" = (
-/obj/machinery/disposal,
-/obj/machinery/light{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/sign/poster/official/soft_cap_pop_art{
-	pixel_x = -32
-	},
-/obj/structure/disposalpipe/trunk{
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor{
-	icon_state = "purplechecker"
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/cargo/storage)
+"bGw" = (
+/obj/structure/table/glass,
+/obj/item/weapon/storage/box/cups{
+	pixel_y = 4
 	},
-/area/station/civilian/barbershop)
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -28
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "escape"
+	},
+/area/station/hallway/secondary/exit)
 "bGx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -47287,14 +45738,15 @@
 	},
 /area/station/civilian/barbershop)
 "bGy" = (
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor{
-	icon_state = "purplechecker"
-	},
-/area/station/civilian/barbershop)
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "bGz" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -47326,14 +45778,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
-"bGC" = (
-/obj/machinery/light_switch{
-	pixel_x = 27
-	},
-/turf/simulated/floor{
-	icon_state = "purplechecker"
-	},
-/area/station/civilian/barbershop)
 "bGD" = (
 /obj/effect/landmark{
 	name = "blobstart"
@@ -47429,12 +45873,16 @@
 	},
 /area/station/engineering/monitoring)
 "bGM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "white"
+	dir = 1;
+	icon_state = "brown"
 	},
 /area/station/hallway/secondary/exit)
 "bGN" = (
@@ -47773,19 +46221,23 @@
 	},
 /area/station/civilian/barbershop)
 "bHu" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/table,
+/obj/item/weapon/crowbar,
+/obj/item/device/flash{
+	pixel_x = 5
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/item/device/radio/off{
+	pixel_x = -6;
+	pixel_y = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/machinery/recharger{
+	pixel_y = 4
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/civilian/barbershop)
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/station/security/checkpoint)
 "bHv" = (
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken7"
@@ -47861,15 +46313,12 @@
 /turf/simulated/floor/carpet/black,
 /area/station/security/iaa_office)
 "bHB" = (
-/obj/machinery/door/airlock/mining{
-	name = "Mining Equpment";
-	req_access = list(48)
+/obj/machinery/light,
+/obj/machinery/iv_drip,
+/turf/simulated/floor{
+	icon_state = "whiteblue"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
-/area/station/cargo/miningoffice)
+/area/station/hallway/secondary/exit)
 "bHC" = (
 /obj/structure/dryer{
 	dir = 4;
@@ -48309,22 +46758,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/station/hallway/primary/starboard)
-"bIn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock{
-	name = "Firefighting equipment"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
 "bIo" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -48402,16 +46835,12 @@
 	},
 /area/station/rnd/robotics)
 "bIv" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/civilian/barbershop)
+/turf/simulated/floor,
+/area/station/hallway/secondary/arrival)
 "bIw" = (
 /obj/structure/table/glass,
 /obj/item/device/radio/intercom{
@@ -48620,19 +47049,22 @@
 	},
 /area/station/civilian/dormitories)
 "bIO" = (
-/obj/machinery/vending/barbervend,
+/obj/item/weapon/flora/random,
 /turf/simulated/floor{
-	icon_state = "purplechecker"
+	dir = 1;
+	icon_state = "whiteblue"
 	},
-/area/station/civilian/barbershop)
+/area/station/hallway/secondary/exit)
 "bIP" = (
-/obj/machinery/newscaster{
-	pixel_y = -30
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -28
 	},
-/turf/simulated/floor{
-	icon_state = "purplechecker"
+/obj/machinery/light{
+	dir = 8
 	},
-/area/station/civilian/barbershop)
+/turf/simulated/floor,
+/area/station/cargo/office)
 "bIQ" = (
 /obj/structure/closet/secure_closet/barber,
 /turf/simulated/floor{
@@ -48667,15 +47099,16 @@
 /turf/simulated/wall,
 /area/station/medical/storage)
 "bIT" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/item/weapon/flora/random,
 /turf/simulated/floor{
-	icon_state = "purplechecker"
+	dir = 1;
+	icon_state = "warning"
 	},
-/area/station/civilian/barbershop)
+/area/station/hallway/secondary/mine_sci_shuttle)
 "bIU" = (
 /obj/item/weapon/storage/firstaid/fire{
 	pixel_x = 4;
@@ -48907,17 +47340,13 @@
 /turf/environment/space/shuttle,
 /area/shuttle/escape_pod2/station)
 "bJr" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
+/obj/structure/stool/bed/chair/office/dark{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/turf/simulated/floor{
+	icon_state = "brown"
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced,
-/turf/simulated/floor/plating,
-/area/station/civilian/barbershop)
+/area/station/cargo/office)
 "bJs" = (
 /obj/machinery/recharge_station,
 /obj/structure/extinguisher_cabinet{
@@ -49005,21 +47434,17 @@
 /turf/simulated/floor/engine,
 /area/station/rnd/telesci)
 "bJz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/door/airlock{
+	name = "Port Emergency Storage"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance{
-	req_access = list(12)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/area/station/storage/emergency2)
 "bJA" = (
 /obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor{
@@ -49055,54 +47480,38 @@
 	icon_state = "carpetsymbol"
 	},
 /area/station/civilian/chapel)
-"bJG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "bJH" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "bJI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warning"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/area/station/hallway/secondary/arrival)
 "bJJ" = (
 /turf/simulated/wall/r_wall,
 /area/station/rnd/telesci)
 "bJK" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
+/obj/structure/closet/secure_closet/security,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/item/weapon/shard{
-	icon_state = "small"
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "red"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/security/checkpoint)
 "bJL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -49121,30 +47530,20 @@
 	icon_state = "bluecorner"
 	},
 /area/station/hallway/primary/central)
-"bJN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
 "bJO" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/structure/table,
+/obj/machinery/cell_charger{
+	pixel_y = 5
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -25
 	},
-/obj/structure/closet/theatrecloset,
-/turf/simulated/floor/carpet/purple,
-/area/station/civilian/theatre)
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "bJP" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall,
@@ -49181,19 +47580,10 @@
 	},
 /area/station/civilian/gym)
 "bJT" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Disposal Access";
-	req_access = list(12)
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/environment/space,
+/area/space)
 "bJU" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -49209,16 +47599,11 @@
 	},
 /area/station/medical/medbreak)
 "bJW" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/item/stack/tile/carpet/orange,
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/area/station/maintenance/escape)
 "bJX" = (
 /obj/structure/closet/crate/freezer,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -50341,13 +48726,18 @@
 /turf/simulated/floor/plating,
 /area/station/rnd/tox_launch)
 "bMg" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "warning"
+/obj/machinery/door/airlock/maintenance{
+	name = "Mining Equipment Maintenance";
+	req_access = list(48)
 	},
-/area/station/hallway/secondary/entry)
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/miningoffice)
 "bMh" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -50363,14 +48753,6 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/janitor)
-"bMi" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "warning"
-	},
-/area/station/hallway/secondary/entry)
 "bMj" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -50747,24 +49129,13 @@
 	},
 /area/station/civilian/gym)
 "bMT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "stationscrap"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/item/weapon/cigbutt,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/maintenance/escape)
+/obj/item/weapon/scrap_lump,
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
 "bMU" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -51595,26 +49966,11 @@
 	},
 /area/station/hallway/primary/starboard)
 "bOt" = (
-/obj/machinery/door/airlock/mining{
-	req_one_access = list(65,48)
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/structure/table,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "warning"
+	icon_state = "brown"
 	},
-/area/station/hallway/secondary/mine_sci_shuttle)
+/area/station/cargo/miningoffice)
 "bOu" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -51644,39 +50000,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/starboard)
-"bOx" = (
-/obj/machinery/door/airlock/external{
-	name = "Arrival Airlock"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
-"bOy" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "bOz" = (
 /turf/simulated/floor/engine,
 /area/station/rnd/telesci)
 "bOA" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/simulated/floor{
-	icon_state = "browncorner"
+	dir = 4;
+	icon_state = "brown"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/cargo/office)
 "bOB" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -51772,24 +50104,8 @@
 	},
 /area/station/civilian/dormitories)
 "bOM" = (
-/obj/structure/table/glass,
-/obj/item/stack/medical/advanced/bruise_pack{
-	pixel_x = -4
-	},
-/obj/item/stack/medical/advanced/bruise_pack{
-	pixel_y = 4
-	},
-/obj/item/stack/medical/advanced/ointment{
-	pixel_x = 4;
-	pixel_y = -1
-	},
-/obj/machinery/vending/wallmed2{
-	pixel_x = 26
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "whiteblue"
-	},
+/obj/structure/closet/emcloset,
+/turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "bON" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -52292,11 +50608,9 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/starboard)
 "bPF" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/machinery/light/small,
 /turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
+/area/station/maintenance/disposal)
 "bPG" = (
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plating,
@@ -52347,11 +50661,10 @@
 	},
 /area/station/engineering/monitoring)
 "bPK" = (
-/obj/machinery/light/small{
-	dir = 4
+/turf/simulated/floor{
+	icon_state = "freezerfloor"
 	},
-/turf/simulated/floor/plating/airless,
-/area/station/cargo/recycler)
+/area/station/civilian/fitness)
 "bPL" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -52706,14 +51019,23 @@
 	},
 /area/station/civilian/dormitories)
 "bQw" = (
-/obj/structure/grille{
-	destroyed = 1
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating{
-	icon_state = "platingdmg1"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/area/station/maintenance/engineering)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "bQx" = (
 /obj/machinery/bodyscanner,
 /obj/machinery/holosign_switch{
@@ -52757,11 +51079,9 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/starboard)
 "bQB" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	icon_state = "browncorner"
-	},
-/area/station/hallway/secondary/entry)
+/obj/structure/lattice,
+/turf/environment/space,
+/area/station/cargo/office)
 "bQC" = (
 /obj/structure/stool,
 /turf/simulated/floor/carpet/green,
@@ -53078,15 +51398,15 @@
 /turf/simulated/wall/r_wall,
 /area/station/rnd/storage)
 "bRn" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=8";
-	freq = 1400;
-	location = "QM #3"
+/obj/machinery/door/airlock/glass{
+	name = "Arrival Access"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	icon_state = "bot"
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
-/area/station/cargo/storage)
+/area/station/hallway/secondary/entry)
 "bRo" = (
 /obj/structure/barricade/wooden,
 /turf/simulated/floor/plating,
@@ -53525,16 +51845,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/starboard)
-"bSt" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
 "bSv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53767,13 +52077,19 @@
 	},
 /area/station/hallway/primary/starboard)
 "bSX" = (
-/obj/machinery/door/firedoor,
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 5
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=8";
+	freq = 1400;
+	location = "QM #2"
 	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
+/obj/machinery/bot/mulebot{
+	home_destination = "QM #2";
+	suffix = "#2"
+	},
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
+/area/station/cargo/storage)
 "bSY" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -53785,10 +52101,10 @@
 "bSZ" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor{
-	dir = 10;
+	dir = 9;
 	icon_state = "warndark"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "bTa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53854,23 +52170,16 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor,
 /area/station/engineering/atmos)
-"bTo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "bTp" = (
-/obj/machinery/camera{
-	c_tag = "Arrival Dock's South 1";
-	dir = 8
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 1
 	},
-/turf/simulated/floor{
-	icon_state = "browncorner"
+/obj/item/weapon/shard{
+	icon_state = "small"
 	},
-/area/station/hallway/secondary/entry)
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "bTq" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -54965,28 +53274,33 @@
 /obj/structure/sign/directions/dock_tablo/tablo3,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "bWw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 9;
-	icon_state = "neutral"
+	dir = 1;
+	icon_state = "brown"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/cargo/office)
 "bWx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "bWy" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	icon_state = "escape"
 	},
@@ -55395,12 +53709,19 @@
 	},
 /area/station/medical/morgue)
 "bXN" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Escape Hallway APC";
+	pixel_x = 24
 	},
-/obj/machinery/disposal/deliveryChute,
-/turf/simulated/floor/plating/airless,
-/area/station/cargo/recycler)
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/hallway/secondary/exit)
 "bXQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on/atmos{
 	dir = 8;
@@ -55956,7 +54277,7 @@
 	name = "Arrival Airlock"
 	},
 /turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "bZB" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -56011,9 +54332,7 @@
 /obj/item/weapon/tank/emergency_oxygen/engi,
 /obj/item/clothing/mask/gas/coloured,
 /obj/item/clothing/mask/gas/coloured,
-/obj/machinery/light_switch{
-	pixel_x = -27
-	},
+/obj/machinery/light_switch,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "yellowcorner"
@@ -56100,8 +54419,21 @@
 /turf/simulated/floor/engine/phoron,
 /area/station/engineering/atmos)
 "bZZ" = (
-/turf/simulated/floor/plating/airless,
-/area/station/cargo/recycler)
+/obj/structure/stool/bed/chair/metal{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "caa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on/atmos{
 	dir = 8;
@@ -56199,12 +54531,27 @@
 /turf/simulated/wall,
 /area/station/cargo/recycler)
 "caq" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "stationscrap"
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Bay";
+	req_one_access = list(31,48,67)
 	},
-/turf/simulated/floor/plating/airless,
-/area/station/cargo/recycler)
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/cargo/storage)
 "cat" = (
 /obj/machinery/portable_atmospherics/powered/pump,
 /obj/machinery/atmospherics/components/unary/portables_connector{
@@ -56354,31 +54701,26 @@
 	icon_state = "white"
 	},
 /area/station/medical/reception)
-"cbd" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "stationscrap"
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor/plating/airless,
-/area/station/cargo/recycler)
 "cbe" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "stationscrap"
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Quartermaster APC";
+	pixel_x = 27;
+	pixel_y = 2
 	},
-/obj/machinery/scrap/stacking_machine,
-/turf/simulated/floor/plating/airless,
-/area/station/cargo/recycler)
-"cbf" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "stationscrap"
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/turf/simulated/floor/plating/airless,
-/area/station/cargo/recycler)
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
+	},
+/area/station/cargo/qm)
 "cbi" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
@@ -56503,12 +54845,41 @@
 /turf/simulated/wall,
 /area/station/storage/emergency3)
 "cbB" = (
-/turf/simulated/floor/airless/ceiling,
-/area/station/cargo/recycler)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "cbC" = (
-/obj/random/foods/food_trash,
-/turf/simulated/floor/airless/ceiling,
-/area/station/cargo/recycler)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/hallway/secondary/exit)
 "cbD" = (
 /turf/simulated/wall/r_wall,
 /area/station/rnd/xenobiology)
@@ -56540,12 +54911,14 @@
 	},
 /area/station/civilian/library)
 "cbS" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "stationscrap"
+/obj/machinery/door/airlock/glass{
+	name = "Arrival Access"
 	},
-/turf/simulated/floor/plating/airless,
-/area/station/cargo/recycler)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "cbT" = (
 /obj/machinery/door/window/northright{
 	dir = 8;
@@ -56599,13 +54972,18 @@
 /turf/simulated/floor,
 /area/station/engineering/break_room)
 "ccd" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "stationscrap"
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/recycler,
-/turf/simulated/floor/plating/airless,
-/area/station/cargo/recycler)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating/airless/catwalk,
+/area/station/solar/auxport)
 "cce" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
@@ -57498,16 +55876,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
-"cfq" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
 "cfr" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -57670,20 +56038,15 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
-"cfS" = (
-/obj/machinery/conveyor_switch{
-	id = "stationscrap"
-	},
-/turf/simulated/floor/plating/airless,
-/area/station/cargo/recycler)
 "cfT" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "stationscrap"
+/obj/structure/grille,
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
+	name = "KEEP CLEAR: DOCKING AREA"
 	},
-/obj/item/weapon/scrap_lump,
-/turf/simulated/floor/plating/airless,
-/area/station/cargo/recycler)
+/obj/structure/lattice,
+/turf/environment/space,
+/area/space)
 "cfV" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -57893,26 +56256,12 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
-"cgx" = (
-/obj/structure/scrap_beacon,
-/turf/simulated/floor/airless/ceiling,
-/area/station/cargo/recycler)
-"cgy" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "stationscrap"
-	},
-/obj/structure/scrap_cube,
-/turf/simulated/floor/plating/airless,
-/area/station/cargo/recycler)
 "cgz" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "stationscrap"
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "warning"
 	},
-/obj/machinery/pile_ripper,
-/turf/simulated/floor/plating/airless,
-/area/station/cargo/recycler)
+/area/station/hallway/secondary/arrival)
 "cgA" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -57991,12 +56340,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor/plating,
 /area/station/construction)
-"cgN" = (
-/obj/item/weapon/scrap_lump,
-/turf/simulated/floor/airless/ceiling,
-/area/station/cargo/recycler)
 "cgO" = (
-/obj/random/foods/food_trash,
+/obj/machinery/conveyor_switch{
+	id = "stationscrap"
+	},
 /turf/simulated/floor/plating/airless,
 /area/station/cargo/recycler)
 "cgP" = (
@@ -58063,13 +56410,26 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "cgX" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "stationscrap"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/random/misc/all,
-/turf/simulated/floor/plating/airless,
-/area/station/cargo/recycler)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/cargo/recycleroffice)
 "cgZ" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -58520,13 +56880,20 @@
 	},
 /area/station/engineering/drone_fabrication)
 "cij" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "stationscrap"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/item/stack/sheet/refined_scrap,
-/turf/simulated/floor/plating/airless,
-/area/station/cargo/recycler)
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-y"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "cik" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /turf/simulated/floor{
@@ -58667,21 +57034,31 @@
 /turf/simulated/floor/engine/oxygen,
 /area/station/engineering/atmos)
 "ciO" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "stationscrap"
-	},
-/obj/effect/decal/cleanable/cobweb2,
+/obj/machinery/mech_bay_recharge_port,
 /turf/simulated/floor/plating/airless,
 /area/station/cargo/recycler)
 "ciP" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/airless/ceiling,
-/area/station/cargo/recycler)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "bar"
+	},
+/area/station/cargo/miningoffice)
 "ciQ" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/plating/airless,
-/area/station/cargo/recycler)
+/obj/machinery/door/airlock/glass{
+	name = "Escape Hall"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/exit)
 "ciR" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
@@ -58858,20 +57235,8 @@
 	},
 /area/station/rnd/xenobiology)
 "cju" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
-	},
-/obj/structure/mirror{
-	pixel_x = -28
-	},
-/obj/structure/dryer{
-	pixel_y = 20
-	},
-/turf/simulated/floor{
-	icon_state = "freezerfloor"
-	},
-/area/station/civilian/fitness)
+/turf/simulated/floor/plating,
+/area/space)
 "cjv" = (
 /turf/simulated/wall,
 /area/station/rnd/xenobiology)
@@ -59175,9 +57540,15 @@
 	},
 /area/station/engineering/drone_fabrication)
 "cks" = (
-/obj/structure/closet/crate,
-/turf/simulated/floor/plating/airless,
-/area/station/cargo/recycler)
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	id_tag = "arrival_dock_outer";
+	locked = 1;
+	name = "Arrival Dock External Access";
+	req_one_access = list(13,45,1)
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/arrival)
 "ckt" = (
 /obj/machinery/computer/operating,
 /turf/simulated/floor{
@@ -59185,9 +57556,16 @@
 	},
 /area/station/medical/surgery2)
 "ckv" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/escape)
+/area/station/maintenance/engineering)
 "ckw" = (
 /obj/structure/reagent_dispensers/aqueous_foam_tank,
 /obj/machinery/camera{
@@ -59544,13 +57922,16 @@
 	},
 /area/station/hallway/primary/aft)
 "clu" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 5
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "packageSort2"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/escape)
+/obj/structure/plasticflaps/mining,
+/turf/simulated/floor/plating{
+	dir = 1;
+	icon_state = "warnplate"
+	},
+/area/station/cargo/office)
 "clv" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 8
@@ -59606,10 +57987,6 @@
 	icon_state = "vault"
 	},
 /area/station/aisat)
-"clF" = (
-/obj/machinery/floodlight,
-/turf/simulated/floor/plating/airless,
-/area/station/cargo/recycler)
 "clG" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/machinery/atmospherics/components/unary/portables_connector{
@@ -59888,12 +58265,6 @@
 	icon_state = "whitepurplefull"
 	},
 /area/station/rnd/mixing)
-"cmn" = (
-/obj/structure/table,
-/obj/item/weapon/storage/toolbox/mechanical,
-/obj/item/device/tagger/shop,
-/turf/simulated/floor/plating/airless,
-/area/station/cargo/recycler)
 "cmp" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -60587,15 +58958,6 @@
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/port)
-"coe" = (
-/obj/structure/closet/crate,
-/obj/item/clothing/gloves/black,
-/obj/item/weapon/crowbar,
-/obj/item/clothing/mask/bandana/black,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
 "cof" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27;
@@ -60965,23 +59327,11 @@
 	},
 /area/station/rnd/xenobiology)
 "coZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 4;
-	icon_state = "pipe-j2"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "cpa" = (
 /turf/environment/space,
 /area/shuttle/syndicate/southwest)
@@ -61125,10 +59475,6 @@
 	},
 /turf/simulated/floor/whitegreed,
 /area/station/aisat/ai_chamber)
-"cps" = (
-/obj/mecha/working/ripley,
-/turf/simulated/floor/plating/airless,
-/area/station/cargo/recycler)
 "cpt" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -61151,15 +59497,28 @@
 /turf/simulated/floor/whitegreed,
 /area/station/aisat/ai_chamber)
 "cpv" = (
-/obj/machinery/mech_bay_recharge_port,
-/turf/simulated/floor/plating/airless,
-/area/station/cargo/recycler)
-"cpw" = (
-/obj/machinery/computer/mech_bay_power_console{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/plating/airless,
-/area/station/cargo/recycler)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "white"
+	},
+/area/station/hallway/secondary/exit)
+"cpw" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor,
+/area/station/cargo/office)
 "cpx" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -62049,11 +60408,17 @@
 	},
 /area/station/bridge/hop_office)
 "cri" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/cargo/office)
+/turf/simulated/floor{
+	icon_state = "floorgrime"
+	},
+/area/station/cargo/storage)
 "crn" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/bluegrid{
@@ -62402,12 +60767,9 @@
 	},
 /area/station/tcommsat/chamber)
 "crY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor,
-/area/station/cargo/office)
+/obj/structure/closet/crate,
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
 "csa" = (
 /obj/structure/rack,
 /obj/item/weapon/circuitboard/crew{
@@ -62477,15 +60839,6 @@
 	temperature = 80
 	},
 /area/station/tcommsat/chamber)
-"csh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "csp" = (
 /obj/machinery/hologram/holopad,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -63529,13 +61882,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "cuZ" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "stationscrap"
+/obj/structure/rack,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/wine{
+	volume = 25
 	},
-/obj/item/weapon/scrap_lump,
-/turf/simulated/floor/plating/airless,
-/area/station/cargo/recycler)
+/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,
+/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "cvb" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/box/cups,
@@ -63569,13 +61923,17 @@
 	},
 /area/station/medical/chemistry)
 "cvf" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "stationscrap"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/item/stack/sheet/refined_scrap,
-/turf/simulated/floor/plating/airless,
-/area/station/cargo/recycler)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "brown"
+	},
+/area/station/cargo/office)
 "cvg" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -63906,14 +62264,6 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/station/medical/reception)
-"cwE" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "stationscrap"
-	},
-/obj/item/weapon/scrap_lump,
-/turf/simulated/floor/plating/airless,
-/area/station/cargo/recycler)
 "cwF" = (
 /obj/machinery/power/solar_control{
 	id = "starboardsolar";
@@ -63989,9 +62339,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "cwT" = (
-/obj/effect/decal/cleanable/spiderling_remains,
-/turf/simulated/floor/airless/ceiling,
-/area/station/cargo/recycler)
+/obj/machinery/door/airlock/glass{
+	name = "Escape Hall"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/exit)
 "cwU" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -64246,10 +62600,6 @@
 	icon_state = "asteroid"
 	},
 /area/station/civilian/garden)
-"cxA" = (
-/obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
 "cxD" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -64258,7 +62608,7 @@
 	},
 /obj/structure/sign/directions/dock_tablo/tablo4,
 /turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "cxE" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -64518,18 +62868,11 @@
 	},
 /area/station/civilian/garden)
 "cyq" = (
-/obj/machinery/computer/crew{
-	dir = 4
-	},
-/obj/machinery/newscaster{
-	pixel_x = -28;
-	pixel_y = 1
-	},
-/turf/simulated/floor{
-	dir = 9;
-	icon_state = "whiteblue"
-	},
-/area/station/hallway/secondary/exit)
+/obj/structure/table,
+/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/device/tagger/shop,
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
 "cyr" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -65963,8 +64306,14 @@
 	pixel_y = 2
 	},
 /obj/item/weapon/gun/syringe,
-/obj/item/weapon/medical/teleporter,
-/obj/item/weapon/medical/teleporter,
+/obj/item/weapon/medical/teleporter{
+	pixel_x = 5;
+	pixel_y = 6
+	},
+/obj/item/weapon/medical/teleporter{
+	pixel_x = 5;
+	pixel_y = 6
+	},
 /obj/item/device/lens/rentgene,
 /obj/item/device/camera,
 /turf/simulated/floor{
@@ -66363,11 +64712,10 @@
 	},
 /area/station/aisat)
 "cDv" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6
-	},
+/obj/item/weapon/cigbutt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
+/area/station/maintenance/eva)
 "cDx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -66688,13 +65036,14 @@
 /turf/simulated/floor/carpet/green,
 /area/station/medical/psych)
 "cEn" = (
-/obj/structure/table,
-/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp,
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/power/tracker,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
 	},
-/turf/simulated/floor/plating/airless,
-/area/station/cargo/recycler)
+/turf/simulated/floor/plating/airless/catwalk,
+/area/station/solar/auxport)
 "cEp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -66879,10 +65228,12 @@
 	},
 /area/station/engineering/drone_fabrication)
 "cEV" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/station/hallway/secondary/exit)
 "cEW" = (
 /turf/simulated/wall/r_wall,
 /area/station/aisat/antechamber)
@@ -66953,41 +65304,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "cFt" = (
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1379;
-	master_tag = "engin_airlock";
-	name = "exterior access button";
-	pixel_x = 25;
-	pixel_y = -25;
-	req_one_access = list(13,45,1)
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "Coworking APC";
+	pixel_x = -26
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
-"cFu" = (
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	id_tag = "engin_airlock";
-	pixel_y = 28;
-	req_one_access = list(13,45,1);
-	tag_airpump = "engin_pump";
-	tag_chamber_sensor = "engin_sensor";
-	tag_exterior_door = "engin_outer";
-	tag_interior_door = "engin_inner"
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/machinery/airlock_sensor{
-	id_tag = "engin_sensor";
-	layer = 3.3;
-	pixel_x = 12;
-	pixel_y = 25
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
-	dir = 4;
-	frequency = 1379;
-	id_tag = "engin_pump";
-	name = "Engineering Large Air Vent"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
 "cFv" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -66999,16 +65326,6 @@
 	},
 /turf/simulated/floor/whitegreed,
 /area/station/aisat/ai_chamber)
-"cFw" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	id_tag = "engin_outer";
-	locked = 1;
-	name = "Engineering External Access";
-	req_one_access = list(13,45,1)
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
 "cFA" = (
 /obj/structure/transit_tube/station{
 	dir = 4
@@ -67062,19 +65379,22 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "cFO" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	id_tag = "engin_inner";
-	locked = 1;
-	name = "Engineering External Access";
-	req_one_access = list(13,45,1)
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "escape"
+	},
+/area/station/hallway/secondary/exit)
 "cFP" = (
 /turf/simulated/wall/r_wall,
 /area/station/aisat/ai_chamber)
@@ -67885,17 +66205,19 @@
 /turf/environment/space,
 /area/space)
 "cIs" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = -12
 	},
-/obj/structure/stool/bed/chair/wood/normal{
-	dir = 4
+/obj/structure/mirror{
+	dir = 4;
+	pixel_x = -28
 	},
-/obj/effect/landmark/start/clown,
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "whiteblue"
+	},
+/area/station/hallway/secondary/exit)
 "cIu" = (
 /obj/structure/table/woodentable,
 /obj/effect/decal/cleanable/cobweb2,
@@ -68239,12 +66561,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
-"cJY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
 "cJZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -68294,10 +66610,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
-"cKo" = (
-/obj/structure/sign/directions/dock_tablo/tablo5,
-/turf/simulated/wall,
-/area/station/hallway/secondary/entry)
 "cKp" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -68960,12 +67272,20 @@
 	},
 /area/station/civilian/garden)
 "cMo" = (
-/obj/item/clothing/suit/justice,
-/obj/item/clothing/gloves/black,
-/obj/item/clothing/head/justice,
-/obj/structure/closet,
-/turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Asteroid Shuttle Hallway APC";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/station/hallway/secondary/mine_sci_shuttle)
 "cMp" = (
 /obj/item/weapon/reagent_containers/glass/rag,
 /obj/item/weapon/table_parts/wood,
@@ -69049,9 +67369,9 @@
 	},
 /turf/simulated/floor{
 	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "warning"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "cMG" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -69215,6 +67535,12 @@
 	icon_state = "vault"
 	},
 /area/station/engineering/drone_fabrication)
+"cNU" = (
+/obj/structure/disposalpipe/sortjunction/wildcard{
+	dir = 8
+	},
+/turf/simulated/wall,
+/area/station/cargo/office)
 "cOb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -69279,31 +67605,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "cSb" = (
-/obj/structure/sink{
-	dir = 8;
-	pixel_x = -12
+/obj/structure/closet/theatrecloset,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
 	},
-/obj/structure/mirror{
-	dir = 4;
-	pixel_x = -28
-	},
-/turf/simulated/floor{
-	dir = 10;
-	icon_state = "whiteblue"
-	},
-/area/station/hallway/secondary/exit)
-"cTO" = (
-/obj/structure/stool/bed/chair/office/dark{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "brown"
-	},
-/area/station/cargo/office)
+/turf/simulated/floor/carpet/purple,
+/area/station/civilian/theatre)
 "cUb" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -69341,17 +67649,6 @@
 	icon_state = "whitered"
 	},
 /area/station/security/brig)
-"cVW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "cWb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -69386,6 +67683,14 @@
 	icon_state = "chapel"
 	},
 /area/station/civilian/chapel/mass_driver)
+"cWV" = (
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "stationscrap"
+	},
+/obj/item/weapon/scrap_lump,
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
 "cXb" = (
 /turf/simulated/floor{
 	icon_state = "white"
@@ -69431,6 +67736,11 @@
 	icon_state = "whiteredcorner"
 	},
 /area/station/medical/reception)
+"dbf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor,
+/area/station/security/checkpoint)
 "dbs" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
 /turf/simulated/floor/plating,
@@ -69455,30 +67765,8 @@
 	},
 /area/station/security/forensic_office)
 "ddh" = (
-/obj/item/weapon/reagent_containers/blood/AMinus{
-	pixel_x = -7;
-	pixel_y = -3
-	},
-/obj/item/weapon/reagent_containers/blood/APlus{
-	pixel_x = -5;
-	pixel_y = 4
-	},
-/obj/item/weapon/reagent_containers/blood/BPlus{
-	pixel_x = 5;
-	pixel_y = 3
-	},
-/obj/item/weapon/reagent_containers/blood/OMinus{
-	pixel_x = -5;
-	pixel_y = -1
-	},
-/obj/structure/table/glass,
-/obj/item/weapon/reagent_containers/blood/empty{
-	pixel_x = 1;
-	pixel_y = -4
-	},
 /turf/simulated/floor{
-	dir = 6;
-	icon_state = "whiteblue"
+	icon_state = "bluecorner"
 	},
 /area/station/hallway/secondary/exit)
 "dex" = (
@@ -69540,13 +67828,20 @@
 /area/station/hallway/secondary/exit)
 "dib" = (
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Escape Maintenance APC";
-	pixel_x = 28
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
@@ -69585,6 +67880,17 @@
 	icon_state = "dark"
 	},
 /area/station/medical/morgue)
+"dlh" = (
+/obj/structure/table,
+/obj/item/device/flashlight,
+/obj/item/weapon/stock_parts/cell/high{
+	charge = 100;
+	maxcharge = 15000
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/cargo/recycleroffice)
 "dlq" = (
 /obj/machinery/door_control{
 	id = "Singularity";
@@ -69622,6 +67928,18 @@
 	icon_state = "dark"
 	},
 /area/station/medical/morgue)
+"doi" = (
+/obj/machinery/power/terminal,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/auxsolarport)
 "doG" = (
 /obj/machinery/door/airlock/external{
 	dock_tag = "pod3"
@@ -69638,6 +67956,17 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/break_room)
+"doT" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "qm_warehouse";
+	name = "Warehouse Shutters"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	icon_state = "floorgrime"
+	},
+/area/station/cargo/storage)
 "dpb" = (
 /obj/structure/sign/warning/secure_area/armory,
 /turf/simulated/wall/r_wall,
@@ -69689,11 +68018,31 @@
 	},
 /area/station/civilian/chapel/office)
 "drP" = (
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutral"
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/station/hallway/secondary/arrival)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/item/weapon/shard{
+	icon_state = "small"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "dsb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -69765,14 +68114,11 @@
 /turf/environment/space,
 /area/space)
 "dvb" = (
-/obj/structure/stool/bed/chair/office/light{
-	dir = 8
-	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "whiteblue"
+	dir = 6;
+	icon_state = "warning"
 	},
-/area/station/hallway/secondary/exit)
+/area/station/hallway/secondary/arrival)
 "dwb" = (
 /obj/structure/cult/tome,
 /turf/simulated/floor{
@@ -69797,6 +68143,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
 /area/station/cargo/office)
@@ -69852,10 +68202,9 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "warning"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "dBu" = (
 /obj/structure/window/reinforced{
 	dir = 5
@@ -69868,15 +68217,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
-"dCb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
+"dBT" = (
+/obj/machinery/light,
 /turf/simulated/floor{
-	dir = 1;
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
+"dCb" = (
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warningcorner"
+	},
+/area/station/hallway/secondary/arrival)
 "dCu" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -69889,20 +68241,12 @@
 	},
 /area/station/hallway/secondary/exit)
 "dDJ" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Cargo Bay Maintenance";
-	req_access = list(31)
+/obj/structure/table,
+/obj/item/device/tagger,
+/turf/simulated/floor{
+	icon_state = "brown"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/area/station/cargo/office)
 "dEb" = (
 /obj/machinery/door/airlock/external{
 	dock_tag = "arrival_ferry";
@@ -69910,7 +68254,7 @@
 	name = "Arrival Airlock"
 	},
 /turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "dFb" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -69971,6 +68315,12 @@
 	icon_state = "vault"
 	},
 /area/station/engineering/drone_fabrication)
+"dLw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor,
+/area/station/security/checkpoint)
 "dMb" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -70058,15 +68408,25 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/engineering/break_room)
-"dQb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+"dPV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/station/cargo/office)
+"dQb" = (
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/turf/simulated/floor{
+	icon_state = "warning"
+	},
+/area/station/hallway/secondary/arrival)
 "dQH" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -70131,6 +68491,22 @@
 	icon_state = "warning"
 	},
 /area/station/rnd/xenobiology)
+"dUy" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "stationscrap"
+	},
+/obj/item/stack/sheet/refined_scrap,
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
+"dUM" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "dVi" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/scrubbers{
 	dir = 8
@@ -70157,6 +68533,24 @@
 	icon_state = "vault"
 	},
 /area/station/civilian/bar)
+"dWl" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
+"dWm" = (
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
+/area/station/cargo/storage)
 "dWu" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -70241,18 +68635,6 @@
 	icon_state = "cult"
 	},
 /area/station/civilian/library)
-"ebk" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/cargo/office)
 "ecb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
@@ -70441,21 +68823,14 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/meeting_room)
 "epm" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
+/turf/simulated/floor,
 /area/station/hallway/secondary/arrival)
 "epH" = (
 /obj/structure/disposalpipe/segment,
@@ -70488,6 +68863,16 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/engineering/engine)
+"eqX" = (
+/obj/machinery/power/port_gen/pacman/scrap,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
+/area/station/cargo/recycleroffice)
 "era" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -70521,13 +68906,6 @@
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/wood,
 /area/station/bridge/meeting_room)
-"euX" = (
-/obj/structure/closet/secure_closet/cargotech,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "brown"
-	},
-/area/station/cargo/office)
 "evb" = (
 /obj/machinery/door/airlock/external{
 	dock_tag = "arrival_specops";
@@ -70535,7 +68913,7 @@
 	name = "Arrival Airlock"
 	},
 /turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "evP" = (
 /obj/structure/stool/bed/chair/pedalgen{
 	anchored = 1;
@@ -70582,6 +68960,19 @@
 	icon_state = "warnplate"
 	},
 /area/station/engineering/engine)
+"ewq" = (
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'VACUUM'";
+	icon_state = "space";
+	layer = 4;
+	name = "VACUUM";
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/station/maintenance/engineering)
 "eyb" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -70594,6 +68985,36 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/civilian/garden)
+"eyP" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal)
+"eyU" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/structure/disposalpipe/sortjunction{
+	dir = 8;
+	name = "Bar Backroom";
+	sortType = "Bar Backroom"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "eAb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -70658,20 +69079,19 @@
 	icon_state = "blue"
 	},
 /area/station/medical/genetics)
-"eFk" = (
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
+"eEs" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/turf/simulated/floor,
+/area/station/hallway/secondary/arrival)
+"eED" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "floorgrime"
 	},
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/cargo/office)
+/area/station/cargo/storage)
 "eGb" = (
 /obj/item/stack/medical/ointment{
 	pixel_y = 4
@@ -70702,6 +69122,12 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
+"eGM" = (
+/obj/effect/decal/cleanable/vomit{
+	icon_state = "vomit_4"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "eHa" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/glass{
@@ -70739,6 +69165,16 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"eIo" = (
+/obj/machinery/door/airlock/mining{
+	name = "Mining Equpment";
+	req_access = list(48)
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor,
+/area/station/cargo/miningoffice)
 "eJb" = (
 /obj/structure/table/glass,
 /obj/item/weapon/reagent_containers/spray/cleaner,
@@ -70767,6 +69203,16 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/port)
+"eLc" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "stationscrap"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
 "eMb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -70901,12 +69347,16 @@
 	},
 /area/station/engineering/break_room)
 "eTT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor{
-	icon_state = "floorgrime"
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	id_tag = "arrival_dock_outer";
+	locked = 1;
+	name = "Arrival Dock External Access";
+	req_one_access = list(13,45,1)
 	},
-/area/station/cargo/storage)
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "eUb" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -70958,11 +69408,12 @@
 	},
 /area/station/bridge/hop_office)
 "eVv" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor{
-	icon_state = "floorgrime"
+/obj/machinery/camera{
+	c_tag = "Cargo Office South";
+	dir = 4
 	},
-/area/station/cargo/storage)
+/turf/simulated/floor,
+/area/station/cargo/office)
 "eVy" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
@@ -71016,16 +69467,17 @@
 	},
 /area/station/civilian/bar)
 "eZb" = (
-/obj/structure/closet/firecloset,
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
-"eZS" = (
-/obj/machinery/camera{
-	c_tag = "Cargo Office South";
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/turf/simulated/floor,
-/area/station/cargo/office)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "fab" = (
 /obj/machinery/door/airlock/external{
 	dock_tag = "arrival_admin";
@@ -71033,16 +69485,32 @@
 	name = "Arrival Airlock"
 	},
 /turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "fbb" = (
-/obj/machinery/light{
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
+"fby" = (
+/obj/machinery/light/small,
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
+"fch" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "whiteblue"
-	},
-/area/station/hallway/secondary/exit)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/civilian/barbershop)
 "fcK" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor/wood,
@@ -71054,6 +69522,16 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
+"ffq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/arrival)
 "ffD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -71064,22 +69542,11 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "fgl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/machinery/iv_drip,
 /turf/simulated/floor{
-	icon_state = "neutralcorner"
+	icon_state = "whiteblue"
 	},
-/area/station/hallway/secondary/arrival)
+/area/station/hallway/secondary/exit)
 "fgF" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
@@ -71087,6 +69554,14 @@
 	},
 /turf/simulated/wall,
 /area/station/hallway/secondary/mine_sci_shuttle)
+"fgI" = (
+/obj/structure/table,
+/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
 "fhb" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/weapon/shard,
@@ -71096,6 +69571,13 @@
 /obj/machinery/power/rad_collector,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"fjD" = (
+/obj/structure/closet,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "fkD" = (
 /obj/item/weapon/packageWrap,
 /obj/structure/table/glass,
@@ -71155,13 +69637,20 @@
 	},
 /area/station/engineering/engine)
 "fnb" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/effect/landmark/start/recycler,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump/on,
-/turf/simulated/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "fng" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -71174,10 +69663,11 @@
 /turf/simulated/floor,
 /area/station/engineering/engine)
 "fob" = (
-/obj/machinery/atmospherics/components/unary/portables_connector,
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/plating,
-/area/station/cargo/recycleroffice)
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor{
+	icon_state = "floorgrime"
+	},
+/area/station/cargo/storage)
 "foN" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -71197,19 +69687,13 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/starboard)
 "fpb" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "stationscrap"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/station/cargo/recycleroffice)
+/obj/item/weapon/scrap_lump,
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
 "fpv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -71221,20 +69705,16 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "fqb" = (
-/obj/machinery/camera{
-	c_tag = "Recycler External North";
-	dir = 8
+/obj/machinery/newscaster{
+	pixel_x = 32
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 4
+/obj/structure/table,
+/obj/machinery/computer/stockexchange,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "brown"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating,
-/area/station/cargo/recycleroffice)
+/area/station/cargo/office)
 "fqd" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -71255,39 +69735,14 @@
 	icon_state = "warningcorner"
 	},
 /area/station/engineering/engine)
-"frb" = (
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1379;
-	master_tag = "recycler_airlock";
-	name = "interior access button";
-	pixel_x = -26;
-	pixel_y = -20;
-	req_access = list(67)
-	},
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/cargo/recycleroffice)
 "fsb" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/closet/secure_closet/recycler,
+/obj/machinery/status_display{
+	pixel_y = 32
 	},
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	id_tag = "recycler_inner";
-	locked = 1;
-	name = "Recycler External Access";
-	req_access = list(67)
+/turf/simulated/floor{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
 "ftb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -71297,24 +69752,24 @@
 	},
 /area/station/medical/reception)
 "fub" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
-	dir = 4;
-	frequency = 1379;
-	id_tag = "recycler_pump";
-	name = "Recycler Large Air Vent"
+/obj/item/clothing/gloves/rainbow,
+/obj/item/clothing/head/soft/rainbow,
+/obj/item/clothing/shoes/rainbow,
+/obj/item/clothing/suit/poncho/rainbow,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/exit)
+"fuR" = (
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/machinery/airlock_sensor{
-	id_tag = "recycler_sensor";
-	pixel_x = -25;
-	pixel_y = -20
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Recycler APC";
+	pixel_y = 24
 	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating{
-	icon_state = "platebotc"
-	},
-/area/station/cargo/recycleroffice)
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
 "fvU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -71336,25 +69791,14 @@
 	},
 /area/station/medical/hallway)
 "fxb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor{
 	dir = 4;
-	frequency = 1379;
-	id_tag = "recycler_pump";
-	name = "Recycler Large Air Vent"
+	icon_state = "white"
 	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	id_tag = "recycler_airlock";
-	pixel_x = -25;
-	req_access = list(67);
-	tag_airpump = "recycler_pump";
-	tag_chamber_sensor = "recycler_sensor";
-	tag_exterior_door = "recycler_outer";
-	tag_interior_door = "recycler_inner"
-	},
-/turf/simulated/floor/plating{
-	icon_state = "platebotc"
-	},
-/area/station/cargo/recycleroffice)
+/area/station/hallway/secondary/exit)
 "fxg" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -71364,30 +69808,50 @@
 /obj/random/foods/food_trash,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
-"fAb" = (
-/obj/machinery/camera{
-	c_tag = "Recycler External South";
-	pixel_x = 4
+"fyb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/plating/airless,
-/area/station/cargo/recycler)
-"fBb" = (
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1379;
-	master_tag = "recycler_airlock";
-	name = "exterior access button";
-	pixel_x = -26;
-	pixel_y = 24;
-	req_access = list(67)
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/cargo/recycler)
+/area/station/maintenance/cargo)
+"fyC" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/closet/theatrecloset,
+/turf/simulated/floor/carpet/purple,
+/area/station/civilian/theatre)
+"fAb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Escape Medical Checkpoint";
+	req_access = list(5)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "whitebluefull"
+	},
+/area/station/hallway/secondary/exit)
+"fBb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "fBF" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1
@@ -71398,32 +69862,32 @@
 	},
 /area/station/engineering/atmos)
 "fCb" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Recycler APC";
-	pixel_y = 24
-	},
 /turf/simulated/floor/plating/airless,
 /area/station/cargo/recycler)
 "fDb" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/table/glass,
+/obj/item/weapon/storage/firstaid/regular{
+	pixel_x = -2;
+	pixel_y = 4
 	},
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-y"
+/obj/item/weapon/reagent_containers/syringe{
+	pixel_x = -4
+	},
+/obj/item/weapon/reagent_containers/syringe{
+	pixel_x = -2;
+	pixel_y = 3
+	},
+/obj/item/weapon/reagent_containers/syringe{
+	pixel_y = 6
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
+	dir = 1;
+	icon_state = "whiteblue"
 	},
-/area/station/cargo/storage)
+/area/station/hallway/secondary/exit)
 "fDx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -71471,13 +69935,12 @@
 	},
 /area/station/hallway/primary/port)
 "fEm" = (
-/obj/machinery/camera{
-	c_tag = "Prison Maintenance";
-	dir = 8;
-	network = list("SS13","Security")
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/eva)
+/area/station/cargo/office)
 "fEy" = (
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -71538,20 +70001,20 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/station/engineering/engine)
-"fHn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+"fHH" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/escape)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor,
+/area/station/cargo/storage)
 "fIV" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Chief Engineer";
@@ -71690,6 +70153,17 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/medical/reception)
+"fPk" = (
+/obj/structure/stool/bed/chair/metal/red{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/hallway/secondary/exit)
 "fPM" = (
 /obj/structure/bookcase/manuals/engineering,
 /obj/structure/sign/poster/random{
@@ -71697,13 +70171,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
-"fQb" = (
-/obj/item/clothing/mask/breath,
-/obj/structure/reagent_dispensers/aqueous_foam_tank,
-/obj/item/weapon/tank/oxygen,
-/obj/item/clothing/mask/breath,
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
 "fRb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood{
@@ -71840,16 +70307,6 @@
 /obj/item/weapon/folder/yellow,
 /turf/simulated/floor,
 /area/station/engineering/engine)
-"fXb" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
 "fXV" = (
 /obj/structure/stool/bed/chair/comfy/black,
 /turf/simulated/floor/carpet/black,
@@ -71882,6 +70339,10 @@
 	icon_state = "redfull"
 	},
 /area/station/medical/reception)
+"gaM" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/simulated/floor,
+/area/station/hallway/secondary/arrival)
 "gbb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -71902,15 +70363,12 @@
 /turf/simulated/floor/grass,
 /area/station/medical/genetics)
 "gdb" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
-/turf/simulated/floor{
-	icon_state = "bot"
-	},
-/area/station/cargo/storage)
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "geb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -71928,6 +70386,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"geR" = (
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	name = "Bar APC";
+	pixel_y = -30
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/bar)
 "gfm" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
@@ -71972,14 +70443,20 @@
 	},
 /area/station/engineering/break_room)
 "gib" = (
-/obj/structure/closet/secure_closet/recycler,
-/obj/machinery/status_display{
-	pixel_y = 32
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 10;
+	icon_state = "brown"
 	},
-/area/station/cargo/recycleroffice)
+/area/station/cargo/office)
+"gif" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/plating{
+	icon_state = "platebotc"
+	},
+/area/station/maintenance/eva)
 "gjb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -71990,18 +70467,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/engineering)
-"glx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "brown"
-	},
-/area/station/cargo/office)
 "glT" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -72026,6 +70491,12 @@
 	icon_state = "darkyellow"
 	},
 /area/station/engineering/chiefs_office)
+"gmF" = (
+/obj/machinery/light,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/arrival)
 "gmI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -72173,6 +70644,14 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/chiefs_office)
+"gth" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "guV" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/two,
@@ -72184,30 +70663,23 @@
 	icon_state = "platebot"
 	},
 /area/station/engineering/engine)
-"gvg" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "gvk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
+"gvw" = (
+/obj/structure/disposalpipe/junction{
+	icon_state = "pipe-j2"
 	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/turf/simulated/floor,
+/area/station/cargo/office)
 "gwb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -72372,6 +70844,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"gHX" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 4
+	},
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_x = 32
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/recycleroffice)
 "gIb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -72410,14 +70900,8 @@
 	},
 /area/station/civilian/hydroponics)
 "gKX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal)
 "gLt" = (
 /obj/machinery/light_switch{
 	pixel_x = -23
@@ -72447,6 +70931,16 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/aft)
+"gMD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/station/cargo/storage)
 "gMY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -72494,13 +70988,15 @@
 	},
 /area/station/civilian/hydroponics)
 "gOl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
+/obj/item/weapon/flora/random,
 /turf/simulated/floor{
-	icon_state = "floorgrime"
+	icon_state = "purplechecker"
 	},
-/area/station/cargo/storage)
+/area/station/civilian/barbershop)
 "gOF" = (
 /obj/structure/transit_tube{
 	icon_state = "N-S"
@@ -72584,16 +71080,6 @@
 	},
 /turf/simulated/floor/engine/vacuum,
 /area/station/maintenance/incinerator)
-"gSX" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/cargo/office)
 "gTb" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/structure/extinguisher_cabinet{
@@ -72838,6 +71324,15 @@
 	icon_state = "platebot"
 	},
 /area/space)
+"hdG" = (
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "brown"
+	},
+/area/station/cargo/office)
 "hfb" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -72893,6 +71388,19 @@
 	},
 /turf/environment/space,
 /area/shuttle/mining/station)
+"hhk" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/cargo/storage)
 "hho" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -72972,22 +71480,14 @@
 	},
 /area/station/engineering/engine)
 "hmR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Disposal APC";
+	pixel_x = 27
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/structure/cable,
 /turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/maintenance/disposal)
 "hnb" = (
 /obj/machinery/computer/mine_sci_shuttle/flight_comp{
 	dir = 8
@@ -73004,12 +71504,16 @@
 /turf/simulated/floor,
 /area/station/cargo/storage)
 "hob" = (
-/obj/machinery/door/airlock/external{
-	name = "Arrival Airlock"
+/obj/structure/table/glass,
+/obj/item/weapon/storage/firstaid/o2,
+/obj/machinery/alarm{
+	pixel_y = 24
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/arrival)
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "whiteblue"
+	},
+/area/station/hallway/secondary/exit)
 "hpb" = (
 /obj/machinery/door/airlock{
 	name = "Sauna"
@@ -73046,6 +71550,19 @@
 /obj/item/weapon/beach_ball/holoball,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"hqv" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/random/tools/tool,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
+/area/station/cargo/storage)
 "hrb" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Library Maintenance";
@@ -73072,6 +71589,16 @@
 	icon_state = "4-3"
 	},
 /area/shuttle/mining/station)
+"huE" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/station/civilian/theatre)
 "hvb" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -73079,18 +71606,9 @@
 	},
 /area/station/hallway/secondary/exit)
 "hvE" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/plating,
+/area/station/storage/emergency2)
 "hwb" = (
 /obj/structure/rack,
 /obj/item/weapon/tank/oxygen,
@@ -73098,6 +71616,26 @@
 /obj/item/clothing/mask/breath,
 /turf/simulated/floor/plating,
 /area/station/storage/emergency)
+"hwh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/vending/cigarette,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
+"hwJ" = (
+/obj/structure/stool,
+/obj/effect/landmark/start/recycler,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/cargo/recycleroffice)
 "hxb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -73332,12 +71870,13 @@
 	},
 /area/station/maintenance/eva)
 "hJt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/wall,
-/area/station/cargo/office)
+/turf/simulated/floor/plating/airless/catwalk,
+/area/station/solar/auxport)
 "hKb" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -73352,6 +71891,11 @@
 	icon_state = "darkblue"
 	},
 /area/station/gateway)
+"hLf" = (
+/obj/structure/closet/theatrecloset,
+/obj/item/device/guitar/electric,
+/turf/simulated/floor/carpet/purple,
+/area/station/civilian/theatre)
 "hMb" = (
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
@@ -73367,13 +71911,19 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "hOV" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/power/solar{
+	id = "auxsolareast";
+	name = "Port Auxiliary Solar Array"
 	},
-/turf/simulated/floor/plating,
-/area/station/storage/emergency2)
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/turf/simulated/floor/airless{
+	icon_state = "solarpanel"
+	},
+/area/station/solar/auxport)
 "hPb" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -73397,21 +71947,33 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "hPU" = (
-/obj/structure/sign/warning/securearea{
-	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/wall,
-/area/station/hallway/secondary/arrival)
-"hQb" = (
-/obj/machinery/alarm{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
 	dir = 4;
-	pixel_x = -25
+	icon_state = "brown"
 	},
+/area/station/cargo/office)
+"hQb" = (
 /obj/structure/table/glass,
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen{
 	layer = 3.1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -28
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -73451,37 +72013,21 @@
 	},
 /area/station/engineering/engine)
 "hSb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor{
-	icon_state = "neutralcorner"
+	dir = 9;
+	icon_state = "warning"
 	},
 /area/station/hallway/secondary/arrival)
 "hSt" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/maintenance/engineering)
 "hTt" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 9
@@ -73528,13 +72074,13 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
-"hVb" = (
-/obj/structure/sign/warning/securearea{
-	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA"
+"hVG" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warning"
 	},
-/turf/simulated/wall/r_wall,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "hVJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -73545,17 +72091,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
-"hXb" = (
-/obj/structure/closet/emcloset,
-/obj/machinery/camera{
-	c_tag = "Arrival Hallway Center";
-	pixel_x = -4
-	},
+"hXd" = (
+/obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "bot"
+	dir = 8;
+	icon_state = "neutralcorner"
 	},
-/area/station/hallway/secondary/arrival)
+/area/station/hallway/secondary/entry)
 "hXl" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
@@ -73594,6 +72136,12 @@
 	icon_state = "blue"
 	},
 /area/station/hallway/primary/central)
+"hYh" = (
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "brown"
+	},
+/area/station/cargo/office)
 "hYn" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -73652,6 +72200,20 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/civilian/toilet)
+"iac" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "ibb" = (
 /obj/structure/closet/emcloset,
 /obj/structure/sign/nanotrasen{
@@ -73675,16 +72237,15 @@
 	dir = 5
 	},
 /turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "ice" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/turf/simulated/floor{
+	icon_state = "floorgrime"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/cargo/storage)
 "icl" = (
 /obj/machinery/airlock_sensor{
 	id_tag = "atmospherics_sensor";
@@ -73726,6 +72287,15 @@
 	icon_state = "warning"
 	},
 /area/station/engineering/engine)
+"idD" = (
+/obj/structure/disposaloutlet{
+	dir = 4
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/office)
 "ieb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -73790,16 +72360,17 @@
 	},
 /area/station/gateway)
 "ihg" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "qm_warehouse";
-	name = "Warehouse Shutters"
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1379;
+	master_tag = "engin_airlock";
+	name = "exterior access button";
+	pixel_x = 25;
+	pixel_y = -25;
+	req_one_access = list(13,45,1)
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
-/area/station/cargo/storage)
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "ihZ" = (
 /obj/structure/stool/bed/chair/pew/left,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -73888,6 +72459,36 @@
 	icon_state = "greencorner"
 	},
 /area/station/hallway/primary/port)
+"ipq" = (
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
+"ipy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
+/area/station/cargo/recycleroffice)
+"ipM" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "bar"
+	},
+/area/station/cargo/miningoffice)
 "iqb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/window/reinforced{
@@ -73904,15 +72505,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor/plating,
 /area/station/maintenance/incinerator)
-"iry" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "irW" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -73951,6 +72543,13 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/reception)
+"itr" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/cargo/storage)
 "itt" = (
 /obj/item/weapon/table_parts/wood/fancy,
 /obj/effect/decal/cleanable/blood/oil,
@@ -73996,13 +72595,11 @@
 	},
 /area/station/civilian/hydroponics)
 "ivL" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
@@ -74067,6 +72664,21 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/hydroponics)
+"iyC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "iyR" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -74126,12 +72738,20 @@
 	},
 /area/station/civilian/hydroponics)
 "iAY" = (
-/obj/effect/decal/cleanable/generic,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/grille,
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK"
 	},
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 5
+	},
+/obj/structure/lattice,
 /turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/hallway/secondary/arrival)
 "iBb" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -74152,11 +72772,19 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "iCC" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
+/obj/structure/table,
+/obj/item/stack/sheet/metal{
+	amount = 50
 	},
-/area/station/hallway/secondary/arrival)
+/obj/item/weapon/storage/box/lights/mixed,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
+/area/station/storage/tools)
 "iCU" = (
 /obj/machinery/embedded_controller/radio/airlock_controller{
 	id_tag = "atmospherics_airlock";
@@ -74173,11 +72801,16 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "iDb" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	icon_state = "browncorner"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/station/hallway/secondary/entry)
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 9
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/recycleroffice)
 "iDo" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor{
@@ -74185,6 +72818,17 @@
 	icon_state = "yellow"
 	},
 /area/station/hallway/primary/aft)
+"iDY" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "brown"
+	},
+/area/station/cargo/miningoffice)
 "iEb" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/directions/security{
@@ -74344,6 +72988,42 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/rnd/xenobiology)
+"iOp" = (
+/obj/machinery/door/airlock/mining{
+	name = "Recycler's workplace";
+	req_access = list(67)
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/recycleroffice)
+"iOM" = (
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "Barbershop APC";
+	pixel_y = 27
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
+/area/station/civilian/barbershop)
 "iPb" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -74369,6 +73049,12 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/engine)
+"iPK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "iQb" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -74401,22 +73087,14 @@
 	icon_state = "delivery"
 	},
 /area/station/bridge)
-"iRH" = (
+"iRp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor,
 /area/station/cargo/storage)
 "iSb" = (
 /obj/structure/sign/warning/securearea{
@@ -74431,16 +73109,6 @@
 	icon_state = "blue"
 	},
 /area/station/hallway/primary/central)
-"iSz" = (
-/obj/machinery/hologram/holopad,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor,
-/area/station/cargo/office)
 "iTb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -74522,6 +73190,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/carpet,
 /area/station/civilian/library)
+"iWA" = (
+/obj/structure/lattice,
+/turf/simulated/wall,
+/area/station/maintenance/eva)
 "iYb" = (
 /obj/machinery/light,
 /obj/structure/sign/nanotrasen{
@@ -74610,18 +73282,20 @@
 /turf/simulated/floor,
 /area/station/construction)
 "jaX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "brown"
+	dir = 4;
+	icon_state = "dark"
 	},
-/area/station/cargo/storage)
+/area/station/cargo/recycleroffice)
 "jbb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -74679,6 +73353,17 @@
 	icon_state = "bot"
 	},
 /area/station/engineering/atmos)
+"jdz" = (
+/obj/structure/closet/hydrant{
+	pixel_x = -32
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/storage/emergency2)
 "jeb" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/directions/security{
@@ -74720,36 +73405,33 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "jhk" = (
-/obj/structure/closet/hydrant{
-	pixel_x = -32
+/obj/machinery/atm{
+	pixel_x = 32
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/mob/living/simple_animal/walle,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
 	},
-/turf/simulated/floor/plating,
-/area/station/storage/emergency2)
+/area/station/cargo/qm)
 "jib" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"jiG" = (
+/obj/item/weapon/flora/pottedplant/large,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "brown"
+	},
+/area/station/cargo/office)
 "jjN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
-"jkb" = (
-/obj/structure/rack,
-/obj/item/weapon/reagent_containers/spray/extinguisher,
-/obj/item/clothing/mask/gas/coloured,
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/turf/simulated/wall,
+/area/station/cargo/office)
 "jkp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -74818,17 +73500,6 @@
 	icon_state = "yellow"
 	},
 /area/station/hallway/primary/aft)
-"jnb" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
 "jnn" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 4
@@ -74867,13 +73538,13 @@
 	},
 /area/station/civilian/chapel/mass_driver)
 "jpM" = (
-/obj/structure/grille,
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 5
+/obj/machinery/newscaster{
+	pixel_y = -30
 	},
-/turf/simulated/floor/plating,
-/area/station/cargo/recycleroffice)
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
+/area/station/civilian/barbershop)
 "jqb" = (
 /obj/item/weapon/reagent_containers/syringe,
 /obj/item/weapon/reagent_containers/pill/methylphenidate,
@@ -74921,6 +73592,12 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/break_room)
+"jrZ" = (
+/obj/structure/closet/secure_closet/recycler,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/cargo/recycleroffice)
 "jsb" = (
 /obj/machinery/door/airlock{
 	name = "Custodial Closet";
@@ -75003,28 +73680,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
-"jyb" = (
-/obj/machinery/camera{
-	c_tag = "Disposals";
-	dir = 8
+"jxO" = (
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1379;
+	master_tag = "recycler_airlock";
+	name = "exterior access button";
+	pixel_x = -26;
+	pixel_y = 24;
+	req_access = list(67)
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Disposal APC";
-	pixel_x = 27
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/structure/cable,
 /turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
-"jyQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
+/area/station/cargo/recycler)
 "jzb" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -75259,14 +73931,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/bridge)
-"jOv" = (
-/obj/structure/stool/bed/chair/office/dark{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "brown"
-	},
-/area/station/cargo/office)
 "jOD" = (
 /obj/machinery/the_singularitygen,
 /turf/simulated/floor/plating/airless{
@@ -75539,6 +74203,15 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/break_room)
+"kdU" = (
+/obj/machinery/power/smes,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/machinery/light/small,
+/turf/simulated/floor/plating,
+/area/station/maintenance/auxsolarport)
 "kdV" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -75589,6 +74262,19 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"keH" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	id_tag = "arrival_dock_inner";
+	locked = 1;
+	name = "Arrival Dock External Access";
+	req_one_access = list(13,45,1)
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "keS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -75596,19 +74282,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
-"kgz" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+"kfK" = (
+/obj/machinery/atmospherics/pipe/manifold/visible,
 /turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/hallway/secondary/arrival)
+"kgz" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/airless/ceiling,
+/area/station/cargo/recycler)
 "khw" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -75617,19 +74298,14 @@
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "khG" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warning"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/area/station/hallway/secondary/arrival)
 "kif" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -75683,14 +74359,11 @@
 	},
 /area/station/medical/chemistry)
 "kkB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/shop_scanner{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
-/area/station/cargo/storage)
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal)
 "klb" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -75714,15 +74387,6 @@
 	icon_state = "blue"
 	},
 /area/station/medical/reception)
-"klI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "kmb" = (
 /obj/structure/stool/bed/chair/office/light{
 	dir = 8
@@ -75808,18 +74472,6 @@
 /obj/machinery/power/emitter,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
-"krG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/station/cargo/office)
 "krJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -75830,12 +74482,23 @@
 	},
 /area/station/engineering/engine)
 "krW" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2"
+/obj/machinery/power/solar_control{
+	id = "auxsolareast";
+	name = "Fore Port Solar Control"
 	},
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_y = 32
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/auxsolarport)
 "ksb" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Teleporter Maintenance";
@@ -75935,14 +74598,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/bridge/hop_office)
-"kwS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "floorgrime"
-	},
-/area/station/cargo/storage)
 "kxb" = (
 /obj/structure/sign/warning/lethal_turrets,
 /turf/simulated/wall/r_wall,
@@ -75971,15 +74626,17 @@
 /turf/simulated/wall/r_wall,
 /area/station/hallway/primary/central)
 "kyH" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -28
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
 	},
-/obj/machinery/light{
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor,
-/area/station/cargo/office)
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced,
+/turf/simulated/floor/plating,
+/area/station/cargo/qm)
 "kzb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -75992,14 +74649,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/storage/emergency)
-"kAe" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 5
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/mine_sci_shuttle)
 "kAR" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -76086,16 +74735,6 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
-"kFb" = (
-/obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/cargo/recycleroffice)
 "kFe" = (
 /obj/effect/landmark/start/botanist,
 /turf/simulated/floor{
@@ -76156,6 +74795,23 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/brig)
+"kKc" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/item/weapon/flora/pottedplant/tropicalfern,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "brown"
+	},
+/area/station/cargo/qm)
+"kKP" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
+	},
+/turf/simulated/floor/wood,
+/area/station/security/vacantoffice)
 "kLb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating{
@@ -76187,12 +74843,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/station/maintenance/medbay)
-"kNq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/wall,
-/area/station/cargo/recycleroffice)
 "kNR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -76227,17 +74877,19 @@
 	},
 /area/station/civilian/chapel/mass_driver)
 "kQm" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
 	},
+/area/station/hallway/secondary/arrival)
+"kQw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 5
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "kRb" = (
@@ -76324,9 +74976,23 @@
 	},
 /area/station/civilian/chapel)
 "kYI" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1379;
+	master_tag = "recycler_airlock";
+	name = "interior access button";
+	pixel_x = -26;
+	pixel_y = -20;
+	req_access = list(67)
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/recycleroffice)
 "kYJ" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -76353,37 +75019,10 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
-"lac" = (
-/obj/effect/landmark/start/cargo_technician,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/cargo/office)
 "lar" = (
 /obj/structure/sign/warning/moving_parts,
 /turf/simulated/wall,
 /area/station/cargo/office)
-"lay" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/arrival)
 "lbb" = (
 /obj/structure/sign/departments/custodian{
 	pixel_y = -32
@@ -76394,14 +75033,9 @@
 	},
 /area/station/hallway/primary/central)
 "lcb" = (
-/obj/machinery/light,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
+/obj/machinery/space_heater,
+/turf/simulated/floor/plating,
+/area/station/storage/emergency2)
 "lcB" = (
 /obj/machinery/door_control{
 	desc = "A remote control-switch for secure storage.";
@@ -76463,6 +75097,15 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/hallway)
+"lfh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "bar"
+	},
+/area/station/cargo/miningoffice)
 "lga" = (
 /obj/item/weapon/reagent_containers/food/snacks/soap/nanotrasen,
 /obj/structure/dryer{
@@ -76570,6 +75213,16 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/locker)
+"lky" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
+/area/station/cargo/recycleroffice)
 "llb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -76601,18 +75254,22 @@
 	},
 /area/station/medical/morgue)
 "lpD" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/plating,
-/area/station/storage/emergency2)
-"lqO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/area/station/cargo/recycleroffice)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor,
+/area/station/cargo/storage)
 "lru" = (
 /obj/random/foods/food_trash,
 /turf/simulated/floor/plating{
@@ -76713,6 +75370,20 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/cargo/office)
+"lwr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/arrival)
 "lwE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -76720,19 +75391,20 @@
 /turf/simulated/floor,
 /area/station/civilian/hydroponics)
 "lxb" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	id_tag = "recycler_outer";
-	locked = 1;
-	name = "Recycler External Access";
-	req_access = list(67)
+/obj/structure/table,
+/obj/item/weapon/folder/brown,
+/obj/item/weapon/stamp{
+	name = "recycler's rubber stamp";
+	stamp_message = "Recycler"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = 20
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "lxr" = (
 /turf/simulated/floor/plating/airless{
@@ -76769,17 +75441,31 @@
 /turf/simulated/floor,
 /area/station/civilian/fitness)
 "lzm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/station/cargo/office)
+"lzs" = (
+/obj/effect/landmark/start/recycler,
 /obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "brown"
+	icon_state = "dark"
 	},
-/area/station/cargo/office)
+/area/station/cargo/recycleroffice)
 "lAb" = (
 /obj/structure/morgue,
 /obj/machinery/camera{
@@ -76829,6 +75515,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"lCC" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/power/port_gen/pacman/scrap,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
+/area/station/cargo/recycleroffice)
 "lDb" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced{
@@ -76857,7 +75556,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "lDy" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -76921,6 +75622,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"lGk" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1379;
+	master_tag = "solar_tool_airlock";
+	name = "exterior access button";
+	pixel_x = -25;
+	pixel_y = -25;
+	req_access = list(13)
+	},
+/turf/simulated/floor/plating/airless/catwalk,
+/area/station/solar/auxport)
 "lHb" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -76932,6 +75650,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"lHP" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "lIb" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -77073,19 +75798,12 @@
 /area/station/maintenance/medbay)
 "lNB" = (
 /obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 5
+	},
 /turf/simulated/floor/plating,
-/area/station/cargo/qm)
+/area/station/cargo/recycleroffice)
 "lOb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -77104,6 +75822,19 @@
 	icon_state = "vault"
 	},
 /area/station/civilian/chapel/mass_driver)
+"lOA" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "lON" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/on{
 	dir = 4;
@@ -77191,16 +75922,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/medical/hallway)
-"lUd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "lVb" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = -28
@@ -77220,6 +75941,20 @@
 	icon_state = "white"
 	},
 /area/station/medical/morgue)
+"lWN" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/recycleroffice)
 "lXb" = (
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
@@ -77254,10 +75989,6 @@
 	icon_state = "barber"
 	},
 /area/station/medical/cmo)
-"lZM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/simulated/floor,
-/area/station/hallway/secondary/arrival)
 "mab" = (
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the department.";
@@ -77272,25 +76003,22 @@
 	},
 /area/station/medical/reception)
 "mah" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/item/stack/tile/wood{
+	amount = 3
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/machinery/light/small{
+	dir = 4
 	},
-/area/station/hallway/secondary/arrival)
-"mal" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "packageSort2"
-	},
-/obj/machinery/light,
 /turf/simulated/floor/plating{
-	dir = 1;
-	icon_state = "warnplate"
+	icon_state = "panelscorched"
 	},
-/area/station/cargo/office)
+/area/station/maintenance/escape)
+"mal" = (
+/obj/item/weapon/flora/random,
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken"
+	},
+/area/station/maintenance/escape)
 "mbb" = (
 /obj/structure/table/glass,
 /obj/machinery/light{
@@ -77312,16 +76040,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "mcG" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
-/obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2"
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
-/turf/simulated/floor,
-/area/station/cargo/office)
+/area/station/hallway/secondary/arrival)
 "mdb" = (
 /obj/structure/table,
 /obj/item/weapon/paper_bin,
@@ -77352,6 +76078,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"meQ" = (
+/obj/machinery/camera{
+	c_tag = "Fore Port Solar Control";
+	dir = 4;
+	network = list("SS13","Engineering")
+	},
+/obj/structure/stool{
+	pixel_y = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/auxsolarport)
 "meU" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -77390,18 +76127,11 @@
 	},
 /area/station/medical/hallway)
 "mhb" = (
-/obj/structure/sign/warning/securearea{
-	desc = "A warning sign which reads 'VACUUM'";
-	icon_state = "space";
-	layer = 4;
-	name = "VACUUM";
-	pixel_x = -32
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/station/maintenance/engineering)
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "mib" = (
 /obj/structure/stool/bed/roller,
 /obj/machinery/alarm{
@@ -77420,6 +76150,19 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/civilian/fitness)
+"mjz" = (
+/obj/structure/table/woodentable,
+/obj/machinery/camera{
+	c_tag = "Theater Backroom"
+	},
+/obj/item/weapon/paper{
+	info = "Wherah is BANANAS?";
+	info_links = "Clown Memo"
+	},
+/obj/item/toy/prize/honk,
+/obj/item/weapon/reagent_containers/spray/watergun,
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "mjX" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -77612,21 +76355,6 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
-"mtS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
-	},
-/area/station/cargo/recycleroffice)
 "mub" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -77670,31 +76398,18 @@
 	icon_state = "bot"
 	},
 /area/station/engineering/atmos)
-"myC" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Bay";
-	req_one_access = list(31,48,67)
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+"myS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "brown"
 	},
-/turf/simulated/floor,
-/area/station/cargo/storage)
-"myS" = (
-/obj/structure/sign/warning/docking,
-/turf/simulated/wall,
 /area/station/cargo/storage)
 "mzF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -77721,25 +76436,16 @@
 /turf/simulated/wall/r_wall,
 /area/station/rnd/xenobiology)
 "mCm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/light_switch{
+	pixel_x = 4;
+	pixel_y = -25
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/camera{
+	c_tag = "Disposals";
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/light,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/arrival)
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal)
 "mDb" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
@@ -77747,14 +76453,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/xenobiology)
-"mDC" = (
-/obj/structure/sign/warning/securearea{
-	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA";
-	pixel_y = -32
-	},
-/turf/environment/space,
-/area/space)
 "mEb" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -77821,20 +76519,6 @@
 /obj/item/weapon/shard,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
-"mJL" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/cargo/storage)
 "mKa" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -77886,6 +76570,13 @@
 	icon_state = "bot"
 	},
 /area/station/civilian/janitor)
+"mLl" = (
+/obj/structure/closet/secure_closet/miner,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "brown"
+	},
+/area/station/cargo/miningoffice)
 "mMb" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -77907,32 +76598,29 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "mNg" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/embedded_controller/radio/airlock_controller{
+	id_tag = "engin_airlock";
+	pixel_y = 28;
+	req_one_access = list(13,45,1);
+	tag_airpump = "engin_pump";
+	tag_chamber_sensor = "engin_sensor";
+	tag_exterior_door = "engin_outer";
+	tag_interior_door = "engin_inner"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/airlock_sensor{
+	id_tag = "engin_sensor";
+	layer = 3.3;
+	pixel_x = 12;
+	pixel_y = 25
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
+	dir = 4;
+	frequency = 1379;
+	id_tag = "engin_pump";
+	name = "Engineering Large Air Vent"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
-"mNC" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/area/station/maintenance/engineering)
 "mOb" = (
 /obj/structure/grille{
 	destroyed = 1
@@ -77940,6 +76628,23 @@
 /obj/item/stack/rods,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"mOZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/closet/crate,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/random/misc/all,
+/obj/random/tools/tech_supply,
+/turf/simulated/floor{
+	icon_state = "floorgrime"
+	},
+/area/station/cargo/storage)
 "mPb" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor{
@@ -77968,6 +76673,13 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/sleeper)
+"mQQ" = (
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor,
+/area/station/cargo/storage)
 "mTb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10
@@ -77982,14 +76694,14 @@
 	},
 /area/station/engineering/singularity)
 "mTP" = (
-/obj/machinery/alarm{
-	pixel_y = 28
+/obj/machinery/light,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+	icon_state = "brown"
 	},
-/area/station/cargo/recycleroffice)
+/area/station/cargo/storage)
 "mUb" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
@@ -78127,6 +76839,15 @@
 	icon_state = "platebotc"
 	},
 /area/station/rnd/tox_launch)
+"ndg" = (
+/obj/machinery/conveyor_switch/oneway{
+	id = "QMLoad"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warning"
+	},
+/area/station/cargo/storage)
 "neb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -78173,6 +76894,19 @@
 	icon_state = "warnwhite"
 	},
 /area/station/rnd/xenobiology)
+"nfY" = (
+/obj/machinery/status_display{
+	layer = 4;
+	pixel_y = 32
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/arrival)
 "ngb" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4
@@ -78308,15 +77042,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
-"nqm" = (
-/obj/machinery/door/airlock/mining/glass{
-	name = "Delivery Office";
-	req_access = list(50)
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/cargo/office)
 "nrb" = (
 /obj/structure/rack,
 /obj/item/weapon/airlock_electronics,
@@ -78568,25 +77293,27 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/hologram/holopad,
+/obj/effect/landmark{
+	name = "Observer-Start"
+	},
 /turf/simulated/floor,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "nGb" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
+/obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8
 	},
-/turf/simulated/floor{
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "nHb" = (
 /obj/structure/rack,
 /obj/item/weapon/storage/briefcase/inflatable{
@@ -78614,9 +77341,13 @@
 /turf/simulated/floor/wood,
 /area/station/maintenance/engineering)
 "nJb" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/wall,
-/area/station/maintenance/cargo)
+/obj/structure/stool/bed/chair/metal{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "nLb" = (
 /obj/structure/table/woodentable,
 /obj/random/misc/book,
@@ -78626,15 +77357,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"nLZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/cargo/office)
 "nMb" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Construction Area Maintenance";
@@ -78660,12 +77382,23 @@
 	},
 /area/station/hallway/primary/central)
 "nMw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/airless/catwalk,
+/area/station/solar/auxport)
 "nNb" = (
 /obj/machinery/door/airlock/security{
 	name = "Security Checkpoint";
@@ -78739,11 +77472,11 @@
 /turf/simulated/floor/plating,
 /area/station/security/vacantoffice)
 "nSy" = (
-/obj/effect/decal/cleanable/vomit{
-	icon_state = "vomit_4"
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/hallway/secondary/arrival)
 "nSP" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 6
@@ -78758,6 +77491,26 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/starboardsolar)
+"nTI" = (
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'LANDFILL'";
+	icon_state = "space";
+	layer = 4;
+	name = "LANDFILL";
+	pixel_x = 32
+	},
+/obj/machinery/conveyor_switch/oneway{
+	id = "packageSort2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "brown"
+	},
+/area/station/cargo/office)
 "nUb" = (
 /obj/structure/closet/l3closet/general,
 /obj/item/clothing/mask/gas/coloured,
@@ -78995,37 +77748,21 @@
 /obj/item/weapon/weldingtool,
 /turf/simulated/floor/plating/airless,
 /area/space)
-"ofi" = (
-/obj/item/weapon/flora/pottedplant/large,
-/turf/simulated/floor{
-	dir = 9;
-	icon_state = "brown"
-	},
-/area/station/cargo/office)
 "ofm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "ofu" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
+	dir = 5;
+	icon_state = "warning"
 	},
-/area/station/cargo/storage)
+/area/station/hallway/secondary/arrival)
 "ofy" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance/four,
@@ -79043,13 +77780,6 @@
 "ogb" = (
 /turf/simulated/wall,
 /area/station/engineering/engine)
-"ogz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/arrival)
 "ohL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -79094,6 +77824,18 @@
 	icon_state = "platebotc"
 	},
 /area/station/engineering/engine)
+"ojC" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "okb" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -79216,6 +77958,12 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"otU" = (
+/obj/random/vending/cola,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/hallway/secondary/exit)
 "oui" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/structure/disposalpipe/segment,
@@ -79233,6 +77981,18 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
+"owr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
+	},
+/area/station/cargo/office)
 "owJ" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -79255,15 +78015,14 @@
 	},
 /area/station/civilian/bar)
 "owL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/firealarm{
+	pixel_y = 28
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/turf/simulated/floor{
+	icon_state = "dark"
 	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/area/station/cargo/recycleroffice)
 "oxb" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
@@ -79295,6 +78054,31 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/grass,
 /area/station/civilian/hydroponics)
+"oyM" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 8
+	},
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1379;
+	master_tag = "solar_tool_airlock";
+	name = "interior access button";
+	pixel_x = 25;
+	pixel_y = 25;
+	req_access = list(13)
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/auxsolarport)
 "oyN" = (
 /turf/simulated/floor{
 	dir = 5;
@@ -79376,6 +78160,13 @@
 	icon_state = "barber"
 	},
 /area/station/medical/cmo)
+"oDC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/station/cargo/office)
 "oEO" = (
 /obj/machinery/camera{
 	c_tag = "Hydroponics Lobby";
@@ -79413,12 +78204,19 @@
 	},
 /area/station/hallway/primary/central)
 "oHZ" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/cargo/qm)
 "oIb" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -79528,27 +78326,65 @@
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/mass_driver)
 "oRm" = (
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=8";
-	freq = 1400;
-	location = "QM #4"
-	},
 /turf/simulated/floor{
-	icon_state = "bot"
+	icon_state = "loadingarea"
 	},
 /area/station/cargo/storage)
-"oTJ" = (
-/obj/structure/disposalpipe/segment,
+"oTq" = (
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 5;
+	dir = 8;
+	icon_state = "brown"
+	},
+/area/station/cargo/qm)
+"oTy" = (
+/obj/structure/table/woodentable,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/item/weapon/storage/fancy/cigarettes{
+	pixel_x = -4
+	},
+/obj/item/weapon/lighter/random{
+	pixel_x = 5
+	},
+/turf/simulated/floor{
+	dir = 1;
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
+"oTJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
+	dir = 4;
+	frequency = 1379;
+	id_tag = "recycler_pump";
+	name = "Recycler Large Air Vent"
+	},
+/obj/machinery/airlock_sensor{
+	id_tag = "recycler_sensor";
+	pixel_x = -25;
+	pixel_y = -20
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor/plating{
+	icon_state = "platebotc"
+	},
+/area/station/cargo/recycleroffice)
 "oUI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -79609,6 +78445,20 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
+"oYf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
+/area/station/civilian/barbershop)
+"oYU" = (
+/obj/structure/rack,
+/obj/item/weapon/storage/toolbox/mechanical,
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "oZb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -79633,16 +78483,39 @@
 /turf/simulated/floor,
 /area/station/engineering/engine)
 "pal" = (
-/obj/machinery/door_control{
-	id = "qm_warehouse";
-	name = "Warehouse Door Control";
-	pixel_x = 25;
-	req_access = list(31)
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/machinery/power/apc{
+	name = "Cargo Bay APC";
+	pixel_y = -26
+	},
+/obj/structure/cable,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/light/small,
 /turf/simulated/floor{
-	icon_state = "floorgrime"
+	icon_state = "brown"
 	},
 /area/station/cargo/storage)
+"pcj" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(12)
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "pcJ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -79691,6 +78564,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"pfi" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "stationscrap"
+	},
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
 "pfz" = (
 /obj/machinery/door/airlock/glass{
 	autoclose = 0;
@@ -79717,21 +78598,20 @@
 /obj/machinery/portable_atmospherics/powered/pump,
 /turf/simulated/floor,
 /area/station/construction)
-"phy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "pib" = (
 /obj/item/seeds/tomatoseed,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"piG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/station/cargo/office)
 "piY" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -79755,7 +78635,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
 	icon_state = "brown"
@@ -79766,6 +78645,14 @@
 	icon_state = "wood_stairs2"
 	},
 /area/station/civilian/chapel)
+"pkz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "brown"
+	},
+/area/station/cargo/office)
 "plH" = (
 /obj/structure/table/woodentable,
 /obj/machinery/newscaster{
@@ -79821,25 +78708,16 @@
 	icon_state = "barber"
 	},
 /area/station/medical/cmo)
-"prb" = (
-/obj/structure/rack,
-/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,
-/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/wine{
-	volume = 25
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/escape)
 "prF" = (
-/obj/structure/disposalpipe/sortjunction{
-	dir = 1;
-	name = "OnlineShop";
-	sortType = "OnlineShop"
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=8";
+	freq = 1400;
+	location = "QM #4"
 	},
 /turf/simulated/floor{
-	icon_state = "browncorner"
+	icon_state = "bot"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/cargo/storage)
 "pst" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -79866,33 +78744,46 @@
 	},
 /area/station/cargo/office)
 "puN" = (
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "brown"
+/obj/structure/cable,
+/obj/machinery/power/apc{
+	name = "Honk Office APC";
+	pixel_y = -30
 	},
-/area/station/cargo/office)
+/obj/structure/table/woodentable,
+/obj/item/clothing/suit/batman,
+/obj/item/clothing/head/batman_helmet,
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "pvb" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "white"
+	},
+/area/station/hallway/secondary/exit)
+"pvq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
+/area/station/maintenance/cargo)
 "pvI" = (
 /obj/structure/flora/junglebush/large,
 /turf/simulated/floor/grass,
 /area/station/civilian/hydroponics)
-"pwb" = (
-/obj/structure/sign/warning/mail_delivery,
-/turf/simulated/wall,
-/area/station/cargo/office)
 "pwt" = (
 /obj/machinery/power/emitter{
 	anchored = 1;
@@ -79988,30 +78879,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/incinerator)
-"pAG" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/disposalpipe/sortjunction{
-	dir = 8;
-	name = "Bar Backroom";
-	sortType = "Bar Backroom"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
 "pAV" = (
 /turf/simulated/floor{
 	icon_state = "yellow"
@@ -80040,6 +78907,23 @@
 	icon_state = "barber"
 	},
 /area/station/medical/cmo)
+"pBt" = (
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "delivery;dir=8";
+	freq = 1400;
+	location = "QM #1"
+	},
+/obj/machinery/bot/mulebot{
+	home_destination = "QM #1";
+	suffix = "#1"
+	},
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
+/area/station/cargo/storage)
 "pBZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/stool/bed/chair/metal/black{
@@ -80111,6 +78995,18 @@
 	icon_state = "floorgrime"
 	},
 /area/station/maintenance/incinerator)
+"pDg" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/stool/bed/chair/wood/normal{
+	dir = 4
+	},
+/obj/effect/landmark/start/clown,
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "pEt" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/status_display{
@@ -80120,6 +79016,12 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/hydroponics)
+"pFO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor/carpet/purple,
+/area/station/civilian/theatre)
 "pGd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -80204,7 +79106,9 @@
 	pixel_x = -6;
 	pixel_y = 36
 	},
-/obj/machinery/computer/card,
+/obj/machinery/computer/card{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "blue"
@@ -80217,20 +79121,30 @@
 	},
 /area/station/medical/chemistry)
 "pRn" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
+/obj/effect/decal/cleanable/blood/oil,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/station/cargo/office)
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
+"pRu" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
+"pRK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal)
 "pSU" = (
 /turf/simulated/floor/carpet,
 /area/station/tcommsat/computer)
@@ -80304,6 +79218,7 @@
 	},
 /area/station/bridge/hop_office)
 "pUQ" = (
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	icon_state = "brown"
 	},
@@ -80327,6 +79242,15 @@
 	icon_state = "vault"
 	},
 /area/station/civilian/chapel)
+"pYa" = (
+/obj/machinery/portable_atmospherics/powered/pump,
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/turf/simulated/floor/plating{
+	icon_state = "platebotc"
+	},
+/area/station/maintenance/eva)
 "pZm" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -80359,20 +79283,6 @@
 	icon_state = "warnplate"
 	},
 /area/station/engineering/singularity)
-"qaV" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
 "qcd" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
@@ -80402,6 +79312,31 @@
 /obj/structure/flora/junglebush,
 /turf/simulated/floor/grass,
 /area/station/civilian/hydroponics)
+"qeB" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
+"qfx" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "qgb" = (
 /obj/structure/stool/bed/chair/office/light,
 /obj/effect/landmark/start/chief_engineer,
@@ -80423,25 +79358,12 @@
 	},
 /area/station/engineering/chiefs_office)
 "qgw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/camera{
+	c_tag = "Recycler External South";
+	pixel_x = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/arrival)
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
 "qhb" = (
 /turf/simulated/floor{
 	icon_state = "white"
@@ -80458,6 +79380,12 @@
 	icon_state = "platebot"
 	},
 /area/station/maintenance/incinerator)
+"qhB" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/arrival)
 "qib" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -80478,18 +79406,6 @@
 	icon_state = "warnplate"
 	},
 /area/station/engineering/singularity)
-"qiM" = (
-/obj/machinery/door/airlock{
-	name = "Port Emergency Storage"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/storage/emergency2)
 "qjb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/machinery/camera{
@@ -80519,9 +79435,14 @@
 	},
 /area/station/medical/chemistry)
 "qla" = (
-/obj/structure/sign/warning/moving_parts,
-/turf/simulated/wall,
-/area/station/maintenance/cargo)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/shop_scanner{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "floorgrime"
+	},
+/area/station/cargo/storage)
 "qlb" = (
 /obj/item/device/assembly/timer{
 	pixel_x = -3;
@@ -80598,24 +79519,45 @@
 	},
 /area/station/engineering/singularity)
 "qmV" = (
+/obj/structure/closet/emcloset,
+/turf/simulated/floor{
+	icon_state = "warning"
+	},
+/area/station/cargo/storage)
+"qna" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
+/turf/simulated/floor{
+	icon_state = "purplechecker"
 	},
-/obj/machinery/door_control{
-	id = "qm_warehouse";
-	name = "Warehouse Door Control";
-	pixel_y = 24;
-	req_access = list(31)
-	},
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/area/station/civilian/barbershop)
 "qob" = (
 /obj/item/seeds/potatoseed,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"qos" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/civilian/barbershop)
 "qoN" = (
 /obj/machinery/light,
 /obj/structure/closet,
@@ -80630,12 +79572,26 @@
 /turf/simulated/floor/engine,
 /area/station/rnd/xenobiology)
 "qoS" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/table,
+/obj/item/device/megaphone{
+	pixel_x = 6;
+	pixel_y = 8
+	},
+/obj/item/device/eftpos{
+	eftpos_name = "Quartermaster EFTPOS scanner"
+	},
+/obj/item/weapon/coin/silver{
+	pixel_x = -10;
+	pixel_y = 3
+	},
+/obj/item/weapon/coin/silver{
+	pixel_x = -8;
+	pixel_y = -2
+	},
 /turf/simulated/floor{
-	dir = 1;
 	icon_state = "brown"
 	},
-/area/station/cargo/office)
+/area/station/cargo/qm)
 "qoW" = (
 /obj/structure/rack,
 /obj/item/weapon/reagent_containers/spray/extinguisher,
@@ -80673,6 +79629,15 @@
 	icon_state = "warnplate"
 	},
 /area/station/engineering/singularity)
+"qpK" = (
+/obj/machinery/alarm{
+	pixel_y = 28
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
+/area/station/cargo/recycleroffice)
 "qrb" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -80697,12 +79662,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/chemistry)
-"qsv" = (
-/obj/structure/table/woodentable,
-/turf/simulated/floor{
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "qsw" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -80714,12 +79673,6 @@
 	icon_state = "warnplate"
 	},
 /area/space)
-"qtj" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "qub" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -80814,14 +79767,8 @@
 /area/station/hallway/primary/central)
 "qCp" = (
 /obj/structure/cable,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Asteroid Shuttle Hallway APC";
-	pixel_x = 24
-	},
-/obj/item/weapon/flora/random,
-/turf/simulated/floor,
-/area/station/hallway/secondary/mine_sci_shuttle)
+/turf/simulated/floor/plating/airless/catwalk,
+/area/station/solar/auxport)
 "qCH" = (
 /obj/effect/spawner/lootdrop/maintenance/two,
 /obj/structure/table,
@@ -80865,6 +79812,19 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/port)
+"qEd" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "qEe" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -80892,6 +79852,15 @@
 	icon_state = "wooden-2"
 	},
 /area/station/civilian/gym)
+"qFd" = (
+/obj/structure/sign/poster/official/the_owl{
+	pixel_x = 32
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
+	},
+/area/station/cargo/qm)
 "qFq" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -80935,20 +79904,13 @@
 	},
 /area/station/civilian/fitness)
 "qJL" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "stationscrap"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door_control{
-	id = "qm_warehouse";
-	name = "Warehouse Door Control";
-	pixel_y = 24;
-	req_access = list(31)
-	},
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/obj/machinery/pile_ripper,
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
 "qKo" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -80968,18 +79930,11 @@
 	},
 /area/station/engineering/singularity)
 "qLl" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/random/tools/tool,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/dispenser/oxygen,
 /turf/simulated/floor{
-	icon_state = "bot"
+	icon_state = "dark"
 	},
-/area/station/cargo/storage)
+/area/station/cargo/recycleroffice)
 "qLs" = (
 /obj/structure/grille,
 /obj/structure/cable{
@@ -81008,13 +79963,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/station/medical/chemistry)
-"qNK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/arrival)
 "qPb" = (
 /turf/simulated/floor{
 	dir = 6;
@@ -81055,6 +80003,19 @@
 	icon_state = "vault"
 	},
 /area/station/medical/genetics_cloning)
+"qQe" = (
+/obj/structure/closet/crate,
+/obj/item/toy/prize/honk,
+/obj/item/weapon/coin/bananium,
+/obj/item/weapon/coin/bananium{
+	pixel_x = -3
+	},
+/obj/item/weapon/coin/bananium{
+	pixel_x = 7;
+	pixel_y = 5
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "qRb" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -81072,25 +80033,20 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
-"qSg" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+"qSe" = (
+/obj/structure/stool/bed/chair/comfy/brown{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
+"qSg" = (
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/arrival)
 "qTb" = (
 /obj/machinery/light_switch{
 	pixel_y = -26
@@ -81134,11 +80090,20 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "qUJ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
+/turf/simulated/floor/carpet/black,
+/area/station/security/vacantoffice)
+"qUN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "qVb" = (
 /obj/random/meds/chemical_bottle,
 /turf/simulated/floor/plating{
@@ -81202,17 +80167,10 @@
 	icon_state = "barber"
 	},
 /area/station/civilian/locker)
-"qYi" = (
-/obj/structure/disposalpipe/junction{
-	icon_state = "pipe-j2"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
-/area/station/cargo/office)
+"qYH" = (
+/obj/structure/sign/directions/dock_tablo/tablo5,
+/turf/simulated/wall,
+/area/station/hallway/secondary/arrival)
 "qZb" = (
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyerOut";
@@ -81241,12 +80199,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
-"rbB" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	icon_state = "brown"
-	},
-/area/station/cargo/office)
 "rcb" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
@@ -81257,6 +80209,14 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/engine)
+"rcg" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor,
+/area/station/hallway/secondary/arrival)
 "rck" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -81343,19 +80303,16 @@
 	},
 /area/station/medical/virology)
 "rhj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/turf/simulated/floor{
+	icon_state = "floorgrime"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/cargo/storage)
 "rib" = (
 /obj/structure/table/glass,
 /obj/item/weapon/virusdish/random,
@@ -81445,22 +80402,15 @@
 	},
 /area/station/medical/virology)
 "rlZ" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
+/obj/machinery/light,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
+/area/station/cargo/recycleroffice)
 "rmb" = (
 /obj/structure/closet/l3closet/virology,
 /obj/item/clothing/mask/gas/coloured,
@@ -81534,6 +80484,27 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
+"roq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/glass{
+	name = "Arrival Access"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "rpb" = (
 /obj/structure/stool,
 /turf/simulated/floor{
@@ -81599,6 +80570,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"rsF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/station/cargo/office)
 "rsM" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/device/radio/intercom{
@@ -81759,6 +80736,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "rBn" = (
@@ -81870,6 +80852,18 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/hydroponics)
+"rGM" = (
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1379;
+	master_tag = "recycler_airlock";
+	name = "exterior access button";
+	pixel_x = -26;
+	pixel_y = 24;
+	req_access = list(67)
+	},
+/turf/simulated/floor/plating,
+/area/space)
 "rHb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -82013,11 +81007,22 @@
 	},
 /area/station/medical/virology)
 "rRu" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/embedded_controller/radio/airlock_controller{
+	id_tag = "arrival_dock_airlock";
+	pixel_x = 25;
+	req_one_access = list(13,45,1);
+	tag_airpump = "arrival_dock_pump";
+	tag_chamber_sensor = "arrival_dock_sensor";
+	tag_exterior_door = "arrival_dock_outer";
+	tag_interior_door = "arrival_dock_inner"
+	},
+/obj/machinery/airlock_sensor{
+	id_tag = "arrival_dock_sensor";
+	pixel_x = 25;
+	pixel_y = 12
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/eva)
+/area/station/hallway/secondary/arrival)
 "rRE" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/closet/wardrobe/white,
@@ -82042,6 +81047,15 @@
 	icon_state = "white"
 	},
 /area/station/medical/virology)
+"rSU" = (
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/arrival)
 "rSY" = (
 /obj/machinery/drone_fabricator,
 /turf/simulated/floor{
@@ -82084,6 +81098,12 @@
 	icon_state = "vault"
 	},
 /area/station/medical/virology)
+"rUm" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "rVb" = (
 /obj/structure/stool/bed/chair/office/light,
 /obj/machinery/light{
@@ -82094,6 +81114,18 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
+"rVE" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/item/device/radio/intercom{
+	dir = 0;
+	name = "Station Intercom (General)";
+	pixel_x = -27
+	},
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "brown"
+	},
+/area/station/cargo/miningoffice)
 "rVP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -82112,10 +81144,42 @@
 	icon_state = "white"
 	},
 /area/station/medical/virology)
-"rXf" = (
-/turf/simulated/floor{
-	icon_state = "loadingarea"
+"rWZ" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
 	},
+/obj/machinery/camera{
+	c_tag = "Cargo Office North";
+	dir = 8
+	},
+/obj/structure/table,
+/obj/item/weapon/folder/brown,
+/obj/item/device/eftpos{
+	eftpos_name = "Cargo Bay EFTPOS scanner"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
+	},
+/area/station/cargo/office)
+"rXf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
 /area/station/cargo/storage)
 "rYb" = (
 /obj/item/weapon/reagent_containers/spray/cleaner,
@@ -82164,6 +81228,17 @@
 	icon_state = "platingdmg3"
 	},
 /area/station/maintenance/engineering)
+"rZI" = (
+/obj/machinery/camera{
+	c_tag = "Ferry shuttle South";
+	dir = 4;
+	pixel_y = -22
+	},
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "warning"
+	},
+/area/station/hallway/secondary/arrival)
 "sab" = (
 /obj/machinery/computer/centrifuge,
 /turf/simulated/floor{
@@ -82180,13 +81255,20 @@
 	},
 /area/station/medical/virology)
 "sbs" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "brown"
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/weapon/weldingtool,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
+"sbM" = (
+/obj/machinery/light_switch{
+	pixel_x = 27
 	},
-/area/station/cargo/storage)
+/turf/simulated/floor{
+	icon_state = "purplechecker"
+	},
+/area/station/civilian/barbershop)
 "scb" = (
 /turf/simulated/floor{
 	dir = 6;
@@ -82223,6 +81305,17 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
+"set" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
+	dir = 8;
+	frequency = 1379;
+	id_tag = "arrival_dock_pump";
+	name = "Arrival Dock Large Air Vent"
+	},
+/turf/simulated/floor/plating{
+	icon_state = "platebotc"
+	},
+/area/station/hallway/secondary/arrival)
 "sfb" = (
 /obj/structure/table/glass,
 /obj/machinery/alarm{
@@ -82241,6 +81334,37 @@
 	icon_state = "green"
 	},
 /area/station/civilian/hydroponics)
+"sfG" = (
+/obj/machinery/camera{
+	c_tag = "Cargo Bay East";
+	pixel_x = 22
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/item/weapon/flora/random,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
+"sfO" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "sgb" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -82270,15 +81394,18 @@
 	icon_state = "vault"
 	},
 /area/station/medical/virology)
-"shv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+"shw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
+"shI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/turf/simulated/wall,
+/area/station/cargo/office)
 "sib" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -82387,12 +81514,6 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/chapel/altar)
-"slP" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	icon_state = "browncorner"
-	},
-/area/station/cargo/office)
 "slU" = (
 /obj/machinery/door/firedoor,
 /obj/structure/grille,
@@ -82409,6 +81530,13 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/medical/virology)
+"smJ" = (
+/obj/structure/closet/emcloset,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "warndark"
+	},
+/area/station/hallway/secondary/arrival)
 "snb" = (
 /obj/structure/rack,
 /obj/item/weapon/crowbar,
@@ -82652,6 +81780,11 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/hallway)
+"sAj" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/rack,
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "sBb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
@@ -82712,15 +81845,23 @@
 	},
 /area/station/medical/virology)
 "sEe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1379;
+	master_tag = "arrival_dock_airlock";
+	name = "interior access button";
+	pixel_y = -20;
+	req_one_access = list(13,45,1)
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/machinery/camera{
+	c_tag = "Arrival Hallway West";
+	dir = 1;
+	pixel_x = 20
 	},
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/arrival)
 "sFb" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /turf/simulated/floor{
@@ -82764,6 +81905,20 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/medical/virology)
+"sHj" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo Bay Maintenance";
+	req_access = list(31)
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal)
 "sIb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -82859,14 +82014,12 @@
 	},
 /area/station/medical/virology)
 "sMn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "browncorner"
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "stationscrap"
 	},
-/area/station/cargo/office)
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
 "sNb" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor{
@@ -82901,9 +82054,15 @@
 	},
 /area/station/medical/virology)
 "sOh" = (
-/obj/structure/sign/warning/moving_parts,
-/turf/simulated/wall,
-/area/station/cargo/recycler)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "sOX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -83007,6 +82166,10 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
+"sTQ" = (
+/obj/structure/sign/directions/dock_tablo/tablo2,
+/turf/simulated/wall,
+/area/station/hallway/secondary/arrival)
 "sUb" = (
 /obj/structure/table/glass,
 /obj/item/weapon/paper_bin,
@@ -83058,21 +82221,19 @@
 	},
 /area/station/medical/virology)
 "sVF" = (
-/obj/effect/landmark/start/recycler,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/table,
+/obj/item/weapon/book/manual/wiki/supply_crates{
+	pixel_x = -4;
+	pixel_y = 7
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "dark"
+	dir = 10;
+	icon_state = "brown"
 	},
-/area/station/cargo/recycleroffice)
+/area/station/cargo/storage)
 "sWb" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -83082,17 +82243,14 @@
 "sWE" = (
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
 /turf/simulated/floor,
-/area/station/cargo/office)
+/area/station/cargo/storage)
 "sWV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -83164,15 +82322,6 @@
 	temperature = 80
 	},
 /area/station/tcommsat/chamber)
-"tbS" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor,
-/area/station/cargo/storage)
 "tcb" = (
 /obj/item/weapon/storage/box/beakers{
 	pixel_x = 2;
@@ -83185,6 +82334,14 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
+"tck" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor,
+/area/station/hallway/secondary/arrival)
 "tdb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -83306,12 +82463,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
-"tlY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/cargo/office)
 "tmb" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -83369,11 +82520,17 @@
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
 "tpb" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 8
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor{
+	icon_state = "floorgrime"
+	},
+/area/station/cargo/storage)
 "tpw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -83397,6 +82554,12 @@
 	icon_state = "warnplate"
 	},
 /area/station/engineering/engine)
+"txK" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/arrival)
 "tyb" = (
 /obj/structure/stool/bed/chair/office/light{
 	dir = 1
@@ -83434,6 +82597,12 @@
 	icon_state = "warnplate"
 	},
 /area/station/engineering/singularity)
+"tAT" = (
+/obj/machinery/vending/assist,
+/turf/simulated/floor{
+	icon_state = "brown"
+	},
+/area/station/cargo/miningoffice)
 "tCO" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -83463,11 +82632,17 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	id_tag = "solar_tool_inner";
+	locked = 1;
+	name = "Engineering External Access";
+	req_access = list(13)
+	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/maintenance/auxsolarport)
 "tFA" = (
 /obj/structure/stool/bed/chair/pew/left,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -83494,17 +82669,13 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "tHb" = (
-/obj/structure/stool/bed/chair/metal{
-	dir = 4
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "stationscrap"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/newscaster{
-	pixel_x = -28;
-	pixel_y = 1
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/exit)
+/obj/random/misc/all,
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
 "tHS" = (
 /obj/machinery/computer/station_alert,
 /obj/machinery/computer/security/telescreen{
@@ -83524,13 +82695,25 @@
 	},
 /area/station/engineering/engine)
 "tHV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/table/glass,
+/obj/item/stack/medical/advanced/bruise_pack{
+	pixel_x = -4
+	},
+/obj/item/stack/medical/advanced/bruise_pack{
+	pixel_y = 4
+	},
+/obj/item/stack/medical/advanced/ointment{
+	pixel_x = 4;
+	pixel_y = -1
+	},
+/obj/machinery/vending/wallmed2{
+	pixel_x = 26
 	},
 /turf/simulated/floor{
-	icon_state = "floorgrime"
+	dir = 4;
+	icon_state = "whiteblue"
 	},
-/area/station/cargo/storage)
+/area/station/hallway/secondary/exit)
 "tIb" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -83621,14 +82804,6 @@
 	icon_state = "floorgrime"
 	},
 /area/station/cargo/storage)
-"tRb" = (
-/obj/structure/window/reinforced{
-	dir = 5
-	},
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/brflowers,
-/turf/simulated/floor/grass,
-/area/station/hallway/secondary/exit)
 "tRI" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -83718,20 +82893,42 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
-"udR" = (
+"udz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=8";
-	freq = 1400;
-	location = "QM #2"
+	codes_txt = "patrol;next_patrol=CHW";
+	location = "Bar"
 	},
-/obj/machinery/bot/mulebot{
-	home_destination = "QM #2";
-	suffix = "#2"
+/turf/simulated/floor,
+/area/station/hallway/secondary/arrival)
+"udX" = (
+/obj/machinery/camera{
+	c_tag = "Quartermaster's Office";
+	dir = 8
 	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/item/weapon/flora/pottedplant/ficus,
 /turf/simulated/floor{
-	icon_state = "bot"
+	dir = 4;
+	icon_state = "brown"
 	},
-/area/station/cargo/storage)
+/area/station/cargo/qm)
 "ueb" = (
 /obj/structure/window/reinforced{
 	dir = 5
@@ -83744,20 +82941,18 @@
 /obj/structure/sign/warning/nosmoking,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
-"uek" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+"ueo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/disposal)
+/area/station/cargo/office)
 "uey" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 6
@@ -83814,11 +83009,10 @@
 	},
 /area/station/medical/genetics)
 "uhJ" = (
-/obj/structure/closet,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "brown"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
+/turf/simulated/floor,
 /area/station/cargo/storage)
 "ujL" = (
 /obj/structure/table/reinforced,
@@ -83901,18 +83095,6 @@
 /obj/structure/cryofeed,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
-"uqD" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/cargo/office)
 "urb" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -83939,6 +83121,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
+"usG" = (
+/obj/item/weapon/flora/pottedplant/orientaltree,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warndark"
+	},
+/area/station/hallway/secondary/arrival)
 "uul" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -83993,14 +83185,30 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/kitchen)
-"uBz" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+"uyK" = (
+/obj/machinery/hologram/holopad,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/turf/simulated/floor/carpet/black,
+/area/station/security/vacantoffice)
+"uBz" = (
+/obj/structure/stool/bed/chair/office/dark,
+/turf/simulated/floor{
+	icon_state = "bar"
+	},
+/area/station/cargo/miningoffice)
+"uCn" = (
+/obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 30
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "red"
+	},
+/area/station/security/checkpoint)
 "uCp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -84014,11 +83222,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "uDb" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "neutralcorner"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/secondary/arrival)
 "uDc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -84044,12 +83256,11 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/starboard)
 "uEX" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "browncorner"
 	},
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/area/station/hallway/secondary/exit)
 "uFT" = (
 /obj/machinery/atmospherics/components/unary/tank/oxygen{
 	dir = 8
@@ -84091,6 +83302,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"uIo" = (
+/obj/machinery/camera{
+	c_tag = "Arrival Dock's South 2";
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warning"
+	},
+/area/station/hallway/secondary/arrival)
 "uIq" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -84113,16 +83334,14 @@
 	},
 /area/station/engineering/singularity)
 "uIs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/machinery/computer/secure_data{
+	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "red"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/escape)
+/area/station/security/checkpoint)
 "uIC" = (
 /obj/structure/big_bell,
 /turf/simulated/floor{
@@ -84145,6 +83364,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/office)
+"uMW" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Arrival Access"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/arrival)
+"uNt" = (
+/obj/structure/stool/bed/chair/metal{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
 "uOD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -84154,6 +83391,17 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/locker)
+"uOJ" = (
+/obj/machinery/door_control{
+	id = "qm_warehouse";
+	name = "Warehouse Door Control";
+	pixel_x = 25;
+	req_access = list(31)
+	},
+/turf/simulated/floor{
+	icon_state = "floorgrime"
+	},
+/area/station/cargo/storage)
 "uPw" = (
 /obj/machinery/door/airlock{
 	name = "Unisex Showers"
@@ -84179,6 +83427,36 @@
 	icon_state = "white"
 	},
 /area/station/rnd/hallway)
+"uTe" = (
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	id_tag = "arrival_dock_inner";
+	locked = 1;
+	name = "Arrival Dock External Access";
+	req_one_access = list(13,45,1)
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/components/binary/pump/on,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/arrival)
+"uTg" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "packageSort2"
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/office)
+"uTF" = (
+/obj/structure/grille,
+/obj/machinery/door/firedoor,
+/obj/structure/window/reinforced{
+	dir = 5
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal)
 "uUU" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/forensic_office)
@@ -84216,14 +83494,15 @@
 	icon_state = "cult"
 	},
 /area/station/civilian/library)
-"vaa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "browncorner"
-	},
-/area/station/hallway/secondary/entry)
+"vbi" = (
+/obj/structure/closet/crate,
+/obj/item/clothing/gloves/black,
+/obj/item/weapon/crowbar,
+/obj/item/clothing/mask/bandana/black,
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "vbU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -84323,6 +83602,15 @@
 	icon_state = "chapel"
 	},
 /area/station/civilian/chapel/mass_driver)
+"vxL" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/arrival)
 "vyZ" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 8
@@ -84340,12 +83628,6 @@
 	icon_state = "warnplate"
 	},
 /area/station/engineering/engine)
-"vBO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/cargo/storage)
 "vCd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -84361,6 +83643,12 @@
 /obj/item/clothing/under/rainbow,
 /turf/simulated/floor/wood,
 /area/station/maintenance/cargo)
+"vEP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "vFP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -84429,6 +83717,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/chiefs_office)
+"vMv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor,
+/area/station/cargo/storage)
 "vNR" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 9
@@ -84473,19 +83771,21 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/break_room)
-"vWv" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+"vVI" = (
+/obj/machinery/camera{
+	c_tag = "Recycler External North";
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
+/turf/simulated/floor/plating,
+/area/station/cargo/recycleroffice)
 "vWx" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -84547,6 +83847,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"wdA" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/cargo/office)
 "wdR" = (
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the singularity chamber.";
@@ -84571,23 +83885,6 @@
 /obj/item/device/tagger/shop,
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
-"wfm" = (
-/obj/machinery/status_display{
-	pixel_y = 32
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "delivery;dir=8";
-	freq = 1400;
-	location = "QM #1"
-	},
-/obj/machinery/bot/mulebot{
-	home_destination = "QM #1";
-	suffix = "#1"
-	},
-/turf/simulated/floor{
-	icon_state = "bot"
-	},
-/area/station/cargo/storage)
 "wfH" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -84640,24 +83937,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/civilian/fitness)
-"wht" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/cargo/office)
 "wjJ" = (
 /obj/machinery/door/firedoor,
 /obj/item/device/radio/intercom{
@@ -84799,19 +84078,18 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/engineering/engine)
+"wsQ" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "stationscrap"
+	},
+/obj/structure/scrap_cube,
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
 "wuI" = (
 /obj/item/weapon/cigbutt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"wwg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "wwC" = (
 /obj/machinery/atmospherics/components/binary/pump,
 /obj/structure/sign/warning/fire{
@@ -84827,6 +84105,34 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/civilian/chapel)
+"wyj" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Fore Starboard Solar Access";
+	req_access = list(10)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/maintenance/auxsolarport)
+"wyr" = (
+/obj/machinery/door_control{
+	id = "bar";
+	name = "Privacy shutter";
+	pixel_x = 8;
+	pixel_y = -24;
+	req_access = list(25,1)
+	},
+/obj/machinery/computer/arcade,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/station/civilian/bar)
 "wyS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
@@ -84881,17 +84187,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
-"wET" = (
-/obj/machinery/door/firedoor,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/grille,
-/turf/simulated/floor/plating,
-/area/station/cargo/office)
 "wFQ" = (
 /obj/structure/window/reinforced,
 /obj/structure/grille,
@@ -84943,19 +84238,14 @@
 	},
 /area/station/engineering/atmos)
 "wHK" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Fore Starboard Solar Access";
-	req_access = list(10)
+/obj/structure/stool/bed/chair/office/light{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "white"
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/auxsolarport)
+/area/station/hallway/secondary/exit)
 "wII" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
@@ -84997,6 +84287,32 @@
 	icon_state = "green"
 	},
 /area/station/civilian/hydroponics)
+"wJI" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/station/security/vacantoffice)
+"wKj" = (
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor/plating{
+	icon_state = "platebotc"
+	},
+/area/station/maintenance/cargo)
 "wLi" = (
 /turf/simulated/wall,
 /area/station/civilian/chapel/mass_driver)
@@ -85039,26 +84355,15 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/chapel/mass_driver)
-"wQY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"wSz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/simulated/floor,
+/area/station/hallway/secondary/arrival)
+"wVh" = (
+/turf/simulated/floor/plating{
+	icon_state = "platingdmg3"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/station/cargo/office)
+/area/station/maintenance/escape)
 "wYU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -85112,6 +84417,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
+"xgc" = (
+/obj/structure/closet/emcloset,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/cargo/recycleroffice)
+"xiF" = (
+/obj/machinery/computer/mech_bay_power_console{
+	dir = 8
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
 "xiQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -85138,17 +84455,6 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/engine)
-"xoX" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "loadingarea"
-	},
-/area/station/cargo/storage)
 "xqb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -85163,6 +84469,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"xrE" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "browncorner"
+	},
+/area/station/cargo/storage)
 "xrW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -85210,6 +84533,26 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"xwS" = (
+/obj/random/foods/food_trash,
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
+"xza" = (
+/obj/item/clothing/suit/justice,
+/obj/item/clothing/gloves/black,
+/obj/item/clothing/head/justice,
+/obj/structure/closet,
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
+"xzh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "browncorner"
+	},
+/area/station/cargo/office)
 "xAL" = (
 /obj/machinery/alarm{
 	dir = 8;
@@ -85227,6 +84570,13 @@
 	icon_state = "blue"
 	},
 /area/station/bridge/hop_office)
+"xBm" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "warning"
+	},
+/area/station/cargo/storage)
 "xCb" = (
 /obj/structure/stool/bed/chair/comfy/black{
 	dir = 8
@@ -85245,6 +84595,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/cargo)
+"xEt" = (
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "stationscrap"
+	},
+/obj/machinery/scrap/stacking_machine,
+/turf/simulated/floor/plating/airless,
+/area/station/cargo/recycler)
 "xFm" = (
 /obj/structure/closet/wardrobe/engineering_yellow,
 /turf/simulated/floor{
@@ -85252,18 +84610,21 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/engine)
-"xGD" = (
+"xGz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/power/apc/mediumcell{
-	dir = 8;
-	name = "Delivery Office APC";
-	pixel_x = -28
-	},
-/turf/simulated/floor,
-/area/station/cargo/office)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "xGY" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -85315,12 +84676,6 @@
 	icon_state = "green"
 	},
 /area/station/civilian/hydroponics)
-"xLk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "xLM" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -85340,8 +84695,9 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
-"xMz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+"xMs" = (
+/obj/effect/landmark/start/cargo_technician,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -85352,11 +84708,21 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "brown"
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
-/area/station/hallway/secondary/arrival)
+/turf/simulated/floor,
+/area/station/cargo/office)
+"xMz" = (
+/obj/machinery/camera{
+	c_tag = "Auxiliary Tool Storage"
+	},
+/obj/item/weapon/flora/random,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "yellow"
+	},
+/area/station/storage/tools)
 "xNk" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -85383,25 +84749,6 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/engine)
-"xQr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	name = "Cargo Bay APC";
-	pixel_y = -26
-	},
-/obj/structure/cable,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor{
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "xRb" = (
 /obj/machinery/hydroponics/constructable,
 /obj/item/device/radio/intercom{
@@ -85425,6 +84772,29 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor,
 /area/station/cargo/qm)
+"xRJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
+"xSM" = (
+/obj/machinery/computer/security/mining,
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = 24
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "brown"
+	},
+/area/station/cargo/qm)
 "xTO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -85436,66 +84806,68 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "xWb" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 4
-	},
-/obj/structure/sign/warning/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 32
-	},
-/turf/simulated/floor/plating,
+/obj/structure/sign/warning/moving_parts,
+/turf/simulated/wall,
 /area/station/cargo/recycleroffice)
 "xXb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
+"xXf" = (
+/obj/structure/closet/secure_closet/miner,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "brown"
+	},
+/area/station/cargo/miningoffice)
+"xXJ" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	id_tag = "solar_tool_outer";
+	locked = 1;
+	name = "Engineering External Access";
+	req_access = list(10,13)
 	},
 /turf/simulated/floor/plating,
-/area/station/cargo/recycleroffice)
+/area/station/maintenance/auxsolarport)
 "xYb" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/plating/airless,
-/area/station/cargo/recycler)
-"xZb" = (
-/obj/structure/disposaloutlet{
-	dir = 4
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor/plating/airless,
-/area/station/cargo/recycler)
-"yab" = (
+/obj/structure/window/reinforced,
 /obj/structure/grille,
-/obj/structure/sign/warning/securearea{
-	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
-	name = "KEEP CLEAR: DOCKING AREA"
-	},
-/obj/structure/lattice,
-/turf/environment/space,
-/area/space)
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
+"xZb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor,
+/area/station/hallway/secondary/exit)
+"yaj" = (
+/obj/structure/grille,
+/obj/item/weapon/shard,
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "yaV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/civilian/hydroponics)
 "ybN" = (
-/obj/structure/sign/warning/moving_parts,
-/turf/simulated/wall,
-/area/station/cargo/recycleroffice)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/carpet/black,
+/area/station/security/vacantoffice)
 "ycW" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced,
@@ -85523,14 +84895,19 @@
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "ydn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/cargo)
+/area/station/maintenance/escape)
 "yji" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -88491,15 +87868,15 @@ aaa
 aaa
 aaa
 aaa
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -88748,15 +88125,15 @@ aaa
 aaa
 aaa
 aaa
-aah
-bWt
-bWt
-bWt
-bWt
-bWt
-bWt
-bWt
-aah
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -89005,15 +88382,15 @@ aaa
 aaa
 aaa
 aaa
-aah
-bWt
-aqM
-ars
-asJ
-atH
-aux
-bWt
-aah
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -89262,18 +88639,18 @@ aaa
 aaa
 aaa
 aaa
-aah
-bWt
-aqO
-art
-asL
-atJ
-auz
-bWt
-aah
-aah
-aah
-aah
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -89519,18 +88896,18 @@ aaa
 aaa
 aaa
 aaa
-aah
-bWt
-gZb
-hgb
-aJO
-hsb
-bjc
-inL
-hib
-hib
-inL
-fgF
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -89776,18 +89153,18 @@ aaa
 aaa
 aaa
 aaa
-aah
-bWt
-gVb
-hcb
-hjb
-brt
-bjg
-hib
-aWq
-aXO
-aXT
-kAe
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -90033,18 +89410,18 @@ aaa
 aaa
 aaa
 aaa
-aah
-bWt
-auy
-aGV
-hjb
-boe
-bjj
-aUN
-aWt
-aXQ
-asG
-kAe
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -90284,24 +89661,24 @@ aaa
 aaa
 aaa
 aaa
+aXZ
+aXZ
+aXZ
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
-aah
-bWt
-gVb
-hcb
-hjb
-brt
-bjn
-era
-aRV
-aXR
-qCp
-kAe
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -90541,24 +89918,24 @@ aaa
 aaa
 aaa
 aaa
+aXZ
+aXZ
+aXZ
 aaa
 aaa
-aag
 aaa
 aaa
 aaa
-aah
-bWt
-aqS
-bjM
-hkb
-atS
-bjq
-inL
-buP
-aXS
-inL
-inL
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -90796,25 +90173,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aah
-bWt
-aOn
-hhb
-hnb
-auB
-bjC
-inL
-baT
-bOt
-inL
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
 aaa
 aaa
 aaa
@@ -90837,6 +90202,18 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+btD
+btD
+btD
+btD
+aaa
+btD
+btD
+btD
+btD
+aag
 aaa
 aaa
 aaa
@@ -91052,26 +90429,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aah
-bWt
-aAm
-aHa
-bjE
-brp
-bsj
-iur
-aCX
-xMz
-iur
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
 aaa
 aaa
 aaa
@@ -91094,6 +90460,17 @@ aaa
 aaa
 aaa
 aaa
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
 aaa
 aaa
 aaa
@@ -91309,30 +90686,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aah
-aah
-aah
-bWt
-aaa
-aaa
-aaa
-aaa
-aaa
-iur
-lay
-aGY
-iur
-aaa
-aaa
-aaa
-aaa
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
 aXZ
 aXZ
 aXZ
@@ -91347,11 +90706,29 @@ aaa
 aaa
 aaa
 aaa
+bgj
+bgj
+bgj
+bgj
+bgj
 aaa
 aaa
 aaa
 aaa
 aaa
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
 aaa
 aaa
 aaa
@@ -91566,30 +90943,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aah
-bWt
-bWt
-bWt
-bWt
-bWt
-bWt
-bWt
-bWt
-iur
-iCC
-aGY
-iur
-aaa
-aaa
-aaa
-aaa
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
 aXZ
 aXZ
 aXZ
@@ -91604,12 +90963,30 @@ aaa
 aaa
 aaa
 aaa
+bgj
+bgj
+bgj
+bgj
+bgj
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
 aaa
 aaa
 aaa
@@ -91823,28 +91200,8 @@ aag
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aah
-bWt
-aGy
-aGy
-aGy
-aGy
-aGy
-aaa
-aaa
-odL
-aGU
-aGX
-odL
-aaa
-aaa
+aXZ
+aXZ
 aXZ
 aXZ
 aXZ
@@ -91858,15 +91215,35 @@ aaa
 aaa
 aaa
 aaa
+avy
+avy
+avy
+aaa
+aaa
+bgj
+bgj
+bgj
+bgj
+bgj
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
 aaa
 aaa
 aaa
@@ -92081,28 +91458,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aah
-bWt
-aGy
-aGy
-aGy
-aGy
-aGy
-qRb
-iur
-iur
-iCC
-aYL
-odL
-aaa
-aXZ
-aXZ
 aXZ
 aXZ
 aXZ
@@ -92117,17 +91472,16 @@ aaa
 aaa
 aaa
 aaa
+avy
+avy
+avy
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bgj
+bgj
+bgj
+bgj
+bgj
 aaa
 aaa
 aaa
@@ -92136,12 +91490,35 @@ btD
 btD
 btD
 btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
 aaa
-btD
-btD
-btD
-btD
-aag
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -92338,28 +91715,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aah
-bWt
-aGy
-aGy
-aGy
-aGy
-aGy
-aTy
-bsx
-hob
-drP
-fgl
-odL
-aaa
-aXZ
-aXZ
 aXZ
 aXZ
 aXZ
@@ -92373,17 +91728,17 @@ aaa
 aaa
 aaa
 aaa
+avy
+avy
+avy
+avy
+avy
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bgj
+bgj
+bgj
+bgj
+bgj
 aaa
 aaa
 aaa
@@ -92399,6 +91754,28 @@ btD
 btD
 btD
 btD
+btD
+btD
+btD
+btD
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -92596,54 +91973,33 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aah
-bWt
-aGy
-aGy
-aGy
-aGy
-aGy
-iur
-iur
-iur
-hIf
-aGY
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
+bdz
 odL
-hPU
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+odL
+odL
+odL
+odL
+bdz
+avy
+avy
+avy
+avy
+avy
+bdz
+bgj
+bgj
+bgj
+bgj
+bgj
+bdz
+iur
+iur
+iur
 btD
 btD
 btD
@@ -92657,6 +92013,27 @@ btD
 btD
 btD
 btD
+btD
+btD
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -92853,68 +92230,68 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aah
-bWt
-aGy
-aGy
-aGy
-aGy
-aGy
-aaa
-buS
-buM
-aFB
-aGY
-awv
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
+dEb
+bsx
+bsx
+baY
+rZI
+bqd
+aDy
+avy
+avy
+avy
+avy
+avy
 odL
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 bgj
 bgj
 bgj
 bgj
 bgj
+odL
+boX
+bsx
+fab
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
 aaa
 aaa
 aaa
 aaa
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93110,68 +92487,68 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aah
-bWt
-aGy
-aGy
-aGy
-aGy
-aGy
-aaa
-iur
-buM
-aHC
-aJJ
-bcY
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
+dEb
+bsx
+aNG
+baY
+bAk
+aYh
+aDy
+avy
+avy
+avy
+avy
+avy
 odL
-aaa
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-hVb
 bgj
 bgj
 bgj
 bgj
 bgj
+odL
+bsx
+bsx
+fab
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
 aaa
 aaa
 aaa
 aaa
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93367,68 +92744,68 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aah
-bWt
-aGy
-aGy
-aGy
-aGy
-aGy
-aaa
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
 odL
-buN
-aEk
-aIk
-azs
 odL
-aaa
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+odL
+odL
+bAk
+aYh
+aDy
 avy
 avy
 avy
-aaa
-apo
+avy
+avy
+odL
 bgj
 bgj
 bgj
 bgj
 bgj
+odL
+baY
+baY
+odL
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
 aaa
 aaa
 aaa
 aaa
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93624,68 +93001,68 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
 aah
-bWt
-aGy
-aGy
-aGy
-aGy
-aGy
-aaa
-iur
-hXb
-lZM
-bvU
-aiw
+aah
+aah
+aDy
+bAk
+aYh
+aDy
+avy
+avy
+avy
+avy
+avy
 odL
-aaa
-aah
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-bdz
-apT
-apT
-aDy
-aDy
-hVb
-aah
-avy
-avy
-avy
-aah
-asD
 bgj
 bgj
 bgj
 bgj
 bgj
-hVb
-aaa
+odL
+hSb
+cgz
+icb
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+btD
+tQb
+btD
+btD
 aaa
 aaa
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93882,52 +93259,32 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aXZ
+aXZ
+aXZ
 aaa
 aah
-bWt
-aGy
-aGy
-aGy
-aGy
-aGy
-aaa
-buS
-buM
-aFB
-bxh
-mah
+aah
+bJT
+aDy
+bAk
+aYh
+aDy
+aah
+icb
+bZz
+iur
+aah
 odL
 aah
-bka
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-dEb
-aro
-baY
-aSI
-atE
-apo
-avy
-avy
-avy
-avy
-avy
-asD
-bgj
-bgj
-bgj
-bgj
-bgj
-apo
-aEb
-aEb
-aEb
+iAY
+evb
+iur
+aah
+odL
+bAk
+aYh
+iur
 btD
 btD
 btD
@@ -93943,6 +93300,26 @@ btD
 btD
 btD
 btD
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -94139,67 +93516,67 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+aXZ
+aXZ
+aXZ
 aaa
 aaa
 aah
-bWt
-aGy
-aGy
-aGy
-aGy
-aGy
-iur
-iur
-iur
-iCC
-hSb
-odL
-odL
 aah
-bkb
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-dEb
-aNG
-baY
-aSI
-biI
 aDy
-avy
-avy
-avy
-avy
-avy
-apT
-bgj
-bgj
-bgj
-bgj
-bgj
-evb
-boX
-aro
-fab
+bAk
+dQb
+odL
+aYA
+iur
+bsx
+iur
+aYA
+odL
+iur
+iur
+bsx
+iur
+iur
+odL
+cMC
+dBb
+bdz
 btD
 btD
 btD
 btD
 btD
 btD
+aaa
+aaa
+aaa
 btD
 btD
 btD
 btD
 btD
 btD
-btD
-btD
-btD
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -94395,68 +93772,68 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
 aaa
 aah
-bWt
-aGy
-aGy
-aGy
-aGy
-aGy
-aTy
-bsx
-hob
-drP
-mCm
+aah
+sTQ
+khG
+btq
 odL
-aah
-aaa
-aah
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-apT
-apT
-apT
-aCR
-atE
+smJ
+bWv
+baY
 aDy
-avy
-avy
-avy
-avy
-avy
-apT
-bgj
-bgj
-bgj
-bgj
-bgj
-evb
-aro
-aro
-fab
+bSZ
+usG
+smJ
+cxD
+baY
+iur
+bSZ
+odL
+dCb
+aml
+qYH
 btD
 btD
 btD
 btD
 btD
 btD
+aaa
+aaa
+aaa
 btD
 btD
 btD
 btD
 btD
 btD
-btD
-btD
-btD
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -94650,70 +94027,70 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
 aah
-bWt
-aGy
-aGy
-aGy
-aGy
-aGy
-qRb
-iur
-iur
+aDy
+bAk
+wSz
+uDb
 hIf
-hSb
-odL
+hIf
+hIf
+hIf
+txK
+aFB
+qhB
+kQm
+kQm
+kQm
+kQm
+ffq
+bwe
+aYh
+iur
+aah
+btD
+btD
+btD
+btD
+btD
 aaa
 aaa
 aaa
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
+btD
+btD
+btD
+btD
+btD
 aaa
 aaa
-aDy
-aSI
-atE
-aDy
-avy
-avy
-avy
-avy
-avy
-apT
-bgj
-bgj
-bgj
-bgj
-bgj
-apT
-baY
-baY
-apT
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -94906,71 +94283,71 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
+aXZ
+aDy
+bAk
+gaM
+rcg
+bxb
+bxb
+bxb
+bxb
+eEs
+vxL
+bIv
+bxb
+bxb
+bxb
+bxb
+tck
+bwx
+aYh
+iur
 aah
-bWt
-aGy
-aGy
-aGy
-aGy
-aGy
-aaa
-aaa
-odL
-aGU
-qgw
-odL
+btD
+btD
+btD
+btD
+btD
 aaa
 aaa
 aaa
+btD
+btD
+btD
+btD
+btD
 aaa
-aXZ
-aXZ
-aXZ
 aaa
 aaa
 aaa
-aDy
-aSI
-atE
-aDy
-avy
-avy
-avy
-avy
-avy
-apT
-bgj
-bgj
-bgj
-bgj
-bgj
-apT
-uDb
-urb
-icb
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-tQb
-btD
-btD
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -95163,71 +94540,71 @@ aaa
 aaa
 aaa
 aaa
+aXZ
+aXZ
+aXZ
+aXZ
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aXZ
+aXZ
+aXZ
+aXZ
+aDy
+ofu
+aMb
+hVG
+aMb
+aMb
+bJI
+uIo
+aFB
+aIm
+aFB
+aMb
+bJI
+aMb
+aMb
+hVG
+aMb
+dvb
+odL
 aah
-bWt
-bWt
-bWt
-bWt
-bWt
-bWt
-bWt
-bWt
-iur
-iCC
-hSb
-iur
+aah
+btD
+btD
+btD
+btD
+aaa
+aaa
+aaa
+btD
+btD
+btD
+btD
 aaa
 aaa
 aaa
 aaa
-aXZ
-aXZ
-aXZ
 aaa
 aaa
 aaa
-aDy
-bMg
-aPN
-aDy
-avy
-avy
-avy
-avy
-avy
-apT
-bgj
-bgj
-bgj
-bgj
-bgj
-apT
-uDb
-urb
-aEb
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
-btD
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -95423,68 +94800,68 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
 aKJ
 aKJ
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-aah
-iur
-ogz
-aiK
-iur
 aaa
 aaa
 aaa
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
 aaa
 aaa
-aDy
-bMi
-baM
-apT
+aaa
+odL
+odL
+odL
+odL
+odL
+odL
+odL
+odL
+aGU
+epm
+nSy
+odL
+odL
+odL
+odL
+odL
+odL
+odL
+odL
 aah
-icb
-bZz
-aEb
 aah
-apT
-aaa
-icb
-evb
-aEb
-aaa
-apT
-cMC
-dBb
-bdz
-btD
-btD
-btD
-btD
-btD
-btD
 aaa
 aaa
 aaa
-btD
-btD
-btD
-btD
-btD
-btD
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -95668,9 +95045,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
 aKJ
 aKJ
 aKJ
@@ -95692,56 +95066,59 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-iur
-lay
+aah
+aah
+aah
+aah
+aah
+aah
+odL
+uMW
 aJZ
-iur
-aaa
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-aDy
-aDy
-aGj
-apT
-bSX
-aEb
-aro
-aEb
-bSX
-apT
-aEb
-aEb
-aro
-aEb
-aEb
-apT
-dCb
-aml
-apT
-btD
-btD
-btD
-btD
-btD
-btD
+aGp
+odL
 aaa
 aaa
 aaa
-btD
-btD
-btD
-btD
-btD
-btD
+aaa
+aaa
+aaa
+aah
+aah
+aah
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -95925,9 +95302,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
 aKJ
 aKJ
 aKJ
@@ -95949,55 +95323,58 @@ aKJ
 aaa
 aaa
 aaa
-aaa
-aaa
-iur
-qNK
+aah
+aah
+aah
+aah
+aah
+aah
+odL
+aGU
 epm
-iur
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-aXZ
-icb
-bOx
-apT
-bSZ
-bWv
-baY
-aDy
-aYx
-apT
-bSZ
-cxD
-baY
-aEb
-aYx
-cKo
-bwe
-aJK
-apT
-aaa
-btD
-btD
-btD
-btD
-btD
+nSy
+odL
 aaa
 aaa
 aaa
-btD
-btD
-btD
-btD
-btD
+aaa
+aaa
+aah
+aah
+aah
+aah
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -96182,9 +95559,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
 aKJ
 aKJ
 aKJ
@@ -96206,55 +95580,58 @@ aKJ
 aaa
 aaa
 aaa
-aaa
-aaa
+bWt
+bWt
+bWt
+bWt
+bWt
+bWt
 odL
-aGU
+mcG
 aIm
+gmF
 odL
-aXZ
-aXZ
-aXZ
-aXZ
+odL
+odL
+odL
+aah
+aah
+aah
+aah
+aah
+bJT
 aaa
 aaa
 aaa
-aXZ
-aXZ
-aXZ
-aXZ
-aEb
-aGj
-apT
-bWw
-bTo
-bTo
-bTo
-bie
-phy
-jyQ
-cVW
-bvc
-bvc
-gKX
-lUd
-bwx
-aYh
-aEb
-aaa
-btD
-btD
-btD
-btD
-btD
 aaa
 aaa
 aaa
-btD
-btD
-btD
-btD
-btD
+aaa
+aaa
+aaa
+aaa
+aah
+aah
+aah
+aah
+aah
+aah
+aah
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -96439,9 +95816,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
 aKJ
 aKJ
 aKJ
@@ -96463,54 +95837,57 @@ aKJ
 aaa
 aaa
 aaa
-aaa
-mDC
-apT
-buT
+bWt
+aGy
+aGy
+aGy
+aGy
+aGy
+odL
+rSU
 bvW
-bwv
 bDi
-apT
-aEb
-aEb
-aEb
-aEb
-aEb
-aEb
-aEb
-aEb
-aHw
-aEb
-aGp
-apT
-wwg
-xLk
-atE
-atE
-bkQ
-qtj
-atE
-qUJ
-bhj
-bvg
-bhj
-bfZ
-aMb
-bhj
-aEb
-aaa
-aaa
-btD
-btD
-btD
-btD
+odL
+aHe
+btV
+odL
+cju
+aah
+aah
+aah
+aah
+aah
+aah
+aah
 aaa
 aaa
 aaa
-btD
-btD
-btD
-btD
+aaa
+aah
+aah
+aah
+aah
+aah
+fBb
+bbN
+bbN
+bbN
+qUN
+aah
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -96693,9 +96070,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
 aKJ
 aKJ
 aKJ
@@ -96720,41 +96094,44 @@ aKJ
 aKJ
 aKJ
 aKJ
-aaa
-aaa
-apT
-bbd
-bvZ
-bdA
-bhc
-bkn
-gKX
-bDc
-gKX
-bJG
-gKX
-gKX
-gKX
-csh
-lUd
-bOy
-vWv
-csh
-baI
-kYI
-prF
+bWt
+aGy
+aGy
+aGy
+aGy
+aGy
+qRb
+buT
+lwr
+bjT
+uTe
+kfK
+bsx
+cks
+rGM
+cju
+aah
+aah
+aah
+aah
+aah
+aah
+aah
+aah
+aah
+aah
 bQB
-bDq
-bis
-bOA
-bgP
-bhd
+fEm
+aZN
+aZN
+aZN
+bxm
 bHe
 bHe
-bio
-bIn
-bio
-bio
+bHe
+aMY
+aah
+aaa
 aaa
 aaa
 aaa
@@ -96949,9 +96326,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
 aKJ
 aKJ
 aKJ
@@ -96977,41 +96351,44 @@ aKJ
 aKJ
 aKJ
 aKJ
-aaa
-aaa
-apT
-bbd
-aFz
+bWt
+aGy
+aGy
+aGy
+aGy
+aGy
+aTy
+buT
 aJT
-bis
-iDb
-bOA
-aNw
-bis
-baq
-bis
-biV
-bkB
-bis
-iDb
-bmq
-bis
-bTp
-bbT
-ajb
-vaa
-bHe
-bll
-bHe
-bHe
+sEe
+odL
+set
+rRu
+odL
+cju
+cju
+aah
+aah
+aah
+aah
+aah
+aah
+aah
+aah
+aah
+aah
+jjN
+cNU
 bHe
 bHe
-hJt
-bvL
-bio
-bJI
-fQb
-bgp
+bHe
+bHe
+jjN
+idD
+bHe
+aMY
+aah
+aah
 aaa
 aaa
 aaa
@@ -97205,9 +96582,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
 aKJ
 aKJ
 aKJ
@@ -97234,17 +96608,17 @@ aKJ
 aKJ
 aKJ
 aKJ
-aaa
-aaa
-apT
-bsU
-bbe
-coZ
-bis
+bWt
+aGy
+aGy
+aGy
+aGy
+aGy
+iur
+buT
+aJT
+qSg
 aon
-eFk
-wET
-aEs
 bHe
 bHe
 bHe
@@ -97252,24 +96626,27 @@ bHe
 bHe
 bHe
 bHe
-pwb
-aDh
-bFr
-aDh
-bGl
 bHe
-blq
-bpe
-bom
-bpe
-bpe
-bll
-bvM
-bio
-bJI
-eZb
-bgp
-aaa
+bHe
+bHe
+bHe
+bHe
+bHe
+jjN
+bDm
+bdA
+bEk
+bDQ
+bfz
+bDQ
+bDQ
+shI
+clu
+bHe
+aMY
+aah
+aah
+aah
 aaa
 aaa
 aaa
@@ -97462,9 +96839,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
 aKJ
 aKJ
 aKJ
@@ -97491,9 +96865,12 @@ aKJ
 aKJ
 aKJ
 aKJ
-aaa
-aaa
-aEb
+bWt
+aGy
+aGy
+aGy
+aGy
+aGy
 bsr
 aEl
 aJW
@@ -97510,27 +96887,27 @@ avD
 awZ
 fec
 bBv
-ofi
-glx
-bDm
-cTO
+jiG
+cvf
+btG
+btG
 bHe
 bHe
 bHe
 lar
 bpM
 bsG
-buX
-bvN
-bio
-bJI
-jkb
-bio
-aaa
-aaa
-aaa
-aaa
-aaa
+gib
+bsY
+bHe
+aMY
+aah
+aah
+aah
+aah
+aah
+aah
+aah
 aaa
 aaa
 aaa
@@ -97719,9 +97096,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
 aKJ
 aKJ
 aKJ
@@ -97748,12 +97122,15 @@ aKJ
 aKJ
 aKJ
 aKJ
-aaa
-aaa
-aEb
-btB
-bbd
-xrW
+bWt
+aGy
+aGy
+aGy
+aGy
+aGy
+iur
+buT
+aJT
 bis
 apk
 bkW
@@ -97762,25 +97139,25 @@ biU
 baB
 bgF
 bkW
-bkW
-bkW
-bkW
+ajN
+aRV
+aRV
 pUQ
 aCd
-buD
-nLZ
+bWw
+dPV
+oDC
+aYl
 bkW
-cri
-bkW
-xGD
-kyH
-eZS
+bfB
+bIP
+eVv
 bpU
 bkW
-buY
-mal
+pkz
+bvN
 bio
-bJz
+uTF
 bio
 bio
 bio
@@ -97977,9 +97354,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
 aKJ
 aKJ
 aKJ
@@ -98005,11 +97379,14 @@ aKJ
 aKJ
 aKJ
 aKJ
-aaa
-aaa
-aEb
-bsX
-bbd
+bWt
+aGy
+aGy
+aGy
+aGy
+aGy
+odL
+nfY
 nFb
 bit
 bnB
@@ -98018,26 +97395,26 @@ brg
 bkz
 baQ
 bgJ
-crY
+ajN
 blz
 lwo
 bpV
-rbB
-nqm
-qoS
-gSX
-mcG
-ebk
-uqD
-sWE
-iSz
-qYi
+pUQ
+aCd
+bWw
+bop
+cpw
+aRi
+lzm
+wdA
+buu
+gvw
 bpV
-slP
-bvb
-bvN
+aoX
+nTI
+bsY
 bio
-bJI
+kkB
 bio
 bip
 iMb
@@ -98235,9 +97612,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
 aKJ
 aKJ
 aKJ
@@ -98262,12 +97636,15 @@ aKJ
 aKJ
 aKJ
 aKJ
-aaa
-aaa
-aEb
-btw
-bbd
-xrW
+bWt
+aGy
+aGy
+aGy
+aGy
+aGy
+iur
+buT
+udz
 bis
 apk
 bkW
@@ -98281,20 +97658,20 @@ jMR
 oaE
 nZG
 bBv
-puN
-krG
-wQY
-lzm
-pRn
-sMn
-tlY
-wht
-bpY
-bsH
+hYh
+owr
+hPU
+ueo
+amc
+xzh
+rsF
+bcY
+piG
+dDJ
 bHe
-bvM
+clu
 bio
-bJI
+kkB
 bcB
 biq
 bio
@@ -98495,9 +97872,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
 aKJ
 aKJ
 aKJ
@@ -98519,12 +97893,15 @@ aKJ
 aaa
 aaa
 aaa
-aaa
-aaa
-aEb
-btx
-bbd
-xrW
+bWt
+aGy
+aGy
+aGy
+aGy
+aGy
+bsr
+buT
+aYm
 bis
 aIY
 bkW
@@ -98532,26 +97909,26 @@ bkW
 bkW
 bbp
 buD
-cri
+aYl
 bkW
-jOv
+bJr
 qlZ
 qlZ
 qlZ
 aHK
-aPV
+kyH
 vIs
 qlZ
 qlZ
-euX
+buD
 bkW
-lac
-bpZ
-bsK
+xMs
+aIk
+asc
 bHe
-bvQ
+uTg
 bio
-bJI
+kkB
 wnx
 bir
 bXq
@@ -98559,8 +97936,8 @@ bnf
 jxb
 bgp
 bgp
-bWt
-bWt
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -98752,9 +98129,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
 aKJ
 aKJ
 aKJ
@@ -98776,12 +98150,15 @@ aKJ
 aaa
 aaa
 aaa
-aaa
-aaa
-aEb
-btv
-bbd
-xrW
+bWt
+aGy
+aGy
+aGy
+aGy
+aGy
+iur
+buT
+aYm
 bis
 aXW
 aOo
@@ -98789,35 +98166,35 @@ aWx
 bgN
 bHe
 bja
-bjT
-blZ
-bDf
-lNB
-axc
+bvI
+rWZ
+fqb
+biV
+aZI
 aCg
 aLW
-aPW
-aVN
-aZI
+kKc
+oTq
+buN
 qlZ
-amz
-asc
+hdG
+bOA
 boo
 puI
 bsL
 bHe
-brf
+buY
 bio
-bJN
+byU
 bJP
 bsn
 bXs
-jnb
-jyb
+gKX
+gKX
 jYb
 bgp
-aah
-bWt
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -99009,9 +98386,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
 aKJ
 aKJ
 aKJ
@@ -99033,12 +98407,15 @@ aKJ
 aaa
 aaa
 aaa
-aaa
-aaa
-apT
-bty
-bbd
-xrW
+bWt
+aGy
+aGy
+aGy
+aGy
+aGy
+aTy
+buT
+aYm
 aEL
 aWW
 aWW
@@ -99053,29 +98430,29 @@ qlZ
 axI
 aCz
 aOb
-aQq
-aVO
-aZM
+bcn
+oHZ
+qoS
 qlZ
-mJL
+bGv
 atX
-myC
-aok
+caq
+acJ
 aFg
 aFg
-bwW
+aiK
 bio
-dQb
-bio
-bio
-bio
-aqP
+gKX
 bio
 bio
+bio
+pRK
+eyP
+bPF
 gGO
-aah
-bWt
-bWt
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -99266,9 +98643,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
 aKJ
 aKJ
 aKJ
@@ -99290,50 +98664,53 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-apT
-btA
-bbd
+bWt
+aGy
+aGy
+aGy
+aGy
+aGy
+qRb
+aGU
 bbr
-bhj
-aWW
+nSy
+vhl
 aHg
 aWB
 bhe
-bbN
-bjG
+cFt
+kKP
 bmD
 bmJ
 bmK
 qlZ
-axK
+xSM
 aCI
 aCI
 xRx
+aoK
 aVP
-aZN
 qlZ
-bRn
-oRm
-bmz
-klI
+bcy
+prF
+bxB
+bve
 brC
-bvj
-bxN
+bJO
+sVF
 bio
-dQb
-aBW
+gKX
+buS
 bhR
 bio
-aqV
+acj
+hmR
+mCm
 bio
-aah
-aah
-aah
-aah
-bWt
-bWt
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -99522,9 +98899,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
 aah
 aah
 gSb
@@ -99542,54 +98916,57 @@ aKJ
 aKJ
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-apT
-bup
-ahw
+aah
+aah
+aah
+aah
+aah
+bWt
+aGy
+aGy
+aGy
+aGy
+aGy
+odL
+buT
 aYm
-bhj
-vhl
+qSg
+nQR
 aHM
 aZw
 aZw
-bcy
+qUJ
 fXV
 blJ
 blY
 aZw
 qlZ
 aCa
-aCJ
-aOI
-aRi
+jhk
+udX
+qFd
+cbe
 aWO
-aZQ
 qlZ
-xoX
+aPW
+oRm
 rXf
-bmA
 iob
 brF
-nMw
+brF
 pjk
-dDJ
-uek
+sHj
+btI
 bhO
-mNC
-bJT
-bJW
+btI
+bba
+bnH
 bio
-aah
-aah
-aah
-aah
-aah
+bio
+bio
+bWt
+bWt
+bWt
 bWt
 bWt
 bWt
@@ -99779,9 +99156,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aah
 aah
 aah
 apW
@@ -99791,10 +99165,11 @@ apW
 bjR
 bwY
 apW
-aaa
+aTJ
 apW
 bwT
 apW
+aah
 aah
 aah
 aah
@@ -99806,16 +99181,18 @@ usq
 aRn
 aRn
 aRn
+aRn
+aRn
 apT
-aWu
-bbd
-xrW
-bhj
-nQR
+apT
+bRn
+roq
+cbS
+aWW
 aIr
 aZw
 bqN
-bcy
+qUJ
 bhg
 bkr
 gXz
@@ -99828,13 +99205,13 @@ qlZ
 qlZ
 qlZ
 qlZ
-wfm
-udR
-iRH
-hvE
-khG
-tbS
-xQr
+pBt
+bSX
+lpD
+hhk
+fHH
+sWE
+pal
 bio
 bio
 bio
@@ -100035,12 +99412,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 aah
 aah
 aah
-aaa
 apW
 aXX
 aXX
@@ -100057,8 +99431,11 @@ aRn
 aRn
 aRn
 aRn
-apy
-apy
+aRn
+bGq
+bGq
+bGq
+brW
 baR
 bqh
 apy
@@ -100072,30 +99449,30 @@ aWW
 aID
 aZw
 brk
-bcK
-bhq
+uyK
+ybN
 kdV
-blO
+wJI
 kdV
 bBa
 bCT
 bBw
 aFg
 aRp
-aWV
-avg
+tpb
+acG
 aFg
 aFg
 aFg
-qmV
+auO
 hUF
 brG
 pGd
-bxb
-alk
+bEJ
+bxh
 aMc
-byG
-bzq
+bcE
+qmV
 bcM
 aaa
 aah
@@ -100291,14 +99668,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aah
 aah
 aah
 aaa
-aaa
-aYA
+apW
 hIb
 hIb
 apW
@@ -100309,13 +99683,16 @@ dDb
 asP
 bqP
 hfb
-bqO
-bqs
+cEV
+bGw
 hQb
+bqO
 brm
 aRn
-bve
-asS
+aPJ
+byX
+axS
+brW
 baU
 bqr
 brV
@@ -100339,16 +99716,16 @@ qAF
 nLo
 aFg
 tQr
-aWX
-baK
-bEx
-aXz
+rhj
+bvL
+ayX
+bvj
 ooW
 bnp
 brb
 brG
 pGd
-ofm
+bxd
 bFS
 bxC
 byS
@@ -100541,16 +99918,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aah
+aah
+aah
+aah
+aah
+aah
+aah
 aah
 aah
 aaa
@@ -100569,10 +99943,13 @@ hvb
 qaa
 aVq
 aVq
+aVq
 brv
 aGT
-bvf
-axS
+btk
+bpN
+asS
+brW
 bou
 bqG
 brW
@@ -100581,7 +99958,7 @@ apT
 btx
 bbd
 xrW
-aHc
+dBT
 aWW
 bRk
 aMl
@@ -100597,14 +99974,14 @@ eXg
 aFg
 bsy
 bxv
-kkB
+qla
 mfD
 mfD
-ihg
+doT
 eGf
 hUF
 bGI
-uEX
+bsX
 bHw
 bFS
 bxk
@@ -100798,17 +100175,14 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aah
+bWt
+bWt
+bWt
+bWt
+bWt
+bWt
+bWt
 aah
 aaa
 aaa
@@ -100826,16 +100200,19 @@ aVq
 aVq
 aVq
 aVq
+aVq
 btd
 aRn
 bvr
+fPk
+bsg
 ayV
 boz
 bqW
-bsg
+fPk
 aYg
 apT
-bsY
+btv
 bbd
 xrW
 bmb
@@ -100852,14 +100229,14 @@ aSM
 ncT
 aEM
 aFg
-aSa
-kwS
-aYD
+btN
+bEF
+bfn
 bxz
 bxz
 aLT
-krW
-sEe
+mQQ
+vMv
 bsC
 pGd
 kTw
@@ -101055,21 +100432,19 @@ aaa
 aaa
 aaa
 aaa
+aah
+bWt
+aqM
+ars
+asJ
+atH
+aux
+bWt
+aah
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-apw
-aRn
-aRn
-aRn
-aRn
-aRn
+apW
+uEX
 aVq
 aVq
 aYe
@@ -101078,12 +100453,14 @@ aYe
 aYe
 cuW
 aVq
-cnY
+aYe
 aYe
 aYe
 aYe
 aVq
 tWb
+aRn
+aRn
 aRn
 aRn
 aRn
@@ -101110,13 +100487,13 @@ qAF
 bEW
 aFg
 aSc
-aXJ
-gOl
+mOZ
+bvH
 bxz
 aOH
 aLT
-ofm
-vBO
+bxd
+uhJ
 sox
 pGd
 rLZ
@@ -101312,24 +100689,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aRn
-cyq
-aOp
-bnH
-cSb
+aah
+bWt
+aqO
+art
+asL
+atJ
+auz
+inL
+hib
+hib
+inL
+inL
+aQJ
+bnL
+bmQ
 akV
-azh
-aQR
-tRb
 aRn
 blP
 tPb
@@ -101339,10 +100714,12 @@ aRn
 blP
 tPb
 tSb
-bnL
+aVq
 bvK
 aLB
-btk
+ciQ
+hXd
+brf
 aFF
 aTB
 brU
@@ -101368,19 +100745,19 @@ bEW
 aPD
 bxz
 rck
-eTT
-eTT
-eTT
+bEg
+bEg
+bEg
 kpu
 kED
-bqy
-ivL
-eVv
-qLl
+bvA
+bkB
+fob
+hqv
 bFS
 bxC
-byX
-bAk
+ndg
+xBm
 bBl
 bCh
 bCw
@@ -101559,49 +100936,49 @@ aaa
 aaa
 aaa
 aaa
-aah
-aah
-agm
-agm
-agm
-agn
-agn
-agn
-agn
-agn
-agn
-agn
-agn
-agn
-agn
-aah
 aaa
 aaa
 aaa
-aRn
-dvb
-aPK
-aly
-aYS
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aah
+bWt
+gZb
+hgb
+aJO
+hsb
+bjc
+inL
+aWq
+aXO
+aXT
+fgF
+bne
+iPK
 bbF
+boi
 bfd
-bqU
-bcn
-tHb
 boi
-tzb
-bne
+bZZ
+bFR
 rBf
-boi
-boi
-tzb
 brN
-bne
+uNt
+tzb
+nJb
+xZb
 bvO
 aLC
-aqN
+aly
+pRu
 atE
-atE
+gth
+gth
 boh
 bss
 bWx
@@ -101623,23 +101000,23 @@ mPD
 qAF
 vdm
 aFg
-bcf
-bBm
-bba
+aVO
+eED
+cri
 vIi
-pal
+uOJ
 ooW
-ofm
-vBO
-gdb
-tHV
+bxd
+uhJ
+ivL
+ice
 kTw
 bFS
 byo
-bzd
-bzd
+baK
+baK
 bBt
-bzd
+baK
 bBt
 rxx
 rxx
@@ -101818,47 +101195,47 @@ aaa
 aaa
 aaa
 aaa
-agm
-aaa
-aah
-aah
-aah
-aaa
-aah
-aah
-aaa
-aaa
-aah
-aah
-aah
 aaa
 aaa
 aaa
 aaa
-aRn
-fbb
-aSf
-aUV
-aFh
+aaa
+aaa
+aaa
+aaa
+aah
+bWt
+gVb
+hcb
+hjb
+brt
+bjg
+hib
+aWt
+aXQ
+asG
+inL
+aOp
+aVq
 bbt
-axU
 aVq
 aVq
 aVq
 aVq
 aVq
 aVq
+aHC
 aVq
 aVq
 aVq
-aVq
-brl
 aVq
 aJL
 ajR
-atL
+cwT
+pRu
 btF
-aUO
+btF
+gdb
 bud
 bhj
 bhj
@@ -101886,15 +101263,15 @@ aFg
 aFg
 aFg
 aFg
-qJL
-vBO
+bhq
+uhJ
 brG
 pGd
-ofm
+bxd
 bFS
-byq
-bze
-bAl
+auC
+bwz
+aVN
 bcM
 bcM
 bCt
@@ -102075,51 +101452,51 @@ aaa
 aaa
 aaa
 aaa
-agm
 aaa
-aeN
-aeX
-afM
 aaa
-aeN
-aeX
-afM
 aaa
-aeN
-aeX
-afM
+aaa
+aaa
+aaa
+aaa
+aaa
 aah
-agm
-aaa
-aaa
-aRn
+bWt
+auy
+aGV
+hjb
+boe
+bjj
+aUN
+aWt
+bzd
 aGS
-aQJ
+aWu
 bGM
 aFh
 bJH
-tIb
-bqf
-tIb
-tIb
-bng
-tIb
-tIb
-tIb
-tIb
-bqf
-bpj
-brl
 aVq
-aJL
+bqf
+tIb
+tIb
+tIb
+tIb
+cFO
+tIb
+tIb
+bqf
+tIb
+brl
 aFG
 aFG
-afW
+aFG
+aFG
+aFG
 aFG
 aNS
 aPf
 aNS
-aFG
+aXR
 aFG
 bbw
 msb
@@ -102141,18 +101518,18 @@ bEW
 bEW
 bEW
 aFg
-uhJ
+fjD
 bFS
-ofm
-vBO
+bxd
+uhJ
 ggb
 iIo
 hne
 lLb
-aMg
+afB
 bzg
 aFg
-myS
+bkb
 aah
 aah
 rxx
@@ -102332,50 +101709,50 @@ aaa
 aaa
 aaa
 aaa
-agm
-aah
-aeN
-ady
-afM
 aaa
-aeN
-ady
-afM
 aaa
-aeN
-ady
-afM
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aah
-aaa
-aaa
-aRn
+bWt
+gVb
+hcb
+hjb
+brt
+bjn
+era
+aWt
+bIT
 aMU
-aQJ
-aQJ
-asb
-aRn
-aRn
-aRn
-aYo
-bmP
+baT
+aUV
+aVq
+bET
+bqI
 aRn
 bnj
-bpf
-bqI
+otU
+bXN
+buB
+cbC
+dDb
 dDb
 aRn
-alw
-brn
-brI
-brO
+aRn
+aRn
 aFG
-btm
+brO
+bJK
 alS
-btG
+uIs
+aUP
 aRX
 aTE
-aUP
+bvu
 aWz
 aFG
 aUO
@@ -102394,20 +101771,20 @@ aSM
 pAb
 jFb
 aQm
-kgz
+atd
 wAe
 wAe
 odV
-oTJ
-gvg
-fDb
-ofu
-bkR
-owL
+aHH
+ojC
+cij
+bwA
+xrE
+gMD
 hne
 bTT
 aFg
-bzj
+dWm
 aFg
 aah
 aah
@@ -102589,35 +101966,30 @@ aaa
 aaa
 aaa
 aaa
-agm
-aah
-aeN
-ady
-afM
-aah
-aeN
-ady
-afM
-aah
-aeN
-ady
-afM
-aah
-aah
 aaa
 aaa
-aRn
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aah
+bWt
+aqS
+bjM
+hkb
+atS
+bjq
+inL
+aPK
+cMo
 auf
-aQJ
-aQJ
-bjL
-aRn
-bmQ
-aRn
-aRn
-aRn
-aRn
-aRn
+inL
+bDf
+aVq
+bET
+azs
 aRn
 aRn
 aRn
@@ -102626,11 +101998,16 @@ aRn
 aIl
 aRn
 aRn
+aRn
+bov
+bxS
 aFG
-aPJ
+bmP
 aQM
-btI
+dbf
+aEk
 bug
+dLw
 buy
 aRZ
 aWA
@@ -102659,9 +102036,9 @@ brd
 brd
 brd
 brd
-jaX
+myS
 uDj
-ofm
+bxd
 lab
 aFg
 aFg
@@ -102847,45 +102224,45 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aah
-aeN
-ady
-afM
-aaa
-aeN
-ady
-afM
-aaa
-aeN
-ady
-afM
-aah
-aah
-aaa
-aaa
-aRn
-anj
-aTJ
+bWt
+aOn
+hhb
+hnb
+auB
+bjC
+inL
+inL
+inL
+inL
+inL
 bOM
 ddh
+bot
+bqs
 aRn
+fub
 aRn
-aRn
-bxS
-cnZ
-clm
-cnZ
-cnZ
 aMW
-bov
-clm
-bpN
-aIn
 cnZ
-bcC
+ydn
+cnZ
+bpf
+xYb
+cnZ
+cnZ
 aFG
-btq
+bcC
 aQP
+uCn
+bHu
 btP
 buk
 aTG
@@ -102911,16 +102288,16 @@ bDk
 eXg
 eXg
 brd
-bfB
-bDX
-bGc
-bop
+rVE
+mLl
+xXf
+byV
 lhs
-bks
-shv
-ofm
-lcb
-myS
+sfG
+lDy
+bxd
+mTP
+bkb
 aah
 aah
 aah
@@ -103100,49 +102477,49 @@ aaa
 aaa
 aaa
 aaa
-agm
-agm
-agm
 aaa
 aaa
-aeN
-ady
-afM
 aaa
-aeN
-ady
-afM
 aaa
-aeN
-ady
-afM
 aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aah
+bWt
+aAm
+aHa
+bjE
+brp
+bsj
+bWt
 aah
 aaa
 aaa
-atI
-atI
-atI
-atI
-atI
+aRn
+aRn
+aRn
+fAb
+aRn
+aRn
+aRn
+aRn
 clm
-bpk
-auC
-arb
-arb
-ayJ
-arb
-arb
+kGr
+xGz
 bBj
-bFv
-arb
-arb
-bMT
 cnZ
-bds
+arb
+cnZ
+cnZ
 aFG
 aFG
 aQQ
+aFG
+aFG
 aFG
 aFG
 aFG
@@ -103168,15 +102545,15 @@ bDk
 wZc
 bEW
 brd
-bfH
+bze
 bRC
-awg
-boq
-bHB
-sbs
-lDy
-ofm
-nGb
+lfh
+aXJ
+eIo
+dUM
+itr
+bxd
+avg
 bcM
 bWt
 bWt
@@ -103357,54 +102734,54 @@ aaa
 aaa
 aaa
 aaa
-agm
-aaa
-aah
 aaa
 aaa
-aah
-akD
-aah
-aah
-aah
-akD
-aah
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aah
-akD
+bWt
+bWt
+bWt
+bWt
+bWt
+bWt
+bWt
 aah
 aaa
-aah
-acG
-acG
-acG
-anx
+aaa
 apN
 aqJ
-atI
-cnZ
-cnZ
-atd
-bbf
-cnZ
+bvC
+aiw
+cIs
+aRn
+abA
+aKp
 clm
-azu
-cnZ
-bbf
-bfM
-cnZ
+awd
+bxl
+brq
+pRn
+cbB
 dib
 brq
-brK
-fHn
+brq
 bbn
-bbn
-bee
-btV
-bfz
-bgD
-bgR
-bii
+iac
+cnZ
+bbf
+bbf
+bbf
+bbf
+cnZ
+wVh
 clm
 bdf
 aTd
@@ -103423,17 +102800,17 @@ aNi
 bBw
 gYf
 wAe
-hmR
-bcE
-bgu
-bEk
-ayX
-bot
+pvq
+bMg
+iDY
+btw
+ciP
+tAT
 lhs
-bsD
-shv
-ofm
-auO
+oTy
+lDy
+bxd
+btm
 bcM
 aaa
 aaa
@@ -103614,54 +102991,54 @@ aaa
 aaa
 aaa
 aaa
-agm
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aah
-abj
-acj
-acj
-ajN
-akE
-akE
-akE
-akE
-akE
-akE
-akE
-akE
-akE
-akE
-akE
-amO
-amc
-amp
-aoK
-aoX
-aol
+aah
+aah
+aah
+aah
+aah
+aah
+aah
+aah
+aaa
+aaa
+aRn
 apn
 wHK
-arb
-arb
-uIs
-bpg
-bqd
+cpv
+bls
+aRn
+cnZ
+bbf
 clm
 clm
 clm
 clm
-clm
-clm
-clm
-aIs
-clm
-clm
+aXS
+aol
+qeB
+bsS
+bgz
 bdt
 cnZ
-bdS
+cnZ
 beI
-bgz
+beI
+aYo
 cnZ
 cnZ
-cnZ
+bfM
 bik
 bbI
 bdX
@@ -103682,15 +103059,15 @@ aSM
 aSM
 tgJ
 brd
-aFc
+axc
 bEl
-ayz
-boB
+ipM
+bsU
 brd
-bsO
-shv
-ofm
-aDw
+bvc
+lDy
+bxd
+ahw
 bcM
 aaa
 aaa
@@ -103871,45 +103248,45 @@ aaa
 aaa
 aaa
 aaa
-agn
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aah
-aaa
 aah
-aah
-aeZ
 aah
 aaa
-aah
-aeZ
-aah
-aaa
-aah
-aeZ
-aah
-aaa
-aah
-acG
-acG
-acG
-aoZ
-apM
+aRn
 apm
-atI
+fxb
 asB
-cnZ
-cnZ
-cnZ
-kGr
-clm
+axU
+aRn
 aBo
 cnZ
-aKp
-abA
+cnZ
+cnZ
+aww
 clm
-aHH
-aJU
-aUY
+clm
+clm
+aIs
+clm
+aGW
 aGW
 aGW
 aOr
@@ -103939,15 +103316,15 @@ fVd
 aSM
 bDk
 brd
-aYl
+bDR
 bEl
-bcw
-boK
+uBz
+bOt
 brd
 bmE
-shv
-ofm
-qsv
+lDy
+bxd
+aEb
 bcM
 aaa
 aaa
@@ -104128,46 +103505,46 @@ aaa
 aaa
 aaa
 aaa
-agn
-agN
-agm
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aah
-aeN
-afB
-afM
-aaa
-aeN
-afB
-afM
-aaa
-aeN
-afB
-afM
-aaa
 aah
-aaa
 aah
-acG
-atI
-atI
-atI
-atI
-clm
+aRn
+bIO
+asb
+pvb
 bnE
-bnX
-cnZ
-awd
-clm
+aRn
 aBv
 aww
 aKr
 abD
+cnZ
 clm
-prb
-aJX
-aWD
+mal
+bvQ
+aJU
+aUY
 aGW
+bAl
 ait
 cnw
 aPL
@@ -104201,10 +103578,10 @@ brd
 brd
 brd
 brd
-bls
-bnI
-iry
-aKF
+hwh
+iyC
+iRp
+qSe
 aFg
 aaa
 aaa
@@ -104390,42 +103767,42 @@ aaa
 aaa
 aaa
 aaa
-aeN
-afB
-afM
 aaa
-aeN
-afB
-afM
 aaa
-aeN
-afB
-afM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bJT
 aah
-aah
-aaa
-aaa
-aaa
-aah
-aaa
-aaa
-aaa
-clm
-clm
-clm
-clm
-clm
-clm
+aRn
+fDb
+atI
+atI
+fgl
+aRn
 aBu
 aEU
 aKq
-aww
+cnZ
+cnZ
 clm
-aHe
-aKi
-atR
+cuZ
+bJW
+aJX
+aWD
 aGW
-aMY
+iCC
+aJo
 aJo
 aPM
 aks
@@ -104454,15 +103831,15 @@ aSM
 bDk
 bEW
 kGX
-bEJ
-jhk
+lcb
+jdz
 jsD
 bNk
-buu
-bvq
-bvV
+bxN
+bqy
+bqU
 bNk
-bNk
+aFg
 aaa
 aaa
 aaa
@@ -104645,43 +104022,43 @@ aaa
 aaa
 aaa
 aaa
-agm
-aah
-aeN
-afB
-afM
-aah
-aeN
-afB
-afM
-aah
-aeN
-afB
-afM
-aaa
-aah
 aaa
 aaa
 aaa
-aah
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
 aaa
 aah
-aaa
-aaa
-aaa
-clu
+aah
+aRn
+hob
+atI
+atI
+bHB
+aRn
+cnZ
 cnZ
 cnZ
 cnZ
 aEm
 clm
-aJR
-aMp
 atQ
+mah
+aKi
+atR
 aGW
+xMz
 aNb
 aOs
 aPO
@@ -104712,12 +104089,12 @@ bDk
 sCd
 kGX
 qPE
-hOV
-lpD
+bpY
+hvE
 bNk
 buA
-bvs
-bxd
+jaX
+lCC
 bNk
 aaa
 aaa
@@ -104902,42 +104279,42 @@ aaa
 aaa
 aaa
 aaa
-agm
-aah
-aeN
-afB
-afM
-aaa
-aeN
-afB
-afM
-aaa
-aeN
-afB
-afM
-aaa
-aah
 aaa
 aaa
 aaa
-aah
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
 aaa
 aah
-aaa
-aaa
-aaa
-clm
-aBw
-ckv
+aRn
+buG
+tHV
+bcw
+bDo
+aRn
+blO
+aYx
+cnZ
 aDb
 aEn
 clm
+clm
+clm
 cnO
 clm
-clm
+aGW
 aGW
 aIc
 aOv
@@ -104969,12 +104346,12 @@ bDk
 bEW
 kGX
 kGX
-qiM
+bJz
 kGX
 bNk
-buB
-bvu
-bwA
+lky
+lzs
+eqX
 bNk
 aaa
 aaa
@@ -105159,32 +104536,25 @@ aaa
 aaa
 aaa
 aaa
-agn
 aaa
-aeN
-aee
-afM
 aaa
-aeN
-aee
-afM
 aaa
-aeN
-aee
-afM
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aah
-agm
-aaa
-aaa
-aaa
-aah
-awz
-awz
-awz
-awz
-awz
-awz
-awz
 avp
 avp
 avp
@@ -105192,6 +104562,13 @@ avp
 avp
 avp
 avp
+avp
+avp
+avp
+avp
+avp
+aFK
+aFK
 whb
 mjb
 nVb
@@ -105225,12 +104602,12 @@ bEW
 gYf
 wAe
 wAe
-hSt
+qEd
 iZg
 hHe
 bNk
-buV
-sVF
+lxb
+fnb
 byv
 bNk
 aaa
@@ -105416,21 +104793,21 @@ aaa
 aaa
 aaa
 aaa
-agn
-aaa
-aah
-aah
-aah
-aaa
-aah
-aah
-aah
-aaa
-aah
-aah
 aaa
 aaa
-agm
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -105447,8 +104824,8 @@ awh
 awh
 aCf
 avp
-cju
-aFK
+bng
+bPK
 whb
 avp
 avp
@@ -105487,8 +104864,8 @@ wuI
 bDk
 bNk
 buA
-mtS
-kFb
+bvX
+rlZ
 bNk
 aBd
 aaa
@@ -105673,21 +105050,21 @@ aaa
 aaa
 aaa
 aaa
-agn
-agm
-agm
-agm
-agm
-agn
-agm
-agm
-agm
-agn
-agm
-agm
-agN
-agm
-agm
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -105736,16 +105113,16 @@ byP
 bEL
 bEW
 aSM
-bGv
+qQe
 aSM
 bEW
 aSM
 qcd
 bDk
 bNk
-bsS
-bvw
-bvV
+bec
+bjG
+bqU
 bNk
 aaa
 aaa
@@ -105931,7 +105308,7 @@ aaa
 aaa
 aaa
 aaa
-aah
+aaa
 aaa
 aaa
 aaa
@@ -106000,9 +105377,9 @@ bDp
 qcd
 bDk
 bNk
-mTP
-mtS
-lqO
+qpK
+bvX
+abj
 bNk
 bNk
 aaa
@@ -106188,7 +105565,7 @@ aaa
 aaa
 aaa
 aaa
-aah
+aaa
 aaa
 aaa
 aaa
@@ -106257,11 +105634,11 @@ bDp
 usn
 tgJ
 bNk
-bsT
-mtS
-lqO
-bxB
-jpM
+qLl
+bvX
+abj
+dlh
+lNB
 aaa
 aaa
 aaa
@@ -106445,7 +105822,7 @@ aaa
 aaa
 aaa
 aaa
-aah
+aaa
 aaa
 aaa
 aaa
@@ -106514,11 +105891,11 @@ atk
 wNf
 bmR
 bNk
-bsZ
-bvA
-bvX
-bxD
-jpM
+owL
+aMT
+ipy
+hwJ
+lNB
 aaa
 aaa
 aaa
@@ -106702,7 +106079,7 @@ aaa
 aaa
 aaa
 aaa
-aah
+aaa
 aaa
 aaa
 aaa
@@ -106771,11 +106148,11 @@ avr
 wZc
 bDk
 bNk
-btH
-lqO
-bwa
-bxH
-jpM
+xgc
+abj
+bEO
+bvg
+lNB
 aaa
 aaa
 aaa
@@ -106959,8 +106336,8 @@ aaa
 aaa
 aaa
 aaa
-aah
-aah
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -107043,7 +106420,7 @@ aah
 aah
 aah
 aah
-yab
+cfT
 agn
 agn
 agn
@@ -107216,9 +106593,9 @@ aaa
 aaa
 aaa
 aaa
-aah
-aah
-aah
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -107285,7 +106662,7 @@ bEW
 bEW
 bDk
 bNk
-gib
+fsb
 bvB
 qTO
 bNk
@@ -107465,20 +106842,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+agm
+agm
+agm
+agn
+agn
+agn
+agn
+agn
+agn
+agn
+agn
+agn
+agn
 aah
-aaa
-aah
-aah
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -107542,18 +106919,18 @@ bEW
 moP
 fDx
 bNk
-btN
-bvC
-bwb
+jrZ
+cgX
+byq
 aLV
-fnb
-fpb
+bpj
+lWN
 bwF
 bNk
-fub
-fxb
+oTJ
+aZM
 bNk
-fAb
+qgw
 aah
 aaa
 aaa
@@ -107722,21 +107099,21 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+agm
 aaa
 aah
-aaa
+aah
+aah
 aaa
 aah
 aah
 aaa
 aaa
+aah
+aah
+aah
+aaa
+agn
 aaa
 aaa
 aaa
@@ -107797,29 +107174,29 @@ oUI
 oUI
 vWx
 oUI
-pAG
+eyU
 bNk
 bNk
-bvE
-kNq
+iOp
+bcf
 bNk
-fob
-fqb
-frb
-fsb
-xWb
-xXb
-lxb
-fBb
-bZZ
-bZZ
-bZZ
-bZZ
-bZZ
-bZZ
-bZZ
-bZZ
-ciQ
+bDc
+vVI
+kYI
+amp
+gHX
+iDb
+bgR
+jxO
+fCb
+fCb
+fCb
+fCb
+fCb
+fCb
+fCb
+fCb
+fby
 cap
 aah
 aaa
@@ -107979,21 +107356,21 @@ aaa
 aaa
 aaa
 aaa
+agm
 aaa
+hOV
+bGt
+aPV
 aaa
+hOV
+bGt
+aPV
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+hOV
+bGt
+aPV
 aah
-aaa
-aaa
-aaa
-aah
-aah
-aaa
+agm
 aaa
 aaa
 aaa
@@ -108054,29 +107431,29 @@ bDn
 bDn
 bDn
 bDn
-rlZ
-fXb
-qSg
-rhj
-bvH
+sfO
+sOh
+alv
+byO
+coZ
 bNk
 bNk
 bNk
 bNk
 bNk
 bNk
-ybN
+xWb
 bNk
+fuR
 fCb
-bZZ
-bZZ
-bZZ
-bZZ
-bZZ
-cgO
-bZZ
-bZZ
-bZZ
+fCb
+fCb
+fCb
+fCb
+xwS
+fCb
+fCb
+fCb
 cap
 aah
 aaa
@@ -108236,20 +107613,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+agm
 aah
+hOV
+bzq
+aPV
 aaa
+hOV
+bzq
+aPV
 aaa
+hOV
+bzq
+aPV
 aaa
-aaa
-aah
 aah
 aaa
 aaa
@@ -108311,29 +107688,29 @@ bDO
 xwj
 bHJ
 bDn
-ice
+fyb
 bEW
-bqM
-bvH
-bvH
+drP
+coZ
+coZ
 aSM
-bxQ
-qla
-xYb
-bZZ
-bZZ
-bZZ
-xYb
-bZZ
-bZZ
-cbC
-cbB
-cwT
-cbB
-cbB
-bZZ
-bZZ
-bZZ
+aok
+bzf
+bvM
+fCb
+fCb
+fCb
+bvM
+fCb
+fCb
+bkR
+brI
+aZQ
+brI
+brI
+fCb
+fCb
+fCb
 cap
 aah
 aah
@@ -108493,20 +107870,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+agm
 aah
-aaa
-aaa
-aaa
-aaa
-aaa
+hOV
+bzq
+aPV
+aah
+hOV
+bzq
+aPV
+aah
+hOV
+bzq
+aPV
+aah
 aah
 aah
 aah
@@ -108561,36 +107938,36 @@ bmd
 btW
 aZe
 bDn
-bDQ
+mjz
 bEf
-bEF
-bFs
-cIs
-apr
+bgu
+huE
+pDg
+puN
 bDn
-bec
+akD
 bqg
-buG
-bvI
-byO
-bwz
-byV
-bzc
-bzf
-bzf
-bzf
-bzf
-xZb
-bZZ
-bZZ
-cbB
-ciP
-cbB
-cgN
-ciP
-bZZ
-bZZ
-bZZ
+azh
+bvV
+boq
+keH
+aro
+eTT
+ady
+ady
+ady
+ady
+bds
+fCb
+fCb
+brI
+kgz
+brI
+blZ
+kgz
+fCb
+fCb
+fCb
 cap
 aah
 aaa
@@ -108751,22 +108128,22 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
 aah
+hOV
+bzq
+aPV
 aaa
+hOV
+bzq
+aPV
 aaa
-aaa
-aaa
-aaa
+hOV
+bzq
+aPV
 aah
-aaa
-aaa
+aah
+aah
+aah
 aaa
 aaa
 aaa
@@ -108818,36 +108195,36 @@ avN
 bvm
 bzk
 bDn
-bDR
-bEg
-bEc
+anx
+pFO
+cSb
 bDn
 sJr
-bEO
+aCR
 bDn
-uBz
+awv
 ikq
-mNg
-iAY
-aMT
+bQw
+bjL
+wKj
 aSM
 aSM
 aSM
-cbS
-bZZ
-cbS
-bZZ
-cbS
-bZZ
-bZZ
-ciP
-cbB
-cgx
-cbB
-cbB
-bZZ
-bZZ
-bZZ
+bks
+fCb
+bks
+fCb
+bks
+fCb
+fCb
+kgz
+brI
+amO
+brI
+brI
+fCb
+fCb
+fCb
 cap
 aah
 aaa
@@ -109004,35 +108381,35 @@ aaa
 aaa
 aaa
 aaa
+agm
+agm
+agm
 aaa
 aaa
+hOV
+bzq
+aPV
 aaa
+hOV
+bzq
+aPV
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aah
-aaa
-aaa
-aaa
-aaa
-aaa
-aah
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+hOV
+bzq
+aPV
 aaa
 aah
 aaa
-aaa
+aah
+aDh
+acO
+acO
+acO
+acO
+agO
+iWA
+agO
+agO
 aaa
 aah
 aaa
@@ -109074,10 +108451,10 @@ avN
 avN
 bwd
 avN
-bDr
+aMg
 bDO
 bEs
-bFR
+hLf
 bDn
 bDn
 bDn
@@ -109085,26 +108462,26 @@ bDn
 aSM
 aSM
 lDp
-ydn
-jjN
-nJb
-bXN
-cgX
-cgX
-cbe
-cbS
-cfS
-cbS
-bZZ
-bZZ
-cbB
-cbC
-cbB
-ciP
-cwT
-bZZ
-bZZ
-bZZ
+ofm
+kQw
+bGc
+baq
+tHb
+tHb
+xEt
+bks
+cgO
+bks
+fCb
+fCb
+brI
+bkR
+brI
+kgz
+aZQ
+fCb
+fCb
+fCb
 cap
 aah
 aaa
@@ -109261,35 +108638,35 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+agm
 aaa
 aah
 aaa
 aaa
-aaa
-aaa
-aaa
+aah
+aKF
+aah
+aah
+aah
+aKF
 aah
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aah
+aKF
 aah
 aaa
-aaa
+aah
+aDh
+aDh
+aDh
+krW
+meQ
+bdS
+acO
+aqd
+gif
+pYa
+agO
 aaa
 aah
 aaa
@@ -109334,7 +108711,7 @@ bzm
 bDn
 bDU
 bGm
-bJO
+fyC
 bDn
 wEL
 lrT
@@ -109343,27 +108720,27 @@ wAe
 wAe
 uIm
 wNf
-kQm
+bsO
 aSM
 cap
 cap
 cap
-cbd
-cbS
-cwE
-cgy
-bZZ
-bZZ
-cbB
-ciP
-cbB
-cbB
-cbB
-bZZ
-bZZ
-cpv
+eLc
+bks
+cWV
+wsQ
+fCb
+fCb
+brI
+kgz
+brI
+brI
+brI
+fCb
+fCb
+ciO
 cap
-cFt
+ihg
 bQl
 aah
 aah
@@ -109518,38 +108895,38 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+agm
 aah
-aaa
-aaa
-aaa
-aaa
-aaa
-aah
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aah
-aaa
-aaa
-aaa
-aah
-aaa
+cEn
+hJt
+hJt
+qCp
+akE
+akE
+akE
+akE
+akE
+akE
+akE
+akE
+akE
+akE
+akE
+lGk
+xXJ
+alw
+tFz
+oyM
+aVn
+aHc
+wyj
+xXb
+alZ
+nGb
+agO
+apl
+apl
+apl
 agO
 agO
 aER
@@ -109587,7 +108964,7 @@ brh
 gTX
 bHL
 gTX
-bAu
+geR
 bDn
 bDn
 bDn
@@ -109597,30 +108974,30 @@ aSM
 bDk
 bdu
 sCd
-bfn
+yaj
 aSM
 bEW
-qaV
-tFz
-pvb
-bxm
+aJK
+qfx
+bEc
+oYU
 cap
-cij
-cuZ
-cbf
-cbS
-bZZ
-bZZ
-bZZ
-bZZ
-bZZ
-bZZ
-bZZ
-bZZ
-bZZ
-cps
+dUy
+bMT
+sMn
+bks
+fCb
+fCb
+fCb
+fCb
+fCb
+fCb
+fCb
+fCb
+fCb
+aJR
 cap
-cFw
+bxD
 bIZ
 aaa
 bIZ
@@ -109775,38 +109152,38 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+agn
 aaa
 aah
 aaa
-aaa
-aaa
-aaa
-aaa
 aah
 aah
+bsZ
 aah
-acO
+aaa
+aah
+bsZ
+aah
+aaa
+aah
+bsZ
+aah
+aaa
+aah
+aDh
+aDh
+aDh
 ahJ
-acJ
 amu
-aah
-aaa
-aah
-aaa
+amu
+acO
+bup
+bkn
+shw
 agO
-agO
-agO
-apl
+afg
+afF
+aqb
 agO
 cFL
 atc
@@ -109846,10 +109223,10 @@ lLD
 aUu
 bhp
 bzi
-bDY
+wyr
 aGn
-bET
-bGt
+bsD
+aWX
 aGn
 bDk
 bEW
@@ -109857,27 +109234,27 @@ bEW
 tKI
 aSM
 bBw
-nSy
+eGM
 usn
 xqb
-bxl
+bAu
 bHa
-cbf
-ccd
-cbf
-cgz
-bPK
-bZZ
-cks
-cks
-cks
-cks
-clF
-cmn
-cEn
-cpw
+sMn
+aSf
+sMn
+qJL
+gvk
+fCb
+crY
+crY
+crY
+crY
+bvE
+cyq
+fgI
+xiF
 cap
-cFu
+mNg
 bIZ
 aaa
 bIZ
@@ -110030,44 +109407,44 @@ aaa
 aaa
 aaa
 aaa
-aag
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+agn
+agN
+agm
 aaa
 aah
-aah
-aah
-aah
-aah
-aah
+hOV
+nMw
+aPV
+aaa
+hOV
+nMw
+aPV
+aaa
+hOV
+nMw
+aPV
+aaa
 aah
 aaa
 aah
-acO
+aDh
 acE
-acE
+doi
+kdU
 acO
-aaa
-agO
-agO
-agO
-agO
-rRu
-alZ
-aqb
-arv
-alZ
-alZ
-alZ
+axm
+bee
+lHP
+aSI
+aNh
+aNh
+aNh
+cDv
+aNh
+aNh
+xXb
 agO
 ayl
 agO
@@ -110119,22 +109496,22 @@ bFW
 xqb
 bQl
 bHa
-cbf
-cvf
-cfT
-cuZ
+sMn
+azu
+fpb
+bMT
 cap
-sOh
+bDr
 cap
-cap
-cap
-bHa
-bHa
 cap
 cap
 bHa
+bHa
 cap
-cFO
+cap
+bHa
+cap
+bwb
 bIZ
 bIZ
 bIZ
@@ -110294,39 +109671,39 @@ aaa
 aaa
 aaa
 aaa
+hOV
+nMw
+aPV
 aaa
+hOV
+nMw
+aPV
 aaa
-aaa
-aaa
-aaa
-aaa
+hOV
+nMw
+aPV
 aah
-aaa
-aaa
-aaa
-aaa
-aaa
 aah
-alm
-alm
-acO
-ahJ
-acJ
-acO
-alm
+akd
+akd
+akd
+akd
+akd
+akd
+akd
+sAj
+aKY
+aKY
 agO
 alZ
 alZ
-ceF
-alZ
-fEm
 alZ
 alZ
 cfP
 agO
-bzA
+fbb
 agO
-axm
+mhb
 aNh
 aNh
 aNh
@@ -110368,18 +109745,18 @@ aGn
 tgJ
 bFW
 bGn
-bGw
+aCJ
 bHp
 bHK
-bIO
+aQq
 bFW
 pxb
 bQl
 cap
-ciO
-caq
-cbf
-caq
+pfi
+btA
+sMn
+btA
 cap
 bFJ
 bRo
@@ -110387,14 +109764,14 @@ bQl
 bFJ
 bQl
 bQl
-mhb
-cDv
+ewq
+apw
 cEr
-cEV
+aHU
 cFN
 mNb
 cGG
-cJY
+vEP
 bIZ
 bSg
 cJw
@@ -110549,31 +109926,31 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+agm
+aah
+hOV
+nMw
+aPV
+aah
+hOV
+nMw
+aPV
+aah
+hOV
+nMw
+aPV
 aaa
 aah
-aaa
-aaa
-aaa
-aaa
-aaa
-aah
-alm
+akd
 abY
 agI
 agI
 akG
 amC
 alm
-aqd
-awE
-bLk
+cFL
+atc
+cfP
 adW
 adW
 adW
@@ -110582,8 +109959,8 @@ adW
 adW
 adW
 asi
-cFL
-alZ
+aNh
+bcK
 arv
 bzB
 atc
@@ -110617,18 +109994,18 @@ bxf
 dWf
 avN
 dWf
-bEM
+aYL
 aGn
 aGn
 aGn
 aGn
 bDk
 bFW
-bGo
+iOM
 bGx
 bHq
 bHV
-bIP
+jpM
 bFW
 aMh
 bQl
@@ -110645,7 +110022,7 @@ bQl
 bTV
 bFJ
 bQl
-tpb
+rUm
 cJa
 bIz
 bQl
@@ -110653,7 +110030,7 @@ bQl
 bIZ
 cJX
 bIZ
-bSt
+bGy
 bIZ
 bIZ
 bIZ
@@ -110806,31 +110183,31 @@ aaa
 aaa
 aaa
 aaa
+agm
+aah
+hOV
+nMw
+aPV
 aaa
+hOV
+nMw
+aPV
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+hOV
+nMw
+aPV
 aaa
 aah
-aaa
-aaa
-aaa
-aaa
-aaa
-aah
-alm
+akd
 abG
 acb
 acA
 alc
 alU
-alv
+alm
+cFL
 alZ
-atc
-alZ
+aru
 adW
 aYP
 agO
@@ -110879,21 +110256,21 @@ bEn
 lrT
 wAe
 wAe
-gvk
+xRJ
 bFW
-bGq
-bGy
+bGr
+oYf
 bHs
 bIl
 bIQ
 bFW
 aMj
-cfq
-cfq
-byU
+hSt
+hSt
+bvq
 bps
-aGM
-aHU
+eZb
+ckv
 bIZ
 bIZ
 bIZ
@@ -110902,11 +110279,11 @@ bIZ
 cog
 bQl
 chX
-oHZ
+dWl
 bIZ
 bIZ
-bPF
-cxA
+bwv
+ipq
 bIZ
 cKa
 cKe
@@ -111063,31 +110440,31 @@ aaa
 aaa
 aaa
 aaa
+agn
 aaa
+hOV
+ccd
+aPV
 aaa
+hOV
+ccd
+aPV
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+hOV
+ccd
+aPV
 aah
-aaa
-aaa
-aaa
-aaa
-aaa
-aex
-alm
+aah
+akd
 agz
 acv
 acB
 acK
 adb
 alm
-afg
-afF
-cfP
+alZ
+alZ
+aru
 adW
 dFe
 aoM
@@ -111135,14 +110512,14 @@ bvJ
 aSM
 bDk
 bEW
-bJK
+bTp
 asa
 bFW
-bGr
-bGC
+qna
+sbM
 bHt
 bHt
-bIT
+gOl
 bFW
 bIZ
 bIZ
@@ -111161,10 +110538,10 @@ bRo
 bIZ
 bIZ
 bIZ
-coe
+vbi
 coV
 bQl
-bQw
+bty
 bEZ
 coV
 bTa
@@ -111320,21 +110697,21 @@ aaa
 aaa
 aaa
 aaa
+agn
 aaa
+aah
+aah
+aah
 aaa
+aah
+aah
+aah
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aah
 aah
 aaa
 aaa
-aaa
-aaa
 aah
-afj
 akd
 akd
 akd
@@ -111390,16 +110767,16 @@ aGn
 aGn
 aGn
 aSM
-bDo
+pcj
 aSM
 aSM
 aSM
 bFW
 bGs
 bFW
-bHu
-bIv
-bJr
+fch
+qos
+apM
 bFW
 oHi
 aOe
@@ -111577,13 +110954,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+agn
+agm
+agm
+agm
+agm
+agn
 aah
 aah
 aah
@@ -111591,7 +110967,8 @@ aah
 aah
 aah
 aah
-afm
+aah
+aah
 adJ
 cVb
 ahh
@@ -111678,7 +111055,7 @@ bZy
 cof
 bYb
 bIZ
-bjD
+sbs
 bXW
 enw
 cLY
@@ -112190,7 +111567,7 @@ bIZ
 mob
 bQl
 bQl
-aNE
+aoZ
 bIZ
 bOZ
 bZw
@@ -112704,7 +112081,7 @@ bIZ
 cmx
 cnr
 bIZ
-cMo
+xza
 bIZ
 ceY
 bTa
@@ -113216,7 +112593,7 @@ bIZ
 bjN
 bUe
 aYE
-aVn
+lOA
 cdU
 cdY
 cgW
@@ -113883,13 +113260,13 @@ aaa
 aaa
 aaa
 aaa
-cAd
-cAd
-cAd
-cAd
-cAd
-cAd
-cAd
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aex
 bEP
 aGr
 aNs
@@ -114140,13 +113517,13 @@ aaa
 aaa
 aaa
 aaa
-cAd
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
+afj
 bEP
 bEP
 rQH
@@ -114397,13 +113774,13 @@ aaa
 aaa
 aaa
 aaa
-cAd
 aaa
 aaa
 aaa
 aaa
 aaa
 aaa
+afm
 aaj
 amB
 abl
@@ -114655,10 +114032,10 @@ aaa
 aaa
 aaa
 cAd
-aaa
-aaa
-aaa
-aaa
+agn
+agn
+agn
+agn
 aaj
 aaj
 aaj

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -29112,10 +29112,6 @@
 /turf/simulated/floor/carpet/blue2,
 /area/station/bridge/captain_quarters)
 "bba" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Disposal Access";
-	req_access = list(12)
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 1;
@@ -29123,6 +29119,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance{
+	name = "Cargo Bay Maintenance";
+	req_access = list(31)
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bbb" = (
@@ -29993,8 +29993,8 @@
 "bcB" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
-	name = "Disposal Access";
-	req_access = list(12)
+	name = "Cargo Bay Maintenance";
+	req_access = list(31)
 	},
 /turf/simulated/floor/plating{
 	icon_state = "warnplate"
@@ -73778,7 +73778,7 @@
 	name = "Disposal Vent Control";
 	pixel_x = -25;
 	pixel_y = 4;
-	req_access = list(12)
+	req_access = list(31)
 	},
 /obj/machinery/driver_button{
 	id = "trash";

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -6130,11 +6130,16 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -7087,6 +7092,17 @@
 /area/station/maintenance/dormitory)
 "alW" = (
 /obj/machinery/door_timer/cell_4,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "red"
@@ -39570,7 +39586,9 @@
 	},
 /area/station/civilian/chapel)
 "buN" = (
-/obj/machinery/light_switch,
+/obj/machinery/light_switch{
+	pixel_x = -27
+	},
 /obj/structure/closet/secure_closet/quartermaster,
 /turf/simulated/floor{
 	dir = 10;
@@ -79207,9 +79225,7 @@
 	pixel_x = -6;
 	pixel_y = 36
 	},
-/obj/machinery/computer/card{
-	dir = 4
-	},
+/obj/machinery/computer/card,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "blue"
@@ -88766,7 +88782,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aag
 aaa
 aaa
 aaa
@@ -109520,7 +109536,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aag
 aaa
 agn
 agN
@@ -109797,8 +109813,8 @@ nMw
 aPV
 aah
 aah
-akd
-akd
+alm
+alm
 akd
 akd
 akd
@@ -110054,7 +110070,7 @@ nMw
 aPV
 aaa
 aah
-akd
+alm
 abY
 agI
 agI
@@ -110311,7 +110327,7 @@ nMw
 aPV
 aaa
 aah
-akd
+alm
 abG
 acb
 acA
@@ -110568,7 +110584,7 @@ ccd
 aPV
 aah
 aah
-akd
+alm
 agz
 acv
 acB


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
![2023 02 12-16 22 05](https://user-images.githubusercontent.com/96499407/218316946-92fba92e-d256-4bb8-b762-39d35429cdef.png)
![2023 02 12-16 20 54](https://user-images.githubusercontent.com/96499407/218316962-6c31d48e-148f-4d85-9d79-74973464882c.png)

<details>
<summary>Пояснения что почему и как к этому пришло:</summary>

- Почему доки теперь другие?

Доки сейчас это гигансткая кишка с вычурными формами потому что у нас нет системы шаттлов. Из всех единственные 2 которые используются в каждом раунде это док прибытия и шахтёров. Они вынесены на самый край станции и в этом нет нужды. Шаттл ОБР начал использоваться в бандах, но остальные доки выполняют свою функцию лишь при щитспавне администрации раз в тысячу раундов. Так почему бы не свапнуть местами то что ближе и не нужно и то что далеко и нужно?

- Почему шаттл прибытия находится там, где он находится?

Дело в том, что шаттлы не вертятся как мне захочется. И потому вынести прибытие в отбытие предполагает, что я нашёл место под шахтёрский шаттл. А это не так. Шахтёрский шаттл может влезть под эвакуационный но его консоль управления - никаким образом.

- Почему шахтёрский шаттл в отбытии? Что это даёт?

Оооо, я рад что ты спросил. Да, возможно это может показаться лишним, однако же с таким расположением заработает медпункт в отбытии, который не используют в раунде до объявления эвакуации. #Спаситевымирающихшахтёров

- На сервере уже убрали вендоматы, а ты поставил их назад?

Да, потому что ПР на удаление вендоматов во первых не удаляет все вендоматы, а во вторых я мапил на текущем билде без учёта тестмержов.

- Почему ты поменял пол в КПП СБ?

Серый с красным ободком смотрелся так, как будто это Гамма. Это очень меня беспокоило, поэтому я решил лучше сделать его менее бросающимся в глаза.

- Почему ты вообще менял КПП СБ?

Дело в том, что я подвинул эвакуационный шаттл вверх, что означает либо растянуть отбытие, либо растянуть это КПП и бриг отбытия. Я пытался сделать первое, но это получилось очень плохо и выглядело как Гамма, поэтому от идеи решил отказаться и незаметно растянуть другие отсеки к прибытию. Переложил в одну сторону большую часть оборудования на КПП по причине что это непроходимая кишка и ей нужно чуть больше свободного пространства. Удалил второй выход в коридор для того, чтобы поставить под эту стенку консоли.

- Зачем ящики в бриге отбытия?

Эти ящики взяты из отдела СБ и предназначены для содержания вещей арестованных. Показалось уместным их наличие там.

- КПП медбея поменялся. Есть ли для этого причина?

Кроме того, что я его повернул, сделав выход на другую стену - причин нет. Если у кого-то есть готовый вариант как выглядело бы лучше, то предложите.

- Почему ассистенсткая, душ голодека и комната с вином немного расширились?

Это последствия растягивания отсеков. Так не появляется двойная стенка при смещении отсеков.

- Зачем между карго и доками выход в космос?

Я не смог придумать отсек, который бы никому не нужен был и при этом мог бы находится в этом квадрате, поэтому сделал выход в космос. Попытался изначально чтобы там стоял мусоросбрасыватель, но эта идея была по причине отмены ремапа карго.

- Почему карго не отремаплено? Это хорошо?

Нет, это не хорошо. Теперь почти всё карго находится на границе с космосом. Это не типично ни для какого отдела, но из-за шаттла и мусорщиков подвести хотя бы техи вокруг красиво не получится.

- Почему ты не ремапил карго, если это плохо?

У меня получилось вывести шахтёров, КМа и мусорщиков на периферию от созданного "коридора карго", как это сделано в практически всех отделах и я вставил туда несколько как мне кажется интересных фич... Но из-за компактного расположения место где раньше были мусорщики и техи под гидропоникой/кухней внезапно опустели. Изначально я подумал что ура, теперь можно убрать кишки в техах бара, сделать красивый отсек барберу, расширить техи инженерных тоннелей. Увы, этого не хватило покрыть даже 20% освободившегося пространства. Делать с этим было нечего, ремап тоннелей и всех отсеков подле них был ревёртнут.

- В мусоросброс теперь никак не пройти всем остальным членам экипажа без помощи ИИ или карготеха, почему?

Насколько я понял, общим был доступ только в "пожарное оборудование" на проходе в мусоросброс, а сам он был предназначен для карготехников. Поэтому оставил его там.

- Что это за трубы в космосе?

Я не вижу чтобы кто-то мапил мусорные трубы по конвеерам и я предполагаю что знаю какой баг может произойти с этим. Поэтому они были выведены как у вирусологии или сжигателя на обочину.

- Солнечные панели вернулись в бриг. Почему они направлены вверх, а не так, как были раньше?

Это быстрый вариант перемещения их туда. Нужды в повороте я не вижу, но вижу кое-что другое и если этому ПРу дадут ход, попытаюсь сделать ремап тоннелей брига потом.
</details>

## Почему и что этот ПР улучшит
![00000000000000000000000000000000000000](https://user-images.githubusercontent.com/96499407/218305367-181c7aad-864b-416b-bb25-0a0714b1b06e.png)

## Авторство
Идею и примерный план придумал Алексей Волос
![0000000000000000000000000000000000](https://user-images.githubusercontent.com/96499407/218305443-fbcc710f-7074-4b39-8a55-ea3c680e235b.png)

## Чеинжлог
:cl: Deahaka
- map: Доки "Исхода" изменены. Шаттл на астероид перенесён в отбытие.