### PR TITLE
Модуль реактора на риг теперь разряжает СПУ

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -562,6 +562,11 @@
 	var/unstable = FALSE
 
 /obj/item/rig_module/nuclear_generator/process_module()
+	if(holder.wearer.get_species() == IPC && !unstable)
+		visible_message("<span class='warning'>The nuclear reactor inside [holder] is gloving red and looks very unstable. This module is not compatible with machines!</span>")
+		unstable = TRUE
+		addtimer(CALLBACK(src, .proc/boom), 7 SECONDS)
+
 	if(damage == MODULE_DAMAGED && prob(2))
 		if(holder.wearer)
 			to_chat(holder.wearer, "<span class='warning'>Your damaged [name] irradiates you</span>")

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -562,10 +562,8 @@
 	var/unstable = FALSE
 
 /obj/item/rig_module/nuclear_generator/process_module()
-	if(holder.wearer.get_species() == IPC && !unstable)
-		visible_message("<span class='warning'>The nuclear reactor inside [holder] is gloving red and looks very unstable. This module is not compatible with machines!</span>")
-		unstable = TRUE
-		addtimer(CALLBACK(src, .proc/boom), 7 SECONDS)
+	if(holder.wearer.get_species() == IPC)
+		holder.wearer.nutrition -= clamp(min(10, holder.wearer.nutrition), 0, 10)
 
 	if(damage == MODULE_DAMAGED && prob(2))
 		if(holder.wearer)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Только избавились от манчера рига Осокакавима, так теперь заходит Бебен и тоже решает побегать в риге потому что он самозаряжающийся, оправдывая это тем что СПУ все равно на то что риг не для постоянного ношения.
![00000000000000000000000000000000000000](https://user-images.githubusercontent.com/96499407/218309342-9283aca8-8536-46cc-afde-ea64194f6681.png)
Что ж игроки на СПУ не понимают по-хорошему, ксеновизорам насрать (я жаловался не раз на одного такого Уэйсона Болта), админам тоже насрать, давайте начнём балансировать механом.
## Почему и что этот ПР улучшит
Добавляет неудобства игрокам, которые хотят нарушать правила (манчить) нося риг Старшего Инженера или другой с ядерным реактором на постоянке.
## Авторство

## Чеинжлог
:cl: Deahaka
- add: Работа ядерного реактора для рига теперь негативно влияет на Самоходных Позитронных Установок.