### PR TITLE
статистика произведенного автолатом

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -425,20 +425,41 @@ var/global/list/datum/autolathe_recipe/autolathe_recipes_all = autolathe_recipes
 			icon_state = "autolathe"
 			flick("autolathe_n",src)
 			spawn(32/coeff)
+				var/m_used = 0
+				var/g_used = 0
+				var/product_name = null
 				if(istype(recipe, /datum/autolathe_recipe/stack))
-					stored_material[MAT_METAL] -= recipe.resources[MAT_METAL] * multiplier
-					stored_material[MAT_GLASS] -= recipe.resources[MAT_GLASS] * multiplier
-					new recipe.result_type(T, multiplier)
+					m_used = recipe.resources[MAT_METAL] * multiplier
+					g_used = recipe.resources[MAT_GLASS] * multiplier
+					stored_material[MAT_METAL] -= m_used
+					stored_material[MAT_GLASS] -= g_used
+					var/atom/A = new recipe.result_type(T, multiplier)
+					product_name = A.name
 				else
+					m_used = recipe.resources[MAT_METAL] / coeff
+					g_used = recipe.resources[MAT_GLASS] / coeff
 					stored_material[MAT_METAL] -= recipe.resources[MAT_METAL] / coeff
 					stored_material[MAT_GLASS] -= recipe.resources[MAT_GLASS] / coeff
 					var/obj/new_item = new recipe.result_type(T)
 					new_item.m_amt /= coeff
 					new_item.g_amt /= coeff
+					product_name = new_item.name
 				if(stored_material[MAT_METAL] < 0)
 					stored_material[MAT_METAL] = 0
 				if(stored_material[MAT_GLASS] < 0)
 					stored_material[MAT_GLASS] = 0
 				busy = FALSE
+				var/datum/stat/autolathe_product/stat = new
+				stat.product_type = recipe.result_type
+				stat.product_name = product_name
+				stat.produced_at_x = x
+				stat.produced_at_y = y
+				stat.power_used = power
+				stat.metal_used = m_used
+				stat.glass_used = g_used
+				stat.efficency = coeff
+				stat.multiplier = multiplier
+				stat.producer_name = usr.name
+				SSStatistics.autolathe_products += stat
 	updateUsrDialog()
 #undef PATH2CSS

--- a/code/modules/statistic/stat_dto.dm
+++ b/code/modules/statistic/stat_dto.dm
@@ -199,3 +199,25 @@
 	var/start_time
 	// string, [hh:mm]
 	var/leave_time
+
+/datum/stat/autolathe_product
+	// string, byond_type
+	var/product_type
+	// string, anything
+	var/product_name
+	// int, [0...]
+	var/produced_at_x
+	// int, [0...]
+	var/produced_at_y
+	// string, anything
+	var/producer_name
+	// float, [0.0...]
+	var/power_used
+	// float, [0.0...]
+	var/metal_used
+	// float, [0.0...]
+	var/glass_used
+	// float, [0.0...]
+	var/efficency
+	// int, [0,...]
+	var/multiplier

--- a/code/modules/statistic/statistics.dm
+++ b/code/modules/statistic/statistics.dm
@@ -17,7 +17,7 @@ var/global/datum/stat_collector/SSStatistics = new /datum/stat_collector
 // To ensure that if output file syntax is changed, we will still be able to process
 // new and old files
 // please increment this version whenever making changes
-#define STAT_OUTPUT_VERSION 6
+#define STAT_OUTPUT_VERSION 7
 #define STAT_FILE_NAME "stat.json"
 
 // Documentation rules:
@@ -75,6 +75,8 @@ var/global/datum/stat_collector/SSStatistics = new /datum/stat_collector
 	var/list/datum/stat/role/orphaned_roles = list()
 	// array of objects
 	var/list/datum/stat/faction/factions = list()
+	// list of objects // what else? duh, it's in the variable type. it's also not an array, arrays have fixed length 🤓  ~Luduk
+	var/list/datum/stat/autolathe_product/autolathe_products = list()
 
 /datum/stat_collector/New()
 	var/datum/default_datum = new


### PR DESCRIPTION
## Описание изменений

Записывает информацию обо всём произведённом на автолате в статистику.

Позволяет узнать какие вещи никогда не производят на автолате, что печатают себе рольки.

## Почему и что этот ПР улучшит

Поддержка https://stats.dushess.net/
