### PR TITLE
Abobination Heat damage

### DIFF
--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -1628,9 +1628,9 @@
 	cold_level_2 = -1
 	cold_level_3 = -1
 
-	heat_level_1 = 2000
-	heat_level_2 = 3000
-	heat_level_3 = 4000
+	heat_level_1 = BODYTEMP_HEAT_DAMAGE_LIMIT
+	heat_level_2 = BODYTEMP_HEAT_DAMAGE_LIMIT + 10
+	heat_level_3 = BODYTEMP_HEAT_DAMAGE_LIMIT + 20
 
 	darksight = 8
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Абоминации убрана неуявзимость к жаркому климату. Из-за брони от лазеров урон от горения будет мизерненьким но последствия пожара смогут медленно убить абоминацию. Раньше (когда её только ввели) от форонового пожара она не умирала, но немножко дамажилась.
## Почему и что этот ПР улучшит
Хочется чтобы генокрады были уязвимы к огню, пытаюсь поспособствовать этому. Почему абоминация должна гореть? Потому что так было в крутом фильме про амогуса и это часто встречается в культуре страшилок.
![2212](https://user-images.githubusercontent.com/96499407/218876945-10b8f895-03ac-416c-8f72-33d1abb53af0.jpg)

## Авторство

## Чеинжлог
:cl: Deahaka
- balance: У переевшего генокрада теперь нет иммунитета к раскалённому воздуху и пожарам.