### PR TITLE
Knowledgebase API

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -177,6 +177,7 @@ var/global/bridge_secret = null
 	var/use_overmap = 0
 
 	var/chat_bridge = 0
+	var/knowledgebase = 0
 	var/check_randomizer = 0
 
 	var/guard_email = null
@@ -579,6 +580,9 @@ var/global/bridge_secret = null
 
 				if("chat_bridge")
 					config.chat_bridge = value
+
+				if("knowledgebase")
+					config.knowledgebase = TRUE
 
 				if("check_randomizer")
 					config.check_randomizer = value

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -178,6 +178,7 @@ var/global/bridge_secret = null
 
 	var/chat_bridge = 0
 	var/knowledgebase = 0
+	var/knowledgebase_secret = null
 	var/check_randomizer = 0
 
 	var/guard_email = null
@@ -583,6 +584,9 @@ var/global/bridge_secret = null
 
 				if("knowledgebase")
 					config.knowledgebase = TRUE
+
+				if("knowledgebase_secret")
+					config.knowledgebase_secret = value
 
 				if("check_randomizer")
 					config.check_randomizer = value

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -184,7 +184,7 @@ var/global/world_topic_spam_protect_time = world.timeofday
 			if(packet_data["bridge"] == "" && addr == "127.0.0.1")
 				bridge2game(packet_data)
 				return "bridge=1" // no return data in topic, feedback should be send only through bridge
-			if(packet_data["knowledgebase"] == "")// && addr == "127.0.0.1")
+			if(packet_data["knowledgebase"] == "" && addr == "127.0.0.1")
 				return process_knowledgebase_request(packet_data)
 
 	else

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -181,10 +181,10 @@ var/global/world_topic_spam_protect_time = world.timeofday
 		if (packet_data)
 			if(packet_data["announce"] == "")
 				return receive_net_announce(packet_data, addr)
-			if(packet_data["bridge"] == "" && addr == "127.0.0.1") //
+			if(packet_data["bridge"] == "" && addr == "127.0.0.1")
 				bridge2game(packet_data)
 				return "bridge=1" // no return data in topic, feedback should be send only through bridge
-			if(packet_data["knowledgebase"] == "")
+			if(packet_data["knowledgebase"] == "")// && addr == "127.0.0.1")
 				return process_knowledgebase_request(packet_data)
 
 	else

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -181,9 +181,11 @@ var/global/world_topic_spam_protect_time = world.timeofday
 		if (packet_data)
 			if(packet_data["announce"] == "")
 				return receive_net_announce(packet_data, addr)
-			if(packet_data["bridge"] == "" && addr == "127.0.0.1") // 
+			if(packet_data["bridge"] == "" && addr == "127.0.0.1") //
 				bridge2game(packet_data)
 				return "bridge=1" // no return data in topic, feedback should be send only through bridge
+			if(packet_data["knowledgebase"] == "")
+				return process_knowledgebase_request(packet_data)
 
 	else
 		log_href("WTOPIC: \"[T]\", from:[addr], master:[master], key:[key]")
@@ -599,7 +601,7 @@ var/global/failed_db_connections = 0
 
 	packet_data["secret"] = "SECRET"
 	log_href("WTOPIC: NET ANNOUNCE: \"[list2params(packet_data)]\", from:[sender]")
-	
+
 	return proccess_net_announce(packet_data["type"], packet_data, sender)
 
 /world/proc/proccess_net_announce(type, list/data, sender)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -690,6 +690,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	return 1
 
+// If adding new stuff to character save, please consider updating character_params in
+// /modules/knowledgebase/api.dm
+// Thanks! ~Luduk.
 /datum/preferences/proc/save_character()
 	if(!path)
 		return 0
@@ -700,6 +703,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	S["version"] << SAVEFILE_VERSION_MAX // load_character will sanitize any bad data, so assume up-to-date.
 
+	S["last_saved"] << world.realtime
 	//Character
 	S["OOC_Notes"]             << metadata
 	S["real_name"]             << real_name

--- a/code/modules/knowledgebase/api.dm
+++ b/code/modules/knowledgebase/api.dm
@@ -1,0 +1,77 @@
+var/global/knowledgebase_secret = "test"
+
+// Returns a list of slots with given character name inside of the savefile.
+/proc/character_name2slots(savefile/S, name)
+	. = list()
+	S.cd = "/"
+
+	// Note: we can't know at this point whether the owner behind savefile
+	// is a supporter, thus must check all slots including supporter slots.
+	for(var/slot in 1 to MAX_SAVE_SLOTS_SUPPORTER)
+		S.cd = "/character[slot]"
+		var/character_name
+		S["real_name"] >> character_name
+		if(!character_name)
+			continue
+		if(ckey(character_name) == name)
+			. += slot
+
+// Topic format: knowledgebase&secret=secret&userid=...&ckey=ckey&name=...&index=...
+// * secret - is a string representing the "password" to this endpoint. If configured, the endpoint will not provide data
+//          to users without valid secret.
+// * userid - is a string representing the user requesting data. Only data the user has permission to will be provided,
+//          for example if a player opted out of statistics, only authorized administrators can access that player's preference file.
+// * ckey - is a string representing the ckey of a player who's preference data is requested.
+// * name - is a string representing the name of a character of the player who's preference data is requested.
+// * index - is an integer used only if the player has multiple characters with the same name to specify which of the characters to output.
+/world/proc/process_knowledgebase_request(list/packed_data)
+	if(!config.knowledgebase)
+		return "error=410"
+
+	if(global.knowledgebase_secret == null)
+		return "error=410"
+	if(!istext(packed_data["secret"]))
+		return "error=403&message=Incorrect secret."
+	if(global.knowledgebase_secret != packed_data["secret"])
+		return "error=403&message=Incorrect secret."
+
+	packed_data["secret"] = "SECRET"
+	log_href("WTOPIC: KNOWLEDGEBASE: \"[list2params(packed_data)]\"")
+
+	packed_data["userid"] = ckey(packed_data["userid"])
+	packed_data["ckey"] = ckey(packed_data["ckey"])
+	packed_data["name"] = ckey(packed_data["name"])
+	packed_data["index"] = sanitize_integer(text2num(packed_data["index"]), min=1, max=MAX_SAVE_SLOTS_SUPPORTER)
+
+	if(!packed_data["userid"] || !packed_data["ckey"] || !packed_data["name"])
+		return
+
+	var/ckey = packed_data["ckey"]
+
+	var/path = "data/player_saves/[ckey[1]]/[ckey]/preferences.sav"
+
+	if(!fexists(path))
+		return "error=404&message=No preferences.sav for [ckey]."
+
+	var/savefile/S = new /savefile(path)
+	if(!S)
+		return "error=500&message=Savefile could not be loaded."
+
+	var/list/slots = character_name2slots(S, packed_data["name"])
+	if(length(slots) == 0)
+		return "error=404&message=No characters with name [packed_data["name"]] for [ckey]."
+
+	if(length(slots) < packed_data["index"])
+		return "error=404&message=No character index [packed_data["index"]] for [ckey]."
+
+	var/slot = slots[packed_data["index"]]
+
+	S.cd = "/character[slot]"
+
+	var/character_age
+	S["age"] >> character_age
+
+	return json_encode(list(
+		"name" = packed_data["name"],
+		"age" = character_age,
+	))

--- a/code/modules/knowledgebase/api.dm
+++ b/code/modules/knowledgebase/api.dm
@@ -1,4 +1,4 @@
-var/global/knowledgebase_secret = "test"
+#define KNOWLEDGEBASE_ERROR(num, message) json_encode(list("error"=num, "message"=message))
 
 // Returns a list of slots with given character name inside of the savefile.
 /proc/character_name2slots(savefile/S, name)
@@ -26,14 +26,14 @@ var/global/knowledgebase_secret = "test"
 // * index - is an integer used if the player has multiple characters with the same name to specify which of the characters to output.
 /world/proc/process_knowledgebase_request(list/packed_data)
 	if(!config.knowledgebase)
-		return "error=410"
+		return KNOWLEDGEBASE_ERROR(410, "")
 
-	if(global.knowledgebase_secret == null)
-		return "error=410"
+	if(config.knowledgebase_secret == null)
+		return KNOWLEDGEBASE_ERROR(410, "")
 	if(!istext(packed_data["secret"]))
-		return "error=403&message=Incorrect secret."
-	if(global.knowledgebase_secret != packed_data["secret"])
-		return "error=403&message=Incorrect secret."
+		return KNOWLEDGEBASE_ERROR(403, "Incorrect secret.")
+	if(config.knowledgebase_secret != packed_data["secret"])
+		return KNOWLEDGEBASE_ERROR(403, "Incorrect secret.")
 
 	packed_data["secret"] = "SECRET"
 	log_href("WTOPIC: KNOWLEDGEBASE: \"[list2params(packed_data)]\"")
@@ -41,41 +41,107 @@ var/global/knowledgebase_secret = "test"
 	// var/userid = ckey(packed_data["userid"])
 	var/ckey = ckey(packed_data["ckey"])
 	if(!ckey)
-		return "error=400&message=Missing or invalid ckey."
+		return KNOWLEDGEBASE_ERROR(400, "Missing or invalid ckey.")
 
 	var/name = ckey(packed_data["name"])
 	if(!name)
-		return "error=400&message=Missing or invalid name."
+		return KNOWLEDGEBASE_ERROR(400, "Missing or invalid name.")
 
 	var/index = sanitize_integer(text2num(packed_data["index"]), min=1, max=MAX_SAVE_SLOTS_SUPPORTER)
 	if(!index)
-		return "error=400&message=Missing or invalid index."
+		return KNOWLEDGEBASE_ERROR(400, "Missing or invalid index.")
 
 	return knowledgebase_get_preferences(ckey, name, index)
 
 /world/proc/knowledgebase_get_preferences(ckey, name, index)
+	// In case the proc crashes unexpectedly.
+	. = KNOWLEDGEBASE_ERROR(500, "Something went wrong when getting preference info.")
+
 	var/path = "data/player_saves/[ckey[1]]/[ckey]/preferences.sav"
 	if(!fexists(path))
-		return "error=404&message=No preferences.sav for [ckey]."
+		return KNOWLEDGEBASE_ERROR(404, "No preferences.sav for [ckey].")
 
 	var/savefile/S = new /savefile(path)
 	if(!S)
-		return "error=500&message=Savefile could not be loaded."
+		return KNOWLEDGEBASE_ERROR(500, "Savefile could not be loaded.")
 
 	var/list/slots = character_name2slots(S, name)
 	if(length(slots) == 0)
-		return "error=404&message=No characters with name [name] for [ckey]."
+		return KNOWLEDGEBASE_ERROR(404, "No characters with name [name] for [ckey].")
 
 	if(length(slots) < index)
-		return "error=404&message=No character index [name] for [ckey]."
+		return KNOWLEDGEBASE_ERROR(404, "No character index [name] for [ckey].")
 
 	var/slot = slots[index]
 	S.cd = "/character[slot]"
 
-	var/character_age
-	S["age"] >> character_age
+	var/static/list/character_params = list(
+		"version",
+		"last_saved",
+		"OOC_Notes",
+		"real_name",
+		"name_is_always_random",
+		"gender",
+		"age",
+		"height",
+		"species",
+		"language",
+		"hair_red",
+		"hair_blue",
+		"hair_green",
+		"grad_red",
+		"grad_blue",
+		"grad_green",
+		"facial_red",
+		"facial_blue",
+		"facial_green",
+		"skin_tone",
+		"skin_red",
+		"skin_blue",
+		"skin_green",
+		"hair_style_name",
+		"grad_style_name",
+		"facial_style_name",
+		"eyes_red",
+		"eyes_green",
+		"eyes_blue",
+		"underwear",
+		"undershit",
+		"socks",
+		"backbag",
+		"b_type",
+		"use_skirt",
+		"alternate_option",
+		"job_preferences",
+		"all_quirks",
+		"positive_quirks",
+		"negative_quirks",
+		"neutral_quirks",
+		"flavor_text",
+		"med_record",
+		"sec_record",
+		"gen_record",
+		"be_role",
+		"ignore_question",
+		"player_alt_titles",
+		"organ_data",
+		"ipc_head",
+		"gear",
+		"custom_items",
+		"nanotrasen_relation",
+		"home_system",
+		"citizenship",
+		"faction",
+		"religion",
+		"vox_rank",
+		"uplinklocation",
+	)
 
-	return json_encode(list(
-		"name" = name,
-		"age" = character_age,
-	))
+	var/list/output_params = list()
+
+	for(var/param in character_params)
+		S[param] >> output_params[param]
+
+	return json_encode(output_params)
+
+#undef KNOWLEDGEBASE_ERROR

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -192,6 +192,11 @@ REQ_CULT_GHOSTWRITER 6
 ## place address for chat bridge
 # CHAT_BRIDGE http://localhost:3000
 
+## knowledgebase API, returning JSON of player preferences.
+# KNOWLEDGEBASE
+## knowledgebase API secret, if not set to anything, the API will only return errors.
+# KNOWLEDGEBASE_SECRET MY_PERSONAL_VERY_SECRETIVE_VALUE
+
 ## Media base URL - determines where to pull the jukebox playlist from.
 # MEDIA_BASE_URL http://game2.tauceti.ru/media
 

--- a/taucetistation.dme
+++ b/taucetistation.dme
@@ -1647,6 +1647,7 @@
 #include "code\modules\keybindings\bindings_atom.dm"
 #include "code\modules\keybindings\bindings_client.dm"
 #include "code\modules\keybindings\setup.dm"
+#include "code\modules\knowledgebase\api.dm"
 #include "code\modules\library\lib_items.dm"
 #include "code\modules\library\lib_machines.dm"
 #include "code\modules\library\lib_readme.dm"


### PR DESCRIPTION
## Описание изменений

Создаёт эндпоинт для получения информации о кукле зная сикей и имя куклы.

Необходимо решить проблемы:
- [ ] Какую информацию можно получать эндпоинтом и кому?
- [x] Доступ напрямую к серверу, или нужна прослойка?
- [ ] Нужно ли сделать эндпоинт красиво, и насколько красиво нужно?

Хочу добавить следующие фичи:
- [x] Дата последнего сохранения куклы. Позволит не парсить кукол которые не обновлялись с момента последнего парса.
- [ ] Список кукол по сикею для тех у кого есть доступ.

Чтобы ПР был готов надо:
- [ ] Более корректно валидировать имя куклы чем `ckey()`.
- [x] Выводить все необходимые данные а не только имя и возраст.
- [x] Вынести в конфиг `knowledgebase_secret`

## Почему и что этот ПР улучшит

Позволит упразднить `manifest_entries` из статистики, которые дублируют инфу о куклах из раунда в раунд.

## Проблемы

Не сохраняет (и надеюсь никогда не понадобится) "предыдущие" версии куклы игрока, то есть чтобы отслеживать динамику изменений куклы, или иметь "слепки" куклы в зависимости от даты надо запускать парсер регулярно.
