### PR TITLE
Ротация роботехнической ветки

### DIFF
--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -1320,7 +1320,7 @@ The tech datums are the actual "tech trees" that you improve through researching
 	tech_type = RESEARCH_ROBOTICS
 
 	x = 0.5
-	y = 0.2
+	y = 0.15
 	icon = "cyborganalyzer"
 
 	required_technologies = list()
@@ -1336,7 +1336,7 @@ The tech datums are the actual "tech trees" that you improve through researching
 	tech_type = RESEARCH_ROBOTICS
 
 	x = 0.4
-	y = 0.3
+	y = 0.25
 	icon = "ripley"
 
 	required_technologies = list("basic_robotics")
@@ -1352,7 +1352,7 @@ The tech datums are the actual "tech trees" that you improve through researching
 	tech_type = RESEARCH_ROBOTICS
 
 	x = 0.6
-	y = 0.3
+	y = 0.25
 	icon = "odyssey"
 
 	required_technologies = list("basic_robotics")
@@ -1463,31 +1463,15 @@ The tech datums are the actual "tech trees" that you improve through researching
 	id = "mech_utility_modules"
 	tech_type = RESEARCH_ROBOTICS
 
-	x = 0.25
-	y = 0.5
+	x = 0.7
+	y = 0.6
 	icon = "mechrcd"
 
 	required_technologies = list("advanced_robotics")
 	required_tech_levels = list()
-	cost = 1000
+	cost = 2500
 
-	unlocks_designs = list("mech_wormhole_gen", "mech_rcd", "mech_gravcatapult", "mech_repair_droid", "mech_energy_relay", "mech_syringe_gun", "mech_diamond_drill", "mech_generator_nuclear")
-
-/datum/technology/mech_teleporter_modules
-	name = "Exosuit Teleporter Module"
-	desc = "Exosuit Teleporter Module"
-	id = "mech_teleporter_modules"
-	tech_type = RESEARCH_ROBOTICS
-
-	x = 0.1
-	y = 0.5
-	icon = "mechteleporter"
-
-	required_technologies = list("mech_utility_modules")
-	required_tech_levels = list()
-	cost = 5000
-
-	unlocks_designs = list("mech_teleporter")
+	unlocks_designs = list("mech_wormhole_gen", "mech_rcd", "mech_gravcatapult", "mech_repair_droid", "mech_energy_relay", "mech_syringe_gun", "mech_diamond_drill", "mech_generator_nuclear", "mech_teleporter")
 
 /datum/technology/mech_armor_modules
 	name = "Exosuit Armor Modules"
@@ -1495,7 +1479,7 @@ The tech datums are the actual "tech trees" that you improve through researching
 	id = "mech_armor_modules"
 	tech_type = RESEARCH_ROBOTICS
 
-	x = 0.25
+	x = 0.7
 	y = 0.8
 	icon = "mecharmor"
 
@@ -1511,8 +1495,8 @@ The tech datums are the actual "tech trees" that you improve through researching
 	id = "mech_weaponry_modules"
 	tech_type = RESEARCH_ROBOTICS
 
-	x = 0.75
-	y = 0.5
+	x = 0.85
+	y = 0.6
 	icon = "mechgrenadelauncher"
 
 	required_technologies = list("advanced_robotics")
@@ -1527,7 +1511,7 @@ The tech datums are the actual "tech trees" that you improve through researching
 	id = "mech_heavy_weaponry_modules"
 	tech_type = RESEARCH_ROBOTICS
 
-	x = 0.75
+	x = 0.85
 	y = 0.8
 	icon = "mechlaser"
 
@@ -1543,8 +1527,8 @@ The tech datums are the actual "tech trees" that you improve through researching
 	id = "basic_hardsuit_modules"
 	tech_type = RESEARCH_ROBOTICS
 
-	x = 0.35
-	y = 0.1
+	x = 0.7
+	y = 0.15
 	icon = "rigscanner"
 
 	required_technologies = list()
@@ -1559,8 +1543,8 @@ The tech datums are the actual "tech trees" that you improve through researching
 	id = "advanced_hardsuit_modules"
 	tech_type = RESEARCH_ROBOTICS
 
-	x = 0.5
-	y = 0.1
+	x = 0.7
+	y = 0.35
 	icon = "rigtaser"
 
 	required_technologies = list("basic_hardsuit_modules")
@@ -1575,8 +1559,8 @@ The tech datums are the actual "tech trees" that you improve through researching
 	id = "toptier_hardsuit_modules"
 	tech_type = RESEARCH_ROBOTICS
 
-	x = 0.65
-	y = 0.1
+	x = 0.85
+	y = 0.35
 	icon = "rignuclearreactor"
 
 	required_technologies = list("advanced_hardsuit_modules")


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Стало выглядеть это вот так
![00000000000000000000000000000000000000](https://user-images.githubusercontent.com/96499407/219396030-644b8f01-2588-4739-b8c5-11f34433ed5a.png)
Удалено отдельное исследование технологии Мехкатапульты за 5к очков, вставлено в технологию с другими утилитами. По этой причине стоимость технологии выросла с 1000 до 2500.

Хз насчёт 5 лет назад, но сейчас это балансить таким образом не нужно и разнообразия/красоты не требуется. А вот для построения вот такого желательно:
![0000000000000000000000000000000000001](https://user-images.githubusercontent.com/96499407/219397203-21a1e2c0-f338-4909-8f3f-ec8a0c76d8f9.png)

## Почему и что этот ПР улучшит
Это ПР в ветку нанитов.
Даёт область для заполнения нанитовыми ветками.
## Авторство

## Чеинжлог
