### PR TITLE
Reliable Statistics Tracking

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -24,6 +24,7 @@
 	if(!visualsOnly)
 		to_chat(world, "<b>[H.real_name] is the captain!</b>")//maybe should be announcment, not OOC notification?
 		SSStatistics.score.captain += H.real_name
+		SSStatistics.score.captain_ckey += SSStatistics.obfuscate_ckey(H.ckey)
 
 /datum/job/captain/get_access()
 	return get_all_accesses()

--- a/code/game/machinery/fax.dm
+++ b/code/game/machinery/fax.dm
@@ -200,7 +200,12 @@ var/global/list/alldepartments = list("Central Command")
 
 	send_fax(sender, P, "Central Command")
 
-	SSStatistics.add_communication_log(type = "fax-station", author = sender.name, content = P.info + "\n" + P.stamp_text)
+	SSStatistics.add_communication_log(
+		type = "fax-station",
+		author = sender.real_name,
+		ckey = sender.ckey,
+		content = P.info + "\n" + P.stamp_text
+	)
 
 	for(var/client/X in global.admins)
 		X.mob.playsound_local(null, 'sound/machines/fax_centcomm.ogg', VOL_NOTIFICATIONS, vary = FALSE, frequency = null, ignore_environment = TRUE)

--- a/code/modules/statistic/gamemode_stat.dm
+++ b/code/modules/statistic/gamemode_stat.dm
@@ -10,6 +10,8 @@
 
 	// string, anything
 	var/target_name
+	// string, hashed "salted" ckey
+	var/target_ckey
 	// string, anything
 	var/target_assigned_role
 	// string, anything

--- a/code/modules/statistic/stat_dto.dm
+++ b/code/modules/statistic/stat_dto.dm
@@ -13,6 +13,8 @@
 	var/title
 	// string, anything
 	var/author
+	// string, hashed "salted" ckey
+	var/ckey
 	// string, [hh:mm]
 	var/time
 	// string, anything
@@ -83,6 +85,8 @@
 	var/crew_survived  = 0      // how many people was registred as crew
 	// array of string, anything
 	var/captain        = list() // who was captain of the shift (or captains?...)
+	// array of string, hashed "salted" ckeys
+	var/captain_ckey  = list()
 
 	// these ones are mainly for the stat panel
 	// int, [0...]
@@ -131,6 +135,8 @@
 	var/real_name
 	// string, anything
 	var/name
+	// string, hashed "salted" ckey
+	var/ckey
 	// string, byond_type
 	var/mob_type
 	// boolean, [0, 1]
@@ -168,6 +174,8 @@
 /datum/stat/manifest_entry
 	// string, anything
 	var/name
+	// string, hashed "salted" ckey
+	var/ckey
 	// string, anything
 	var/assigned_role
 	// string, anything, name of antagonists' role
@@ -186,6 +194,8 @@
 /datum/stat/leave_stat
 	// string, anything
 	var/name
+	// string, hashed "salted" ckey
+	var/ckey
 	// string, anything
 	var/assigned_role
 	// string, anything, name of antagonists' role

--- a/code/modules/statistic/statistics.dm
+++ b/code/modules/statistic/statistics.dm
@@ -139,4 +139,4 @@ var/global/datum/stat_collector/SSStatistics = new /datum/stat_collector
 		if(M.assigned_role == "Cyborg" && is_drone.Find(M.name)) // useless data
 			continue
 		var/my_mob = M.original ? M.original : M.current
-		add_manifest_entry(M.key, M.name, M.assigned_role, M.special_role, M.antag_roles, my_mob)
+		add_manifest_entry(ckey(M.key), M.name, M.assigned_role, M.special_role, M.antag_roles, my_mob)

--- a/code/modules/statistic/statistics_helpers.dm
+++ b/code/modules/statistic/statistics_helpers.dm
@@ -1,8 +1,17 @@
-/datum/stat_collector/proc/add_communication_log(type, title, author, content, time = roundduration2text())
+/datum/stat_collector/proc/obfuscate_ckey(ckey)
+	if(!ckey)
+		return null
+	if(ckey == "")
+		return null
+	return sha1("[ckey]-[global.round_id]")
+
+/datum/stat_collector/proc/add_communication_log(type, title, author, content, ckey = null, time = roundduration2text())
 	var/datum/stat/communication_log/stat = new
 	stat.__type = type
 	stat.title = title
 	stat.author = author
+	if(ckey)
+		stat.ckey = obfuscate_ckey(ckey)
 	stat.time = time
 	stat.content = content
 	communication_logs += stat
@@ -36,6 +45,7 @@
 
 	stat.name = H.name
 	stat.real_name = H.real_name
+	stat.ckey = obfuscate_ckey(H.ckey)
 	stat.last_attacker_name = H.lastattacker_name
 
 	stat.damage["BRUTE"] = H.getBruteLoss()
@@ -65,11 +75,12 @@
 	stat.flash_range = flash_range
 	explosions += stat
 
-/datum/stat_collector/proc/add_manifest_entry(key, name, assigned_role, special_role, list/antag_roles, mob/controlled_mob)
+/datum/stat_collector/proc/add_manifest_entry(ckey, name, assigned_role, special_role, list/antag_roles, mob/controlled_mob)
 	var/datum/stat/manifest_entry/stat = new
 	stat.name = STRIP_NEWLINE(name)
 	stat.assigned_role = STRIP_NEWLINE(assigned_role)
 	stat.special_role = STRIP_NEWLINE(special_role)
+	stat.ckey = obfuscate_ckey(ckey)
 	if(controlled_mob)
 		stat.species = controlled_mob.get_species()
 		stat.gender = controlled_mob.gender
@@ -88,6 +99,7 @@
 /datum/stat_collector/proc/get_leave_stat(datum/mind/M, leave_type, leave_time = roundduration2text())
 	var/datum/stat/leave_stat/stat = new
 	stat.name = STRIP_NEWLINE(M.name)
+	stat.ckey = obfuscate_ckey(ckey(M.key))
 	stat.assigned_role = STRIP_NEWLINE(M.assigned_role)
 	stat.special_role = STRIP_NEWLINE(M.special_role)
 
@@ -120,6 +132,7 @@
 	if(istype(O, /datum/objective/target))
 		var/datum/objective/target/T = O
 		stat.target_name = STRIP_NEWLINE(T.target.name)
+		stat.target_ckey = obfuscate_ckey(ckey(T.target.key))
 		stat.target_assigned_role = T.target.assigned_role
 		stat.target_special_role = T.target.special_role
 


### PR DESCRIPTION
## Описание изменений

Сейчас меняя имя куклы внутриигровыми (генокрады) или читерными(педали) методами можно подставлять собой статистику других, так как ничего кроме имени куклы не идентифицирует записи связанные с нею.

Добавляет хешированный сикей куклы вместе с каждой записью об имени, если отсутствует запись о нехешированном сикее.

Сикей хешируется вместе с айди раунда чтобы тяжелее было делать табличку радужную сикей-хеш сикея, если понадобится то вместо айди раунда будет просто рандомная строка которая будет храниться рядом с хешем.

Для статистов:

При желании определить где была кукла того или иного игрока, зная его сикей нужно: sha1("[известный-вам-сикей]-[айди раунда записи]") == хеш из бд.