### PR TITLE
stats that are only written into the database and not to json

### DIFF
--- a/code/__DEFINES/statistics.dm
+++ b/code/__DEFINES/statistics.dm
@@ -1,0 +1,7 @@
+#define DECLARE_DB_STAT(stat) var/DB_STAT_PREFFIX_##stat
+#define GET_DB_STAT(source, stat) source.DB_STAT_PREFFIX_##stat
+
+/proc/_is_not_db_stat(stat)
+	return copytext(stat, 1, length("DB_STAT_PREFFIX") + 1) != "DB_STAT_PREFFIX"
+
+#define JSON_ONLY_STAT_CALLBACK CALLBACK(GLOBAL_PROC, .proc/_is_not_db_stat)

--- a/code/modules/statistic/stat_dto.dm
+++ b/code/modules/statistic/stat_dto.dm
@@ -183,6 +183,8 @@
 	// array of strings, where strings are antagonists' roles
 	var/list/antag_roles = null
 
+	DECLARE_DB_STAT(desc)
+
 /datum/stat/leave_stat
 	// string, anything
 	var/name

--- a/code/modules/statistic/statistics.dm
+++ b/code/modules/statistic/statistics.dm
@@ -19,6 +19,7 @@ var/global/datum/stat_collector/SSStatistics = new /datum/stat_collector
 // please increment this version whenever making changes
 #define STAT_OUTPUT_VERSION 6
 #define STAT_FILE_NAME "stat.json"
+#define DB_FILE_NAME "db.json"
 
 // Documentation rules:
 //  * First write the type of data
@@ -90,7 +91,16 @@ var/global/datum/stat_collector/SSStatistics = new /datum/stat_collector
 	do_post_round_checks()
 
 	var/start_time = world.realtime
-	statfile << datum2json(src)
+	statfile << datum2json(src, should_copy=JSON_ONLY_STAT_CALLBACK)
+
+	// write to db
+	var/dbfile = file("[global.log_directory]/[DB_FILE_NAME]")
+	if(length(dbfile))
+		fdel(dbfile)
+		dbfile = file("[global.log_directory]/[DB_FILE_NAME]")
+	// This script should dump the JSON into the database and delete the file.
+	// execute("python3 json2db.py [global.log_directory]/[DB_FILE_NAME]")
+
 	to_chat(stealth ? usr : world, "<span class='info'>Статистика была записана в файл за [(start_time - world.realtime)/10] секунд. </span>")
 
 	to_chat(stealth ? usr : world, "<span class='info'>Статистика по этому раунду вскоре будет доступа по ссылке [generate_url()]</span>")

--- a/code/modules/statistic/statistics_helpers.dm
+++ b/code/modules/statistic/statistics_helpers.dm
@@ -78,6 +78,8 @@
 			var/mob/living/carbon/human/H = controlled_mob
 			stat.age = H.age
 
+	GET_DB_STAT(stat, desc) = controlled_mob.desc
+
 	if(antag_roles?.len)
 		stat.antag_roles = list()
 		for(var/role in antag_roles)

--- a/taucetistation.dme
+++ b/taucetistation.dme
@@ -80,6 +80,7 @@
 #include "code\__DEFINES\spaceman_dmm.dm"
 #include "code\__DEFINES\spawners.dm"
 #include "code\__DEFINES\stat.dm"
+#include "code\__DEFINES\statistics.dm"
 #include "code\__DEFINES\status_effects.dm"
 #include "code\__DEFINES\subsystem.dm"
 #include "code\__DEFINES\telepathy.dm"


### PR DESCRIPTION
## Описание изменений

Добавляет возможность деклерить статистику которая не будет идти в джсон, но будет идти в БДшку (которая обязательно будет)

Проблемы:
- [ ] Запись в БД. Если БДшка табличная то нужен какой-то скрипт который будет джсон конвертить ОРМ-кой какой-то
- [ ] Синтаксис очень страшный
