### PR TITLE
быстрый эквип карты теперь сует её в пда

### DIFF
--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -24,6 +24,11 @@
 					delay_clothing_equip_to_slot_if_possible(J, SLOT_WEAR_SUIT)
 					return 0
 
+		if(istype(I, /obj/item/weapon/card/id))
+			if(istype(H.wear_id, /obj/item/device/pda))
+				wear_id.attackby(I, H)
+				return
+
 		if(H.equip_to_appropriate_slot(I, TRUE))
 			if(hand)
 				update_inv_l_hand()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
но только если пда в слоте карты
## Почему и что этот ПР улучшит
удобно... нубы часто карту теряют...
## Авторство
я
## Чеинжлог
:cl:
- rscadd: Быстрая экипировка (Е) айди-карты суёт её в КПК