### PR TITLE
Уменьшение шанса на выбор Инфейстейшен

### DIFF
--- a/code/game/gamemodes/modes_declares/infestation.dm
+++ b/code/game/gamemodes/modes_declares/infestation.dm
@@ -1,7 +1,7 @@
 /datum/game_mode/infestation
 	name = "Infestation"
 	config_name = "infestation"
-	probability = 100
+	probability = 60
 
 	factions_allowed = list(/datum/faction/infestation)
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Я в данный момент вижу, что игрокам хочется, чтобы чужих занерфили в нулину, но ПРы с нерфами алиенов не проходят, либо уходят в совсем другую степь, убирая фичи которые никому кроме плохих хлопчиков не мешали. В игре люди жалуются, что им надоел этот режим, что закономерно, особенно когда он падает сразу через раунд после предыдущего и что игроки на чужих занимаются откровенной игрок на победку (моё мнение что это из-за скил ишуя на ксеноморфе, но мб есть и другие причины). Игроков мы изменять не будем, а по остальному: я посмотрел сколько у него пробабилити для появления в раунде, сколько у других режимов и вывел 60% допустимого нижнего предела пробабилити. Точно столько же стоит у абдукторов, которые частые гости на сервере.
## Почему и что этот ПР улучшит
Качество жизни игрокам на первом сервере. В связи с меньшей повторяемостью тотального уничтожения станции, предполагается больше часов на экстендед режим (Хорошо ведь!). А чем больше экстендед, тем меньше натренированного навыка у чужих и людей друг друга убивать. А это в свою очередь увеличит колличество мирных раундов в режиме Чужих.

Ну и частое повторение уничтожения станции чужими это сродни блобу, который я думаю никто за хороший режим не считает. Так давайте будем чуть реже встречаться с этим.
## Авторство

## Чеинжлог
:cl: Deahaka
- tweak: Шанс выпадения режима Infestation понижен с 100% до 60%.