### PR TITLE
Фиксы багов, связанных с последним изменением вендоматов, которые я не заметил когда делал ПРы.

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -70,7 +70,7 @@
 	// so if slogantime is 10 minutes, it will say it at somewhere between 10 and 20 minutes after the machine is crated.
 	last_slogan = world.time + rand(0, slogan_delay)
 
-	build_inventory(products)
+	build_inventory(products, mapload)
 	 //Add hidden inventory
 	build_inventory(contraband, mapload, hidden = 1)
 	build_inventory(premium, mapload, req_coin = 1)
@@ -106,13 +106,16 @@
 /obj/machinery/vending/proc/build_inventory(list/productlist, mapload, hidden = 0, req_coin = 0 , req_emag = 0)
 	for(var/typepath in productlist)
 		var/amount = productlist[typepath]
-		if(mapload && is_station_level(src.z) && !hidden && !req_coin && !req_emag)
-			var/players_coefficient = num_players() / 75 //75 players = max load, 0 players = min load
-			var/randomness_coefficient = rand(50,100) / 100 //50-100% randomness
+		if(!hidden && !req_coin && !req_emag)
+			if(mapload && is_station_level(src.z) && refill_canister)
+				var/players_coefficient = num_players() / 75 //75 players = max load, 0 players = min load
+				var/randomness_coefficient = rand(50,100) / 100 //50-100% randomness
+				var/final_coefficient = clamp(players_coefficient * randomness_coefficient, 0.1, 1.0) //10% minimum, 100% maximum
 
-			var/final_coefficient = clamp(players_coefficient * randomness_coefficient, 0.1, 1.0) //10% minimum, 100% maximum
+				amount = round(amount * final_coefficient) //10-100% roundstart load depending on player amount and randomness
 
-			amount = round(amount * final_coefficient) //10-100% roundstart load depending on player amount and randomness
+				if(!amount && prob(20)) //20% that empty slot will be not empty. For very low-pop rounds.
+					amount = 1
 
 		var/price = prices[typepath]
 		if(isnull(amount)) amount = 1
@@ -566,25 +569,32 @@
 
 //Oh no we're malfunctioning!  Dump out some product and break.
 /obj/machinery/vending/proc/malfunction()
-	//Dropping actual items
-	var/max_drop = rand(1, 3)
-	for(var/i = 1, i < max_drop, i++)
-		var/datum/data/vending_product/R = pick(src.product_records)
-		var/dump_path = R.product_path
-		if(!R.amount)
-			continue
-		new dump_path(src.loc)
-		R.amount--
-
-	//Dropping remaining items in a pack
-	var/refilling = 0
-	for(var/datum/data/vending_product/R in src.product_records)
-		while(R.amount > 0)
-			refilling++
+	if(refill_canister)
+		//Dropping actual items
+		var/max_drop = rand(1, 3)
+		for(var/i = 1, i < max_drop, i++)
+			var/datum/data/vending_product/R = pick(src.product_records)
+			var/dump_path = R.product_path
+			if(!R.amount)
+				continue
+			new dump_path(src.loc)
 			R.amount--
 
-	var/obj/item/weapon/vending_refill/Refill = new refill_canister(src.loc)
-	Refill.charges = refilling
+		//Dropping remaining items in a pack
+		var/refilling = 0
+		for(var/datum/data/vending_product/R in src.product_records)
+			while(R.amount > 0)
+				refilling++
+				R.amount--
+
+		var/obj/item/weapon/vending_refill/Refill = new refill_canister(src.loc)
+		Refill.charges = refilling
+	else //If no canister - drop everything
+		for(var/datum/data/vending_product/R in src.product_records)
+			while(R.amount > 0)
+				var/dump_path = R.product_path
+				new dump_path(src.loc)
+				R.amount--
 
 	stat |= BROKEN
 	src.icon_state = "[initial(icon_state)]-broken"

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -55,6 +55,8 @@
 	var/datum/wires/vending/wires = null
 	var/scan_id = TRUE
 
+	var/private = FALSE
+
 
 /obj/machinery/vending/atom_init(mapload)
 	. = ..()
@@ -107,7 +109,7 @@
 	for(var/typepath in productlist)
 		var/amount = productlist[typepath]
 		if(!hidden && !req_coin && !req_emag)
-			if(mapload && is_station_level(src.z) && refill_canister)
+			if(mapload && is_station_level(src.z) && !private)
 				var/players_coefficient = num_players() / 75 //75 players = max load, 0 players = min load
 				var/randomness_coefficient = rand(50,100) / 100 //50-100% randomness
 				var/final_coefficient = clamp(players_coefficient * randomness_coefficient, 0.1, 1.0) //10% minimum, 100% maximum

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -55,7 +55,7 @@
 	var/datum/wires/vending/wires = null
 	var/scan_id = TRUE
 
-	var/private = TRUE
+	var/private = TRUE // Whether the vending machine is privately operated, and thus must not start with a deficit of goods.
 
 
 /obj/machinery/vending/atom_init(mapload)

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -55,7 +55,7 @@
 	var/datum/wires/vending/wires = null
 	var/scan_id = TRUE
 
-	var/private = FALSE
+	var/private = TRUE
 
 
 /obj/machinery/vending/atom_init(mapload)

--- a/code/game/machinery/vending/clothing.dm
+++ b/code/game/machinery/vending/clothing.dm
@@ -180,6 +180,7 @@
 		/obj/item/clothing/glasses/gar = 34,
 	)
 	refill_canister = /obj/item/weapon/vending_refill/clothing
+	private = FALSE
 
 /obj/machinery/vending/theater
 	name = "Theater-o-mat"
@@ -236,6 +237,7 @@
 	contraband = list(
 		/obj/item/clothing/mask/gas/fawkes = 2,
 	)
+	private = TRUE
 
 /obj/machinery/vending/noiromat
 	name = "Noir-O-Mat"
@@ -276,6 +278,7 @@
 	product_slogans = "The cheaper the crook, the gaudier the patter.;Dead men are heavier than broken hearts.;Life is a bucket of shit with a barbed wire handle.;After all, you are only an immortal until someone manages to kill you. After that, you were just long-lived.;The rain fell like dead bullets.;Though I often run out of courage and good sense, stubbornness keeps me going."
 	product_ads = "Keep your mind too open, and you never know what might walk in.;After all, you are only an immortal until someone manages to kill you. After that, you were just long-lived.;If you don't trust anyone, they can't let you down.;Wait. You've got principles? We'll have to update your file.;I always feel most alive when everything else is dying all around me."
 	req_access = list(68)
+	private = TRUE
 
 /obj/machinery/vending/magivend
 	name = "MagiVend"
@@ -309,3 +312,4 @@
 	contraband = list(
 		/obj/item/weapon/reagent_containers/pill/adminordrazine = 1,
 	)
+	private = TRUE

--- a/code/game/machinery/vending/eat.dm
+++ b/code/game/machinery/vending/eat.dm
@@ -44,6 +44,7 @@
 	product_ads = "Drink up!;Booze is good for you!;Alcohol is humanity's best friend.;Quite delighted to serve you!;Care for a nice, cold beer?;Nothing cures you like booze!;Have a sip!;Have a drink!;Have a beer!;Beer is good for you!;Only the finest alcohol!;Best quality booze since 2053!;Award-winning wine!;Maximum alcohol!;Man loves beer.;A toast for progress!"
 	req_access = list(25)
 	refill_canister = /obj/item/weapon/vending_refill/boozeomat
+	private = TRUE
 
 /obj/machinery/vending/coffee
 	name = "Hot Drinks machine"
@@ -67,6 +68,7 @@
 		/obj/item/weapon/reagent_containers/food/drinks/h_chocolate = 15,
 	)
 	refill_canister = /obj/item/weapon/vending_refill/coffee
+	private = FALSE
 
 /obj/machinery/vending/snack
 	name = "Getmore Chocolate Corp"
@@ -103,6 +105,7 @@
 		/obj/item/weapon/storage/food/normal/honkers = 15,
 	)
 	refill_canister = /obj/item/weapon/vending_refill/snack
+	private = FALSE
 
 /obj/random/vending/snack
 	name = "random snack vendor"
@@ -151,6 +154,7 @@
 		/obj/item/weapon/kitchen/utensil/fork/sticks = 1,
 	)
 	refill_canister = /obj/item/weapon/vending_refill/chinese
+	private = FALSE
 
 /obj/machinery/vending/cola
 	name = "Robust Softdrinks"
@@ -183,6 +187,7 @@
 		/obj/item/weapon/reagent_containers/food/drinks/cans/grape_juice = 3,
 	)
 	refill_canister = /obj/item/weapon/vending_refill/cola
+	private = FALSE
 
 /obj/random/vending/cola
 	name = "random cola vendor"
@@ -240,6 +245,7 @@
 	syndie = list(
 		/obj/item/weapon/reagent_containers/food/drinks/drinkingglass/kvass = 10,
 	)
+	private = TRUE
 
 /obj/machinery/vending/junkfood
 	name = "McNuffin's Fast Food"
@@ -271,6 +277,7 @@
 		/obj/item/weapon/reagent_containers/food/snacks/fishfingers = 2,
 	)
 	refill_canister = /obj/item/weapon/vending_refill/junkfood
+	private = FALSE
 
 /obj/machinery/vending/donut
 	name = "Monkin' Donuts"
@@ -301,6 +308,7 @@
 		/obj/item/weapon/storage/fancy/donut_box = 3,
 	)
 	refill_canister = /obj/item/weapon/vending_refill/donut
+	private = FALSE
 
 /obj/machinery/vending/sustenance
 	name = "Sustenance Vendor"
@@ -318,3 +326,4 @@
 	contraband = list(
 		/obj/item/weapon/kitchenknife = 6,
 	)
+	private = TRUE

--- a/code/game/machinery/vending/engineering.dm
+++ b/code/game/machinery/vending/engineering.dm
@@ -12,6 +12,7 @@
 	)
 	product_ads = "Only the finest!;Have some tools.;The most robust equipment.;The finest gear in space!"
 	refill_canister = /obj/item/weapon/vending_refill/assist
+	private = FALSE
 
 /obj/machinery/vending/phoronresearch
 	name = "Toximate 3000"
@@ -23,6 +24,7 @@
 		/obj/item/device/assembly/prox_sensor = 6,
 		/obj/item/device/assembly/igniter = 6,
 	)
+	private = TRUE
 
 /obj/machinery/vending/tool
 	name = "YouTool"
@@ -50,6 +52,7 @@
 		/obj/item/weapon/gun/energy/pyrometer/engineering = 1,
 	)
 	refill_canister = /obj/item/weapon/vending_refill/tool
+	private = TRUE
 
 /obj/machinery/vending/engivend
 	name = "Engi-Vend"
@@ -81,6 +84,7 @@
 		/obj/item/weapon/storage/part_replacer = 1,
 	)
 	refill_canister = /obj/item/weapon/vending_refill/engivend
+	private = TRUE
 
 /obj/machinery/vending/engineering
 	name = "Robco Tool Maker"
@@ -116,6 +120,7 @@
 		/obj/item/weapon/stock_parts/console_screen = 5,
 		/obj/item/weapon/gun/energy/pyrometer/engineering = 4,
 	)
+	private = TRUE
 	// There was an incorrect entry (cablecoil/power).  I improvised to cablecoil/heavyduty.
 	// Another invalid entry, /obj/item/weapon/circuitry.  I don't even know what that would translate to, removed it.
 	// The original products list wasn't finished.  The ones without given quantities became quantity 5.  -Sayu
@@ -140,3 +145,4 @@
 		/obj/item/weapon/gun/energy/pyrometer/engineering/robotics = 2,
 		/obj/item/clothing/glasses/hud/diagnostic = 5,
 	)
+	private = TRUE

--- a/code/game/machinery/vending/hydroponics.dm
+++ b/code/game/machinery/vending/hydroponics.dm
@@ -19,6 +19,7 @@
 		/obj/item/weapon/reagent_containers/glass/bottle/diethylamine = 5,
 	)
 	refill_canister = /obj/item/weapon/vending_refill/hydronutrients
+	private = TRUE
 
 /obj/machinery/vending/hydroseeds
 	name = "MegaSeed Servitor"
@@ -75,3 +76,4 @@
 		/obj/item/toy/waterflower = 1,
 	)
 	refill_canister = /obj/item/weapon/vending_refill/hydroseeds
+	private = TRUE

--- a/code/game/machinery/vending/medical.dm
+++ b/code/game/machinery/vending/medical.dm
@@ -27,6 +27,7 @@
 		/obj/item/weapon/reagent_containers/pill/dylovene = 6,
 	)
 	refill_canister = /obj/item/weapon/vending_refill/medical
+	private = TRUE
 
 /obj/machinery/vending/wallmed1
 	name = "NanoMed"
@@ -49,6 +50,7 @@
 		/obj/item/weapon/reagent_containers/syringe/antiviral = 4,
 		/obj/item/weapon/reagent_containers/pill/tox = 1,
 	)
+	private = TRUE
 
 /obj/machinery/vending/wallmed2
 	name = "NanoMed"
@@ -70,6 +72,7 @@
 	contraband = list(
 		/obj/item/weapon/reagent_containers/pill/tox = 3,
 	)
+	private = TRUE
 
 /obj/machinery/vending/omskvend
 	name = "Omsk-o-mat"
@@ -82,6 +85,7 @@
 	contraband = list(
 		/obj/item/weapon/reagent_containers/glass/bottle/antitoxin = 4,
 	)
+	private = TRUE
 
 /obj/item/weapon/reagent_containers/pill/LSD
 	name = "LSD"

--- a/code/game/machinery/vending/modkit.dm
+++ b/code/game/machinery/vending/modkit.dm
@@ -8,6 +8,7 @@
 		/obj/item/device/modkit/vox = 15,
 		/obj/item/device/modkit = 30,
 	)
+	private = TRUE
 
 /obj/machinery/vending/eva/mining
 	name = "Mining Hardsuit Kits"
@@ -20,6 +21,7 @@
 		/obj/item/device/modkit/vox = 3,
 		/obj/item/device/modkit = 5,
 	)
+	private = TRUE
 
 /obj/machinery/vending/eva/engineering
 	name = "Engineering Hardsuit Kits"
@@ -33,3 +35,4 @@
 		/obj/item/device/modkit/vox = 6,
 		/obj/item/device/modkit = 12,
 	)
+	private = TRUE

--- a/code/game/machinery/vending/other.dm
+++ b/code/game/machinery/vending/other.dm
@@ -15,6 +15,7 @@
 		/obj/item/weapon/cartridge/captain = 3,
 		/obj/item/weapon/cartridge/quartermaster = 10,
 	)
+	private = TRUE
 
 /obj/machinery/vending/cigarette
 	name = "Cigarette machine" //OCD had to be uppercase to look nice with the new formating
@@ -48,6 +49,7 @@
 		/obj/item/clothing/mask/ecig = 40,
 	)
 	refill_canister = /obj/item/weapon/vending_refill/cigarette
+	private = FALSE
 
 /obj/machinery/vending/security
 	name = "SecTech"
@@ -71,6 +73,7 @@
 		/obj/item/ammo_box/a357 = 1,
 		/obj/item/ammo_box/magazine/m9mm = 1,
 	)
+	private = TRUE
 
 /obj/machinery/vending/weirdomat
 	name = "Weird-O-Mat"
@@ -112,6 +115,7 @@
 	product_slogans = "Amicitiae nostrae memoriam spero sempiternam fore;Aequam memento rebus in arduis servare mentem;Vitanda est improba siren desidia;Serva me, servabo te;Faber est suae quisque fortunae"
 	vend_reply = "Have fun! No returns!"
 	product_ads = "Occult is magic;Knowledge is magic;All the magic!;None to spook us;The dice has been cast"
+	private = TRUE
 
 /obj/machinery/vending/weirdomat/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/device/occult_scanner))
@@ -173,6 +177,7 @@
 		/obj/item/weapon/reagent_containers/glass/bottle/hair_growth_accelerator = 3,
 		/obj/item/weapon/storage/box/lipstick = 3,
 	)
+	private = TRUE
 
 /obj/machinery/vending/dinnerware
 	name = "Dinnerware"
@@ -203,6 +208,7 @@
 		/obj/item/weapon/reagent_containers/glass/bottle/alphaamanitin/syndie = 1,
 	)
 	refill_canister = /obj/item/weapon/vending_refill/dinnerware
+	private = TRUE
 
 /obj/machinery/vending/blood
 	name = "Blood'O'Matic"
@@ -225,6 +231,7 @@
 		/obj/item/weapon/reagent_containers/blood/empty = 10,
 	)
 	refill_canister = /obj/item/weapon/vending_refill/blood
+	private = TRUE
 
 /obj/machinery/vending/syndi
 	name = "KillNTVend"
@@ -267,8 +274,9 @@
 		"Heavy hybrid suit" = /obj/item/weapon/storage/box/syndie_kit/heavy_rig,
 		"Assault Armor" = /obj/item/weapon/storage/box/syndie_kit/armor,
 	)
-	
+
 	var/static/list/selections_armor
+	private = TRUE
 
 /obj/machinery/vending/syndi/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/weapon/mining_voucher/kit))
@@ -396,3 +404,4 @@
 		/obj/item/clothing/mask/tie/golden_cross = 1000,
 		/obj/item/clothing/shoes/jolly_gravedigger = 200,
 	)
+	private = TRUE


### PR DESCRIPTION
## Описание изменений
1.Вендоматы становятся полупустыми только если их возможно пополнить...
2.Вендоматы дропают рефил канистру только если она существует, если нет то дропают как раньше все предметы...
3.Для лоу попа 20% шанс у пустых ячеек на то чтобы стать не пустыми.

## Почему и что этот ПР улучшит
Фиксы багов и недоработок.

## Авторство
AndreyGysev и все все все, кто помогал в дискорде.

## Чеинжлог
 :cl:
  - bugfix: Вендоматы становятся полупустыми только если их возможно пополнить.
  - bugfix: Вендоматы дропают рефил канистру только если она существует, если нет то дропают как раньше все предметы.
  - bugfix: Для лоу попа 20% шанс у пустых ячеек на то чтобы стать не пустыми.