### PR TITLE
Mine Items Rebalance

### DIFF
--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -271,29 +271,29 @@
 	RefreshParts()
 	prize_list = list()
 	prize_list["Gear"] = list(
-		EQUIPMENT("GPS Device",						/obj/item/device/gps/mining,													200),
+		EQUIPMENT("GPS Device",						/obj/item/device/gps/mining,													100),
 	)
 	prize_list["Consumables"] = list(
-		EQUIPMENT("Stimpack",						/obj/item/weapon/reagent_containers/hypospray/autoinjector/stimpack,			150),
+		EQUIPMENT("Stimpack",						/obj/item/weapon/reagent_containers/hypospray/autoinjector/stimpack,			100),
 		EQUIPMENT("lipozine pill",					/obj/item/weapon/reagent_containers/pill/lipozine,								200),
 		EQUIPMENT("leporazine autoinjector",		/obj/item/weapon/reagent_containers/hypospray/autoinjector/leporazine,			300),
-		EQUIPMENT("Stimpack Bundle",				/obj/item/weapon/storage/box/autoinjector/stimpack,								700),
-		EQUIPMENT("Space first-aid kit",			/obj/item/weapon/storage/firstaid/small_firstaid_kit/space,						1200),
-		EQUIPMENT("Standart capsule",				/obj/item/weapon/survivalcapsule,												1300),
-		EQUIPMENT("Improved capsule",				/obj/item/weapon/survivalcapsule/improved,										1900),
-		EQUIPMENT("Elite capsule(Bar)",				/obj/item/weapon/survivalcapsule/elite,											3000),
+		EQUIPMENT("Stimpack Bundle",				/obj/item/weapon/storage/box/autoinjector/stimpack,								400),
+		EQUIPMENT("Space first-aid kit",			/obj/item/weapon/storage/firstaid/small_firstaid_kit/space,						1000),
+		EQUIPMENT("Standart capsule",				/obj/item/weapon/survivalcapsule,												500),
+		EQUIPMENT("Improved capsule",				/obj/item/weapon/survivalcapsule/improved,										1000),
+		EQUIPMENT("Elite capsule(Bar)",				/obj/item/weapon/survivalcapsule/elite,											1500),
 	)
 	prize_list["Upgrades"] = list(
 		EQUIPMENT("Accelerator resources upgrade",	/obj/item/kinetic_upgrade/resources,											1750),
 		EQUIPMENT("Accelerator damage upgrade",		/obj/item/kinetic_upgrade/damage,												2000),
-		EQUIPMENT("Accelerator recharge upgrade",	/obj/item/kinetic_upgrade/speed,												2250),
+		EQUIPMENT("Accelerator recharge upgrade",	/obj/item/kinetic_upgrade/speed,												1250),
 		EQUIPMENT("Accelerator range upgrade",		/obj/item/kinetic_upgrade/range,												2500),
 		EQUIPMENT("Expander for accelerator",		/obj/item/kinetic_expander,														3000),
 	)
 	prize_list["Miscellaneous"] = list(
 		EQUIPMENT("Chili",							/obj/item/weapon/reagent_containers/food/snacks/hotchili,						150),
 		EQUIPMENT("Vodka",							/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka,					200),
-		EQUIPMENT("Soap",							/obj/item/weapon/reagent_containers/food/snacks/soap/nanotrasen,				250),
+		EQUIPMENT("Soap",							/obj/item/weapon/reagent_containers/food/snacks/soap/nanotrasen,				150),
 		EQUIPMENT("Alien toy",						/obj/item/clothing/mask/facehugger_toy,											300),
 		EQUIPMENT("Point card",						/obj/item/weapon/card/mining_point_card,										1000),
 		EQUIPMENT("Space cash",						/obj/item/weapon/spacecash/c1000,												5000),

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -504,7 +504,7 @@ var/global/mining_shuttle_location = 0 // 0 = station 13, 1 = mining station
 	item_state = "kineticgun"
 	ammo_type = list(/obj/item/ammo_casing/energy/kinetic)
 	cell_type = /obj/item/weapon/stock_parts/cell/crap
-	var/recharge_time = 2.1 SECONDS
+	var/recharge_time = 2.0 SECONDS
 	var/damage = 10
 	var/range = 3
 	var/mineral_multiply_coefficient = 1.0
@@ -693,7 +693,6 @@ var/global/mining_shuttle_location = 0 // 0 = station 13, 1 = mining station
 	if((iswallturf(target)) && (prob(destruction_chance)))
 		target.ex_act(EXPLODE_HEAVY)
 
-
 /obj/item/weapon/gun/energy/laser/cutter/atom_init()
 	. = ..()
 	power_supply.AddComponent(/datum/component/cell_selfrecharge, 50)
@@ -707,6 +706,25 @@ var/global/mining_shuttle_location = 0 // 0 = station 13, 1 = mining station
 	emagged = TRUE
 	to_chat(user, "<span class='warning'>Ошибка: Обнаружен несовместимый модуль. Ошибкаошибкаошибка.</span>")
 	return TRUE
+
+/obj/item/weapon/gun/energy/laser/cutter/attackby(obj/item/A, mob/user)
+	if(istype(A, /obj/item/stack/sheet/mineral/phoron))
+		if(power_supply.charge >= power_supply.maxcharge)
+			to_chat(user,"<span class='notice'>[src] is already fully charged.")
+			return
+		var/obj/item/stack/sheet/S = A
+		S.use(1)
+		power_supply.give(1000)
+		to_chat(user, "<span class='notice'>You insert [A] in [src], recharging it.</span>")
+	else if(istype(A, /obj/item/weapon/ore/phoron))
+		if(power_supply.charge >= power_supply.maxcharge)
+			to_chat(user,"<span class='notice'>[src] is already fully charged.")
+			return
+		qdel(A)
+		power_supply.give(500)
+		to_chat(user, "<span class='notice'>You insert [A] in [src], recharging it.</span>")
+	else
+		return ..()
 
 /obj/item/weapon/gun/energy/laser/cutter/emagged //for robots
 	emagged = TRUE
@@ -807,7 +825,7 @@ var/global/mining_shuttle_location = 0 // 0 = station 13, 1 = mining station
 /obj/item/kinetic_upgrade/speed
 	name = "accelerator upgrade(speed)"
 	icon_state = "accelerator_upg_speed"
-	var/cooldown_reduction = 0.35 SECOND
+	var/cooldown_reduction = 0.4 SECOND
 
 /obj/item/kinetic_upgrade/speed/atom_init()
 	desc += "Ускоряет <span class='notice'><B>перезарядку</B></span> на <span class='notice'><B>[cooldown_reduction / 10]</B></span> секунды."


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Ребаланс цен шахтерского вендомата: они возвращены к старым значениям для всего, кроме новых апгрейдов для кинетика. Улучшение кинетического акселератора: перезарядка возвращена к старым значениям, а именно 2 секунды до апгрейдов и 1.2 секунды после. Плазменный резак теперь можно заряжать фороном (листовым и рудой),что позволит  шахтерам им копать (сейчас это не особо возможно из-за крайне быстрой разрядки).
## Почему и что этот ПР улучшит
Сделано на основе ишуя #10638, геймплей шахтеров был необоснованно замедлен, откат цен и перезарядки кинетика улучшит ситуацию. Плазменный резак шахтер сможет на месте быстро заряжать фороном, что сделает его юзабельным.
## Авторство
  Код перезарядки плазменного резака взят с билда парадизов и переработан под реалии Тау.
## Чеинжлог
:cl:
 - balance: Уменьшены цены в шахтерском вендомате
 - balance: Ускорена перезарядка кинетического акселератора
 - add: Плазменный резак перезаряжается фороном (листовым и рудой)