### PR TITLE
Нерф коктелей нейротоксина и бипски смэша

### DIFF
--- a/code/modules/reagents/reagent_types/Chemistry-Drinks.dm
+++ b/code/modules/reagents/reagent_types/Chemistry-Drinks.dm
@@ -598,6 +598,7 @@
 	description = "A strong neurotoxin that puts the subject into a death-like state."
 	reagent_state = LIQUID
 	color = "#2e2e61" // rgb: 46, 46, 97
+	custom_metabolism = 2
 	taste_message = "brain damageeeEEeee"
 	restrict_species = list(IPC, DIONA)
 
@@ -1206,13 +1207,14 @@
 	description = "Deny drinking this and prepare for THE LAW."
 	reagent_state = LIQUID
 	color = "#664300" // rgb: 102, 67, 0
+	custom_metabolism = 2
 	boozepwr = 4
 	taste_message = "THE LAW"
 
 /datum/reagent/consumable/ethanol/beepsky_smash/on_general_digest(mob/living/M)
 	..()
 	if(!HAS_TRAIT(M, TRAIT_ALCOHOL_TOLERANCE))
-		M.Stun(10)
+		M.Stun(5)
 
 /datum/reagent/consumable/ethanol/irish_cream
 	name = "Irish Cream"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Уменьшить стан нейротоксина и Бипски Смєша
Цель ПРа в первую очередь занерфить слишком имбовый предмет вместо удаления. Уменьшив время действия, этот коктейль станет менее эффективнее против больших групп игроков. Против соло игрока он все еще останется сильным, на что наверное он и задумывался.
## Почему и что этот ПР улучшит
В нынешних реалиях 1 укол(5 унций) бипски станет на 50 секунд, а нейротоксином на 30 секунд. С этим изменением стан уменьшиться в разы, где то 10-15 секунд за укол, это все еще много, но уже более приемлемо.
## Авторство

## Чеинжлог
