### PR TITLE
Исправление рантайма при стрельбе по стенам

### DIFF
--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -485,7 +485,7 @@
 
 /turf/simulated/wall/bullet_act(obj/item/projectile/Proj, def_zone)
 	. = ..()
-	if(!Proj.nodamage && (Proj.damage_type == BRUTE || Proj.damage_type == BURN) && prob(75))
+	if(!Proj.nodamage && (Proj.damage_type == BRUTE || Proj.damage_type == BURN) && prob(75) && iswallturf(src))
 		add_dent(WALL_DENT_SHOT, Proj.p_x, Proj.p_y)
 
 /turf/simulated/wall/proc/add_dent(denttype, x, y)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Исправление рантайма при стрельбе по стенам оружием разрушающим его, например pulse rifle или plasma cutter
Runtime in walls.dm:489 : undefined proc or verb /turf/simulated/floor/plating/add dent().
  proc name: bullet act (/turf/simulated/wall/bullet_act)
  usr.loc: The floor  (174,128,2) (/turf/simulated/floor)
  src: the plating (178,131,2) (/turf/simulated/floor/plating)
  call stack:
  the plating (178,131,2) (/turf/simulated/floor/plating): bullet act(the pulse (/obj/item/projectile/beam/pulse), "chest")
  the pulse (/obj/item/projectile/beam/pulse): Bump(the plating (178,131,2) (/turf/simulated/floor/plating), 1)
  the plating (178,131,2) (/turf/simulated/floor/plating): Enter(the pulse (/obj/item/projectile/beam/pulse), the floor (177,130,2) (/turf/simulated/floor))
  the pulse (/obj/item/projectile/beam/pulse): Move(the plating (178,131,2) (/turf/simulated/floor/plating), 0, 0, 0)
  the pulse (/obj/item/projectile/beam/pulse): process(1)
## Почему и что этот ПР улучшит
Меньше багов
## Авторство

## Чеинжлог
:cl:
- bugfix: Исправление рантайма при стрельбе по стенам оружием разрушающим его