### PR TITLE
голосование за шатл в красный код хотя бы

### DIFF
--- a/code/controllers/subsystem/voting/poll_types.dm
+++ b/code/controllers/subsystem/voting/poll_types.dm
@@ -101,8 +101,6 @@
 		return
 	if(SSshuttle.online || SSshuttle.location != 0)
 		return "Шаттл используется"
-	if(security_level >= SEC_LEVEL_RED)
-		return "Код безопасности КРАСНЫЙ или выше"
 
 /datum/poll/crew_transfer/get_vote_power(client/C, datum/vote_choice/choice)
 	return get_vote_power_by_role(C) * choice.vote_weight


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Голосование за шатл доступно в красный код
## Почему и что этот ПР улучшит
Бывают ситуации когда сделают красный код и из-за него раунд может идти очень долго, при этом в раунде ниче особо не происходит, а выведенных игроков много. Этот ПР позволит быстрее завершать подобные раунды.
## Авторство

## Чеинжлог
:cl: 
- tweak: Голосование за шатл доступно в красный код