### PR TITLE
Удаляет Диагональное Движение

### DIFF
--- a/code/modules/keybindings/bindings_atom.dm
+++ b/code/modules/keybindings/bindings_atom.dm
@@ -3,8 +3,10 @@
 
 /atom/movable/keyLoop(client/user)
 	var/movement_dir = NONE
-	for(var/_key in user.keys_held)
-		movement_dir = movement_dir | user.movement_keys[_key]
+	if(length(user.keys_held) > 0)
+		var/_key = user.keys_held[1]
+		movement_dir = user.movement_keys[_key]
+
 	if(user.next_move_dir_add)
 		movement_dir |= user.next_move_dir_add
 	if(user.next_move_dir_sub)

--- a/code/modules/keybindings/bindings_atom.dm
+++ b/code/modules/keybindings/bindings_atom.dm
@@ -7,16 +7,6 @@
 		var/_key = user.keys_held[1]
 		movement_dir = user.movement_keys[_key]
 
-	if(user.next_move_dir_add)
-		movement_dir |= user.next_move_dir_add
-	if(user.next_move_dir_sub)
-		movement_dir &= ~user.next_move_dir_sub
-	// Sanity checks in case you hold left and right and up to make sure you only go up
-	if((movement_dir & NORTH) && (movement_dir & SOUTH))
-		movement_dir &= ~(NORTH|SOUTH)
-	if((movement_dir & EAST) && (movement_dir & WEST))
-		movement_dir &= ~(EAST|WEST)
-
 	if(movement_dir) //If we're not moving, don't compensate, as byond will auto-fill dir otherwise
 		movement_dir = turn(movement_dir, -dir2angle(user.dir)) //By doing this we ensure that our input direction is offset by the client (camera) direction
 


### PR DESCRIPTION
## Описание изменений

При нажатии нескольких клавиш, первая попавшая в список нажатий будет использоваться, а остальные нет.

Соответственно диагональное движение не возможно.

Не стал выпиливать тысячу проверок на диагональное движение там где они есть на случай если появится моб которому оно очень нужно, чтобы он не ломал весь билд :). А так же для совместимости с теми репо откуда вы эту гадость украли. Если увижу поддержку этой инициативы, то можно обсудить и выпилить всё связанное с этой фичей.

В теории кто-то особо умелый мог бы сделать всё необходимо чтобы диагональное движение перестало быть костылём из двух Мувов, и стало на равных с обычным. Это бы нивелировали все пункты ниже кроме пункта 3, не знаю как вообще пункт 3 адекватно балансить :), ирациональные числа всё такое

## Почему и что этот ПР улучшит

1. Любые механики требующие точного и предсказуемого движения
    а) Проход по диагонали мимо ловушки (никогда не знаешь триггернешь ли ты её!)
    б) Случайное открытие двух шлюзов при выходе из системы двойных шлюзов (вниз - нет, а вверх- да!)
2. Любые механики перемещения по трубам (они сейчас и так блокируют диагональное движение чем создаёт путанницу, почему везде можно, а в месте где это было бы особенно удобно позволять - нет :) )
    а) фиксит все баги с запрыгиванием мусорку и выпригиванием в стене!
3. Пофиксит проблему того что по диагонали бежишь быстрее чем двумя шагами
   а) почему-то убегать по диагонали быстрее

4. всегда так было и было хорошо!!! !!! !!!

![image](https://user-images.githubusercontent.com/17705613/221633435-1d0c6420-5e07-4472-a21e-d1ea5274bbf7.png)

## Что может улучшить полное удаление
2. б) фиксит все баги с прокидыванием предметов в стену через мусорку
5. Фиксит стрельбу через угловые стены
   а) Я сказал недостаточно?


## Чеинжлог
:cl: Luduk
- rscdel: Диагональное движение удалено.