### PR TITLE
remove update_canmove from silicons

### DIFF
--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -207,3 +207,6 @@
 	if(laws && isobserver(user))
 		to_chat(user, "<b>[src] has the following laws:</b><br>[write_laws()]")
 
+/mob/living/silicon/update_canmove(no_transform)
+	return
+


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Убрал у ИИ и ПИИ update_canmove т.к. она  может ломать их логику (к примеру отцепить ИИ от пола).
P.s. у robot update_canmove предопределено.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
