### PR TITLE
Обновление скилов на установку столов

### DIFF
--- a/code/game/objects/items/weapons/table_rack_parts.dm
+++ b/code/game/objects/items/weapons/table_rack_parts.dm
@@ -46,8 +46,6 @@
 	..()
 
 /obj/item/weapon/table_parts/attack_self(mob/user)
-	if(!handle_fumbling(user, src, SKILL_TASK_AVERAGE, list(/datum/skill/engineering = SKILL_LEVEL_NOVICE)))
-		return
 	var/turf/simulated/T = get_turf(user)
 	if(!T || !T.CanPass(null, T))
 		to_chat(user, "<span class='warning'>You can't put it here!</span>")
@@ -66,6 +64,9 @@
 		return TRUE
 	return FALSE
 
+/obj/item/weapon/table_parts/reinforced/attack_self(mob/user)
+	if(handle_fumbling(user, src, SKILL_TASK_AVERAGE, list(/datum/skill/engineering = SKILL_LEVEL_NOVICE)))
+		return ..()
 /*
  * Glass Table Parts
  */

--- a/code/game/objects/items/weapons/table_rack_parts.dm
+++ b/code/game/objects/items/weapons/table_rack_parts.dm
@@ -15,6 +15,9 @@
  * Table Parts
  */
 // Return TRUE if reacted to a tool.
+/obj/item/weapon/table_parts
+	var/build_time = 0
+
 /obj/item/weapon/table_parts/proc/attack_tools(obj/item/W, mob/user)
 	if(iswrenching(W))
 		deconstruct(TRUE, user)
@@ -47,26 +50,34 @@
 
 /obj/item/weapon/table_parts/attack_self(mob/user)
 	var/turf/simulated/T = get_turf(user)
-	if(!T || !T.CanPass(null, T))
+	if(!can_place(T))
 		to_chat(user, "<span class='warning'>You can't put it here!</span>")
 		return
-	var/obj/structure/table/R = new table_type( T )
+	if(build_time > 0 && !handle_fumbling(user, src, build_time, list(/datum/skill/engineering = SKILL_LEVEL_NOVICE)))
+		return
+	if(!can_place(T))
+		to_chat(user, "<span class='warning'>You can't put it here!</span>")
+		return
+	var/obj/structure/table/R = new table_type(T)
 	to_chat(user, "<span class='notice'>You assemble [src].</span>")
 	R.add_fingerprint(user)
 	qdel(src)
 
+/obj/item/weapon/table_parts/proc/can_place(turf/T)
+	return T && T.CanPass(null, T)
+
 /*
  * Reinforced Table Parts
  */
+/obj/item/weapon/table_parts/reinforced
+	build_time = SKILL_TASK_AVERAGE
+
 /obj/item/weapon/table_parts/reinforced/attack_tools(obj/item/W, mob/user)
 	if(iswrenching(W))
 		deconstruct(TRUE, user)
 		return TRUE
 	return FALSE
 
-/obj/item/weapon/table_parts/reinforced/attack_self(mob/user)
-	if(handle_fumbling(user, src, SKILL_TASK_AVERAGE, list(/datum/skill/engineering = SKILL_LEVEL_NOVICE)))
-		return ..()
 /*
  * Glass Table Parts
  */


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Твик #10723, в соответствии с #10890.
Проблема что офицеры могут установить обычные столы в действительности незначительна, так как обычные столы можно опрокидывать и ставить назад без каких либо усилий всем. Также можно легко проползти под столом. Переносим фамблинг на установку стола только таким столам, которые являются серьёзным препятствием.
## Почему и что этот ПР улучшит
квалити оф лайф игрокам которые устанавливают столы не для того, чтобы создать препятствия для движения персонажей. Удаление минусов и добавление плюсов механики скилов.
## Авторство

## Чеинжлог
:cl: Deahaka
- tweak: Установка обычного стола теперь не требует навыков.