### PR TITLE
Цены предметов в аплинке трейтора будут немного меняться

### DIFF
--- a/code/datums/uplinks_items.dm
+++ b/code/datums/uplinks_items.dm
@@ -45,6 +45,7 @@
 	var/category = "item category"
 	var/desc = "item description"
 	var/item = null
+	var/group = "standart"
 	var/cost = 0
 	var/last = 0 // Appear last
 	var/list/uplink_types = list() //Empty list means that the object will be available in all types of uplinks. Alias you will need to state its type.
@@ -124,6 +125,7 @@
 
 /datum/uplink_item/dangerous
 	category = "Conspicuous and Dangerous Weapons"
+	group = "dangerous"
 
 /datum/uplink_item/dangerous/revolver
 	name = "TR-7 Revolver"
@@ -365,6 +367,7 @@
 
 /datum/uplink_item/ammo
 	category = "Ammunition"
+	group = "ammo"
 
 /datum/uplink_item/ammo/borg
 	name = "Robot Ammo Box"
@@ -525,6 +528,7 @@
 
 /datum/uplink_item/stealthy_weapons
 	category = "Stealthy and Inconspicuous Weapons"
+	group = "stealthy_weapons"
 	uplink_types = list("nuclear", "traitor")
 
 /datum/uplink_item/stealthy_weapons/dart_pistol
@@ -584,6 +588,7 @@
 
 /datum/uplink_item/stealthy_tools
 	category = "Stealth and Camouflage Items"
+	group = "stealthy_tools"
 	uplink_types = list("nuclear", "traitor")
 
 /datum/uplink_item/stealthy_tools/switchblade
@@ -695,6 +700,7 @@
 
 /datum/uplink_item/device_tools
 	category = "Devices and Tools"
+	group = "device_tools"
 
 /datum/uplink_item/device_tools/rad_laser
 	name = "Radioactive Microlaser"
@@ -931,6 +937,7 @@
 
 /datum/uplink_item/implants
 	category = "Implants"
+	group = "implants"
 	uplink_types = list("nuclear", "traitor")
 
 /datum/uplink_item/implants/freedom

--- a/code/game/gamemodes/roles/traitor.dm
+++ b/code/game/gamemodes/roles/traitor.dm
@@ -3,6 +3,7 @@
 	id = TRAITOR
 	required_pref = ROLE_TRAITOR
 	logo_state = "synd-logo"
+	var/discount_group = "group"
 
 	restricted_jobs = list("Cyborg", "Security Cadet", "Internal Affairs Agent", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Velocity Officer", "Velocity Chief", "Velocity Medical Doctor", "Blueshield Officer")
 	antag_hud_type = ANTAG_HUD_TRAITOR
@@ -18,6 +19,21 @@
 /datum/role/traitor/New()
 	..()
 	AddComponent(/datum/component/gamemode/syndicate, telecrystals, "traitor")
+
+/datum/role/traitor/proc/get_discount_group()
+	switch(rand(1,60))
+		if (1 to 10)
+			return "dangerous"
+		if (11 to 20)
+			return "ammo"
+		if (21 to 30)
+			return "stealthy_weapons"
+		if (31 to 40)
+			return "stealthy_tools"
+		if (41 to 50)
+			return "device_tools"
+		if(51 to 60)
+			return "implants"
 
 /datum/role/traitor/proc/add_one_objective(datum/mind/traitor)
 	switch(rand(1,120))
@@ -94,6 +110,7 @@
 		else
 			to_chat(antag.current, "[bicon(logo, css = "style='position:relative; top:10;'")] <span class='danger'>You are a Traitor.</span>")
 
+	group = get_discount_group()
 	return TRUE
 
 /datum/role/traitor/OnPostSetup(laterole)

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -22,6 +22,16 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 	dat += "<HR>"
 	dat += "<B>Request item:</B><BR>"
 	dat += "<I>Each item costs a number of tele-crystals as indicated by the number following their name.</I><br><BR>"
+	var/mob_discount_group = "discount_group"
+	var/is_mob_traitor = FALSE
+
+
+	var/datum/role/traitor/R = user.mind.antag_roles["Traitor"]
+	if(R)
+		is_mob_traitor = TRUE
+		mob_discount_group = R.discount_group
+
+
 
 	if(uplink_items.len)
 		uplink_items.Cut()
@@ -40,6 +50,15 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 		for(var/datum/uplink_item/item in buyable_items[category])
 			i++
 			var/cost_text = ""
+
+
+			if(is_mob_traitor==TRUE && item.group != "standart")
+				if(item.group == mob_discount_group)
+					item.cost *= 0.5
+				else
+					item.cost *= 2		
+
+
 			if(item.cost > 0)
 				cost_text = "([item.cost])"
 			if(item.cost <= uses)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Разделил предметы аплинка на несколько групп (dangerous, implants и т.д)
Каждому трейтору случайным образом присваивается группа предметов, на которую он получит скидку в 50%
На предметы из остальных групп цена вырастет в 2 раза.
Цена комплектов/случайных предметов без изменений.
Аплинки ревы, нюки и трейторчана не трогал.
(подорожание и удешевление можно и не в 2 раза сделать)
## Почему и что этот ПР улучшит
Трейтор не сможет гарантированно взять дабл-сворд, адреналин, и пойти кошмарить станцию.
(Или пусть ищет трейтора со скидкой на эти предметы)
Больше взаимодействия между трейторами.
Меньше резни?
## Авторство
-
## Чеинжлог
:cl: Kandrey
 - tweak: Цены на предметы из аплинка будут меняться