### PR TITLE
сhem master buff

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -351,7 +351,7 @@
 
 /obj/machinery/chem_master/atom_init()
 	. = ..()
-	var/datum/reagents/R = new/datum/reagents(100)
+	var/datum/reagents/R = new/datum/reagents(150)
 	reagents = R
 	R.my_atom = src
 


### PR DESCRIPTION
## Описание изменений
Изменён внутренний буфер chem master с 100 до 150 юнитов.
## Почему и что этот ПР улучшит
QOL для химиков. Не надо прокликивать лишний раз когда наварил 120\150 юнитов лекарства.
## Авторство

## Чеинжлог
:cl:
- tweak: Внутренний буфер chem master увеличен с 100 до 150 юнитов