### PR TITLE
fixes runtime: рандом мув не имел аргумента

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -211,9 +211,9 @@
 
 		SEND_SIGNAL(mob, COMSIG_CLIENTMOB_POSTMOVE, n, direct)
 
-/mob/proc/random_move(mob/M)
-	if(isturf(M.loc) && !isspaceturf(M.loc) || (M.canmove && !M.incapacitated()))
-		step(M, pick(cardinal))
+/mob/proc/random_move()
+	if(isturf(loc) && !isspaceturf(loc) || (canmove && !incapacitated()))
+		step(src, pick(cardinal))
 
 /mob/proc/SelfMove(turf/n, direct)
 	if(camera_move(direct))


### PR DESCRIPTION
## Описание изменений

654 Runtime in mob_movement.dm:215 : Cannot read null.loc

Вызывалась функция random_move которая ожидала аргумент M, но нигде его не принимала.

## Почему и что этот ПР улучшит

котики зло
