### PR TITLE
fixes runtime: atmos fucks CanPass up

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -5,6 +5,9 @@
 	else if(retVal & COMPONENT_CANPASS)
 		return TRUE
 
+	if(!mover)
+		return TRUE
+
 	if(istype(mover, /obj/item/projectile) || mover.throwing)
 		return (!density || lying)
 	if(mover.checkpass(PASSMOB) || checkpass(PASSMOB))


### PR DESCRIPTION
## Описание изменений

697 Runtime in mob_movement.dm:8 : Cannot read null.throwing

Фикист этот рантайм. CanPass может принимать null в качестве mover если идёт речь о проверке атмосовой.

## Почему и что этот ПР улучшит

котики
