### PR TITLE
КМ дебил пароль не поставил

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -13508,7 +13508,8 @@
 /area/station/security/range)
 "axc" = (
 /obj/machinery/computer/cargo{
-	dir = 1
+	dir = 1;
+	req_access = list()
 	},
 /turf/simulated/floor{
 	dir = 9;


### PR DESCRIPTION
## Описание изменений
У КМа нет пароля на консоли

## Почему и что этот ПР улучшит
Ломимся к КМу и заказываем штуки.

Станцию можно будет прокормить/обеспечить в раундах где нет КМ-а, по аналогии с тем как можно запустить двигатель без инженеров, или лечиь людей без медиков.

## Авторство
AndreyGysev и все все все, кто помогал в дискорде.

## Чеинжлог
 :cl:
 - tweak: На консоли заказа у КМа нет требования доступа.