### PR TITLE
Удаление вечного рантайма мага

### DIFF
--- a/maps/centcom/centcom.dmm
+++ b/maps/centcom/centcom.dmm
@@ -11919,7 +11919,6 @@
 	},
 /area/custom/wizard_station)
 "aBs" = (
-/mob/living/simple_animal/cat/runtime/fake,
 /turf/unsimulated/floor{
 	icon = 'icons/turf/carpets.dmi';
 	icon_state = "bluecarpet";


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Зачем он там? Он вроде никак не коррелирует с магией, а является чистым порождением пересечения флуктуаций блюспейса

## Почему и что этот ПР улучшит
Маги не будут умирать при тесте заклинания "превращения в мышь" (или че-то подобное)

## Авторство

## Чеинжлог
