### PR TITLE
токсидемедж не вызывает рвоту

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -161,7 +161,7 @@ var/global/list/tourette_bad_words= list(
 				return
 	if (disabilities & TOURETTES || HAS_TRAIT(src, TRAIT_TOURETTE))
 		if(!(get_species() in tourette_bad_words))
-			return 
+			return
 		speech_problem_flag = 1
 		if (prob(10))
 			spawn( 0 )
@@ -1108,10 +1108,6 @@ var/global/list/tourette_bad_words= list(
 	return TRUE
 
 /mob/living/carbon/human/proc/handle_random_events()
-	// Puke if toxloss is too high
-	if(stat == CONSCIOUS)
-		if (getToxLoss() >= 45)
-			invoke_vomit_async()
 
 	//0.1% chance of playing a scary sound to someone who's in complete darkness
 	if(isturf(loc) && rand(1,1000) == 1)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
токсидемедж не вызывает рвоту
## Почему и что этот ПР улучшит
делает яды юзабельными
сейчас яды никому нах не всрались по причине того что они могут нанести от силы 80 урона, после чего они вылезают из организма благодаря рвоте
## Авторство

## Чеинжлог
🆑 Simbaka
- del: Токсины не вызывают рвоту.