### PR TITLE
[DNM] Prometheus Map Edit. Assistent's room

### DIFF
--- a/maps/prometheus/prometheus.dmm
+++ b/maps/prometheus/prometheus.dmm
@@ -3606,9 +3606,13 @@
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
 "arm" = (
-/obj/structure/closet/firecloset,
-/obj/machinery/newscaster{
+/obj/machinery/power/apc{
+	name = "apc down";
 	pixel_y = -28
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor{
 	icon_state = "yellow"
@@ -4230,11 +4234,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -5707,6 +5706,9 @@
 "aQd" = (
 /obj/item/weapon/storage/firstaid,
 /obj/structure/table,
+/obj/machinery/newscaster{
+	pixel_x = -28
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -24425,6 +24427,9 @@
 /obj/item/weapon/reagent_containers/food/drinks/cans/grape_juice{
 	pixel_y = 4
 	},
+/obj/machinery/newscaster{
+	pixel_y = 28
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "yellow"
@@ -24558,13 +24563,9 @@
 	pixel_y = 4
 	},
 /obj/item/device/flashlight,
-/obj/machinery/power/apc{
-	name = "apc down";
-	pixel_y = -28
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -32
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -24591,10 +24592,13 @@
 	},
 /area/station/storage/tech)
 "fvf" = (
-/obj/machinery/space_heater,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -22
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/alarm{
+	pixel_y = -32
 	},
 /turf/simulated/floor{
 	icon_state = "yellow"
@@ -25305,9 +25309,6 @@
 /area/station/maintenance/brig)
 "fEb" = (
 /obj/structure/reagent_dispensers/water_cooler,
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = -28;
@@ -25676,10 +25677,10 @@
 	},
 /area/station/maintenance/medbay)
 "fHH" = (
-/obj/structure/closet/crate/engi,
 /obj/structure/sign/departments/engineering{
 	pixel_y = -32
 	},
+/obj/structure/closet/emcloset,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -30398,6 +30399,11 @@
 /turf/simulated/floor,
 /area/station/medical/reception)
 "gLU" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "yellow"
 	},
@@ -36581,9 +36587,6 @@
 /area/station/medical/reception)
 "ikr" = (
 /obj/machinery/disposal,
-/obj/machinery/light/small{
-	dir = 1
-	},
 /obj/structure/disposalpipe/trunk,
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor{
@@ -37748,9 +37751,6 @@
 "iAF" = (
 /obj/structure/rack,
 /obj/item/weapon/storage/toolbox/emergency,
-/obj/machinery/light/small{
-	dir = 4
-	},
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "yellow"
@@ -43087,6 +43087,11 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor{
 	icon_state = "yellow"
 	},
@@ -49659,12 +49664,6 @@
 /area/station/maintenance/medbay)
 "lDb" = (
 /obj/machinery/recharge_station,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 29
-	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "yellow"
@@ -53077,13 +53076,10 @@
 /area/station/maintenance/science)
 "mur" = (
 /obj/structure/table,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/alarm{
-	pixel_y = 22
-	},
 /obj/item/weapon/storage/belt/utility,
+/obj/machinery/light_switch{
+	pixel_y = 28
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -59956,7 +59952,6 @@
 /area/station/engineering/atmos)
 "oeW" = (
 /obj/structure/closet/emcloset,
-/obj/machinery/light/small,
 /turf/simulated/floor{
 	icon_state = "yellow"
 	},
@@ -63399,7 +63394,6 @@
 	},
 /area/station/maintenance/medbay)
 "oXg" = (
-/obj/structure/closet/emcloset,
 /obj/machinery/alarm{
 	pixel_x = 29;
 	pixel_y = -6
@@ -63844,10 +63838,15 @@
 	},
 /area/station/hallway/secondary/arrival)
 "pdR" = (
-/obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/machinery/light,
-/obj/machinery/light_switch{
-	pixel_y = -28
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor{
 	icon_state = "yellow"
@@ -64744,12 +64743,6 @@
 "prS" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 28
-	},
-/obj/machinery/newscaster{
-	pixel_y = 28
-	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "yellow"
@@ -65002,12 +64995,17 @@
 	},
 /area/station/civilian/kitchen)
 "puI" = (
-/obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -22
 	},
+/obj/structure/rack,
+/obj/item/clothing/suit/storage/hazardvest,
+/obj/item/weapon/tank/emergency_oxygen/engi,
+/obj/item/weapon/tank/emergency_oxygen/engi,
+/obj/item/clothing/mask/gas/coloured,
+/obj/item/clothing/mask/gas/coloured,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "yellow"
@@ -70969,6 +70967,7 @@
 	dir = 4;
 	pixel_y = 38
 	},
+/obj/item/clothing/suit/storage/hazardvest,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -85399,6 +85398,11 @@
 "uEB" = (
 /obj/structure/stool,
 /obj/effect/landmark/start/technical_assistant,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "yellow"
 	},
@@ -87858,13 +87862,6 @@
 	},
 /area/station/civilian/barbershop)
 "vhx" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/storage/hazardvest,
-/obj/item/clothing/suit/storage/hazardvest,
-/obj/item/weapon/tank/emergency_oxygen/engi,
-/obj/item/weapon/tank/emergency_oxygen/engi,
-/obj/item/clothing/mask/gas/coloured,
-/obj/item/clothing/mask/gas/coloured,
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "apc top";
@@ -98463,10 +98460,6 @@
 /obj/structure/table,
 /obj/machinery/light{
 	dir = 1
-	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 22
 	},
 /obj/item/device/assembly/signaler{
 	pixel_x = -5;

--- a/maps/prometheus/prometheus.dmm
+++ b/maps/prometheus/prometheus.dmm
@@ -5705,10 +5705,8 @@
 /turf/simulated/floor/carpet/green,
 /area/station/civilian/dormitories)
 "aQd" = (
-/obj/item/weapon/storage/belt/utility,
 /obj/item/weapon/storage/firstaid,
 /obj/structure/table,
-/obj/random/tools/tool,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -7831,7 +7829,6 @@
 	pixel_y = -4
 	},
 /obj/item/weapon/screwdriver,
-/obj/random/tools/tool,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -24561,8 +24558,6 @@
 	pixel_y = 4
 	},
 /obj/item/device/flashlight,
-/obj/random/tools/tool,
-/obj/random/tools/technology_scanner,
 /obj/machinery/power/apc{
 	name = "apc down";
 	pixel_y = -28
@@ -37753,7 +37748,6 @@
 "iAF" = (
 /obj/structure/rack,
 /obj/item/weapon/storage/toolbox/emergency,
-/obj/random/tools/tool,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -53083,14 +53077,13 @@
 /area/station/maintenance/science)
 "mur" = (
 /obj/structure/table,
-/obj/random/tools/technology_scanner,
-/obj/random/tools/tool,
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
+/obj/item/weapon/storage/belt/utility,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -56680,9 +56673,7 @@
 /area/station/cargo/office)
 "nny" = (
 /obj/structure/table,
-/obj/item/weapon/wrench,
-/obj/item/device/analyzer,
-/obj/random/tools/tool,
+/obj/item/device/tagger/shop,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -70962,9 +70953,7 @@
 /area/station/maintenance/medbay)
 "qWo" = (
 /obj/structure/table,
-/obj/item/device/t_scanner,
 /obj/item/clothing/gloves/fyellow,
-/obj/random/tools/tool,
 /obj/structure/sign/directions/security{
 	buildable_sign = 0;
 	dir = 4;
@@ -76152,7 +76141,6 @@
 "smC" = (
 /obj/structure/rack,
 /obj/item/weapon/storage/toolbox/electrical,
-/obj/random/tools/tool,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "yellow"
@@ -83745,7 +83733,6 @@
 	pixel_y = 5
 	},
 /obj/item/weapon/stock_parts/cell/high,
-/obj/random/tools/tool,
 /obj/machinery/camera{
 	c_tag = "Primary Tool Storage"
 	},
@@ -93286,14 +93273,16 @@
 /area/station/civilian/bar)
 "wxH" = (
 /obj/structure/rack,
-/obj/item/stack/cable_coil/random{
-	pixel_y = 4
-	},
-/obj/item/stack/cable_coil/random,
-/obj/random/tools/tool,
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_y = 8
+	},
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_y = 4
+	},
+/obj/item/weapon/storage/toolbox/mechanical,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -98472,9 +98461,6 @@
 /area/station/ai_monitored/storage_secure)
 "xPR" = (
 /obj/structure/table,
-/obj/item/weapon/crowbar,
-/obj/item/device/assembly/signaler,
-/obj/random/tools/tool,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -98482,7 +98468,15 @@
 	name = "Station Intercom (General)";
 	pixel_y = 22
 	},
-/obj/item/device/tagger/shop,
+/obj/item/device/assembly/signaler{
+	pixel_x = -5;
+	pixel_y = 8
+	},
+/obj/item/device/assembly/signaler{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/device/assembly/signaler,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
1. Пожарные ящики не нужны в коридоре, им самое место в техах.
2. Обогреватели не нужны в коридоре, максимум у инженерки/атмосферки, им самое место в техах.
3. Разбросанные инструменты не нужны в ассистентской, для этого есть вендомат.
4. Избыток света - больше потребление энергии в пустую. Не надо так.
5. Ящики, тем более пустые (!), не нужны в коридоре, им самое место в техах.

Уменьшил всего этого добра в ассистентской и соседнем отсеке.

UPD. 
6. АПЦ в местах где стоит стол или какая-то ещё хрень плох, потому что терминала не видно. Перенёс всё.
## Почему и что этот ПР улучшит
# Было:
![000000000000000000000000000000000000007 - копия](https://user-images.githubusercontent.com/96499407/223664892-7733a73f-9eb7-4c2a-96ee-d3bc7b0ff4b0.png)
# Стало:
![000000000000000000000000000000000000007](https://user-images.githubusercontent.com/96499407/223664955-89deca74-bcf7-4f70-aaa6-6f6d01252b37.png)
И соседний отсек немножко потыкал:
![0000000000000000000000000000000000](https://user-images.githubusercontent.com/96499407/223665003-8031a109-5f03-47e8-b508-5ab1edc4f312.png)


## Авторство

## Чеинжлог
:cl: Deahaka
- map: Ассистентская и лобби инженерки на NSS Prometheus получили немного косметических изменений.