### PR TITLE
Фикс+облегчение строительства вендоматов

### DIFF
--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -262,7 +262,7 @@ to destroy them and players will be able to make replacements.
 					continue
 				names_of_vendings["[initial(type.name)] ([initial(type.icon_state)])"] = type
 
-		var/vending_name = tgui_input_list(user, "Выбери новую марку", "Выбор торгового автомата", names_of_vendings)
+		var/vending_name = tgui_input_list(user, "Выберите новую марку", "Выбор торгового автомата", names_of_vendings)
 		if(isnull(vending_name))
 			return
 		

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -260,7 +260,15 @@ to destroy them and players will be able to make replacements.
 			for(var/obj/machinery/vending/type as anything in typesof(/obj/machinery/vending))
 				if(!initial(type.refill_canister))
 					continue
-				names_of_vendings["[initial(type.name)] ([initial(type.icon_state)])"] = type
+				var/full_name
+				if(initial(type.subname))
+					full_name = "[initial(type.name)] ([initial(type.subname)])"
+				else
+					full_name = initial(type.name)
+
+				ASSERT(!names_of_vendings[full_name])
+
+				names_of_vendings[full_name] = type
 
 		var/vending_name = tgui_input_list(user, "Выберите новую марку", "Выбор торгового автомата", names_of_vendings)
 		if(isnull(vending_name))

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -254,40 +254,25 @@ to destroy them and players will be able to make replacements.
 
 /obj/item/weapon/circuitboard/vendor/attackby(obj/item/I, mob/user, params)
 	if(isscrewing(I))
-		var/list/names = list(/obj/machinery/vending/boozeomat = "Booze-O-Mat",
-							/obj/machinery/vending/snack = "Getmore Chocolate Corp (Red)",
-							/obj/machinery/vending/snack/blue = "Getmore Chocolate Corp (Blue)",
-							/obj/machinery/vending/snack/orange = "Getmore Chocolate Corp (Orange)",
-							/obj/machinery/vending/snack/green = "Getmore Chocolate Corp (Green)",
-							/obj/machinery/vending/snack/teal = "Getmore Chocolate Corp (Teal)",
-							/obj/machinery/vending/coffee = "Hot Drinks",
-							/obj/machinery/vending/cola = "Robust Softdrinks (Blue)",
-							/obj/machinery/vending/cola/black = "Robust Softdrinks (Black)",
-							/obj/machinery/vending/cola/red = "Robust Softdrinks (Red)",
-							/obj/machinery/vending/cola/spaceup = "Robust Softdrinks (Space-Up!)",
-							/obj/machinery/vending/cola/starkist = "Robust Softdrinks (Starkist)",
-							/obj/machinery/vending/cola/soda = "Robust Softdrinks (Soda)",
-							/obj/machinery/vending/cola/gib = "Robust Softdrinks (Dr. Gibb)",
-							/obj/machinery/vending/cigarette = "Cigarette",
-							/obj/machinery/vending/barbervend = "Fab-O-Vend",
-							/obj/machinery/vending/chinese = "Mr. Chang",
-							/obj/machinery/vending/medical = "NanoMed Plus",
-							/obj/machinery/vending/hydronutrients = "NutriMax",
-							/obj/machinery/vending/hydroseeds = "MegaSeed Servitor",
-							/obj/machinery/vending/dinnerware = "Dinnerware",
-							/obj/machinery/vending/tool = "YouTool",
-							/obj/machinery/vending/engivend = "Engi-Vend",
-							/obj/machinery/vending/clothing = "ClothesMate",
-							/obj/machinery/vending/blood = "Blood'O'Matic",
-							/obj/machinery/vending/junkfood = "McNuffin's Fast Food",
-							/obj/machinery/vending/donut = "Monkin' Donuts",
-			)
-//							/obj/machinery/vending/autodrobe = "AutoDrobe")
+		var/static/list/names_of_vendings = list()
 
-		build_path = pick(names)
-		name = "circuit board ([names[build_path]] Vendor)"
-		to_chat(user, "<span class='notice'>You set the board to [names[build_path]].</span>")
-		req_components = list(text2path("/obj/item/weapon/vending_refill/[copytext("[build_path]", 24)]") = 3)       //Never before has i used a method as horrible as this one, im so sorry
+		if(names_of_vendings.len == 0)
+			for(var/obj/machinery/vending/type as anything in typesof(/obj/machinery/vending))
+				if(!initial(type.refill_canister))
+					continue
+				names_of_vendings["[initial(type.name)] ([initial(type.icon_state)])"] = type
+
+		var/vending_name = tgui_input_list(user, "Выбери новую марку", "Выбор торгового автомата", names_of_vendings)
+		if(isnull(vending_name))
+			return
+		
+		var/obj/machinery/vending/vending_type = names_of_vendings[vending_name]
+
+		to_chat(user, "<span class='notice'>You set the board to [vending_name].</span>")
+
+		name = "circuit board ([vending_name] Vendor)"
+		build_path = vending_type
+		req_components = list(initial(vending_type.refill_canister) = 3)
 		return
 	return ..()
 

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -255,6 +255,7 @@ to destroy them and players will be able to make replacements.
 /obj/item/weapon/circuitboard/vendor/attackby(obj/item/I, mob/user, params)
 	if(isscrewing(I))
 		var/static/list/names_of_vendings = list()
+		var/static/list/radial_icons = list()
 
 		if(names_of_vendings.len == 0)
 			for(var/obj/machinery/vending/type as anything in typesof(/obj/machinery/vending))
@@ -269,8 +270,9 @@ to destroy them and players will be able to make replacements.
 				ASSERT(!names_of_vendings[full_name])
 
 				names_of_vendings[full_name] = type
+				radial_icons[full_name] = icon(initial(type.icon), initial(type.icon_state))
 
-		var/vending_name = tgui_input_list(user, "Выберите новую марку", "Выбор торгового автомата", names_of_vendings)
+		var/vending_name = show_radial_menu(user, src, radial_icons, require_near = TRUE, tooltips = TRUE)
 		if(isnull(vending_name))
 			return
 		

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -10,6 +10,9 @@
 	desc = "A generic vending machine."
 	icon = 'icons/obj/vending.dmi'
 	icon_state = "generic"
+
+	var/subname = null // subname for vendor's circuit name
+
 	var/light_range_on = 3
 	var/light_power_on = 1
 	layer = 2.9

--- a/code/game/machinery/vending/eat.dm
+++ b/code/game/machinery/vending/eat.dm
@@ -72,6 +72,7 @@
 
 /obj/machinery/vending/snack
 	name = "Getmore Chocolate Corp"
+	subname = "Red"
 	desc = "A snack machine courtesy of the Getmore Chocolate Corporation, based out of Mars."
 	product_slogans = "Try our new nougat bar!;Twice the calories for half the price!"
 	product_ads = "The healthiest!;Award-winning chocolate bars!;Mmm! So good!;Oh my god it's so juicy!;Have a snack.;Snacks are good for you!;Have some more Getmore!;Best quality snacks straight from mars.;We love chocolate!;Try our new jerky!"
@@ -116,20 +117,24 @@
 	return pick(typesof(/obj/machinery/vending/snack))
 
 /obj/machinery/vending/snack/blue
+	subname = "Blue"
 	icon_state = "snackblue"
 	light_color = "#5efb00"
 
 /obj/machinery/vending/snack/orange
+	subname = "Orange"
 	icon_state = "snackorange"
 	light_color = "#ff8b02"
 
 /obj/machinery/vending/snack/green
+	subname = "Green"
 	icon_state = "snackgreen"
 	light_color = "#10ff1f"
 
 /obj/machinery/vending/snack/teal
 	icon_state = "snackteal"
 	light_color = "#ffc400"
+	subname = "Teal"
 
 /obj/machinery/vending/chinese
 	name = "Mr. Chang"
@@ -158,6 +163,7 @@
 
 /obj/machinery/vending/cola
 	name = "Robust Softdrinks"
+	subname = "Blue"
 	desc = "A softdrink vendor provided by Robust Industries, LLC."
 	icon_state = "colablue"
 	light_color = "#315ab4"
@@ -197,39 +203,43 @@
 /obj/random/vending/cola/item_to_spawn()
 	return pick(typesof(/obj/machinery/vending/cola))
 
-/obj/machinery/vending/cola/blue
-
 /obj/machinery/vending/cola/black
+	subname = "Black"
 	icon_state = "colablack"
 	light_color = "#dddddd"
 
 /obj/machinery/vending/cola/red
+	subname = "Red"
 	desc = "It vends cola, in space."
 	icon_state = "colared"
 	product_slogans = "Cola in space!"
 	light_color = "#bf0a38"
 
 /obj/machinery/vending/cola/spaceup
+	subname = "Lime, Space-up"
 	desc = "Indulge in an explosion of flavor."
 	icon_state = "spaceup"
 	product_slogans = "Space-up! Like a hull breach in your mouth."
 	light_color = "#18d32f"
 
 /obj/machinery/vending/cola/starkist
+	subname = "Orange, Starkist"
 	desc = "The taste of a star in liquid form."
 	icon_state = "starkist"
 	product_slogans = "Drink the stars! Star-kist!"
 	light_color = "#d1751a"
 
 /obj/machinery/vending/cola/soda
+	subname = "Red, Soda"
 	icon_state = "soda"
-	light_color = "c8c8be"
+	light_color = "#c8c8be"
 
 /obj/machinery/vending/cola/gib
+	subname = "Red, Dr. Gibb"
 	desc = "Canned explosion of different flavors in this very vendor!"
 	icon_state = "gib"
 	product_slogans = "You will lose your guts because of our drinks!; Explosion - in a can!"
-	light_color = "d23c3c"
+	light_color = "#d23c3c"
 
 /obj/machinery/vending/sovietsoda
 	name = "BODA"

--- a/code/game/machinery/vending/eat.dm
+++ b/code/game/machinery/vending/eat.dm
@@ -132,9 +132,9 @@
 	light_color = "#10ff1f"
 
 /obj/machinery/vending/snack/teal
+	subname = "Teal"
 	icon_state = "snackteal"
 	light_color = "#ffc400"
-	subname = "Teal"
 
 /obj/machinery/vending/chinese
 	name = "Mr. Chang"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Теперь можно создать любой вендомат, для которого установлен refills (включая различные цвета). Выбор типа vendor circuit теперь на tgui.
Из сомнительных решений, в скобках указан icon_state вендомата чтобы нормально работали цвета, и не пришлось менять названия / доп переменную ставить.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
