### PR TITLE
Убирает эксту из team based

### DIFF
--- a/code/game/gamemodes/modesbundle.dm
+++ b/code/game/gamemodes/modesbundle.dm
@@ -89,6 +89,10 @@
 	black_types = subtypesof(/datum/game_mode/mix) + list(/datum/game_mode/extended, /datum/game_mode/malfunction)
 	..()
 
+/datum/modesbundle/all/teambased/New()
+	black_types = list(/datum/game_mode/extended)
+	..()
+	
 /datum/modesbundle/run_anyway
 	name = "Modes that will ALWAYS start"
 	votable = FALSE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Пишите если чё неправильно в коде, я хз будет ли это работать
## Почему и что этот ПР улучшит
Не будет эксты там где она не нужна
## Авторство

## Чеинжлог
:cl:
- tweak: Убрана экста из team based