### PR TITLE
фикс зарплат

### DIFF
--- a/nano/templates/pda.tmpl
+++ b/nano/templates/pda.tmpl
@@ -1076,7 +1076,7 @@ Used In File(s): \code\game\objects\items\devices\PDA\PDA.dm
                     <tr><th>Name</th><th>Rank</th><th>Salary</th></tr>
                     {{for data.subordinate_staff}}
                         <tr><td>{{:value.name}}</td><td>{{:value.rank}}</td><td>{{:value.salary}}</td>
-                        <td>{{:helper.link('Change', null, {'choice' : "Change Salary", 'account' : value.acc_number}, null, null)}}</td></tr>
+                        <td>{{:helper.link('Change', null, {'choice' : "Change Salary", 'account' : value.account}, null, null)}}</td></tr>
                     {{/for}}
                 </table></center>
             </div>


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
в шаблонах везде берётся value.account, а в зарплатах почему-то был value.acc_number
## Почему и что этот ПР улучшит
closes #10901 
## Авторство

## Чеинжлог
:cl: Kandrey
 - bugfix: Зарплаты снова можно менять
