### PR TITLE
рандомная сытость

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -432,7 +432,7 @@
 	new_character.dna.ready_dna(new_character)
 	new_character.dna.b_type = client.prefs.b_type
 	new_character.dna.UpdateSE()
-
+	new_character.nutrition = rand(NUTRITION_LEVEL_STARVING, NUTRITION_LEVEL_FAT)
 	if(key)
 		new_character.key = key		//Manually transfer the key to log them in
 

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -433,8 +433,8 @@
 	new_character.dna.b_type = client.prefs.b_type
 	new_character.dna.UpdateSE()
 	new_character.nutrition = rand(NUTRITION_LEVEL_STARVING, NUTRITION_LEVEL_FAT)
-	var/c = new_character.get_metabolism_factor()
-	new_character.metabolism_factor.Set(c * (1 + pick(-0.1, 0.1)))
+	var/old_base_metabolism = new_character.get_metabolism_factor()
+	new_character.metabolism_factor.Set(old_base_metabolism * rand(9, 11) * 0.1)
 	
 	if(key)
 		new_character.key = key		//Manually transfer the key to log them in

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -434,7 +434,7 @@
 	new_character.dna.UpdateSE()
 	new_character.nutrition = rand(NUTRITION_LEVEL_STARVING, NUTRITION_LEVEL_FAT)
 	var/c = new_character.get_metabolism_factor()
-	new_character.metabolism_factor.Set(c*(1+pick(-0.1,0.1)))
+	new_character.metabolism_factor.Set(c * (1 + pick(-0.1, 0.1)))
 	
 	if(key)
 		new_character.key = key		//Manually transfer the key to log them in

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -433,6 +433,9 @@
 	new_character.dna.b_type = client.prefs.b_type
 	new_character.dna.UpdateSE()
 	new_character.nutrition = rand(NUTRITION_LEVEL_STARVING, NUTRITION_LEVEL_FAT)
+	var/c = new_character.get_metabolism_factor()
+	new_character.metabolism_factor.Set(c*(1+pick(-0.1,0.1)))
+	
 	if(key)
 		new_character.key = key		//Manually transfer the key to log them in
 

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -432,7 +432,7 @@
 	new_character.dna.ready_dna(new_character)
 	new_character.dna.b_type = client.prefs.b_type
 	new_character.dna.UpdateSE()
-	new_character.nutrition = rand(NUTRITION_LEVEL_STARVING, NUTRITION_LEVEL_FAT)
+	new_character.nutrition = rand(NUTRITION_LEVEL_HUNGRY, NUTRITION_LEVEL_FULL)
 	var/old_base_metabolism = new_character.get_metabolism_factor()
 	new_character.metabolism_factor.Set(old_base_metabolism * rand(9, 11) * 0.1)
 	


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
При создании куклы для игрока её уровень насыщения будет устанавливаться случайно
upd: Теперь у каждой куклы метаболизм будет меняться на 10% (в плюс или минус)
## Почему и что этот ПР улучшит
Экипаж будет прибывать с разным уровнем сытости (реализм?)
Чуть более равномерная нагрузка на повара (а не так, что первую половину смены он никому не нужен, а во вторую все разом побегут кухню обчищать)


## Авторство

## Чеинжлог
:cl: Kandrey
 - tweak: Экипаж будет прибывать на станцию с разным уровнем сытости
 - tweak: Метаболизм каждой куклы будет на 10% быстрее/медленнее