### PR TITLE
использование шприца на себе делает персонажа грустным

### DIFF
--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -59,6 +59,11 @@
 	mood_change = -3
 	timeout = 1 MINUTE
 
+/datum/mood_event/self_inject
+	description = "<span class='warning'>I hate it when I inject something into myself, let someone else do it to me.</span>"
+	mood_change = -2
+	timeout = 1 MINUTE
+
 /datum/mood_event/depression
 	description = "<span class='boldwarning'>I feel bad for no apparent reason. My life sucks...</span>"
 	mood_change = -6

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -162,6 +162,7 @@
 				else
 					if(!L.try_inject(user, TRUE, TRUE))
 						return
+					SEND_SIGNAL(target, COMSIG_ADD_MOOD_EVENT, "self_inject", /datum/mood_event/self_inject)
 					user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [src.name] to inject self ([user.ckey]). Reagents: [contained]</font>")
 					reagents.reaction(target, INGEST)
 					infect_limb(user, target)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

## Почему и что этот ПР улучшит
собственно, игра наказывает персонажей за самолечение бинтиками, почему тогда это не распространяется на шприцы с лекарствами, которые в пару раз эффективнее бинтов?
если прям очень хочецца полечиться - ешьте таблетки
## Авторство

## Чеинжлог
🆑 Simbaka
- tweak: Если персонаж вкалывает что-то в себя с помощью шприца, то у него опускается настроение.