### PR TITLE
Geiger hotfix

### DIFF
--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -94,12 +94,12 @@
 	flag = ENERGY
 
 /obj/item/projectile/energy/floramut/on_hit(atom/target, def_zone = BP_CHEST, blocked = 0)
-	irradiate_one_mob(target, rand(30, 80))
 	var/mob/living/M = target
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = M
 		if((H.species.flags[IS_PLANT]) && (M.nutrition < 500))
 			if(prob(15))
+				irradiate_one_mob(M, rand(30, 80))
 				M.Stun(2)
 				M.Weaken(5)
 				visible_message("<span class='warning'>[M] writhes in pain as \his vacuoles boil.</span>", blind_message = "<span class='warning'>You hear the crunching of leaves.</span>")


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
выдавал раньше от таргета-турфа в рендже радиацию, поменял на прок который работает только на моба, а не поменял аргументы. Если стрелять флорамутом по не мобу то будут рантаймы так как сможет нанести apply_effect(_, IRRADIATE)

Посмотрел другие места с этим проком, там всё корректно по мобам работает.
## Почему и что этот ПР улучшит
меньше багов
## Авторство

## Чеинжлог
