### PR TITLE
небольшой фикс

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -714,7 +714,7 @@ var/global/list/tourette_bad_words= list(
 			var/pain = getHalLoss()
 			if(pain > 0)
 				nutrition = max(0, nutrition - met_factor * pain * 0.01)
-	if (nutrition > 450)
+	if (nutrition > NUTRITION_LEVEL_FULL)
 		if(overeatduration < 600) //capped so people don't take forever to unfat
 			overeatduration++
 	else


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Чтобы потолстеть, кукле нужно набрать определённое количество переедания (переедание начисляется, если насыщение превышает определённое значение)
этот ПР https://github.com/TauCetiStation/TauCetiClassic/pull/10986
ставит голод от 250 до 550
Если выпадет около 510, то к 20 минуте раунда у куклы наберётся переедание для превращения в толстяка
фиксится это или понижением порога в том ПРе, или этим ПРом, который поднимает планку начисления переедания на 100
## Почему и что этот ПР улучшит
Люди перестанут толстеть на 20 минуте
## Авторство

## Чеинжлог
:cl: Kandrey
- bugfix: Люди перестанут толстеть без причины