### PR TITLE
Игроки не спавнятся раундстарт с ожирением

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -432,10 +432,10 @@
 	new_character.dna.ready_dna(new_character)
 	new_character.dna.b_type = client.prefs.b_type
 	new_character.dna.UpdateSE()
-	new_character.nutrition = rand(NUTRITION_LEVEL_HUNGRY, NUTRITION_LEVEL_FULL)
+	new_character.nutrition = rand(NUTRITION_LEVEL_HUNGRY, NUTRITION_LEVEL_WELL_FED)
 	var/old_base_metabolism = new_character.get_metabolism_factor()
 	new_character.metabolism_factor.Set(old_base_metabolism * rand(9, 11) * 0.1)
-	
+
 	if(key)
 		new_character.key = key		//Manually transfer the key to log them in
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -714,7 +714,7 @@ var/global/list/tourette_bad_words= list(
 			var/pain = getHalLoss()
 			if(pain > 0)
 				nutrition = max(0, nutrition - met_factor * pain * 0.01)
-	if (nutrition > 450)
+	if (nutrition > NUTRITION_LEVEL_WELL_FED)
 		if(overeatduration < 600) //capped so people don't take forever to unfat
 			overeatduration++
 	else


### PR DESCRIPTION
## Описание изменений

всё что выше WELL_FED это ожирение, теперь игроки не будут спавниться с ожирением. так же воткнул этот дефайн в лайф чтобы это было очевидно

## Почему и что этот ПР улучшит

меньше бомбежки у игроков
