### PR TITLE
CentComm Buying Underpriced CargoTrade Items

### DIFF
--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -18,6 +18,9 @@ SUBSYSTEM_DEF(economy)
 		for(var/datum/money_account/D in all_money_accounts)
 			if(D.owner_salary && !D.suspended)
 				charge_to_account(D.account_number, D.account_number, "Salary payment", "CentComm", D.owner_salary)
+
+		monitor_cargo_shop()
+
 	payment_counter += 1
 
 /datum/controller/subsystem/economy/proc/set_endtime()

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -692,9 +692,8 @@
 				var/list/Lots = global.online_shop_lots_hashed[index]
 				for(var/datum/shop_lot/Lot in Lots)
 					if(Lot && Lot.category == category && !Lot.sold)
-						var/datum/money_account/Acc = get_account(Lot.account)
 						shop_lots.len++
-						shop_lots[shop_lots.len] = Lot.to_list(Acc ? Acc.owner_name : "Unknown")
+						shop_lots[shop_lots.len] = Lot.to_list()
 						break
 
 		shop_lots_frontend = list()
@@ -1136,13 +1135,15 @@
 						if(online_shop_lots_hashed.Find(Lot.hash))
 							for(var/datum/shop_lot/NewLot in online_shop_lots_hashed[Lot.hash])
 								if(NewLot && !NewLot.sold && (Lot.get_discounted_price() <= NewLot.get_discounted_price()))
-									if(!order_item(NewLot, T))
+									if(!order_onlineshop_item(owner, owner_account, NewLot, T))
+										shopping_cart[NewLot.number] = Lot.to_list()
 										to_chat(U, "<span class='notice'>ОШИБКА: Недостаточно средств.</span>")
 									return
 						to_chat(U, "<span class='notice'>ОШИБКА: Этот предмет уже куплен.</span>")
 						return
 					else
-						if(!order_item(Lot, T))
+						if(!order_onlineshop_item(owner, owner_account, Lot, T))
+							shopping_cart[Lot.number] = Lot.to_list()
 							to_chat(U, "<span class='notice'>ОШИБКА: Недостаточно средств.</span>")
 				else
 					to_chat(U, "<span class='notice'>ОШИБКА: Не введён адрес доставки.</span>")
@@ -1839,53 +1840,6 @@
 /obj/item/device/pda/proc/check_rank(rank)
 	if((rank in command_positions) || (rank == "Quartermaster"))
 		boss_PDA = 1
-
-/obj/item/device/pda/proc/order_item(datum/shop_lot/Lot, destination)
-	var/datum/money_account/MA = get_account(owner_account)
-	if(!MA || !Lot)
-		return FALSE
-
-	var/discount_price = Lot.get_discounted_price()
-	var/delivery_cost = Lot.get_delivery_cost()
-
-	if(delivery_cost > MA.money)
-		return FALSE
-	Lot.sold = TRUE
-	for(var/i=1, i<=3, i++)
-		if(global.online_shop_lots_latest[i] == Lot)
-			global.online_shop_lots_latest[i] = null
-			break
-	var/datum/money_account/Acc = get_account(Lot.account)
-	shopping_cart[Lot.number] = Lot.to_list(Acc ? Acc.owner_name : "Unknown", discount_price)
-
-	global.shop_categories[Lot.category]--
-
-	charge_to_account(MA.account_number, global.cargo_account.account_number, "Предоплата за покупку [Lot.name] в [CARGOSHOPNAME]", CARGOSHOPNAME, -delivery_cost)
-	charge_to_account(global.cargo_account.account_number, MA.account_number, "Предоплата за покупку [Lot.name] в [CARGOSHOPNAME]", CARGOSHOPNAME, delivery_cost)
-
-	for(var/obj/machinery/computer/cargo/Console in global.cargo_consoles)
-		if(istype(Console, /obj/machinery/computer/cargo/request))
-			continue
-		var/obj/item/weapon/paper/P = new(get_turf(Console.loc))
-
-		P.name = "Заказ предмета №[Lot.number] из магазина"
-		P.info += "Посылка номер №[Lot.number]<br>"
-		P.info += "Наименование: [Lot.name]<br>"
-		P.info += "Цена: [Lot.price]$<br>"
-		P.info += "Заказал: [owner ? owner : "Unknown"]<br>"
-		P.info += "Подпись заказчика: <span class=\"sign_field\"></span><br>"
-		P.info += "Комментарий: [destination]<br>"
-		P.info += "<hr>"
-		P.info += "МЕСТО ДЛЯ ШТАМПОВ:<br>"
-
-		var/obj/item/weapon/pen/Pen = new(src)
-
-		P.parsepencode(P.info, Pen)
-		P.updateinfolinks()
-		qdel(Pen)
-
-		P.update_icon()
-	return TRUE
 
 /obj/item/device/pda/proc/add_order_or_offer(name, desc)
 	global.orders_and_offers["[orders_and_offers_number]"] = list("name" = name, "description" = desc, "time" = worldtime2text())

--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -21,6 +21,15 @@ ADD_TO_GLOBAL_LIST(/obj/machinery/computer/cargo, cargo_consoles)
 		cannot transport live organisms, classified nuclear weaponry or \
 		homing beacons."
 
+/obj/machinery/computer/cargo/attackby(obj/item/I, mob/user, params)
+	if(isprying(I))
+		to_chat(world, "Starting shop monitoring...")
+		SSeconomy.monitor_cargo_shop()
+		to_chat(world, "Done!")
+		return
+
+	return ..()
+
 /obj/machinery/computer/cargo/request
 	name = "Supply request console"
 	desc = "Used to request supplies from cargo."

--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -21,15 +21,6 @@ ADD_TO_GLOBAL_LIST(/obj/machinery/computer/cargo, cargo_consoles)
 		cannot transport live organisms, classified nuclear weaponry or \
 		homing beacons."
 
-/obj/machinery/computer/cargo/attackby(obj/item/I, mob/user, params)
-	if(isprying(I))
-		to_chat(world, "Starting shop monitoring...")
-		SSeconomy.monitor_cargo_shop()
-		to_chat(world, "Done!")
-		return
-
-	return ..()
-
 /obj/machinery/computer/cargo/request
 	name = "Supply request console"
 	desc = "Used to request supplies from cargo."

--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -48,8 +48,12 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 					E.sell_object(thing, contraband, hacked)
 					sold_str += " [thing.name]"
 				break
-		if(!dry_run)
-			qdel(thing)
+
+		if(dry_run)
+			continue
+
+		SSeconomy.handle_centcomm_onlineshop_orders(thing)
+		qdel(thing)
 
 	if(dry_run)
 		return cost

--- a/code/modules/cargo/shop.dm
+++ b/code/modules/cargo/shop.dm
@@ -9,7 +9,7 @@ var/global/list/orders_and_offers = list()
 var/global/orders_and_offers_number = 0
 
 var/global/online_shop_discount = 0
-var/global/online_shop_delivery_cost = 0.25
+var/global/online_shop_delivery_cost = 0.15
 var/global/online_shop_profits = 0
 
 /datum/shop_lot
@@ -24,8 +24,10 @@ var/global/online_shop_profits = 0
 	var/item_icon = ""
 	var/hash = ""
 
+	// How much would exporting this item via cargo shuttle pay up.
+	var/market_price = 0
 
-/datum/shop_lot/New(name, description, price, category, account, icon)
+/datum/shop_lot/New(name, description, price, category, account, icon, market_price)
 	global.online_shop_number++
 	global.online_shop_lots["[global.online_shop_number]"] = src
 
@@ -37,6 +39,8 @@ var/global/online_shop_profits = 0
 	src.account = account
 	src.item_icon = icon
 	src.hash = "[src.category]-[src.name]-[src.description]-[src.price]-[src.account]"
+
+	src.market_price = market_price
 
 	LAZYADDASSOCLIST(global.online_shop_lots_hashed, src.hash, src)
 
@@ -54,11 +58,75 @@ var/global/online_shop_profits = 0
 	LAZYREMOVEASSOC(global.online_shop_lots_hashed, src.hash, src)
 	return ..()
 
-/datum/shop_lot/proc/to_list(account = "Unknown", postpayment = 0)
-	return list("name" = src.name, "description" = src.description, "price" = (global.online_shop_discount ? "<S>[src.price + get_delivery_cost()]$</S> <B>[get_discounted_price() + get_delivery_cost()]</B>" : (src.price + get_delivery_cost())), "number" = src.number, "account" = account, "delivered" = src.delivered, "postpayment" = postpayment, "icon" = src.item_icon)
+/datum/shop_lot/proc/to_list()
+	var/datum/money_account/MA = get_account(account)
+
+	var/price_str = "[get_discounted_price() + get_delivery_cost()]"
+	if(global.online_shop_discount)
+		price_str = "<S>[src.price + get_delivery_cost()]</S> <B>[get_discounted_price() + get_delivery_cost()]</B>"
+
+	return list(
+		"name" = MA ? MA.owner_name : "Unknown",
+		"description" = src.description,
+		"price" = price_str,
+		"number" = number,
+		"account" = account,
+		"delivered" = delivered,
+		"postpayment" = get_discounted_price(),
+		"icon" = item_icon
+	)
 
 /datum/shop_lot/proc/get_delivery_cost()
 	return round(price * global.online_shop_delivery_cost)
 
 /datum/shop_lot/proc/get_discounted_price()
 	return round((1 - global.online_shop_discount) * price)
+
+/proc/order_onlineshop_item(orderer_name, account, datum/shop_lot/Lot, destination)
+	if(!Lot)
+		return FALSE
+
+	var/datum/money_account/MA = get_account(account)
+	if(!MA)
+		return FALSE
+
+	var/delivery_cost = Lot.get_delivery_cost()
+	if(delivery_cost > MA.money)
+		return FALSE
+
+	Lot.sold = TRUE
+
+	for(var/i in 1 to 3)
+		if(global.online_shop_lots_latest[i] == Lot)
+			global.online_shop_lots_latest[i] = null
+			break
+
+	global.shop_categories[Lot.category]--
+
+	charge_to_account(MA.account_number, global.cargo_account.account_number, "Предоплата за покупку [Lot.name] в [CARGOSHOPNAME]", CARGOSHOPNAME, -delivery_cost)
+	charge_to_account(global.cargo_account.account_number, MA.account_number, "Предоплата за покупку [Lot.name] в [CARGOSHOPNAME]", CARGOSHOPNAME, delivery_cost)
+
+	for(var/obj/machinery/computer/cargo/Console in global.cargo_consoles)
+		if(istype(Console, /obj/machinery/computer/cargo/request))
+			continue
+
+		var/obj/item/weapon/paper/P = new(get_turf(Console.loc))
+
+		P.name = "Заказ предмета №[Lot.number] из магазина"
+		P.info += "Посылка номер №[Lot.number]<br>"
+		P.info += "Наименование: [Lot.name]<br>"
+		P.info += "Цена: [Lot.price]$<br>"
+		P.info += "Заказал: [orderer_name ? orderer_name : "Unknown"]<br>"
+		P.info += "Подпись заказчика: <span class=\"sign_field\"></span><br>"
+		P.info += "Комментарий: [destination]<br>"
+		P.info += "<hr>"
+		P.info += "МЕСТО ДЛЯ ШТАМПОВ:<br>"
+
+		var/obj/item/weapon/pen/Pen = new(src)
+
+		P.parsepencode(P.info, Pen)
+		P.updateinfolinks()
+		qdel(Pen)
+
+		P.update_icon()
+	return TRUE

--- a/code/modules/cargo/shop.dm
+++ b/code/modules/cargo/shop.dm
@@ -122,7 +122,7 @@ var/global/online_shop_profits = 0
 		P.info += "<hr>"
 		P.info += "МЕСТО ДЛЯ ШТАМПОВ:<br>"
 
-		var/obj/item/weapon/pen/Pen = new(src)
+		var/obj/item/weapon/pen/Pen = new
 
 		P.parsepencode(P.info, Pen)
 		P.updateinfolinks()

--- a/code/modules/cargo/shop_market_monitoring.dm
+++ b/code/modules/cargo/shop_market_monitoring.dm
@@ -1,0 +1,58 @@
+/datum/controller/subsystem/economy
+	var/list/wanted_shop_lots
+
+/datum/controller/subsystem/economy/proc/evaluate_demand(price, target_price)
+	if(target_price == 0.0)
+		return 0.0
+
+	var/price_fraction = price / target_price
+	if(price_fraction ** 2 > 1.6)
+		return 0.0
+
+	return 1.05 * sqrt(1 - 0.66 * (price_fraction ** 2))
+
+/datum/controller/subsystem/economy/proc/monitor_cargo_shop()
+	for(var/number in global.online_shop_lots)
+		var/datum/shop_lot/SL = global.online_shop_lots[number]
+		if(SL.sold)
+			continue
+
+		var/order_chance = evaluate_demand(SL.get_discounted_price() + SL.get_delivery_cost(), SL.market_price)
+		if(!prob(order_chance * 100))
+			continue
+
+		if(order_onlineshop_item("CentComm", global.centcomm_account.account_number, SL, "Отправьте с помощью карго шаттла."))
+			LAZYSET(wanted_shop_lots, "[SL.number]", SL.to_list())
+
+/datum/controller/subsystem/economy/proc/handle_centcomm_onlineshop_orders(atom/movable/thing)
+	var/lot_number = null
+
+	if(istype(thing, /obj/structure/bigDelivery))
+		var/obj/structure/bigDelivery/package = thing
+		lot_number = package.lot_number
+	else if(istype(thing, /obj/item/smallDelivery))
+		var/obj/item/smallDelivery/package = thing
+		lot_number = package.lot_number
+
+	if(isnull(lot_number))
+		return
+
+	var/list/shop_lot = LAZYACCESS(wanted_shop_lots, "[lot_number]")
+	if(!shop_lot)
+		return
+
+	var/postpayment = shop_lot["postpayment"]
+	var/datum/shop_lot/Lot = global.online_shop_lots[lot_number]
+
+	if(!Lot || !global.centcomm_account || postpayment > global.centcomm_account.money)
+		return
+
+	LAZYREMOVE(wanted_shop_lots, "[lot_number]")
+	Lot.delivered = TRUE
+
+	if(global.online_shop_discount)
+		charge_to_account(Lot.account, global.cargo_account.account_number, "Возмещение скидки на [Lot.name] в [CARGOSHOPNAME]", CARGOSHOPNAME, Lot.price - postpayment)
+		charge_to_account(global.cargo_account.account_number, global.centcomm_account.account_number, "Возмещение скидки на [Lot.name] в [CARGOSHOPNAME]", CARGOSHOPNAME, -(Lot.price - postpayment))
+
+	charge_to_account(global.centcomm_account.account_number, global.cargo_account.account_number, "Счёт за покупку [Lot.name] в [CARGOSHOPNAME]", CARGOSHOPNAME, -postpayment)
+	charge_to_account(Lot.account, global.cargo_account.account_number, "Прибыль за продажу [Lot.name] в [CARGOSHOPNAME]", CARGOSHOPNAME, postpayment)

--- a/code/modules/cargo/shop_market_monitoring.dm
+++ b/code/modules/cargo/shop_market_monitoring.dm
@@ -17,12 +17,18 @@
 		if(SL.sold)
 			continue
 
-		var/order_chance = evaluate_demand(SL.get_discounted_price() + SL.get_delivery_cost(), SL.market_price)
+		var/price = SL.get_discounted_price() + SL.get_delivery_cost()
+		// Delivery fees are not taxed, only export is.
+		var/tax = round(SL.get_discounted_price() * SSeconomy.tax_cargo_export * 0.01)
+
+		var/order_chance = evaluate_demand(price + tax, SL.market_price)
 		if(!prob(order_chance * 100))
 			continue
 
 		if(order_onlineshop_item("CentComm", global.centcomm_account.account_number, SL, "Отправьте с помощью карго шаттла."))
-			LAZYSET(wanted_shop_lots, "[SL.number]", SL.to_list())
+			var/list/L = SL.to_list()
+			L["tax"] = SSeconomy.tax_cargo_export
+			LAZYSET(wanted_shop_lots, "[SL.number]", L)
 
 /datum/controller/subsystem/economy/proc/handle_centcomm_onlineshop_orders(atom/movable/thing)
 	var/lot_number = null
@@ -56,3 +62,9 @@
 
 	charge_to_account(global.centcomm_account.account_number, global.cargo_account.account_number, "Счёт за покупку [Lot.name] в [CARGOSHOPNAME]", CARGOSHOPNAME, -postpayment)
 	charge_to_account(Lot.account, global.cargo_account.account_number, "Прибыль за продажу [Lot.name] в [CARGOSHOPNAME]", CARGOSHOPNAME, postpayment)
+
+	// Paying taxes on the item.
+	var/tax = round(postpayment * shop_lot["tax"] * 0.01)
+
+	charge_to_account(global.centcomm_account.account_number, global.station_account.account_number, "Налог на экспорт [Lot.name] из [CARGOSHOPNAME]", "NTS Велосити", -tax)
+	charge_to_account(global.station_account.account_number, global.station_account.owner_name, "Налог на экспорт", "NTS Велосити", tax)

--- a/code/modules/economy/economy_misc.dm
+++ b/code/modules/economy/economy_misc.dm
@@ -68,6 +68,7 @@ var/global/current_date_string
 var/global/datum/money_account/vendor_account
 var/global/datum/money_account/cargo_account
 var/global/datum/money_account/station_account
+var/global/datum/money_account/centcomm_account
 var/global/list/datum/money_account/department_accounts = list()
 var/global/num_financial_terminals = 1
 var/global/next_account_number = 0
@@ -105,6 +106,10 @@ var/global/initial_station_money = 7500
 	create_department_account("Vendor")
 	vendor_account = department_accounts["Vendor"]
 	cargo_account = department_accounts["Cargo"]
+
+	create_department_account("CentComm")
+	global.centcomm_account = department_accounts["CentComm"]
+	global.centcomm_account.money = 10000000
 
 	current_date_string = "[num2text(rand(1,31))] [pick("January","February","March","April","May","June","July","August","September","October","November","December")], [game_year]"
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -1116,7 +1116,8 @@
 	else
 		return
 
-	var/datum/shop_lot/Lot = new /datum/shop_lot(lot_name, lot_desc, lot_price, lot_category, lot_account, item_icon)
+	var/market_price = export_item_and_contents(Item, FALSE, FALSE, dry_run=TRUE)
+	var/datum/shop_lot/Lot = new /datum/shop_lot(lot_name, lot_desc, lot_price, lot_category, lot_account, item_icon, market_price)
 
 	global.shop_categories[lot_category]++
 

--- a/taucetistation.dme
+++ b/taucetistation.dme
@@ -1403,6 +1403,7 @@
 #include "code\modules\cargo\packs.dm"
 #include "code\modules\cargo\prices.dm"
 #include "code\modules\cargo\shop.dm"
+#include "code\modules\cargo\shop_market_monitoring.dm"
 #include "code\modules\cargo\supplyshuttle.dm"
 #include "code\modules\cargo\exports\gear.dm"
 #include "code\modules\cargo\exports\large_objects.dm"


### PR DESCRIPTION
## Описание изменений

(в коде ГрузТорг вообще OnlineShop а не CargoTrade but okay)

Каждых 15 минут (вместе с выдачей зарплат) ЦК мониторит все выставленные в ГрузТорг лоты. Если среди них есть те которые (с учетом скидок и доставки) дешевле чем экспортная цена предмета, они выставляют заказ на этот предмет из ГрузТорга.

В карго приходит бумажка о том что ЦК хочет купить лот, и с инструкцией доставить его на шаттл карго.

В случае отправки такого лота на шаттле карго игрок выставивший лот получает деньги за предмет, карго деньги за доставку, а предмет... исчезает.

Покупка вещи не гарантированна, а идёт по не-совсем-линейному распределению с такими критическими точками:
- Цена выше экспортной в 1.25 раз - 0%
- Цена равна экспортной - 60% (то есть каждый второй предмет, или предмет каждых пол часа)
- Цена ниже экспортной в 2 раза - 95%

Заодно рефакторнул совсем мозолящие глаза места ГрузТорга, теперь на его код совсем чуть-чуть проще смотреть...

## Почему и что этот ПР улучшит

closes #10998 

Популяризирует ГрузТорг, создаёт "минимум" цены на некоторые вещи, даёт работу каргонцам, даёт взаимодействием другим игрокам с карго.

## Чеинжлог
:cl: Luduk
- rscadd: Раз в 15 минут ЦК может скупать вещи с ГрузТорга если те дешевле чем их экспортная цена.