### PR TITLE
when scanning something with shop tagger in your hand manually choose the price

### DIFF
--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -356,6 +356,16 @@
 		to_chat(user, "<span class='notice'>Нельзя повесить ценник на [target].</span>")
 		return
 
+	if(user.get_inactive_hand() == target)
+		var/new_price = input("Введите цену:", "Маркировщик", input_default(lot_price), null)  as num
+		if(user.get_active_hand() != src || user.get_inactive_hand() != target)
+			return
+		if(user.incapacitated())
+			return
+
+		if(new_price && isnum(new_price) && new_price >= 0)
+			lot_price = min(new_price, 5000)
+
 	user.visible_message("<span class='notice'>[user] adds a price tag to [target].</span>", \
 						 "<span class='notice'>You added a price tag to [target].</span>")
 


### PR DESCRIPTION
## Описание изменений

Сейчас у ГрузТорг таггера довольно удобный воркфлоу для ботаника, повара, бармена - выбираешь цену предмету - тыкаешь по всем предмета с ценой (нифига не удобно если предметов реально много, надо чтобы клик по тайлу ставил бирку на все)

Но очень неудобный для всех кто выставляет разные предметы на продажу. Для них предлагаю альтернативный воркфлоу - тыкая таггером по предмету во второй руке предложит ввести цену. Думаю это хорошее решение потому-что не делает жизнь хуже тем кому предпочтительней старый воркфлоу, но делает жизнь лучше тем кому он неудобен.

То есть вместо:
- Клик таггером по вещи
- Переводить мышку на таггер интерфейс кнопку с ценой...
- Введение цены
- Энтер

Теперь:
- Клик таггером по вещи (в руке, где же ещё)
- Введение цены
- Энтер

## Почему и что этот ПР улучшит

QoL ГрузТорг Торгашей

## Авторство

## Чеинжлог
:cl: Luduk
- tweak: Клик по вещи в неактивной руке таггером предложит ввести ей цену.