### PR TITLE
See Tagger Auto Action

### DIFF
--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -377,7 +377,8 @@
 
 	target.underlays += icon(icon = 'icons/obj/device.dmi', icon_state = "tag")
 
-	updateUsrDialog()
+	if(user.client && LAZYACCESS(user.client.browsers, "destTagScreen"))
+		openwindow(user)
 
 /obj/item/device/tagger/proc/label(obj/target, mob/user)
 	if(!label || !length(label))

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -377,6 +377,8 @@
 
 	target.underlays += icon(icon = 'icons/obj/device.dmi', icon_state = "tag")
 
+	updateUsrDialog()
+
 /obj/item/device/tagger/proc/label(obj/target, mob/user)
 	if(!label || !length(label))
 		to_chat(user, "<span class='notice'>Нет текста на бирке.</span>")


### PR DESCRIPTION
## Описание изменений

У ГрузТорг таггера есть удобный но не очевидный механ автоматического подбора таких значений как айди карта, описание, название предмета.

Не очевидный он потому-что после клика таггером по вещи с открытым окном оно не обновляется чтобы увидеть как он всё автомагически подобрал!!!

Теперь таггер будет обновлять свой интерфейс после навешивания бирки на предмет

## Почему и что этот ПР улучшит

QoL

## Чеинжлог

Я думаю эта фича настолько обязательная к существованию таггера что её описание не нужно в ченжлоге.