### PR TITLE
bro tip for tagger usage

### DIFF
--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -377,6 +377,8 @@
 
 	target.underlays += icon(icon = 'icons/obj/device.dmi', icon_state = "tag")
 
+	to_chat(user, "<span class='notice'>Теперь осталось только отправить этот предмет по пневмопочте(смыть в мусорку), или выставить на прилавок - и денюжки будут у тебя в кармане!")
+
 /obj/item/device/tagger/proc/label(obj/target, mob/user)
 	if(!label || !length(label))
 		to_chat(user, "<span class='notice'>Нет текста на бирке.</span>")

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -377,7 +377,7 @@
 
 	target.underlays += icon(icon = 'icons/obj/device.dmi', icon_state = "tag")
 
-	to_chat(user, "<span class='notice'>Теперь осталось только отправить этот предмет по пневмопочте(смыть в мусорку), или выставить на прилавок - и денюжки будут у тебя в кармане!")
+	to_chat(user, "<span class='notice'>Теперь осталось только отправить этот предмет по пневмопочте(смыть в мусорку), или выставить на прилавок - и денюжки будут у тебя в кармане!</span>")
 
 /obj/item/device/tagger/proc/label(obj/target, mob/user)
 	if(!label || !length(label))

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -377,7 +377,7 @@
 
 	target.underlays += icon(icon = 'icons/obj/device.dmi', icon_state = "tag")
 
-	to_chat(user, "<span class='notice'>Теперь осталось только отправить этот предмет по пневмопочте(смыть в мусорку), или выставить на прилавок - и денюжки будут у тебя в кармане!</span>")
+	to_chat(user, "<span class='notice'>Осталось отправить этот предмет по пневмопочте(смыть в мусорку) или выставить на прилавок - и денюжки будут у тебя в кармане!</span>")
 
 /obj/item/device/tagger/proc/label(obj/target, mob/user)
 	if(!label || !length(label))


### PR DESCRIPTION
## Описание изменений

После налепливания метки выводит игроку в чатик сообщение с тем что делать дальше.

Чуть больше игроков будут "в теме" о том как торгашить.

## Почему и что этот ПР улучшит

QoL, иц документация фич

## Чеинжлог
:cl: Luduk
- tweak: Налепливание ГрузТорг бирки на предмет сообщает что дальше делать с этим предметом.