### PR TITLE
vending machines don't charge twice

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -311,7 +311,6 @@
 						if(transaction_amount <= D.money)
 
 							//transfer the money
-							D.adjust_money(-transaction_amount)
 							var/tax = round(transaction_amount * SSeconomy.tax_vendomat_sales * 0.01)
 							charge_to_account(global.station_account.account_number, global.station_account.owner_name, "Налог на продажу в вендомате", src.name, tax)
 


### PR DESCRIPTION
## Описание изменений

после переделки на плату на счета карго почему-то все равно деньги снимались напрямую со счёта

## Почему и что этот ПР улучшит

цены в вендоматах упадут в два раза до их задуманного числа

## Чеинжлог
:cl: Luduk
- bugfix: Вендоматы не снимают деньги дважды из-за потешной ошибки в бухгалтерии.