### PR TITLE
fixes centcomm account money glitch

### DIFF
--- a/code/modules/economy/Accounts.dm
+++ b/code/modules/economy/Accounts.dm
@@ -17,6 +17,8 @@
 	var/security_level = 0	//0 - auto-identify from worn ID, require only account number
 							//1 - require manual login / account number and pin
 							//2 - require card and manual login
+	// Whether this account is hidden from databases. In the future, if required, abstract to Database ID, and make the financial database connect to said ID and view accounts only for that ID.
+	var/hidden = FALSE
 
 /datum/money_account/New()
 	all_money_accounts += src

--- a/code/modules/economy/Accounts_DB.dm
+++ b/code/modules/economy/Accounts_DB.dm
@@ -172,7 +172,9 @@
 			if("view_account_detail")
 				var/index = text2num(href_list["account_index"])
 				if(index && index <= all_money_accounts.len)
-					detailed_account_view = all_money_accounts[index]
+					var/datum/money_account/MA = all_money_accounts[index]
+					if(!MA.hidden)
+						detailed_account_view = all_money_accounts[index]
 
 			if("view_accounts_list")
 				detailed_account_view = null

--- a/code/modules/economy/Accounts_DB.dm
+++ b/code/modules/economy/Accounts_DB.dm
@@ -92,6 +92,8 @@
 	var/list/accounts[0]
 	for(var/i=1, i<=all_money_accounts.len, i++)
 		var/datum/money_account/D = all_money_accounts[i]
+		if(D.hidden)
+			continue
 		accounts.Add(list(list(\
 			"account_number"=D.account_number,\
 			"owner_name"=D.owner_name,\

--- a/code/modules/economy/economy_misc.dm
+++ b/code/modules/economy/economy_misc.dm
@@ -100,6 +100,7 @@ var/global/initial_station_money = 7500
 		weighted_mundaneevent_locations[D] = D.viable_mundane_events.len
 
 	create_station_account()
+	create_centcomm_account()
 
 	for(var/department in station_departments)
 		create_department_account(department)
@@ -107,14 +108,33 @@ var/global/initial_station_money = 7500
 	vendor_account = department_accounts["Vendor"]
 	cargo_account = department_accounts["Cargo"]
 
-	create_department_account("CentComm")
-	global.centcomm_account = department_accounts["CentComm"]
-	global.centcomm_account.money = 10000000
-
 	current_date_string = "[num2text(rand(1,31))] [pick("January","February","March","April","May","June","July","August","September","October","November","December")], [game_year]"
 
 	economy_init = TRUE
 	return 1
+
+/proc/create_centcomm_account()
+	if(global.centcomm_account)
+		return
+
+	global.centcomm_account = new
+	global.centcomm_account.owner_name = "CentComm Station Account"
+	global.centcomm_account.account_number = rand(111111, 999999)
+	global.centcomm_account.remote_access_pin = rand(1111, 111111)
+	global.centcomm_account.security_level = 2
+	global.centcomm_account.money = 10000000
+	global.centcomm_account.hidden = TRUE
+
+	//create an entry in the account transaction log for when it was created
+	var/datum/transaction/T = new()
+	T.target_name = global.centcomm_account.owner_name
+	T.purpose = "Account creation"
+	T.amount = global.centcomm_account.money
+	T.date = "2nd May, [gamestory_start_year - 10]"
+	T.time = "10:41"
+	T.source_terminal = "Biesel GalaxyNet Terminal #277"
+
+	station_account.transaction_log.Add(T)
 
 /proc/create_station_account()
 	if(!station_account)


### PR DESCRIPTION
## Описание изменений

Убирает из консоли ГП счёт ЦК, не позволяет с него снимать деньги.

Довольно важный фикс потому-что сейчас у Карго бесконечные деньги на печатание пушек при любом режиме.

## Почему и что этот ПР улучшит

fixes #11077 
