### PR TITLE
solves all extinguisher abuses

### DIFF
--- a/code/modules/reagents/reagent_containers/extinguisher.dm
+++ b/code/modules/reagents/reagent_containers/extinguisher.dm
@@ -8,7 +8,7 @@ ADD_TO_GLOBAL_LIST(/obj/item/weapon/reagent_containers/spray/extinguisher, extin
 	hitsound = 'sound/weapons/smash.ogg'
 	flags = CONDUCT
 	throwforce = 10
-	w_class = SIZE_SMALL
+	w_class = SIZE_NORMAL
 	throw_speed = 2
 	throw_range = 10
 	force = 10.0


### PR DESCRIPTION
## Описание изменений

Делает огнетушители на размер больше. Теперь они замедляют пока в руках, и их нельзя засунуть в рюкзак.

На intended юз-кейс огнетушителя - схватить, потушить, вернуть на место сильно повлиять не должно (микросекунды разницы скорости тушения), но на робастность огнетушителя повлияет ожидаемо сильно.

## Почему и что этот ПР улучшит

close #10833 

## Авторство

Идея - @simb11, за что ему большое спасибо.

## Чеинжлог
:cl: Simbaka
- balance: Размер огнетушителя не позволяет класть его в рюкзак.