### PR TITLE
holodeck in shutdown() don't reload same empty scene

### DIFF
--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -228,6 +228,8 @@
 	return 1
 
 /obj/machinery/computer/HolodeckControl/proc/loadIdProgram(id = "turnoff")
+	if(id == "turnoff" && ((current_scene && id == current_scene.holoscene_id) || !current_scene))
+		return
 	if(id in restricted_programs && !safety_disabled) return
 	current_scene = holoscene_templates[id]
 	loadProgram()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

микрооптимизация, что бы он в холостую не перегружал сцену в офф, когда мы уже в ней. Могло случаться при отключении энергии, уничтожении консоли.

closes #11100

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
