### PR TITLE
nerf pumped metabolism factor

### DIFF
--- a/code/modules/organs/external/flesh.dm
+++ b/code/modules/organs/external/flesh.dm
@@ -40,7 +40,7 @@
 	if(BP.pumped <= 0 && old_pumped > 0)
 		BP.owner.metabolism_factor.RemoveModifier("Pumped_[BP.name]")
 	else
-		BP.owner.metabolism_factor.AddModifier("Pumped_[BP.name]", base_additive = 0.002 * BP.pumped)
+		BP.owner.metabolism_factor.AddModifier("Pumped_[BP.name]", base_additive = 0.0005 * BP.pumped)
 
 	return BP.pumped - old_pumped
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

При ``max_pumped = 60`` и 5 конечностях в прошлом добавочный фактор был ``0,6`` - больше 50% базовой модификации без учета других параметров.

Новое значение будет ``0.15``

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог

:cl:
 - tweak: Накаченные конечности меньше влияют на голод.