### PR TITLE
Удаление раундстарт ксеноморфов

### DIFF
--- a/code/modules/events/_event_container.dm
+++ b/code/modules/events/_event_container.dm
@@ -179,15 +179,16 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_FEATURE = "RoundStart", EV
 /datum/event_container/mundane
 	severity = EVENT_LEVEL_MUNDANE
 	available_events = list(
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Nothing",           /datum/event/nothing,           1100),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "PDA Spam",          /datum/event/pda_spam,          0,    list(ASSIGNMENT_ANY = 4),       0, 1, 0, 25, 50),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Money Lotto",       /datum/event/money_lotto,       0,    list(ASSIGNMENT_ANY = 1), ONESHOT, 1, 0,  5, 15),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Money Hacker",      /datum/event/money_hacker,      0,    list(ASSIGNMENT_ANY = 4), ONESHOT, 1, 0, 10, 25),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Economic Event",    /datum/event/economic_event,    300),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Trivial News",      /datum/event/trivial_news,      400),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Mundane News",      /datum/event/mundane_news,      300),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Vermin Infestation",/datum/event/infestation,       100,  list(ASSIGNMENT_JANITOR = 100)),
-		new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Wallrot",           /datum/event/wallrot,           0,    list(ASSIGNMENT_ENGINEER = 30, ASSIGNMENT_BOTANIST = 50)),
+	new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Nothing",            /datum/event/nothing,                                 1100),
+	new /datum/event_meta(EVENT_LEVEL_MUNDANE, "PDA Spam",           /datum/event/pda_spam,                                0,    list(ASSIGNMENT_ANY = 4),       0, 1, 0, 25, 50),
+	new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Money Lotto",        /datum/event/money_lotto,                             0,    list(ASSIGNMENT_ANY = 1), ONESHOT, 1, 0,  5, 15),
+	new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Money Hacker",       /datum/event/money_hacker,                            0,    list(ASSIGNMENT_ANY = 4), ONESHOT, 1, 0, 10, 25),
+	new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Economic Event",     /datum/event/economic_event,                          300),
+	new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Trivial News",       /datum/event/trivial_news,                            400),
+	new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Mundane News",       /datum/event/mundane_news,                            300),
+	new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Vermin Infestation", /datum/event/infestation,                             100,  list(ASSIGNMENT_JANITOR = 100)),
+	new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Wallrot",            /datum/event/wallrot,                                 0,    list(ASSIGNMENT_ENGINEER = 30, ASSIGNMENT_BOTANIST = 50)),
+	new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Xenohive",           /datum/event/feature/area/maintenance_spawn/xenohive, 300),
 	)
 
 /datum/event_container/moderate

--- a/code/modules/events/roundstart_events/area/maintenance.dm
+++ b/code/modules/events/roundstart_events/area/maintenance.dm
@@ -27,8 +27,6 @@
 	possible_types = list(
 		/mob/living/simple_animal/hostile/giant_spider,
 		/mob/living/simple_animal/hostile/pylon,
-		/mob/living/simple_animal/hostile/xenomorph/drone,
-		/mob/living/simple_animal/hostile/xenomorph,
 		/mob/living/simple_animal/hostile/hivebot,
 		/mob/living/carbon/slime,
 	)

--- a/code/modules/events/xenohive.dm
+++ b/code/modules/events/xenohive.dm
@@ -1,0 +1,7 @@
+/datum/event/feature/area/maintenance_spawn/xenohive
+	possible_types = list(/obj/structure/alien/weeds/node,
+						/mob/living/simple_animal/hostile/xenomorph/drone,
+						/mob/living/simple_animal/hostile/xenomorph,
+						/obj/structure/alien/resin/membrane,
+						/obj/structure/alien/air_plant,
+						)

--- a/taucetistation.dme
+++ b/taucetistation.dme
@@ -1582,6 +1582,7 @@
 #include "code\modules\events\viral_infection.dm"
 #include "code\modules\events\wallrot.dm"
 #include "code\modules\events\wormholes.dm"
+#include "code\modules\events\xenohive.dm"
 #include "code\modules\events\cellular_biomass\biomass.dm"
 #include "code\modules\events\cellular_biomass\biome_bluespace.dm"
 #include "code\modules\events\cellular_biomass\biome_meat.dm"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Удалены раундстарт-ивентовые ксеноморфы. Добавлен mundane ивент на рандомно присутствие ксеноморфов.

Писать в чейнджлоге смысла нет.
## Почему и что этот ПР улучшит
Ивент выполняет плохую для станции функцию как раундстартовый ивент. Добавлен на замену подходящий и выполняющий функцию "фейк-детект" ивент с примерно таким же содержимым в mundane пул.
## Авторство

## Чеинжлог
