### PR TITLE
Hunger level don't affect moob speed anymore

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -354,7 +354,7 @@
 	return
 
 /mob/living/carbon/human/LaserEyes(atom/A, params)
-	if(get_nutrition() > 300)
+	if(get_satiation() > 300)
 		..()
 		SetNextMove(CLICK_CD_MELEE)
 		var/obj/item/projectile/beam/LE = new (loc)

--- a/code/game/gamemodes/modes_gameplays/changeling/powers/absorb.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/absorb.dm
@@ -58,7 +58,7 @@
 
 	changeling.absorb_dna(target)
 
-	var/nutr = user.get_nutrition()
+	var/nutr = user.get_satiation()
 	if(nutr < NUTRITION_LEVEL_NORMAL)
 		user.nutrition += min(target.nutrition, NUTRITION_LEVEL_NORMAL - nutr)
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -987,7 +987,7 @@
 /mob/living/carbon/proc/crawl_in_blood(obj/effect/decal/cleanable/blood/floor_blood)
 	return
 
-/mob/living/carbon/get_nutrition()
+/mob/living/carbon/get_satiation()
 	return nutrition + (reagents.get_reagent_amount("nutriment") \
 					+ reagents.get_reagent_amount("plantmatter") \
 					+ reagents.get_reagent_amount("protein") \

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -37,9 +37,9 @@
 		if(health_deficiency >= 40)
 			tally += health_deficiency / 25
 
-		var/hungry = 500 - get_nutrition()
+		var/hungry = 500 - get_satiation()
 		if(hungry >= 350) // Slow down if nutrition <= 150
-			tally += hungry / 250
+			tally += hungry / 250 // 1,4 - 2
 
 		if(shock_stage >= 10)
 			tally += round(log(3.5, shock_stage), 0.1) // (40 = ~3.0) and (starts at ~1.83)

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -37,10 +37,6 @@
 		if(health_deficiency >= 40)
 			tally += health_deficiency / 25
 
-		var/hungry = 500 - get_satiation()
-		if(hungry >= 350) // Slow down if nutrition <= 150
-			tally += hungry / 250 // 1,4 - 2
-
 		if(shock_stage >= 10)
 			tally += round(log(3.5, shock_stage), 0.1) // (40 = ~3.0) and (starts at ~1.83)
 

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -994,7 +994,7 @@ var/global/list/tourette_bad_words= list(
 				get_nutrition_max = 1 // IPC nutrition should be set to zero to this moment
 		else
 			get_nutrition_max = NUTRITION_LEVEL_FAT
-		full_perc = clamp(((get_nutrition() / get_nutrition_max) * 100), NUTRITION_PERCENT_ZERO, NUTRITION_PERCENT_MAX)
+		full_perc = clamp(((get_satiation() / get_nutrition_max) * 100), NUTRITION_PERCENT_ZERO, NUTRITION_PERCENT_MAX)
 		nutrition_icon.icon_state = "[fullness_icon][CEILING(full_perc, 20)]"
 
 	//OH cmon...

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1303,7 +1303,7 @@
 /mob/living/proc/naturechild_check()
 	return TRUE
 
-/mob/living/proc/get_nutrition()
+/mob/living/proc/get_satiation()
 	// This proc gets nutrition value with all possible alters.
 	// E.g. see how in carbon nutriment, plant matter, meat reagents are accounted.
 	// The difference between this and just nutrition, is that this proc shows how much nutrition a mob has

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -58,7 +58,7 @@
 
 	if(iscarbon(M))
 		var/mob/living/carbon/C = M
-		var/fullness = C.get_nutrition()
+		var/fullness = C.get_satiation()
 		if(C == user) // If you're eating it yourself
 			if(fullness > (550 * (1 + M.overeatduration / 2000))) // The more you eat - the more you can eat
 				to_chat(C, "<span class='rose'>You cannot force any more of [src] to go down your throat.</span>")


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Убирает модификацию скорости мобов от голода. У нас уже есть муд, который точно так же наказывает за голод штрафом на скорость, и сейчас получается двойное наказание.

От самого муда дебафф скорости меньше, чем сейчас чисто от голода, но нужно иметь в виду, что муд и влияет не только на скорость. И в целом мы уже ввели достаточно много отрицательных модификаторов скорости, что некоторые мобы в некоторых обстоятельствах едва ползают.

И нутришен сам по себе всё еще имеет применение в некоторых абилках, без дела не останется.

--

По предложению людука заодно переименовал ``get_nutrition()`` в ``get_satiation()``, потому что он имел слабое отношение к чистому ``var/nutrition``.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог

:cl:
 - tweak: Голод сам по себе больше не влияет на скорость мобов. Только косвенно, через систему настроения.