### PR TITLE
contraband finder doesn't scan mobs instantly

### DIFF
--- a/code/game/objects/items/devices/scanners/contraband_finder.dm
+++ b/code/game/objects/items/devices/scanners/contraband_finder.dm
@@ -421,7 +421,18 @@
 			scanner_ready = FALSE
 			playsound(user, 'sound/effects/triple_beep.ogg', VOL_EFFECTS_MASTER)
 			flash_color("red")
+		return
 
+	if(user.is_busy())
+		return
+	if(ismob(target))
+		if(!do_after(user, SKILL_TASK_TRIVIAL, target = target))
+			return
+		if(!can_scan(target, user))
+			if(scanner_ready)
+				scanner_ready = FALSE
+				playsound(user, 'sound/effects/triple_beep.ogg', VOL_EFFECTS_MASTER)
+				flash_color("red")
 		return
 
 	scanner_ready = FALSE

--- a/code/game/objects/items/devices/scanners/contraband_finder.dm
+++ b/code/game/objects/items/devices/scanners/contraband_finder.dm
@@ -433,7 +433,7 @@
 				scanner_ready = FALSE
 				playsound(user, 'sound/effects/triple_beep.ogg', VOL_EFFECTS_MASTER)
 				flash_color("red")
-		return
+			return
 
 	scanner_ready = FALSE
 


### PR DESCRIPTION
## Описание изменений

Сканнер контрабанды сканит мобов после задержки в одну секунду.

Фиксит дегенеративные мгновенные проклики моба... Но при этом не влияет на задуманное использование - "позвольте вас просканить"

## Почему и что этот ПР улучшит

фиксит дегенеративные стратки у щитспвана
