### PR TITLE
remove price tag on item purchase, instamagnetize

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -635,7 +635,7 @@
 			table_attached_to.visible_message("[bicon(table_attached_to)]<span class='warning'>Недостаточно средств!</span>")
 			return
 
-	held_item.remove_price_tag()
+	held_Item.remove_price_tag()
 	qdel(src)
 
 /obj/structure/table/reinforced/stall

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -635,6 +635,7 @@
 			table_attached_to.visible_message("[bicon(table_attached_to)]<span class='warning'>Недостаточно средств!</span>")
 			return
 
+	held_item.remove_price_tag()
 	qdel(src)
 
 /obj/structure/table/reinforced/stall
@@ -652,7 +653,7 @@
 
 /obj/structure/table/reinforced/stall/proc/try_magnet(atom/A, obj/item/I, mob/user)
 	if(I.price_tag)
-		addtimer(CALLBACK(src, .proc/magnet_item, I), 1 SECONDS)
+		magnet_item(I)
 
 /obj/structure/table/reinforced/stall/proc/magnet_item(obj/item/I)
 	if(I.loc != get_turf(src))

--- a/code/modules/cargo/shop.dm
+++ b/code/modules/cargo/shop.dm
@@ -92,6 +92,9 @@ var/global/online_shop_profits = 0
 	if(!A)
 		return
 
+	for(var/obj/thing in A)
+		thing.remove_price_tag()
+
 	if(istype(A, /obj/item/smallDelivery))
 		var/obj/item/smallDelivery/package = A
 		package.cut_overlay(package.lot_lock_image)


### PR DESCRIPTION
## Описание изменений

Убирает ценник после покупки предмета на прилавке, или отметки предмета как доставленный в ГрузТорге

Убирает задержку при примагничивании к прилавку

## Почему и что этот ПР улучшит

1. визуальный фидбек что вещь куплена, игроки ассоциируют предмет без бирки на прилавке с чем-то что можно забрать, и теперь так и есть
2. задержку намагничивания абузили чтобы воровать с прилавков а пользы выставляющему это особой не даёт

## Авторство

QoL

## Чеинжлог
:cl: Luduk
- tweak: Ценник слетает после покупки предмета в ГрузТорге или с прилавков.
- tweak: Вещи с ценником мгновенно магнитятся к прилавкам.