### PR TITLE
packages removed from cart when marked through clicking

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1696,6 +1696,7 @@
 			to_chat(user, "<span class='notice'>Это не один из твоих заказов. Это заказ номер №[package.lot_number].</span>")
 			return
 		if(package.lot_number && onlineshop_mark_as_delivered(user, package.lot_number, owner_account, shopping_cart["[package.lot_number]"]["postpayment"]))
+			shopping_cart -= "[package.lot_number]"
 			return
 
 	if(istype(target, /obj/item/smallDelivery))


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

видимо когда мержил все ГрузТорг пры в конфликтах затерялось

фиксит баг с тем что при клике по посылке ПДА она не удалялась из корзины заказов хотя отмечалась как доставленная

## Почему и что этот ПР улучшит

фиксит баг

