### PR TITLE
амброзия деус теперь лечит

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks/grown.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/grown.dm
@@ -395,7 +395,7 @@
 	. = ..()
 	reagents.add_reagent("nutriment", 2)
 	reagents.add_reagent("bicaridine", 1+round(potency / 6, 1))
-	reagents.add_reagent("synaptizine", 1+round(potency / 6, 1))
+	reagents.add_reagent("tricordrazine", 1+round(potency / 6, 1))
 	reagents.add_reagent("space_drugs", 1+round(potency / 9, 1))
 	bitesize = 1+round(reagents.total_volume / 2, 1)
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
заменяет синаптизин на трикодразин в амброзии деус
## Почему и что этот ПР улучшит
какой то садист добавил в амброзию деус такой прекрасный реагент как синаптизин, из-за чего любой кто её укусит получает кучу токсидемеджа
мутация амброзии, судя по описанию, должна лечить, а не убивать
## Авторство 

## Чеинжлог
🆑 Simbaka
- tweak: Синаптизин в ambrosia deus был заменён на трикодразин.