### PR TITLE
Прикол на первое апреля 5

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -648,7 +648,7 @@
 			lube |= SLIDE_ICE
 
 		if(lube & SLIDE)
-			new /datum/forced_movement(C, get_ranged_target_turf(C, olddir, 4), 1, FALSE, CALLBACK(C, /mob/living/carbon/.proc/spin, 1, 1))
+			new /datum/forced_movement(C, get_ranged_target_turf(C, olddir, max(world.maxy, world.maxx)), 1, FALSE, CALLBACK(C, /mob/living/carbon/.proc/spin, 1, 1))
 			C.take_bodypart_damage(2) // Was 5 -- TLE
 		else if(lube & SLIDE_ICE)
 			var/has_NOSLIP = FALSE

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -648,7 +648,7 @@
 			lube |= SLIDE_ICE
 
 		if(lube & SLIDE)
-			new /datum/forced_movement(C, get_ranged_target_turf(C, olddir, max(world.maxy, world.maxx)), 1, FALSE, CALLBACK(C, /mob/living/carbon/.proc/spin, 1, 1))
+			new /datum/forced_movement(C, get_ranged_target_turf(C, olddir, 255), 1, FALSE, CALLBACK(C, /mob/living/carbon/.proc/spin, 1, 1))
 			C.take_bodypart_damage(2) // Was 5 -- TLE
 		else if(lube & SLIDE_ICE)
 			var/has_NOSLIP = FALSE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
но я не хочу банить людей за это, мне не нравятся правила как механизм ограничения игроков, поэтому я делаю изменения в игре
теперь инструменты будут не так легкодоступны, что ограничит их лутабельность, игрокам придется взаимодействовать с карго, с теми же инженерами или кто там имеет доступ к тулбоксам
если скиллы ограничивают все по максимуму, то какая разница, есть эти инструменты или нет?
## Почему и что этот ПР улучшит
ассистентская заменена на кусок техтоннелей, в котором спавнятся подопытные. маперы, если захотят, поменяют на что-то более прикольные
спавны подпроф раскиданы по карте
из техтонеллей удалены инструменты
инструментами пользоваться должны только инженеры, так что и свободный доступ к ним будет только у инженеров и некоторых других проф.
## Авторство

## Чеинжлог
