### PR TITLE
getting swole improves mood

### DIFF
--- a/code/datums/mood_events/generic_positive_events.dm
+++ b/code/datums/mood_events/generic_positive_events.dm
@@ -67,3 +67,12 @@
 
 /datum/mood_event/besthug/add_effects(mob/friend)
 	description = "<span class='nicegreen'>[friend.name] is great to be around, [friend.name] makes me feel so happy!</span>"
+
+/datum/mood_event/swole
+	description = "<span class='nicegreen'>I am getting swole!</span>"
+	timeout = 6 MINUTES
+
+/datum/mood_event/swole/add_effects(pain)
+	// 2.5 is stronger then cigs, because we believe in a healthy lifestyle!
+	// also getting swole loses nutriments so it has a sizable debuff which we need offset
+	mood_change = 2.5 + pain * 0.5

--- a/code/game/objects/fitness.dm
+++ b/code/game/objects/fitness.dm
@@ -28,13 +28,17 @@
 	user.nutrition -= 6
 	user.overeatduration -= 8
 
-
 	var/obj/item/organ/external/chest/C = user.get_bodypart(BP_CHEST)
 	var/obj/item/organ/external/groin/G = user.get_bodypart(BP_GROIN)
+
 	if(C)
-		user.apply_effect(7 * C.adjust_pumped(1), AGONY, 0)
+		var/pain_amount = 7 * C.adjust_pumped(1)
+		user.apply_effect(pain_amount, AGONY, 0)
+		SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "swole", /datum/mood_event/swole, pain_amount)
 	if(G)
-		user.apply_effect(7 * C.adjust_pumped(1), AGONY, 0)
+		var/pain_amount = 7 * G.adjust_pumped(1)
+		user.apply_effect(pain_amount, AGONY, 0)
+		SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "swole", /datum/mood_event/swole, pain_amount)
 
 	user.update_body()
 
@@ -136,9 +140,13 @@
 	var/obj/item/organ/external/l_arm/LA = user.get_bodypart(BP_L_ARM)
 	var/obj/item/organ/external/r_arm/RA = user.get_bodypart(BP_R_ARM)
 	if(LA)
-		user.apply_effect(12 * LA.adjust_pumped(1), AGONY, 0)
+		var/pain_amount = 12 * LA.adjust_pumped(1)
+		user.apply_effect(pain_amount, AGONY, 0)
+		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "swole", /datum/mood_event/swole, pain_amount)
 	if(RA)
-		user.apply_effect(12 * RA.adjust_pumped(1), AGONY, 0)
+		var/pain_amount = 12 * RA.adjust_pumped(1)
+		user.apply_effect(pain_amount, AGONY, 0)
+		SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "swole", /datum/mood_event/swole, pain_amount)
 
 	user.update_body()
 
@@ -317,7 +325,9 @@
 	if(!BP)
 		return
 
-	H.apply_effect(3 * BP.adjust_pumped(mass, max_pumped), AGONY, 0)
+	var/pain_amount = 3 * BP.adjust_pumped(mass, max_pumped)
+	H.apply_effect(pain_amount, AGONY, 0)
+	SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "swole", /datum/mood_event/swole, pain_amount)
 	H.update_body()
 
 	H.nutrition -= 2 * mass

--- a/code/modules/sports/PedalGen.dm
+++ b/code/modules/sports/PedalGen.dm
@@ -87,7 +87,9 @@
 		var/leg = pedal_left_leg ? BP_L_LEG : BP_R_LEG
 		var/obj/item/organ/external/BP = pedaler.get_bodypart(leg)
 		if(BP)
-			pedaler.apply_effect(BP.adjust_pumped(1), AGONY, 0)
+			var/pain_amount = BP.adjust_pumped(1)
+			pedaler.apply_effect(pain_amount, AGONY, 0)
+			SEND_SIGNAL(pedaler, COMSIG_ADD_MOOD_EVENT, "swole", /datum/mood_event/swole, pain_amount)
 			pedaler.update_body()
 
 	buckled_mob.nutrition -= 0.5


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Качалка повышает настроение. Сильнее чем всякие ваши сигареты!

Чем больше боль от упражнения тем сильнее повышается настроение, это нужно чтобы смещать дебафф настроения от боли полученный в качалке.

closes #11054 

## Почему и что этот ПР улучшит

ЗОЖ!

А ещё фиксит что пах нельзя было накачать.

## Чеинжлог
:cl: Luduk
- rscadd: Качалка повышает настроение.