### PR TITLE
Machinery integrity decrease

### DIFF
--- a/code/game/machinery/airlock_control.dm
+++ b/code/game/machinery/airlock_control.dm
@@ -200,7 +200,7 @@
 	icon = 'icons/obj/airlock_machines.dmi'
 	icon_state = "access_button_standby"
 	name = "access button"
-
+	max_integrity = 25
 	layer = 3.3	//Above windows
 	anchored = TRUE
 	power_channel = STATIC_ENVIRON

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -985,10 +985,9 @@ FIRE ALARM
 	return
 
 /obj/machinery/firealarm/bullet_act(obj/item/projectile/P, def_zone)
-	. = ..()
-	if(!is_operational())
-		return
-	alarm()
+	if(is_operational())
+		alarm()
+	return ..()
 
 /obj/machinery/firealarm/emp_act(severity)
 	if(prob(50/severity))

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -33,6 +33,7 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 80
 	active_power_usage = 1000 // For heating/cooling rooms. 1000 joules equates to about 1 degree every 2 seconds for a single tile of air.
+	max_integrity = 25
 	power_channel = STATIC_ENVIRON
 	req_one_access = list(access_atmospherics, access_engine_equip)
 	frequency = 1439
@@ -956,6 +957,7 @@ FIRE ALARM
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 2
 	active_power_usage = 6
+	max_integrity = 25
 	power_channel = STATIC_ENVIRON
 	allowed_checks = ALLOWED_CHECK_NONE
 	var/last_process = 0

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -33,7 +33,6 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 80
 	active_power_usage = 1000 // For heating/cooling rooms. 1000 joules equates to about 1 degree every 2 seconds for a single tile of air.
-	max_integrity = 25
 	power_channel = STATIC_ENVIRON
 	req_one_access = list(access_atmospherics, access_engine_equip)
 	frequency = 1439

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -9,6 +9,7 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 2
 	active_power_usage = 4
+	max_integrity = 25
 
 /obj/machinery/ignition_switch
 	name = "ignition switch"
@@ -21,6 +22,7 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 2
 	active_power_usage = 4
+	max_integrity = 25
 
 /obj/machinery/flasher_button
 	name = "flasher button"
@@ -33,12 +35,14 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 2
 	active_power_usage = 4
+	max_integrity = 25
 
 /obj/machinery/crema_switch
 	desc = "Burn baby burn!"
 	name = "crematorium igniter"
 	icon = 'icons/obj/power.dmi'
 	icon_state = "crema_switch"
+	max_integrity = 25
 	anchored = TRUE
 	req_access = list(access_crematorium)
 	var/on = FALSE
@@ -52,6 +56,7 @@
 	icon = 'icons/obj/power.dmi'
 	icon_state = "light0"
 	anchored = TRUE
+	max_integrity = 25
 	var/id = null
 	var/active = FALSE
 	var/range = 7

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -6,6 +6,7 @@
 	use_power = ACTIVE_POWER_USE
 	idle_power_usage = 5
 	active_power_usage = 10
+	max_integrity = 25
 	layer = 5
 
 	var/list/network = list("SS13")

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -283,6 +283,7 @@
 	desc = "Used for watching an empty arena."
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "telescreen"
+	max_integrity = 25
 	state_broken_preset = null
 	state_nopower_preset = null
 	light_color = "#ffffbb"

--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -5,6 +5,7 @@
 	name = "guest pass"
 	desc = "Allows temporary access to station areas."
 	icon_state = "guest"
+	max_integrity = 25
 	light_color = "#0099ff"
 	customizable_view = FORDBIDDEN_VIEW
 

--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -5,7 +5,6 @@
 	name = "guest pass"
 	desc = "Allows temporary access to station areas."
 	icon_state = "guest"
-	max_integrity = 25
 	light_color = "#0099ff"
 	customizable_view = FORDBIDDEN_VIEW
 
@@ -40,8 +39,8 @@
 	name = "guest pass terminal"
 	icon_state = "guest"
 	desc = "It's a wall-mounted console that allows you to issue temporary access. Be careful when issuing guest passes. Maximum guest pass card time - one hour."
+	max_integrity = 25
 	density = FALSE
-
 
 	var/obj/item/weapon/card/id/scan
 	var/list/accesses = list()

--- a/code/game/machinery/door_control.dm
+++ b/code/game/machinery/door_control.dm
@@ -19,6 +19,7 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 2
 	active_power_usage = 4
+	max_integrity = 25
 	allowed_checks = ALLOWED_CHECK_A_HAND
 	var/id = null
 	var/list/obj/machinery/door/connected_doors = list()

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -5,6 +5,7 @@
 	desc = "A wall-mounted flashbulb device."
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "mflash1"
+	max_integrity = 25
 	light_color = LIGHT_COLOR_WHITE
 	light_power = FLASH_LIGHT_POWER
 	var/id = null
@@ -32,6 +33,7 @@
 	name = "portable flasher"
 	desc = "A portable flashing device. Wrench to activate and deactivate. Cannot detect slow movements."
 	icon_state = "pflash1"
+	max_integrity = 200
 	strength = 8
 	anchored = FALSE
 	base_state = "pflash"

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -8,6 +8,7 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 2
 	active_power_usage = 4
+	max_integrity = 25
 	var/id = null
 	var/on = TRUE
 

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -8,6 +8,7 @@
 	icon_state = "light1"
 	anchored = TRUE
 	idle_power_usage = 20
+	max_integrity = 25
 	power_channel = STATIC_LIGHT
 	var/on = TRUE
 	var/area/area = null

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -113,6 +113,7 @@ var/global/list/obj/machinery/newscaster/allCasters = list() //Global list that 
 	desc = "A standard Nanotrasen-licensed newsfeed handler for use in commercial space stations. All the news you absolutely have no use for, in one place!"
 	icon = 'icons/obj/terminals.dmi'
 	icon_state = "newscaster_normal"
+	max_integrity = 25
 	//var/list/datum/feed_channel/channel_list = list() //This list will contain the names of the feed channels. Each name will refer to a data region where the messages of the feed channels are stored.
 	//OBSOLETE: We're now using a global news network
 	var/screen = 0                  //Or maybe I'll make it into a list within a list afterwards... whichever I prefer, go fuck yourselves :3

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -158,6 +158,7 @@
 	name = "wall recharger"
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "wrecharger0"
+	max_integrity = 25
 
 /obj/machinery/recharger/wallcharger/process()
 	if(stat & (NOPOWER|BROKEN) || !anchored)

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -21,6 +21,7 @@ var/global/list/departments_genitive = list()
 	anchored = TRUE
 	icon = 'icons/obj/terminals.dmi'
 	icon_state = "req_comp0"
+	max_integrity = 25
 	var/department = "Неизвестный"
 	// The list of all departments on the station (Determined from this variable on each unit)
 	// Set this to the same thing if you want several consoles in one department

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -19,6 +19,7 @@
 	density = FALSE
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 10
+	max_integrity = 25
 	var/mode = 5	// 0 = Blank
 					// 1 = Shuttle timer
 					// 2 = Arbitrary message(s)
@@ -230,6 +231,7 @@
 	icon = 'icons/obj/status_display.dmi'
 	icon_state = "frame"
 	name = "AI display"
+	max_integrity = 25
 	anchored = TRUE
 	density = FALSE
 

--- a/code/game/machinery/vending/medical.dm
+++ b/code/game/machinery/vending/medical.dm
@@ -34,6 +34,7 @@
 	desc = "Wall-mounted Medical Equipment dispenser."
 	product_ads = "Go save some lives!;The best stuff for your medbay.;Only the finest tools.;Natural chemicals!;This stuff saves lives.;Don't you want some?"
 	icon_state = "wallmed"
+	max_integrity = 25
 	light_power_on = 1
 	light_color = "#e6fff2"
 	icon_deny = "wallmed-deny"

--- a/code/modules/atmospheric/machinery/other/meter.dm
+++ b/code/modules/atmospheric/machinery/other/meter.dm
@@ -11,6 +11,7 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 2
 	active_power_usage = 5
+	max_integrity = 25
 
 /obj/machinery/meter/atom_init()
 	. = ..()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -88,6 +88,7 @@
 	icon_state = "apc0"
 	anchored = TRUE
 	use_power = NO_POWER_USE
+	max_integrity = 25
 	req_access = list(access_engine_equip)
 	allowed_checks = ALLOWED_CHECK_NONE
 	var/area/area

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -88,7 +88,6 @@
 	icon_state = "apc0"
 	anchored = TRUE
 	use_power = NO_POWER_USE
-	max_integrity = 25
 	req_access = list(access_engine_equip)
 	allowed_checks = ALLOWED_CHECK_NONE
 	var/area/area

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -81,6 +81,7 @@
 	icon_state = "tube-construct-stage1"
 	anchored = TRUE
 	layer = 5
+	max_integrity = 25
 	var/stage = 1
 	var/fixture_type = "tube"
 	var/sheets_refunded = 2

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -81,7 +81,6 @@
 	icon_state = "tube-construct-stage1"
 	anchored = TRUE
 	layer = 5
-	max_integrity = 25
 	var/stage = 1
 	var/fixture_type = "tube"
 	var/sheets_refunded = 2
@@ -211,6 +210,7 @@
 	use_power = ACTIVE_POWER_USE
 	idle_power_usage = 0
 	active_power_usage = 20
+	max_integrity = 25
 	power_channel = STATIC_LIGHT //Lights are calc'd via area so they dont need to be in the machine list
 	interact_offline = TRUE
 	var/on = 0					// 1 if on, 0 if off

--- a/code/modules/security_levels/keycard_authentication.dm
+++ b/code/modules/security_levels/keycard_authentication.dm
@@ -18,6 +18,7 @@
 	use_power = IDLE_POWER_USE
 	idle_power_usage = 2
 	active_power_usage = 6
+	max_integrity = 25
 	power_channel = STATIC_ENVIRON
 	required_skills = list(/datum/skill/command = SKILL_LEVEL_TRAINED)
 	resistance_flags = FULL_INDESTRUCTIBLE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Это не первоапрельский ПР.
Всей настенной машинерии сделал прочность на 1 выстрел из любого ружья.
Я думал после полной разрушаемости всё само прийдёт в норму, что будет примерно как в https://github.com/TauCetiStation/TauCetiClassic/pull/9853, но всё осталось как было. Сейчас у всей машинерии 200 интегрити, что делает разрушение всякой мелочёвки практически невыполнимой задачей, либо очень дорогостоящей.
Я понимаю когда всякие консоли РД, автолаты и фабрикаторы прочность имеют чтобы их меньше грифонили, чтобы через них не могли быстро пройти в отсек в всяких режимах типо ксеноморфов, но зачем 200 интегрити камерам, пожарным алярмам, кнопкам и ЛАМПОЧКАМ?

Не делал разрушаемость стойкам с огнетушителями, так как это структура и интеркомам, так как это итем. Все дочерние типы, которые не являются настенной машинерией не меняли свои 200 интегрити, думаю там нужно каждое отдельно смотреть и прикидывать сколько можно выдать прочности.

АПЦ и аир алярм сохранили свою прочность по соображениям баланса (чтобы уничтожить их прийдётся потратить побольше патронов, либо взламывай)
## Почему и что этот ПР улучшит
Улучшение геймплея, баланс механики полной разрушаемости.
## Авторство

## Чеинжлог
:cl: Deahaka
- tweak: Вся настенная машинерия стала ломаться от физического воздействия намного быстрее.