### PR TITLE
ботанов подменили

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -156,6 +156,17 @@
 	outfit = /datum/outfit/job/hydro
 	skillsets = list("Botanist" = /datum/skillset/botanist)
 
+/datum/job/hydro/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	H.set_species(PODMAN)
+	if(visualsOnly)
+		return
+
+	var/msg = "<span class='notice'><B>You awaken slowly, feeling your sap stir into sluggish motion as the warm air caresses your bark.</B></span><BR>"
+	msg += "<B>You are now in possession of Podmen's body. It's previous owner found it no longer appealing, by rejecting it - they brought you here. You are now, again, an empty shell full of hollow nothings, neither belonging to humans, nor them.</B><BR>"
+	msg += "<B>Too much darkness will send you into shock and starve you, but light will help you heal.</B>"
+
+	to_chat(H, msg)
+
 
 /datum/job/janitor
 	title = "Janitor"


### PR DESCRIPTION
## Описание изменений

На старом форуме у меня была тема про экспедиции, которую я использовал для выкладывания своих набросков и мелких идей. Ну здесь я хочу организовать нечто подобное.

Итак, на повестке дня у нас наборы для зарядки вендоматов с ТГ. Оную хренотень можно заказывать в карго, а потом с её помощью пополнять запасы товаров в автоматах. Вопрос: а надо ли?

А ещё, меня накрыло и я выдал гени(т)альную идею - воткнуть в бар Sexualizer - голопроектор, проецирующий изображение стриптизёрши. Круто жи и бюджетно: не нужно живых танцовщиц завозить.

## Почему и что этот ПР улучшит

Насчёт новых вкусняшек не знаю, но количество, думаю, можно будет подрезать, чтобы дать стимулировать заказы комплектов зарядки.

