### PR TITLE
Фикс бага качков

### DIFF
--- a/code/__DEFINES/math.dm
+++ b/code/__DEFINES/math.dm
@@ -215,4 +215,4 @@ var/global/normal_next
 #define TRANSLATE_RANGE(x, minx, maxx, miny, maxy) clamp(((x - minx) * (maxy - miny) / (maxx - minx)) + miny, miny, maxy)
 
 //A parabola y = multiplier*x^2 + pike
-#define PARABOLIC_SCALING(x, pike, multiplier) (pike + multiplier * (x ** 2))
+#define PARABOLIC_SCALING(x, pike, multiplier) (pike - multiplier * (x ** 2))

--- a/code/__DEFINES/math.dm
+++ b/code/__DEFINES/math.dm
@@ -215,4 +215,4 @@ var/global/normal_next
 #define TRANSLATE_RANGE(x, minx, maxx, miny, maxy) clamp(((x - minx) * (maxy - miny) / (maxx - minx)) + miny, miny, maxy)
 
 //A parabola y = multiplier*x^2 + pike
-#define PARABOLIC_SCALING(x, pike, multiplier) (pike - multiplier * (x ** 2))
+#define PARABOLIC_SCALING(x, pike, multiplier) (pike + multiplier * (x ** 2))

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -281,11 +281,11 @@
 	if(!attacking_item.force)
 		return
 
-	var/power = attacking_item.force
+	var/attackpower = attacking_item.force
 
-	power = scale_attack_bonuses(power, user, attacking_item.damtype)
+	attackpower = scale_attack_bonuses(attackpower, user, attacking_item.damtype)
 
-	var/damage = take_damage(power, attacking_item.damtype, MELEE, 1, get_dir(src, attacking_item))
+	var/damage = take_damage(attackpower, attacking_item.damtype, MELEE, 1, get_dir(src, attacking_item))
 	//only witnesses close by and the victim see a hit message.
 	user.visible_message(
 		"<span class='danger'>[user] hits [src] with [attacking_item][damage ? "." : ", without leaving a mark!"]</span>",

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -287,7 +287,6 @@
 	if(!attacking_item.force)
 		return
 
-	var/attackforce = attacking_item.force
 	var/power = attacking_item.force
 	power = apply_skill_bonus(user, power, list(/datum/skill/melee = SKILL_LEVEL_NOVICE), 0.15) // 15% for each level
 	if(ishuman(user))

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -112,14 +112,8 @@
 	M.log_combat(user, "attacked with [name] (INTENT: [uppertext(user.a_intent)]) (DAMTYPE: [uppertext(damtype)])")
 
 	var/power = force
-	power = apply_skill_bonus(user, power, list(/datum/skill/melee = SKILL_LEVEL_NOVICE), 0.15) // 15% for each level
-	if(ishuman(user) && damtype == BRUTE)
-		var/mob/living/carbon/human/H = user
-		var/obj/item/organ/external/BP = H.get_bodypart(H.hand ? BP_L_ARM : BP_R_ARM)
-		if(BP.pumped)
-			power += max(round((PARABOLIC_SCALING(power, 1, -0.01) * BP.pumped * 0.5)), 0) //We need a pumped force multiplied by parabolic scaled item's force with a borders of 1 to 0
-	if(HULK in user.mutations)
-		power *= 2
+	power = scale_attack_bonuses(power, user, damtype)
+
 	if(!ishuman(M))
 		if(isslime(M))
 			var/mob/living/carbon/slime/slime = M
@@ -288,14 +282,8 @@
 		return
 
 	var/power = attacking_item.force
-	power = apply_skill_bonus(user, power, list(/datum/skill/melee = SKILL_LEVEL_NOVICE), 0.15) // 15% for each level
-	if(ishuman(user) && attacking_item.damtype == BRUTE)
-		var/mob/living/carbon/human/H = user
-		var/obj/item/organ/external/BP = H.get_bodypart(H.hand ? BP_L_ARM : BP_R_ARM)
-		if(BP.pumped)
-			power += max(round((PARABOLIC_SCALING(power, 1, -0.01) * BP.pumped * 0.5)), 0) //We need a pumped force multiplied by parabolic scaled item's force with a borders of 1 to 0
-	if(HULK in user.mutations)
-		power *= 2
+
+	power = scale_attack_bonuses(power, user, attacking_item.damtype)
 
 	var/damage = take_damage(power, attacking_item.damtype, MELEE, 1, get_dir(src, attacking_item))
 	//only witnesses close by and the victim see a hit message.
@@ -308,3 +296,14 @@
 
 /area/attacked_by(obj/item/attacking_item, mob/living/user)
 	CRASH("areas are NOT supposed to have attacked_by() called on them!")
+
+/proc/scale_attack_bonuses(power, mob/livling/user, damtype)
+	power = apply_skill_bonus(user, power, list(/datum/skill/melee = SKILL_LEVEL_NOVICE), 0.15) // 15% for each level
+	if(ishuman(user) && damtype == BRUTE)
+		var/mob/living/carbon/human/H = user
+		var/obj/item/organ/external/BP = H.get_bodypart(H.hand ? BP_L_ARM : BP_R_ARM)
+		if(BP.pumped)
+			power += max(round((PARABOLIC_SCALING(power, 1, -0.01) * BP.pumped * 0.5)), 0) //We need a pumped force multiplied by parabolic scaled item's force with a borders of 1 to 0
+	if(HULK in user.mutations)
+		power *= 2
+	return power

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -112,12 +112,12 @@
 	M.log_combat(user, "attacked with [name] (INTENT: [uppertext(user.a_intent)]) (DAMTYPE: [uppertext(damtype)])")
 
 	var/power = force
+	power = apply_skill_bonus(user, power, list(/datum/skill/melee = SKILL_LEVEL_NOVICE), 0.15) // 15% for each level
 	if(ishuman(user) && damtype == BRUTE)
 		var/mob/living/carbon/human/H = user
 		var/obj/item/organ/external/BP = H.get_bodypart(H.hand ? BP_L_ARM : BP_R_ARM)
 		if(BP.pumped)
-			power += max(round((PARABOLIC_SCALING(force, 1, 0.01) * BP.pumped * 0.1)), 0) //We need a pumped force multiplied by parabolic scaled item's force with a borders of 1 to 0
-	power = apply_skill_bonus(user, power, list(/datum/skill/melee = SKILL_LEVEL_NOVICE), 0.15) // 15% for each level
+			power += max(round((PARABOLIC_SCALING(power, 1, 0.01) * BP.pumped * 0.5)), 0) //We need a pumped force multiplied by parabolic scaled item's force with a borders of 1 to 0
 	if(HULK in user.mutations)
 		power *= 2
 	if(!ishuman(M))
@@ -287,7 +287,14 @@
 	if(!attacking_item.force)
 		return
 
-	var/damage = take_damage(attacking_item.force, attacking_item.damtype, MELEE, 1, get_dir(src, attacking_item))
+	var/attackforce = attacking_item.force
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		var/obj/item/organ/external/BP = H.get_bodypart(H.hand ? BP_L_ARM : BP_R_ARM)
+		if(BP.pumped)
+			attackforce += max(round((PARABOLIC_SCALING(attackforce, 1, 0.01) * BP.pumped * 0.5)), 0) //We need a pumped force multiplied by parabolic scaled item's force with a borders of 1 to 0
+
+	var/damage = take_damage(attackforce, attacking_item.damtype, MELEE, 1, get_dir(src, attacking_item))
 	//only witnesses close by and the victim see a hit message.
 	user.visible_message(
 		"<span class='danger'>[user] hits [src] with [attacking_item][damage ? "." : ", without leaving a mark!"]</span>",

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -290,7 +290,7 @@
 	var/attackforce = attacking_item.force
 	var/power = attacking_item.force
 	power = apply_skill_bonus(user, power, list(/datum/skill/melee = SKILL_LEVEL_NOVICE), 0.15) // 15% for each level
-	if(ishuman(user) && damtype == BRUTE)
+	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		var/obj/item/organ/external/BP = H.get_bodypart(H.hand ? BP_L_ARM : BP_R_ARM)
 		if(BP.pumped)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -289,7 +289,7 @@
 
 	var/power = attacking_item.force
 	power = apply_skill_bonus(user, power, list(/datum/skill/melee = SKILL_LEVEL_NOVICE), 0.15) // 15% for each level
-	if(ishuman(user))
+	if(ishuman(user) && attacking_item.damtype == BRUTE)
 		var/mob/living/carbon/human/H = user
 		var/obj/item/organ/external/BP = H.get_bodypart(H.hand ? BP_L_ARM : BP_R_ARM)
 		if(BP.pumped)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -297,7 +297,7 @@
 /area/attacked_by(obj/item/attacking_item, mob/living/user)
 	CRASH("areas are NOT supposed to have attacked_by() called on them!")
 
-/proc/scale_attack_bonuses(power, mob/livling/user, damtype)
+/proc/scale_attack_bonuses(power, mob/living/user, damtype)
 	power = apply_skill_bonus(user, power, list(/datum/skill/melee = SKILL_LEVEL_NOVICE), 0.15) // 15% for each level
 	if(ishuman(user) && damtype == BRUTE)
 		var/mob/living/carbon/human/H = user

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -117,7 +117,7 @@
 		var/mob/living/carbon/human/H = user
 		var/obj/item/organ/external/BP = H.get_bodypart(H.hand ? BP_L_ARM : BP_R_ARM)
 		if(BP.pumped)
-			power += max(round((PARABOLIC_SCALING(power, 1, 0.01) * BP.pumped * 0.5)), 0) //We need a pumped force multiplied by parabolic scaled item's force with a borders of 1 to 0
+			power += max(round((PARABOLIC_SCALING(power, 1, -0.01) * BP.pumped * 0.5)), 0) //We need a pumped force multiplied by parabolic scaled item's force with a borders of 1 to 0
 	if(HULK in user.mutations)
 		power *= 2
 	if(!ishuman(M))
@@ -288,13 +288,17 @@
 		return
 
 	var/attackforce = attacking_item.force
-	if(ishuman(user))
+	var/power = attacking_item.force
+	power = apply_skill_bonus(user, power, list(/datum/skill/melee = SKILL_LEVEL_NOVICE), 0.15) // 15% for each level
+	if(ishuman(user) && damtype == BRUTE)
 		var/mob/living/carbon/human/H = user
 		var/obj/item/organ/external/BP = H.get_bodypart(H.hand ? BP_L_ARM : BP_R_ARM)
 		if(BP.pumped)
-			attackforce += max(round((PARABOLIC_SCALING(attackforce, 1, 0.01) * BP.pumped * 0.5)), 0) //We need a pumped force multiplied by parabolic scaled item's force with a borders of 1 to 0
+			power += max(round((PARABOLIC_SCALING(power, 1, -0.01) * BP.pumped * 0.5)), 0) //We need a pumped force multiplied by parabolic scaled item's force with a borders of 1 to 0
+	if(HULK in user.mutations)
+		power *= 2
 
-	var/damage = take_damage(attackforce, attacking_item.damtype, MELEE, 1, get_dir(src, attacking_item))
+	var/damage = take_damage(power, attacking_item.damtype, MELEE, 1, get_dir(src, attacking_item))
 	//only witnesses close by and the victim see a hit message.
 	user.visible_message(
 		"<span class='danger'>[user] hits [src] with [attacking_item][damage ? "." : ", without leaving a mark!"]</span>",


### PR DESCRIPTION
## Описание изменений
Фикс бага что урон не скейлился по атомам, а также плохо скейлился по мобам из-за ошибки в формуле.

## Почему и что этот ПР улучшит
Багфикс.

## Авторство
AndreyGysev и все все все, кто помогал в дискорде.

## Чеинжлог
 :cl:
  - bugfix: Качки скейлят урон от лёгких предметов до десяточки на максимальном каче.