### PR TITLE
Fix projectile reaction on window with grille

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -591,7 +591,7 @@
 /atom/proc/isinspace()
 	return isspaceturf(get_turf(src))
 
-/atom/proc/checkpass(passflag)
+/atom/proc/checkpass(passflag) // todo: define as macro
 	return pass_flags&passflag
 
 //This proc is called on the location of an atom when the atom is Destroy()'d

--- a/code/game/objects/structures/windows/shuttle.dm
+++ b/code/game/objects/structures/windows/shuttle.dm
@@ -22,6 +22,12 @@
 				return damage_amount * 0.3
 	return ..()
 
+/obj/structure/window/shuttle/bullet_act(obj/item/projectile/Proj, def_zone)
+	if(Proj.checkpass(PASSGLASS))
+		return PROJECTILE_FORCE_MISS
+
+	return ..()
+
 /**
  * Shuttle reinforced(?)
  */

--- a/code/game/objects/structures/windows/window.dm
+++ b/code/game/objects/structures/windows/window.dm
@@ -109,12 +109,6 @@
 
 	return ..()
 
-/obj/structure/window/bullet_act(obj/item/projectile/Proj, def_zone)
-	if(Proj.pass_flags & PASSGLASS)	//Lasers mostly use this flag.. Why should they able to focus damage with direct click...
-		return PROJECTILE_FORCE_MISS
-
-	return ..()
-
 /obj/structure/window/ex_act(severity)
 	switch(severity)
 		if(EXPLODE_DEVASTATE)

--- a/code/game/objects/structures/windows/window_fulltile.dm
+++ b/code/game/objects/structures/windows/window_fulltile.dm
@@ -89,6 +89,12 @@
 		return TRUE
 	return !density
 
+/obj/structure/window/fulltile/bullet_act(obj/item/projectile/Proj, def_zone)
+	if(Proj.checkpass(PASSGLASS) && (!grilled || Proj.checkpass(PASSGRILLE)))
+		return PROJECTILE_FORCE_MISS
+
+	return ..()
+
 /obj/structure/window/fulltile/deconstruct(disassembled)
 	if(flags & NODECONSTRUCT)
 		return ..()

--- a/code/game/objects/structures/windows/window_thin.dm
+++ b/code/game/objects/structures/windows/window_thin.dm
@@ -32,6 +32,12 @@
 		anchored = FALSE
 		step(src, reverse_dir[attack_dir])
 
+/obj/structure/window/thin/bullet_act(obj/item/projectile/Proj, def_zone)
+	if(Proj.checkpass(PASSGLASS))
+		return PROJECTILE_FORCE_MISS
+
+	return ..()
+
 /obj/structure/window/thin/CanPass(atom/movable/mover, turf/target, height=0)
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return TRUE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Fixes #11196

гриль раньше окна всё равно не уничтожить, но если такая возможность нужна - я могу посмотреть отдельно.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
