### PR TITLE
Fulltile windows rebalance

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -591,7 +591,7 @@
 /atom/proc/isinspace()
 	return isspaceturf(get_turf(src))
 
-/atom/proc/checkpass(passflag)
+/atom/proc/checkpass(passflag) // todo: define as macro
 	return pass_flags&passflag
 
 //This proc is called on the location of an atom when the atom is Destroy()'d

--- a/code/game/objects/structures/windows/shuttle.dm
+++ b/code/game/objects/structures/windows/shuttle.dm
@@ -22,6 +22,12 @@
 				return damage_amount * 0.3
 	return ..()
 
+/obj/structure/window/shuttle/bullet_act(obj/item/projectile/Proj, def_zone)
+	if(Proj.checkpass(PASSGLASS))
+		return PROJECTILE_FORCE_MISS
+
+	return ..()
+
 /**
  * Shuttle reinforced(?)
  */

--- a/code/game/objects/structures/windows/window.dm
+++ b/code/game/objects/structures/windows/window.dm
@@ -109,12 +109,6 @@
 
 	return ..()
 
-/obj/structure/window/bullet_act(obj/item/projectile/Proj, def_zone)
-	if(Proj.pass_flags & PASSGLASS)	//Lasers mostly use this flag.. Why should they able to focus damage with direct click...
-		return PROJECTILE_FORCE_MISS
-
-	return ..()
-
 /obj/structure/window/ex_act(severity)
 	switch(severity)
 		if(EXPLODE_DEVASTATE)

--- a/code/game/objects/structures/windows/window.dm
+++ b/code/game/objects/structures/windows/window.dm
@@ -110,14 +110,20 @@
 
 	return ..()
 
+// almost same take_damage values as for turf/walls and /obj
+// need to reload because for some reason we have stupid parent /obj/structure/ex_act doing nothing
 /obj/structure/window/ex_act(severity)
+	if(resistance_flags & INDESTRUCTIBLE)
+		return
+	if(QDELETED(src))
+		return
 	switch(severity)
 		if(EXPLODE_DEVASTATE)
 			qdel(src)
 		if(EXPLODE_HEAVY)
-			take_damage(rand(30, 50), BRUTE, BOMB)
+			take_damage(rand(150, 250), BRUTE, BOMB)
 		if(EXPLODE_LIGHT)
-			take_damage(rand(5, 15), BRUTE, BOMB)
+			take_damage(rand(0, 55), BRUTE, BOMB)
 
 /obj/structure/window/airlock_crush_act()
 	take_damage(DOOR_CRUSH_DAMAGE * 2, BRUTE, MELEE)

--- a/code/game/objects/structures/windows/window.dm
+++ b/code/game/objects/structures/windows/window.dm
@@ -152,16 +152,6 @@
 /obj/structure/window/attack_paw(mob/user)
 	return attack_hand(user)
 
-/obj/structure/window/attack_generic(mob/user, damage_amount = 0, damage_type = BRUTE, damage_flag = 0, sound_effect = TRUE)
-	if(!damage_amount)
-		return
-	if(damage_amount >= 10)
-		visible_message("<span class='danger'>[user] smashes into [src]!</span>")
-		return ..(user, damage_amount, damage_type, damage_flag, sound_effect)
-
-	visible_message("<span class='notice'>\The [user] bonks \the [src] harmlessly.</span>")
-	user.do_attack_animation(src)
-
 /obj/structure/window/attack_slime(mob/user)
 	if(!isslimeadult(user))
 		return

--- a/code/game/objects/structures/windows/window.dm
+++ b/code/game/objects/structures/windows/window.dm
@@ -50,6 +50,7 @@
 
 	var/ratio = get_integrity() / max_integrity
 
+	// we owerwrite integrity_failure because we have multiple break stages and need to trigger atom_break() multiple times to use them
 	switch(ratio)
 		if(0 to 0.25)
 			if(!istype(src, /obj/structure/window/fulltile))

--- a/code/game/objects/structures/windows/window_fulltile.dm
+++ b/code/game/objects/structures/windows/window_fulltile.dm
@@ -89,6 +89,12 @@
 		return TRUE
 	return !density
 
+/obj/structure/window/fulltile/bullet_act(obj/item/projectile/Proj, def_zone)
+	if(Proj.checkpass(PASSGLASS) && (!grilled || Proj.checkpass(PASSGRILLE)))
+		return PROJECTILE_FORCE_MISS
+
+	return ..()
+
 /obj/structure/window/fulltile/deconstruct(disassembled)
 	if(flags & NODECONSTRUCT)
 		return ..()

--- a/code/game/objects/structures/windows/window_fulltile.dm
+++ b/code/game/objects/structures/windows/window_fulltile.dm
@@ -126,6 +126,13 @@
 
 	return ..()
 
+/obj/structure/window/fulltile/atom_destruction(damage_flag)
+	switch(damage_flag)
+		if(BOMB, FIRE, ACID)
+			grilled = FALSE
+
+	return ..()
+
 /**
  * Fulltile phoron
  */

--- a/code/game/objects/structures/windows/window_fulltile.dm
+++ b/code/game/objects/structures/windows/window_fulltile.dm
@@ -22,8 +22,12 @@
 	var/glass_color_blend_to_color
 	var/glass_color_blend_to_ratio
 
-	var/damage_threshold = 5   // this will be deducted from any physical damage source. Main difference in sturdiness between fulltiles and thin windows
 	var/image/crack_overlay
+
+	max_integrity = 20
+	damage_deflection = 2
+
+	armor = list(melee = 50, fire = 70)
 
 	var/disassemble_glass_type = /obj/item/stack/sheet/glass // any better ideas to handle drops and disassembles?
 
@@ -47,15 +51,6 @@
 		glass_color = new_color
 	
 	regenerate_smooth_icon()
-
-/obj/structure/window/fulltile/run_atom_armor(damage_amount, damage_type, damage_flag, attack_dir)
-	if(damage_threshold)
-		switch(damage_type)
-			if(BRUTE)
-				return max(0, damage_amount - damage_threshold)
-			if(BURN)
-				return damage_amount * 0.3
-	return ..()
 
 /obj/structure/window/fulltile/attackby(obj/item/W, mob/user)
 	if(isprying(W) && !(resistance_flags & DECONSTRUCT_IMMUNE)) // bad use of resistance_flags? we need some flag to prevent deconstructs
@@ -142,15 +137,12 @@
 	icon_state = "window_phoron"
 
 	max_integrity = 120
+	armor = list(melee = 50, fire = 99)
 
 	glass_color_blend_to_color = "#8000ff"
 	glass_color_blend_to_ratio = 0.5
 
 	disassemble_glass_type = /obj/item/stack/sheet/glass/phoronglass
-
-/obj/structure/window/fulltile/phoron/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
-	if(exposed_temperature > T0C + 32000)
-		take_damage(round(exposed_volume / 1000), BURN, FIRE, FALSE)
 
 /**
  * Fulltile reinforced
@@ -164,7 +156,8 @@
 	icon_state = "window_reinforced"
 
 	max_integrity = 100
-	damage_threshold = 10
+	damage_deflection = 5
+	armor = list(melee = 80, fire = 70, bomb = 25)
 
 	disassemble_glass_type = /obj/item/stack/sheet/rglass
 
@@ -178,15 +171,13 @@
 
 	icon_state = "window_reinforced_phoron"
 
-	max_integrity = 160
+	max_integrity = 200
+	armor = list(melee = 80, fire = 100, bomb = 50)
 
 	glass_color_blend_to_color = "#8000ff"
 	glass_color_blend_to_ratio = 0.5
 
 	disassemble_glass_type = /obj/item/stack/sheet/glass/phoronrglass
-
-/obj/structure/window/fulltile/reinforced/phoron/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
-	return
 
 /**
  * Fulltile reinforced tinted

--- a/code/game/objects/structures/windows/window_thin.dm
+++ b/code/game/objects/structures/windows/window_thin.dm
@@ -32,6 +32,12 @@
 		anchored = FALSE
 		step(src, reverse_dir[attack_dir])
 
+/obj/structure/window/thin/bullet_act(obj/item/projectile/Proj, def_zone)
+	if(Proj.checkpass(PASSGLASS))
+		return PROJECTILE_FORCE_MISS
+
+	return ..()
+
 /obj/structure/window/thin/CanPass(atom/movable/mover, turf/target, height=0)
 	if(istype(mover) && mover.checkpass(PASSGLASS))
 		return TRUE

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -99,7 +99,7 @@
 			return grab.affecting
 	return H
 
-/obj/item/projectile/proc/on_hit(atom/target, def_zone = BP_CHEST, blocked = 0)
+/obj/item/projectile/proc/on_hit(atom/target, def_zone = BP_CHEST, blocked = 0) // why we have this and on_impact at the same time
 	if(!isliving(target))
 		return 0
 	if(isanimal(target))


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Содержит #11219 (close #11219), исправляет #11196 (fix #11196) и первый шаг к #11199. Альтернатива #11205.

Кратко по человечески:
* Ребаланс урона. В целом не сильно изменяется по сравнению с тем, что сейчас, в некоторых случаях будет ломаться чуть дольше, в других чуть быстрее. Окна лучше противостоят рукопашному типу урона (в т.ч. подручным огнетушителем), но уязвимее к остальным (огнестрельное). Еще стоит напомнить, что у некоторых предметов урон от бросания больше, чем если колотить самому (тулбоксы).
* Ребаланс сделан с оглядкой на замещение укрепленных окон обычными (например #11195) там, где предполагается возможность их легко сломать. И с оглядкой на тг. Обычные окна довольно хрупкие и расправится с ними дело нескольких ударов. Укрепленные всё еще будут отстаивать своё имя и защищать космонавтов от сурового космоса.
* Взрывы более разрушительны для окон -> #11199
* Реплики своими выстрелами могут сломать сетку раньше окна -> #11196

## Почему и что этот ПР улучшит

Подробнее технически.

Старый механизм ``damage_threshold`` был убран в пользу комбинации ``damage_deflection`` и ``armor``.

``damage_deflection`` остался только для вида, 2 для обычных окон и 5 для укрепленных, просто что бы избежать абсурдных ситуаций как ломание окна крапивой. Прочность теперь определяется только количеством ``integrity`` и броней для тонкой настройки.

Идея с ``armor`` напрашивалась хотя-бы потому, что окна уже имели какой-то свой перегруженный ``run_atom_armor``, а фороновые окна перегружали ``fire_act``. После переприкрутки этих особенностей на броню стало почище. 

К тому же, я сверился с тг, где примерно так же. И где была интересная идея делать окна более бронированными от ``melee``. Так что в данной реализации окна получились примерно похожи на тг-шные по статам.

<details>
<summary>Броня окон с tg для сравнения (актуальную в PR-е смотрите во вкладке diff-а)</summary>

```
/datum/armor/structure_window
	melee = 50
	fire = 80
	acid = 100

/datum/armor/window_reinforced
	melee = 80
	bomb = 25
	fire = 80
	acid = 100

/datum/armor/window_plasma
	melee = 80
	bullet = 5
	bomb = 45
	fire = 99
	acid = 100

/datum/armor/reinforced_plasma
	melee = 80
	bullet = 20
	bomb = 60
	fire = 99
	acid = 100
```

</details>

По факту, reinforced окна всё еще достаточно долго ковырять в ручную (хотя без ``damage_threshold`` и с малым ``damage_deflection`` инструментов для ковыряния стало больше), но вопрос только замены не критичных окон на обычные (гражданские отсеки, общие коридоры). Огнестрел зато более эффективен. В дальнейшем мы можем тонко донастроить урон через броню.

Урон от взрывов был бафнут (взяты значения от стен), отдельные типы окон могут чуть лучше сопротивляться взрывам (фонон). Окна, уничтоженные взрывом, больше не оставляют сеточку. От вылетов в космос нас отделяет только возможность летать (работаю над этим).

Реплики... я починил репликов (снаряды с PASSGLASS но без PASSGRILL только у них). Есть зависимость от ``integrity`` самого окна и небольшое rng (обсуждаемо), в целом они ломают решетку за 1-10 выстрелов. С каждым следующим выстрелом шанс возрастает.

Я всё еще не трогал тонкие окна, они как были, так и остаются. И не притрагивался к шаттло-окнам. Это отдельные грустные темы.

## Авторство

## Чеинжлог

:cl: 
 - tweak: Ребаланс урона по новым окнам. Сейчас вы этого почти не заметите (пока мы не расставим по станции не-reinforced окна), но если кратко - взрывы и огнестрел теперь более эффективны против окон.