### PR TITLE
Ревплакат фикс

### DIFF
--- a/code/game/objects/effects/decals/contraband.dm
+++ b/code/game/objects/effects/decals/contraband.dm
@@ -645,6 +645,8 @@
 
 /obj/structure/sign/poster/revolution/examine(mob/user)
 	. = ..()
+	if(ruined)
+		return
 	if(!ishuman(user))
 		return
 	to_chat(user, "<span class='notice'>The image on the poster feels memetic. It makes you feel things you shouldn't be feeling staring on a QR code wannabe.</span>")

--- a/code/game/objects/effects/decals/contraband.dm
+++ b/code/game/objects/effects/decals/contraband.dm
@@ -640,7 +640,7 @@
 	else if(jobban_isbanned(user, ROLE_REV) || jobban_isbanned(user, "Syndicate"))
 		to_chat(user, "<span class='bold warning'>You can't overcome the guilt to join the revolutionaries. (You are banned.)</span>")
 		return
-	else if(!isrevhead(user) || !isrev(user))
+	else if(!isrevhead(user) && !isrev(user))
 		rev.convert_revolutionare(user)
 
 /obj/structure/sign/poster/revolution/examine(mob/user)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Главрева может перевступить в реву через плакат. Теперь не может.
## Почему и что этот ПР улучшит
fix bugs
## Авторство

## Чеинжлог
