### PR TITLE
Ремонт кидания игрушек

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -140,7 +140,7 @@
 
 	. = ..()
 
-/obj/item/toy/throw_at(atom/target, range, speed, mob/thrower, spin = TRUE, diagonals_first = FALSE, datum/callback/callback)
+/obj/item/toy/spinningtoy/throw_at(atom/target, range, speed, mob/thrower, spin = TRUE, diagonals_first = FALSE, datum/callback/callback)
 	return
 
 /obj/item/toy/spinningtoy/attack_hand(mob/user)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Теперь из всех игрушек не кидается только фейковая сингулярность
## Почему и что этот ПР улучшит
Починятся мини метеоры, взрывные пакетики, шарики с водой, и прочие игрушки которые весело кидать
closes #10555
## Авторство
Буквально Гусев, которому лень полгода уже как починить это
## Чеинжлог
:cl: Sivean
- bugfix: Исправлено бросание игрушек