### PR TITLE
Удаление ивентов с новостями

### DIFF
--- a/code/modules/economy/economy_misc.dm
+++ b/code/modules/economy/economy_misc.dm
@@ -80,20 +80,6 @@ var/global/initial_station_money = 7500
 	if(economy_init)
 		return 2
 
-	var/datum/feed_channel/newChannel = new /datum/feed_channel
-	newChannel.channel_name = "[system_name()] Daily"
-	newChannel.author = "CentComm Minister of Information"
-	newChannel.locked = 1
-	newChannel.is_admin_channel = 1
-	news_network.network_channels += newChannel
-
-	newChannel = new /datum/feed_channel
-	newChannel.channel_name = "The Gibson Gazette"
-	newChannel.author = "Editor Mike Hammers"
-	newChannel.locked = 1
-	newChannel.is_admin_channel = 1
-	news_network.network_channels += newChannel
-
 	for(var/loc_type in subtypesof(/datum/trade_destination))
 		var/datum/trade_destination/D = new loc_type
 		weighted_randomevent_locations[D] = D.viable_random_events.len

--- a/code/modules/events/_event_container.dm
+++ b/code/modules/events/_event_container.dm
@@ -184,8 +184,6 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_FEATURE = "RoundStart", EV
 	new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Money Lotto",        /datum/event/money_lotto,                             0,    list(ASSIGNMENT_ANY = 1), ONESHOT, 1, 0,  5, 15),
 	new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Money Hacker",       /datum/event/money_hacker,                            0,    list(ASSIGNMENT_ANY = 4), ONESHOT, 1, 0, 10, 25),
 	new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Economic Event",     /datum/event/economic_event,                          300),
-	new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Trivial News",       /datum/event/trivial_news,                            400),
-	new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Mundane News",       /datum/event/mundane_news,                            300),
 	new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Vermin Infestation", /datum/event/infestation,                             100,  list(ASSIGNMENT_JANITOR = 100)),
 	new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Wallrot",            /datum/event/wallrot,                                 0,    list(ASSIGNMENT_ENGINEER = 30, ASSIGNMENT_BOTANIST = 50)),
 	new /datum/event_meta(EVENT_LEVEL_MUNDANE, "Xenohive",           /datum/event/feature/area/maintenance_spawn/xenohive, 300),


### PR DESCRIPTION
## Описание изменений
Оно мешает продвижению новостей от **людей**. Что это значит?
Мы привыкли, что вот пищит Ньювскастер. “Да там ничего интересного…” Уже на автомате. А вот если удалить ивенты с новостями, то наше устройство начнёт пишать только тогда, когда реальный человек зальёт туда свою новость.
Что я сделал конкретно, просто удалил эти два канала и ивенты с их автоматическим заполнением.
![image](https://user-images.githubusercontent.com/115452414/230588448-42b84ed8-77cf-49c6-a638-289174a7d838.png)
## Почему и что этот ПР улучшит
Какие плюсы? Подумайте сами. Мы, надеюсь, перестанем игнорировать эту довольно полезную вещь. Там иногда бывают реально интересные и забавные статьи, сделанные игроками во время раунда, но их никто не замечает, ведь уведомления перекрывают проклятые ивенты с новостями…
## Авторство
## Чеинжлог
:cl: Basia
- del: Удалены ивенты с новостями у "Newscaster"