### PR TITLE
New windows for other maps

### DIFF
--- a/maps/falcon/falcon.dmm
+++ b/maps/falcon/falcon.dmm
@@ -109,18 +109,13 @@
 /obj/machinery/computer/operating{
 	dir = 8
 	},
-/obj/machinery/windowtint{
-	id = "op1";
-	pixel_x = -10;
-	pixel_y = -30
-	},
 /obj/machinery/holosign_switch{
 	id = "op1";
-	pixel_x = -3;
+	pixel_x = -5;
 	pixel_y = -30
 	},
 /obj/machinery/light_switch{
-	pixel_x = 4;
+	pixel_x = 5;
 	pixel_y = -30
 	},
 /turf/simulated/floor{
@@ -479,10 +474,9 @@
 	name = "Surgery Shutters";
 	opacity = 0
 	},
-/obj/structure/window/fulltile/reinforced/polarized{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced_polarized";
-	id = "op1"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/surgery)
@@ -998,9 +992,9 @@
 /area/station/civilian/bar)
 "abM" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/surgeryobs)
@@ -3736,9 +3730,9 @@
 	id = "Security_private";
 	opacity = 0
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
@@ -4601,9 +4595,9 @@
 /area/station/tcommsat/computer)
 "aig" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/locker)
@@ -4634,9 +4628,9 @@
 /area/station/civilian/locker)
 "aij" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
@@ -5957,9 +5951,9 @@
 /area/station/maintenance/escape)
 "akY" = (
 /obj/structure/barricade/wooden,
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
@@ -6050,9 +6044,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
@@ -6209,9 +6203,9 @@
 "alB" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/construction/assembly_line)
@@ -6441,9 +6435,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
@@ -7955,10 +7949,8 @@
 	},
 /area/station/engineering/drone_fabrication)
 "apg" = (
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced,
 /turf/simulated/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -9476,9 +9468,9 @@
 	},
 /area/station/rnd/hallway)
 "arG" = (
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/asteroid/mine/eva)
@@ -10327,6 +10319,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/bridge/hop_office)
+"aXo" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/checkpoint)
 "aXD" = (
 /obj/machinery/atm{
 	pixel_x = 28
@@ -11695,9 +11695,9 @@
 /turf/simulated/floor/plating,
 /area/station/bridge/server)
 "cmp" = (
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced{
+	dir = 8
 	},
 /turf/simulated/floor/plating{
 	icon_state = "panelscorched"
@@ -12283,9 +12283,9 @@
 /area/station/maintenance/science)
 "cWy" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/outpost_misc_lab)
@@ -12547,10 +12547,6 @@
 /area/station/maintenance/medbay)
 "dnr" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "dns" = (
@@ -13200,6 +13196,14 @@
 	},
 /turf/simulated/floor/engine/airmix,
 /area/station/engineering/atmos)
+"dMV" = (
+/obj/structure/barricade/wooden,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/escape)
 "dMZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -13641,18 +13645,16 @@
 	name = "Security Blast Door";
 	opacity = 0
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "emi" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "emk" = (
@@ -13853,9 +13855,9 @@
 /area/station/medical/cmo)
 "ews" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
@@ -14171,9 +14173,9 @@
 	name = "Security Blast Door";
 	opacity = 0
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
@@ -15146,6 +15148,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
+"fVM" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	icon_state = "shutter0";
+	id = "chapel";
+	name = "Privacy Shutters";
+	opacity = 0
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/chapel/office)
 "fXC" = (
 /obj/machinery/alarm{
 	pixel_y = 21
@@ -16837,9 +16858,9 @@
 	},
 /area/station/hallway/primary/central)
 "hGT" = (
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
@@ -16861,9 +16882,9 @@
 	icon_state = "shock";
 	name = "HIGH VOLTAGE"
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison)
@@ -17089,9 +17110,9 @@
 /area/station/bridge/nuke_storage)
 "hYy" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/telesci)
@@ -17722,9 +17743,9 @@
 /area/station/engineering/drone_fabrication)
 "iDh" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/spectro)
@@ -22688,9 +22709,9 @@
 "nrV" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/departments/cargo,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
@@ -23566,9 +23587,9 @@
 /turf/simulated/floor/grass,
 /area/station/civilian/kitchen)
 "omu" = (
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/asteroid/mine/dwarf)
@@ -24249,9 +24270,9 @@
 /area/station/hallway/primary/central)
 "oRV" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/dormitories)
@@ -24289,7 +24310,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/security/glass{
+/obj/machinery/door/airlock/security{
 	name = "Security Checkpoint";
 	req_access = list(1)
 	},
@@ -24605,9 +24626,9 @@
 /area/station/hallway/secondary/exit)
 "phW" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/bar)
@@ -24805,10 +24826,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
+/obj/structure/window/thin/reinforced,
+/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "ptp" = (
@@ -25236,10 +25255,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "pIw" = (
@@ -25965,9 +25982,9 @@
 /obj/item/weapon/shard{
 	icon_state = "small"
 	},
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
@@ -26136,9 +26153,9 @@
 /area/station/maintenance/medbay)
 "qyn" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel)
@@ -26948,8 +26965,12 @@
 	pixel_x = -32;
 	pixel_y = 4
 	},
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/pen,
+/obj/item/weapon/paper_bin{
+	pixel_y = 4
+	},
+/obj/item/weapon/pen{
+	pixel_y = 6
+	},
 /obj/structure/table/glass,
 /turf/simulated/floor{
 	dir = 5;
@@ -27076,12 +27097,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "rsc" = (
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
 /turf/simulated/floor/plating,
 /area/station/engineering/break_room)
 "rsx" = (
@@ -27448,9 +27469,9 @@
 /area/station/hallway/primary/central)
 "rJp" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
@@ -28259,10 +28280,6 @@
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "sCU" = (
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -28278,6 +28295,10 @@
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
 	name = "HIGH VOLTAGE"
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/break_room)
@@ -28985,9 +29006,9 @@
 /area/station/maintenance/medbay)
 "tvX" = (
 /obj/structure/spider/stickyweb,
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced{
+	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
@@ -29743,9 +29764,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/bar)
@@ -30309,10 +30330,6 @@
 	},
 /area/station/tcommsat/chamber)
 "uGd" = (
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -30326,6 +30343,10 @@
 	icon_state = "0-4"
 	},
 /obj/structure/sign/departments/engineering,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
 /turf/simulated/floor/plating,
 /area/station/engineering/break_room)
 "uIb" = (
@@ -30965,9 +30986,9 @@
 /area/station/engineering/atmos)
 "vrd" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
@@ -31323,10 +31344,8 @@
 /area/station/hallway/primary/central)
 "vMW" = (
 /obj/structure/spider/stickyweb,
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced,
 /turf/simulated/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -31542,6 +31561,14 @@
 	icon_state = "warndark"
 	},
 /area/station/rnd/lab)
+"vZj" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/storage)
 "waf" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots,
@@ -31989,9 +32016,9 @@
 	name = "Security Blast Door";
 	opacity = 0
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison)
@@ -32310,9 +32337,9 @@
 	icon_state = "shock";
 	name = "HIGH VOLTAGE"
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
@@ -32382,9 +32409,9 @@
 /area/shuttle/escape_pod4/station)
 "wMu" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
@@ -32569,6 +32596,14 @@
 /obj/random/tools/tool,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
+"wXK" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/central)
 "wYk" = (
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/auxsolarstarboard)
@@ -33097,6 +33132,12 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
+"xwY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced,
+/turf/simulated/floor/plating,
+/area/station/maintenance/science)
 "xxm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
 	frequency = 1379;
@@ -33949,9 +33990,9 @@
 	},
 /area/station/civilian/kitchen)
 "yiI" = (
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced{
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
@@ -52859,7 +52900,7 @@ ahz
 vyl
 ahz
 qBV
-qBV
+fVM
 qBV
 ahz
 ilV
@@ -53127,9 +53168,9 @@ jAT
 epi
 ffn
 pNu
-nsB
+aXo
 lDV
-nsB
+aXo
 pNu
 pNu
 aks
@@ -54421,8 +54462,8 @@ akv
 akV
 alo
 alM
-akY
-akY
+dMV
+dMV
 akb
 akb
 akb
@@ -64449,7 +64490,7 @@ ifz
 jcU
 nYR
 mGI
-scr
+vZj
 xFt
 ggc
 xQe
@@ -64960,10 +65001,10 @@ afX
 oQo
 xwG
 ifz
-pTS
+wXK
 wji
 ygZ
-scr
+vZj
 eJt
 ykW
 dyA
@@ -72681,7 +72722,7 @@ lUt
 lUt
 acL
 agV
-rJp
+xwY
 aok
 lUt
 lUt

--- a/maps/prometheus/prometheus.dmm
+++ b/maps/prometheus/prometheus.dmm
@@ -388,9 +388,9 @@
 	icon_state = "shock";
 	name = "HIGH VOLTAGE"
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/equip)
@@ -3020,10 +3020,6 @@
 	},
 /area/station/security/checkpoint)
 "ajj" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "qm_warehouse";
-	name = "Warehouse Shutters"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3038,6 +3034,10 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "qm_warehouse";
+	name = "Warehouse Shutters"
 	},
 /turf/simulated/floor{
 	icon_state = "delivery"
@@ -3191,10 +3191,6 @@
 	},
 /area/station/security/brig)
 "akX" = (
-/obj/machinery/door/poddoor{
-	id = "Armoury";
-	name = "Emergency Access"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -3206,6 +3202,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor{
+	id = "Armoury";
+	name = "Emergency Access"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -4126,9 +4126,9 @@
 /area/station/maintenance/dormitory)
 "awq" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
@@ -5056,11 +5056,11 @@
 	},
 /area/station/maintenance/atmos)
 "aGK" = (
+/obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
 	id = "Armoury0";
 	name = "Emergency Access"
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -7649,9 +7649,9 @@
 	name = "Chemistry Shutters";
 	opacity = 0
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/chemistry)
@@ -7825,9 +7825,9 @@
 /area/station/maintenance/science)
 "bsK" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/misc_lab)
@@ -7934,6 +7934,15 @@
 	icon_state = "darkgreen"
 	},
 /area/station/rnd/misc_lab)
+"btG" = (
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced{
+	dir = 1
+	},
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/station/maintenance/science)
 "btH" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor{
@@ -8467,11 +8476,11 @@
 	name = "Tribunal"
 	})
 "bBk" = (
+/obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
 	id = "cell4";
 	name = "Cell Door"
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -8726,9 +8735,9 @@
 	name = "Engineering Security Doors";
 	opacity = 0
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/equip)
@@ -8781,10 +8790,8 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "bFX" = (
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced,
 /turf/simulated/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -8983,9 +8990,6 @@
 /area/station/hallway/primary/fore)
 "bIC" = (
 /obj/structure/grille,
-/obj/structure/window/thin/reinforced{
-	dir = 8
-	},
 /obj/structure/barricade/wooden,
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
@@ -9534,6 +9538,14 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/misc_lab)
+"bPn" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/storage)
 "bPo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/space_heater,
@@ -9944,9 +9956,9 @@
 /area/station/maintenance/dormitory)
 "bUy" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
@@ -9962,6 +9974,14 @@
 	icon_state = "panelscorched"
 	},
 /area/station/maintenance/science)
+"bUJ" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos)
 "bUT" = (
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plating,
@@ -10874,9 +10894,9 @@
 	icon_state = "shock";
 	name = "HIGH VOLTAGE"
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
@@ -12544,9 +12564,9 @@
 "cIj" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/departments/holy,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/mass_driver)
@@ -14596,7 +14616,12 @@
 /obj/structure/flora/ausbushes/ppflowers{
 	layer = 2.7
 	},
-/obj/structure/window/fulltile/reinforced,
+/obj/structure/window/thin/reinforced{
+	dir = 4
+	},
+/obj/structure/window/thin/reinforced{
+	dir = 8
+	},
 /turf/simulated/floor/grass,
 /area/station/hallway/secondary/exit)
 "diJ" = (
@@ -14904,9 +14929,9 @@
 /area/station/maintenance/chapel)
 "dmE" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/medbreak)
@@ -15931,9 +15956,9 @@
 	opacity = 0
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/monitoring)
@@ -16484,9 +16509,9 @@
 	name = "Surgery Shutters";
 	opacity = 0
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/surgery{
@@ -17007,9 +17032,9 @@
 	buildable_sign = 0;
 	dir = 1
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
@@ -17584,9 +17609,9 @@
 /area/station/security/prison)
 "dRV" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
@@ -18673,9 +18698,9 @@
 /area/station/maintenance/brig)
 "ehC" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/interrogation)
@@ -18763,11 +18788,11 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
+/obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
 	id = "Skynet_launch";
 	name = "Mech Bay"
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	icon_state = "delivery"
 	},
@@ -19613,6 +19638,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"esl" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters{
+	density = 0;
+	icon_state = "shutter0";
+	id = "HoP_queue";
+	opacity = 0
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/bridge/hop_office)
 "esq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -20569,9 +20608,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
@@ -21437,9 +21476,9 @@
 "ePg" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/warden)
@@ -21466,11 +21505,11 @@
 /turf/simulated/floor,
 /area/station/engineering/engine)
 "ePy" = (
+/obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
 	id = "Armoury";
 	name = "Emergency Access"
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -21712,9 +21751,9 @@
 "eSo" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
@@ -21727,9 +21766,9 @@
 	name = "Privacy Shutters";
 	opacity = 0
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/office)
@@ -21739,6 +21778,15 @@
 	icon_state = "floorgrime"
 	},
 /area/station/maintenance/incinerator)
+"eSN" = (
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/station/maintenance/science)
 "eST" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor/engine{
@@ -22450,9 +22498,9 @@
 /area/station/medical/cryo)
 "faY" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/library)
@@ -23313,9 +23361,9 @@
 /area/station/maintenance/brig)
 "flQ" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/lobby)
@@ -23525,9 +23573,9 @@
 /area/station/cargo/storage)
 "fol" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/genetics)
@@ -23598,9 +23646,9 @@
 /area/station/security/checkpoint)
 "foG" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/primary)
@@ -23815,9 +23863,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
@@ -24413,11 +24461,11 @@
 /turf/simulated/floor,
 /area/station/civilian/garden)
 "fxS" = (
+/obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
 	id = "Gateway_shutters";
 	name = "Gateway Shutters"
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	icon_state = "darkbluefull"
 	},
@@ -27412,9 +27460,9 @@
 	},
 /area/station/rnd/misc_lab)
 "ghy" = (
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced{
+	dir = 4
 	},
 /turf/simulated/floor/plating{
 	icon_state = "panelscorched"
@@ -27493,9 +27541,9 @@
 /area/station/hallway/secondary/exit)
 "giq" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/reception)
@@ -29173,10 +29221,6 @@
 	},
 /area/station/bridge)
 "gDP" = (
-/obj/machinery/door/poddoor{
-	id = "cell6";
-	name = "Cell Door"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -29184,6 +29228,10 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/door/poddoor{
+	id = "cell6";
+	name = "Cell Door"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -30098,10 +30146,6 @@
 	},
 /area/station/civilian/library)
 "gNJ" = (
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d2 = 2;
@@ -30113,6 +30157,10 @@
 	id = "Engineering";
 	name = "Engineering Security Doors";
 	opacity = 0
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/equip)
@@ -31392,9 +31440,9 @@
 /area/station/security/lobby)
 "hcf" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/brainstorm_center)
@@ -31559,6 +31607,14 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
+"hdZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/brig)
 "hee" = (
 /obj/structure/stool/bed/roller,
 /turf/simulated/floor{
@@ -32627,9 +32683,9 @@
 /area/station/civilian/locker)
 "hrP" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/cafeteria)
@@ -33250,9 +33306,9 @@
 /area/station/maintenance/starboardsolar)
 "hBe" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
@@ -35667,9 +35723,9 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/warden)
@@ -37033,6 +37089,13 @@
 	icon_state = "panelscorched"
 	},
 /area/station/maintenance/engineering)
+"izO" = (
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/science)
 "izP" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -37678,16 +37741,16 @@
 	},
 /area/station/medical/chemistry)
 "iIp" = (
-/obj/machinery/door/poddoor{
-	id = "Armoury0";
-	name = "Emergency Access"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	id = "Armoury0";
+	name = "Emergency Access"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -38888,9 +38951,9 @@
 /area/station/engineering/engine)
 "iYJ" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/eva)
@@ -40008,11 +40071,11 @@
 	},
 /area/station/rnd/storage)
 "joS" = (
+/obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
 	id = "qm_warehouse";
 	name = "Warehouse Shutters"
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	icon_state = "delivery"
 	},
@@ -40368,9 +40431,9 @@
 /area/station/security/secconfhall)
 "jtc" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/telesci)
@@ -41154,11 +41217,11 @@
 	},
 /area/station/security/prison)
 "jDG" = (
+/obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
 	id = "cell1";
 	name = "Cell Door"
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -43600,9 +43663,9 @@
 /area/station/civilian/library)
 "knP" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/storage)
@@ -43730,9 +43793,9 @@
 /area/station/civilian/gym)
 "kqa" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/barbershop)
@@ -44896,13 +44959,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "kEE" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/poddoor{
 	id = "Secure Storage";
 	name = "Secure Storage"
 	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating{
 	icon_state = "warnplate"
 	},
@@ -46410,9 +46473,9 @@
 /area/station/security/brig)
 "kYw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
@@ -47245,11 +47308,11 @@
 	},
 /area/station/medical/medbreak)
 "lhk" = (
+/obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
 	id = "Secure Storage";
 	name = "Secure Storage"
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating{
 	icon_state = "warnplate"
 	},
@@ -47676,9 +47739,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig)
@@ -47814,6 +47877,17 @@
 	icon_state = "warndark"
 	},
 /area/station/rnd/misc_lab)
+"loC" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos)
 "loZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -48042,9 +48116,9 @@
 /area/station/security/prison)
 "lrU" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/port)
@@ -48358,6 +48432,14 @@
 	icon_state = "dark"
 	},
 /area/station/bridge)
+"lwk" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/recycleroffice)
 "lwo" = (
 /obj/machinery/computer/security/mining,
 /obj/machinery/light/small{
@@ -48648,6 +48730,14 @@
 	icon_state = "warnplate"
 	},
 /area/station/engineering/engine)
+"lAq" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/garden)
 "lAw" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
 /turf/simulated/floor/plating,
@@ -48833,9 +48923,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/warden)
@@ -49787,9 +49877,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/lobby)
@@ -49842,9 +49932,11 @@
 	},
 /area/station/maintenance/chapel)
 "lPt" = (
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
+/obj/structure/grille{
+	destroyed = 1
+	},
+/obj/structure/window/thin/reinforced{
+	dir = 8
 	},
 /turf/simulated/floor/plating{
 	icon_state = "panelscorched"
@@ -50248,6 +50340,16 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
+"lUY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced{
+	dir = 4
+	},
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/station/maintenance/brig)
 "lVa" = (
 /obj/machinery/door_control{
 	desc = "A remote control switch for the brig foyer.";
@@ -50435,9 +50537,9 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
@@ -53664,11 +53766,11 @@
 	},
 /area/station/hallway/secondary/arrival)
 "mKe" = (
+/obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
 	id = "cell3";
 	name = "Cell Door"
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -54396,9 +54498,9 @@
 /area/station/maintenance/dormitory)
 "mUD" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/miningoffice)
@@ -55557,16 +55659,16 @@
 	},
 /area/station/hallway/primary/central)
 "njL" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "Gateway_shutters";
-	name = "Gateway Shutters"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "Gateway_shutters";
+	name = "Gateway Shutters"
 	},
 /turf/simulated/floor{
 	icon_state = "darkbluefull"
@@ -55615,11 +55717,11 @@
 /turf/environment/space/shuttle,
 /area/shuttle/escape_pod4/station)
 "nkt" = (
+/obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
 	id = "cell5";
 	name = "Cell Door"
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -56534,9 +56636,9 @@
 /area/station/maintenance/chapel)
 "nxg" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/secconfhall)
@@ -57670,9 +57772,9 @@
 /area/station/rnd/xenobiology)
 "nMY" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/hallway)
@@ -57685,9 +57787,9 @@
 	name = "Privacy Shutters";
 	opacity = 0
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/psych)
@@ -57707,10 +57809,7 @@
 /area/space)
 "nNv" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
+/obj/structure/grille,
 /turf/simulated/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -58392,9 +58491,9 @@
 	name = "Security Blast Door";
 	opacity = 0
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison)
@@ -58780,9 +58879,9 @@
 /area/station/rnd/lab)
 "ocK" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
@@ -59876,16 +59975,16 @@
 	},
 /area/station/civilian/holodeck)
 "orb" = (
-/obj/machinery/door/poddoor/shutters{
-	id = "Gateway_shutters_entrance";
-	name = "Gateway Shutters"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters{
+	id = "Gateway_shutters_entrance";
+	name = "Gateway Shutters"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -60264,9 +60363,9 @@
 	buildable_sign = 0;
 	dir = 8
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/aft)
@@ -61169,9 +61268,9 @@
 	})
 "oHh" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison)
@@ -61979,9 +62078,9 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
@@ -62515,10 +62614,8 @@
 /area/station/civilian/cafeteria)
 "oZl" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "oZp" = (
@@ -63216,9 +63313,9 @@
 "piZ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/departments/medbay,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison)
@@ -64059,9 +64156,9 @@
 "pws" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/departments/holy,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel)
@@ -64279,9 +64376,9 @@
 /obj/structure/sign/directions/medical{
 	buildable_sign = 0
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/bar)
@@ -65242,13 +65339,13 @@
 	},
 /area/station/maintenance/brig)
 "pMi" = (
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
@@ -65872,9 +65969,9 @@
 /area/station/aisat/teleport)
 "pUW" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/fitness)
@@ -66330,9 +66427,9 @@
 /area/station/engineering/chiefs_office)
 "qaC" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/cryo)
@@ -67201,9 +67298,9 @@
 /area/station/maintenance/portsolar)
 "qlk" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/theatre)
@@ -68984,9 +69081,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "qJE" = (
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/garden)
@@ -69040,9 +69137,9 @@
 	name = "Security Blast Door";
 	opacity = 0
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison)
@@ -69474,9 +69571,9 @@
 /area/station/security/detectives_office)
 "qRA" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/fore)
@@ -70708,9 +70805,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "riq" = (
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
+/obj/structure/grille{
+	destroyed = 1
+	},
+/obj/structure/window/thin/reinforced{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
@@ -71037,9 +71136,9 @@
 /area/station/bridge/captain_quarters)
 "rmK" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/office)
@@ -71297,9 +71396,9 @@
 	id = "Security_private";
 	opacity = 0
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
@@ -71756,9 +71855,9 @@
 /area/station/cargo/recycler)
 "rwS" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/robotics)
@@ -73496,11 +73595,11 @@
 	},
 /area/station/rnd/telesci)
 "rTa" = (
+/obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
 	id = "Gateway_shutters_entrance";
 	name = "Gateway Shutters"
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -74167,9 +74266,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/warden)
@@ -74508,9 +74607,9 @@
 "sgo" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/plaques/kiddie/library,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/library)
@@ -74855,10 +74954,10 @@
 /turf/simulated/floor/plating,
 /area/station/security/detectives_office)
 "smc" = (
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
+/obj/structure/window/thin/reinforced{
+	dir = 8
 	},
+/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "smm" = (
@@ -75025,6 +75124,14 @@
 	icon_state = "whitegreen"
 	},
 /area/station/maintenance/medbay)
+"soF" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/virology)
 "soH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -75488,9 +75595,9 @@
 /area/station/maintenance/medbay)
 "suL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced{
+	dir = 4
 	},
 /turf/simulated/floor/plating{
 	icon_state = "platingdmg2"
@@ -75712,9 +75819,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
@@ -77265,6 +77372,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"sRF" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/exit)
 "sRO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -78202,9 +78317,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
@@ -80351,10 +80466,8 @@
 /obj/structure/sign/warning/pods{
 	pixel_x = -32
 	},
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "tHL" = (
@@ -80367,6 +80480,15 @@
 	icon_state = "warndark"
 	},
 /area/station/medical/chemistry)
+"tHO" = (
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/station/maintenance/atmos)
 "tIb" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	dir = 1;
@@ -80707,9 +80829,9 @@
 	name = "Engineering Security Doors";
 	opacity = 0
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/equip)
@@ -83093,9 +83215,9 @@
 "urM" = (
 /obj/machinery/door/firedoor,
 /obj/structure/barricade/wooden,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
@@ -83895,9 +84017,9 @@
 /area/station/civilian/chapel/crematorium)
 "uCx" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/vacantoffice{
@@ -84151,9 +84273,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/eva)
@@ -84400,9 +84522,9 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "uJd" = (
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
@@ -85652,9 +85774,9 @@
 /area/station/rnd/brainstorm_center)
 "uZp" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/genetics_cloning)
@@ -85997,9 +86119,9 @@
 /area/station/maintenance/cargo)
 "vcT" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/patients_rooms)
@@ -86702,9 +86824,9 @@
 "vlu" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
@@ -86865,9 +86987,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/lobby)
@@ -87117,9 +87239,9 @@
 /area/station/engineering/atmos)
 "vrv" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/surgeryobs)
@@ -87149,6 +87271,14 @@
 	icon_state = "neutral"
 	},
 /area/station/hallway/secondary/arrival)
+"vrY" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/break_room)
 "vrZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -87294,11 +87424,11 @@
 	},
 /area/station/civilian/library)
 "vtZ" = (
+/obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
 	id = "cell2";
 	name = "Cell Door"
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -87437,11 +87567,18 @@
 	icon_state = "warndark"
 	},
 /area/station/rnd/robotics)
+"vwA" = (
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/brig)
 "vwE" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
@@ -88658,9 +88795,9 @@
 "vLL" = (
 /obj/machinery/door/firedoor,
 /obj/structure/barricade/wooden,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
@@ -91694,15 +91831,9 @@
 /area/station/storage/primary)
 "wxJ" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters{
-	density = 0;
-	icon_state = "shutter0";
-	id = "HoP_queue";
-	opacity = 0
-	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/bridge/hop_office)
@@ -92082,6 +92213,14 @@
 	},
 /turf/simulated/floor,
 /area/station/security/brig)
+"wEH" = (
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced,
+/obj/structure/window/thin/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/atmos)
 "wEP" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /turf/simulated/floor{
@@ -92199,7 +92338,13 @@
 /obj/structure/flora/ausbushes/ywflowers{
 	layer = 2.7
 	},
-/obj/structure/window/fulltile/reinforced,
+/obj/structure/window/thin/reinforced{
+	dir = 4
+	},
+/obj/structure/window/thin/reinforced{
+	dir = 8
+	},
+/obj/structure/window/thin/reinforced,
 /turf/simulated/floor/grass,
 /area/station/hallway/secondary/exit)
 "wGn" = (
@@ -92261,9 +92406,9 @@
 "wGJ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/plaques/kiddie,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/robotics)
@@ -93699,9 +93844,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/iaa_office)
@@ -94088,9 +94233,9 @@
 /area/station/bridge/hop_office)
 "xdY" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
@@ -94563,6 +94708,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
+"xjt" = (
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced,
+/turf/simulated/floor/plating,
+/area/station/maintenance/medbay)
 "xjw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -94580,9 +94730,9 @@
 /obj/structure/sign/directions/medical{
 	buildable_sign = 0
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/fore)
@@ -94700,10 +94850,8 @@
 /area/shuttle/mining/station)
 "xmd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
+/obj/structure/grille,
+/obj/structure/window/thin/reinforced,
 /turf/simulated/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -95500,11 +95648,21 @@
 	icon_state = "blue"
 	},
 /area/station/medical/reception)
+"xwM" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/asteroid/research_outpost/entry{
+	name = "Research Shuttle Dock"
+	})
 "xwN" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/qm)
@@ -95537,6 +95695,17 @@
 	icon_state = "platebotc"
 	},
 /area/station/maintenance/escape)
+"xxs" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos)
 "xxv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -96301,7 +96470,15 @@
 /obj/structure/flora/ausbushes/brflowers{
 	layer = 2.7
 	},
-/obj/structure/window/fulltile/reinforced,
+/obj/structure/window/thin/reinforced{
+	dir = 4
+	},
+/obj/structure/window/thin/reinforced{
+	dir = 8
+	},
+/obj/structure/window/thin/reinforced{
+	dir = 1
+	},
 /turf/simulated/floor/grass,
 /area/station/hallway/secondary/exit)
 "xKc" = (
@@ -96376,9 +96553,9 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
@@ -96600,9 +96777,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/lobby)
@@ -97004,9 +97181,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/lobby)
@@ -97362,9 +97539,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/lobby)
@@ -113761,7 +113938,7 @@ uMK
 fQF
 uTL
 hpx
-wDR
+soF
 bsn
 ryA
 vNd
@@ -114533,9 +114710,9 @@ bHn
 aey
 ilQ
 bFm
-wDR
-wDR
-wDR
+soF
+soF
+soF
 vaI
 cJy
 cJy
@@ -114789,7 +114966,7 @@ kYJ
 fTt
 aeG
 isk
-wDR
+soF
 kIY
 tQC
 lZS
@@ -115303,7 +115480,7 @@ vaI
 fWO
 gKf
 isB
-wDR
+soF
 kKG
 lPk
 mBr
@@ -117374,7 +117551,7 @@ oLF
 yfu
 hjL
 lpR
-bfr
+sRF
 vEV
 hYa
 fyw
@@ -117631,7 +117808,7 @@ dQZ
 fWh
 rnx
 lkf
-bfr
+sRF
 bJl
 wOG
 fyw
@@ -120930,7 +121107,7 @@ cbf
 vBB
 iNT
 pUx
-uPx
+xjt
 dIw
 dIw
 sEM
@@ -124844,7 +125021,7 @@ sct
 pBl
 uQC
 jxb
-uoN
+lwk
 sis
 svN
 wcB
@@ -125101,12 +125278,12 @@ mfo
 cKZ
 mng
 uwO
-uoN
+lwk
 rRO
 tJm
 vLy
 ozg
-uoN
+lwk
 ozg
 cps
 lYa
@@ -125261,8 +125438,8 @@ bsP
 uNS
 dKq
 rQn
-tjf
-tjf
+xwM
+xwM
 dKq
 gus
 kdY
@@ -125359,9 +125536,9 @@ iUm
 dhu
 vks
 ozg
-uoN
+lwk
 kIF
-uoN
+lwk
 ozg
 dps
 abD
@@ -126638,7 +126815,7 @@ xSl
 hJz
 vqa
 mEf
-wlk
+bPn
 rzj
 xML
 udD
@@ -127084,7 +127261,7 @@ xBA
 bUI
 nID
 czC
-bFX
+btG
 glE
 sAt
 sGS
@@ -127326,7 +127503,7 @@ cxE
 dOk
 dOk
 lyi
-cit
+izO
 wDq
 nID
 nID
@@ -127409,7 +127586,7 @@ ijk
 xdo
 eGm
 qDP
-wlk
+bPn
 dne
 msp
 uYa
@@ -127849,7 +128026,7 @@ iXP
 nID
 nID
 pKL
-bFX
+eSN
 nID
 tJr
 nhc
@@ -130513,7 +130690,7 @@ wWp
 cWQ
 nJc
 mxm
-smc
+wEH
 ryM
 vqU
 lfl
@@ -130769,7 +130946,7 @@ usd
 qOp
 auD
 gny
-ghy
+tHO
 fbr
 pKw
 pKw
@@ -131033,12 +131210,12 @@ mAO
 hPi
 pKw
 pKw
-sFy
+loC
 irK
 tLN
 pMi
-nWE
-sFy
+xxs
+loC
 pKw
 cJy
 cJy
@@ -131515,7 +131692,7 @@ xxh
 aiW
 apl
 oBY
-azq
+vrY
 mpD
 rbq
 wQj
@@ -132542,7 +132719,7 @@ mfB
 ujQ
 aiW
 apl
-azq
+vrY
 pGR
 uKk
 bpK
@@ -132566,9 +132743,9 @@ oyh
 peu
 pKw
 pKw
-qUW
-qUW
-qUW
+bUJ
+bUJ
+bUJ
 gsn
 mGu
 lKX
@@ -133056,7 +133233,7 @@ kmU
 rFj
 rZZ
 oXg
-azq
+vrY
 iMC
 uTv
 rwP
@@ -133564,7 +133741,7 @@ wja
 dDK
 laj
 xvZ
-qJE
+lAq
 rkq
 guE
 klJ
@@ -133821,7 +133998,7 @@ vfl
 fxN
 jxZ
 mWR
-qJE
+lAq
 vHZ
 fYf
 iMx
@@ -134834,7 +135011,7 @@ teH
 teH
 rsy
 wxJ
-wxJ
+esl
 wxJ
 hYr
 teH
@@ -144838,7 +145015,7 @@ rZd
 aGo
 sQT
 rsC
-xmd
+lUY
 qNI
 vIk
 wgg
@@ -146146,7 +146323,7 @@ nYm
 nYm
 eXv
 eXv
-kYw
+hdZ
 hmy
 xmd
 jQd
@@ -146905,9 +147082,9 @@ sQT
 sQT
 eII
 sQT
-kYw
+prq
 rCg
-wGL
+vwA
 nYm
 lhE
 ahL

--- a/maps/stroechka/stroechka.dmm
+++ b/maps/stroechka/stroechka.dmm
@@ -170,9 +170,6 @@
 /area/station/engineering/engine)
 "av" = (
 /obj/structure/fans/tiny,
-/obj/machinery/door/poddoor/shutters{
-	id = "Out"
-	},
 /obj/machinery/door_control{
 	id = "Out";
 	name = "Out Door Control";
@@ -180,6 +177,9 @@
 	req_access = list(71)
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters{
+	id = "Out"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "vault"
@@ -2793,6 +2793,14 @@
 	icon_state = "delivery"
 	},
 /area/station/rnd/chargebay)
+"gs" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/storage)
 "gv" = (
 /obj/item/weapon/flora/floorleaf,
 /obj/machinery/firealarm{
@@ -2834,9 +2842,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
@@ -3219,11 +3227,11 @@
 	},
 /area/station/rnd/chargebay)
 "jR" = (
+/obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
 	id = "Skynet_launch";
 	name = "Mech Bay"
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	icon_state = "delivery"
 	},
@@ -3344,6 +3352,13 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/lab)
+"lk" = (
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/storage)
 "lw" = (
 /obj/effect/landmark/start/new_player,
 /turf/simulated/floor,
@@ -3634,9 +3649,9 @@
 "oz" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/departments/science,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
@@ -3900,6 +3915,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
+"rm" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos)
 "rA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -4048,9 +4071,9 @@
 /area/station/engineering/equip)
 "sJ" = (
 /obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/equip)
@@ -4063,9 +4086,9 @@
 "sS" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/departments/science,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/chargebay)
@@ -5460,6 +5483,14 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/arrival)
+"EI" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/rnd/lab)
 "EM" = (
 /obj/machinery/conveyor{
 	id = "QMLoad"
@@ -5649,9 +5680,9 @@
 "FL" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/departments/engineering,
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/equip)
@@ -6725,6 +6756,14 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"PR" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/exit)
 "PS" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8
@@ -7152,9 +7191,6 @@
 /area/station/engineering/equip)
 "Ui" = (
 /obj/structure/fans/tiny,
-/obj/machinery/door/poddoor/shutters{
-	id = "Out"
-	},
 /obj/machinery/door_control{
 	id = "Out";
 	name = "Out Door Control";
@@ -7162,6 +7198,9 @@
 	req_access = list(71)
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters{
+	id = "Out"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "vault"
@@ -7567,6 +7606,18 @@
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"Xj" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/storage)
 "Xm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -7742,10 +7793,10 @@
 	dir = 4
 	},
 /obj/structure/fans/tiny,
+/obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
 	id = "Out"
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "vault"
@@ -31980,11 +32031,11 @@ Zw
 as
 MC
 XB
-Wx
+PR
 DJ
 ee
 DJ
-Wx
+PR
 FD
 FD
 FD
@@ -32778,7 +32829,7 @@ SY
 cg
 cs
 cH
-bN
+lk
 dh
 FQ
 dG
@@ -33031,15 +33082,15 @@ aR
 be
 bu
 Pi
-si
+Xj
 Zu
 cs
 cI
-bN
+lk
 di
 FQ
 IQ
-si
+gs
 dS
 lx
 UV
@@ -33802,15 +33853,15 @@ ew
 ew
 ew
 bC
-si
+gs
 ci
 cw
 cK
-bN
+lk
 at
 FQ
 aE
-si
+gs
 RH
 EM
 EM
@@ -34059,15 +34110,15 @@ aS
 bg
 nI
 bE
-si
+gs
 cj
 cx
 cL
-bN
+lk
 YO
 dx
 xk
-si
+gs
 cW
 CV
 Nc
@@ -35587,9 +35638,9 @@ Zi
 Zi
 GM
 Zi
-il
-il
-il
+EI
+EI
+EI
 Zi
 Zi
 qC
@@ -35599,9 +35650,9 @@ Az
 qs
 Gl
 Gl
-Gn
-Gn
-Gn
+rm
+rm
+rm
 Gl
 XG
 XG
@@ -35848,13 +35899,13 @@ jk
 kw
 li
 mK
-il
+EI
 qL
 tk
 wi
 AC
 Ds
-Gn
+rm
 IH
 MH
 PP
@@ -36625,7 +36676,7 @@ tk
 wE
 Bh
 Hi
-Gn
+rm
 Jj
 Nv
 VX
@@ -36876,13 +36927,13 @@ kj
 GF
 LI
 Vi
-il
+EI
 Ri
 ty
 wM
 Bt
 aB
-Gn
+rm
 Jn
 Ny
 Qq


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Новые окна интегрированы на прометее фалконе строечке.

Везде, где раньше стояли составленные из укреп стекол окна, теперь стоят обычные фулл тайловые:
![image](https://user-images.githubusercontent.com/88531962/230612022-47b165ff-9d17-4601-a475-77ec56b16449.png)

А также в техах исправлены вкрапления фулл тайл укрепок.

## Почему и что этот ПР улучшит

## Авторство
я
## Чеинжлог
:cl: 
 - map: Окончательная интеграция новых окон на прометее, фалконе, строечке.