### PR TITLE
Ремонт иконки дефиб падла

### DIFF
--- a/code/game/objects/items/weapons/defibrillator.dm
+++ b/code/game/objects/items/weapons/defibrillator.dm
@@ -530,7 +530,7 @@
 /obj/item/weapon/shockpaddles/linked/make_announcement(message)
 	base_unit.audible_message("<b>\The [base_unit]</b> [message]", "\The [base_unit] vibrates slightly.")
 
-/obj/item/weapon/shockpaddles/update_icon()
+/obj/item/weapon/shockpaddles/linked/update_icon()
 	icon_state = "defibpaddleslinked[is_wielded()]"
 	if(cooldown)
 		icon_state = "defibpaddleslinked[is_wielded()]_cooldown"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
немного пропустил в копипастинге указание подтипа для переопределения и после использования автономные ласты превращались в обычные.
## Почему и что этот ПР улучшит
фиксик бага
## Авторство

## Чеинжлог
