### PR TITLE
Микрофикс срабатывания хим импланта

### DIFF
--- a/code/datums/atom_huds/atom_hud_data.dm
+++ b/code/datums/atom_huds/atom_hud_data.dm
@@ -190,10 +190,11 @@
 
 	for(var/obj/item/weapon/implant/I in src)
 		if(istype(I, /obj/item/weapon/implant/chem))
-			holder = hud_list[IMPCHEM_HUD]
-			holder.icon_state = "hud_imp_chem"
-			holder.pixel_y = y
-			y += -5
+			if(I.implanted)
+				holder = hud_list[IMPCHEM_HUD]
+				holder.icon_state = "hud_imp_chem"
+				holder.pixel_y = y
+				y += -5
 
 		if(istype(I, /obj/item/weapon/implant/tracking))
 			holder = hud_list[IMPTRACK_HUD]

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/obj/device.dmi'
 	icon_state = "implant"
 	var/implanted = null
-	var/mob/imp_in = null
+	var/mob/living/carbon/imp_in = null
 	var/obj/item/organ/external/part = null
 	var/allow_reagents = 0
 	var/malfunction = 0
@@ -374,14 +374,14 @@ the implant may become unstable and either pre-maturely inject the subject or si
 
 
 /obj/item/weapon/implant/chem/activate(cause)
-	if((!cause) || (!src.imp_in))	return 0
+	if((!cause) || (!src.imp_in))
+		return 0
 	var/mob/living/carbon/R = src.imp_in
 	reagents.trans_to(R, cause)
 	to_chat(R, "You hear a faint *beep*.")
 	if(!src.reagents.total_volume)
 		to_chat(R, "You hear a faint click from your chest.")
-		spawn(0)
-			qdel(src)
+	removeChemImplant(R)
 	return
 
 /obj/item/weapon/implant/chem/emp_act(severity)
@@ -399,6 +399,11 @@ the implant may become unstable and either pre-maturely inject the subject or si
 
 	spawn(20)
 		malfunction--
+
+/obj/item/weapon/implant/chem/proc/removeChemImplant(mob/living/carbon/C)
+	set waitfor = FALSE
+	qdel(src)
+	C.sec_hud_set_implants()
 
 var/global/list/death_alarm_stealth_areas = list(
 	/area/shuttle/syndicate,

--- a/code/game/objects/items/weapons/implants/implant.dm
+++ b/code/game/objects/items/weapons/implants/implant.dm
@@ -20,13 +20,13 @@
 /obj/item/weapon/implant/Destroy()
 	implant_list -= src
 	implanted = FALSE
-	imp_in = null
 	if(part)
 		part.implants.Remove(src)
 		part = null
 		if(isliving(imp_in))
 			var/mob/living/L = imp_in
 			L.sec_hud_set_implants()
+	imp_in = null
 	return ..()
 
 /obj/item/weapon/implant/proc/trigger(emote, source)
@@ -381,7 +381,8 @@ the implant may become unstable and either pre-maturely inject the subject or si
 	to_chat(R, "You hear a faint *beep*.")
 	if(!src.reagents.total_volume)
 		to_chat(R, "You hear a faint click from your chest.")
-	removeChemImplant(R)
+		spawn(0)
+			qdel(src)
 	return
 
 /obj/item/weapon/implant/chem/emp_act(severity)
@@ -399,11 +400,6 @@ the implant may become unstable and either pre-maturely inject the subject or si
 
 	spawn(20)
 		malfunction--
-
-/obj/item/weapon/implant/chem/proc/removeChemImplant(mob/living/carbon/C)
-	set waitfor = FALSE
-	qdel(src)
-	C.sec_hud_set_implants()
 
 var/global/list/death_alarm_stealth_areas = list(
 	/area/shuttle/syndicate,


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Починил удаление хим импланта, который оставался висеть в СБ худе, до его обновления.

Из того что я ещё посмотрел, там есть Destroy() которй как я понял, должен был использоватся в подобных целях, но я не понял прикола, зачем оно обнуляет все переменные, а потом проводит проверки и вызовы методов класса. Если на ревью, фикс предпочтут сделать через дестрой, попробую его пофиксить.
## Почему и что этот ПР улучшит
Меньше багов
## Авторство
Я
## Чеинжлог
