### PR TITLE
Pylons: optimization and nerfs

### DIFF
--- a/code/controllers/subsystem/aura_healing.dm
+++ b/code/controllers/subsystem/aura_healing.dm
@@ -2,4 +2,4 @@
 PROCESSING_SUBSYSTEM_DEF(aura_healing)
 	name = "Aura Healing"
 	flags = SS_NO_INIT | SS_BACKGROUND | SS_KEEP_TIMING
-	wait = 0.3 SECONDS
+	wait = 1 SECOND

--- a/code/controllers/subsystem/objects.dm
+++ b/code/controllers/subsystem/objects.dm
@@ -1,6 +1,6 @@
 SUBSYSTEM_DEF(obj)
 	name = "Objects"
-
+	wait = 200
 	priority   = SS_PRIORITY_OBJECTS
 	flags = SS_NO_INIT | SS_SHOW_IN_MC_TAB
 

--- a/code/controllers/subsystem/objects.dm
+++ b/code/controllers/subsystem/objects.dm
@@ -1,6 +1,5 @@
 SUBSYSTEM_DEF(obj)
 	name = "Objects"
-	wait = 200
 	priority   = SS_PRIORITY_OBJECTS
 	flags = SS_NO_INIT | SS_SHOW_IN_MC_TAB
 

--- a/code/controllers/subsystem/objects.dm
+++ b/code/controllers/subsystem/objects.dm
@@ -1,5 +1,6 @@
 SUBSYSTEM_DEF(obj)
 	name = "Objects"
+
 	priority   = SS_PRIORITY_OBJECTS
 	flags = SS_NO_INIT | SS_SHOW_IN_MC_TAB
 

--- a/code/datums/components/aura_healing.dm
+++ b/code/datums/components/aura_healing.dm
@@ -47,8 +47,6 @@
 	/// A list of being healed to active alerts
 	var/list/current_alerts = list()
 
-	COOLDOWN_DECLARE(last_heal_effect_time)
-
 /datum/component/aura_healing/Initialize(
 	range,
 	requires_visibility = TRUE,
@@ -94,10 +92,6 @@
 	return ..()
 
 /datum/component/aura_healing/process(delta_time)
-	var/should_show_effect = COOLDOWN_FINISHED(src, last_heal_effect_time)
-	if (should_show_effect)
-		COOLDOWN_START(src, last_heal_effect_time, HEAL_EFFECT_COOLDOWN)
-
 	var/list/remove_alerts_from = current_alerts.Copy()
 
 	var/alert_category = "aura_healing_[REF(src)]"
@@ -113,7 +107,7 @@
 			alert.desc = "You are being healed by [parent]."
 			current_alerts += candidate
 
-		if (should_show_effect && candidate.health < candidate.maxHealth)
+		if (candidate.health < candidate.maxHealth)
 			var/obj/effect/temp_visual/heal/H = new(get_turf(candidate))
 			H.color = healing_color
 
@@ -138,7 +132,7 @@
 
 		else if (isanimal(candidate))
 			var/mob/living/simple_animal/simple_candidate = candidate
-			simple_candidate.heal_overall_damage(simple_heal * delta_time * 0.5, simple_heal * delta_time * 0.5)
+			simple_candidate.heal_overall_damage(simple_heal * delta_time * 0.2, simple_heal * delta_time * 0.2)
 		candidate.updatehealth()
 
 	for (var/mob/remove_alert_from as anything in remove_alerts_from)

--- a/code/game/gamemodes/modes_gameplays/cult/structures/cult_structures.dm
+++ b/code/game/gamemodes/modes_gameplays/cult/structures/cult_structures.dm
@@ -48,9 +48,6 @@
 	light_power = 2
 	light_range = 3
 
-#define CORRUPT_FORBIDDEN 0
-#define CORRUPT_NOT_ALLOWED 1 //We don't know whether we should or not corrupt
-#define CORRUPT_ALLOWED 2
 ADD_TO_GLOBAL_LIST(/obj/structure/cult/pylon, pylons)
 /obj/structure/cult/pylon
 	name = "pylon"
@@ -62,7 +59,6 @@ ADD_TO_GLOBAL_LIST(/obj/structure/cult/pylon, pylons)
 	pass_flags = PASSTABLE
 	max_integrity = 200
 	var/list/validturfs = list()
-	var/corrupting = CORRUPT_NOT_ALLOWED
 	var/datum/religion/cult/C
 
 	var/corruption_delay = 50 //Increases currupting delay by 5 each time it procs
@@ -70,7 +66,8 @@ ADD_TO_GLOBAL_LIST(/obj/structure/cult/pylon, pylons)
 
 /obj/structure/cult/pylon/atom_init()
 	. = ..()
-	if(global.cult_religion && global.cult_religion.get_tech(RTECH_IMPROVED_PYLONS))
+	//if(global.cult_religion && global.cult_religion.get_tech(RTECH_IMPROVED_PYLONS))
+	if(global.cult_religion)
 		init_healing()
 
 /obj/structure/cult/pylon/proc/init_healing()
@@ -109,9 +106,6 @@ ADD_TO_GLOBAL_LIST(/obj/structure/cult/pylon, pylons)
 		corruption_delay += 5
 
 	COOLDOWN_START(src, corruption, corruption_delay)
-#undef CORRUPT_FORBIDDEN
-#undef CORRUPT_NOT_ALLOWED
-#undef CORRUPT_ALLOWED
 
 /obj/structure/cult/pylon/proc/activate(time_to_stop, datum/religion/R)
 	var/mob/living/simple_animal/hostile/pylon/charged = new(loc)

--- a/code/game/gamemodes/modes_gameplays/cult/structures/cult_structures.dm
+++ b/code/game/gamemodes/modes_gameplays/cult/structures/cult_structures.dm
@@ -66,8 +66,7 @@ ADD_TO_GLOBAL_LIST(/obj/structure/cult/pylon, pylons)
 
 /obj/structure/cult/pylon/atom_init()
 	. = ..()
-	//if(global.cult_religion && global.cult_religion.get_tech(RTECH_IMPROVED_PYLONS))
-	if(global.cult_religion)
+	if(global.cult_religion && global.cult_religion.get_tech(RTECH_IMPROVED_PYLONS))
 		init_healing()
 
 /obj/structure/cult/pylon/proc/init_healing()

--- a/code/game/gamemodes/modes_gameplays/cult/structures/cult_structures.dm
+++ b/code/game/gamemodes/modes_gameplays/cult/structures/cult_structures.dm
@@ -62,7 +62,7 @@ ADD_TO_GLOBAL_LIST(/obj/structure/cult/pylon, pylons)
 	pass_flags = PASSTABLE
 	max_integrity = 200
 	var/list/validturfs = list()
-	var/should_corrupt = CORRUPT_NOT_ALLOWED
+	var/corrupting = CORRUPT_NOT_ALLOWED
 	var/datum/religion/cult/C
 
 	var/corruption_delay = 50 //Increases currupting delay by 5 each time it procs
@@ -76,7 +76,8 @@ ADD_TO_GLOBAL_LIST(/obj/structure/cult/pylon, pylons)
 /obj/structure/cult/pylon/proc/init_healing()
 	AddComponent(/datum/component/aura_healing, 5, TRUE, 0.4, 0.4, 0.1, 1, 1, 0.1, 0.4, null, 1.2, \
 	TRAIT_HEALS_FROM_PYLONS,"#960000")
-	START_PROCESSING(SSprocessing, src)
+	if(!is_centcom_level(z))
+		START_PROCESSING(SSobj, src)
 	C = cult_religion
 
 /obj/structure/cult/pylon/deconstruct(disassembled)
@@ -84,7 +85,7 @@ ADD_TO_GLOBAL_LIST(/obj/structure/cult/pylon, pylons)
 		return ..()
 	new /obj/structure/cult/pylon_platform(loc)
 	new /obj/item/stack/sheet/metal(loc)
-	STOP_PROCESSING(SSprocessing, src)
+	STOP_PROCESSING(SSobj, src)
 	validturfs = null
 	return ..()
 
@@ -94,17 +95,8 @@ ADD_TO_GLOBAL_LIST(/obj/structure/cult/pylon, pylons)
 			validturfs = list()
 		return
 
-	//Now we have to decide whether we need to corrupt or not
-	if(should_corrupt == CORRUPT_FORBIDDEN)
-		return
-	else if(should_corrupt == CORRUPT_ALLOWED)
-		if(COOLDOWN_FINISHED(src, corruption))
-			corrupt()
-	else if(should_corrupt == CORRUPT_NOT_ALLOWED)
-		if(is_centcom_level(z))//It is cult' area, after all
-			should_corrupt = CORRUPT_FORBIDDEN
-		else
-			should_corrupt = CORRUPT_ALLOWED
+	if(COOLDOWN_FINISHED(src, corruption))
+		corrupt()
 
 /obj/structure/cult/pylon/proc/corrupt()
 	if(!length(validturfs))


### PR DESCRIPTION

## Описание изменений
- Пилоны должны теперь меньше жрать у сервера, за счёт остановки процессинга на ЦК, но:
  - Лечение теперь появляется раз в секунду, а не точно по времени. Чистый визуал
  - Возможен коррапт у пилонов даже в раю, хотя это и не критично учитывая увеличивающееся время.
- Сабсистема ауры стала действовать раз в секунду, а не трижды.
- Пилоны слабее хилят симпл мобов. Им не столь критично. Пускай немного страдать будут.

`еще не понятно, зачем использовать локальный кулдаун last_heal_effect_time, когда процессинг уже в своей сабсистеме со своим wait`
Это было во избежание визуальной свалки

Нескольких процессингов не обнаружил, полагаю, что это были 3 вызова в секунду.
## Почему и что этот ПР улучшит
## Авторство

## Чеинжлог
:cl: 
- balance: Нар-Си стал экономить на лечении от пилонов