### PR TITLE
Фикс флафф униформы

### DIFF
--- a/code/modules/fluff/customitems.dm
+++ b/code/modules/fluff/customitems.dm
@@ -40,7 +40,6 @@
 
 /obj/item/clothing/under/custom
 	name = "Custom uniform"
-	body_parts_covered = 0
 
 /obj/item/clothing/suit/custom
 	name = "Custom suit"

--- a/code/modules/fluff/customitems.dm
+++ b/code/modules/fluff/customitems.dm
@@ -40,6 +40,7 @@
 
 /obj/item/clothing/under/custom
 	name = "Custom uniform"
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 
 /obj/item/clothing/suit/custom
 	name = "Custom suit"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
По задумке флафф вещи не должны влиять на баланс, потому и получили body_parts_covered = 0
Но из-за этого появились проблемы:
 - можно оперировать через флафф одежду
 - она не учитывается перком дитя природы
 - муд улетает в ноль у того, кого экзамайнуть во флафф униформе

Все эти проблемы по большей части связаны с флафф униформой, потому она теперь нормально покрывает тело. Баланс вроде не затронул
## Почему и что этот ПР улучшит
fixes #7866
## Авторство

## Чеинжлог
