### PR TITLE
Pylons: Melee fix and balance

### DIFF
--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -301,13 +301,13 @@
 	icon_state = "pylon_glow"
 	icon_living = "pylon"
 	ranged = TRUE
-	amount_shoot = 3
+	amount_shoot = 4
 	projectiletype = /obj/item/projectile/beam/cult_laser
 	projectilesound = 'sound/weapons/guns/gunpulse_laser.ogg'
 	ranged_cooldown = 5
 	ranged_cooldown_cap = 0
-	maxHealth = 200
-	health = 200
+	maxHealth = 120
+	health = 120
 	melee_damage = 0
 	speed = 0
 	anchored = TRUE
@@ -345,3 +345,7 @@
 
 /mob/living/simple_animal/hostile/pylon/update_canmove()
 	return
+
+/mob/living/simple_animal/hostile/pylon/AttackingTarget()
+	SEND_SIGNAL(src, COMSIG_MOB_HOSTILE_ATTACKINGTARGET, target)
+	OpenFire(target)


### PR DESCRIPTION

## Описание изменений
fixes #10995
- Пилоны научились стрелять в упор
- ХП у пилонов упало с 200 до 120. Из-за фикса мили, их будет сложнее снести телескопиком или топором, а 5 выстрелов на пилон многовато.
- А что бы последнее не лишило их функции - отвлечения внимания, они получили дополнительный выстрел, ещё больше сократив перерыв между оными.
## Почему и что этот ПР улучшит
bugfix
## Авторство

## Чеинжлог
:cl: 
- bugfix: Нар-Си сделал пилоны злее.