### PR TITLE
Constructs balance

### DIFF
--- a/code/datums/spells/conjure.dm
+++ b/code/datums/spells/conjure.dm
@@ -170,12 +170,19 @@
 	charge_max = 5 SECONDS
 	action_icon_state = "areaconvert"
 	action_background_icon_state = "bg_cult"
+	range = 3
+
+/obj/effect/proc_holder/spell/no_target/area_conversion/atom_init()
+	if(!SSticker.nar_sie_has_risen)
+		charge_max = 25 SECONDS
+		range = 2
+	return ..()
 
 /obj/effect/proc_holder/spell/no_target/area_conversion/cast(list/targets, mob/user)
 	if(!user.my_religion)
 		return
 	. = ..()
-	for(var/turf/nearby_turf in range(3, user))
+	for(var/turf/nearby_turf in range(range, user))
 		if(prob(100 - (get_dist(nearby_turf, user) * 25)))
 			playsound(nearby_turf, 'sound/items/welder.ogg', VOL_EFFECTS_MASTER)
 			nearby_turf.atom_religify(user.my_religion)

--- a/code/datums/spells/conjure.dm
+++ b/code/datums/spells/conjure.dm
@@ -172,12 +172,6 @@
 	action_background_icon_state = "bg_cult"
 	range = 3
 
-/obj/effect/proc_holder/spell/no_target/area_conversion/atom_init()
-	if(!SSticker.nar_sie_has_risen)
-		charge_max = 25 SECONDS
-		range = 2
-	return ..()
-
 /obj/effect/proc_holder/spell/no_target/area_conversion/cast(list/targets, mob/user)
 	if(!user.my_religion)
 		return
@@ -186,3 +180,7 @@
 		if(prob(100 - (get_dist(nearby_turf, user) * 25)))
 			playsound(nearby_turf, 'sound/items/welder.ogg', VOL_EFFECTS_MASTER)
 			nearby_turf.atom_religify(user.my_religion)
+
+/obj/effect/proc_holder/spell/no_target/area_conversion/lesser
+	charge_max = 25 SECONDS
+	range = 2

--- a/code/game/gamemodes/modes_gameplays/cult/structures/cult_structures.dm
+++ b/code/game/gamemodes/modes_gameplays/cult/structures/cult_structures.dm
@@ -235,6 +235,13 @@ ADD_TO_GLOBAL_LIST(/obj/structure/cult/pylon, pylons)
 
 	return TRUE
 
+/obj/structure/mineral_door/cult/attack_animal(mob/user)
+	if(user.my_religion && user.a_intent != INTENT_HARM && !isSwitchingStates)
+		add_fingerprint(user)
+		SwitchState()
+		return
+	return ..()
+
 /obj/structure/mineral_door/cult/MechChecks(obj/mecha/user)
 	if(!..())
 		return FALSE

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -14,6 +14,9 @@
 	stop_automated_movement = TRUE
 	status_flags = CANPUSH
 	universal_speak = 1
+	see_in_dark = 8
+	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
+	see_invisible = SEE_INVISIBLE_LIVING
 	min_oxy = 0
 	max_oxy = 0
 	min_tox = 0
@@ -29,6 +32,7 @@
 	animalistic = FALSE
 	has_head = TRUE
 	has_arm = TRUE
+	can_point = TRUE
 
 /mob/living/simple_animal/construct/atom_init()
 	attack_sound = SOUNDIN_PUNCH_MEDIUM
@@ -109,7 +113,7 @@
 	attack_sound = SOUNDIN_PUNCH_VERYHEAVY
 	. = ..()
 	var/obj/effect/effect/forcefield/rune/R = new
-	AddComponent(/datum/component/forcefield, "strong blood aura", 80, 5 SECONDS, 6 SECONDS, R, TRUE, TRUE)
+	AddComponent(/datum/component/forcefield, "strong blood aura", 80, 5 SECONDS, 8 SECONDS, R, TRUE, TRUE)
 	SEND_SIGNAL(src, COMSIG_FORCEFIELD_PROTECT, src)
 
 /mob/living/simple_animal/construct/armoured/bullet_act(obj/item/projectile/P, def_zone)
@@ -146,7 +150,6 @@
 	melee_damage = 20
 	attacktext = "slash"
 	speed = -1
-	see_in_dark = 7
 	attack_sound = list('sound/weapons/bladeslice.ogg')
 	attack_push_vis_effect = ATTACK_EFFECT_SLASH
 	attack_disarm_vis_effect = ATTACK_EFFECT_SLASH
@@ -154,6 +157,11 @@
 		/obj/effect/proc_holder/spell/targeted/ethereal_jaunt/phaseshift,
 		)
 
+/mob/living/simple_animal/construct/wraith/atom_init()
+	. = ..()
+	var/obj/effect/effect/forcefield/rune/R = new
+	AddComponent(/datum/component/forcefield, "blood aura", 20, 8 SECONDS, 8 SECONDS, R, TRUE, TRUE)
+	SEND_SIGNAL(src, COMSIG_FORCEFIELD_PROTECT, src)
 
 /////////////////////////////Artificer/////////////////////////
 /mob/living/simple_animal/construct/builder
@@ -224,8 +232,6 @@
 	attacktext = "prodd"
 	speed = 0
 	environment_smash = 1
-	see_in_dark = 7
-	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 	density = FALSE
 	attack_sound = list('sound/weapons/slash.ogg')
 	attack_push_vis_effect = ATTACK_EFFECT_SLASH

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -233,8 +233,13 @@
 	pass_flags = PASSTABLE
 	construct_spells = list(
 		/obj/effect/proc_holder/spell/aoe_turf/conjure/smoke,
-		/obj/effect/proc_holder/spell/no_target/area_conversion,
 		)
+/mob/living/simple_animal/construct/harvester/atom_init()
+	. = ..()
+	if(SSticker.nar_sie_has_risen)
+		AddSpell(new /obj/effect/proc_holder/spell/no_target/area_conversion(src))
+	else
+		AddSpell(new /obj/effect/proc_holder/spell/no_target/area_conversion/lesser(src))
 
 /mob/living/simple_animal/construct/harvester/Bump(atom/A)
 	. = ..()

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -155,6 +155,7 @@
 		/obj/effect/proc_holder/spell/targeted/ethereal_jaunt/phaseshift,
 		)
 
+
 /////////////////////////////Artificer/////////////////////////
 /mob/living/simple_animal/construct/builder
 	name = "Artificer"

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -14,9 +14,6 @@
 	stop_automated_movement = TRUE
 	status_flags = CANPUSH
 	universal_speak = 1
-	see_in_dark = 8
-	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE
-	see_invisible = SEE_INVISIBLE_LIVING
 	min_oxy = 0
 	max_oxy = 0
 	min_tox = 0
@@ -113,7 +110,7 @@
 	attack_sound = SOUNDIN_PUNCH_VERYHEAVY
 	. = ..()
 	var/obj/effect/effect/forcefield/rune/R = new
-	AddComponent(/datum/component/forcefield, "strong blood aura", 80, 5 SECONDS, 8 SECONDS, R, TRUE, TRUE)
+	AddComponent(/datum/component/forcefield, "strong blood aura", 80, 5 SECONDS, 6 SECONDS, R, TRUE, TRUE)
 	SEND_SIGNAL(src, COMSIG_FORCEFIELD_PROTECT, src)
 
 /mob/living/simple_animal/construct/armoured/bullet_act(obj/item/projectile/P, def_zone)
@@ -150,18 +147,13 @@
 	melee_damage = 20
 	attacktext = "slash"
 	speed = -1
+	see_in_dark = 7
 	attack_sound = list('sound/weapons/bladeslice.ogg')
 	attack_push_vis_effect = ATTACK_EFFECT_SLASH
 	attack_disarm_vis_effect = ATTACK_EFFECT_SLASH
 	construct_spells = list(
 		/obj/effect/proc_holder/spell/targeted/ethereal_jaunt/phaseshift,
 		)
-
-/mob/living/simple_animal/construct/wraith/atom_init()
-	. = ..()
-	var/obj/effect/effect/forcefield/rune/R = new
-	AddComponent(/datum/component/forcefield, "blood aura", 20, 8 SECONDS, 8 SECONDS, R, TRUE, TRUE)
-	SEND_SIGNAL(src, COMSIG_FORCEFIELD_PROTECT, src)
 
 /////////////////////////////Artificer/////////////////////////
 /mob/living/simple_animal/construct/builder
@@ -232,6 +224,8 @@
 	attacktext = "prodd"
 	speed = 0
 	environment_smash = 1
+	see_in_dark = 7
+	lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 	density = FALSE
 	attack_sound = list('sound/weapons/slash.ogg')
 	attack_push_vis_effect = ATTACK_EFFECT_SLASH


### PR DESCRIPTION
## Описание изменений
Пачка изменений конструктам, но все они мелкие. Наиболее спорные буду выносить в отдельный ПР, если таковые будут.
1) Конверт области у харвестера из ивента стал слабее. Всё же он сам по себе силён, так что кулдаун не должен его прикончить. Тем же протеонам или тем более строителям приходится хуже. Кулдаун в 5 раз выше, а ренж на 1 меньше.
2) Конструкты, животные и им подобные ИЗ КУЛЬТА научились закрывать и открывать двери fixes #11294
3) Конструкты научились указывать на вещи fixes #11293
## Почему и что этот ПР улучшит
Багфиксы и баланс.
## Авторство

## Чеинжлог
:cl:
- balance: Харвестеры без Нар-Си стали куда менее активными в захвате новых территорий.
- bugfix: Конструкты научились указывать на вещи.
- bugfix: Братья меньшие в религии научились открывать двери культа.