### PR TITLE
machinery can_interact_with update

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -18,7 +18,7 @@
 	if(istype(G) && G.Touch(src, A, TRUE))
 		return
 
-	//if(src.interact_prob_brain_damage(A)) maybe in future...
+	//if(interact_prob_brain_damage(A)) maybe in future...
 	//	return
 
 	A.attack_hand(src)

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -18,7 +18,7 @@
 	if(istype(G) && G.Touch(src, A, TRUE))
 		return
 
-	//if(!A.can_mob_interact(src)) maybe in future...
+	//if(src.interact_prob_brain_damage(A)) maybe in future...
 	//	return
 
 	A.attack_hand(src)

--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -260,7 +260,7 @@ var/global/list/wire_daltonism_colors = list()
 
 	var/mob/living/L = usr
 
-	if(!can_use(src) || !holder.can_mob_interact(L))
+	if(!can_use(src) || L.interact_prob_brain_damage(holder))
 		return
 	var/target_wire = params["wire"]
 	var/obj/item/I = L.get_active_hand()

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -204,17 +204,6 @@
 	return flags & INSERT_CONTAINER
 */
 
-/atom/proc/can_mob_interact(mob/user)
-	if (ishuman(user))
-		var/mob/living/carbon/human/H = user
-		if(H.getBrainLoss() >= 60)
-			user.visible_message("<span class='warning'>[H] stares cluelessly at [isturf(loc) ? src : ismob(loc) ? src : "something"] and drools.</span>")
-			return FALSE
-		else if(prob(H.getBrainLoss()))
-			to_chat(user, "<span class='warning'>You momentarily forget how to use [src].</span>")
-			return FALSE
-	return TRUE
-
 /atom/proc/allow_drop()
 	return 1
 

--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -96,7 +96,7 @@
 /obj/var/list/req_one_access = list()
 
 //returns 1 if this mob has sufficient access to use this object
-/obj/proc/allowed(mob/M)
+/obj/proc/allowed(mob/M) // todo: rename to try_access or something
 	//check if it doesn't require any access at all
 	if(check_access(null))
 		return TRUE
@@ -112,7 +112,7 @@
 	else if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		//if they are holding or wearing a card that has access, that works
-		if(check_access(H.get_active_hand()) || check_access(H.wear_id))
+		if(check_access(H.wear_id) || check_access(H.get_active_hand()) || check_access(H.get_inactive_hand()))
 			return TRUE
 	else if(isIAN(M))
 		var/mob/living/carbon/ian/IAN = M

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -635,6 +635,8 @@
 		var/max_temperature = min(selected[3] - T0C-1, MAX_TEMPERATURE) // (-/+ 1) required because it won't heat/cool, if (target_temperature == TLV)
 		var/min_temperature = max(selected[2] - T0C+1, MIN_TEMPERATURE)
 		var/input_temperature = input("What temperature would you like the system to mantain? (Capped between [min_temperature] and [max_temperature]C)", "Thermostat Controls", target_temperature - T0C) as num|null
+		if(!can_still_interact_with(usr))
+			return
 		if(isnum(input_temperature))
 			if(input_temperature > max_temperature || input_temperature < min_temperature)
 				to_chat(usr, "Temperature must be between [min_temperature]C and [max_temperature]C")
@@ -654,6 +656,8 @@
 
 				if("set_external_pressure")
 					var/input_pressure = input("What pressure you like the system to mantain?", "Pressure Controls") as num|null
+					if(!can_still_interact_with(usr))
+						return
 					if(isnum(input_pressure))
 						send_signal(device_id, list(href_list["command"] = input_pressure))
 					return FALSE
@@ -664,6 +668,8 @@
 
 				if("set_internal_pressure")
 					var/input_pressure = input("What pressure you like the system to mantain?", "Pressure Controls") as num|null
+					if(!can_still_interact_with(usr))
+						return
 					if(isnum(input_pressure))
 						send_signal(device_id, list(href_list["command"] = input_pressure))
 					return FALSE
@@ -698,6 +704,8 @@
 					var/list/selected = TLV[env]
 					var/list/thresholds = list("lower bound", "low warning", "high warning", "upper bound")
 					var/newval = input("Enter [thresholds[threshold]] for [env]", "Alarm triggers", selected[threshold]) as null|num
+					if(!can_still_interact_with(usr))
+						return
 					if (isnull(newval))
 						return TRUE
 					if (newval < 0)

--- a/code/game/machinery/barber.dm
+++ b/code/game/machinery/barber.dm
@@ -483,10 +483,14 @@ A proc that does all the animations before mix()-ing.
 			menustat = href_list["stat"]
 		if("choose_color")
 			var/new_color = input(user, "Choose your desired color.", "Dye Mixer") as color|null
+			if(!can_still_interact_with(usr))
+				return
 			if(new_color)
 				chosen_color = new_color
 		if("choose_quantity")
 			var/new_quantity = input(user, "Choose amount to create.", "Dye Mixer") as num|null
+			if(!can_still_interact_with(usr))
+				return
 			if(new_quantity && new_quantity > 0 && beakers["output"] && new_quantity <= beakers["output"].reagents.maximum_volume)
 				chosen_quantity = new_quantity
 		if("load_tank")

--- a/code/game/machinery/computer/smartlight_console.dm
+++ b/code/game/machinery/computer/smartlight_console.dm
@@ -62,6 +62,8 @@
 	if(href_list["change_default"])
 		var/list/datum/light_mode/available_modes = SLP.get_user_available_modes()
 		var/mode_name = input(usr, "Please choose new default lighting mode.") as null|anything in available_modes
+		if(!can_still_interact_with(usr))
+			return
 		if(mode_name && available_modes[mode_name])
 			SLP.default_mode = available_modes[mode_name].type
 			updateUsrDialog()
@@ -69,6 +71,8 @@
 	else if(href_list["change_nightshift"])
 		var/list/datum/light_mode/available_modes = SLP.get_user_available_modes()
 		var/mode_name = input(usr, "Please choose new night shift lighting mode.") as null|anything in available_modes
+		if(!can_still_interact_with(usr))
+			return
 		if(mode_name && available_modes[mode_name])
 			SLP.default_mode = available_modes[mode_name].type
 			updateUsrDialog()

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -64,6 +64,8 @@ var/global/list/frozen_items = list()
 			return
 
 		var/obj/item/I = input(usr, "Please choose which object to retrieve.","Object recovery",null) as obj in frozen_items
+		if(!can_still_interact_with(usr))
+			return
 
 		if(!I || frozen_items.len == 0)
 			to_chat(user, "<span class='notice'>There is nothing to recover from storage.</span>")

--- a/code/game/machinery/droppod.dm
+++ b/code/game/machinery/droppod.dm
@@ -280,8 +280,9 @@
 
 /obj/structure/droppod/proc/SimpleAiming()
 	flags |= STATE_AIMING
-	var/A
-	A = input("Select Area for Droping Pod", "Select", A) in allowed_areas.areas
+	var/A = input("Select Area for Droping Pod", "Select") in allowed_areas.areas
+	if(intruder != usr)
+		return
 	var/area/thearea = allowed_areas.areas[A]
 	var/list/L = list()
 	for(var/turf/T in get_area_turfs(thearea.type))

--- a/code/game/machinery/fax.dm
+++ b/code/game/machinery/fax.dm
@@ -144,9 +144,10 @@ var/global/list/alldepartments = list("Central Command")
 		authenticated = 0
 
 	if(href_list["dept"])
-		var/lastdpt = dptdest
-		dptdest = input(usr, "Which department?", "Choose a department", "") as null|anything in alldepartments
-		if(!dptdest) dptdest = lastdpt
+		var/new_dep_dest = input(usr, "Which department?", "Choose a department", "") as null|anything in alldepartments
+		if(!new_dep_dest || !can_still_interact_with(usr))
+			return
+		dptdest = new_dep_dest
 
 	if(href_list["auth"])
 		if ( (!( authenticated ) && (scan)) )

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -311,6 +311,8 @@ Class Procs:
 
 /**
  * Any input()/alert() pause proc, so sometimes we need to check after if user still around and can interact
+ * For topics and tgui_act
+ * todo: we need atom analogues for attack_hand/attackby/topic/etc.
  */
 /obj/machinery/proc/can_still_interact_with(mob/user)
 	// in the future we maybe need to add or change to TGUI can_use_topic, should be fine now

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -290,15 +290,35 @@ Class Procs:
 
 /**
  * Can this particular `user` interact with the machine?
- * Calls `is_operational()` first.
- * If you're going to override it, in most cases don't forget: `. = ..()`
+ * Does not check access or distance
  */
 /obj/machinery/proc/can_interact_with(mob/user)
+	SHOULD_CALL_PARENT(TRUE)
+
+	if(user.incapacitated())
+		return FALSE
+	if(!(ishuman(user) || issilicon(user) || ismonkey(user) || isxenoqueen(user) || IsAdminGhost(user))) //can we just swap it for IsAdvancedToolUser
+		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
+		return FALSE
 	if(!is_operational() && !interact_offline)
 		return FALSE
 	if(panel_open && !interact_open)
 		return FALSE
-	if(!can_mob_interact(user))
+	if(user.interact_prob_brain_damage(src))
+		return FALSE
+
+	return TRUE
+
+/**
+ * Any input()/alert() pause proc, so sometimes we need to check after if user still around and can interact
+ */
+/obj/machinery/proc/can_still_interact_with(mob/user)
+	// in the future we maybe need to add or change to TGUI can_use_topic, should be fine now
+	if(usr.can_use_topic(src) != STATUS_INTERACTIVE || !can_interact_with(user))
+		usr.unset_machine(src)
+		return FALSE
+	if((allowed_checks & ALLOWED_CHECK_TOPIC) && !allowed(user))
+		allowed_fail(user)
 		return FALSE
 
 	return TRUE
@@ -334,6 +354,10 @@ Class Procs:
 /obj/machinery/tgui_act(action, list/params, datum/tgui/ui, datum/tgui_state/state)
 	if(..())
 		return TRUE
+
+	if(!can_interact_with(usr))
+		return
+
 	usr.set_machine(src)
 	add_fingerprint(usr)
 
@@ -383,11 +407,6 @@ Class Procs:
 
 // set_machine must be 0 if clicking the machinery doesn't bring up a dialog
 /obj/machinery/attack_hand(mob/user)
-	if((user.lying || user.stat != CONSCIOUS) && !IsAdminGhost(user))
-		return TRUE
-	if(!(ishuman(user) || issilicon(user) || ismonkey(user) || isxenoqueen(user) || IsAdminGhost(user)))
-		to_chat(user, "<span class='warning'>You don't have the dexterity to do this!</span>")
-		return TRUE
 	if(!can_interact_with(user))
 		return TRUE
 	if(HAS_TRAIT_FROM(user, TRAIT_GREASY_FINGERS, QUALITY_TRAIT))

--- a/code/game/machinery/magnet.dm
+++ b/code/game/machinery/magnet.dm
@@ -305,7 +305,9 @@
 					speed = 1
 			if("setpath")
 				var/newpath = sanitize_safe(input(usr, "Please define a new path!",,input_default(path)) as text|null)
-				if(newpath && newpath != "")
+				if(!can_still_interact_with(usr))
+					return
+				if(length(newpath))
 					moving = 0 // stop moving
 					path = newpath
 					pathpos = 1 // reset position

--- a/code/game/machinery/navbeacon.dm
+++ b/code/game/machinery/navbeacon.dm
@@ -188,19 +188,27 @@
 
 	else if(href_list["locedit"])
 		var/newloc = sanitize_safe(input("Enter New Location", "Navigation Beacon", input_default(location)) as text|null)
-		if(newloc)
-			location = newloc
+		if(!can_still_interact_with(usr))
+			return
+		if(!length(newloc))
+			return
+
+		location = newloc
 
 	else if(href_list["edit"])
 		var/codekey = href_list["code"]
 
 		var/newkey = sanitize_safe(input("Enter Transponder Code Key", "Navigation Beacon", input_default(codekey)) as text|null)
+		if(!can_still_interact_with(usr))
+			return
 		if(!newkey)
 			return FALSE
 
 		var/codeval = codes[codekey]
 		var/newval = sanitize_safe(input("Enter Transponder Code Value", "Navigation Beacon", input_default(codeval)) as text|null)
-		if(!newval)
+		if(!can_still_interact_with(usr))
+			return
+		if(!length(newval))
 			return FALSE
 
 		codes.Remove(codekey)
@@ -214,11 +222,15 @@
 
 	else if(href_list["add"])
 		var/newkey = sanitize(input("Enter New Transponder Code Key", "Navigation Beacon") as text|null)
-		if(!newkey)
+		if(!can_still_interact_with(usr))
+			return
+		if(!length(newkey))
 			return FALSE
 
 		var/newval = sanitize(input("Enter New Transponder Code Value", "Navigation Beacon") as text|null)
-		if(!newval)
+		if(!can_still_interact_with(usr))
+			return
+		if(!length(newval))
 			return FALSE
 
 		if(!codes)

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -538,7 +538,10 @@ var/global/list/obj/machinery/newscaster/allCasters = list() //Global list that 
 		return
 
 	if(href_list["set_channel_name"])
-		src.channel_name = sanitize_safe(input(usr, "Название Новостного Канала", "Обработчик Сети Новостей", input_default(channel_name)), MAX_LNAME_LEN)
+		var/new_name = sanitize_safe(input(usr, "Название Новостного Канала", "Обработчик Сети Новостей", input_default(channel_name)), MAX_LNAME_LEN)
+		if(!can_still_interact_with(usr) || !length(new_name))
+			return
+		src.channel_name = new_name
 		//update_icon()
 
 	else if(href_list["set_channel_lock"])
@@ -563,6 +566,8 @@ var/global/list/obj/machinery/newscaster/allCasters = list() //Global list that 
 			src.screen = 7
 		else
 			var/choice = tgui_alert(usr,"Подтвердите создание Новостного Канала","Обработчик Сети Новостей", list("Подтвердить","Отменить"))
+			if(!can_still_interact_with(usr))
+				return
 			if(choice=="Подтвердить")
 				var/datum/feed_channel/newChannel = new /datum/feed_channel
 				newChannel.channel_name = src.channel_name
@@ -581,10 +586,16 @@ var/global/list/obj/machinery/newscaster/allCasters = list() //Global list that 
 		for(var/datum/feed_channel/F in news_network.network_channels)
 			if( (!F.locked || F.author == scanned_user) && !F.censored)
 				available_channels += F.channel_name
-		src.channel_name = input(usr, "Выберите Канал", "Обработчик Сети Новостей") in available_channels
+		var/new_name = input(usr, "Выберите Канал", "Обработчик Сети Новостей") in available_channels
+		if(!can_still_interact_with(usr) || !length(new_name))
+			return
+		src.channel_name = new_name
 
 	else if(href_list["set_new_message"])
-		src.msg = sanitize(input(usr, "Напишите вашу Историю", "Обработчик Сети Новостей", input_default(src.msg)), extra = FALSE)
+		var/new_msg = sanitize(input(usr, "Напишите вашу Историю", "Обработчик Сети Новостей", input_default(src.msg)), extra = FALSE)
+		if(!can_still_interact_with(usr) || !length(new_msg))
+			return
+		src.msg = new_msg
 
 	else if(href_list["set_attachment"])
 		AttachPhoto(usr)
@@ -641,10 +652,16 @@ var/global/list/obj/machinery/newscaster/allCasters = list() //Global list that 
 		src.screen = 14
 
 	else if(href_list["set_wanted_name"])
-		src.channel_name = sanitize(input(usr, "Укажите имя разыскиваемого лица", "Сетевой Обработчик Безопасности", input_default(channel_name)), MAX_LNAME_LEN)
+		var/new_name = sanitize(input(usr, "Укажите имя разыскиваемого лица", "Сетевой Обработчик Безопасности", input_default(channel_name)), MAX_LNAME_LEN)
+		if(!can_still_interact_with(usr) || !length(new_name))
+			return
+		channel_name = new_name
 
 	else if(href_list["set_wanted_desc"])
-		src.msg = sanitize(input(usr, "Укажите описание разыскиваемого лица. Это могут быть любые детали, которые вы считаете важными.", "Сетевой Обработчик Безопасности", input_default(msg)), extra = FALSE)
+		var/new_msg = sanitize(input(usr, "Укажите описание разыскиваемого лица. Это могут быть любые детали, которые вы считаете важными.", "Сетевой Обработчик Безопасности", input_default(msg)), extra = FALSE)
+		if(!can_still_interact_with(usr) || !length(new_msg))
+			return
+		msg = new_msg
 
 	else if(href_list["submit_wanted"])
 		var/input_param = text2num(href_list["submit_wanted"])
@@ -652,6 +669,8 @@ var/global/list/obj/machinery/newscaster/allCasters = list() //Global list that 
 			src.screen = 16
 		else
 			var/choice = tgui_alert(usr,"Подтвердите [(input_param==1) ? ("создание") : ("редактирование")] объявления.","Сетевой Обработчик Безопасности", list("Подтвердить","Отменить"))
+			if(!can_still_interact_with(usr))
+				return
 			if(choice == "Подтвердить")
 				if(input_param == 1)          //If input_param == 1 we're submitting a new wanted issue. At 2 we're just editing an existing one. See the else below
 					var/datum/feed_message/WANTED = new /datum/feed_message
@@ -681,6 +700,8 @@ var/global/list/obj/machinery/newscaster/allCasters = list() //Global list that 
 			to_chat(usr, "The wanted issue has been distributed by a Nanotrasen higherup. You cannot take it down.")
 			return FALSE
 		var/choice = tgui_alert(usr, "Подтвердите удаление розыска.","Сетевой Обработчик Безопасности", list("Подтвердить","Отменить"))
+		if(!can_still_interact_with(usr))
+			return
 		if(choice=="Подтвердить")
 			news_network.wanted_issue = null
 			for(var/obj/machinery/newscaster/NEWSCASTER in allCasters)
@@ -812,6 +833,8 @@ var/global/list/obj/machinery/newscaster/allCasters = list() //Global list that 
 	else if(href_list["leave_a_comment"])
 		var/datum/feed_message/FM = locate(href_list["leave_a_comment"])
 		src.comment_msg = sanitize(input(usr, "Напишите комментарий", "Обработчик Сети Новостей", input_default(src.comment_msg)), extra = FALSE)
+		if(!can_still_interact_with(usr))
+			return
 		if(src.comment_msg == "" || src.comment_msg == null || src.scanned_user == "Unknown")
 			src.screen = 22
 		else
@@ -1094,13 +1117,11 @@ var/global/list/obj/machinery/newscaster/allCasters = list() //Global list that 
 		if(src.scribble_page == src.curr_page)
 			to_chat(user, "<FONT COLOR='blue'>There's already a scribble in this page... You wouldn't want to make things too cluttered, would you?</FONT>")
 		else
-			var/s = sanitize(input(user, "Write something", "Newspaper", ""))
-			if (!s)
-				return
-			if (!user.Adjacent(src))
+			var/new_scribble = sanitize(input(user, "Write something", "Newspaper", ""))
+			if (!length(new_scribble))
 				return
 			src.scribble_page = src.curr_page
-			src.scribble = s
+			src.scribble = new_scribble
 			attack_self(user)
 		return
 	return ..()

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -851,13 +851,11 @@ var/global/list/turret_icons
 				return
 
 	if(istype(I, /obj/item/weapon/pen))	//you can rename turrets like bots!
-		var/t = sanitize_safe(input(user, "Enter new turret name", name, input_default(finish_name)), MAX_NAME_LEN)
-		if(!t)
-			return
-		if(!Adjacent(user))
+		var/new_name = sanitize_safe(input(user, "Enter new turret name", name, input_default(finish_name)), MAX_NAME_LEN)
+		if(!length(new_name) || !Adjacent(user))
 			return
 
-		finish_name = t
+		finish_name = new_name
 		return
 
 	..()

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -234,7 +234,9 @@ var/global/list/departments_genitive = list()
 			return
 
 		var/new_message = sanitize(input(usr, "Напишите ваше сообщение:", "Ожидание Ввода", ""))
-		if(new_message)
+		if(!can_still_interact_with(usr))
+			return
+		if(length(new_message))
 			message = new_message
 			screen = 9
 			switch(href_list["priority"])
@@ -251,7 +253,9 @@ var/global/list/departments_genitive = list()
 
 	if(href_list["writeAnnouncement"])
 		var/new_message = sanitize(input(usr, "Напишите ваше сообщение:", "Ожидание Ввода", "") as null|message)
-		if(new_message)
+		if(!can_still_interact_with(usr))
+			return
+		if(length(new_message))
 			message = new_message
 			switch(href_list["priority"])
 				if("2")

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -179,7 +179,7 @@
 		var/value
 		if(href_list["temp"] == "custom")
 			value = input("Please input the target temperature", name) as num|null
-			if(isnull(value))
+			if(isnull(value) || !can_still_interact_with(usr))
 				return
 			value += T0C
 		else

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -188,6 +188,8 @@
 				L[tmpname] = I
 
 		var/desc = input("Please select a location to lock in.", "Locking Computer") in L
+		if(!can_still_interact_with(user))
+			return
 		target = L[desc]
 
 	else
@@ -210,6 +212,8 @@
 				areaindex[tmpname] = 1
 			L[tmpname] = R
 		var/desc = input("Please select a station to lock in.", "Locking Computer") in L
+		if(!can_still_interact_with(user))
+			return
 		target = L[desc]
 		if(target)
 			var/obj/machinery/teleport/station/trg = target

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1506,3 +1506,12 @@
 
 /mob/living/proc/get_pumped(bodypart)
 	return 0
+
+// return TRUE if we failed our interaction
+/mob/living/interact_prob_brain_damage(atom/object)
+	if(getBrainLoss() >= 60)
+		visible_message("<span class='warning'>[src] stares cluelessly at [isturf(object.loc) ? object : ismob(object.loc) ? object : "something"] and drools.</span>")
+		return TRUE
+	else if(prob(getBrainLoss()))
+		to_chat(src, "<span class='warning'>You momentarily forget how to use [object].</span>")
+		return TRUE

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -1263,3 +1263,7 @@ note dizziness decrements automatically in the mob's Life() proc.
 			. += 1 + config.run_speed
 		if("walk")
 			. += 2.5 + config.walk_speed
+
+// return TRUE if we failed our interaction
+/mob/proc/interact_prob_brain_damage(atom/object)
+	return FALSE

--- a/code/modules/nano/nanointeraction.dm
+++ b/code/modules/nano/nanointeraction.dm
@@ -1,3 +1,6 @@
+// todo: this is not a nano-ui only thing anymore, we need to move methods for better place and rename *_nano_interaction
+// do not mistake with tgui methods like /datum/tgui_state/default/can_use_topic
+
 /datum/proc/nano_host()
 	return src
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Я прокрастинировал, лишь бы не браться за следующий большой пр.

Небольшой рефакторинг машинерии в первом коммите ради нового метода ``can_still_interact_with``, во втором расставил новые проверки после input-а в топиках.

Пока делал, подумал, что нужны глобальные аналоги ``can_still_interact_with`` и для всяких attack_hand/attackby, да и топики можно было бы перепроверять не только машинерии. Сейчас в лучшем случае везде ставится проверка на ``Adjacent``, но это во первых ломает телепатию, во вторых не учитывает прочие состояния юзера (мертв, ограничен) и предмета. Не критичное и нужно продумывать, как лучше делать.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
