### PR TITLE
Добавление нарукавников в крафт

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -236,3 +236,54 @@
 	result = /obj/item/weapon/storage/pneumatic
 	time = 45
 	required_proficiency = list(/datum/skill/construction = SKILL_LEVEL_PRO)
+
+// Armband craft
+
+/datum/crafting_recipe/armband_red
+	name = "Armband red"
+	reqs = list(/obj/item/stack/sheet/cloth = 1)
+	tools = list(/obj/item/toy/crayon/spraycan)
+	result = /obj/item/clothing/accessory/armband
+	time = 30
+
+/datum/crafting_recipe/armband_cargo
+	name = "Armband cargo"
+	reqs = list(/obj/item/stack/sheet/cloth = 1)
+	tools = list(/obj/item/toy/crayon/spraycan)
+	result = /obj/item/clothing/accessory/armband/cargo
+	time = 30
+
+/datum/crafting_recipe/armband_engine
+	name = "Armband engine"
+	reqs = list(/obj/item/stack/sheet/cloth = 1)
+	tools = list(/obj/item/toy/crayon/spraycan)
+	result = /obj/item/clothing/accessory/armband/engine
+	time = 30
+
+/datum/crafting_recipe/armband_science
+	name = "Armband science"
+	reqs = list(/obj/item/stack/sheet/cloth = 1)
+	tools = list(/obj/item/toy/crayon/spraycan)
+	result = /obj/item/clothing/accessory/armband/science
+	time = 30
+
+/datum/crafting_recipe/armband_hydro
+	name = "Armband hydro"
+	reqs = list(/obj/item/stack/sheet/cloth = 1)
+	tools = list(/obj/item/toy/crayon/spraycan)
+	result = /obj/item/clothing/accessory/armband/hydro
+	time = 30
+
+/datum/crafting_recipe/armband_med
+	name = "Armband med"
+	reqs = list(/obj/item/stack/sheet/cloth = 1)
+	tools = list(/obj/item/toy/crayon/spraycan)
+	result = /obj/item/clothing/accessory/armband/med
+	time = 30
+
+/datum/crafting_recipe/armband_medgreen
+	name = "Armband medgreen"
+	reqs = list(/obj/item/stack/sheet/cloth = 1)
+	tools = list(/obj/item/toy/crayon/spraycan)
+	result = /obj/item/clothing/accessory/armband/medgreen
+	time = 30


### PR DESCRIPTION
## Описание изменений
Добавляет крафт нарукавников.
![image](https://user-images.githubusercontent.com/115452414/236618913-c8799fc2-8af3-4302-be9b-38aaa67bae72.png)
Крафт простой. Одна тряпка и баллончик краски.
## Почему и что этот ПР улучшит
Редко вижу их в игре. На самом деле, штука полезная, если нужно отметиться цветом, например, в какой-нибудь группе СБ.
## Авторство
I am.
## Чеинжлог
:cl: Basia
- add: В список крафта добавлены нарукавники разных цветов