### PR TITLE
Boxstation. Camera Review Map Edit.

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -141,13 +141,25 @@
 /turf/simulated/floor/plating,
 /area/station/security/range)
 "aau" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/machinery/alarm{
-	pixel_y = 24
+	dir = 1;
+	pixel_y = -25
 	},
 /turf/simulated/floor{
-	icon_state = "floorgrime"
+	icon_state = "neutralcorner"
 	},
-/area/station/security/range)
+/area/station/hallway/secondary/arrival)
 "aav" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -211,11 +223,6 @@
 	},
 /obj/item/clothing/ears/earmuffs,
 /obj/item/clothing/ears/earmuffs,
-/obj/machinery/camera{
-	c_tag = "Firing Range East";
-	dir = 8;
-	network = list("SS13","Security")
-	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
@@ -504,15 +511,15 @@
 /turf/environment/space,
 /area/space)
 "aaX" = (
+/obj/machinery/cryopod,
 /obj/machinery/camera{
-	c_tag = "Firing Range West";
-	dir = 1;
-	network = list("SS13","Security")
+	c_tag = "Cryogenic Storage"
 	},
 /turf/simulated/floor{
-	icon_state = "floorgrime"
+	dir = 8;
+	icon_state = "neutral"
 	},
-/area/station/security/range)
+/area/station/civilian/dormitories)
 "aaY" = (
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -564,11 +571,6 @@
 	},
 /area/station/security/range)
 "abe" = (
-/obj/machinery/camera{
-	c_tag = "Security Office West";
-	dir = 4;
-	network = list("SS13","Security")
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -637,7 +639,7 @@
 /obj/item/weapon/paper,
 /obj/item/weapon/pen,
 /obj/machinery/light/small{
-	dir = 1
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig/solitary_confinement)
@@ -827,10 +829,6 @@
 /turf/simulated/floor/plating,
 /area/station/security/interrogation)
 "abG" = (
-/obj/machinery/camera{
-	c_tag = "Labor Shuttle Dock North";
-	network = list("SS13","Security")
-	},
 /obj/structure/table,
 /obj/item/clothing/under/color/orange{
 	pixel_x = -7;
@@ -847,6 +845,9 @@
 /obj/item/clothing/shoes/orange/candals{
 	pixel_x = 14;
 	pixel_y = -5
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
 	},
 /turf/simulated/floor{
 	dir = 9;
@@ -1082,11 +1083,6 @@
 /area/station/security/main)
 "abW" = (
 /obj/structure/rack,
-/obj/machinery/camera{
-	c_tag = "Secure Armory East";
-	dir = 8;
-	network = list("SS13","Security")
-	},
 /obj/structure/window/thin/reinforced{
 	dir = 1
 	},
@@ -1123,8 +1119,10 @@
 /area/station/security/armoury)
 "abY" = (
 /obj/machinery/constructable_frame/machine_frame,
-/obj/machinery/firealarm{
-	pixel_y = 24
+/obj/machinery/camera{
+	c_tag = "Labor Shuttle Dock North";
+	network = list("SS13","Security");
+	dir = 6
 	},
 /turf/simulated/floor{
 	dir = 9;
@@ -1790,11 +1788,6 @@
 /area/station/security/brig)
 "adi" = (
 /obj/machinery/disposal,
-/obj/machinery/camera{
-	c_tag = "Security Equipment North";
-	dir = 4;
-	network = list("SS13","Security")
-	},
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/light/smart{
 	dir = 1
@@ -2206,6 +2199,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/camera{
+	c_tag = "Bar South";
+	dir = 10
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -2248,11 +2245,6 @@
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/eva)
 "adX" = (
-/obj/machinery/camera{
-	c_tag = "Armory";
-	dir = 4;
-	network = list("SS13","Security")
-	},
 /obj/structure/rack,
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -2411,10 +2403,6 @@
 /area/station/security/armoury)
 "aej" = (
 /obj/machinery/photocopier,
-/obj/machinery/camera{
-	c_tag = "HoS Office North";
-	network = list("SS13","Security")
-	},
 /obj/machinery/firealarm{
 	pixel_y = 28
 	},
@@ -2664,6 +2652,11 @@
 	},
 /area/station/security/main)
 "aeG" = (
+/obj/machinery/camera{
+	c_tag = "Armory";
+	dir = 6;
+	network = list("SS13","Security")
+	},
 /turf/simulated/floor{
 	icon_state = "delivery"
 	},
@@ -2876,10 +2869,12 @@
 /area/station/solar/auxport)
 "afa" = (
 /obj/structure/closet/wardrobe/red,
-/obj/machinery/light/smart{
-	dir = 8
-	},
 /obj/structure/window/thin/reinforced,
+/obj/machinery/camera{
+	c_tag = "Security Equipment";
+	dir = 4;
+	network = list("SS13","Security")
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "bot"
@@ -3494,6 +3489,11 @@
 /area/shuttle/escape_pod3/station)
 "agf" = (
 /obj/machinery/computer/secure_data{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Head of Security";
+	network = list("SS13","Security");
 	dir = 8
 	},
 /turf/simulated/floor{
@@ -4373,6 +4373,10 @@
 /area/station/security/hos)
 "ahF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "neutral"
@@ -4621,10 +4625,6 @@
 /turf/environment/space,
 /area/shuttle/escape_pod3/station)
 "aib" = (
-/obj/machinery/camera{
-	c_tag = "Third Escape Pod";
-	dir = 4
-	},
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
@@ -4951,8 +4951,7 @@
 /obj/machinery/camera{
 	c_tag = "Security Processing";
 	dir = 8;
-	network = list("SS13","Security");
-	pixel_y = -18
+	network = list("SS13","Security")
 	},
 /obj/item/device/camera/polar/detective,
 /turf/simulated/floor{
@@ -5436,8 +5435,10 @@
 /obj/machinery/alarm{
 	pixel_y = 28
 	},
-/obj/machinery/light/smart{
-	dir = 1
+/obj/machinery/camera{
+	c_tag = "Brig Center";
+	dir = 6;
+	network = list("SS13","Security")
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -5652,20 +5653,16 @@
 	},
 /area/station/security/brig)
 "ajQ" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/camera{
-	c_tag = "Brig Center";
-	dir = 1;
-	network = list("SS13","Security")
+	c_tag = "Atmospherics Center";
+	dir = 5;
+	network = list("SS13","Engineering")
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "redcorner"
+	icon_state = "bot"
 	},
-/area/station/security/brig)
+/area/station/engineering/atmos)
 "ajR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -5691,10 +5688,6 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
-	},
-/obj/machinery/camera{
-	c_tag = "Security Equipment South";
-	dir = 4
 	},
 /obj/structure/table,
 /obj/item/weapon/paper_bin,
@@ -5753,11 +5746,6 @@
 /obj/machinery/light_switch{
 	pixel_y = -25
 	},
-/obj/machinery/camera{
-	c_tag = "HoS Office South";
-	dir = 1;
-	network = list("SS13","Security")
-	},
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots,
 /obj/item/clothing/suit/space/rig/security/hos,
@@ -5802,16 +5790,6 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
-"akc" = (
-/obj/machinery/camera{
-	c_tag = "Brig Center-East";
-	network = list("SS13","Security")
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "redcorner"
-	},
-/area/station/security/brig)
 "akd" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/processing)
@@ -6334,10 +6312,6 @@
 	},
 /area/station/security/brig)
 "akU" = (
-/obj/machinery/camera{
-	c_tag = "Brig Center-West";
-	network = list("SS13","Security")
-	},
 /obj/item/device/radio/intercom{
 	pixel_y = 26
 	},
@@ -6509,6 +6483,10 @@
 	},
 /area/station/security/brig)
 "alk" = (
+/obj/machinery/camera{
+	c_tag = "Cargo Bay South";
+	dir = 5
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "brown"
@@ -7140,6 +7118,11 @@
 	dir = 9
 	},
 /obj/machinery/vending/coffee,
+/obj/machinery/camera{
+	c_tag = "Brig Observation";
+	dir = 8;
+	network = list("SS13","Security")
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -7162,10 +7145,6 @@
 /turf/simulated/floor/carpet/red,
 /area/station/security/detectives_office)
 "amn" = (
-/obj/machinery/camera{
-	c_tag = "Forensic's Office";
-	network = list("SS13","Security")
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -7381,6 +7360,11 @@
 	pixel_x = 6;
 	pixel_y = -36;
 	req_access = list(2)
+	},
+/obj/machinery/camera{
+	c_tag = "Brig Center-West";
+	network = list("SS13","Security");
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "redcorner"
@@ -7819,6 +7803,10 @@
 /obj/machinery/newscaster{
 	pixel_x = 30
 	},
+/obj/machinery/camera{
+	c_tag = "Forensic's Office";
+	network = list("SS13","Security")
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "whitered"
@@ -7896,12 +7884,14 @@
 	},
 /area/station/maintenance/dormitory)
 "anB" = (
-/obj/machinery/camera{
-	c_tag = "Security Maintenance";
-	network = list("SS13","Security")
+/obj/machinery/camera/motion{
+	c_tag = "AI Chamber North";
+	network = list("RD","MiniSat")
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/dormitory)
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/aisat/ai_chamber)
 "anC" = (
 /obj/machinery/door_timer/cell_1,
 /turf/simulated/floor{
@@ -8521,11 +8511,6 @@
 /turf/simulated/floor/carpet/red,
 /area/station/security/detectives_office)
 "aoC" = (
-/obj/machinery/camera{
-	c_tag = "Brig Observation";
-	dir = 1;
-	network = list("SS13","Security")
-	},
 /obj/machinery/computer/security{
 	dir = 8
 	},
@@ -12469,8 +12454,7 @@
 /obj/machinery/camera{
 	c_tag = "Prison Rec Room South";
 	dir = 1;
-	network = list("SS13","Prison");
-	pixel_x = 22
+	network = list("SS13","Prison")
 	},
 /obj/structure/dumbbells_rack,
 /turf/simulated/floor{
@@ -13938,9 +13922,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Telescience Control Room";
-	dir = 8;
-	network = list("SS13","Research");
-	pixel_y = -22
+	dir = 9;
+	network = list("SS13","Research")
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -13994,10 +13977,9 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Escape Security Room";
-	dir = 8;
-	network = list("SS13","Security");
-	pixel_y = -20
+	c_tag = "Brig Escape";
+	dir = 9;
+	network = list("SS13","Security")
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -14007,7 +13989,7 @@
 /obj/structure/closet/l3closet/scientist,
 /obj/machinery/camera{
 	c_tag = "Miscellaneous Research";
-	dir = 8
+	dir = 9
 	},
 /turf/simulated/floor,
 /area/station/rnd/misc_lab)
@@ -14207,6 +14189,10 @@
 "azp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
+	},
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 24
 	},
 /turf/simulated/floor{
 	icon_state = "bluecorner"
@@ -14469,10 +14455,6 @@
 "azR" = (
 /obj/structure/stool/bed/chair/comfy/beige{
 	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Toxins Launch Room";
-	network = list("SS13","Research")
 	},
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the test chamber.";
@@ -15190,10 +15172,6 @@
 	},
 /area/station/civilian/kitchen)
 "aBj" = (
-/obj/machinery/camera{
-	c_tag = "EVA Maintenance";
-	dir = 8
-	},
 /obj/effect/decal/cleanable/blood/oil,
 /obj/machinery/light/small{
 	dir = 4
@@ -15240,6 +15218,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/machinery/camera{
+	c_tag = "Fore Primary Hallway-South";
+	dir = 8
+	},
 /turf/simulated/floor{
 	icon_state = "bluecorner"
 	},
@@ -15278,12 +15260,17 @@
 	name = "EXTERNAL AIRLOCK";
 	pixel_x = -30
 	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
 /obj/machinery/light/smart{
 	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Toxins Launch Room";
+	network = list("SS13","Research");
+	dir = 10
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -22
 	},
 /turf/simulated/floor{
 	icon_state = "bot"
@@ -15850,6 +15837,10 @@
 	},
 /area/station/rnd/mixing)
 "aCx" = (
+/obj/machinery/camera/motion{
+	c_tag = "EVA North";
+	dir = 6
+	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "warning"
@@ -15870,9 +15861,6 @@
 /turf/simulated/floor,
 /area/station/cargo/qm)
 "aCA" = (
-/obj/machinery/camera{
-	c_tag = "Fitness Room"
-	},
 /obj/structure/table/glass,
 /obj/item/stack/medical/ointment{
 	pixel_y = 4
@@ -16043,8 +16031,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "aCR" = (
-/obj/machinery/light/smart{
-	dir = 1
+/obj/machinery/camera{
+	c_tag = "Ferry shuttle South";
+	dir = 6
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -16094,6 +16083,10 @@
 	},
 /area/station/medical/hallway)
 "aCX" = (
+/obj/machinery/camera{
+	c_tag = "Arrival Hallway West";
+	dir = 5
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "browncorner"
@@ -16176,10 +16169,6 @@
 /turf/simulated/floor/wood,
 /area/station/maintenance/chapel)
 "aDm" = (
-/obj/machinery/camera/motion{
-	c_tag = "EVA Motion Sensor";
-	dir = 4
-	},
 /obj/structure/table/reinforced,
 /obj/item/device/multitool{
 	pixel_x = -3;
@@ -16209,10 +16198,6 @@
 	},
 /area/station/ai_monitored/eva)
 "aDn" = (
-/obj/machinery/camera{
-	c_tag = "EVA East";
-	dir = 8
-	},
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/metal{
 	amount = 50
@@ -16458,8 +16443,12 @@
 	},
 /area/station/civilian/dormitories)
 "aDL" = (
-/obj/machinery/firealarm{
+/obj/machinery/alarm{
 	pixel_y = 24
+	},
+/obj/machinery/camera{
+	c_tag = "Firing Range";
+	network = list("SS13","Security")
 	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
@@ -16499,14 +16488,20 @@
 	},
 /area/station/civilian/toilet)
 "aDP" = (
-/obj/machinery/alarm{
-	dir = 8;
-	pixel_x = 24
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/camera/motion{
+	c_tag = "EVA South";
+	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "bluecorner"
+	dir = 4;
+	icon_state = "warning"
 	},
-/area/station/hallway/primary/fore)
+/area/station/ai_monitored/eva)
 "aDR" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -16639,6 +16634,11 @@
 	name = "Security Monitor";
 	network = list("Security");
 	pixel_y = 30
+	},
+/obj/machinery/camera{
+	c_tag = "Security Office";
+	dir = 6;
+	network = list("SS13","Security")
 	},
 /turf/simulated/floor{
 	dir = 9;
@@ -16884,6 +16884,10 @@
 /obj/machinery/atm{
 	pixel_y = -32
 	},
+/obj/machinery/camera{
+	c_tag = "Cargo Hallway";
+	dir = 10
+	},
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
@@ -16923,6 +16927,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light/smart,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -22
+	},
 /turf/simulated/floor{
 	icon_state = "floorgrime"
 	},
@@ -19689,10 +19697,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Arrival Hallway East";
-	dir = 1
-	},
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
@@ -19743,12 +19747,6 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/port)
 "aKe" = (
-/turf/simulated/floor{
-	dir = 10;
-	icon_state = "whitehall"
-	},
-/area/station/civilian/fitness)
-"aKf" = (
 /obj/structure/closet,
 /obj/item/weapon/broom,
 /obj/item/weapon/broom,
@@ -19762,10 +19760,16 @@
 /obj/item/clothing/under/bathrobe,
 /obj/item/clothing/under/bathrobe,
 /obj/item/clothing/under/bathrobe,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
+/obj/machinery/camera{
+	c_tag = "Fitness Room";
+	dir = 4
 	},
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "whitehall"
+	},
+/area/station/civilian/fitness)
+"aKf" = (
 /turf/simulated/floor{
 	icon_state = "whitehall"
 	},
@@ -20907,11 +20911,12 @@
 	},
 /area/station/maintenance/eva)
 "aMl" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/structure/sign/poster/official/space_cops{
 	pixel_x = 32
+	},
+/obj/machinery/camera{
+	c_tag = "Coworking";
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
@@ -21137,10 +21142,6 @@
 	},
 /area/station/ai_monitored/eva)
 "aMI" = (
-/obj/machinery/camera{
-	c_tag = "EVA South";
-	dir = 1
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -21303,9 +21304,6 @@
 /area/station/maintenance/medbay)
 "aNb" = (
 /obj/structure/closet/toolcloset,
-/obj/machinery/camera{
-	c_tag = "Auxiliary Tool Storage"
-	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "yellow"
@@ -22135,28 +22133,12 @@
 /turf/simulated/floor/grass,
 /area/station/civilian/hydroponics)
 "aOK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/camera{
-	c_tag = "Medbay Mid-East";
-	network = list("SS13","Medical")
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "white"
-	},
-/area/station/medical/hallway)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "aOL" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -22179,9 +22161,6 @@
 	},
 /area/station/medical/hallway)
 "aOM" = (
-/obj/machinery/alarm{
-	pixel_y = 23
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
@@ -22200,6 +22179,10 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Medbay Mid-East";
+	network = list("SS13","Medical")
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -22729,6 +22712,9 @@
 	dir = 4;
 	pixel_x = 24
 	},
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
 "aPQ" = (
@@ -22745,6 +22731,10 @@
 /area/station/storage/tools)
 "aPR" = (
 /obj/item/weapon/flora/random,
+/obj/machinery/camera{
+	c_tag = "Auxiliary Tool Storage";
+	dir = 8
+	},
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "yellow"
@@ -22965,11 +22955,13 @@
 	},
 /area/station/civilian/kitchen)
 "aQo" = (
-/obj/machinery/newscaster{
-	pixel_y = 32
-	},
 /obj/machinery/ai_status_display{
 	pixel_x = -32
+	},
+/obj/machinery/camera{
+	c_tag = "Research Director's Office";
+	dir = 6;
+	network = list("SS13","Research")
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -23864,20 +23856,26 @@
 	},
 /obj/structure/table/glass,
 /obj/item/weapon/flora/deskleaf,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -32
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
 	},
 /area/station/rnd/scibreak)
 "aRV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/camera{
-	c_tag = "Mining Shuttle";
-	pixel_x = 18
+	c_tag = "Locker Room"
 	},
-/turf/simulated/floor{
-	icon_state = "delivery"
+/obj/machinery/light_switch{
+	pixel_y = 28
 	},
-/area/station/hallway/secondary/mine_sci_shuttle)
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "aRW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -23913,8 +23911,7 @@
 /area/station/security/checkpoint)
 "aSa" = (
 /obj/machinery/camera{
-	c_tag = "Cargo Bay Storage";
-	dir = 0
+	c_tag = "Cargo Bay Warehouse"
 	},
 /obj/structure/rack,
 /obj/random/science/circuit,
@@ -23967,7 +23964,7 @@
 "aSh" = (
 /obj/machinery/camera{
 	c_tag = "Secondary Storage";
-	dir = 8;
+	dir = 9;
 	network = list("SS13","Medical")
 	},
 /obj/structure/closet/l3closet/general,
@@ -24605,10 +24602,6 @@
 /obj/item/device/radio/intercom{
 	pixel_x = -25
 	},
-/obj/machinery/camera{
-	c_tag = "Bar Backroom";
-	dir = 4
-	},
 /obj/item/device/tagger/shop,
 /turf/simulated/floor/wood,
 /area/station/civilian/bar)
@@ -24724,8 +24717,7 @@
 "aTB" = (
 /obj/machinery/camera{
 	c_tag = "Escape Hallway";
-	dir = 4;
-	pixel_y = -18
+	dir = 5
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -24772,10 +24764,12 @@
 	},
 /area/station/security/checkpoint)
 "aTF" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -32
-	},
 /obj/structure/table/glass,
+/obj/machinery/camera{
+	c_tag = "Research Break";
+	dir = 4;
+	network = list("SS13","Research")
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -25038,11 +25032,6 @@
 /turf/simulated/floor/engine/vacuum,
 /area/station/rnd/mixing)
 "aUf" = (
-/obj/machinery/camera{
-	c_tag = "Research Break";
-	dir = 4;
-	network = list("SS13","Research")
-	},
 /obj/structure/table,
 /obj/item/weapon/storage/box/donkpockets{
 	pixel_x = 6;
@@ -26003,16 +25992,15 @@
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "aVR" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
 /obj/machinery/camera{
-	c_tag = "Research Division North";
-	dir = 8;
-	network = list("SS13","Research")
+	c_tag = "Atmospherics North East";
+	network = list("SS13","Engineering")
 	},
-/turf/simulated/floor{
-	dir = 9;
-	icon_state = "whitehall"
-	},
-/area/station/rnd/hallway)
+/turf/simulated/floor,
+/area/station/engineering/atmos)
 "aVS" = (
 /obj/structure/sign/warning/biohazard{
 	pixel_x = 32
@@ -26448,7 +26436,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Security Checkpoint";
-	dir = 1;
+	dir = 4;
 	network = list("SS13","Security")
 	},
 /turf/simulated/floor{
@@ -26504,11 +26492,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/machinery/camera{
-	c_tag = "Security Office East";
-	dir = 8;
-	network = list("SS13","Security")
 	},
 /obj/machinery/photocopier,
 /turf/simulated/floor{
@@ -26898,11 +26881,6 @@
 /area/station/bridge/ai_upload)
 "aXr" = (
 /obj/structure/table,
-/obj/machinery/camera{
-	c_tag = "Research Director's Office";
-	dir = 1;
-	network = list("SS13","Research")
-	},
 /obj/machinery/computer/skills,
 /turf/simulated/floor{
 	dir = 5;
@@ -27213,6 +27191,10 @@
 /obj/machinery/status_display{
 	layer = 4;
 	pixel_x = -32
+	},
+/obj/machinery/camera{
+	c_tag = "Mining Shuttle";
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "delivery"
@@ -27658,26 +27640,16 @@
 /turf/simulated/floor/whitegreed,
 /area/station/bridge/ai_upload)
 "aYL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
-	c_tag = "Arrival Hallway West";
-	dir = 1;
-	pixel_x = 20
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	c_tag = "Central Hallway West";
+	dir = 4
 	},
 /turf/simulated/floor{
+	dir = 8;
 	icon_state = "neutralcorner"
 	},
-/area/station/hallway/secondary/arrival)
+/area/station/hallway/primary/central)
 "aYM" = (
 /obj/machinery/camera{
 	c_tag = "Containment Cell 6";
@@ -27687,14 +27659,14 @@
 /turf/simulated/floor/engine,
 /area/station/rnd/xenobiology)
 "aYN" = (
-/obj/machinery/camera{
-	c_tag = "Bridge East Entrance"
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 1;
-	icon_state = "blue"
+	icon_state = "chapel"
 	},
-/area/station/hallway/primary/central)
+/area/station/civilian/chapel/mass_driver)
 "aYO" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -27902,10 +27874,6 @@
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -25
-	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -28
 	},
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
@@ -28847,8 +28815,7 @@
 /obj/structure/flora/junglebush/b,
 /obj/machinery/camera{
 	c_tag = "Garden East";
-	dir = 8;
-	pixel_y = -22
+	dir = 9
 	},
 /turf/simulated/floor/grass,
 /turf/simulated/floor{
@@ -29191,6 +29158,10 @@
 	dir = 8;
 	pixel_y = 36
 	},
+/obj/machinery/camera{
+	c_tag = "Arrival East";
+	dir = 6
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "neutral"
@@ -29325,6 +29296,9 @@
 "bbK" = (
 /obj/machinery/alarm{
 	pixel_y = 26
+	},
+/obj/machinery/camera{
+	c_tag = "Port Hallway 3"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -30704,9 +30678,6 @@
 	layer = 4;
 	pixel_y = 32
 	},
-/obj/machinery/camera{
-	c_tag = "Conference Room"
-	},
 /obj/machinery/light/smart{
 	dir = 1
 	},
@@ -30725,6 +30696,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/camera{
+	c_tag = "Conference Room"
 	},
 /turf/simulated/floor/wood,
 /area/station/bridge/meeting_room)
@@ -31025,9 +30999,6 @@
 	},
 /area/station/civilian/locker)
 "beK" = (
-/obj/machinery/camera{
-	c_tag = "Central Hallway North-West"
-	},
 /obj/machinery/alarm{
 	pixel_y = 23
 	},
@@ -31049,7 +31020,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = 27
@@ -31176,7 +31146,7 @@
 "beX" = (
 /obj/machinery/camera{
 	c_tag = "Research Division Mid";
-	dir = 1;
+	dir = 10;
 	network = list("SS13","Research")
 	},
 /obj/structure/cable{
@@ -31529,6 +31499,10 @@
 	name = "Station Intercom (General)";
 	pixel_x = -27
 	},
+/obj/machinery/camera{
+	c_tag = "Mining office";
+	dir = 6
+	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "brown"
@@ -31583,9 +31557,6 @@
 	},
 /area/station/rnd/hallway)
 "bfH" = (
-/obj/machinery/camera{
-	c_tag = "Mining office"
-	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "brown"
@@ -31744,10 +31715,10 @@
 /obj/structure/morgue{
 	dir = 8
 	},
-/obj/item/device/radio/intercom{
-	frequency = 1485;
-	name = "Station Intercom (Medbay)";
-	pixel_x = 28
+/obj/machinery/camera{
+	c_tag = "Medbay Morgue";
+	dir = 8;
+	network = list("SS13","Medical")
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -32210,10 +32181,6 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "bgP" = (
-/obj/machinery/camera{
-	c_tag = "Arrival Dock's South 2";
-	dir = 8
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
@@ -32304,9 +32271,6 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "bgX" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -23
@@ -32368,10 +32332,6 @@
 	},
 /area/station/hallway/secondary/entry)
 "bhe" = (
-/obj/machinery/camera{
-	c_tag = "Coworking";
-	dir = 4
-	},
 /obj/structure/filingcabinet/chestdrawer/black,
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
@@ -32399,10 +32359,6 @@
 	},
 /area/station/hallway/secondary/entry)
 "bhi" = (
-/obj/machinery/camera{
-	c_tag = "Arrival East";
-	dir = 1
-	},
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
@@ -32735,10 +32691,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bhS" = (
-/obj/machinery/camera{
-	c_tag = "Research Division West";
-	network = list("SS13","Research")
-	},
 /obj/machinery/computer/guestpass{
 	dir = 1;
 	pixel_y = 26
@@ -32929,11 +32881,6 @@
 /area/station/maintenance/escape)
 "bij" = (
 /obj/machinery/telecomms/bus/preset_four,
-/obj/machinery/camera{
-	c_tag = "Central Compartment East";
-	dir = 8;
-	network = list("Tcomsat")
-	},
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -33144,10 +33091,7 @@
 	},
 /area/shuttle/escape_pod1/station)
 "biI" = (
-/obj/machinery/camera{
-	c_tag = "Ferry shuttle South";
-	dir = 1
-	},
+/obj/machinery/light/smart,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "biK" = (
@@ -33240,9 +33184,6 @@
 "biT" = (
 /obj/item/weapon/storage/box/lights/mixed,
 /obj/item/weapon/storage/box/lights/mixed,
-/obj/machinery/camera{
-	c_tag = "Custodial Closet"
-	},
 /turf/simulated/floor,
 /area/station/civilian/janitor)
 "biU" = (
@@ -33805,13 +33746,13 @@
 /area/station/bridge/captain_quarters)
 "bkj" = (
 /obj/machinery/camera{
-	c_tag = "Central Hallway West";
-	dir = 8
+	c_tag = "Port Hallway";
+	dir = 10
 	},
 /turf/simulated/floor{
-	icon_state = "bluecorner"
+	icon_state = "neutralcorner"
 	},
-/area/station/hallway/primary/central)
+/area/station/hallway/primary/port)
 "bkk" = (
 /obj/machinery/door/window/eastright{
 	dir = 1;
@@ -33882,10 +33823,6 @@
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
 "bks" = (
-/obj/machinery/camera{
-	c_tag = "Cargo Bay East";
-	pixel_x = 22
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -34673,11 +34610,6 @@
 /obj/machinery/requests_console/robotics{
 	pixel_y = 30
 	},
-/obj/machinery/camera{
-	c_tag = "Robotics";
-	network = list("SS13","Research");
-	pixel_x = 22
-	},
 /turf/simulated/floor{
 	icon_state = "delivery"
 	},
@@ -34755,6 +34687,9 @@
 	},
 /obj/machinery/alarm{
 	pixel_y = 28
+	},
+/obj/machinery/camera{
+	c_tag = "Bar Backroom"
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/bar)
@@ -34886,7 +34821,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/camera{
-	c_tag = "Cargo Office North";
+	c_tag = "Cargo Office";
 	dir = 8
 	},
 /obj/structure/table,
@@ -34929,10 +34864,6 @@
 "bmd" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/beer{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Bar West";
 	dir = 4
 	},
 /obj/machinery/power/apc{
@@ -35036,7 +34967,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Surgery Observation";
-	dir = 8;
+	dir = 9;
 	network = list("SS13","Medical")
 	},
 /obj/machinery/firealarm{
@@ -37241,6 +37172,10 @@
 	pixel_y = 32
 	},
 /obj/structure/table,
+/obj/machinery/camera{
+	c_tag = "Research and Development Lab";
+	network = list("SS13","Research")
+	},
 /turf/simulated/floor{
 	icon_state = "warning"
 	},
@@ -37249,10 +37184,6 @@
 /obj/item/weapon/pen,
 /obj/machinery/light/smart{
 	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Research and Development Lab";
-	network = list("SS13","Research")
 	},
 /obj/item/taperoll/science,
 /obj/item/taperoll/science,
@@ -37814,9 +37745,8 @@
 	},
 /area/station/construction/assembly_line)
 "brC" = (
-/obj/machinery/camera{
-	c_tag = "Cargo Bay West";
-	dir = 4
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -28
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -38623,8 +38553,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Escape Hall South";
-	dir = 1;
-	pixel_x = 22
+	dir = 10
 	},
 /turf/simulated/floor{
 	icon_state = "escape"
@@ -38886,9 +38815,6 @@
 	},
 /area/station/tcommsat/computer)
 "btA" = (
-/obj/machinery/camera{
-	c_tag = "Cargo Hallway"
-	},
 /obj/machinery/computer/arcade,
 /obj/machinery/alarm{
 	pixel_y = 23
@@ -39382,6 +39308,11 @@
 	dir = 4;
 	pixel_x = 24
 	},
+/obj/machinery/camera{
+	c_tag = "Robotics";
+	dir = 8;
+	network = list("SS13","Research")
+	},
 /turf/simulated/floor{
 	icon_state = "delivery"
 	},
@@ -39818,7 +39749,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cyborg Station";
-	dir = 1
+	dir = 4
 	},
 /obj/structure/closet/crate{
 	name = "Camera Assembly Crate"
@@ -39939,7 +39870,7 @@
 /area/station/medical/storage)
 "bvw" = (
 /obj/machinery/door/airlock/mining{
-	name = "Recycler office";
+	name = "Recycler Workplace";
 	req_access = list(67)
 	},
 /obj/machinery/door/firedoor,
@@ -39987,11 +39918,6 @@
 	dir = 4;
 	name = "Cloning Cell";
 	req_access = list(5)
-	},
-/obj/machinery/camera{
-	c_tag = "Genetics Cloning";
-	dir = 4;
-	network = list("SS13","Medical")
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -40210,9 +40136,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -25
+/obj/machinery/camera{
+	c_tag = "Arrival Hallway Center";
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
@@ -41725,7 +41651,7 @@
 /area/station/bridge/cmf_room)
 "byv" = (
 /obj/machinery/camera{
-	c_tag = "Recycler Lobby";
+	c_tag = "Recycler Office";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -41741,7 +41667,8 @@
 /area/station/bridge/cmf_room)
 "byx" = (
 /obj/machinery/camera{
-	c_tag = "Pre Vault"
+	c_tag = "Pre Vault";
+	dir = 6
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -42265,22 +42192,16 @@
 	},
 /area/station/rnd/server)
 "bzv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/light_switch{
-	pixel_y = 25
-	},
 /obj/machinery/camera{
-	c_tag = "Locker Room"
+	c_tag = "Research Division West";
+	network = list("SS13","Research");
+	dir = 5
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "whitehall"
 	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
+/area/station/rnd/hallway)
 "bzw" = (
 /obj/machinery/computer/message_monitor,
 /turf/simulated/floor{
@@ -43079,15 +43000,19 @@
 /turf/simulated/wall/r_wall,
 /area/station/rnd/hor)
 "bAV" = (
-/obj/machinery/camera{
-	c_tag = "Dormitories West"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/cryopod/right,
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -28
+	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutral"
+	icon_state = "dark"
 	},
-/area/station/civilian/dormitories)
+/area/station/civilian/bar)
 "bAW" = (
 /obj/machinery/computer/crew{
 	dir = 8
@@ -43710,6 +43635,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/alarm{
+	pixel_y = 23
+	},
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "whitehall"
@@ -44148,12 +44076,11 @@
 /area/station/medical/cryo)
 "bCX" = (
 /obj/machinery/camera{
-	c_tag = "Central Hallway South-East";
-	dir = 8
+	c_tag = "Central Hallway North-West"
 	},
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "bluecorner"
 	},
 /area/station/hallway/primary/central)
 "bCY" = (
@@ -44622,28 +44549,24 @@
 /area/station/civilian/theatre)
 "bDP" = (
 /obj/machinery/camera{
-	c_tag = "Central Hallway South-West";
-	dir = 4
-	},
-/obj/machinery/light/smart{
-	dir = 8
+	c_tag = "Arrival Hallway East"
 	},
 /turf/simulated/floor{
-	dir = 1;
+	dir = 4;
 	icon_state = "neutralcorner"
 	},
-/area/station/hallway/primary/central)
+/area/station/hallway/secondary/entry)
 "bDQ" = (
 /obj/structure/table/woodentable,
-/obj/machinery/camera{
-	c_tag = "Theater Backroom"
-	},
 /obj/item/weapon/paper{
 	info = "Wherah is BANANAS?";
 	info_links = "Clown Memo"
 	},
 /obj/item/toy/prize/honk,
 /obj/item/weapon/reagent_containers/spray/watergun,
+/obj/structure/mirror{
+	pixel_y = 26
+	},
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "bDR" = (
@@ -44891,6 +44814,9 @@
 	pixel_x = 27
 	},
 /obj/machinery/icecream_vat,
+/obj/machinery/camera{
+	c_tag = "Kitchen Cold Room"
+	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -44924,8 +44850,9 @@
 	pixel_x = -30
 	},
 /obj/structure/dresser,
-/obj/structure/mirror{
-	pixel_y = 26
+/obj/machinery/camera{
+	c_tag = "Honk Office";
+	dir = 6
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
@@ -45103,10 +45030,6 @@
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
 "bEM" = (
-/obj/machinery/camera{
-	c_tag = "Bar South";
-	dir = 1
-	},
 /obj/structure/stool/bed/chair/comfy/black{
 	dir = 8
 	},
@@ -45731,9 +45654,8 @@
 "bFT" = (
 /obj/machinery/camera{
 	c_tag = "Telescience Test Room";
-	dir = 8;
-	network = list("SS13","Research");
-	pixel_y = -22
+	dir = 9;
+	network = list("SS13","Research")
 	},
 /turf/simulated/floor/engine,
 /area/station/rnd/telesci)
@@ -47318,9 +47240,6 @@
 /area/station/medical/hallway)
 "bIJ" = (
 /obj/structure/kitchenspike,
-/obj/machinery/camera{
-	c_tag = "Kitchen Cold Room"
-	},
 /obj/machinery/alarm{
 	pixel_y = 23
 	},
@@ -47337,11 +47256,6 @@
 /area/station/civilian/cold_room)
 "bIL" = (
 /obj/machinery/vending/robotics,
-/obj/machinery/camera{
-	c_tag = "Robotics South";
-	dir = 1;
-	network = list("SS13","Research")
-	},
 /obj/machinery/light/smart,
 /turf/simulated/floor{
 	icon_state = "delivery"
@@ -47472,11 +47386,6 @@
 /area/station/medical/cryo)
 "bIX" = (
 /obj/machinery/photocopier,
-/obj/machinery/camera{
-	c_tag = "Brainstorm Center";
-	dir = 0;
-	network = list("SS13","Research")
-	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "whitepurple"
@@ -49319,9 +49228,10 @@
 	},
 /obj/item/weapon/storage/firstaid/toxin,
 /obj/structure/table/glass,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/machinery/camera{
+	c_tag = "Medbay Storage";
+	dir = 4;
+	network = list("SS13","Medical")
 	},
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
@@ -49556,16 +49466,15 @@
 	},
 /area/station/security/prison)
 "bNb" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/camera{
-	c_tag = "Central Hallway East";
-	dir = 4
+	c_tag = "Brainstorm Center";
+	dir = 4;
+	network = list("SS13","Research")
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "bluecorner"
+	icon_state = "white"
 	},
-/area/station/hallway/primary/central)
+/area/station/rnd/brainstorm_center)
 "bNc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor,
@@ -49666,13 +49575,14 @@
 /area/space)
 "bNm" = (
 /obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway 2"
+	c_tag = "Bar North";
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "purplecorner"
+	icon_state = "dark"
 	},
-/area/station/hallway/primary/starboard)
+/area/station/civilian/bar)
 "bNn" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 4
@@ -49925,6 +49835,10 @@
 /obj/item/weapon/grenade/chem_grenade/antiweed,
 /obj/item/weapon/grenade/chem_grenade/antiweed,
 /obj/item/weapon/grenade/chem_grenade/antiweed,
+/obj/machinery/camera{
+	c_tag = "Custodial Closet";
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/civilian/janitor)
 "bNI" = (
@@ -50140,11 +50054,6 @@
 	},
 /area/station/hallway/primary/starboard)
 "bOc" = (
-/obj/machinery/camera{
-	c_tag = "Medbay East";
-	dir = 8;
-	network = list("SS13","Medical")
-	},
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "whitehall"
@@ -50367,10 +50276,6 @@
 "bOB" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
-	},
-/obj/machinery/camera{
-	c_tag = "Fore Primary Hallway-South";
-	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -50695,6 +50600,10 @@
 	},
 /obj/item/weapon/storage/firstaid/regular,
 /obj/structure/table/glass,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -52725,6 +52634,10 @@
 /turf/simulated/floor/plating,
 /area/station/rnd/mixing)
 "bTT" = (
+/obj/machinery/camera{
+	c_tag = "Cargo Bay East";
+	dir = 1
+	},
 /turf/simulated/floor{
 	icon_state = "brown"
 	},
@@ -53174,9 +53087,10 @@
 "bVt" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -30
+/obj/machinery/camera{
+	c_tag = "Engineering South-West";
+	dir = 4;
+	network = list("SS13","Engineering")
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -53802,15 +53716,14 @@
 /area/station/hallway/primary/aft)
 "bWY" = (
 /obj/machinery/camera{
-	c_tag = "Atmospherics Waste Tank";
-	network = list("SS13","Engineering")
+	c_tag = "Central Hallway South-West";
+	dir = 4
 	},
-/turf/simulated/floor/engine{
-	name = "vacuum floor";
-	nitrogen = 0.01;
-	oxygen = 0.01
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
 	},
-/area/station/engineering/atmos)
+/area/station/hallway/primary/central)
 "bWZ" = (
 /turf/simulated/floor/engine{
 	name = "vacuum floor";
@@ -54120,11 +54033,6 @@
 	},
 /area/station/civilian/library)
 "bYf" = (
-/obj/machinery/camera{
-	c_tag = "Assembly Line";
-	dir = 5;
-	network = list("SS13","Engineering")
-	},
 /obj/structure/disposalconstruct,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -54540,10 +54448,6 @@
 /area/shuttle/escape_pod4/station)
 "bZu" = (
 /obj/structure/closet/toolcloset,
-/obj/machinery/camera{
-	c_tag = "Construction Area";
-	network = list("SS13","Engineering")
-	},
 /turf/simulated/floor,
 /area/station/construction)
 "bZv" = (
@@ -55152,9 +55056,6 @@
 	dir = 8;
 	name = "Library Desk Door";
 	req_access = list(37)
-	},
-/obj/machinery/light/small{
-	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Library North";
@@ -56046,11 +55947,6 @@
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = -28
-	},
-/obj/machinery/camera{
-	c_tag = "Aft Primary Hallway 1";
-	dir = 4;
-	pixel_y = -22
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -57679,13 +57575,13 @@
 /area/station/maintenance/engineering)
 "cki" = (
 /obj/machinery/camera{
-	c_tag = "Port Hallway 3"
+	c_tag = "Starboard Primary Hallway 2";
+	dir = 10
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "bluecorner"
 	},
-/area/station/hallway/primary/port)
+/area/station/hallway/primary/starboard)
 "ckl" = (
 /obj/machinery/optable,
 /turf/simulated/floor{
@@ -57752,7 +57648,8 @@
 /obj/structure/reagent_dispensers/aqueous_foam_tank,
 /obj/machinery/camera{
 	c_tag = "Atmospherics Access";
-	network = list("SS13","Engineering")
+	network = list("SS13","Engineering");
+	dir = 6
 	},
 /turf/simulated/floor{
 	icon_state = "bot"
@@ -58548,11 +58445,6 @@
 /area/station/aisat/antechamber_interior)
 "cmE" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
-/obj/machinery/camera{
-	c_tag = "Atmospherics West";
-	dir = 5;
-	network = list("SS13","Engineering")
-	},
 /obj/structure/window/thin/reinforced{
 	dir = 1
 	},
@@ -59234,9 +59126,6 @@
 	network = list("MiniSat")
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/machinery/light/small{
-	dir = 4
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -59366,10 +59255,6 @@
 /area/station/aisat)
 "coF" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/blue,
-/obj/machinery/camera{
-	c_tag = "Atmospherics North East";
-	network = list("SS13","Engineering")
-	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "blue"
@@ -59405,6 +59290,9 @@
 "coN" = (
 /obj/machinery/vending/coffee,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/simulated/floor/wood{
 	icon_state = "wood-broken5"
 	},
@@ -59544,6 +59432,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/machinery/light/small,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -59894,6 +59783,11 @@
 	pixel_x = 10;
 	pixel_y = 28
 	},
+/obj/machinery/camera/motion{
+	c_tag = "AI Chamber South";
+	network = list("RD","MiniSat");
+	dir = 6
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -59924,11 +59818,6 @@
 	name = "AI Chamber turret control";
 	pixel_x = 26;
 	pixel_y = 24
-	},
-/obj/machinery/camera/motion{
-	c_tag = "AI Chamber South";
-	network = list("RD","MiniSat");
-	pixel_x = 32
 	},
 /obj/structure/cable{
 	d1 = 2;
@@ -60222,12 +60111,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
 	dir = 9
-	},
-/obj/machinery/camera/motion{
-	c_tag = "MiniSat Maintenance";
-	dir = 4;
-	network = list("MiniSat");
-	pixel_y = 12
 	},
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -61177,12 +61060,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/camera{
-	c_tag = "MiniSat Entrance";
-	dir = 8;
-	network = list("MiniSat");
-	pixel_y = 12
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -62033,10 +61910,6 @@
 	},
 /area/station/rnd/brainstorm_center)
 "cvc" = (
-/obj/machinery/camera{
-	c_tag = "Head of Personnel's Office";
-	dir = 1
-	},
 /obj/machinery/light/smart,
 /turf/simulated/floor{
 	dir = 0;
@@ -62137,6 +62010,10 @@
 	pixel_y = -30
 	},
 /obj/item/weapon/book/manual/wiki/possible_threats,
+/obj/machinery/camera{
+	c_tag = "Head of Personnel's Office";
+	dir = 10
+	},
 /turf/simulated/floor{
 	dir = 0;
 	icon_state = "blue"
@@ -62791,16 +62668,20 @@
 /area/station/hallway/primary/central)
 "cxN" = (
 /obj/machinery/camera{
-	c_tag = "Central Primary Hallway South-West";
-	dir = 1
+	c_tag = "Brig Center-East";
+	network = list("SS13","Security");
+	dir = 10
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	icon_state = "neutralcorner"
+	icon_state = "redcorner"
 	},
-/area/station/hallway/primary/central)
+/area/station/security/brig)
 "cxO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/camera{
+	c_tag = "Central Primary Hallway South-West";
 	dir = 1
 	},
 /turf/simulated/floor{
@@ -63621,7 +63502,8 @@
 /obj/structure/table,
 /obj/machinery/camera{
 	c_tag = "Surgery Operating 2";
-	network = list("SS13","Medical")
+	network = list("SS13","Medical");
+	dir = 6
 	},
 /obj/item/weapon/reagent_containers/spray/cleaner{
 	desc = "Someone has crossed out the Space from Space Cleaner and written in Surgery. 'Do not remove under punishment of death!!!' is scrawled on the back.";
@@ -63722,13 +63604,6 @@
 	icon_state = "platebot"
 	},
 /area/station/engineering/engine)
-"cAu" = (
-/obj/machinery/camera{
-	c_tag = "Incinerator";
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
 "cAx" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Break Room Maintenance";
@@ -63780,19 +63655,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "cAE" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -28
-	},
 /obj/machinery/camera{
-	c_tag = "Aft Primary Hallway 2";
-	dir = 4
+	c_tag = "Central Hallway East";
+	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "yellowcorner"
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
-/area/station/hallway/primary/aft)
+/area/station/hallway/primary/central)
 "cAF" = (
 /obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor/plating{
@@ -64222,6 +64093,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -28
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "yellowcorner"
@@ -64356,9 +64231,8 @@
 	},
 /obj/machinery/camera/emp_proof{
 	c_tag = "Singularity North-West";
-	dir = 3;
-	network = list("Singularity");
-	pixel_x = 20
+	dir = 6;
+	network = list("Singularity")
 	},
 /turf/simulated/floor/plating/airless{
 	dir = 5;
@@ -64446,6 +64320,10 @@
 	},
 /obj/item/clothing/glasses/welding,
 /obj/item/clothing/glasses/welding,
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -30
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "yellow"
@@ -65287,11 +65165,6 @@
 /turf/simulated/wall/r_wall,
 /area/station/ai_monitored/storage_secure)
 "cFb" = (
-/obj/machinery/camera/motion{
-	c_tag = "AI Chamber North";
-	network = list("RD","MiniSat");
-	pixel_x = 32
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -65543,6 +65416,11 @@
 	},
 /obj/structure/window/thin/reinforced{
 	dir = 4
+	},
+/obj/machinery/camera{
+	c_tag = "Genetics Cloning";
+	dir = 1;
+	network = list("SS13","Medical")
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -65841,8 +65719,7 @@
 "cGY" = (
 /obj/machinery/camera{
 	c_tag = "Garden West";
-	dir = 8;
-	pixel_y = -22
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -66684,6 +66561,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics North North";
+	network = list("SS13","Engineering");
+	dir = 8
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "warning"
@@ -67443,6 +67325,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/machinery/camera{
+	c_tag = "Central Hallway South-East";
+	dir = 8
+	},
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "neutral"
@@ -68180,10 +68066,10 @@
 "dBb" = (
 /obj/machinery/camera{
 	c_tag = "Arrival Auxillar Dock's South";
-	dir = 1
+	dir = 6
 	},
 /turf/simulated/floor{
-	dir = 8;
+	dir = 1;
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
@@ -68458,6 +68344,11 @@
 	dir = 4;
 	pixel_x = -25
 	},
+/obj/machinery/camera/motion{
+	c_tag = "MiniSat Maintenance";
+	dir = 5;
+	network = list("MiniSat")
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -68535,11 +68426,6 @@
 	},
 /area/station/civilian/chapel)
 "ead" = (
-/obj/machinery/camera{
-	c_tag = "Engineering South-West";
-	dir = 4;
-	network = list("SS13","Engineering")
-	},
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
 	dir = 8;
@@ -69310,7 +69196,7 @@
 /area/station/maintenance/disposal)
 "eZS" = (
 /obj/machinery/camera{
-	c_tag = "Cargo Office South";
+	c_tag = "Cargo Delivery Office";
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -69662,8 +69548,7 @@
 /area/station/hallway/secondary/exit)
 "fAb" = (
 /obj/machinery/camera{
-	c_tag = "Recycler External South";
-	pixel_x = 4
+	c_tag = "Recycler External South"
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/cargo/recycler)
@@ -69773,12 +69658,13 @@
 /area/station/hallway/primary/port)
 "fEm" = (
 /obj/machinery/camera{
-	c_tag = "Prison Maintenance";
-	dir = 8;
-	network = list("SS13","Security")
+	c_tag = "Starboard Primary Hallway 3"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/eva)
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "purplecorner"
+	},
+/area/station/hallway/primary/starboard)
 "fEy" = (
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -69897,10 +69783,6 @@
 	},
 /area/station/security/main)
 "fJJ" = (
-/obj/machinery/camera{
-	c_tag = "Starboard Primary Hallway 3";
-	dir = 1
-	},
 /obj/machinery/light/small,
 /obj/structure/stool/bed/chair/metal/yellow{
 	dir = 1
@@ -70167,11 +70049,12 @@
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "fZb" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
 /obj/structure/closet/bombcloset,
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -28;
+	pixel_y = -5
+	},
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
@@ -70767,6 +70650,10 @@
 /area/station/medical/reception)
 "gMs" = (
 /obj/effect/landmark/start/technical_assistant,
+/obj/machinery/camera{
+	c_tag = "Aft Primary Hallway 1";
+	dir = 8
+	},
 /turf/simulated/floor{
 	icon_state = "yellowcorner"
 	},
@@ -70779,10 +70666,6 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/camera{
-	c_tag = "Chapel Mass Driver";
-	dir = 1
-	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -71707,6 +71590,16 @@
 	icon_state = "warning"
 	},
 /area/station/engineering/engine)
+"hRX" = (
+/obj/machinery/camera{
+	c_tag = "MiniSat Entrance";
+	dir = 9;
+	network = list("MiniSat")
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/aisat/antechamber)
 "hSb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -71805,16 +71698,15 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "hXb" = (
-/obj/structure/closet/emcloset,
 /obj/machinery/camera{
-	c_tag = "Arrival Hallway Center";
-	pixel_x = -4
+	c_tag = "Bridge East Entrance";
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 1;
-	icon_state = "bot"
+	icon_state = "bluecorner"
 	},
-/area/station/hallway/secondary/arrival)
+/area/station/hallway/primary/central)
 "hXl" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
@@ -71869,9 +71761,6 @@
 	},
 /area/station/engineering/engine)
 "hZb" = (
-/obj/machinery/camera{
-	c_tag = "Central Hallway North"
-	},
 /obj/machinery/light/smart{
 	dir = 1
 	},
@@ -71915,6 +71804,10 @@
 /obj/structure/closet/emcloset,
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
+	},
+/obj/machinery/camera{
+	c_tag = "Central Hallway North";
+	dir = 6
 	},
 /turf/simulated/floor{
 	dir = 9;
@@ -72349,14 +72242,18 @@
 	},
 /area/station/engineering/engine)
 "izb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/camera{
-	c_tag = "Port Hallway";
-	dir = 1
+	c_tag = "Recycler Office";
+	dir = 10
 	},
 /turf/simulated/floor{
-	icon_state = "neutralcorner"
+	dir = 4;
+	icon_state = "dark"
 	},
-/area/station/hallway/primary/port)
+/area/station/cargo/recycleroffice)
 "iAb" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -73168,8 +73065,7 @@
 /obj/machinery/camera{
 	c_tag = "Psychiatric Office";
 	dir = 8;
-	network = list("SS13","Medical");
-	pixel_y = -22
+	network = list("SS13","Medical")
 	},
 /obj/item/toy/plushie/tuxedo_cat,
 /turf/simulated/floor/carpet/green,
@@ -75057,10 +74953,11 @@
 /area/station/cargo/office)
 "lAb" = (
 /obj/structure/morgue,
-/obj/machinery/camera{
-	c_tag = "Medbay Morgue";
-	dir = 4;
-	network = list("SS13","Medical")
+/obj/item/device/radio/intercom{
+	frequency = 1485;
+	name = "Station Intercom (Medbay)";
+	pixel_x = -28;
+	pixel_y = -5
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -75889,10 +75786,6 @@
 	},
 /area/station/medical/hallway)
 "mwb" = (
-/obj/machinery/camera{
-	c_tag = "Atmospherics North West";
-	network = list("SS13","Engineering")
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -75902,8 +75795,9 @@
 	},
 /area/station/engineering/atmos)
 "mwB" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/camera{
+	c_tag = "Chapel Mass Driver";
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -76356,9 +76250,6 @@
 	},
 /area/station/medical/genetics_cloning)
 "neo" = (
-/obj/machinery/camera{
-	c_tag = "Bar North"
-	},
 /obj/structure/stool/bar,
 /obj/structure/window/thin/reinforced{
 	dir = 4
@@ -76789,7 +76680,8 @@
 /obj/item/weapon/storage/briefcase/inflatable,
 /obj/machinery/camera{
 	c_tag = "Virology Access South";
-	network = list("SS13","Medical")
+	network = list("SS13","Medical");
+	dir = 6
 	},
 /turf/simulated/floor{
 	dir = 9;
@@ -77892,6 +77784,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
+/obj/machinery/camera{
+	c_tag = "Arrival Dock's South 2";
+	dir = 5
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -78288,6 +78184,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "yellowcorner"
@@ -78387,11 +78284,6 @@
 	},
 /obj/item/weapon/storage/firstaid/o2,
 /obj/structure/table/glass,
-/obj/machinery/camera{
-	c_tag = "Medbay Storage";
-	dir = 4;
-	network = list("SS13","Medical")
-	},
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -80598,18 +80490,14 @@
 	},
 /area/station/medical/virology)
 "sqt" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/light/small{
 	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Recycler Office";
-	dir = 0
 	},
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "dark"
+	icon_state = "chapel"
 	},
-/area/station/cargo/recycleroffice)
+/area/station/civilian/chapel/mass_driver)
 "srb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -80642,6 +80530,16 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/medical/virology)
+"sth" = (
+/obj/machinery/camera{
+	c_tag = "Aft Primary Hallway 2";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/aft)
 "stq" = (
 /obj/item/weapon/flora/random,
 /obj/structure/window/thin/reinforced,
@@ -81062,9 +80960,8 @@
 	},
 /obj/machinery/camera/emp_proof{
 	c_tag = "Singularity Observation";
-	dir = 1;
-	network = list("Singularity");
-	pixel_x = 20
+	dir = 10;
+	network = list("Singularity")
 	},
 /obj/structure/cable,
 /turf/simulated/floor/plating/airless{
@@ -81249,11 +81146,6 @@
 /area/station/tcommsat/computer)
 "tbb" = (
 /obj/machinery/telecomms/bus/preset_two,
-/obj/machinery/camera{
-	c_tag = "Central Compartment West";
-	dir = 4;
-	network = list("Tcomsat")
-	},
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -81853,7 +81745,7 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "neutralcorner"
+	icon_state = "greencorner"
 	},
 /area/station/hallway/primary/starboard)
 "ufb" = (
@@ -82242,6 +82134,11 @@
 /obj/machinery/telescience_jammer{
 	radius = 5
 	},
+/obj/machinery/camera{
+	c_tag = "Secure Armory East";
+	dir = 1;
+	network = list("SS13","Security")
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "vault"
@@ -82629,6 +82526,9 @@
 /obj/machinery/bot/mulebot{
 	home_destination = "QM #1";
 	suffix = "#1"
+	},
+/obj/machinery/light/small{
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "bot"
@@ -83161,11 +83061,8 @@
 	},
 /area/station/engineering/engine)
 "xoX" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 30
-	},
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/camera{
+	c_tag = "Cargo Bay West"
 	},
 /turf/simulated/floor{
 	icon_state = "loadingarea"
@@ -83306,10 +83203,6 @@
 	dir = 8;
 	name = "Chapel Hall APC";
 	pixel_x = -26
-	},
-/obj/machinery/camera{
-	c_tag = "Chapel Dressing Room";
-	dir = 4
 	},
 /obj/structure/cable{
 	d2 = 4;
@@ -88313,7 +88206,7 @@ hjb
 brt
 bjn
 era
-aRV
+aWt
 aXR
 qCp
 kAe
@@ -90113,7 +90006,7 @@ qRb
 iur
 iur
 iCC
-aYL
+aGY
 hPU
 aaa
 aXZ
@@ -90884,7 +90777,7 @@ aaa
 buS
 buM
 aFB
-aGY
+aau
 odL
 aaa
 aXZ
@@ -91653,7 +91546,7 @@ aGy
 aGy
 aaa
 iur
-hXb
+buM
 lZM
 bvU
 odL
@@ -91926,7 +91819,7 @@ dEb
 aro
 baY
 aSI
-atE
+biI
 apo
 avy
 avy
@@ -92183,7 +92076,7 @@ dEb
 aNG
 baY
 aSI
-biI
+atE
 aDy
 avy
 avy
@@ -92968,7 +92861,7 @@ bgj
 bgj
 bgj
 apT
-uDb
+dBb
 urb
 icb
 btD
@@ -93483,7 +93376,7 @@ aEb
 aaa
 apT
 cMC
-dBb
+urb
 bdz
 btD
 btD
@@ -94995,7 +94888,7 @@ aKJ
 aaa
 aaa
 apT
-bbd
+bDP
 atE
 aJT
 bis
@@ -95010,8 +94903,8 @@ bkB
 bis
 iDb
 bmq
-bis
 bTp
+bis
 bbT
 ajb
 vaa
@@ -100654,7 +100547,7 @@ bbC
 aKb
 bhj
 aSP
-bzv
+bzP
 aUs
 aZr
 bfg
@@ -100911,7 +100804,7 @@ bbD
 aJS
 bfZ
 aSP
-bzP
+aRV
 aZK
 aZK
 aZK
@@ -103220,7 +103113,7 @@ aJk
 aVl
 aWI
 aYX
-cki
+bdv
 bdZ
 ipb
 bod
@@ -103982,8 +103875,8 @@ aHn
 avp
 avp
 avp
-cnt
-cnz
+cnx
+cnx
 aFL
 aQT
 aSv
@@ -104017,7 +103910,7 @@ bDk
 bNk
 mTP
 mtS
-lqO
+izb
 bNk
 bNk
 aaa
@@ -104238,9 +104131,9 @@ aie
 aig
 nPb
 aKe
-hpb
-cnu
-cnx
+avp
+qJb
+cny
 aFL
 aQU
 aJk
@@ -104495,9 +104388,9 @@ aFR
 lzb
 aIv
 aKf
-avp
-qJb
-cny
+hpb
+cnu
+cnx
 aFL
 aQV
 aSw
@@ -104753,8 +104646,8 @@ aHs
 aIx
 aKg
 avp
-cnx
-cnx
+cnt
+cnz
 aFL
 aFL
 aFL
@@ -105044,7 +104937,7 @@ bEW
 fDx
 bNk
 bNk
-sqt
+lqO
 sNO
 bNk
 bNk
@@ -107143,7 +107036,7 @@ cgQ
 aOG
 cjc
 coV
-cAu
+bQl
 ckB
 bdU
 mty
@@ -107596,13 +107489,13 @@ ayv
 dWf
 avN
 dWf
-avN
+bNm
 gTX
 brh
 gTX
 bHL
 gTX
-aDx
+bAV
 bDn
 bDn
 bDn
@@ -107848,7 +107741,7 @@ bag
 aCq
 bdj
 aKd
-izb
+bgE
 arZ
 avM
 nCQ
@@ -108334,7 +108227,7 @@ alZ
 alZ
 ceF
 alZ
-fEm
+alZ
 alZ
 alZ
 cfP
@@ -108362,7 +108255,7 @@ baj
 bci
 byj
 bfx
-bgE
+bkj
 aGn
 neo
 dbM
@@ -109658,21 +109551,21 @@ bav
 bpt
 bwB
 bmp
-bmp
+aYL
 bmp
 bmZ
 btQ
 bFy
 sVa
 aMM
-aMM
-bgZ
+aFE
+bWY
 bmS
 pOb
 aIR
 aIR
 aIR
-bDP
+aTR
 aIR
 aIR
 aIR
@@ -109922,8 +109815,8 @@ bhJ
 bHF
 cux
 boW
+aOK
 cro
-aXb
 oYb
 cro
 cro
@@ -110175,7 +110068,7 @@ bbo
 bbo
 bbo
 ciW
-bkj
+bbo
 blS
 bXt
 oMb
@@ -110930,7 +110823,7 @@ ayf
 azT
 ayf
 aCu
-aMN
+bCX
 aKx
 bbo
 aGZ
@@ -111475,7 +111368,7 @@ cvc
 bra
 bFG
 aKz
-cxN
+bEd
 aMR
 aaa
 bLW
@@ -112469,7 +112362,7 @@ aDn
 aEE
 aFq
 aEE
-aEE
+aDP
 aMH
 aIC
 aML
@@ -113467,7 +113360,7 @@ aeq
 aeq
 ajw
 alI
-fmb
+ali
 adJ
 adJ
 adJ
@@ -113703,7 +113596,7 @@ aah
 rtF
 aaj
 aaj
-aau
+aao
 aaG
 aaU
 abl
@@ -113796,9 +113689,9 @@ aMq
 aKU
 czu
 cAk
-cAE
-cAZ
 cim
+cAZ
+sth
 cBL
 czc
 czu
@@ -114219,7 +114112,7 @@ aBS
 aaq
 aao
 aaF
-aaX
+aao
 abl
 abN
 aan
@@ -114262,7 +114155,7 @@ bLI
 bNI
 bOB
 azp
-aDP
+aCH
 aBp
 aCH
 aCH
@@ -114495,7 +114388,7 @@ agV
 ajp
 ajx
 alK
-ajQ
+alj
 adM
 ami
 aqE
@@ -114814,7 +114707,7 @@ brY
 btR
 bvl
 byA
-cxh
+aIR
 aKx
 bht
 bJe
@@ -115071,7 +114964,7 @@ byC
 bzW
 bBQ
 byA
-aIR
+cxh
 aKx
 bht
 bJe
@@ -115539,7 +115432,7 @@ awv
 cea
 aBe
 awT
-bAV
+azG
 azG
 azG
 azG
@@ -116037,7 +115930,7 @@ ajS
 aju
 ajs
 ako
-fmb
+cxN
 afV
 anK
 aoB
@@ -116310,7 +116203,7 @@ azs
 cea
 aBe
 awT
-azx
+aaX
 azx
 bIF
 bKV
@@ -117063,7 +116956,7 @@ ahn
 aiW
 ajZ
 aaV
-akc
+ajs
 alO
 fmb
 ama
@@ -117148,7 +117041,7 @@ bQQ
 ctd
 cgH
 bRT
-bNO
+ajQ
 cAG
 cAG
 bVP
@@ -117362,7 +117255,7 @@ aGZ
 aaa
 aaa
 aGZ
-aYN
+aPv
 bat
 bad
 bdc
@@ -117879,8 +117772,8 @@ aRR
 aML
 bau
 aRR
-aML
-bNb
+hXb
+bDK
 aML
 aML
 aML
@@ -118402,7 +118295,7 @@ jAb
 bWl
 aPE
 bXR
-aPE
+cAE
 aPE
 aPE
 qMb
@@ -118411,7 +118304,7 @@ aMN
 aMN
 aMN
 aPE
-bCX
+aPE
 cxv
 bME
 cMQ
@@ -118865,7 +118758,7 @@ agg
 aeJ
 alQ
 aef
-anB
+aeJ
 anR
 ang
 aoW
@@ -119973,7 +119866,7 @@ cdA
 cce
 bQa
 bSV
-bQQ
+aVR
 bVD
 bUw
 bYu
@@ -120430,10 +120323,10 @@ aOV
 chC
 aHS
 aRE
-tmb
+bNb
 xwC
 gUO
-czf
+tmb
 aSN
 aUh
 aVA
@@ -121211,7 +121104,7 @@ bKL
 bOr
 aZy
 bOr
-bOr
+bzv
 bib
 blo
 boE
@@ -121260,7 +121153,7 @@ cAi
 cdA
 aah
 bVI
-bWY
+bWZ
 bWZ
 bWZ
 bVI
@@ -121721,7 +121614,7 @@ dWb
 czf
 aSO
 buH
-aVR
+buH
 aXp
 buH
 bqc
@@ -123537,7 +123430,7 @@ bjt
 bjt
 bNd
 bcb
-cpX
+cki
 bjk
 bkq
 bmv
@@ -124306,7 +124199,7 @@ bCy
 bGT
 bxJ
 bxJ
-bNm
+bNd
 bcb
 cpX
 bjd
@@ -125609,7 +125502,7 @@ nsb
 qQb
 bAB
 bvR
-aOK
+rAb
 aSW
 aTq
 bCj
@@ -125665,7 +125558,7 @@ cDy
 cmU
 cGo
 cFP
-cmf
+anB
 cmk
 cqp
 cFP
@@ -126362,7 +126255,7 @@ bOz
 bOz
 bOz
 bJJ
-bNe
+fEm
 bPu
 bMv
 ctM
@@ -126619,7 +126512,7 @@ bCC
 bOz
 bOz
 bJJ
-bNd
+bNe
 bPu
 bMv
 fJJ
@@ -127474,7 +127367,7 @@ aaa
 cEW
 cqP
 crN
-crN
+hRX
 csP
 ctp
 aWZ
@@ -130733,7 +130626,7 @@ xbF
 tMB
 uEB
 iKb
-ueK
+bMv
 aKs
 bYL
 uZG
@@ -130990,7 +130883,7 @@ aRt
 aTs
 aTw
 aUT
-bhQ
+ueK
 aKs
 bYM
 cvy
@@ -132263,7 +132156,7 @@ aKv
 baJ
 bdy
 bgX
-vwv
+aYN
 bdb
 aQa
 sld
@@ -133291,7 +133184,7 @@ bCO
 xGY
 kPR
 mwB
-xGY
+sqt
 cWL
 aQa
 sKk


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Это возрождение https://github.com/TauCetiStation/TauCetiClassic/pull/11227. Изменения карты вроде закончились, так что можно повторить. Это актуальный вариант изменений, проведённый с учётом ревью от мапдепа, где было добавлено ещё больше, чем ранее, изменений расположений камер.
![2023 05 07-13 06 32](https://user-images.githubusercontent.com/96499407/236671657-94ce4a10-ee14-4a93-a751-cf3a404dc4b6.png)

Было проведено ревью всех камер на станции. Были удалены дубликаты камер в некоторых отсеках. Было удалено смещение не через dir переменную у камер (исключение центрирование). Были удалены все камеры в техах. Были перемещены камеры возле технических тоннелей, которые было куда переместить. Были переименованы некоторые камеры в сооветствии с названием отсеков.

Принципы которыми руководствовался в процессе принятия решений:

* Чем больше ИИ видит в техах, тем хуже геймплей антагонистам и обычным членам экипажа;
* Чем больше охранники и ИИ видят камерами, тем хуже геймплей антагонистам;
* Чем больше камер в отсеке, тем сложнее избавится от слежки за этим отделом;
* ИИ должен видеть как можно больше шлюзов, которые не расположены в технических тоннелях для выполнения своей работы служить экипажу открывашкой;
* Камеры на лампах не красиво выглядят и имеют худший способ интеракта с собой;
* ИИ не должен быть урезан в полезных игрокам действиях. Конкретный пример: камера в холодилке медбея не должна быть убрана, чтобы ИИ в отсутствии медиков смог помочь пострадавшим управляя криокапсулой и устанавливая рабочую температуру.

Не все камеры можно переставить красиво. В основном такое прослеживается во всех отсеках где много стёкол. Не все камеры можно переставить впринципе, в связи с маленькими размерами отсека.
## Почему и что этот ПР улучшит
Улучшение геймплея всем, для кого камеры являются фактором при антагонизме. Дублирование камер на карте убрано. Увеличение колличества непросматриваемых ролькохантерами зон на карте.
## Авторство
Консультировался с [Tap0r](https://github.com/Tap0r)
## Чеинжлог
:cl: Deahaka, Tap0r
- map: Большое количество камер на станции "Исход" поменяли своё местоположение.
- map: Небольшие косметические изменения станции "Исход" в связи с пересмотром камер.