### PR TITLE
(Не)Большой бафф для репликов

### DIFF
--- a/code/modules/replicators/replicators_forcefields.dm
+++ b/code/modules/replicators/replicators_forcefields.dm
@@ -171,6 +171,11 @@
 		return FALSE
 	return ..()
 
+/obj/structure/stabilization_field/Crossed(mob/living/carbon/M)
+	if(ishuman(M))
+		irradiate_one_mob(M, 50)
+		to_chat(M, "<span class='notice'>Микроскопические кристаллы силового поля испускают волну облучения.</span>")
+	return ..()
 
 /obj/structure/replicator_barricade
 	name = "forcefield barricade"

--- a/code/modules/replicators/replicators_forcefields.dm
+++ b/code/modules/replicators/replicators_forcefields.dm
@@ -173,8 +173,8 @@
 
 /obj/structure/stabilization_field/Crossed(mob/living/carbon/M)
 	if(ishuman(M))
-		irradiate_one_mob(M, 50)
-		to_chat(M, "<span class='notice'>Микроскопические кристаллы силового поля испускают волну облучения.</span>")
+		irradiate_one_mob(M, 25)
+		to_chat(M, "<span class='warning'>Микроскопические кристаллы силового поля испускают волну облучения.</span>")
 	return ..()
 
 /obj/structure/replicator_barricade


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Еще 1 изменение для репликаторов из списка Людука, а именно - при вхождении в силовое поле репликаторов человека облучает радиацией.

Количество радиации было обговорено с Людуком, но ОКОНЧАТЕЛЬНОГО решения не имеет. Одежда/броня учитываются при накидывании радейки. 

P.S.: Скорее всего нужно скинуть радейку до 25 хотя бы, но на данный момент кукла при получении 50 радиации получается всего лишь 15-18 токсинов, которые легко вывести. Если есть одежда/броня что защищают от радиации то тогда и радиации меньше и токсинов. Но все же если словить 3-4 поля ПОДРЯД, то кукла упадет в стан ненадолго, а сам кап радейки не больше 100 единиц которые в сумме дадут кукле до 50 токсинов. Ну и не забываем про мутации.

## Почему и что этот ПР улучшит
С этим ПРом теперь поле не будет как "портал"/окно для экипажа благодаря которому можно тупо выйти в космос без проблем, либо стрелять через тайл который был стеной(да и было довольно много нерфа репликов, а тут хоть какой-то баф)
## Авторство
Я
## Чеинжлог
Стабилизационное поле теперь облучает людей