### PR TITLE
ГП квоты на профы.

### DIFF
--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -80,6 +80,8 @@ SUBSYSTEM_DEF(economy)
 		if(D.owner_salary && !D.suspended)
 			charge_to_account(D.account_number, D.account_number, "Salary payment", "CentComm", D.owner_salary)
 
+	global.station_jobs_quotas = list(null, null, null)
+
 	monitor_cargo_shop()
 
 	var/obj/item/device/radio/intercom/announcer = new /obj/item/device/radio/intercom(null)

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -119,12 +119,8 @@ var/global/list/station_jobs_quotas[3]
 	data["fast_modify_region"] = is_skill_competent(user, list(/datum/skill/command = SKILL_LEVEL_PRO))
 	data["fast_full_access"] = is_skill_competent(user, list(/datum/skill/command = SKILL_LEVEL_MASTER))
 
-	var/list/jobs_quotas = list()
-	for(var/datum/job/job in SSjob.occupations)
-		if(job && job.map_check())
-			jobs_quotas += list(list("name" = job.title))
-	data["jobs_quotas"] = jobs_quotas
-	data["quotted_jobs"] = global.station_jobs_quotas
+	data["jobs_can_be_quota"] = setup_quotas()
+	data["quota_jobs"] = global.station_jobs_quotas
 
 	if (modify && is_centcom())
 		var/list/all_centcom_access = list()
@@ -334,15 +330,24 @@ var/global/list/station_jobs_quotas[3]
 			var/job_name = sanitize(href_list["quotajob_name"])
 			if(!job_name)
 				return
-
-			global.station_jobs_quotas.Swap(2, 3)
-			global.station_jobs_quotas.Swap(1, 2)
-			global.station_jobs_quotas[1] = job_name
+			add_quota(job_name)
 
 	if (modify)
 		modify.name = text("[modify.registered_name]'s ID Card ([modify.assignment])")
 
 	return 1
+
+/obj/machinery/computer/card/proc/add_quota(job_name)
+	global.station_jobs_quotas.Swap(2, 3)
+	global.station_jobs_quotas.Swap(1, 2)
+	global.station_jobs_quotas[1] = job_name
+
+/obj/machinery/computer/card/proc/setup_quotas()
+	var/list/jobs_quotas = list()
+	for(var/datum/job/job in SSjob.occupations)
+		if(job && job.map_check())
+			jobs_quotas += list(list("name" = job.title))
+	return jobs_quotas
 
 /obj/machinery/computer/card/centcom
 	name = "CentCom Identification Computer"

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -1,3 +1,5 @@
+var/global/list/station_jobs_quotas[3]
+
 /obj/machinery/computer/card
 	name = "Identification Computer"
 	desc = "Terminal for programming NanoTrasen employee ID cards to access parts of the station."
@@ -116,6 +118,13 @@
 
 	data["fast_modify_region"] = is_skill_competent(user, list(/datum/skill/command = SKILL_LEVEL_PRO))
 	data["fast_full_access"] = is_skill_competent(user, list(/datum/skill/command = SKILL_LEVEL_MASTER))
+
+	var/list/jobs_quotas = list()
+	for(var/datum/job/job in SSjob.occupations)
+		if(job && job.map_check())
+			jobs_quotas += list(list("name" = job.title))
+	data["jobs_quotas"] = jobs_quotas
+	data["quotted_jobs"] = global.station_jobs_quotas
 
 	if (modify && is_centcom())
 		var/list/all_centcom_access = list()
@@ -321,6 +330,14 @@
 				modify.access = list()
 				if(datum_account)
 					datum_account.set_salary(0)		//no salary
+		if ("add_job_to_quotas")
+			var/job_name = sanitize(href_list["quotajob_name"])
+			if(!job_name)
+				return
+
+			global.station_jobs_quotas.Swap(2, 3)
+			global.station_jobs_quotas.Swap(1, 2)
+			global.station_jobs_quotas[1] = job_name
 
 	if (modify)
 		modify.name = text("[modify.registered_name]'s ID Card ([modify.assignment])")

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -369,11 +369,16 @@
 					for(var/mob/M in player_list) // Only players with the job assigned and AFK for less than 10 minutes count as active
 						if(M.mind && M.client && M.mind.assigned_role == job.title && M.client.inactivity <= 10 * 60 * 10)
 							active++
+				var/job_quota = "<B><FONT COLOR=red>"
+				for(var/job_name in global.station_jobs_quotas)
+					if(job.title == job_name)
+						job_quota += "!"
+				job_quota += "</FONT></B>"
 				if(job.current_positions && active < job.current_positions)
-					dat += "<a class='[position_class]' style='display:block;width:170px' href='byond://?src=\ref[src];SelectedJob=[job.title]'>[job.title] ([job.current_positions])<br><i>(Active: [active])</i></a>"
+					dat += "<a class='[position_class]' style='display:block;width:170px' href='byond://?src=\ref[src];SelectedJob=[job.title]'>[job_quota] [job.title] ([job.current_positions])<br><i>(Active: [active])</i></a>"
 					number_of_extra_line_breaks++
 				else
-					dat += "<a class='[position_class]' style='display:block;width:170px' href='byond://?src=\ref[src];SelectedJob=[job.title]'>[job.title] ([job.current_positions])</a>"
+					dat += "<a class='[position_class]' style='display:block;width:170px' href='byond://?src=\ref[src];SelectedJob=[job.title]'>[job_quota] [job.title] ([job.current_positions])</a>"
 				categorizedJobs[jobcat]["jobs"] -= job
 
 			dat += "</fieldset><br>"

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -369,11 +369,11 @@
 					for(var/mob/M in player_list) // Only players with the job assigned and AFK for less than 10 minutes count as active
 						if(M.mind && M.client && M.mind.assigned_role == job.title && M.client.inactivity <= 10 * 60 * 10)
 							active++
-				var/job_quota = "<B><FONT COLOR=red>"
+				var/job_quota = "<B><span class='red'>"
 				for(var/job_name in global.station_jobs_quotas)
 					if(job.title == job_name)
 						job_quota += "!"
-				job_quota += "</FONT></B>"
+				job_quota += "</span></B>"
 				if(job.current_positions && active < job.current_positions)
 					dat += "<a class='[position_class]' style='display:block;width:170px' href='byond://?src=\ref[src];SelectedJob=[job.title]'>[job_quota] [job.title] ([job.current_positions])<br><i>(Active: [active])</i></a>"
 					number_of_extra_line_breaks++

--- a/nano/templates/identification_computer.tmpl
+++ b/nano/templates/identification_computer.tmpl
@@ -15,16 +15,16 @@
   {{if data.mode == 2}}
     <div class='notice'>
       <span class="bad">
-        Quotted jobs:  
+        Quotta jobs:  
       </span>
-      {{for data.quotted_jobs}}
+      {{for data.quota_jobs}}
         {{if value}}
           '{{:value}}'
         {{/if}}
       {{/for}}
     </div>
     <div class='item'>
-      {{for data.jobs_quotas}}
+      {{for data.jobs_can_be_quota}}
         {{:helper.link(value.name, null, {'choice' : "add_job_to_quotas", 'quotajob_name' : value.name}, null, null)}}
       {{/for}}
     </div>

--- a/nano/templates/identification_computer.tmpl
+++ b/nano/templates/identification_computer.tmpl
@@ -9,9 +9,26 @@
 {{else}}
   {{:helper.link('Access Modification', 'home', {'choice' : 'mode', 'mode_target' : 0}, !data.mode ? 'disabled' : null)}}
   {{:helper.link('Crew Manifest', 'folder-open', {'choice' : 'mode', 'mode_target' : 1}, data.mode ? 'disabled' : null)}}
+  {{:helper.link('Quotas', 'star', {'choice' : 'mode', 'mode_target' : 2}, data.mode ? 'disabled' : null)}}
   {{:helper.link('Print', 'print', {'choice' : 'print'}, (data.mode || data.has_modify) ? null : 'disabled')}}
 
-  {{if data.mode}}
+  {{if data.mode == 2}}
+    <div class='notice'>
+      <span class="bad">
+        Quotted jobs:  
+      </span>
+      {{for data.quotted_jobs}}
+        {{if value}}
+          '{{:value}}'
+        {{/if}}
+      {{/for}}
+    </div>
+    <div class='item'>
+      {{for data.jobs_quotas}}
+        {{:helper.link(value.name, null, {'choice' : "add_job_to_quotas", 'quotajob_name' : value.name}, null, null)}}
+      {{/for}}
+    </div>
+  {{else data.mode == 1}}
     <div class='item'>
       <h2>Crew Manifest</h2>
     </div>


### PR DESCRIPTION
## Описание изменений
ГП может поставить акцент на выбранную профу и этот акцент увидят заходящие на сервер, дескать, станции нужна эта профа.
Акцентов в списке сохраняется всего три, можно все три в одну профу и игрок увидит три !!!, или 2 в одну 1 в другую или по одному в разные и т.п., в зависимости от того что надо ГП. Каждый следующий выбор перезаписывает старый.
![image](https://github.com/TauCetiStation/TauCetiClassic/assets/21008918/e247627e-adae-4a76-a468-2c3185f51118)
![image](https://github.com/TauCetiStation/TauCetiClassic/assets/21008918/fc50ab79-ed6b-41d3-bf17-97acab4bc950)

Квоты удаляются каждый раз когда приходит зарплатка, т.е. раз в 15 минут.

## Почему и что этот ПР улучшит
Удобно всяким заходящим далеко после старта раунда.

## Авторство
AndreyGysev и все все все, кто помогал в дискорде.

## Чеинжлог
 :cl:
  - rscadd: Появилась возможность выставить акцент на профессию, который увидят заходящие на сервер.