### PR TITLE
Костюмы защищают от ударов тока

### DIFF
--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -316,13 +316,9 @@
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		def_zone = H.bodyparts_by_name[H.hand ? BP_L_ARM : BP_R_ARM] //strikes only active hand
-		if(H.gloves)
-			var/obj/item/clothing/gloves/G = H.gloves
-			if(G.siemens_coefficient == 0)	return 0		//to avoid spamming with insulated glvoes on
-
-		if(H.wear_suit)
-			var/obj/item/clothing/suit/S = H.wear_suit
-			if((S.siemens_coefficient == 0) && (S.body_parts_covered && ARMS))	return 0
+		siemens_coeff *= H.get_siemens_coefficient_organ(def_zone)
+		if(!siemens_coeff)
+			return
 
 	var/area/source_area
 	if(istype(power_source,/area))

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -320,6 +320,10 @@
 			var/obj/item/clothing/gloves/G = H.gloves
 			if(G.siemens_coefficient == 0)	return 0		//to avoid spamming with insulated glvoes on
 
+		if(H.wear_suit)
+			var/obj/item/clothing/suit/S = H.wear_suit
+			if((S.siemens_coefficient == 0) && (S.body_parts_covered && ARMS))	return 0
+
 	var/area/source_area
 	if(istype(power_source,/area))
 		source_area = power_source


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Костюмы с высоким siemens_coefficient (риги инженеров, броня культистов и ТД) защищают от наэлектролизированных шлюзов и не только.
## Почему и что этот ПР улучшит
fixes #11228
## Авторство

## Чеинжлог
🆑 Simbaka
- fix: РИГи инженеров, синдиката и прочая хорошо изолированная одежда не защищала от ударов тока.