### PR TITLE
Фотки на стене сбрасывают смещение, когда перемещаются.

### DIFF
--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -443,6 +443,7 @@
 		W.pixel_x = X_OFFSET(24, get_dir(user, src))
 		W.pixel_y = Y_OFFSET(24, get_dir(user, src))
 		RegisterSignal(W, COMSIG_MOVABLE_MOVED, CALLBACK(src, .proc/tied_object_reset_pixel_offset, W))
+		RegisterSignal(W, COMSIG_PARENT_QDELETING, CALLBACK(src, .proc/tied_object_reset_pixel_offset, W))
 		return
 	else
 		return attack_hand(user)
@@ -490,3 +491,4 @@
 	O.pixel_y = rand(-8, 8)
 	O.pixel_x = rand(-9, 9)
 	UnregisterSignal(O, COMSIG_MOVABLE_MOVED)
+	UnregisterSignal(O, COMSIG_PARENT_QDELETING)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -442,6 +442,7 @@
 		user.drop_from_inventory(W)
 		W.pixel_x = X_OFFSET(24, get_dir(user, src))
 		W.pixel_y = Y_OFFSET(24, get_dir(user, src))
+		RegisterSignal(W, COMSIG_MOVABLE_MOVED, CALLBACK(src, .proc/tied_object_reset_pixel_offset, W))
 		return
 	else
 		return attack_hand(user)
@@ -484,3 +485,8 @@
 
 	LAZYADD(dent_decals, decal)
 	add_overlay(decal)
+
+/turf/simulated/wall/proc/tied_object_reset_pixel_offset(obj/O)
+	O.pixel_y = rand(-8, 8)
+	O.pixel_x = rand(-9, 9)
+	UnregisterSignal(O, COMSIG_MOVABLE_MOVED)

--- a/code/game/turfs/simulated/walls_reinforced.dm
+++ b/code/game/turfs/simulated/walls_reinforced.dm
@@ -344,6 +344,7 @@
 		user.drop_from_inventory(W)
 		W.pixel_x = X_OFFSET(24, get_dir(user, src))
 		W.pixel_y = Y_OFFSET(24, get_dir(user, src))
+		RegisterSignal(W, COMSIG_MOVABLE_MOVED, CALLBACK(src, .proc/tied_object_reset_pixel_offset, W))
 		return
 
 	//Finally, CHECKING FOR FALSE WALLS if it isn't damaged

--- a/code/game/turfs/simulated/walls_reinforced.dm
+++ b/code/game/turfs/simulated/walls_reinforced.dm
@@ -345,6 +345,7 @@
 		W.pixel_x = X_OFFSET(24, get_dir(user, src))
 		W.pixel_y = Y_OFFSET(24, get_dir(user, src))
 		RegisterSignal(W, COMSIG_MOVABLE_MOVED, CALLBACK(src, .proc/tied_object_reset_pixel_offset, W))
+		RegisterSignal(W, COMSIG_PARENT_QDELETING, CALLBACK(src, .proc/tied_object_reset_pixel_offset, W))
 		return
 
 	//Finally, CHECKING FOR FALSE WALLS if it isn't damaged


### PR DESCRIPTION
## Описание изменений
Фотки на стене сбрасывают смещение, когда перемещаются.

## Почему и что этот ПР улучшит
Только расово верные смещения.

## Авторство
AndreyGysev и все все все, кто помогал в дискорде.

## Чеинжлог
 :cl:
  - bugfix: Фотки на стене сбрасывают смещение, когда перемещаются.