### PR TITLE
Можно быстрее замержить этот фикс одной строчкой?

### DIFF
--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -584,7 +584,8 @@
 	add_overlay(Item)
 	name = Item.name
 	var/list/pricetag = Item.price_tag
-	name = "[name] ([pricetag["price"]]$)"
+	if(pricetag)
+		name = "[name] ([pricetag["price"]]$)"
 
 	var/old_invisibility = invisibility
 	invisibility = INVISIBILITY_ABSTRACT


### PR DESCRIPTION
## Описание изменений
Добавив изменение имени лот холдеру на цену предмета я, случайно, забыл про то, что лот холдер может иметь в себе и посылку карго вместо предмета с ценником. Из-за чего посылки карго не магнитились к холдеру. Кароч, быстрофикс, можно такой же быстромерж?

## Почему и что этот ПР улучшит
Быстрофикс случайного бага.

## Авторство
Andrey Gysev и все все все, кто помогал в дискорде.

## Чеинжлог
 :cl: 
 - bugfix: Карго посылки не магнитились к прилавкам.