### PR TITLE
Element: Digital camo and balance

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -333,6 +333,9 @@
 	#define COMPONENT_BLOCK_SWAP 1
 ///from mob/living/vomit(): (/mob)
 #define COMSIG_LIVING_VOMITED "living_vomited"
+///from base of /mob/living/can_track(): (mob/user)
+#define COMSIG_LIVING_CAN_TRACK "mob_cantrack"
+	#define COMPONENT_CANT_TRACK (1<<0)
 
 /// from /datum/action/changeling/transform/sting_action(): (mob/living/carbon/human/user)
 #define COMSIG_CHANGELING_TRANSFORM "changeling_transform"

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -333,7 +333,7 @@
 	#define COMPONENT_BLOCK_SWAP 1
 ///from mob/living/vomit(): (/mob)
 #define COMSIG_LIVING_VOMITED "living_vomited"
-///from base of /mob/living/can_track(): (mob/user)
+///from ai_actual_track(): (mob/living)
 #define COMSIG_LIVING_CAN_TRACK "mob_cantrack"
 	#define COMPONENT_CANT_TRACK (1<<0)
 

--- a/code/datums/elements/digitalcamo.dm
+++ b/code/datums/elements/digitalcamo.dm
@@ -1,0 +1,48 @@
+/datum/element/digitalcamo
+	element_flags = ELEMENT_DETACH
+	var/list/attached_mobs = list()
+
+/datum/element/digitalcamo/Attach(datum/target)
+	. = ..()
+	if(!isliving(target) || (target in attached_mobs))
+		return ELEMENT_INCOMPATIBLE
+	RegisterSignal(target, COMSIG_PARENT_EXAMINE, .proc/on_examine)
+	RegisterSignal(target, COMSIG_LIVING_CAN_TRACK, .proc/can_track)
+	var/image/img = image(loc = target)
+	img.override = TRUE
+	attached_mobs[target] = img
+	for(var/mob/living/silicon/ai/AI as anything in ai_list)
+		if(AI.client)
+			AI.client.images += img
+	HideFromAIHuds(target)
+
+/datum/element/digitalcamo/Detach(datum/target)
+	. = ..()
+	UnregisterSignal(target, list(COMSIG_PARENT_EXAMINE, COMSIG_LIVING_CAN_TRACK))
+	for(var/mob/living/silicon/ai/AI as anything in ai_list)
+		if(AI.client)
+			AI.client.images -= attached_mobs[target]
+	UnhideFromAIHuds(target)
+
+/datum/element/digitalcamo/proc/HideFromAIHuds(mob/living/target)
+	for(var/mob/living/silicon/ai/AI in global.ai_list)
+		var/datum/atom_hud/M = global.huds[DATA_HUD_MEDICAL]
+		M.hide_single_atomhud_from(AI, target)
+		var/datum/atom_hud/S = global.huds[DATA_HUD_SECURITY]
+		S.hide_single_atomhud_from(AI, target)
+
+/datum/element/digitalcamo/proc/UnhideFromAIHuds(mob/living/target)
+	for(var/mob/living/silicon/ai/AI in global.ai_list)
+		var/datum/atom_hud/M = global.huds[DATA_HUD_MEDICAL]
+		M.unhide_single_atomhud_from(AI, target)
+		var/datum/atom_hud/S = global.huds[DATA_HUD_SECURITY]
+		S.unhide_single_atomhud_from(AI, target)
+
+/datum/element/digitalcamo/proc/on_examine(datum/source, mob/M)
+	SIGNAL_HANDLER
+	to_chat(world, "[source], [M]")
+	to_chat(M, "<span_class='warning'>[source] skin seems to be shifting like something is moving below it.</span>")
+
+/datum/element/digitalcamo/proc/can_track(datum/source, mob/user)
+	SIGNAL_HANDLER
+	return COMPONENT_CANT_TRACK

--- a/code/datums/elements/digitalcamo.dm
+++ b/code/datums/elements/digitalcamo.dm
@@ -22,6 +22,7 @@
 	for(var/mob/living/silicon/ai/AI as anything in ai_list)
 		if(AI.client)
 			AI.client.images -= attached_mobs[target]
+	attached_mobs -= target
 	UnhideFromAIHuds(target)
 
 /datum/element/digitalcamo/proc/HideFromAIHuds(mob/living/target)
@@ -42,6 +43,6 @@
 	SIGNAL_HANDLER
 	to_chat(M, "<span class='warning'>[source] skin seems to be shifting like something is moving below it.</span>")
 
-/datum/element/digitalcamo/proc/can_track(datum/source, mob/user)
+/datum/element/digitalcamo/proc/can_track(datum/source)
 	SIGNAL_HANDLER
 	return COMPONENT_CANT_TRACK

--- a/code/datums/elements/digitalcamo.dm
+++ b/code/datums/elements/digitalcamo.dm
@@ -40,8 +40,7 @@
 
 /datum/element/digitalcamo/proc/on_examine(datum/source, mob/M)
 	SIGNAL_HANDLER
-	to_chat(world, "[source], [M]")
-	to_chat(M, "<span_class='warning'>[source] skin seems to be shifting like something is moving below it.</span>")
+	to_chat(M, "<span class='warning'>[source] skin seems to be shifting like something is moving below it.</span>")
 
 /datum/element/digitalcamo/proc/can_track(datum/source, mob/user)
 	SIGNAL_HANDLER

--- a/code/game/gamemodes/modes_gameplays/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/modes_gameplays/abduction/abduction_gear.dm
@@ -353,9 +353,24 @@
 					C.network = helm_cam.network
 
 		helm_cam.hidden = 1
-		blockTracking = 1
 		to_chat(user, "<span class='notice'>Abductor detected. Camera activated.</span>")
 		return
+
+/obj/item/clothing/head/helmet/abductor/equipped(mob/living/user, slot)
+	. = ..()
+	if(slot_flags & slot)
+		RegisterSignal(user, COMSIG_LIVING_CAN_TRACK, .proc/can_track)
+	else
+		UnregisterSignal(user, COMSIG_LIVING_CAN_TRACK)
+
+/obj/item/clothing/head/helmet/abductor/dropped(mob/living/user)
+	. = ..()
+	UnregisterSignal(user, COMSIG_LIVING_CAN_TRACK)
+
+/obj/item/clothing/head/helmet/abductor/proc/can_track(datum/source, mob/user)
+	SIGNAL_HANDLER
+
+	return COMPONENT_CANT_TRACK
 
 //ADVANCED BATON
 #define BATON_STUN 0

--- a/code/game/gamemodes/modes_gameplays/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/modes_gameplays/abduction/abduction_gear.dm
@@ -358,7 +358,7 @@
 
 /obj/item/clothing/head/helmet/abductor/equipped(mob/living/user, slot)
 	. = ..()
-	if(slot_flags & slot)
+	if(slot == SLOT_HEAD)
 		RegisterSignal(user, COMSIG_LIVING_CAN_TRACK, .proc/can_track)
 	else
 		UnregisterSignal(user, COMSIG_LIVING_CAN_TRACK)
@@ -367,9 +367,8 @@
 	. = ..()
 	UnregisterSignal(user, COMSIG_LIVING_CAN_TRACK)
 
-/obj/item/clothing/head/helmet/abductor/proc/can_track(datum/source, mob/user)
+/obj/item/clothing/head/helmet/abductor/proc/can_track(datum/source)
 	SIGNAL_HANDLER
-
 	return COMPONENT_CANT_TRACK
 
 //ADVANCED BATON

--- a/code/game/gamemodes/modes_gameplays/changeling/evolution_menu.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/evolution_menu.dm
@@ -382,7 +382,6 @@ var/global/list/sting_paths
 /mob/proc/remove_changeling_powers(keep_free_powers=0)
 	if(ishuman(src) || ismonkey(src))
 		if(ischangeling(src))
-			digitalcamo = 0
 			if(digitaldisguise)
 				digitaldisguise.override = 0
 			var/datum/role/changeling/C = mind.GetRoleByType(/datum/role/changeling)

--- a/code/game/gamemodes/modes_gameplays/changeling/evolution_menu.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/evolution_menu.dm
@@ -382,8 +382,7 @@ var/global/list/sting_paths
 /mob/proc/remove_changeling_powers(keep_free_powers=0)
 	if(ishuman(src) || ismonkey(src))
 		if(ischangeling(src))
-			if(digitaldisguise)
-				digitaldisguise.override = 0
+			RemoveElement(/datum/element/digitalcamo)
 			var/datum/role/changeling/C = mind.GetRoleByType(/datum/role/changeling)
 			C.reset()
 			for(var/obj/effect/proc_holder/changeling/p in C.purchasedpowers)

--- a/code/game/gamemodes/modes_gameplays/changeling/powers/digitalcamo.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/digitalcamo.dm
@@ -3,44 +3,17 @@
 	desc = "By evolving the ability to distort our form and proprotions, we defeat common altgorithms used to detect lifeforms on cameras."
 	helptext = "We cannot be tracked by camera while using this skill. However, humans looking at us will find us... uncanny. We must constantly expend chemicals to maintain our form like this."
 	genomecost = 1
+	var/active = FALSE
 
 //Prevents AIs tracking you but makes you easily detectable to the human-eye.
 /obj/effect/proc_holder/changeling/digitalcamo/sting_action(mob/user)
-	if(user.digitalcamo)
+	if(active)
 		to_chat(user, "<span class='notice'>We return to normal.</span>")
-		for(var/mob/living/silicon/ai/AI as anything in ai_list)
-			if(AI.client)
-				AI.client.images -= user.digitaldisguise
-		UnhideFromAIHuds(user)
+		user.RemoveElement(/datum/element/digitalcamo)
 	else
 		to_chat(user, "<span class='notice'>We distort our form to prevent AI-tracking.</span>")
-		user.digitaldisguise = image(loc = user)
-		user.digitaldisguise.override = 1
-		for(var/mob/living/silicon/ai/AI as anything in ai_list)
-			if(AI.client)
-				AI.client.images += user.digitaldisguise
-		HideFromAIHuds(user)
-	user.digitalcamo = !user.digitalcamo
-
-	spawn(0)
-		var/datum/role/changeling/C = user.mind.GetRoleByType(/datum/role/changeling)
-		while(user && user.digitalcamo && C)
-			C.chem_charges = max(C.chem_charges - 1, 0)
-			sleep(40)
+		user.AddElement(/datum/element/digitalcamo)
+	active = !active
 
 	feedback_add_details("changeling_powers","CAM")
 	return TRUE
-
-/obj/effect/proc_holder/changeling/digitalcamo/proc/HideFromAIHuds(mob/living/target)
-	for(var/mob/living/silicon/ai/AI in global.ai_list)
-		var/datum/atom_hud/M = global.huds[DATA_HUD_MEDICAL]
-		M.hide_single_atomhud_from(AI, target)
-		var/datum/atom_hud/S = global.huds[DATA_HUD_SECURITY]
-		S.hide_single_atomhud_from(AI, target)
-
-/obj/effect/proc_holder/changeling/digitalcamo/proc/UnhideFromAIHuds(mob/living/target)
-	for(var/mob/living/silicon/ai/AI in global.ai_list)
-		var/datum/atom_hud/M = global.huds[DATA_HUD_MEDICAL]
-		M.unhide_single_atomhud_from(AI, target)
-		var/datum/atom_hud/S = global.huds[DATA_HUD_SECURITY]
-		S.unhide_single_atomhud_from(AI, target)

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -125,25 +125,15 @@
 			continue
 		if(M.invisibility)//cloaked
 			continue
-		if(SEND_SIGNAL(M, COMSIG_LIVING_CAN_TRACK, src) & COMPONENT_CANT_TRACK)
+		if(SEND_SIGNAL(M, COMSIG_LIVING_CAN_TRACK) & COMPONENT_CANT_TRACK)
 			continue
-
-		// Human check
-		var/human = 0
-		if(ishuman(M))
-			human = 1
-			var/mob/living/carbon/human/H = M
-			//Cameras can't track people wearing an agent card or hat with blockTracking.
-			if(H.wear_id && istype(H.wear_id.GetID(), /obj/item/weapon/card/id/syndicate))
-				continue
-			if(istype(H.head, /obj/item/clothing/head))
-				var/obj/item/clothing/head/hat = H.head
-				if(hat.blockTracking)
-					continue
 
 		 // Now, are they viewable by a camera? (This is last because it's the most intensive check)
 		if(!near_camera(M))
 			continue
+
+		// Human check
+		var/human = ishuman(M) ? TRUE : FALSE
 
 		var/name = M.name
 		if (name in TB.names)
@@ -194,47 +184,30 @@
 	to_chat(U, "Now tracking [target.name] on camera.")
 	target.tracking_initiated()
 
-	INVOKE_ASYNC(src, .proc/do_track, target, U)
-
-/mob/living/silicon/ai/proc/do_track(mob/living/target)
-	var/mob/living/silicon/ai/U = src
-	var/datum/orbit/O = new(U.eyeobj, target, FALSE)
-	if (!orbiting) //something failed, and our orbit datum deleted itself
-		return
-	var/matrix/initial_transform = matrix(transform)
-	cached_transform = initial_transform
-	while (O)
-		if(SEND_SIGNAL(target, COMSIG_LIVING_CAN_TRACK, src) & COMPONENT_CANT_TRACK)
-			to_chat(U, "Follow camera mode terminated.")
-			return
-		if(ishuman(target))
-			var/mob/living/carbon/human/H = target
-			if(H.wear_id && istype(H.wear_id.GetID(), /obj/item/weapon/card/id/syndicate))
-				to_chat(U, "Follow camera mode terminated.")
-				U.eyeobj.stop_orbit()
+	spawn (0)
+		while (U.cameraFollow == target)
+			if (U.cameraFollow == null)
 				return
-			if(istype(H.head, /obj/item/clothing/head))
-				var/obj/item/clothing/head/hat = H.head
-				if(hat.blockTracking)
-					to_chat(U, "Follow camera mode terminated.")
-					U.eyeobj.stop_orbit()
-					return
-		if(istype(target.loc,/obj/effect/dummy))
-			to_chat(U, "Follow camera mode ended.")
-			U.eyeobj.stop_orbit()
-			return
-		if (!near_camera(target))
-			to_chat(U, "Target is not near any active cameras.")
-			U.eyeobj.stop_orbit()
-			sleep(100)
-			continue
-		/*if(U.eyeobj)
-			U.eyeobj.setLoc(get_turf(target))
-		else
-			view_core()
-			return*/
-		sleep(10)
+			if(SEND_SIGNAL(target, COMSIG_LIVING_CAN_TRACK) & COMPONENT_CANT_TRACK)
+				to_chat(U, "Follow camera mode terminated.")
+				return
 
+			if(istype(target.loc,/obj/effect/dummy))
+				to_chat(U, "Follow camera mode ended.")
+				U.cameraFollow = null
+				return
+
+			if (!near_camera(target))
+				to_chat(U, "Target is not near any active cameras.")
+				sleep(100)
+				continue
+
+			if(U.eyeobj)
+				U.eyeobj.setLoc(get_turf(target))
+			else
+				view_core()
+				return
+			sleep(10)
 
 /proc/near_camera(mob/living/M)
 	if (!isturf(M.loc))

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -362,7 +362,20 @@
 	else
 		..()
 
+/obj/item/weapon/card/id/syndicate/equipped(mob/living/user, slot)
+	. = ..()
+	if(slot == SLOT_WEAR_ID)
+		RegisterSignal(user, COMSIG_LIVING_CAN_TRACK, .proc/can_track)
+	else
+		UnregisterSignal(user, COMSIG_LIVING_CAN_TRACK)
 
+/obj/item/weapon/card/id/syndicate/dropped(mob/living/user)
+	. = ..()
+	UnregisterSignal(user, COMSIG_LIVING_CAN_TRACK)
+
+/obj/item/weapon/card/id/syndicate/proc/can_track(datum/source)
+	SIGNAL_HANDLER
+	return COMPONENT_CANT_TRACK
 
 /obj/item/weapon/card/id/syndicate_command
 	name = "syndicate ID card"

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -354,8 +354,6 @@ BLIND     // can't see anything
 	body_parts_covered = HEAD
 	slot_flags = SLOT_FLAGS_HEAD
 	w_class = SIZE_TINY
-	var/blockTracking = 0
-
 	sprite_sheet_slot = SPRITE_SHEET_HEAD
 
 //Mask

--- a/code/modules/clothing/spacesuits/ninja.dm
+++ b/code/modules/clothing/spacesuits/ninja.dm
@@ -11,6 +11,21 @@
 	force = 0
 	hitsound = list()
 
+/obj/item/clothing/head/helmet/space/space_ninja/equipped(mob/living/user, slot)
+	. = ..()
+	if(slot_flags & slot)
+		RegisterSignal(user, COMSIG_LIVING_CAN_TRACK, .proc/can_track)
+	else
+		UnregisterSignal(user, COMSIG_LIVING_CAN_TRACK)
+
+/obj/item/clothing/head/helmet/space/space_ninja/dropped(mob/living/user)
+	. = ..()
+	UnregisterSignal(user, COMSIG_LIVING_CAN_TRACK)
+
+/obj/item/clothing/head/helmet/space/space_ninja/proc/can_track(datum/source, mob/user)
+	SIGNAL_HANDLER
+	return COMPONENT_CANT_TRACK
+
 /obj/item/clothing/suit/space/space_ninja
 	name = "ninja suit"
 	desc = "A unique, vaccum-proof suit of nano-enhanced armor designed specifically for Spider Clan assassins."

--- a/code/modules/clothing/spacesuits/ninja.dm
+++ b/code/modules/clothing/spacesuits/ninja.dm
@@ -7,13 +7,12 @@
 	armor = list(melee = 60, bullet = 50, laser = 60,energy = 45, bomb = 50, bio = 100, rad = 50)
 	species_restricted = null
 	body_parts_covered = HEAD|FACE
-	blockTracking = 1
 	force = 0
 	hitsound = list()
 
 /obj/item/clothing/head/helmet/space/space_ninja/equipped(mob/living/user, slot)
 	. = ..()
-	if(slot_flags & slot)
+	if(slot == SLOT_HEAD)
 		RegisterSignal(user, COMSIG_LIVING_CAN_TRACK, .proc/can_track)
 	else
 		UnregisterSignal(user, COMSIG_LIVING_CAN_TRACK)
@@ -22,7 +21,7 @@
 	. = ..()
 	UnregisterSignal(user, COMSIG_LIVING_CAN_TRACK)
 
-/obj/item/clothing/head/helmet/space/space_ninja/proc/can_track(datum/source, mob/user)
+/obj/item/clothing/head/helmet/space/space_ninja/proc/can_track(datum/source)
 	SIGNAL_HANDLER
 	return COMPONENT_CANT_TRACK
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -594,6 +594,8 @@
 
 	to_chat(user, msg)
 
+	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, user)
+
 //Helper procedure. Called by /mob/living/carbon/human/examine() and /mob/living/carbon/human/Topic() to determine HUD access to security and medical records.
 // Only used for humans and other personal of station.
 /proc/hasHUD(mob/M, hudtype)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -459,8 +459,7 @@
 	for(var/implant in implants)
 		var/obj/item/organ/external/BP = implants[implant]
 		msg += "<span class='warning'><b>[src] has \a [implant] sticking out of their [BP.name]!</b></span>\n"
-	if(digitalcamo)
-		msg += "<span class='warning'>[t_He] [t_is] moving [t_his] body in an unnatural and blatantly inhuman manner.</span>\n"
+
 	if(ischangeling(src))
 		var/datum/role/changeling/C = mind.GetRoleByType(/datum/role/changeling)
 		if(C.isabsorbing)

--- a/code/modules/mob/living/carbon/monkey/examine.dm
+++ b/code/modules/mob/living/carbon/monkey/examine.dm
@@ -36,9 +36,6 @@
 			msg += "It isn't responding to anything around it; it seems to be asleep.\n"
 		msg += "</span>"
 
-	if (src.digitalcamo)
-		msg += "<span class='warning'>It is moving its body in an unnatural and blatantly unsimian manner.</span>\n"
-
 	if(w_class)
 		msg += "It is a [get_size_flavor()] sized creature.\n"
 

--- a/code/modules/mob/living/silicon/ai/login.dm
+++ b/code/modules/mob/living/silicon/ai/login.dm
@@ -3,9 +3,9 @@
 	if(wipe_timer_id)
 		deltimer(wipe_timer_id)
 		wipe_timer_id = 0
-	for(var/mob/living/M as anything in living_list)
-		if(M.digitalcamo && M.digitaldisguise)
-			client.images += M.digitaldisguise
+	var/datum/element/digitalcamo/ele = SSdcs.GetElement(list(/datum/element/digitalcamo))
+	for(var/i in ele.attached_mobs)
+		client.images += ele.attached_mobs[i]
 	regenerate_icons()
 
 	if(stat != DEAD)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -174,7 +174,6 @@
 
 	var/area/lastarea = null
 
-	var/digitalcamo = 0 // Can they be tracked by the AI?
 	var/image/digitaldisguise = null  //what does the AI see instead of them?
 
 	var/has_unlimited_silicon_privilege = 0 // Can they interact with station electronics

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -174,8 +174,6 @@
 
 	var/area/lastarea = null
 
-	var/image/digitaldisguise = null  //what does the AI see instead of them?
-
 	var/has_unlimited_silicon_privilege = 0 // Can they interact with station electronics
 
 	var/obj/control_object //Used by admins to possess objects. All mobs should have this var

--- a/code/modules/replicators/replicators.dm
+++ b/code/modules/replicators/replicators.dm
@@ -187,7 +187,7 @@ ADD_TO_GLOBAL_LIST(/mob/living/simple_animal/hostile/replicator, alive_replicato
 
 	RegisterSignal(src, list(COMSIG_CLIENTMOB_MOVE), .proc/on_clientmob_move)
 
-/mob/living/simple_animal/hostile/replicator/proc/can_track(datum/source)
+/mob/living/simple_animal/hostile/replicator/proc/can_be_tracked(datum/source)
 	SIGNAL_HANDLER
 	return COMPONENT_CANT_TRACK
 

--- a/code/modules/replicators/replicators.dm
+++ b/code/modules/replicators/replicators.dm
@@ -183,10 +183,16 @@ ADD_TO_GLOBAL_LIST(/mob/living/simple_animal/hostile/replicator, alive_replicato
 
 	AddComponent(/datum/component/replicator_regeneration)
 
+	RegisterSignal(src, COMSIG_LIVING_CAN_TRACK, .proc/can_track)
+
 	RegisterSignal(src, list(COMSIG_CLIENTMOB_MOVE), .proc/on_clientmob_move)
 
+/mob/living/simple_animal/hostile/replicator/proc/can_track(datum/source)
+	SIGNAL_HANDLER
+	return COMPONENT_CANT_TRACK
+
 /mob/living/simple_animal/hostile/replicator/Destroy()
-	UnregisterSignal(src, list(COMSIG_CLIENTMOB_MOVE))
+	UnregisterSignal(src, list(COMSIG_CLIENTMOB_MOVE, COMSIG_LIVING_CAN_TRACK))
 
 	global.idle_replicators -= src
 

--- a/code/modules/replicators/replicators.dm
+++ b/code/modules/replicators/replicators.dm
@@ -183,7 +183,7 @@ ADD_TO_GLOBAL_LIST(/mob/living/simple_animal/hostile/replicator, alive_replicato
 
 	AddComponent(/datum/component/replicator_regeneration)
 
-	RegisterSignal(src, COMSIG_LIVING_CAN_TRACK, .proc/can_track)
+	RegisterSignal(src, COMSIG_LIVING_CAN_TRACK, .proc/can_be_tracked)
 
 	RegisterSignal(src, list(COMSIG_CLIENTMOB_MOVE), .proc/on_clientmob_move)
 

--- a/taucetistation.dme
+++ b/taucetistation.dme
@@ -342,6 +342,7 @@
 #include "code\datums\components\rites\spawn_item.dm"
 #include "code\datums\elements\_element.dm"
 #include "code\datums\elements\beauty.dm"
+#include "code\datums\elements\digitalcamo.dm"
 #include "code\datums\emotes\emote.dm"
 #include "code\datums\emotes\misc.dm"
 #include "code\datums\emotes\state_checks.dm"


### PR DESCRIPTION
## Описание изменений
- Порт с ТГ элемента цифрового камуфляжа. А также сигнал, запрещающий трекинг, что значительно упрощает код со стороны ИИ. 
- Камуфляж перестал есть химикаты у генокрада в активном состоянии. Однако, его видно при осмотре человека. Часто ли вы видите использование этой способности? Вот и я не видел. Банально слишком редко нужно, так ещё и в бою мешает.
- ИИ не может отслеживать: генокрада с камуфляжем, а также карты синдиката.
  - Абдуктор в шлеме обзавёлся такой же фишкой.
## Почему и что этот ПР улучшит
Собственно, особой причины нет. Хочу сделать некоторые вещи чуть более удобными, как в игре, так и более красивыми в коде.
## Авторство
Порт с ТГ
## Чеинжлог
:cl:
- balance: Последние исследования показывают, что цифровой камуфляж перестал тратить химикаты у генокрадов
- balance: ИИ более не могут отслеживать некоторых из серых человечков
- balance: Репликаторы также научились скрывать сигналы от ИИ