### PR TITLE
больше мобов у которых нет лога экзамина

### DIFF
--- a/code/game/gamemodes/modes_gameplays/cult/eminence.dm
+++ b/code/game/gamemodes/modes_gameplays/cult/eminence.dm
@@ -18,6 +18,8 @@
 	COOLDOWN_DECLARE(command_point)
 	COOLDOWN_DECLARE(point_to)
 
+	show_examine_log = FALSE
+
 /mob/camera/eminence/atom_init()
 	. = ..()
 	add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/my_religion, "eminence", image(icon, src, icon_state), src, cult_religion)

--- a/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenomorph.dm
@@ -34,6 +34,8 @@
 
 	var/list/alien_spells = list()
 
+	show_examine_log = FALSE
+
 /mob/living/carbon/xenomorph/atom_init()
 	. = ..()
 	add_language(LANGUAGE_XENOMORPH)

--- a/code/modules/mob/living/simple_animal/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer.dm
@@ -2,6 +2,8 @@
 	name = "host brain"
 	real_name = "host brain"
 
+	show_examine_log = FALSE
+
 /mob/living/captive_brain/say_understands(mob/other, datum/language/speaking)
 	var/mob/living/simple_animal/borer/my_borer = loc
 	if(!istype(loc))
@@ -74,6 +76,8 @@
 	var/docile = FALSE                         // Sugar can stop borers from acting.
 	var/leaving = FALSE
 	var/has_reproduced = FALSE                 // Whether or not the borer has reproduced, for objective purposes.
+
+	show_examine_log = FALSE
 
 /mob/living/simple_animal/borer/atom_init(mapload, request_ghosts = FALSE, gen = 1)
 	. = ..()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
у ксеноморфов - у них литералли нет глаз
у бореров - они жуки
у эминенса - это баг
## Почему и что этот ПР улучшит
ролеплей...
## Авторство

## Чеинжлог
:cl:
- tweak: Ксеноморфы, бореры, и эминенс больше не показывают лога об экзамине.
