### PR TITLE
Дополнение кода ролей антагонистов

### DIFF
--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -171,65 +171,65 @@
 
 #define isanyantag(H) (H?.mind && H.mind.antag_roles.len)
 
-#define isabductor(H) isrolebytype(/datum/role/abductor, H)
+#define isabductor(H) HAS_TRAIT(H, TRAIT_ABDUCTOR_OP)
 
-#define isabductorsci(H) isrole(ABDUCTOR_SCI, H)
+#define isabductorsci(H) HAS_TRAIT(H, TRAIT_ABDUCTOR_OP_SCIENTIST)
 
-#define isabductoragent(H) isrole(ABDUCTOR_AGENT, H)
+#define isabductoragent(H) HAS_TRAIT(H, TRAIT_ABDUCTOR_OP_AGENT)
 
-#define isshadowling(H) isrole(SHADOW, H)
+#define isshadowling(H) HAS_TRAIT(H, TRAIT_SHADOWLING_MASTER)
 
-#define isshadowthrall(H) isrole(SHADOW_THRALL, H)
+#define isshadowthrall(H) HAS_TRAIT(H, TRAIT_SHADOWLING_CREWSLAVE)
 
 #define iscultist(mob) (mob && global.cult_religion?.is_member(mob))
 
 #define iseminence(A) (istype(A, /mob/camera/eminence))
 
-#define isvoxraider(H) isrole(VOXRAIDER, H)
+#define isvoxraider(H) HAS_TRAIT(H, TRAIT_HEIST_CREWMEMBER)
 
-#define ischangeling(H) isrolebytype(/datum/role/changeling, H)
+#define ischangeling(H) HAS_TRAIT(H, TRAIT_CHANGELING_INDIVIDUAL)
 
-#define isanyrev(H) (isrev(H) || isrevhead(H))
+#define isanyrev(H) HAS_TRAIT(H, TRAIT_REVOLUTION_PARTICIPANT)
 
-#define isrev(H) isrole(REV, H)
+#define isrev(H) HAS_TRAIT(H, TRAIT_REVOLUTION_PROTESTER)
 
-#define isrevhead(H) isrole(HEADREV, H)
+#define isrevhead(H) HAS_TRAIT(H, TRAIT_REVOLUTION_LEADER)
 
-#define istraitor(H) isrole(TRAITOR, H)
+#define istraitor(H) HAS_TRAIT(H, TRAIT_SYNDICATE_AGENT)
 
-#define iselitesyndie(H) isrole(SYNDIESQUADIE, H)
+#define iselitesyndie(H) HAS_TRAIT(H, TRAIT_ELITE_SQUAD_MEMBER)
 
-#define ismalf(H) isrole(MALF, H)
+#define ismalf(H) HAS_TRAIT(H, TRAIT_MALFUNCTION_AI)
 
-#define isnukeop(H) (isrole(NUKE_OP, H) || isrole(NUKE_OP_LEADER, H) || isrole(SYNDIESQUADIE, H))
+#define isnukeop(H) HAS_TRAIT(H, TRAIT_NUKE_OP) || HAS_TRAIT(H, TRAIT_ELITE_SQUAD_MEMBER)
 
-#define iswizard(H) isrole(WIZARD, H)
+#define iswizard(H) HAS_TRAIT(H, TRAIT_WIZARD_MASTER)
 
-#define iswizardapprentice(H) isrole(WIZ_APPRENTICE, H)
+#define iswizardapprentice(H) HAS_TRAIT(H, TRAIT_WIZARD_APPERNTICE)
 
-#define isdeathsquad(H) isrole(DEATHSQUADIE, H)
+#define isdeathsquad(H) HAS_TRAIT(H, TRAIT_DEATHSQUAD_MEMBER)
 
-#define isninja(H) isrole(NINJA, H)
+#define isninja(H) HAS_TRAIT(H, TRAIT_SPRIDER_CLAN_NINJA)
 
-#define isERT(H) isrole(RESPONDER, H)
+#define isERT(H) HAS_TRAIT(H, TRAIT_STRIKE_TEAMMATE)
 
-#define isrolezombie(H) isrole(ZOMBIE, H)
+#define isrolezombie(H) HAS_TRAIT(H, TRAIT_ZOMBIETIDE_MEMBER)
 
 #define iszombie(H) (H.get_species() in global.all_zombie_species_names)
 
-#define isalien(H) isrole(XENOMORPH, H)
+#define isalien(H) HAS_TRAIT(H, TRAIT_ALIEN_HIVEPART)
 
-#define isgangster(H) isrole(GANGSTER, H)
+#define isgangster(H) HAS_TRAIT(H, TRAIT_FAMILIES_GANGSTER)
 
-#define isgangsterlead(H) isrole(GANGSTER_LEADER, H)
+#define isgangsterlead(H) HAS_TRAIT(H, TRAIT_FAMILIES_LEADER)
 
-#define isanygangster(H) isrolebytype(/datum/role/gangster, H)
+#define isanygangster(H) HAS_TRAIT(H, TRAIT_FAMILIES_MEMBER)
 
-#define isgundealer(H) isrole(GANGSTER_DEALER, H)
+#define isgundealer(H) HAS_TRAIT(H, TRAIT_SYNDICATE_GUN_DEALER)
 
-#define isanycop(H) isrolebytype(/datum/role/cop, H)
+#define isanycop(H) HAS_TRAIT(H, TRAIT_COP_PERSON)
 
-#define isanyblob(H) isrolebytype(/datum/role/blob_overmind, H)
+#define isanyblob(H) HAS_TRAIT(H, TRAIT_BLOB_HIVEMIND_MEMBER)
 
 // BLOB
 

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -171,7 +171,7 @@
 
 #define isanyantag(H) (H?.mind && H.mind.antag_roles.len)
 
-#define isabductor(H) HAS_TRAIT(H, TRAIT_ABDUCTOR_OP)
+#define isabductor(H) HAS_TRAIT(H, TRAIT_ABDUCTOR_MEMBER)
 
 #define isabductorsci(H) HAS_TRAIT(H, TRAIT_ABDUCTOR_OP_SCIENTIST)
 
@@ -221,11 +221,11 @@
 
 #define isgangster(H) HAS_TRAIT(H, TRAIT_FAMILIES_GANGSTER)
 
-#define isgangsterlead(H) HAS_TRAIT(H, TRAIT_FAMILIES_LEADER)
+#define isgangsterlead(H) isrole(GANGSTER_LEADER, H)
 
-#define isanygangster(H) HAS_TRAIT(H, TRAIT_FAMILIES_MEMBER)
+#define isanygangster(H) isrolebytype(/datum/role/gangster, H)
 
-#define isgundealer(H) HAS_TRAIT(H, TRAIT_SYNDICATE_GUN_DEALER)
+#define isgundealer(H) isrole(GANGSTER_DEALER, H)
 
 #define isanycop(H) HAS_TRAIT(H, TRAIT_COP_PERSON)
 

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -221,11 +221,11 @@
 
 #define isgangster(H) HAS_TRAIT(H, TRAIT_FAMILIES_GANGSTER)
 
-#define isgangsterlead(H) isrole(GANGSTER_LEADER, H)
+#define isgangsterlead(H) HAS_TRAIT(H, TRAIT_FAMILIES_LEADER)
 
-#define isanygangster(H) isrolebytype(/datum/role/gangster, H)
+#define isanygangster(H) HAS_TRAIT(H, TRAIT_FAMILIES_MEMBER)
 
-#define isgundealer(H) isrole(GANGSTER_DEALER, H)
+#define isgundealer(H) HAS_TRAIT(H, TRAIT_SYNDICATE_GUN_DEALER)
 
 #define isanycop(H) HAS_TRAIT(H, TRAIT_COP_PERSON)
 

--- a/code/__DEFINES/is_helpers.dm
+++ b/code/__DEFINES/is_helpers.dm
@@ -205,7 +205,7 @@
 
 #define iswizard(H) HAS_TRAIT(H, TRAIT_WIZARD_MASTER)
 
-#define iswizardapprentice(H) HAS_TRAIT(H, TRAIT_WIZARD_APPERNTICE)
+#define iswizardapprentice(H) HAS_TRAIT(H, TRAIT_WIZARD_APPERENTICE)
 
 #define isdeathsquad(H) HAS_TRAIT(H, TRAIT_DEATHSQUAD_MEMBER)
 

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -367,7 +367,7 @@
 #define TRAIT_WIZARD_PARTY "wizard_party"
 /// child
 #define TRAIT_WIZARD_MASTER "wizard_master"
-#define TRAIT_WIZARD_APPERNTICE "wizard_apprentice"
+#define TRAIT_WIZARD_APPERENTICE "wizard_apprentice"
 /// variables
 #define TRAIT_WIZARD_CONFLUX "wizard_conflux"
 #define TRAIT_WIZARD_VISITOR "wizard_visitor"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -260,9 +260,9 @@
 #define TRAIT_CULTIST_MEMBER "cultist_member"
 /// child
 #define TRAIT_CULTIST_DEDICATED "cultist_dedicated"
-#define TRAIT_CULTIST_HARBINGER "cultist_harbinger"
 #define TRAIT_CULTIST_HIGHPRIEST "cultist_highpriest"
 /// variables
+#define TRAIT_CULTIST_HARBINGER "cultist_harbinger"
 #define TRAIT_CULTIST_ROUNDSTART "cultist_roundstart"
 #define TRAIT_CULTIST_REVOLUTION_OF_NARSIE "cultist_revolution_of_narsie"
 #define TRAIT_CULTIST_CONFLUX "cultist_conflux"

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -188,11 +188,207 @@
 /*
  * Used for items that have different behaviour when they are two-hand wielded
  */
+// atom traits
+#define TRAIT_XENO_FUR "xeno_fur"
+
 #define TRAIT_DOUBLE_WIELDED "double_wielded"
 
 // item trait
 #define TRAIT_NO_SACRIFICE "religion_no_sacrifice"
 
+// gamemodes roles traits
+/// overall
+#define TRAIT_ABDUCTOR_MEMBER "abductor_member"
+/// child
+#define TRAIT_ABDUCTOR_OP "abductor_op"
+#define TRAIT_ABDUCTOR_ABDUCTED "abductor_abducted"
+/// variables
+#define TRAIT_ABDUCTOR_OP_AGENT "abductor_op_agent"
+#define TRAIT_ABDUCTOR_OP_SCIENTIST "abductor_op_scientist"
+#define TRAIT_ABDUCTOR_ASSISTANT "abductor_assistant"
+#define TRAIT_ABDUCTOR_VISITOR "abductor_visitor"
+#define TRAIT_ABDUCTOR_RESEARCH_MISSION "abductor_research_mission"
+
+/// overall
+#define TRAIT_ALIEN_HIVEPART "alien_hivepart"
+/// child
+#define TRAIT_ALIEN_SPECIMEN "alien_specimen"
+/// variables
+#define TRAIT_ALIEN_ROUNDSTART "alien_roundstart"
+#define TRAIT_ALIEN_MIDROUND "alien_midround"
+#define TRAIT_ALIEN_REAL_INFESTATION "alien_real_infestation"
+
+/// overall
+#define TRAIT_BLOB_HIVEMIND_MEMBER "blob_hivemind_member"
+/// child
+#define TRAIT_BLOB_HIVEMIND_CORE "blob_hivemind_core"
+#define TRAIT_BLOB_HIVEMIND_PAWN "blob_hivemind_pawn"
+/// variables
+#define TRAIT_BLOB_HIVEMIND_CORE_MIDROUND "blob_hivemind_core_midround"
+
+/// overall
+#define TRAIT_BORER_CREATURE "borer_creature"
+/// child
+#define TRAIT_BORER_PARASITE "borer_parasite"
+/// variables
+#define TRAIT_BORER_MIDROUND "borer_midround"
+#define TRAIT_BORER_REAL_INFESTATION "borer_real_infestation"
+
+/// overall
+#define TRAIT_CHANGELING_INDIVIDUAL "changeling_individual"
+/// child
+#define TRAIT_CHANGELING_HIVEMIND_MEMBER "changeling_hivemind_member"
+/// variables
+#define TRAIT_CHANGELING_SYNDICATE_AGENT "changeling_syndicate_agent"
+#define TRAIT_CHANGELING_RESEARCH_MISSION "changeling_research_mission"
+#define TRAIT_CHANGELING_REAL_INFESTATION "changeling_real_infestation"
+
+/// overall
+#define TRAIT_COP_PERSON "cop_person"
+/// child
+#define TRAIT_COP_UNDERCOVER "cop_undercover"
+#define TRAIT_COP_SWAT "cop_swat"
+/// variables
+#define TRAIT_COP_ARMED_OFFICER "cop_armed_officer"
+#define TRAIT_COP_TACTICAL_GROUP_FIGHTER "cop_tactical_group_fighter"
+#define TRAIT_COP_INSPECTOR "cop_inspector"
+#define TRAIT_COP_MFNT_FIGHTER "cop_mfnt_fighter"
+#define TRAIT_COP_ROUNDSTART "cop_roundstart"
+#define TRAIT_COP_LATEJOIN "cop_latejoin"
+
+/// overall
+#define TRAIT_CULTIST_MEMBER "cultist_member"
+/// child
+#define TRAIT_CULTIST_DEDICATED "cultist_dedicated"
+#define TRAIT_CULTIST_HARBINGER "cultist_harbinger"
+#define TRAIT_CULTIST_HIGHPRIEST "cultist_highpriest"
+/// variables
+#define TRAIT_CULTIST_ROUNDSTART "cultist_roundstart"
+#define TRAIT_CULTIST_REVOLUTION_OF_NARSIE "cultist_revolution_of_narsie"
+#define TRAIT_CULTIST_CONFLUX "cultist_conflux"
+
+/// overall
+#define TRAIT_CUSTOM_ROLE "custom_role"
+/// variables
+#define TRAIT_CUSTOM_ROLE_ROUNDSTART "custom_role_roundstart"
+
+/// overall
+#define TRAIT_FAMILIES_MEMBER "families_member"
+/// child
+#define TRAIT_FAMILIES_GANGSTER "families_gangster"
+#define TRAIT_FAMILIES_LEADER "families_leader"
+/// variables
+#define TRAIT_FAMILIES_DUTCH "families_dutch"
+#define TRAIT_FAMILIES_GREEN "families_green"
+#define TRAIT_FAMILIES_HENCHMEN "families_henchmen"
+#define TRAIT_FAMILIES_ITALIAN_MOB "families_italian_mob"
+#define TRAIT_FAMILIES_JACKBROS "families_jackbros"
+#define TRAIT_FAMILIES_PURPLE "families_purple"
+#define TRAIT_FAMILIES_RED "families_red"
+#define TRAIT_FAMILIES_RUSSIAN_MAFIA "families_russian_mafia"
+#define TRAIT_FAMILIES_SNAKES "families_snakes"
+#define TRAIT_FAMILIES_VAGOS "families_vagos"
+#define TRAIT_FAMILIES_YAKUZA "families_yakuza"
+
+/// overall
+#define TRAIT_HEIST_CREWMEMBER "heist_crewmember"
+/// variables
+#define TRAIT_HEIST_RAIDER_MIDROUND "heist_raider_midround"
+#define TRAIT_HEIST_SABOTEUR "heist_saboteur"
+
+/// overall
+#define TRAIT_MALFUNCTION_SILICON "malfunction_silicon"
+/// child
+#define TRAIT_MALFUNCTION_AI "malfunction_ai"
+#define TRAIT_MALFUNCTION_BOT "malfunction_bot"
+
+/// overall
+#define TRAIT_SPRIDER_CLAN_MEMBER "spider_clan_member"
+/// child
+#define TRAIT_SPRIDER_CLAN_NINJA "spider_clan_ninja"
+
+/// overall
+#define TRAIT_PROP_INDIVIDUAL "prop_individual"
+
+/// overall
+#define TRAIT_REPLICATOR_HIVEMIND_MEMBER "replicator_hivemind_member"
+/// child
+#define TRAIT_REPLICATOR_UNIT "replicator_unit"
+
+/// overall
+#define TRAIT_REVOLUTION_PARTICIPANT "revolution_participant"
+/// child
+#define TRAIT_REVOLUTION_LEADER "revolution_leader"
+#define TRAIT_REVOLUTION_PROTESTER "revolution_protester"
+/// variables
+#define TRAIT_REVOLUTION_NARSIE_REVOLUTIONEER "revolution_narsie_revolutioneer"
+
+/// overall
+#define TRAIT_SHADOWLING_GROUP_MEMBER "shadowling_group_member"
+/// child
+#define TRAIT_SHADOWLING_MASTER "shadowling_master"
+#define TRAIT_SHADOWLING_CREWSLAVE "shadowling_crewslave"
+
+/// overall
+#define TRAIT_SLAVE_PERSON "slave_person"
+
+/// overall
+#define TRAIT_NUKE_OP "nuke_op"
+/// child
+#define TRAIT_NUKE_TEAMSTRIKE_MEMBER "nuke_teamstrike_member"
+#define TRAIT_NUKE_OP_LONE "nuke_op_lone"
+/// variables
+#define TRAIT_NUKE_TEAMSTRIKE_LEADER "nuke_teamstrike_leader"
+#define TRAIT_NUKE_OP_ROUNDSTART "nuke_op_roundstart"
+#define TRAIT_NUKE_OP_MIDROUND "nuke_op_midround"
+#define TRAIT_NUKE_OP_CROSSFIRE "nuke_op_crossfire"
+
+/// overall
+#define TRAIT_STRIKE_TEAMMATE "strike_teammate"
+/// child
+#define TRAIT_STRIKE_TEAM_MEMBER "strike_team_member"
+#define TRAIT_STRIKE_TEAM_LEADER "strike_team_leader"
+
+/// overall
+#define TRAIT_SYNDICATE_AGENT "syndicate_agent"
+/// child
+#define TRAIT_SYNDICATE_TRAITOR "syndicate_traitor"
+#define TRAIT_SYNDICATE_GUN_DEALER "syndicate_gun_dealer"
+/// variables
+#define TRAIT_SYNDICATE_ROUNDSTART "syndicate_roundstart"
+#define TRAIT_SYNDICATE_MIDROUND "syndicate_midround"
+#define TRAIT_SYNDICATE_SLEEPER "syndicate_sleeper"
+#define TRAIT_SYNDICATE_WISHGRANTED "syndicate_wishgranted"
+#define TRAIT_SYNDICATE_BEACONED "syndicate_beaconed"
+#define TRAIT_SYNDICATE_CHANGELING_TEAMMATE "syndicate_changeling_teammate"
+#define TRAIT_SYNDICATE_FUSS "syndicate_fuss"
+
+/// overall
+#define TRAIT_WIZARD_PARTY "wizard_party"
+/// child
+#define TRAIT_WIZARD_MASTER "wizard_master"
+#define TRAIT_WIZARD_APPERNTICE "wizard_apprentice"
+/// variables
+#define TRAIT_WIZARD_CONFLUX "wizard_conflux"
+#define TRAIT_WIZARD_VISITOR "wizard_visitor"
+#define TRAIT_WIZARD_FUSS "wizard_fuss"
+
+/// overall
+#define TRAIT_ZOMBIETIDE_MEMBER "zombietide_member"
+/// variables
+#define TRAIT_ZOMBIE_ROUNDSTART "zombietide_roundstart"
+
+/// overall
+#define TRAIT_ELITE_SQUAD_MEMBER "elite_squad_member"
+/// child
+#define TRAIT_ELITE_SQUAD_OP "elite_squad_op"
+
+/// overall
+#define TRAIT_DEATHSQUAD_MEMBER "deathsquad_member"
+/// child
+#define TRAIT_DEATHSQUAD_OP "deathsquad_op"
+
+// trait sources
 // idk why this exists on TG
 #define GENERIC_TRAIT "generic"
 // common trait sources
@@ -200,6 +396,7 @@
 #define QUALITY_TRAIT      "quality"
 #define TWOHANDED_TRAIT    "twohanded"
 #define RELIGION_TRAIT     "religion"
+#define GAMEMODE_TRAIT     "gamemode"
 
 // self explanatory
 #define BEAUTY_ELEMENT_TRAIT "beauty_element"
@@ -210,11 +407,6 @@
 #define OBESITY_TRAIT      "obesity"
 #define LIFE_ASSIST_MACHINES_TRAIT            "life_assist_machines"
 #define FEAR_TRAIT         "fear"
-
-// atom traits
-#define TRAIT_XENO_FUR "xeno_fur"
-
-// trait sources
 #define EYE_DAMAGE_TRAIT "eye_damage"
 #define EYE_DAMAGE_TEMPORARY_TRAIT "eye_damage_temporary"
 #define GENETIC_MUTATION_TRAIT "genetic"

--- a/code/game/gamemodes/modes_gameplays/families/gang_handler.dm
+++ b/code/game/gamemodes/modes_gameplays/families/gang_handler.dm
@@ -52,7 +52,7 @@ var/global/deaths_during_shift = 0
 		for(var/mob/living/carbon/human/H in A)
 			if(H.stat != CONSCIOUS || !H.mind || !H.client)
 				continue
-			var/datum/role/gangster/is_gangster = isanygangster(H)
+			var/datum/role/gangster/is_gangster = isrolebytype(/datum/role/gangster, H)
 			if(is_gangster in members)
 				members_in_area++
 			CHECK_TICK

--- a/code/game/gamemodes/modes_gameplays/families/induction_package.dm
+++ b/code/game/gamemodes/modes_gameplays/families/induction_package.dm
@@ -27,7 +27,7 @@
 			new threads(get_turf(src))
 		qdel(src)
 		return
-	var/datum/role/gangster/is_gangster = isgangsterlead(user)
+	var/datum/role/gangster/is_gangster = user?.mind?.GetRole(GANGSTER_LEADER)
 	if(is_gangster)
 		if(is_gangster.faction == team_to_use)
 			to_chat(user, "You started your family. You don't need to join it.")

--- a/code/game/gamemodes/roles/abductor.dm
+++ b/code/game/gamemodes/roles/abductor.dm
@@ -8,6 +8,18 @@
 	logo_state = "abductor-logo"
 	skillset_type = /datum/skillset/abductor
 
+/datum/role/abductor/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_ABDUCTOR_MEMBER, GAMEMODE_TRAIT)
+	ADD_TRAIT(M.current, TRAIT_ABDUCTOR_OP, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/abductor/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_ABDUCTOR_OP, GAMEMODE_TRAIT)
+	REMOVE_TRAIT(M.current, TRAIT_ABDUCTOR_MEMBER, GAMEMODE_TRAIT)
+
 /datum/role/abductor/Greet(greeting, custom)
 	if(!..())
 		return FALSE
@@ -55,6 +67,16 @@
 	id = ABDUCTOR_AGENT
 	skillset_type = /datum/skillset/abductor/agent
 
+/datum/role/abductor/agent/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_ABDUCTOR_OP_AGENT, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/abductor/agent/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_ABDUCTOR_OP_AGENT, GAMEMODE_TRAIT)
+
 /datum/role/abductor/agent/Greet(greeting, custom)
 	if(!..())
 		return FALSE
@@ -85,6 +107,16 @@
 	name = "Scientist"
 	id = ABDUCTOR_SCI
 	skillset_type = /datum/skillset/abductor/scientist
+
+/datum/role/abductor/scientist/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_ABDUCTOR_OP_SCIENTIST, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/abductor/scientist/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_ABDUCTOR_OP_SCIENTIST, GAMEMODE_TRAIT)
 
 /datum/role/abductor/scientist/Greet(greeting, custom)
 	if(!..())
@@ -118,6 +150,16 @@
 	id = ABDUCTOR_ASSISTANT
 	skillset_type = /datum/skillset/abductor/scientist
 
+/datum/role/abductor/assistant/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_ABDUCTOR_ASSISTANT, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/abductor/assistant/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_ABDUCTOR_ASSISTANT, GAMEMODE_TRAIT)
+
 /datum/role/abductor/assistant/equip_common()
 	return
 
@@ -143,3 +185,15 @@
 		return FALSE
 	AppendObjective(pick(subtypesof(/datum/objective/abductee)))
 	return TRUE
+
+/datum/role/abducted/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_ABDUCTOR_MEMBER, GAMEMODE_TRAIT)
+	ADD_TRAIT(M.current, TRAIT_ABDUCTOR_ABDUCTED, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/abducted/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_ABDUCTOR_ABDUCTED, GAMEMODE_TRAIT)
+	REMOVE_TRAIT(M.current, TRAIT_ABDUCTOR_MEMBER, GAMEMODE_TRAIT)

--- a/code/game/gamemodes/roles/abductor.dm
+++ b/code/game/gamemodes/roles/abductor.dm
@@ -8,13 +8,6 @@
 	logo_state = "abductor-logo"
 	skillset_type = /datum/skillset/abductor
 
-/datum/role/abductor/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_ABDUCTOR_MEMBER, GAMEMODE_TRAIT)
-	ADD_TRAIT(M.current, TRAIT_ABDUCTOR_OP, GAMEMODE_TRAIT)
-	return TRUE
-
 /datum/role/abductor/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
 	. = ..()
 	REMOVE_TRAIT(M.current, TRAIT_ABDUCTOR_OP, GAMEMODE_TRAIT)
@@ -44,6 +37,8 @@
 
 /datum/role/abductor/OnPostSetup(laterole)
 	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_ABDUCTOR_MEMBER, GAMEMODE_TRAIT)
+	ADD_TRAIT(antag.current, TRAIT_ABDUCTOR_OP, GAMEMODE_TRAIT)
 	var/mob/living/carbon/human/abductor/H = antag.current
 	H.set_species(ABDUCTOR)
 	var/faction_name = faction ? faction.name : ""
@@ -67,11 +62,9 @@
 	id = ABDUCTOR_AGENT
 	skillset_type = /datum/skillset/abductor/agent
 
-/datum/role/abductor/agent/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_ABDUCTOR_OP_AGENT, GAMEMODE_TRAIT)
-	return TRUE
+/datum/role/abductor/agent/OnPostSetup(laterole)
+	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_ABDUCTOR_OP_AGENT, GAMEMODE_TRAIT)
 
 /datum/role/abductor/agent/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
 	. = ..()
@@ -108,15 +101,13 @@
 	id = ABDUCTOR_SCI
 	skillset_type = /datum/skillset/abductor/scientist
 
-/datum/role/abductor/scientist/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_ABDUCTOR_OP_SCIENTIST, GAMEMODE_TRAIT)
-	return TRUE
-
 /datum/role/abductor/scientist/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
 	. = ..()
 	REMOVE_TRAIT(M.current, TRAIT_ABDUCTOR_OP_SCIENTIST, GAMEMODE_TRAIT)
+
+/datum/role/abductor/scientist/OnPostSetup(laterole)
+	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_ABDUCTOR_OP_SCIENTIST, GAMEMODE_TRAIT)
 
 /datum/role/abductor/scientist/Greet(greeting, custom)
 	if(!..())
@@ -150,11 +141,9 @@
 	id = ABDUCTOR_ASSISTANT
 	skillset_type = /datum/skillset/abductor/scientist
 
-/datum/role/abductor/assistant/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_ABDUCTOR_ASSISTANT, GAMEMODE_TRAIT)
-	return TRUE
+/datum/role/abductor/assistant/OnPostSetup(laterole)
+	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_ABDUCTOR_ASSISTANT, GAMEMODE_TRAIT)
 
 /datum/role/abductor/assistant/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
 	. = ..()
@@ -186,12 +175,10 @@
 	AppendObjective(pick(subtypesof(/datum/objective/abductee)))
 	return TRUE
 
-/datum/role/abducted/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_ABDUCTOR_MEMBER, GAMEMODE_TRAIT)
-	ADD_TRAIT(M.current, TRAIT_ABDUCTOR_ABDUCTED, GAMEMODE_TRAIT)
-	return TRUE
+/datum/role/abducted/OnPostSetup(laterole)
+	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_ABDUCTOR_MEMBER, GAMEMODE_TRAIT)
+	ADD_TRAIT(antag.current, TRAIT_ABDUCTOR_ABDUCTED, GAMEMODE_TRAIT)
 
 /datum/role/abducted/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
 	. = ..()

--- a/code/game/gamemodes/roles/alien.dm
+++ b/code/game/gamemodes/roles/alien.dm
@@ -9,6 +9,18 @@
 
 	logo_state = "xeno-logo"
 
+/datum/role/alien/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_ALIEN_HIVEPART, GAMEMODE_TRAIT)
+	ADD_TRAIT(M.current, TRAIT_ALIEN_SPECIMEN, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/alien/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_ALIEN_HIVEPART, GAMEMODE_TRAIT)
+	REMOVE_TRAIT(M.current, TRAIT_ALIEN_SPECIMEN, GAMEMODE_TRAIT)
+
 /datum/role/alien/Greet(greeting, custom)
 	. = ..()
 	to_chat(antag.current, {"<span class='notice'><b>Вы - ксеноморф. Ваша текущая форма - грудолом.

--- a/code/game/gamemodes/roles/alien.dm
+++ b/code/game/gamemodes/roles/alien.dm
@@ -9,12 +9,10 @@
 
 	logo_state = "xeno-logo"
 
-/datum/role/alien/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_ALIEN_HIVEPART, GAMEMODE_TRAIT)
-	ADD_TRAIT(M.current, TRAIT_ALIEN_SPECIMEN, GAMEMODE_TRAIT)
-	return TRUE
+/datum/role/alien/OnPostSetup(laterole)
+	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_ALIEN_HIVEPART, GAMEMODE_TRAIT)
+	ADD_TRAIT(antag.current, TRAIT_ALIEN_SPECIMEN, GAMEMODE_TRAIT)
 
 /datum/role/alien/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
 	. = ..()

--- a/code/game/gamemodes/roles/blob.dm
+++ b/code/game/gamemodes/roles/blob.dm
@@ -7,10 +7,30 @@
 
 	disallow_job = TRUE
 
+/datum/role/blob_overmind/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_BLOB_HIVEMIND_MEMBER, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/blob_overmind/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_BLOB_HIVEMIND_MEMBER, GAMEMODE_TRAIT)
+
 /datum/role/blob_overmind/cerebrate
 	name = BLOBCEREBRATE
 	id = BLOBCEREBRATE
 	logo_state = "cerebrate-logo"
+
+/datum/role/blob_overmind/cerebrate/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_BLOB_HIVEMIND_CORE, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/blob_overmind/cerebrate/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_BLOB_HIVEMIND_CORE, GAMEMODE_TRAIT)
 
 /datum/role/blob_overmind/OnPostSetup(laterole)
 	. = ..()
@@ -82,3 +102,15 @@
 	greets = list(GREET_DEFAULT,GREET_CUSTOM)
 
 	disallow_job = TRUE
+
+/datum/role/blobbernaut/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_BLOB_HIVEMIND_MEMBER, GAMEMODE_TRAIT)
+	ADD_TRAIT(M.current, TRAIT_BLOB_HIVEMIND_PAWN, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/blobbernaut/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_BLOB_HIVEMIND_PAWN, GAMEMODE_TRAIT)
+	REMOVE_TRAIT(M.current, TRAIT_BLOB_HIVEMIND_MEMBER, GAMEMODE_TRAIT)

--- a/code/game/gamemodes/roles/blob.dm
+++ b/code/game/gamemodes/roles/blob.dm
@@ -7,12 +7,6 @@
 
 	disallow_job = TRUE
 
-/datum/role/blob_overmind/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_BLOB_HIVEMIND_MEMBER, GAMEMODE_TRAIT)
-	return TRUE
-
 /datum/role/blob_overmind/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
 	. = ..()
 	REMOVE_TRAIT(M.current, TRAIT_BLOB_HIVEMIND_MEMBER, GAMEMODE_TRAIT)
@@ -22,11 +16,9 @@
 	id = BLOBCEREBRATE
 	logo_state = "cerebrate-logo"
 
-/datum/role/blob_overmind/cerebrate/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_BLOB_HIVEMIND_CORE, GAMEMODE_TRAIT)
-	return TRUE
+/datum/role/blob_overmind/cerebrate/OnPostSetup(laterole)
+	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_BLOB_HIVEMIND_CORE, GAMEMODE_TRAIT)
 
 /datum/role/blob_overmind/cerebrate/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
 	. = ..()
@@ -34,6 +26,7 @@
 
 /datum/role/blob_overmind/OnPostSetup(laterole)
 	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_BLOB_HIVEMIND_MEMBER, GAMEMODE_TRAIT)
 	var/wait_time = rand(INTERCEPT_TIME_LOW, INTERCEPT_TIME_HIGH)
 	var/time_to_stage1 = wait_time
 	var/time_to_stage2 = wait_time * 2
@@ -103,12 +96,10 @@
 
 	disallow_job = TRUE
 
-/datum/role/blobbernaut/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_BLOB_HIVEMIND_MEMBER, GAMEMODE_TRAIT)
-	ADD_TRAIT(M.current, TRAIT_BLOB_HIVEMIND_PAWN, GAMEMODE_TRAIT)
-	return TRUE
+/datum/role/blobbernaut/OnPostSetup(laterole)
+	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_BLOB_HIVEMIND_MEMBER, GAMEMODE_TRAIT)
+	ADD_TRAIT(antag.current, TRAIT_BLOB_HIVEMIND_PAWN, GAMEMODE_TRAIT)
 
 /datum/role/blobbernaut/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
 	. = ..()

--- a/code/game/gamemodes/roles/borer.dm
+++ b/code/game/gamemodes/roles/borer.dm
@@ -5,6 +5,18 @@
 
 	logo_state = "borer-logo"
 
+/datum/role/borer/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_BORER_CREATURE, GAMEMODE_TRAIT)
+	ADD_TRAIT(M.current, TRAIT_BORER_PARASITE, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/borer/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_BORER_CREATURE, GAMEMODE_TRAIT)
+	REMOVE_TRAIT(M.current, TRAIT_BORER_PARASITE, GAMEMODE_TRAIT)
+
 /datum/role/borer/Greet(greeting, custom)
 	. = ..()
 	to_chat(antag.current, "Use your Infest power to crawl into the ear of a host and fuse with their brain.")

--- a/code/game/gamemodes/roles/borer.dm
+++ b/code/game/gamemodes/roles/borer.dm
@@ -5,12 +5,10 @@
 
 	logo_state = "borer-logo"
 
-/datum/role/borer/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_BORER_CREATURE, GAMEMODE_TRAIT)
-	ADD_TRAIT(M.current, TRAIT_BORER_PARASITE, GAMEMODE_TRAIT)
-	return TRUE
+/datum/role/borer/OnPostSetup(laterole)
+	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_BORER_CREATURE, GAMEMODE_TRAIT)
+	ADD_TRAIT(antag.current, TRAIT_BORER_PARASITE, GAMEMODE_TRAIT)
 
 /datum/role/borer/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
 	. = ..()

--- a/code/game/gamemodes/roles/changeling.dm
+++ b/code/game/gamemodes/roles/changeling.dm
@@ -43,6 +43,18 @@
 	var/atom/movable/screen/lingchemdisplay
 	var/atom/movable/screen/lingstingdisplay
 
+/datum/role/changeling/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_CHANGELING_INDIVIDUAL, GAMEMODE_TRAIT)
+	ADD_TRAIT(M.current, TRAIT_CHANGELING_HIVEMIND_MEMBER, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/changeling/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_CHANGELING_INDIVIDUAL, GAMEMODE_TRAIT)
+	REMOVE_TRAIT(M.current, TRAIT_CHANGELING_HIVEMIND_MEMBER, GAMEMODE_TRAIT)
+
 /datum/role/changeling/OnPostSetup(laterole = FALSE)
 	. = ..()
 	antag.current.make_changeling()

--- a/code/game/gamemodes/roles/changeling.dm
+++ b/code/game/gamemodes/roles/changeling.dm
@@ -43,13 +43,6 @@
 	var/atom/movable/screen/lingchemdisplay
 	var/atom/movable/screen/lingstingdisplay
 
-/datum/role/changeling/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_CHANGELING_INDIVIDUAL, GAMEMODE_TRAIT)
-	ADD_TRAIT(M.current, TRAIT_CHANGELING_HIVEMIND_MEMBER, GAMEMODE_TRAIT)
-	return TRUE
-
 /datum/role/changeling/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
 	. = ..()
 	REMOVE_TRAIT(M.current, TRAIT_CHANGELING_INDIVIDUAL, GAMEMODE_TRAIT)
@@ -57,6 +50,8 @@
 
 /datum/role/changeling/OnPostSetup(laterole = FALSE)
 	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_CHANGELING_INDIVIDUAL, GAMEMODE_TRAIT)
+	ADD_TRAIT(antag.current, TRAIT_CHANGELING_HIVEMIND_MEMBER, GAMEMODE_TRAIT)
 	antag.current.make_changeling()
 	set_changeling_identifications()
 

--- a/code/game/gamemodes/roles/cops.dm
+++ b/code/game/gamemodes/roles/cops.dm
@@ -16,18 +16,13 @@
 	skillset_type = /datum/skillset/undercover
 	moveset_type = /datum/combat_moveset/cqc
 
-/datum/role/cop/undercover/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_COP_UNDERCOVER, GAMEMODE_TRAIT)
-	return TRUE
-
 /datum/role/cop/undercover/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
 	. = ..()
 	REMOVE_TRAIT(M.current, TRAIT_COP_UNDERCOVER, GAMEMODE_TRAIT)
 
 /datum/role/cop/undercover/OnPostSetup(laterole)
 	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_COP_UNDERCOVER, GAMEMODE_TRAIT)
 	if(ishuman(antag.current))
 		for(var/type in free_clothes)
 			var/mob/living/carbon/human/H = antag.current
@@ -67,18 +62,13 @@
 	var/outfit
 	skillset_type = /datum/skillset/cop
 
-/datum/role/cop/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_COP_PERSON, GAMEMODE_TRAIT)
-	return TRUE
-
 /datum/role/cop/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
 	. = ..()
 	REMOVE_TRAIT(M.current, TRAIT_COP_PERSON, GAMEMODE_TRAIT)
 
 /datum/role/cop/OnPostSetup(laterole)
 	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_COP_PERSON, GAMEMODE_TRAIT)
 	var/mob/living/carbon/human/M = antag.current
 
 	if(outfit)
@@ -94,11 +84,9 @@
 	name = "Officer"
 	outfit = /datum/outfit/families_police/beatcop
 
-/datum/role/cop/beatcop/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_COP_SWAT, GAMEMODE_TRAIT)
-	return TRUE
+/datum/role/cop/beatcop/OnPostSetup(laterole)
+	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_COP_SWAT, GAMEMODE_TRAIT)
 
 /datum/role/cop/beatcop/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
 	. = ..()
@@ -126,11 +114,9 @@
 	name = "Armed Officer"
 	outfit = /datum/outfit/families_police/beatcop/armored
 
-/datum/role/cop/beatcop/armored/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_COP_ARMED_OFFICER, GAMEMODE_TRAIT)
-	return TRUE
+/datum/role/cop/beatcop/armored/OnPostSetup(laterole)
+	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_COP_ARMED_OFFICER, GAMEMODE_TRAIT)
 
 /datum/role/cop/beatcop/armored/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
 	. = ..()
@@ -140,11 +126,9 @@
 	name = "Tactical Group Fighter"
 	outfit = /datum/outfit/families_police/beatcop/swat
 
-/datum/role/cop/beatcop/swat/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_COP_TACTICAL_GROUP_FIGHTER, GAMEMODE_TRAIT)
-	return TRUE
+/datum/role/cop/beatcop/swat/OnPostSetup(laterole)
+	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_COP_TACTICAL_GROUP_FIGHTER, GAMEMODE_TRAIT)
 
 /datum/role/cop/beatcop/swat/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
 	. = ..()
@@ -154,11 +138,9 @@
 	name = "Inspector"
 	outfit = /datum/outfit/families_police/beatcop/fbi
 
-/datum/role/cop/beatcop/fbi/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_COP_INSPECTOR, GAMEMODE_TRAIT)
-	return TRUE
+/datum/role/cop/beatcop/fbi/OnPostSetup(laterole)
+	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_COP_INSPECTOR, GAMEMODE_TRAIT)
 
 /datum/role/cop/beatcop/fbi/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
 	. = ..()
@@ -168,11 +150,9 @@
 	name = "MFNT Fighter"
 	outfit = /datum/outfit/families_police/beatcop/military
 
-/datum/role/cop/beatcop/military/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_COP_MFNT_FIGHTER, GAMEMODE_TRAIT)
-	return TRUE
+/datum/role/cop/beatcop/military/OnPostSetup(laterole)
+	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_COP_MFNT_FIGHTER, GAMEMODE_TRAIT)
 
 /datum/role/cop/beatcop/military/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
 	. = ..()

--- a/code/game/gamemodes/roles/cops.dm
+++ b/code/game/gamemodes/roles/cops.dm
@@ -16,6 +16,16 @@
 	skillset_type = /datum/skillset/undercover
 	moveset_type = /datum/combat_moveset/cqc
 
+/datum/role/cop/undercover/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_COP_UNDERCOVER, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/cop/undercover/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_COP_UNDERCOVER, GAMEMODE_TRAIT)
+
 /datum/role/cop/undercover/OnPostSetup(laterole)
 	. = ..()
 	if(ishuman(antag.current))
@@ -57,6 +67,16 @@
 	var/outfit
 	skillset_type = /datum/skillset/cop
 
+/datum/role/cop/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_COP_PERSON, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/cop/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_COP_PERSON, GAMEMODE_TRAIT)
+
 /datum/role/cop/OnPostSetup(laterole)
 	. = ..()
 	var/mob/living/carbon/human/M = antag.current
@@ -73,6 +93,16 @@
 /datum/role/cop/beatcop
 	name = "Officer"
 	outfit = /datum/outfit/families_police/beatcop
+
+/datum/role/cop/beatcop/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_COP_SWAT, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/cop/beatcop/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_COP_SWAT, GAMEMODE_TRAIT)
 
 /datum/role/cop/beatcop/Greet(greeting, custom)
 	if(!..())
@@ -96,14 +126,54 @@
 	name = "Armed Officer"
 	outfit = /datum/outfit/families_police/beatcop/armored
 
+/datum/role/cop/beatcop/armored/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_COP_ARMED_OFFICER, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/cop/beatcop/armored/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_COP_ARMED_OFFICER, GAMEMODE_TRAIT)
+
 /datum/role/cop/beatcop/swat
 	name = "Tactical Group Fighter"
 	outfit = /datum/outfit/families_police/beatcop/swat
+
+/datum/role/cop/beatcop/swat/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_COP_TACTICAL_GROUP_FIGHTER, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/cop/beatcop/swat/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_COP_TACTICAL_GROUP_FIGHTER, GAMEMODE_TRAIT)
 
 /datum/role/cop/beatcop/fbi
 	name = "Inspector"
 	outfit = /datum/outfit/families_police/beatcop/fbi
 
+/datum/role/cop/beatcop/fbi/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_COP_INSPECTOR, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/cop/beatcop/fbi/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_COP_INSPECTOR, GAMEMODE_TRAIT)
+
 /datum/role/cop/beatcop/military
 	name = "MFNT Fighter"
 	outfit = /datum/outfit/families_police/beatcop/military
+
+/datum/role/cop/beatcop/military/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_COP_MFNT_FIGHTER, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/cop/beatcop/military/RemoveFromRole(datum/mind/M, msg_admins = TRUE)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_COP_MFNT_FIGHTER, GAMEMODE_TRAIT)

--- a/code/game/gamemodes/roles/cultist.dm
+++ b/code/game/gamemodes/roles/cultist.dm
@@ -31,6 +31,15 @@
 	var/datum/faction/cult/C = faction
 	if(istype(C))
 		C.religion?.remove_member(M.current)
+	REMOVE_TRAIT(M.current, TRAIT_CULTIST_MEMBER, GAMEMODE_TRAIT)
+	REMOVE_TRAIT(M.current, TRAIT_CULTIST_DEDICATED, GAMEMODE_TRAIT)
+
+/datum/role/cultist/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_CULTIST_MEMBER, GAMEMODE_TRAIT)
+	ADD_TRAIT(M.current, TRAIT_CULTIST_DEDICATED, GAMEMODE_TRAIT)
+	return TRUE
 
 /datum/role/cultist/proc/equip_cultist(mob/living/carbon/human/mob)
 	if(!istype(mob))
@@ -101,3 +110,13 @@
 
 	holy_rank = CULT_ROLE_MASTER
 	skillset_type = /datum/skillset/cultist/leader
+
+/datum/role/cultist/leader/RemoveFromRole(datum/mind/M, msg_admins)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_CULTIST_HARBINGER, GAMEMODE_TRAIT)
+
+/datum/role/cultist/leader/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_CULTIST_HARBINGER, GAMEMODE_TRAIT)
+	return TRUE

--- a/code/game/gamemodes/roles/cultist.dm
+++ b/code/game/gamemodes/roles/cultist.dm
@@ -34,13 +34,6 @@
 	REMOVE_TRAIT(M.current, TRAIT_CULTIST_MEMBER, GAMEMODE_TRAIT)
 	REMOVE_TRAIT(M.current, TRAIT_CULTIST_DEDICATED, GAMEMODE_TRAIT)
 
-/datum/role/cultist/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_CULTIST_MEMBER, GAMEMODE_TRAIT)
-	ADD_TRAIT(M.current, TRAIT_CULTIST_DEDICATED, GAMEMODE_TRAIT)
-	return TRUE
-
 /datum/role/cultist/proc/equip_cultist(mob/living/carbon/human/mob)
 	if(!istype(mob))
 		return
@@ -58,6 +51,8 @@
 
 /datum/role/cultist/OnPostSetup(laterole)
 	..()
+	ADD_TRAIT(antag.current, TRAIT_CULTIST_MEMBER, GAMEMODE_TRAIT)
+	ADD_TRAIT(antag.current, TRAIT_CULTIST_DEDICATED, GAMEMODE_TRAIT)
 	if(!laterole)
 		equip_cultist(antag.current)
 	var/datum/faction/cult/C = faction
@@ -115,8 +110,6 @@
 	. = ..()
 	REMOVE_TRAIT(M.current, TRAIT_CULTIST_HARBINGER, GAMEMODE_TRAIT)
 
-/datum/role/cultist/leader/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_CULTIST_HARBINGER, GAMEMODE_TRAIT)
-	return TRUE
+/datum/role/cultist/leader/OnPostSetup(laterole)
+	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_CULTIST_HARBINGER, GAMEMODE_TRAIT)

--- a/code/game/gamemodes/roles/custom.dm
+++ b/code/game/gamemodes/roles/custom.dm
@@ -60,8 +60,6 @@
 	. = ..()
 	REMOVE_TRAIT(M.current, TRAIT_CUSTOM_ROLE, GAMEMODE_TRAIT)
 
-/datum/role/custom/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_CUSTOM_ROLE, GAMEMODE_TRAIT)
-	return TRUE
+/datum/role/custom/OnPostSetup(laterole)
+	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_CUSTOM_ROLE, GAMEMODE_TRAIT)

--- a/code/game/gamemodes/roles/custom.dm
+++ b/code/game/gamemodes/roles/custom.dm
@@ -55,3 +55,13 @@
 		return
 
 	show_setting(M)
+
+/datum/role/custom/RemoveFromRole(datum/mind/M, msg_admins)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_CUSTOM_ROLE, GAMEMODE_TRAIT)
+
+/datum/role/custom/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_CUSTOM_ROLE, GAMEMODE_TRAIT)
+	return TRUE

--- a/code/game/gamemodes/roles/families.dm
+++ b/code/game/gamemodes/roles/families.dm
@@ -16,13 +16,6 @@
 	. = ..()
 	package_spawner = new(src)
 
-/datum/role/gangster/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_FAMILIES_MEMBER, GAMEMODE_TRAIT)
-	ADD_TRAIT(M.current, TRAIT_FAMILIES_GANGSTER, GAMEMODE_TRAIT)
-	return TRUE
-
 /datum/role/gangster/RemoveFromRole(datum/mind/M, msg_admins)
 	. = ..()
 	REMOVE_TRAIT(M.current, TRAIT_FAMILIES_MEMBER, GAMEMODE_TRAIT)
@@ -39,6 +32,8 @@
 
 /datum/role/gangster/OnPostSetup(laterole)
 	..()
+	ADD_TRAIT(antag.current, TRAIT_FAMILIES_MEMBER, GAMEMODE_TRAIT)
+	ADD_TRAIT(antag.current, TRAIT_FAMILIES_GANGSTER, GAMEMODE_TRAIT)
 	package_spawner.Grant(antag.current)
 	package_spawner.my_gang_datum = faction
 
@@ -104,18 +99,13 @@
 	id = GANGSTER_LEADER
 	skillset_type = /datum/skillset/gangster
 
-/datum/role/gangster/leader/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_FAMILIES_LEADER, GAMEMODE_TRAIT)
-	return TRUE
-
 /datum/role/gangster/leader/RemoveFromRole(datum/mind/M, msg_admins)
 	. = ..()
 	REMOVE_TRAIT(M.current, TRAIT_FAMILIES_LEADER, GAMEMODE_TRAIT)
 
 /datum/role/gangster/leader/OnPostSetup(laterole)
 	..()
+	ADD_TRAIT(antag.current, TRAIT_FAMILIES_LEADER, GAMEMODE_TRAIT)
 	equip_gangster_in_inventory()
 
 /datum/role/traitor/dealer
@@ -125,17 +115,12 @@
 	change_to_maximum_skills = TRUE
 	telecrystals = 10
 
-/datum/role/traitor/dealer/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_SYNDICATE_GUN_DEALER, GAMEMODE_TRAIT)
-	return TRUE
-
 /datum/role/traitor/dealer/RemoveFromRole(datum/mind/M, msg_admins)
 	. = ..()
 	REMOVE_TRAIT(M.current, TRAIT_SYNDICATE_GUN_DEALER, GAMEMODE_TRAIT)
 
 /datum/role/traitor/dealer/OnPostSetup(laterole)
+	ADD_TRAIT(antag.current, TRAIT_SYNDICATE_GUN_DEALER, GAMEMODE_TRAIT)
 	var/mob/living/carbon/human/H = antag.current
 	notify_ghosts("New gun dealer!", source = H, action = NOTIFY_ORBIT, header = "Gun Dealer")
 	H.equipOutfit(/datum/outfit/families_traitor)

--- a/code/game/gamemodes/roles/families.dm
+++ b/code/game/gamemodes/roles/families.dm
@@ -16,6 +16,18 @@
 	. = ..()
 	package_spawner = new(src)
 
+/datum/role/gangster/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_FAMILIES_MEMBER, GAMEMODE_TRAIT)
+	ADD_TRAIT(M.current, TRAIT_FAMILIES_GANGSTER, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/gangster/RemoveFromRole(datum/mind/M, msg_admins)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_FAMILIES_MEMBER, GAMEMODE_TRAIT)
+	REMOVE_TRAIT(M.current, TRAIT_FAMILIES_GANGSTER, GAMEMODE_TRAIT)
+
 /datum/role/gangster/OnPreSetup()
 	. = ..()
 	var/datum/faction/gang/G = faction
@@ -92,6 +104,16 @@
 	id = GANGSTER_LEADER
 	skillset_type = /datum/skillset/gangster
 
+/datum/role/gangster/leader/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_FAMILIES_LEADER, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/gangster/leader/RemoveFromRole(datum/mind/M, msg_admins)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_FAMILIES_LEADER, GAMEMODE_TRAIT)
+
 /datum/role/gangster/leader/OnPostSetup(laterole)
 	..()
 	equip_gangster_in_inventory()
@@ -102,6 +124,16 @@
 	required_pref = ROLE_FAMILIES
 	change_to_maximum_skills = TRUE
 	telecrystals = 10
+
+/datum/role/traitor/dealer/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_SYNDICATE_GUN_DEALER, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/traitor/dealer/RemoveFromRole(datum/mind/M, msg_admins)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_SYNDICATE_GUN_DEALER, GAMEMODE_TRAIT)
 
 /datum/role/traitor/dealer/OnPostSetup(laterole)
 	var/mob/living/carbon/human/H = antag.current

--- a/code/game/gamemodes/roles/heist.dm
+++ b/code/game/gamemodes/roles/heist.dm
@@ -10,11 +10,9 @@
 	logo_state = "raider-logo"
 	skillset_type = /datum/skillset/max
 
-/datum/role/vox_raider/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_HEIST_CREWMEMBER, GAMEMODE_TRAIT)
-	return TRUE
+/datum/role/vox_raider/OnPostSetup(laterole)
+	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_HEIST_CREWMEMBER, GAMEMODE_TRAIT)
 
 /datum/role/vox_raider/RemoveFromRole(datum/mind/M, msg_admins)
 	. = ..()

--- a/code/game/gamemodes/roles/heist.dm
+++ b/code/game/gamemodes/roles/heist.dm
@@ -10,6 +10,16 @@
 	logo_state = "raider-logo"
 	skillset_type = /datum/skillset/max
 
+/datum/role/vox_raider/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_HEIST_CREWMEMBER, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/vox_raider/RemoveFromRole(datum/mind/M, msg_admins)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_HEIST_CREWMEMBER, GAMEMODE_TRAIT)
+
 /datum/role/vox_raider/Greet(greeting, custom)
 	. = ..()
 

--- a/code/game/gamemodes/roles/malf_unit.dm
+++ b/code/game/gamemodes/roles/malf_unit.dm
@@ -10,6 +10,18 @@
 
 	logo_state = "malf-logo"
 
+/datum/role/malfAI/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_MALFUNCTION_SILICON, GAMEMODE_TRAIT)
+	ADD_TRAIT(M.current, TRAIT_MALFUNCTION_AI, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/malfAI/RemoveFromRole(datum/mind/M, msg_admins)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_MALFUNCTION_AI, GAMEMODE_TRAIT)
+	REMOVE_TRAIT(M.current, TRAIT_MALFUNCTION_SILICON, GAMEMODE_TRAIT)
+
 /datum/role/malfAI/OnPostSetup(laterole)
 	. = ..()
 	var/mob/living/silicon/ai/AI_mind_current = antag.current
@@ -86,6 +98,18 @@
 	antag_hud_name = "hudmalborg"
 
 	logo_state = "malf-logo"
+
+/datum/role/malfbot/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_MALFUNCTION_BOT, GAMEMODE_TRAIT)
+	ADD_TRAIT(M.current, TRAIT_MALFUNCTION_SILICON, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/malfbot/RemoveFromRole(datum/mind/M, msg_admins)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_MALFUNCTION_BOT, GAMEMODE_TRAIT)
+	REMOVE_TRAIT(M.current, TRAIT_MALFUNCTION_SILICON, GAMEMODE_TRAIT)
 
 /datum/role/malfbot/extraPanelButtons()
 	var/dat = ..()

--- a/code/game/gamemodes/roles/malf_unit.dm
+++ b/code/game/gamemodes/roles/malf_unit.dm
@@ -10,13 +10,6 @@
 
 	logo_state = "malf-logo"
 
-/datum/role/malfAI/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_MALFUNCTION_SILICON, GAMEMODE_TRAIT)
-	ADD_TRAIT(M.current, TRAIT_MALFUNCTION_AI, GAMEMODE_TRAIT)
-	return TRUE
-
 /datum/role/malfAI/RemoveFromRole(datum/mind/M, msg_admins)
 	. = ..()
 	REMOVE_TRAIT(M.current, TRAIT_MALFUNCTION_AI, GAMEMODE_TRAIT)
@@ -24,6 +17,8 @@
 
 /datum/role/malfAI/OnPostSetup(laterole)
 	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_MALFUNCTION_SILICON, GAMEMODE_TRAIT)
+	ADD_TRAIT(antag.current, TRAIT_MALFUNCTION_AI, GAMEMODE_TRAIT)
 	var/mob/living/silicon/ai/AI_mind_current = antag.current
 	new /datum/AI_Module/module_picker(AI_mind_current)
 	new /datum/AI_Module/takeover(AI_mind_current)
@@ -99,12 +94,10 @@
 
 	logo_state = "malf-logo"
 
-/datum/role/malfbot/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_MALFUNCTION_BOT, GAMEMODE_TRAIT)
-	ADD_TRAIT(M.current, TRAIT_MALFUNCTION_SILICON, GAMEMODE_TRAIT)
-	return TRUE
+/datum/role/malfbot/OnPostSetup(laterole)
+	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_MALFUNCTION_BOT, GAMEMODE_TRAIT)
+	ADD_TRAIT(antag.current, TRAIT_MALFUNCTION_SILICON, GAMEMODE_TRAIT)
 
 /datum/role/malfbot/RemoveFromRole(datum/mind/M, msg_admins)
 	. = ..()

--- a/code/game/gamemodes/roles/ninja.dm
+++ b/code/game/gamemodes/roles/ninja.dm
@@ -11,6 +11,18 @@
 	logo_state = "ninja-logo"
 	skillset_type = /datum/skillset/max
 
+/datum/role/ninja/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_SPRIDER_CLAN_MEMBER, GAMEMODE_TRAIT)
+	ADD_TRAIT(M.current, TRAIT_SPRIDER_CLAN_NINJA, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/ninja/RemoveFromRole(datum/mind/M, msg_admins)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_SPRIDER_CLAN_MEMBER, GAMEMODE_TRAIT)
+	REMOVE_TRAIT(M.current, TRAIT_SPRIDER_CLAN_NINJA, GAMEMODE_TRAIT)
+
 /datum/role/ninja/OnPostSetup(laterole)
 	. = ..()
 	var/mob/living/carbon/human/ninja = antag.current

--- a/code/game/gamemodes/roles/ninja.dm
+++ b/code/game/gamemodes/roles/ninja.dm
@@ -11,13 +11,6 @@
 	logo_state = "ninja-logo"
 	skillset_type = /datum/skillset/max
 
-/datum/role/ninja/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_SPRIDER_CLAN_MEMBER, GAMEMODE_TRAIT)
-	ADD_TRAIT(M.current, TRAIT_SPRIDER_CLAN_NINJA, GAMEMODE_TRAIT)
-	return TRUE
-
 /datum/role/ninja/RemoveFromRole(datum/mind/M, msg_admins)
 	. = ..()
 	REMOVE_TRAIT(M.current, TRAIT_SPRIDER_CLAN_MEMBER, GAMEMODE_TRAIT)
@@ -25,6 +18,8 @@
 
 /datum/role/ninja/OnPostSetup(laterole)
 	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_SPRIDER_CLAN_MEMBER, GAMEMODE_TRAIT)
+	ADD_TRAIT(antag.current, TRAIT_SPRIDER_CLAN_NINJA, GAMEMODE_TRAIT)
 	var/mob/living/carbon/human/ninja = antag.current
 	ninja.real_name = "[pick(ninja_titles)] [pick(ninja_names)]"
 	ninja.dna.ready_dna(ninja)

--- a/code/game/gamemodes/roles/prop.dm
+++ b/code/game/gamemodes/roles/prop.dm
@@ -5,6 +5,16 @@
 
 	logo_state = "change-logoa"
 
+/datum/role/prop/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_PROP_INDIVIDUAL, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/prop/RemoveFromRole(datum/mind/M, msg_admins)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_PROP_INDIVIDUAL, GAMEMODE_TRAIT)
+
 /datum/role/prop/Greet(greeting, custom)
 	. = ..()
 	to_chat(antag.current, "Вы - аморфное существо, которое способно превращаться в любой предмет.")

--- a/code/game/gamemodes/roles/prop.dm
+++ b/code/game/gamemodes/roles/prop.dm
@@ -5,11 +5,9 @@
 
 	logo_state = "change-logoa"
 
-/datum/role/prop/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_PROP_INDIVIDUAL, GAMEMODE_TRAIT)
-	return TRUE
+/datum/role/prop/OnPostSetup(laterole)
+	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_PROP_INDIVIDUAL, GAMEMODE_TRAIT)
 
 /datum/role/prop/RemoveFromRole(datum/mind/M, msg_admins)
 	. = ..()

--- a/code/game/gamemodes/roles/replicator.dm
+++ b/code/game/gamemodes/roles/replicator.dm
@@ -11,12 +11,10 @@
 	antag_hud_type = ANTAG_HUD_REPLICATOR
 	antag_hud_name = "replicator"
 
-/datum/role/replicator/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_REPLICATOR_HIVEMIND_MEMBER, GAMEMODE_TRAIT)
-	ADD_TRAIT(M.current, TRAIT_REPLICATOR_UNIT, GAMEMODE_TRAIT)
-	return TRUE
+/datum/role/replicator/OnPostSetup(laterole)
+	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_REPLICATOR_HIVEMIND_MEMBER, GAMEMODE_TRAIT)
+	ADD_TRAIT(antag.current, TRAIT_REPLICATOR_UNIT, GAMEMODE_TRAIT)
 
 /datum/role/replicator/RemoveFromRole(datum/mind/M, msg_admins)
 	. = ..()

--- a/code/game/gamemodes/roles/replicator.dm
+++ b/code/game/gamemodes/roles/replicator.dm
@@ -11,6 +11,18 @@
 	antag_hud_type = ANTAG_HUD_REPLICATOR
 	antag_hud_name = "replicator"
 
+/datum/role/replicator/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_REPLICATOR_HIVEMIND_MEMBER, GAMEMODE_TRAIT)
+	ADD_TRAIT(M.current, TRAIT_REPLICATOR_UNIT, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/replicator/RemoveFromRole(datum/mind/M, msg_admins)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_REPLICATOR_HIVEMIND_MEMBER, GAMEMODE_TRAIT)
+	REMOVE_TRAIT(M.current, TRAIT_REPLICATOR_UNIT, GAMEMODE_TRAIT)
+
 /datum/role/replicator/Greet(greeting, custom)
 	. = ..()
 	to_chat(antag.current, {"<span class='notice'><b>You are a replicator. A part of a Swarm. You must consume materials and create infrastructure required for a Bluespace Catapult,

--- a/code/game/gamemodes/roles/revolution.dm
+++ b/code/game/gamemodes/roles/revolution.dm
@@ -22,6 +22,15 @@
 /datum/role/rev/RemoveFromRole(datum/mind/M, msg_admins)
 	SEND_SIGNAL(antag.current, COMSIG_CLEAR_MOOD_EVENT, "rev_convert")
 	..()
+	REMOVE_TRAIT(M.current, TRAIT_REVOLUTION_PARTICIPANT, GAMEMODE_TRAIT)
+	REMOVE_TRAIT(M.current, TRAIT_REVOLUTION_PROTESTER, GAMEMODE_TRAIT)
+
+/datum/role/rev/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_REVOLUTION_PARTICIPANT, GAMEMODE_TRAIT)
+	ADD_TRAIT(M.current, TRAIT_REVOLUTION_PROTESTER, GAMEMODE_TRAIT)
+	return TRUE
 
 /datum/role/rev/Greet(greeting, custom)
 	. = ..()
@@ -45,6 +54,18 @@
 /datum/role/rev_leader/New()
 	..()
 	AddComponent(/datum/component/gamemode/syndicate, 1, "rev")
+
+/datum/role/rev_leader/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_REVOLUTION_PARTICIPANT, GAMEMODE_TRAIT)
+	ADD_TRAIT(M.current, TRAIT_REVOLUTION_LEADER, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/rev_leader/RemoveFromRole(datum/mind/M, msg_admins)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_REVOLUTION_PARTICIPANT, GAMEMODE_TRAIT)
+	REMOVE_TRAIT(M.current, TRAIT_REVOLUTION_LEADER, GAMEMODE_TRAIT)
 
 /datum/role/rev_leader/OnPostSetup(laterole)
 	. = ..()

--- a/code/game/gamemodes/roles/revolution.dm
+++ b/code/game/gamemodes/roles/revolution.dm
@@ -25,12 +25,10 @@
 	REMOVE_TRAIT(M.current, TRAIT_REVOLUTION_PARTICIPANT, GAMEMODE_TRAIT)
 	REMOVE_TRAIT(M.current, TRAIT_REVOLUTION_PROTESTER, GAMEMODE_TRAIT)
 
-/datum/role/rev/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_REVOLUTION_PARTICIPANT, GAMEMODE_TRAIT)
-	ADD_TRAIT(M.current, TRAIT_REVOLUTION_PROTESTER, GAMEMODE_TRAIT)
-	return TRUE
+/datum/role/rev/OnPostSetup(laterole)
+	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_REVOLUTION_PARTICIPANT, GAMEMODE_TRAIT)
+	ADD_TRAIT(antag.current, TRAIT_REVOLUTION_PROTESTER, GAMEMODE_TRAIT)
 
 /datum/role/rev/Greet(greeting, custom)
 	. = ..()
@@ -55,13 +53,6 @@
 	..()
 	AddComponent(/datum/component/gamemode/syndicate, 1, "rev")
 
-/datum/role/rev_leader/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_REVOLUTION_PARTICIPANT, GAMEMODE_TRAIT)
-	ADD_TRAIT(M.current, TRAIT_REVOLUTION_LEADER, GAMEMODE_TRAIT)
-	return TRUE
-
 /datum/role/rev_leader/RemoveFromRole(datum/mind/M, msg_admins)
 	. = ..()
 	REMOVE_TRAIT(M.current, TRAIT_REVOLUTION_PARTICIPANT, GAMEMODE_TRAIT)
@@ -69,6 +60,8 @@
 
 /datum/role/rev_leader/OnPostSetup(laterole)
 	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_REVOLUTION_PARTICIPANT, GAMEMODE_TRAIT)
+	ADD_TRAIT(antag.current, TRAIT_REVOLUTION_LEADER, GAMEMODE_TRAIT)
 	antag.current.verbs += /mob/living/carbon/human/proc/RevConvert
 
 	// Show each head revolutionary up to 3 candidates

--- a/code/game/gamemodes/roles/shadowling.dm
+++ b/code/game/gamemodes/roles/shadowling.dm
@@ -14,13 +14,6 @@
 	skillset_type = /datum/skillset/shadowling
 	change_to_maximum_skills = TRUE
 
-/datum/role/shadowling/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_SHADOWLING_GROUP_MEMBER, GAMEMODE_TRAIT)
-	ADD_TRAIT(M.current, TRAIT_SHADOWLING_MASTER, GAMEMODE_TRAIT)
-	return TRUE
-
 /datum/role/shadowling/RemoveFromRole(datum/mind/M, msg_admins)
 	. = ..()
 	REMOVE_TRAIT(M.current, TRAIT_SHADOWLING_GROUP_MEMBER, GAMEMODE_TRAIT)
@@ -35,6 +28,8 @@
 
 /datum/role/shadowling/OnPostSetup(laterole)
 	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_SHADOWLING_GROUP_MEMBER, GAMEMODE_TRAIT)
+	ADD_TRAIT(antag.current, TRAIT_SHADOWLING_MASTER, GAMEMODE_TRAIT)
 	var/mob/living/carbon/human/S = antag.current
 
 	if(antag.assigned_role == "Clown")
@@ -70,9 +65,7 @@
 	REMOVE_TRAIT(M.current, TRAIT_SHADOWLING_GROUP_MEMBER, GAMEMODE_TRAIT)
 	REMOVE_TRAIT(M.current, TRAIT_SHADOWLING_CREWSLAVE, GAMEMODE_TRAIT)
 
-/datum/role/shadowling/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_SHADOWLING_GROUP_MEMBER, GAMEMODE_TRAIT)
-	ADD_TRAIT(M.current, TRAIT_SHADOWLING_CREWSLAVE, GAMEMODE_TRAIT)
-	return TRUE
+/datum/role/thrall/OnPostSetup(laterole)
+	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_SHADOWLING_GROUP_MEMBER, GAMEMODE_TRAIT)
+	ADD_TRAIT(antag.current, TRAIT_SHADOWLING_CREWSLAVE, GAMEMODE_TRAIT)

--- a/code/game/gamemodes/roles/shadowling.dm
+++ b/code/game/gamemodes/roles/shadowling.dm
@@ -14,6 +14,18 @@
 	skillset_type = /datum/skillset/shadowling
 	change_to_maximum_skills = TRUE
 
+/datum/role/shadowling/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_SHADOWLING_GROUP_MEMBER, GAMEMODE_TRAIT)
+	ADD_TRAIT(M.current, TRAIT_SHADOWLING_MASTER, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/shadowling/RemoveFromRole(datum/mind/M, msg_admins)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_SHADOWLING_GROUP_MEMBER, GAMEMODE_TRAIT)
+	REMOVE_TRAIT(M.current, TRAIT_SHADOWLING_MASTER, GAMEMODE_TRAIT)
+
 /datum/role/shadowling/Greet(greeting, custom)
 	. = ..()
 	to_chat(antag.current, "<b>Currently, you are disguised as an employee aboard [station_name()].</b>")
@@ -55,3 +67,12 @@
 	for(var/obj/effect/proc_holder/spell/targeted/shadowling_hivemind/S in antag.current.spell_list)
 		antag.current.RemoveSpell(S)
 	..()
+	REMOVE_TRAIT(M.current, TRAIT_SHADOWLING_GROUP_MEMBER, GAMEMODE_TRAIT)
+	REMOVE_TRAIT(M.current, TRAIT_SHADOWLING_CREWSLAVE, GAMEMODE_TRAIT)
+
+/datum/role/shadowling/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_SHADOWLING_GROUP_MEMBER, GAMEMODE_TRAIT)
+	ADD_TRAIT(M.current, TRAIT_SHADOWLING_CREWSLAVE, GAMEMODE_TRAIT)
+	return TRUE

--- a/code/game/gamemodes/roles/slave.dm
+++ b/code/game/gamemodes/roles/slave.dm
@@ -2,6 +2,16 @@
 	name = SLAVE
 	id = SLAVE
 
+/datum/role/slave/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_SLAVE_PERSON, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/slave/RemoveFromRole(datum/mind/M, msg_admins)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_SLAVE_PERSON, GAMEMODE_TRAIT)
+
 /datum/role/slave/proc/copy_variables(datum/role/master)
 	antag_hud_type = master.antag_hud_type
 	antag_hud_name = master.antag_hud_name

--- a/code/game/gamemodes/roles/slave.dm
+++ b/code/game/gamemodes/roles/slave.dm
@@ -2,11 +2,9 @@
 	name = SLAVE
 	id = SLAVE
 
-/datum/role/slave/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_SLAVE_PERSON, GAMEMODE_TRAIT)
-	return TRUE
+/datum/role/slave/OnPostSetup(laterole)
+	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_SLAVE_PERSON, GAMEMODE_TRAIT)
 
 /datum/role/slave/RemoveFromRole(datum/mind/M, msg_admins)
 	. = ..()

--- a/code/game/gamemodes/roles/strike_teams.dm
+++ b/code/game/gamemodes/roles/strike_teams.dm
@@ -8,12 +8,10 @@
 	antag_hud_name = "huddeathsquad"
 	skillset_type = /datum/skillset/max
 
-/datum/role/death_commando/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_DEATHSQUAD_MEMBER, GAMEMODE_TRAIT)
-	ADD_TRAIT(M.current, TRAIT_DEATHSQUAD_OP, GAMEMODE_TRAIT)
-	return TRUE
+/datum/role/death_commando/OnPostSetup(laterole)
+	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_DEATHSQUAD_MEMBER, GAMEMODE_TRAIT)
+	ADD_TRAIT(antag.current, TRAIT_DEATHSQUAD_OP, GAMEMODE_TRAIT)
 
 /datum/role/death_commando/RemoveFromRole(datum/mind/M, msg_admins)
 	. = ..()
@@ -30,12 +28,10 @@
 	antag_hud_name = "hudoperative"
 	skillset_type = /datum/skillset/max
 
-/datum/role/emergency_responder/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_STRIKE_TEAMMATE, GAMEMODE_TRAIT)
-	ADD_TRAIT(M.current, TRAIT_STRIKE_TEAM_MEMBER, GAMEMODE_TRAIT)
-	return TRUE
+/datum/role/emergency_responder/OnPostSetup(laterole)
+	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_STRIKE_TEAMMATE, GAMEMODE_TRAIT)
+	ADD_TRAIT(antag.current, TRAIT_STRIKE_TEAM_MEMBER, GAMEMODE_TRAIT)
 
 /datum/role/emergency_responder/RemoveFromRole(datum/mind/M, msg_admins)
 	. = ..()
@@ -52,12 +48,10 @@
 	antag_hud_name = "hudsyndicate"
 	skillset_type = /datum/skillset/max
 
-/datum/role/syndicate_elite_commando/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_ELITE_SQUAD_MEMBER, GAMEMODE_TRAIT)
-	ADD_TRAIT(M.current, TRAIT_ELITE_SQUAD_OP, GAMEMODE_TRAIT)
-	return TRUE
+/datum/role/syndicate_elite_commando/OnPostSetup(laterole)
+	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_ELITE_SQUAD_MEMBER, GAMEMODE_TRAIT)
+	ADD_TRAIT(antag.current, TRAIT_ELITE_SQUAD_OP, GAMEMODE_TRAIT)
 
 /datum/role/syndicate_elite_commando/RemoveFromRole(datum/mind/M, msg_admins)
 	. = ..()

--- a/code/game/gamemodes/roles/strike_teams.dm
+++ b/code/game/gamemodes/roles/strike_teams.dm
@@ -8,6 +8,18 @@
 	antag_hud_name = "huddeathsquad"
 	skillset_type = /datum/skillset/max
 
+/datum/role/death_commando/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_DEATHSQUAD_MEMBER, GAMEMODE_TRAIT)
+	ADD_TRAIT(M.current, TRAIT_DEATHSQUAD_OP, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/death_commando/RemoveFromRole(datum/mind/M, msg_admins)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_DEATHSQUAD_MEMBER, GAMEMODE_TRAIT)
+	REMOVE_TRAIT(M.current, TRAIT_DEATHSQUAD_OP, GAMEMODE_TRAIT)
+
 /datum/role/emergency_responder
 	name = RESPONDER
 	id = RESPONDER
@@ -18,6 +30,18 @@
 	antag_hud_name = "hudoperative"
 	skillset_type = /datum/skillset/max
 
+/datum/role/emergency_responder/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_STRIKE_TEAMMATE, GAMEMODE_TRAIT)
+	ADD_TRAIT(M.current, TRAIT_STRIKE_TEAM_MEMBER, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/emergency_responder/RemoveFromRole(datum/mind/M, msg_admins)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_STRIKE_TEAMMATE, GAMEMODE_TRAIT)
+	REMOVE_TRAIT(M.current, TRAIT_STRIKE_TEAM_MEMBER, GAMEMODE_TRAIT)
+
 /datum/role/syndicate_elite_commando
 	name = SYNDIESQUADIE
 	id = SYNDIESQUADIE
@@ -27,3 +51,15 @@
 	antag_hud_type = ANTAG_HUD_OPS
 	antag_hud_name = "hudsyndicate"
 	skillset_type = /datum/skillset/max
+
+/datum/role/syndicate_elite_commando/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_ELITE_SQUAD_MEMBER, GAMEMODE_TRAIT)
+	ADD_TRAIT(M.current, TRAIT_ELITE_SQUAD_OP, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/syndicate_elite_commando/RemoveFromRole(datum/mind/M, msg_admins)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_ELITE_SQUAD_MEMBER, GAMEMODE_TRAIT)
+	REMOVE_TRAIT(M.current, TRAIT_ELITE_SQUAD_OP, GAMEMODE_TRAIT)

--- a/code/game/gamemodes/roles/syndicate.dm
+++ b/code/game/gamemodes/roles/syndicate.dm
@@ -20,6 +20,18 @@
 	..()
 	AddComponent(/datum/component/gamemode/syndicate, TC_num, "nuclear")
 
+/datum/role/operative/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_NUKE_OP, GAMEMODE_TRAIT)
+	ADD_TRAIT(M.current, TRAIT_NUKE_TEAMSTRIKE_MEMBER, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/operative/RemoveFromRole(datum/mind/M, msg_admins)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_NUKE_OP, GAMEMODE_TRAIT)
+	REMOVE_TRAIT(M.current, TRAIT_NUKE_TEAMSTRIKE_MEMBER, GAMEMODE_TRAIT)
+
 /datum/role/operative/proc/NukeNameAssign(datum/mind/synd_mind)
 	var/choose_name = sanitize_safe(input(synd_mind.current, "You are a Gorlex Maradeurs agent! What is your name?", "Choose a name") as text, MAX_NAME_LEN)
 
@@ -77,6 +89,16 @@
 	skillset_type = /datum/skillset/nuclear_operative_leader
 
 	TC_num = 25
+
+/datum/role/operative/leader/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_NUKE_TEAMSTRIKE_LEADER, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/operative/leader/RemoveFromRole(datum/mind/M, msg_admins)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_NUKE_TEAMSTRIKE_LEADER, GAMEMODE_TRAIT)
 
 /datum/role/operative/leader/OnPostSetup(laterole)
 	. = ..()

--- a/code/game/gamemodes/roles/syndicate.dm
+++ b/code/game/gamemodes/roles/syndicate.dm
@@ -20,13 +20,6 @@
 	..()
 	AddComponent(/datum/component/gamemode/syndicate, TC_num, "nuclear")
 
-/datum/role/operative/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_NUKE_OP, GAMEMODE_TRAIT)
-	ADD_TRAIT(M.current, TRAIT_NUKE_TEAMSTRIKE_MEMBER, GAMEMODE_TRAIT)
-	return TRUE
-
 /datum/role/operative/RemoveFromRole(datum/mind/M, msg_admins)
 	. = ..()
 	REMOVE_TRAIT(M.current, TRAIT_NUKE_OP, GAMEMODE_TRAIT)
@@ -42,6 +35,8 @@
 	synd_mind.current.real_name = choose_name
 
 /datum/role/operative/OnPostSetup(laterole)
+	ADD_TRAIT(antag.current, TRAIT_NUKE_OP, GAMEMODE_TRAIT)
+	ADD_TRAIT(antag.current, TRAIT_NUKE_TEAMSTRIKE_MEMBER, GAMEMODE_TRAIT)
 	antag.current.faction = "syndicate"
 	antag.current.real_name = "Gorlex Maradeurs Operative"
 
@@ -90,18 +85,13 @@
 
 	TC_num = 25
 
-/datum/role/operative/leader/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_NUKE_TEAMSTRIKE_LEADER, GAMEMODE_TRAIT)
-	return TRUE
-
 /datum/role/operative/leader/RemoveFromRole(datum/mind/M, msg_admins)
 	. = ..()
 	REMOVE_TRAIT(M.current, TRAIT_NUKE_TEAMSTRIKE_LEADER, GAMEMODE_TRAIT)
 
 /datum/role/operative/leader/OnPostSetup(laterole)
 	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_NUKE_TEAMSTRIKE_LEADER, GAMEMODE_TRAIT)
 	var/datum/faction/nuclear/N = faction
 	if (istype(N) && N.nuke_code)
 		antag.store_memory("<B>Syndicate Nuclear Bomb Code</B>: [N.nuke_code]", 0)

--- a/code/game/gamemodes/roles/traitor.dm
+++ b/code/game/gamemodes/roles/traitor.dm
@@ -108,8 +108,27 @@
 		AI.aiRadio.keyslot1 = new /obj/item/device/encryptionkey()
 		AI.aiRadio.recalculateChannels()
 	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_SYNDICATE_AGENT, GAMEMODE_TRAIT)
+	REMOVE_TRAIT(M.current, TRAIT_SYNDICATE_TRAITOR, GAMEMODE_TRAIT)
+
+/datum/role/traitor/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_SYNDICATE_AGENT, GAMEMODE_TRAIT)
+	ADD_TRAIT(M.current, TRAIT_SYNDICATE_TRAITOR, GAMEMODE_TRAIT)
+	return TRUE
 
 /datum/role/traitor/wishgranter
+
+/datum/role/traitor/wishgranter/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_SYNDICATE_WISHGRANTED, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/traitor/wishgranter/RemoveFromRole(datum/mind/M, msg_admins)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_SYNDICATE_WISHGRANTED, GAMEMODE_TRAIT)
 
 /datum/role/traitor/wishgranter/forgeObjectives()
 	if(!..())
@@ -120,6 +139,16 @@
 
 /datum/role/traitor/syndbeacon
 
+/datum/role/traitor/syndbeacon/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_SYNDICATE_BEACONED, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/traitor/syndbeacon/RemoveFromRole(datum/mind/M, msg_admins)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_SYNDICATE_BEACONED, GAMEMODE_TRAIT)
+
 /datum/role/traitor/syndbeacon/forgeObjectives()
 	if(!..())
 		return FALSE
@@ -127,6 +156,16 @@
 	return TRUE
 
 /datum/role/traitor/syndcall
+
+/datum/role/traitor/syndcall/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_SYNDICATE_SLEEPER, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/traitor/syndcall/RemoveFromRole(datum/mind/M, msg_admins)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_SYNDICATE_SLEEPER, GAMEMODE_TRAIT)
 
 /datum/role/traitor/syndcall/Greet(greeting, custom)
 	..()

--- a/code/game/gamemodes/roles/traitor.dm
+++ b/code/game/gamemodes/roles/traitor.dm
@@ -98,6 +98,8 @@
 
 /datum/role/traitor/OnPostSetup(laterole)
 	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_SYNDICATE_AGENT, GAMEMODE_TRAIT)
+	ADD_TRAIT(antag.current, TRAIT_SYNDICATE_TRAITOR, GAMEMODE_TRAIT)
 	if(issilicon(antag.current))
 		add_law_zero(antag.current)
 
@@ -111,20 +113,11 @@
 	REMOVE_TRAIT(M.current, TRAIT_SYNDICATE_AGENT, GAMEMODE_TRAIT)
 	REMOVE_TRAIT(M.current, TRAIT_SYNDICATE_TRAITOR, GAMEMODE_TRAIT)
 
-/datum/role/traitor/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_SYNDICATE_AGENT, GAMEMODE_TRAIT)
-	ADD_TRAIT(M.current, TRAIT_SYNDICATE_TRAITOR, GAMEMODE_TRAIT)
-	return TRUE
-
 /datum/role/traitor/wishgranter
 
-/datum/role/traitor/wishgranter/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_SYNDICATE_WISHGRANTED, GAMEMODE_TRAIT)
-	return TRUE
+/datum/role/traitor/wishgranter/OnPostSetup(laterole)
+	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_SYNDICATE_WISHGRANTED, GAMEMODE_TRAIT)
 
 /datum/role/traitor/wishgranter/RemoveFromRole(datum/mind/M, msg_admins)
 	. = ..()
@@ -139,11 +132,9 @@
 
 /datum/role/traitor/syndbeacon
 
-/datum/role/traitor/syndbeacon/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_SYNDICATE_BEACONED, GAMEMODE_TRAIT)
-	return TRUE
+/datum/role/traitor/syndbeacon/OnPostSetup(laterole)
+	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_SYNDICATE_BEACONED, GAMEMODE_TRAIT)
 
 /datum/role/traitor/syndbeacon/RemoveFromRole(datum/mind/M, msg_admins)
 	. = ..()
@@ -157,12 +148,6 @@
 
 /datum/role/traitor/syndcall
 
-/datum/role/traitor/syndcall/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_SYNDICATE_SLEEPER, GAMEMODE_TRAIT)
-	return TRUE
-
 /datum/role/traitor/syndcall/RemoveFromRole(datum/mind/M, msg_admins)
 	. = ..()
 	REMOVE_TRAIT(M.current, TRAIT_SYNDICATE_SLEEPER, GAMEMODE_TRAIT)
@@ -173,5 +158,6 @@
 
 /datum/role/traitor/syndcall/OnPostSetup(laterole)
 	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_SYNDICATE_SLEEPER, GAMEMODE_TRAIT)
 	var/mob/living/carbon/human/H = antag.current
 	H.equip_or_collect(new /obj/item/device/encryptionkey/syndicate(antag.current), SLOT_R_STORE)

--- a/code/game/gamemodes/roles/traitorchan.dm
+++ b/code/game/gamemodes/roles/traitorchan.dm
@@ -9,3 +9,13 @@
 /datum/role/changeling/traitor/New()
 	..()
 	AddComponent(/datum/component/gamemode/syndicate, 20, "traitor")
+
+/datum/role/changeling/traitor/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_CHANGELING_SYNDICATE_AGENT, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/changeling/traitor/RemoveFromRole(datum/mind/M, msg_admins)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_CHANGELING_SYNDICATE_AGENT, GAMEMODE_TRAIT)

--- a/code/game/gamemodes/roles/traitorchan.dm
+++ b/code/game/gamemodes/roles/traitorchan.dm
@@ -10,11 +10,9 @@
 	..()
 	AddComponent(/datum/component/gamemode/syndicate, 20, "traitor")
 
-/datum/role/changeling/traitor/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_CHANGELING_SYNDICATE_AGENT, GAMEMODE_TRAIT)
-	return TRUE
+/datum/role/changeling/traitor/OnPostSetup(laterole)
+	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_CHANGELING_SYNDICATE_AGENT, GAMEMODE_TRAIT)
 
 /datum/role/changeling/traitor/RemoveFromRole(datum/mind/M, msg_admins)
 	. = ..()

--- a/code/game/gamemodes/roles/wizard.dm
+++ b/code/game/gamemodes/roles/wizard.dm
@@ -162,12 +162,12 @@
 /datum/role/wizard_apprentice/OnPostSetup(laterole)
 	. = ..()
 	ADD_TRAIT(antag.current, TRAIT_WIZARD_PARTY, GAMEMODE_TRAIT)
-	ADD_TRAIT(antag.current, TRAIT_WIZARD_APPERNTICE, GAMEMODE_TRAIT)
+	ADD_TRAIT(antag.current, TRAIT_WIZARD_APPERENTICE, GAMEMODE_TRAIT)
 
 /datum/role/wizard_apprentice/RemoveFromRole(datum/mind/M, msg_admins)
 	. = ..()
 	REMOVE_TRAIT(M.current, TRAIT_WIZARD_PARTY, GAMEMODE_TRAIT)
-	REMOVE_TRAIT(M.current, TRAIT_WIZARD_APPERNTICE, GAMEMODE_TRAIT)
+	REMOVE_TRAIT(M.current, TRAIT_WIZARD_APPERENTICE, GAMEMODE_TRAIT)
 
 /datum/role/wizard_apprentice/GetScoreboard()
 	. = ..()

--- a/code/game/gamemodes/roles/wizard.dm
+++ b/code/game/gamemodes/roles/wizard.dm
@@ -22,6 +22,15 @@
 /datum/role/wizard/RemoveFromRole(datum/mind/M, msg_admins)
 	. = ..()
 	M.current.ClearSpells()
+	REMOVE_TRAIT(M.current, TRAIT_WIZARD_PARTY, GAMEMODE_TRAIT)
+	REMOVE_TRAIT(M.current, TRAIT_WIZARD_MASTER, GAMEMODE_TRAIT)
+
+/datum/role/wizard/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_WIZARD_PARTY, GAMEMODE_TRAIT)
+	ADD_TRAIT(M.current, TRAIT_WIZARD_MASTER, GAMEMODE_TRAIT)
+	return TRUE
 
 /datum/role/wizard/proc/name_wizard(mob/living/carbon/human/wizard_mob)
 	var/wizard_name_first = pick(wizard_first)
@@ -154,6 +163,18 @@
 	antag_hud_name = "hudwizard"
 
 	logo_state = "wizard-logo"
+
+/datum/role/wizard_apprentice/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_WIZARD_PARTY, GAMEMODE_TRAIT)
+	ADD_TRAIT(M.current, TRAIT_WIZARD_APPERNTICE, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/wizard_apprentice/RemoveFromRole(datum/mind/M, msg_admins)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_WIZARD_PARTY, GAMEMODE_TRAIT)
+	REMOVE_TRAIT(M.current, TRAIT_WIZARD_APPERNTICE, GAMEMODE_TRAIT)
 
 /datum/role/wizard_apprentice/GetScoreboard()
 	. = ..()

--- a/code/game/gamemodes/roles/wizard.dm
+++ b/code/game/gamemodes/roles/wizard.dm
@@ -25,13 +25,6 @@
 	REMOVE_TRAIT(M.current, TRAIT_WIZARD_PARTY, GAMEMODE_TRAIT)
 	REMOVE_TRAIT(M.current, TRAIT_WIZARD_MASTER, GAMEMODE_TRAIT)
 
-/datum/role/wizard/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_WIZARD_PARTY, GAMEMODE_TRAIT)
-	ADD_TRAIT(M.current, TRAIT_WIZARD_MASTER, GAMEMODE_TRAIT)
-	return TRUE
-
 /datum/role/wizard/proc/name_wizard(mob/living/carbon/human/wizard_mob)
 	var/wizard_name_first = pick(wizard_first)
 	var/wizard_name_second = pick(wizard_second)
@@ -82,6 +75,8 @@
 
 /datum/role/wizard/OnPostSetup(laterole)
 	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_WIZARD_PARTY, GAMEMODE_TRAIT)
+	ADD_TRAIT(antag.current, TRAIT_WIZARD_MASTER, GAMEMODE_TRAIT)
 	equip_wizard(antag.current)
 	INVOKE_ASYNC(src, .proc/name_wizard, antag.current)
 
@@ -164,12 +159,10 @@
 
 	logo_state = "wizard-logo"
 
-/datum/role/wizard_apprentice/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_WIZARD_PARTY, GAMEMODE_TRAIT)
-	ADD_TRAIT(M.current, TRAIT_WIZARD_APPERNTICE, GAMEMODE_TRAIT)
-	return TRUE
+/datum/role/wizard_apprentice/OnPostSetup(laterole)
+	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_WIZARD_PARTY, GAMEMODE_TRAIT)
+	ADD_TRAIT(antag.current, TRAIT_WIZARD_APPERNTICE, GAMEMODE_TRAIT)
 
 /datum/role/wizard_apprentice/RemoveFromRole(datum/mind/M, msg_admins)
 	. = ..()

--- a/code/game/gamemodes/roles/zombie.dm
+++ b/code/game/gamemodes/roles/zombie.dm
@@ -7,11 +7,9 @@
 
 	logo_state = "zombie-logo"
 
-/datum/role/zombie/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
-	if(!..())
-		return FALSE
-	ADD_TRAIT(M.current, TRAIT_ZOMBIETIDE_MEMBER, GAMEMODE_TRAIT)
-	return TRUE
+/datum/role/zombie/OnPostSetup(laterole)
+	. = ..()
+	ADD_TRAIT(antag.current, TRAIT_ZOMBIETIDE_MEMBER, GAMEMODE_TRAIT)
 
 /datum/role/zombie/RemoveFromRole(datum/mind/M, msg_admins)
 	. = ..()

--- a/code/game/gamemodes/roles/zombie.dm
+++ b/code/game/gamemodes/roles/zombie.dm
@@ -7,6 +7,16 @@
 
 	logo_state = "zombie-logo"
 
+/datum/role/zombie/AssignToRole(datum/mind/M, override = FALSE, msg_admins = TRUE, laterole = TRUE)
+	if(!..())
+		return FALSE
+	ADD_TRAIT(M.current, TRAIT_ZOMBIETIDE_MEMBER, GAMEMODE_TRAIT)
+	return TRUE
+
+/datum/role/zombie/RemoveFromRole(datum/mind/M, msg_admins)
+	. = ..()
+	REMOVE_TRAIT(M.current, TRAIT_ZOMBIETIDE_MEMBER, GAMEMODE_TRAIT)
+
 /datum/role/zombie/Greet(greeting, custom)
 	. = ..()
 	to_chat(antag.current, "You are reanimated, mindless, decaying corpses with a hunger for human brains. Avoid plants.")

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -62,7 +62,7 @@
 
 	var/datum/faction/gang/gang_mode
 	if(user.mind)
-		var/datum/role/R = isanygangster(user)
+		var/datum/role/R = isrolebytype(/datum/role/gangster, user)
 		if(R && istype(R.faction, /datum/faction/gang))
 			gang_mode = R.faction
 

--- a/code/game/objects/items/weapons/fulton.dm
+++ b/code/game/objects/items/weapons/fulton.dm
@@ -153,14 +153,14 @@
 	return TRUE
 
 /obj/item/weapon/extraction_pack/dealer/try_use_fulton(atom/movable/target, mob/user)
-	if(!isgundealer(user))
+	if(!isrole(GANGSTER_DEALER, user))
 		return FALSE
 	if(isitem(target))
 		for(var/item in global.lowrisk_objectives_cache)
 			if(item != target.type)
 				continue
 			to_chat(user, "<span class='warning'>Этот предмет нужен одной из банд, мы не можем его принять.</span>")
-			return FALSE	
+			return FALSE
 	RegisterSignal(target, COMSIG_PARENT_QDELETING, CALLBACK(src, .proc/give_telecrystal, target.type, user))
 	if(!..())
 		UnregisterSignal(target, COMSIG_PARENT_QDELETING)
@@ -169,7 +169,7 @@
 
 /obj/item/weapon/extraction_pack/dealer/proc/give_telecrystal(atom/movable/target_type, mob/user)
 	sleep(10 SECONDS) // signals are called async
-	var/datum/role/traitor/dealer/is_traitor = isgundealer(user)
+	var/datum/role/traitor/dealer/is_traitor = isrole(GANGSTER_DEALER, user)
 	if(!is_traitor)
 		return
 	var/datum/component/gamemode/syndicate/S = is_traitor.GetComponent(/datum/component/gamemode/syndicate)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Добавлены трейты, которые выдаются ролями при спавне антагонистов. Переделана большая часть проверок на роли из истайпов на проверку трейтов. Попробовал сразу создать все комбинации доступные без щитспавна в игре в виде кучи трейтов. Не все из них используются, но в идеале как-то должны.
## Почему и что этот ПР улучшит
Код. Конкретный юз предполагает что можно будет выдать разные трейты одним и тем же ролям, а после на этом построить их особенности геймплея. Также возможен юз выдачей таких трейтов мобам без роли, чтобы те могли проходить проверки на роли и пользоваться некоторыми шмотками антагов не требуя выдачи роли.
## Авторство
Luduk
## Чеинжлог
