### PR TITLE
фиксы лон опса

### DIFF
--- a/code/datums/outfits/nuclear.dm
+++ b/code/datums/outfits/nuclear.dm
@@ -83,8 +83,7 @@
 	/obj/item/clothing/accessory/holster/armpit,
 	/obj/item/weapon/pinpointer/nukeop,
 	/obj/item/weapon/kitchenknife/combat,
-	/obj/item/clothing/accessory/storage/syndi_vest,
-	/obj/item/weapon/paper/nuclear_code)
+	/obj/item/clothing/accessory/storage/syndi_vest)
 
 /datum/outfit/nuclear/solo
 	name = "Syndicate: Lone Agent"

--- a/code/game/gamemodes/roles/syndicate.dm
+++ b/code/game/gamemodes/roles/syndicate.dm
@@ -99,6 +99,28 @@
 	nuclear_outfit = /datum/outfit/nuclear/solo
 	skillset_type = /datum/skillset/max
 
+/datum/role/operative/lone/OnPostSetup(laterole)
+	. = ..()
+	var/datum/objective/nuclear/N = objectives.FindObjective(/datum/objective/nuclear)
+	if(!N)
+		return
+
+	var/nukecode = "ERROR"
+	for(var/obj/machinery/nuclearbomb/bomb in poi_list)
+		if(!bomb.r_code)
+			continue
+		if(bomb.r_code == "LOLNO")
+			continue
+		if(bomb.r_code == "ADMIN")
+			continue
+		if(bomb.nuketype != "NT")
+			continue
+
+		nukecode = bomb.r_code
+
+	to_chat(antag.current, "<span class='bold notice'>Код от бомбы: [nukecode]</span>")
+	antag.current.mind.store_memory("Код от бомбы: [nukecode]")
+
 /datum/role/operative/lone/forgeObjectives()
 	if(!..())
 		return FALSE

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -227,6 +227,7 @@ ADD_TO_GLOBAL_LIST(/mob/living/simple_animal/mouse/brown/Tom, chief_animal_list)
 	icon_state = "mouse_nuke"
 	icon_living = "mouse_nuke"
 	icon_move = "mouse_nuke_move"
+	body_color = "nuke"
 	holder_type = /obj/item/weapon/holder/mouse/nuke
 
 	changes_color = FALSE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
фикс не отображения кода ядерки
теперь код известен только если цель на ядерку
мышь теперь не будет становиться невидимой когда адыхает
## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
:cl:
- tweak: Ядерный оперативник знает код, только если он должен взорвать станцию.