### PR TITLE
Issuing Insurance stocks to medics.

### DIFF
--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -84,7 +84,7 @@ SUBSYSTEM_DEF(economy)
 			charge_to_account(D.account_number, D.account_number, "Salary payment", "CentComm", D.owner_salary)
 
 	handle_insurances()
-	
+
 
 	monitor_cargo_shop()
 
@@ -128,9 +128,9 @@ SUBSYSTEM_DEF(economy)
 
 /datum/controller/subsystem/economy/proc/set_endtime()
 	endtime = world.timeofday + wait
-	
-	
-	
+
+
+
 /datum/controller/subsystem/economy/proc/handle_insurances()
 	var/insurance_sum = 0
 	var/list/problem_record_id = list()
@@ -153,7 +153,7 @@ SUBSYSTEM_DEF(economy)
 	if(insurance_sum > 0)
 		var/med_account_number = global.department_accounts["Medical"].account_number
 		charge_to_account(med_account_number, med_account_number, "Insurance", "NT Insurance", insurance_sum)
-	
+
 	if(problem_record_id.len)
 		send_message_about_problem_insurances(problem_record_id)
 

--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -149,7 +149,7 @@ SUBSYSTEM_DEF(economy)
 			R.fields["insurance_type"] = INSURANCE_NONE
 			problem_record_id.Add(R.fields["id"])
 			continue
-		var/insurance_type = get_next_insurance_type(current_insurance_type = R.fields["insurance_type"], MA)
+		var/insurance_type = get_next_insurance_type(R.fields["insurance_type"], MA)
 		var/insurance_price = SSeconomy.insurance_prices[insurance_type]
 		R.fields["insurance_type"] = insurance_type
 		if(insurance_price == 0)

--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -104,9 +104,16 @@ SUBSYSTEM_DEF(economy)
 
 	for(var/department in total_department_stocks)
 		var/datum/money_account/DA = global.department_accounts[department]
+		if(DA.suspended)
+			capitals[department] = 0.0
+			continue
+
 		capitals[department] = DA.money
 
 	for(var/datum/money_account/D in all_money_accounts)
+		if(D.suspended)
+			continue
+
 		var/total_dividend_payout = 0.0
 		for(var/department in D.stocks)
 			// Don't pay stocks to ourselves, less transaction spam.
@@ -142,7 +149,7 @@ SUBSYSTEM_DEF(economy)
 			R.fields["insurance_type"] = INSURANCE_NONE
 			problem_record_id.Add(R.fields["id"])
 			continue
-		var/insurance_type = get_next_insurance_type(current_insurance_type = R.fields["insurance_type"], preferred_insurance_type = MA.owner_preferred_insurance_type, money = MA.money, max_insurance_payment = MA.owner_max_insurance_payment)
+		var/insurance_type = get_next_insurance_type(current_insurance_type = R.fields["insurance_type"], MA)
 		var/insurance_price = SSeconomy.insurance_prices[insurance_type]
 		R.fields["insurance_type"] = insurance_type
 		if(insurance_price == 0)
@@ -164,18 +171,21 @@ SUBSYSTEM_DEF(economy)
 	return R.fields["insurance_type"]
 
 
-/proc/get_next_insurance_type(current_insurance_type, preferred_insurance_type, money, max_insurance_payment)
+/proc/get_next_insurance_type(current_insurance_type, datum/money_account/MA)
+	if(MA.suspended)
+		return INSURANCE_NONE
+
 	var/current_insurance_price = SSeconomy.insurance_prices[current_insurance_type]
-	if(current_insurance_type == preferred_insurance_type && money >= current_insurance_price  && max_insurance_payment >= current_insurance_price)
+	if(current_insurance_type == MA.owner_preferred_insurance_type && MA.money >= current_insurance_price  && MA.owner_max_insurance_payment >= current_insurance_price)
 		return current_insurance_type
 
-	var/prefprice = SSeconomy.insurance_prices[preferred_insurance_type]
-	if(money >= prefprice && max_insurance_payment >= prefprice)
-		return preferred_insurance_type
+	var/prefprice = SSeconomy.insurance_prices[MA.owner_preferred_insurance_type]
+	if(MA.money >= prefprice && MA.owner_max_insurance_payment >= prefprice)
+		return MA.owner_preferred_insurance_type
 
 	for(var/insurance_type in SSeconomy.insurance_quality_decreasing)
 		var/insprice = SSeconomy.insurance_prices[insurance_type]
-		if(money >= insprice && max_insurance_payment >= insprice)
+		if(MA.money >= insprice && MA.owner_max_insurance_payment >= insprice)
 			return insurance_type
 
 

--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -590,7 +590,7 @@ SUBSYSTEM_DEF(job)
 				MA.owner_preferred_insurance_type = job.is_head ? SSeconomy.insurance_quality_decreasing[1] : H.roundstart_insurance
 				MA.owner_max_insurance_payment = SSeconomy.insurance_prices[H.roundstart_insurance]
 
-				var/insurance_type = get_next_insurance_type(current_insurance_type = H.roundstart_insurance, preferred_insurance_type = H.roundstart_insurance, money = MA.money, max_insurance_payment = MA.owner_max_insurance_payment)
+				var/insurance_type = get_next_insurance_type(H.roundstart_insurance, MA)
 				H.roundstart_insurance = insurance_type
 
 				var/med_account_number = global.department_accounts["Medical"].account_number

--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -587,10 +587,12 @@ SUBSYSTEM_DEF(job)
 			if(MA)
 				C.associated_account_number = MA.account_number
 				MA.set_salary(job.salary, job.salary_ratio)	//set the salary equal to job
-				MA.owner_preferred_insurance_type = H.roundstart_insurance
+				MA.owner_preferred_insurance_type = job.is_head ? SSeconomy.insurance_quality_decreasing[1] : H.roundstart_insurance
 				MA.owner_max_insurance_payment = SSeconomy.insurance_prices[H.roundstart_insurance]
+
 				var/insurance_type = get_next_insurance_type(current_insurance_type = H.roundstart_insurance, preferred_insurance_type = H.roundstart_insurance, money = MA.money, max_insurance_payment = MA.owner_max_insurance_payment)
 				H.roundstart_insurance = insurance_type
+
 				var/med_account_number = global.department_accounts["Medical"].account_number
 				var/insurance_price = SSeconomy.insurance_prices[insurance_type]
 				charge_to_account(med_account_number, med_account_number, "[insurance_type] Insurance payment", "NT Insurance", insurance_price)

--- a/code/datums/qualities/positiveish.dm
+++ b/code/datums/qualities/positiveish.dm
@@ -362,3 +362,4 @@
 	if(!MA)
 		return
 	SSeconomy.issue_founding_stock(MA.account_number, "Cargo", rand(10, 20))
+	SSeconomy.issue_founding_stock(MA.account_number, "Medical", rand(10, 20))

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -9,6 +9,7 @@
 	selection_color = "#ccccff"
 	idtype = /obj/item/weapon/card/id/gold
 	req_admin_notify = 1
+	is_head = TRUE
 	access = list() 			//See get_access()
 	salary = 300
 	minimal_player_age = 14
@@ -39,6 +40,7 @@
 	selection_color = "#ddddff"
 	idtype = /obj/item/weapon/card/id/silver
 	req_admin_notify = 1
+	is_head = TRUE
 	salary = 250
 	minimal_player_age = 10
 	minimal_player_ingame_minutes = 2400

--- a/code/game/jobs/job/engineering.dm
+++ b/code/game/jobs/job/engineering.dm
@@ -9,6 +9,7 @@
 	selection_color = "#ffeeaa"
 	idtype = /obj/item/weapon/card/id/engGold
 	req_admin_notify = 1
+	is_head = TRUE
 	access = list(
 		access_engine, access_engine_equip, access_tech_storage, access_maint_tunnels,
 		access_teleporter, access_external_airlocks, access_atmospherics, access_emergency_storage, access_eva,

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -35,6 +35,9 @@
 	//If this is set to 1, a text is printed to the player when jobs are assigned, telling him that he should let admins know that he has to disconnect.
 	var/req_admin_notify
 
+	// Is this position of a Head of some department? They always start with max level insurance.
+	var/is_head = FALSE
+
 	//If you have use_age_restriction_for_jobs config option enabled and the database set up, this option will add a requirement for players to be at least minimal_player_age days old. (meaning they first signed in at least that many days before.)
 	var/minimal_player_age = 0
 

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -9,6 +9,7 @@
 	selection_color = "#ffddf0"
 	idtype = /obj/item/weapon/card/id/medGold
 	req_admin_notify = 1
+	is_head = TRUE
 	access = list(
 		access_medical, access_morgue, access_paramedic, access_genetics, access_heads,
 		access_chemistry, access_virology, access_cmo, access_surgery, access_RC_announce,

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -28,6 +28,8 @@
 	*/
 	restricted_species = list(UNATHI, TAJARAN, VOX, DIONA)
 
+	department_stocks = list("Medical" = 40)
+
 
 /datum/job/doctor
 	title = "Medical Doctor"
@@ -60,6 +62,8 @@
 	*/
 	restricted_species = list(UNATHI, TAJARAN, DIONA)
 
+	department_stocks = list("Medical" = 20)
+
 
 /datum/job/paramedic
 	title = "Paramedic"
@@ -84,6 +88,8 @@
 	*/
 	restricted_species = list(IPC)
 
+	department_stocks = list("Medical" = 15)
+
 // Slow species shouldn't be paramedics.
 /datum/job/paramedic/special_species_check(datum/species/S)
 	return S.speed_mod <= 1
@@ -107,6 +113,8 @@
 	outfit = /datum/outfit/job/chemist
 	skillsets = list("Chemist" = /datum/skillset/chemist)
 
+	department_stocks = list("Medical" = 10)
+
 
 /datum/job/geneticist
 	title = "Geneticist"
@@ -123,6 +131,8 @@
 	minimal_player_ingame_minutes = 960
 	outfit = /datum/outfit/job/geneticist
 	skillsets = list("Geneticist" = /datum/skillset/geneticist)
+
+	department_stocks = list("Medical" = 10)
 
 
 /datum/job/virologist
@@ -149,6 +159,8 @@
 	*/
 	restricted_species = list(UNATHI, TAJARAN, DIONA)
 
+	department_stocks = list("Medical" = 10)
+
 
 /datum/job/psychiatrist
 	title = "Psychiatrist"
@@ -167,6 +179,8 @@
 	outfit = /datum/outfit/job/psychiatrist
 	skillsets = list("Psychiatrist" = /datum/skillset/psychiatrist)
 
+	department_stocks = list("Medical" = 10)
+
 
 /datum/job/intern
 	title = "Medical Intern"
@@ -183,3 +197,4 @@
 	outfit = /datum/outfit/job/intern
 	skillsets = list("Medical Intern" = /datum/skillset/intern)
 
+	department_stocks = list("Medical" = 5)

--- a/code/game/jobs/job/science.dm
+++ b/code/game/jobs/job/science.dm
@@ -9,6 +9,7 @@
 	selection_color = "#ffddff"
 	idtype = /obj/item/weapon/card/id/sciGold
 	req_admin_notify = 1
+	is_head = TRUE
 	access = list(
 		access_rd, access_heads, access_tox, access_genetics, access_morgue,
 		access_tox_storage, access_teleporter, access_sec_doors, access_minisat,

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -9,6 +9,7 @@
 	selection_color = "#ffdddd"
 	idtype = /obj/item/weapon/card/id/secGold
 	req_admin_notify = 1
+	is_head = TRUE
 	access = list(
 		access_security, access_sec_doors, access_brig, access_armory,
 		access_forensics_lockers, access_morgue, access_maint_tunnels, access_all_personal_lockers,

--- a/code/modules/economy/ATM.dm
+++ b/code/modules/economy/ATM.dm
@@ -231,7 +231,7 @@ log transactions
 							dat += "<input type='hidden' name='src' value='\ref[src]'>"
 							dat += "<input type='hidden' name='choice' value='change_max_insurance_payment'>"
 							dat += "<input type='text' name='new_max_insurance_payment' value='[authenticated_account.owner_max_insurance_payment]' style='width:150px; background-color:white;'><input type='submit' value='Change max insurance payment'>"
-							dat += "</form><br><br>"	
+							dat += "</form><br><br>"
 
 
 							var/time_addition = round((SSeconomy.endtime - world.timeofday) / 600) * 10
@@ -503,7 +503,7 @@ log transactions
 
 			if("change_preferred_insurance")
 				if(!authenticated_account)
-					return		
+					return
 
 				var/insurance_type = href_list["insurance_type"]
 				var/insurance_price = text2num(href_list["insurance_price"])
@@ -511,7 +511,7 @@ log transactions
 					tgui_alert(usr, "Price of this insurance was changed. Press \"Refresh\" and try again.")
 					return
 
-				authenticated_account.owner_preferred_insurance_type = insurance_type			
+				authenticated_account.owner_preferred_insurance_type = insurance_type
 				authenticated_account.owner_max_insurance_payment = max(insurance_price, authenticated_account.owner_max_insurance_payment)
 
 			if("change_max_insurance_payment")

--- a/code/modules/economy/economy_misc.dm
+++ b/code/modules/economy/economy_misc.dm
@@ -112,6 +112,10 @@ var/global/initial_station_money = 7500
 	SSeconomy.set_dividend_rate("Cargo", 0.1)
 	// Enough stock to supply 2 cargos of employees with it. TO-DO: calculate it programatically depending on map changes to jobs?
 	SSeconomy.issue_founding_stock(cargo_account.account_number, "Cargo", 260)
+	// Pay out the insurance to everyone completely.
+	SSeconomy.set_dividend_rate("Medical", 1.0)
+	// Enoguh stock to supply 2 medbay employees. See comment above.
+	SSeconomy.issue_founding_stock(cargo_account.account_number, "Medical", 410)
 
 	current_date_string = "[num2text(rand(1,31))] [pick("January","February","March","April","May","June","July","August","September","October","November","December")], [game_year]"
 
@@ -131,6 +135,7 @@ var/global/initial_station_money = 7500
 	global.centcomm_account.hidden = TRUE
 	// Is needed in case admins want to have some !!!FUN!!!
 	SSeconomy.issue_founding_stock(global.centcomm_account.account_number, "Cargo", 10)
+	SSeconomy.issue_founding_stock(global.centcomm_account.account_number, "Medical", 10)
 
 	//create an entry in the account transaction log for when it was created
 	var/datum/transaction/T = new()
@@ -156,6 +161,7 @@ var/global/initial_station_money = 7500
 	station_account.money = global.initial_station_money
 	// Station gets a slight rebound on all cargo activity from stock ownership. In theory HoP or Captain can also sell this.
 	SSeconomy.issue_founding_stock(station_account.account_number, "Cargo", 10)
+	SSeconomy.issue_founding_stock(global.centcomm_account.account_number, "Medical", 10)
 
 	//create an entry in the account transaction log for when it was created
 	var/datum/transaction/T = new()

--- a/code/modules/economy/economy_misc.dm
+++ b/code/modules/economy/economy_misc.dm
@@ -115,7 +115,7 @@ var/global/initial_station_money = 7500
 	// Pay out the insurance to everyone completely.
 	SSeconomy.set_dividend_rate("Medical", 1.0)
 	// Enoguh stock to supply 2 medbay employees. See comment above.
-	SSeconomy.issue_founding_stock(cargo_account.account_number, "Medical", 410)
+	SSeconomy.issue_founding_stock(global.department_accounts["Medical"], "Medical", 410)
 
 	current_date_string = "[num2text(rand(1,31))] [pick("January","February","March","April","May","June","July","August","September","October","November","December")], [game_year]"
 
@@ -161,7 +161,7 @@ var/global/initial_station_money = 7500
 	station_account.money = global.initial_station_money
 	// Station gets a slight rebound on all cargo activity from stock ownership. In theory HoP or Captain can also sell this.
 	SSeconomy.issue_founding_stock(station_account.account_number, "Cargo", 10)
-	SSeconomy.issue_founding_stock(global.centcomm_account.account_number, "Medical", 10)
+	SSeconomy.issue_founding_stock(station_account.account_number, "Medical", 10)
 
 	//create an entry in the account transaction log for when it was created
 	var/datum/transaction/T = new()


### PR DESCRIPTION
## Описание изменений

Медбей получает деньги от выплаченной им страховки.

100% денег на счету медбея распыляется между медиками каждых 15 минут.

При 80 игроках онлайна, если подразумевать что у всех дефолтная страховка в 10 кредитов это 800 кредитов распыленные на 635 акции:
- 205 акций у экипажа в медбее
- 410 акций на счету медбея для найма дополнительных сотрудников
- 10 акций на счету станции
- 10 акций на счету ЦК

Медик за акцию будет получать условных 1.2 кредита, то есть
СМО (40 акций) - 48 кредитов (почти 2 рамена)
Врачи - 24 кредита
Парамедик - 18 кредитов
Все остальные - 12 кредитов
Интерны - 6 кредитов

Если у людей будет отключена страховка, или включен премиум соответственно рассчёт чутка меняется, но ориентировочно суммы выше. Чем больше людей на станции тем больше выплата.

Зарплаты медикам пока не менял потому-что ну и что что у них больше денег куда они их потратят...

Кроме того, главы теперь всегда начинают с максимально возможно дорогой страховкой.

Ну и пофиксил что замороженные аккаунты могли платить за страховку и получать дивиденды.

## Почему и что этот ПР улучшит

Явная заинтерисованность медиков в том чтобы у игрока была включена страховка при том что она ни на что иное игромеханически не влияет, а медик может все равно лечить игроков без неё.

## Чеинжлог
:cl: Luduk
- rscadd: Медики получили акции приносящие деньги со страховок которые платит экипаж.
- tweak: Главы всегда стартуют с Премиальной страховкой независимо от префов.
- bugfix: Замороженные счета не могут получать дивиденды и платить за страховку.