### PR TITLE
automatic onlineshop package coloring

### DIFF
--- a/code/modules/cargo/shop.dm
+++ b/code/modules/cargo/shop.dm
@@ -138,12 +138,27 @@ var/global/online_shop_profits = 0
 		if(istype(Console, /obj/machinery/computer/cargo/request))
 			continue
 
+		var/static/list/category2color = list(
+			"Еда" = "orange",
+			"Одежда" = "green",
+			"Устройства" = "purple",
+			"Инструменты" = "red",
+			"Ресурсы" = "blue",
+			"Наборы" = "yellow",
+			// "Разное" = no colour,
+		)
+
+		var/color_string = ""
+		if(category2color[Lot.category])
+			color_string = " ([category2color[Lot.category]])"
+
 		var/obj/item/weapon/paper/P = new(get_turf(Console.loc))
 
 		P.name = "Заказ предмета №[Lot.number] из магазина"
 		P.info += "Посылка номер №[Lot.number]<br>"
 		P.info += "Наименование: [Lot.name]<br>"
 		P.info += "Цена: [Lot.price]$<br>"
+		P.info += "Категория: [Lot.category][color_string]<br>"
 		P.info += "Время заказа: [worldtime2text()]<br>"
 		P.info += "Заказал: [orderer_name ? orderer_name : "Unknown"]<br>"
 		P.info += "Подпись заказчика: <span class=\"sign_field\"></span><br>"

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -1122,6 +1122,19 @@
 	var/market_price = export_item_and_contents(Item, FALSE, FALSE, dry_run=TRUE)
 	var/datum/shop_lot/Lot = new /datum/shop_lot(lot_name, lot_desc, lot_price, lot_category, lot_account, item_icon, "[REF(Item)]", market_price)
 
+	var/static/list/category2color = list(
+		"Еда" = "#ff9300",
+		"Одежда" = "#a8e61d",
+		"Устройства" = "#da00ff",
+		"Инструменты" = "#da0000",
+		"Ресурсы" = "#00b7ef",
+		"Наборы" = "#fff200",
+		// "Разное" = no colour,
+	)
+
+	if(category2color[lot_category])
+		Item.color = category2color[lot_category]
+
 	global.shop_categories[lot_category]++
 
 	Item.name = "Посылка номер: [global.online_shop_number]"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Изначально я надеялся что выдумывание системы раскраски посылок будет часть мем геймплея грузчиков по сортировке оных. Но времени на станции чтобы утвердить стандарт раскраски нету, поэтому он будет кодифицирован и частично автоматизирован.

Посылки прилетевшие по той или иной категории магазина будут получать соответствующей категории цвет выбранный мной, дальтоником, по принципу левой пятки.

В бумажке заказа будет указана категория товара, и соответствующе цвет, чтобы грузчики привыкали к нему.

![image](https://github.com/TauCetiStation/TauCetiClassic/assets/17705613/82235c8c-9c0a-4eb3-8e33-a9116ef42833)

## Почему и что этот ПР улучшит

Грузчики быстрее смогут доставать нужные посылки потому-что они посортированны по цветам. При этом сортировка и расскладывание посылок всё ещё скилл который они должны проявлять..

Если бы ещё на самой посылке писался её номер ух...

## Чеинжлог
:cl: Luduk
- rscadd: ГрузТорг труба автоматически расскрашивает посылки в зависимости от категории товара.