### PR TITLE
Delta Map Edit. Update Floor Tiles

### DIFF
--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -18,7 +18,10 @@
 	dir = 8;
 	name = "Unfiltered & Air to Mix"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "green"
+	},
 /area/station/engineering/atmos)
 "aam" = (
 /obj/structure/stool/bed/chair/comfy/brown{
@@ -27,7 +30,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "redyellowfull"
+	},
 /area/station/civilian/bar)
 "aaq" = (
 /obj/structure/flora/rock/jungle,
@@ -242,7 +247,10 @@
 "abN" = (
 /obj/structure/table,
 /obj/item/weapon/storage/box,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "abO" = (
 /obj/machinery/computer/security/mining,
@@ -261,7 +269,8 @@
 	pixel_y = -30
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 6;
+	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
 "abU" = (
@@ -292,20 +301,28 @@
 	pixel_y = 16;
 	req_access = list(24)
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/chiefs_office)
 "acf" = (
 /obj/effect/landmark/start/assistant,
 /obj/structure/stool/bed/chair/metal/black{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/hallway/secondary/entry)
 "ach" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
 /area/station/rnd/xenobiology)
 "acj" = (
 /obj/structure/table/glass,
@@ -352,7 +369,10 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 8;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/portsolar)
 "acz" = (
 /obj/structure/cable{
@@ -378,8 +398,7 @@
 "acH" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/security/interrogation)
 "acL" = (
@@ -427,6 +446,13 @@
 	icon_state = "red"
 	},
 /area/station/security/main)
+"acP" = (
+/obj/structure/table,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "bluecorner"
+	},
+/area/station/maintenance/chapel)
 "acR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/dresser,
@@ -510,7 +536,7 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "whitebluefull"
+	icon_state = "bluefull"
 	},
 /area/station/medical/reception)
 "ado" = (
@@ -542,7 +568,8 @@
 "adw" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/simulated/floor{
-	icon_state = "bot"
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/station/engineering/monitoring)
 "adB" = (
@@ -591,8 +618,8 @@
 "adG" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "warningcorner"
+	dir = 9;
+	icon_state = "red"
 	},
 /area/station/security/brig)
 "adH" = (
@@ -713,7 +740,8 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "warndark"
 	},
 /area/station/security/armoury)
 "ael" = (
@@ -766,7 +794,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "orange"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "aeC" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -822,7 +853,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor{
-	icon_state = "bot"
+	icon_state = "delivery"
 	},
 /area/station/engineering/engine)
 "aeZ" = (
@@ -856,7 +887,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitebluefull"
 	},
 /area/station/medical/hallway)
 "afj" = (
@@ -980,7 +1011,7 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "bar"
+	icon_state = "redyellowfull"
 	},
 /area/station/rnd/scibreak)
 "agS" = (
@@ -1009,6 +1040,26 @@
 	icon_state = "grimy"
 	},
 /area/station/tcommsat/computer)
+"ahh" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "whiteblue"
+	},
+/area/station/medical/hallway)
 "ahi" = (
 /obj/item/cardboard_cutout,
 /obj/structure/sign/poster/contraband/tools{
@@ -1027,7 +1078,9 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "ahz" = (
 /obj/machinery/alarm{
@@ -1096,7 +1149,8 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/engineering/atmos)
 "ahV" = (
@@ -1118,6 +1172,15 @@
 /obj/item/weapon/storage/box/lights/tubes,
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"aip" = (
+/obj/structure/stool/bed/chair{
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
+/area/station/civilian/dormitories)
 "air" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1185,7 +1248,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "whitepurplefull"
+	},
 /area/station/rnd/hallway)
 "ajk" = (
 /obj/structure/table,
@@ -1282,8 +1347,7 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "escape"
+	icon_state = "redchecker"
 	},
 /area/station/civilian/kitchen)
 "ajM" = (
@@ -1406,7 +1470,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/station/medical/storage)
 "alz" = (
 /obj/machinery/door/firedoor,
@@ -1429,13 +1496,15 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "brown"
+	},
 /area/station/cargo/qm)
 "alT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "red"
+	icon_state = "redyellowfull"
 	},
 /area/station/civilian/bar)
 "amg" = (
@@ -1496,7 +1565,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whitebluecorner"
 	},
 /area/station/medical/hallway)
 "amY" = (
@@ -1575,7 +1645,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
-	icon_state = "escape"
+	icon_state = "redchecker"
 	},
 /area/station/civilian/kitchen)
 "anp" = (
@@ -1613,7 +1683,10 @@
 /obj/machinery/light/smart{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/engineering/atmos)
 "anG" = (
 /obj/machinery/door/firedoor,
@@ -1699,6 +1772,22 @@
 	icon_state = "red"
 	},
 /area/station/security/warden)
+"aoy" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
+/area/station/maintenance/chapel)
 "aoM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -1756,7 +1845,9 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "warning"
+	},
 /area/station/engineering/atmos)
 "apq" = (
 /obj/machinery/door/firedoor,
@@ -1787,7 +1878,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
 "apV" = (
 /turf/simulated/floor/carpet/blue2,
@@ -1851,7 +1942,10 @@
 /area/station/rnd/hallway)
 "aqn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 10;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/chapel)
 "aqx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1870,7 +1964,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "aqy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1898,7 +1992,10 @@
 /area/station/hallway/primary/port)
 "aqI" = (
 /obj/item/weapon/flora/random,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/security/hos)
 "aqK" = (
 /obj/machinery/door/firedoor,
@@ -1921,7 +2018,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/maintenance/engineering)
 "are" = (
 /obj/structure/table/reinforced,
@@ -1937,7 +2036,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "warning"
+	},
 /area/station/maintenance/chapel)
 "arm" = (
 /obj/structure/sign/nanotrasen{
@@ -1996,7 +2098,8 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "warndark"
 	},
 /area/station/rnd/tox_launch)
 "asq" = (
@@ -2073,7 +2176,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "ati" = (
 /obj/effect/landmark/start/paramedic,
@@ -2108,7 +2214,8 @@
 /area/station/maintenance/engineering)
 "atv" = (
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/civilian/chapel)
 "aty" = (
@@ -2152,6 +2259,25 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/lab)
+"atN" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "whitepurplefull"
+	},
+/area/station/rnd/hallway)
 "atS" = (
 /obj/machinery/computer/cargo/request,
 /obj/structure/cable{
@@ -2168,7 +2294,10 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 1;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/portsolar)
 "auc" = (
 /obj/machinery/door/firedoor,
@@ -2327,7 +2456,10 @@
 /area/station/security/warden)
 "awS" = (
 /obj/machinery/light/smart,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
 /area/station/engineering/engine)
 "awU" = (
 /turf/simulated/floor{
@@ -2359,6 +2491,12 @@
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
+"axy" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "whitehall"
+	},
+/area/station/rnd/hallway)
 "axI" = (
 /obj/machinery/camera{
 	c_tag = "Mining Shuttle Dock";
@@ -2420,7 +2558,8 @@
 /obj/item/clothing/suit/bio_suit/particle_protection,
 /obj/item/clothing/head/bio_hood/particle_protection,
 /turf/simulated/floor{
-	icon_state = "delivery"
+	dir = 4;
+	icon_state = "yellow"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "ayO" = (
@@ -2466,7 +2605,9 @@
 /obj/machinery/computer/monitor{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
 /area/station/maintenance/chapel)
 "azQ" = (
 /obj/machinery/atmospherics/components/binary/pump/on,
@@ -2482,6 +2623,17 @@
 	icon_state = "red"
 	},
 /area/station/cargo/office)
+"azT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "yellowfull"
+	},
+/area/station/engineering/engine)
 "azV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -2493,8 +2645,7 @@
 "aAi" = (
 /obj/structure/table,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/hallway/primary/fore)
 "aAn" = (
@@ -2511,7 +2662,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "aAt" = (
 /obj/structure/cable{
@@ -2576,7 +2729,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "red"
+	},
 /area/station/hallway/secondary/exit)
 "aAP" = (
 /obj/structure/cable{
@@ -2634,7 +2790,10 @@
 	dir = 4;
 	pixel_x = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
 /area/station/rnd/xenobiology)
 "aBb" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -2662,19 +2821,24 @@
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/engineering/atmos)
 "aBx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "aBG" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/stamp/ce,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/chiefs_office)
 "aBJ" = (
 /turf/simulated/floor{
@@ -2836,7 +3000,9 @@
 	name = "Library Museum";
 	req_access = list(37)
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/civilian/library)
 "aEB" = (
 /obj/machinery/computer/security/telescreen{
@@ -2861,7 +3027,10 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
 /area/station/cargo/storage)
 "aEE" = (
 /obj/structure/cable{
@@ -2937,7 +3106,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whitebluecorner"
 	},
 /area/station/medical/hallway)
 "aFa" = (
@@ -2973,7 +3143,7 @@
 /obj/structure/table,
 /obj/item/trash/raisins,
 /turf/simulated/floor{
-	icon_state = "redyellowfull"
+	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
 "aFR" = (
@@ -3076,7 +3246,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "aGL" = (
 /turf/simulated/wall,
@@ -3163,7 +3336,9 @@
 	name = "Station Intercom (Security)";
 	pixel_y = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/security/brig)
 "aHT" = (
 /obj/structure/cable{
@@ -3206,7 +3381,10 @@
 "aIv" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/atmospherics/pipe/simple/visible/green,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/engineering/atmos)
 "aID" = (
 /obj/machinery/door/window/eastleft{
@@ -3221,6 +3399,15 @@
 "aIJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor,
+/area/station/engineering/atmos)
+"aIO" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/engineering/atmos)
 "aIW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3249,14 +3436,18 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
+	dir = 8;
+	icon_state = "warndark"
 	},
 /area/station/rnd/xenobiology)
 "aJo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/simulated/floor,
-/area/station/civilian/dormitories)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
+/area/station/civilian/gym)
 "aJp" = (
 /obj/machinery/cell_charger,
 /obj/structure/table/woodentable,
@@ -3266,8 +3457,7 @@
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/briefcase,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/maintenance/chapel)
 "aJG" = (
@@ -3423,8 +3613,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
+	dir = 9;
+	icon_state = "warndark"
 	},
 /area/station/rnd/xenobiology)
 "aMp" = (
@@ -3554,7 +3744,8 @@
 /obj/structure/morgue,
 /obj/machinery/light/smart,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/medical/morgue)
 "aOc" = (
@@ -3580,6 +3771,12 @@
 /obj/structure/plasticflaps/mining,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
+"aOp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
+/area/station/civilian/dormitories)
 "aOw" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -3590,6 +3787,19 @@
 	icon_state = "vault"
 	},
 /area/station/civilian/dormitories)
+"aOG" = (
+/obj/structure/table,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warndark"
+	},
+/area/station/rnd/tox_launch)
+"aOO" = (
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "warning"
+	},
+/area/station/cargo/storage)
 "aPm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -3623,8 +3833,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/hallway/secondary/entry)
 "aPN" = (
@@ -3717,7 +3926,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "aRb" = (
 /turf/simulated/floor{
@@ -3789,8 +4000,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "escape"
+	icon_state = "redchecker"
 	},
 /area/station/civilian/kitchen)
 "aRP" = (
@@ -3810,7 +4020,9 @@
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
 /area/station/storage/tools)
 "aRY" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -3857,7 +4069,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	icon_state = "bar"
+	dir = 9;
+	icon_state = "bluered"
 	},
 /area/station/medical/medbreak)
 "aSP" = (
@@ -3921,6 +4134,12 @@
 	icon_state = "white"
 	},
 /area/station/rnd/hallway)
+"aTU" = (
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "warning"
+	},
+/area/station/maintenance/chapel)
 "aTZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3935,6 +4154,11 @@
 	icon_state = "red"
 	},
 /area/station/security/main)
+"aUg" = (
+/turf/simulated/floor{
+	icon_state = "browncorner"
+	},
+/area/station/cargo/storage)
 "aUh" = (
 /obj/structure/table,
 /obj/item/weapon/scalpel,
@@ -3954,7 +4178,10 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warningcorner"
+	},
 /area/station/maintenance/chapel)
 "aUp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -3964,13 +4191,20 @@
 	icon_state = "dark"
 	},
 /area/station/aisat/ai_chamber)
+"aUs" = (
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "warning"
+	},
+/area/station/cargo/storage)
 "aUA" = (
 /obj/structure/morgue,
 /obj/machinery/light/smart{
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/civilian/chapel/mass_driver)
 "aUN" = (
@@ -3998,7 +4232,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/maintenance/atmos)
 "aVf" = (
 /obj/structure/cable{
@@ -4012,7 +4248,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitepurplefull"
 	},
 /area/station/rnd/hallway)
 "aVg" = (
@@ -4033,7 +4269,9 @@
 	pixel_x = -28;
 	pixel_y = -5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
 /area/station/engineering/engine)
 "aVD" = (
 /obj/item/target,
@@ -4085,6 +4323,11 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
+"aWD" = (
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "aWR" = (
 /obj/structure/stool/bed/chair/metal/green{
 	dir = 8
@@ -4124,7 +4367,9 @@
 "aXN" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/green,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
 /area/station/engineering/singularity)
 "aXP" = (
 /obj/structure/disposalpipe/segment{
@@ -4235,14 +4480,17 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/security/checkpoint)
 "aZF" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "grimy"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/storage/tools)
 "baa" = (
@@ -4291,10 +4539,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "brown"
-	},
+/turf/simulated/floor,
 /area/station/cargo/miningoffice)
 "baP" = (
 /obj/structure/cable{
@@ -4403,7 +4648,9 @@
 "bbY" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/storage)
 "bbZ" = (
 /obj/structure/cable{
@@ -4427,7 +4674,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/civilian/dormitories)
 "bcg" = (
 /turf/simulated/floor{
@@ -4460,6 +4709,13 @@
 	icon_state = "bot"
 	},
 /area/station/medical/cryo)
+"bcO" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "whitepurple"
+	},
+/area/station/rnd/hallway)
 "bcP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -4568,8 +4824,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"bed" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/port)
 "beo" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -4582,7 +4844,9 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/storage/tech)
 "beC" = (
 /obj/structure/cable{
@@ -4670,8 +4934,16 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
 /area/station/hallway/primary/port)
+"beX" = (
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "bluecorner"
+	},
+/area/station/maintenance/chapel)
 "beY" = (
 /obj/machinery/telecomms/server/presets/supply,
 /turf/simulated/floor/bluegrid{
@@ -4729,11 +5001,15 @@
 	dir = 1;
 	name = "Port Mix to Starboard Ports"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "bfD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/monitoring)
 "bfG" = (
 /obj/structure/cable{
@@ -4756,7 +5032,9 @@
 	name = "Library Desk Door";
 	req_access = list(37)
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/civilian/library)
 "bgs" = (
 /obj/machinery/door/firedoor,
@@ -4768,7 +5046,7 @@
 	name = "KitchenShutters";
 	opacity = 0
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
 "bgu" = (
 /obj/machinery/door/firedoor,
@@ -4829,7 +5107,16 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/station/engineering/engine)
+"bhh" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
 	},
 /area/station/engineering/engine)
 "bhn" = (
@@ -4837,7 +5124,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/singularity)
 "bhp" = (
 /obj/effect/decal/cleanable/dirt,
@@ -4856,7 +5145,10 @@
 /area/station/medical/psych)
 "bhy" = (
 /obj/item/weapon/flora/random,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warningcorner"
+	},
 /area/station/maintenance/chapel)
 "bhz" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -4944,6 +5236,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
+"biK" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "warning"
+	},
+/area/station/engineering/atmos)
 "biT" = (
 /obj/machinery/camera{
 	c_tag = "Vault";
@@ -5024,8 +5323,7 @@
 "bjH" = (
 /obj/machinery/computer/arcade,
 /turf/simulated/floor{
-	dir = 9;
-	icon_state = "red"
+	icon_state = "redyellowfull"
 	},
 /area/station/civilian/bar)
 "bjK" = (
@@ -5050,7 +5348,9 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/secondary/exit)
 "bjW" = (
 /obj/machinery/meter{
@@ -5102,6 +5402,9 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/primary/fore)
+"bkq" = (
+/turf/simulated/floor/plating,
+/area/station/storage/tools)
 "bks" = (
 /obj/machinery/drone_fabricator,
 /turf/simulated/floor{
@@ -5161,6 +5464,27 @@
 	icon_state = "white"
 	},
 /area/station/medical/hallway)
+"blq" = (
+/obj/structure/stool/bed/chair/office/light,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "whitepurplecorner"
+	},
+/area/station/rnd/hor)
 "bls" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
@@ -5198,6 +5522,18 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"blI" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/engine)
 "blJ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -5208,7 +5544,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/maintenance/chapel)
 "blR" = (
 /obj/effect/decal/cleanable/ash{
@@ -5242,11 +5580,15 @@
 	dir = 1;
 	name = "Pure to Ports"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "bmj" = (
 /obj/structure/closet/radiation,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "bmn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5306,7 +5648,9 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "cafeteria"
+	},
 /area/station/engineering/singularity)
 "bmU" = (
 /obj/effect/decal/cleanable/blood/splatter,
@@ -5340,7 +5684,9 @@
 	name = "Secure Creature Pen";
 	req_access = list(8)
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
 /area/station/rnd/xenobiology)
 "bns" = (
 /obj/structure/sign/nanotrasen{
@@ -5450,7 +5796,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/civilian/chapel)
 "bpv" = (
@@ -5472,7 +5819,9 @@
 /turf/simulated/floor,
 /area/station/rnd/robotics)
 "bpA" = (
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/medical/psych)
 "bpO" = (
 /obj/effect/landmark/start/assistant,
@@ -5531,7 +5880,9 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/singularity)
 "bqn" = (
 /obj/structure/cable{
@@ -5556,15 +5907,17 @@
 	pixel_x = 29;
 	pixel_y = -6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/civilian/gym)
 "bqI" = (
 /obj/structure/stool/bed/chair/comfy/brown{
 	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "redyellowfull"
 	},
 /area/station/civilian/bar)
 "bra" = (
@@ -5594,7 +5947,10 @@
 /obj/structure/window/thin{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "red"
+	},
 /area/station/engineering/atmos)
 "brh" = (
 /turf/simulated/floor{
@@ -5686,7 +6042,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "red"
+	},
 /area/station/hallway/secondary/exit)
 "bsn" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
@@ -5703,7 +6061,10 @@
 /obj/structure/window/thin{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "blue"
+	},
 /area/station/engineering/atmos)
 "bsA" = (
 /obj/structure/cable{
@@ -5713,13 +6074,12 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "cautioncorner"
+	icon_state = "caution"
 	},
 /area/station/engineering/engine)
 "bsD" = (
 /turf/simulated/floor{
-	icon_state = "redyellowfull"
+	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
 "bsO" = (
@@ -5745,7 +6105,7 @@
 	dock_tag = "pod4";
 	name = "Escape Pod 4"
 	},
-/turf/environment/space,
+/turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "bsW" = (
 /obj/structure/disposalpipe/junction{
@@ -5772,6 +6132,12 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"bsZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "btc" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -5859,6 +6225,15 @@
 	},
 /turf/simulated/floor/carpet/red,
 /area/station/security/detectives_office)
+"buf" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "bur" = (
 /obj/effect/landmark/start/scientist,
 /turf/simulated/floor{
@@ -5879,7 +6254,9 @@
 /area/station/rnd/storage)
 "buH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/medical/reception)
 "buL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5945,7 +6322,7 @@
 "bvx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "bvC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -5966,13 +6343,18 @@
 	dir = 1
 	},
 /obj/item/weapon/clipboard,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/tcommsat/computer)
 "bvI" = (
 /obj/machinery/light/smart{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/primary/fore)
 "bvK" = (
 /obj/item/weapon/flora/random,
@@ -5985,7 +6367,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 28
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/singularity)
 "bvL" = (
 /turf/simulated/floor{
@@ -6027,8 +6411,7 @@
 	pixel_y = 22
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/security/interrogation)
 "bwr" = (
@@ -6115,8 +6498,7 @@
 "bxB" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "browncorner"
+	icon_state = "yellowpatch_inv"
 	},
 /area/station/hallway/primary/fore)
 "bxE" = (
@@ -6126,7 +6508,9 @@
 	pixel_y = 5
 	},
 /obj/item/weapon/storage/briefcase/inflatable,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/engine)
 "bxO" = (
 /turf/simulated/floor/plating/airless{
@@ -6158,7 +6542,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "byu" = (
 /turf/simulated/wall/r_wall,
@@ -6186,11 +6573,31 @@
 	icon_state = "vault"
 	},
 /area/station/civilian/library)
+"byH" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/civilian/chapel/mass_driver)
 "byS" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "byU" = (
 /obj/machinery/computer/mine_sci_shuttle,
@@ -6326,11 +6733,13 @@
 /obj/machinery/door/airlock/external{
 	name = "Arrival Airlock"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "bAH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/civilian/dormitories)
 "bAM" = (
 /obj/machinery/conveyor{
@@ -6365,7 +6774,9 @@
 	name = "Medbay Break Room";
 	sortType = "Medbay Break Room"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/secondary/exit)
 "bAS" = (
 /obj/machinery/door/firedoor,
@@ -6412,7 +6823,9 @@
 /area/station/civilian/library)
 "bBP" = (
 /obj/machinery/power/port_gen/pacman,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
 /area/station/engineering/engine)
 "bBR" = (
 /obj/structure/cable{
@@ -6472,6 +6885,13 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"bCv" = (
+/obj/item/weapon/flora/random,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "whitegreencorner"
+	},
+/area/station/medical/hallway)
 "bCG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -6488,7 +6908,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "whiteyellowcorner"
+	dir = 4;
+	icon_state = "yellowcorner"
 	},
 /area/station/medical/chemistry)
 "bCI" = (
@@ -6499,7 +6920,10 @@
 /area/station/security/brig)
 "bCJ" = (
 /obj/structure/closet/l3closet/janitor,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/hallway/secondary/entry)
 "bCO" = (
 /obj/structure/cable{
@@ -6527,6 +6951,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
@@ -6553,7 +6978,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warning"
+	},
 /area/station/security/prison)
 "bDc" = (
 /obj/structure/table/woodentable,
@@ -6572,7 +7000,10 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
 /area/station/engineering/atmos)
 "bDu" = (
 /obj/structure/table/reinforced,
@@ -6647,7 +7078,8 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/civilian/chapel/mass_driver)
 "bEf" = (
@@ -6693,7 +7125,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/bridge/teleporter)
 "bEV" = (
 /obj/structure/cable{
@@ -6788,6 +7222,22 @@
 	icon_state = "red"
 	},
 /area/station/security/brig)
+"bFD" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
+/area/station/maintenance/engineering)
 "bFH" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
@@ -6801,7 +7251,10 @@
 /obj/structure/stool/bed/chair/metal/white{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
 /area/station/civilian/gym)
 "bFR" = (
 /obj/machinery/door/window/brigdoor{
@@ -6810,7 +7263,7 @@
 	req_access = list(8)
 	},
 /turf/simulated/floor{
-	dir = 5;
+	dir = 8;
 	icon_state = "vault"
 	},
 /area/station/rnd/xenobiology)
@@ -6826,6 +7279,12 @@
 	icon_state = "delivery"
 	},
 /area/station/cargo/storage)
+"bGg" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/cargo/miningoffice)
 "bGi" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/virology{
@@ -6846,7 +7305,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 3;
+	icon_state = "whitegreenfull"
 	},
 /area/station/medical/chemistry)
 "bGj" = (
@@ -7001,7 +7461,9 @@
 	name = "Creature Pen";
 	req_access = list(8)
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
 /area/station/rnd/xenobiology)
 "bGY" = (
 /turf/simulated/floor{
@@ -7100,8 +7562,7 @@
 /obj/structure/table/woodentable,
 /obj/item/device/flashlight/lamp/green,
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "whiteblue"
+	icon_state = "wooden"
 	},
 /area/station/medical/psych)
 "bIZ" = (
@@ -7147,7 +7608,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "bJs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7159,7 +7620,10 @@
 /obj/machinery/firealarm{
 	pixel_y = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "purple"
+	},
 /area/station/rnd/hor)
 "bJz" = (
 /turf/simulated/floor{
@@ -7318,7 +7782,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "redyellowfull"
+	},
 /area/station/civilian/bar)
 "bKW" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -7332,7 +7798,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 29
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/hallway/primary/central)
 "bLj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7343,6 +7811,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories)
+"bLn" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutral"
+	},
+/area/station/engineering/atmos)
 "bLz" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/firealarm{
@@ -7365,7 +7839,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/secondary/exit)
 "bLF" = (
 /obj/machinery/hydroponics/constructable,
@@ -7515,7 +7991,10 @@
 /obj/machinery/ai_status_display{
 	pixel_y = -32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "bOd" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -7568,14 +8047,19 @@
 	dir = 1;
 	name = "Port Mix to Port Ports"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "bOJ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
 	name = "Port to Fuel Pipe"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "bOK" = (
 /obj/machinery/power/apc{
@@ -7588,7 +8072,9 @@
 	network = list("SS13","Security");
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "red"
+	},
 /area/station/hallway/secondary/exit)
 "bOT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7624,7 +8110,9 @@
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/qm)
 "bPT" = (
 /obj/machinery/firealarm{
@@ -7655,7 +8143,10 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
 /area/station/engineering/engine)
 "bQj" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
@@ -7679,7 +8170,9 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/secondary/exit)
 "bQs" = (
 /obj/structure/table/reinforced,
@@ -7843,14 +8336,17 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "whiteyellowcorner"
+	dir = 4;
+	icon_state = "yellowcorner"
 	},
 /area/station/medical/chemistry)
 "bTo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/office)
 "bTp" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7875,13 +8371,17 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowcorner"
+	},
 /area/station/engineering/atmos)
 "bTG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "bTR" = (
 /obj/machinery/door/firedoor,
@@ -7896,7 +8396,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitebluefull"
 	},
 /area/station/medical/surgeryobs)
 "bUb" = (
@@ -7939,7 +8439,9 @@
 /obj/structure/table/reinforced,
 /obj/item/device/flashlight/lamp,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/qm)
 "bUI" = (
 /obj/structure/cable{
@@ -7973,7 +8475,7 @@
 /area/station/maintenance/engineering)
 "bUP" = (
 /turf/simulated/floor{
-	icon_state = "cautioncorner"
+	icon_state = "caution"
 	},
 /area/station/engineering/engine)
 "bUV" = (
@@ -8010,7 +8512,9 @@
 	name = "Library Desk Door";
 	req_access = list(37)
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/civilian/library)
 "bVA" = (
 /obj/structure/table/reinforced,
@@ -8184,8 +8688,7 @@
 	},
 /obj/structure/stool/bed/chair/office/light,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "dark"
 	},
 /area/station/security/brig)
 "bXH" = (
@@ -8213,14 +8716,18 @@
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "whitepurplefull"
+	},
 /area/station/rnd/hallway)
 "bXL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/warning/electricshock{
 	pixel_x = -32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
 /area/station/maintenance/engineering)
 "bXP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -8282,7 +8789,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "redfull"
+	},
 /area/station/hallway/secondary/exit)
 "bYu" = (
 /obj/structure/closet,
@@ -8291,7 +8800,9 @@
 /area/station/maintenance/atmos)
 "bYx" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/fuel,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "bYy" = (
 /obj/structure/rack,
@@ -8347,9 +8858,7 @@
 	freq = 1400;
 	location = "Kitchen"
 	},
-/turf/simulated/floor{
-	icon_state = "showroomfloor"
-	},
+/turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "bZA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8424,7 +8933,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "caF" = (
 /obj/machinery/kitchen_machine/grill,
@@ -8448,7 +8960,9 @@
 "caP" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/mask/gas,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/engine)
 "caY" = (
 /obj/structure/closet/secure_closet/quartermaster,
@@ -8461,12 +8975,27 @@
 	dir = 8;
 	pixel_x = -22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "warning"
+	},
 /area/station/cargo/qm)
 "cbc" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowfull"
+	},
 /area/station/engineering/engine)
+"cbk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
+/area/station/engineering/atmos)
 "cbo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8555,6 +9084,12 @@
 	icon_state = "darkbrown"
 	},
 /area/station/medical/chemistry)
+"ccq" = (
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/station/rnd/xenobiology)
 "ccG" = (
 /obj/structure/sign/warning/fire,
 /turf/simulated/wall/r_wall,
@@ -8570,7 +9105,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "ccT" = (
 /obj/structure/cable{
@@ -8606,7 +9144,8 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor{
-	icon_state = "bar"
+	dir = 6;
+	icon_state = "bluered"
 	},
 /area/station/medical/medbreak)
 "cdm" = (
@@ -8625,7 +9164,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "cdy" = (
 /obj/structure/cable{
@@ -8649,7 +9190,10 @@
 /area/station/storage/tech)
 "cdI" = (
 /obj/machinery/light/small,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warning"
+	},
 /area/station/security/prison)
 "cdK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -8705,7 +9249,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light/smart,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "red"
+	},
 /area/station/hallway/secondary/exit)
 "ceI" = (
 /obj/machinery/camera{
@@ -8767,6 +9313,12 @@
 	icon_state = "vault"
 	},
 /area/station/civilian/library)
+"cfD" = (
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "cfF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
@@ -8817,7 +9369,8 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "yellow"
 	},
 /area/station/rnd/hallway)
 "cfY" = (
@@ -8832,7 +9385,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
 /area/station/civilian/dormitories)
 "cgg" = (
 /obj/structure/curtain/open/shower/security,
@@ -8866,7 +9422,9 @@
 /area/station/engineering/atmos)
 "cgv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/monitoring)
 "cgJ" = (
 /obj/structure/cable{
@@ -8909,6 +9467,12 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
+"chf" = (
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/station/security/main)
 "chj" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Atmospherics Desk"
@@ -8992,7 +9556,8 @@
 	pixel_y = -22
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/hallway/primary/starboard)
 "ciQ" = (
@@ -9056,7 +9621,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/hallway/primary/central)
 "cjg" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9067,7 +9634,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "cjq" = (
 /obj/structure/toilet{
@@ -9088,7 +9655,10 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "cjz" = (
 /obj/structure/window/shuttle/reinforced/mining{
@@ -9114,7 +9684,7 @@
 	network = list("SS13","Security")
 	},
 /turf/simulated/floor{
-	dir = 9;
+	dir = 8;
 	icon_state = "warning"
 	},
 /area/station/security/brig)
@@ -9152,13 +9722,18 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos)
 "ckw" = (
 /obj/machinery/light/smart{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "blackcorner"
+	},
 /area/station/hallway/secondary/exit)
 "ckx" = (
 /obj/machinery/door/firedoor,
@@ -9191,8 +9766,7 @@
 /obj/structure/table/woodentable,
 /obj/machinery/computer/med_data/laptop,
 /turf/simulated/floor{
-	dir = 10;
-	icon_state = "whiteblue"
+	icon_state = "wooden"
 	},
 /area/station/medical/psych)
 "clG" = (
@@ -9261,7 +9835,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/engine)
 "cmk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -9313,25 +9889,17 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/station/rnd/hallway)
 "cmG" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance,
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	icon_state = "neutralfull"
 	},
-/area/station/maintenance/atmos)
+/area/station/engineering/atmos)
 "cmN" = (
 /turf/simulated/wall,
 /area/station/security/iaa_office)
@@ -9345,11 +9913,16 @@
 /obj/structure/stool/bed/chair/metal/black{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/hallway/secondary/entry)
 "cmY" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/storage)
 "cna" = (
 /obj/structure/table/woodentable,
@@ -9389,7 +9962,9 @@
 	name = "Station Intercom (General)";
 	pixel_y = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "redchecker"
+	},
 /area/station/civilian/kitchen)
 "cno" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9397,6 +9972,12 @@
 /obj/item/weapon/storage/box/drinkingglasses,
 /turf/simulated/floor/wood,
 /area/station/maintenance/science)
+"cnr" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "whitegreencorner"
+	},
+/area/station/medical/hallway)
 "cnS" = (
 /obj/machinery/conveyor{
 	dir = 10;
@@ -9432,6 +10013,14 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
+"cox" = (
+/obj/structure/table/woodentable,
+/obj/item/device/radio/intercom,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/station/civilian/dormitories)
 "coy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -9468,7 +10057,7 @@
 	name = "KitchenShutters";
 	opacity = 0
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
 "coL" = (
 /obj/structure/window/thin/reinforced{
@@ -9480,7 +10069,10 @@
 /obj/machinery/light/smart{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "coV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9543,8 +10135,8 @@
 	pixel_y = 22
 	},
 /turf/simulated/floor{
-	dir = 10;
-	icon_state = "vault"
+	dir = 8;
+	icon_state = "black"
 	},
 /area/station/civilian/chapel)
 "cqG" = (
@@ -9572,9 +10164,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor,
 /area/station/rnd/hallway)
 "cra" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -9615,6 +10205,12 @@
 	icon_state = "white"
 	},
 /area/station/rnd/hallway)
+"csG" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "ctb" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -9623,6 +10219,13 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/engineering)
+"ctc" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "ctm" = (
 /obj/structure/stool,
 /obj/machinery/camera{
@@ -9746,6 +10349,20 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/hydroponics)
+"cvs" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "whiteblue"
+	},
+/area/station/medical/hallway)
 "cvv" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/bluegrid{
@@ -9805,7 +10422,10 @@
 	name = "Station Intercom (Security)";
 	pixel_y = -32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/security/hos)
 "cwe" = (
 /obj/structure/table/reinforced,
@@ -9835,7 +10455,7 @@
 	req_access = list(47)
 	},
 /turf/simulated/floor{
-	icon_state = "purplechecker"
+	icon_state = "white"
 	},
 /area/station/rnd/hor)
 "cwt" = (
@@ -9856,7 +10476,10 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "cwA" = (
 /obj/structure/stool/bed/chair/pedalgen{
@@ -9956,7 +10579,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
 /area/station/engineering/atmos)
 "cxU" = (
 /obj/machinery/shower/free{
@@ -9988,7 +10613,8 @@
 	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "whitered"
 	},
 /area/station/medical/hallway)
 "cym" = (
@@ -10029,7 +10655,9 @@
 /obj/structure/table/woodentable,
 /obj/item/device/flashlight/lamp,
 /obj/structure/window/thin,
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/civilian/library)
 "cyz" = (
 /obj/effect/landmark/start/chemist,
@@ -10131,8 +10759,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "red"
+	icon_state = "redyellowfull"
 	},
 /area/station/civilian/bar)
 "czF" = (
@@ -10164,6 +10791,15 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
+"cAb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/rnd/hallway)
 "cAe" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
@@ -10174,16 +10810,31 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"cAq" = (
+/turf/simulated/floor{
+	icon_state = "whitebluecorner"
+	},
+/area/station/medical/hallway)
 "cAr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "cAw" = (
 /obj/machinery/photocopier,
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/civilian/library)
+"cAF" = (
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/civilian/dormitories)
 "cAO" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -10206,8 +10857,8 @@
 	dir = 9
 	},
 /turf/simulated/floor{
-	dir = 6;
-	icon_state = "neutral"
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/station/civilian/dormitories)
 "cAY" = (
@@ -10236,7 +10887,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/cargo/miningoffice)
 "cBu" = (
 /obj/structure/lattice,
@@ -10263,7 +10914,7 @@
 "cBY" = (
 /turf/simulated/floor{
 	dir = 1;
-	icon_state = "darkred"
+	icon_state = "warndark"
 	},
 /area/station/security/armoury)
 "cCo" = (
@@ -10294,7 +10945,9 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
 /area/station/engineering/atmos)
 "cCx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -10304,8 +10957,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "red"
+	icon_state = "redyellowfull"
 	},
 /area/station/civilian/bar)
 "cCI" = (
@@ -10376,7 +11028,8 @@
 	},
 /obj/item/weapon/storage/wallet,
 /turf/simulated/floor{
-	icon_state = "bot"
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/station/civilian/dormitories)
 "cDM" = (
@@ -10387,7 +11040,9 @@
 	name = "Station Intercom (General)";
 	pixel_y = -32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/engineering/atmos)
 "cDX" = (
 /obj/machinery/hydroponics/constructable,
@@ -10464,7 +11119,9 @@
 /area/station/medical/chemistry)
 "cEO" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/green,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "cER" = (
 /turf/simulated/floor/wood,
@@ -10509,6 +11166,15 @@
 	icon_state = "warning"
 	},
 /area/station/engineering/atmos)
+"cFh" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "cFi" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -10543,6 +11209,18 @@
 	},
 /turf/simulated/floor/carpet/red,
 /area/station/security/detectives_office)
+"cFz" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
+/area/station/maintenance/atmos)
 "cFK" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -10656,12 +11334,15 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "purplechecker"
+	dir = 4;
+	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/hor)
 "cHg" = (
 /obj/machinery/atmospherics/components/binary/pump,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "warning"
+	},
 /area/station/maintenance/chapel)
 "cHh" = (
 /obj/structure/cable{
@@ -10716,7 +11397,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/office)
 "cHG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -10794,21 +11477,30 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/primary/fore)
 "cIT" = (
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor,
 /area/station/rnd/hallway)
+"cJd" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/civilian/chapel/mass_driver)
 "cJr" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "purple"
+	},
 /area/station/rnd/xenobiology)
 "cJC" = (
 /turf/simulated/floor{
@@ -10835,6 +11527,12 @@
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "warning"
+	},
+/area/station/engineering/atmos)
+"cKf" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/turf/simulated/floor{
+	icon_state = "yellow"
 	},
 /area/station/engineering/atmos)
 "cKj" = (
@@ -10988,14 +11686,20 @@
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/primary/fore)
 "cMF" = (
 /obj/structure/sign/poster/official/do_not_question{
 	pixel_x = 32
 	},
 /obj/structure/filingcabinet/security,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/storage/tools)
 "cMM" = (
 /obj/structure/cable{
@@ -11016,7 +11720,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	icon_state = "bar"
+	icon_state = "redyellowfull"
 	},
 /area/station/rnd/scibreak)
 "cNa" = (
@@ -11032,7 +11736,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/station/engineering/chiefs_office)
 "cNi" = (
 /obj/machinery/computer/security{
@@ -11047,6 +11754,13 @@
 	icon_state = "grimy"
 	},
 /area/station/security/hos)
+"cNp" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/station/maintenance/chapel)
 "cNz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/woodentable,
@@ -11071,9 +11785,7 @@
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor,
 /area/station/rnd/xenobiology)
 "cNU" = (
 /obj/machinery/power/tesla_coil,
@@ -11091,7 +11803,10 @@
 	c_tag = "Courtroom North";
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "cOt" = (
 /turf/simulated/floor{
@@ -11152,7 +11867,10 @@
 /obj/machinery/light/smart{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos)
 "cPi" = (
 /obj/structure/stool/bed/chair{
@@ -11203,7 +11921,9 @@
 	pixel_y = 3
 	},
 /obj/item/clothing/glasses/science,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/medical/chemistry)
 "cPG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -11230,8 +11950,27 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
+"cQq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/singularity)
 "cQt" = (
 /obj/item/device/flash,
 /obj/item/clothing/glasses/sunglasses,
@@ -11281,8 +12020,18 @@
 	network = list("SS13","Research");
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
 /area/station/rnd/hallway)
+"cQO" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/station/maintenance/chapel)
 "cQR" = (
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_y = -32
@@ -11297,13 +12046,17 @@
 /area/station/security/brig)
 "cQU" = (
 /obj/structure/closet/secure_closet/courtroom,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "cRa" = (
 /obj/structure/table/glass,
 /obj/item/clothing/gloves/latex,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/medical/surgeryobs)
 "cRg" = (
@@ -11356,8 +12109,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "red"
+	icon_state = "redyellowfull"
 	},
 /area/station/civilian/bar)
 "cRz" = (
@@ -11393,7 +12145,9 @@
 /obj/structure/window/thin/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
 /area/station/rnd/xenobiology)
 "cRL" = (
 /obj/structure/cable{
@@ -11420,7 +12174,10 @@
 	pixel_x = 4;
 	pixel_y = -2
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "brown"
+	},
 /area/station/cargo/storage)
 "cSl" = (
 /obj/structure/stool/bed/chair/office/dark,
@@ -11450,6 +12207,11 @@
 	},
 /turf/environment/space,
 /area/shuttle/mining/station)
+"cSH" = (
+/turf/simulated/floor{
+	icon_state = "caution"
+	},
+/area/station/engineering/atmos)
 "cTc" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -11462,7 +12224,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/security/hos)
 "cTd" = (
 /obj/machinery/alarm{
@@ -11584,7 +12349,10 @@
 	icon_state = "1-8"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
 /area/station/rnd/xenobiology)
 "cUG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -11613,7 +12381,7 @@
 	dir = 6
 	},
 /turf/simulated/floor{
-	icon_state = "bar"
+	icon_state = "redyellowfull"
 	},
 /area/station/rnd/scibreak)
 "cUU" = (
@@ -11640,7 +12408,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/storage/tech)
 "cVc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -11682,7 +12452,8 @@
 	dir = 6
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 5;
+	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
 "cWi" = (
@@ -11791,14 +12562,19 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/auxsolarport)
 "cXP" = (
 /obj/machinery/shower/free{
 	dir = 8
 	},
 /obj/structure/drain,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "blue"
+	},
 /area/station/civilian/toilet)
 "cXU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -11867,14 +12643,26 @@
 	name = "Abandoned Room APC";
 	pixel_y = 28
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "caution"
+	},
+/area/station/engineering/atmos)
+"daq" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "dat" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "dax" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -11923,7 +12711,10 @@
 /obj/machinery/light/smart{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/hallway/secondary/entry)
 "dbJ" = (
 /obj/structure/rack,
@@ -11940,7 +12731,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "neutral"
+	},
 /area/station/rnd/hor)
 "dcr" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -11968,7 +12762,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "dcY" = (
 /obj/structure/disposalpipe/segment,
@@ -12083,10 +12880,27 @@
 /obj/machinery/biogenerator,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"dfa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor,
+/area/station/rnd/hallway)
 "dfb" = (
 /obj/machinery/computer/arcade,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"dff" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "dfg" = (
 /turf/simulated/floor/carpet/black,
 /area/station/bridge)
@@ -12153,7 +12967,10 @@
 /area/station/rnd/tox_launch)
 "dfI" = (
 /obj/item/weapon/flora/random,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
 /area/station/civilian/chapel/mass_driver)
 "dfK" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -12257,7 +13074,10 @@
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "warning"
+	},
 /area/station/maintenance/chapel)
 "dhs" = (
 /obj/item/device/radio/beacon,
@@ -12297,8 +13117,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "warningcorner"
+	dir = 10;
+	icon_state = "red"
 	},
 /area/station/security/brig)
 "dhG" = (
@@ -12332,7 +13152,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "redyellowfull"
+	},
 /area/station/civilian/bar)
 "dhY" = (
 /obj/structure/sign/directions/engineering{
@@ -12349,7 +13171,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/security/prison)
 "did" = (
 /turf/simulated/floor{
@@ -12365,7 +13189,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/engine)
 "dim" = (
 /obj/machinery/door/firedoor,
@@ -12460,6 +13286,12 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"diQ" = (
+/obj/structure/closet/emcloset,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/atmos)
 "diU" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -12471,7 +13303,9 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/storage)
 "djc" = (
 /obj/structure/cable{
@@ -12489,7 +13323,9 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/secondary/exit)
 "djv" = (
 /obj/structure/closet/wardrobe/robotics_black,
@@ -12545,8 +13381,8 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor{
-	dir = 9;
-	icon_state = "darkred"
+	dir = 8;
+	icon_state = "darkredcorners"
 	},
 /area/station/security/armoury)
 "djJ" = (
@@ -12603,7 +13439,9 @@
 /obj/item/weapon/kitchen/utensil/spoon{
 	pixel_x = -5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "redchecker"
+	},
 /area/station/civilian/kitchen)
 "dkg" = (
 /obj/machinery/disposal,
@@ -12671,7 +13509,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 10
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "dlj" = (
 /obj/machinery/light/small{
@@ -12688,7 +13528,10 @@
 	pixel_x = 28;
 	pixel_y = -5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
 /area/station/engineering/engine)
 "dlE" = (
 /obj/structure/cable{
@@ -12718,6 +13561,20 @@
 /obj/effect/spawner/lootdrop/maintenance/two,
 /turf/simulated/floor/wood,
 /area/station/storage/tools)
+"dmc" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "medbay_biohazard";
+	name = "Medbay Biohazard Blast Doors";
+	opacity = 0
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "whitegreencorner"
+	},
+/area/station/medical/hallway)
 "dmr" = (
 /obj/structure/closet/crate/secure/woodseccrate,
 /obj/item/toy/prize/honk,
@@ -12739,14 +13596,29 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "red"
+	icon_state = "redyellowfull"
 	},
 /area/station/civilian/bar)
+"dmK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
+/area/station/maintenance/engineering)
 "dmP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/storage)
 "dmY" = (
 /obj/machinery/conveyor{
@@ -12775,6 +13647,12 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/medbay)
+"dnn" = (
+/turf/simulated/floor{
+	dir = 2;
+	icon_state = "bluecorner"
+	},
+/area/station/security/lobby)
 "dnt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -12795,7 +13673,9 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "dnK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -12825,7 +13705,10 @@
 	c_tag = "Arrival East";
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/hallway/secondary/exit)
 "dnW" = (
 /obj/machinery/door/firedoor,
@@ -12847,7 +13730,7 @@
 	freq = 1400;
 	location = "Engineering"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/engineering/monitoring)
 "dpd" = (
 /obj/structure/rack,
@@ -12983,7 +13866,7 @@
 	req_access = list(64)
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitebluefull"
 	},
 /area/station/medical/psych)
 "dqQ" = (
@@ -13008,14 +13891,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/storage/tech)
 "drg" = (
 /obj/machinery/shower/free{
 	dir = 4
 	},
 /obj/structure/drain,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "blue"
+	},
 /area/station/civilian/toilet)
 "drn" = (
 /obj/structure/cable{
@@ -13075,7 +13963,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "drM" = (
 /obj/item/device/radio/beacon,
@@ -13114,7 +14002,10 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "dsQ" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -13159,8 +14050,7 @@
 "dtr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "red"
+	icon_state = "redyellowfull"
 	},
 /area/station/civilian/bar)
 "dtv" = (
@@ -13217,7 +14107,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "due" = (
 /obj/structure/cable{
@@ -13253,7 +14146,9 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "duu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -13289,7 +14184,10 @@
 /area/station/civilian/library)
 "duP" = (
 /obj/item/weapon/flora/random,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/civilian/gym)
 "duT" = (
 /obj/structure/cable{
@@ -13324,7 +14222,9 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
 /area/station/engineering/singularity)
 "dvy" = (
 /obj/effect/landmark/start/bartender,
@@ -13406,7 +14306,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 29
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "bluecorner"
+	},
 /area/station/engineering/engine)
 "dwB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13466,7 +14369,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
 	dir = 1;
-	icon_state = "darkred"
+	icon_state = "warndark"
 	},
 /area/station/security/armoury)
 "dxt" = (
@@ -13573,7 +14476,7 @@
 /area/station/medical/reception)
 "dyG" = (
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "dza" = (
 /obj/structure/cable{
@@ -13608,7 +14511,10 @@
 	name = "Chemistry APC";
 	pixel_y = 28
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "neutral"
+	},
 /area/station/medical/chemistry)
 "dzl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -13633,7 +14539,7 @@
 "dzK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	icon_state = "whitebluecorner"
+	icon_state = "whiteblue"
 	},
 /area/station/medical/psych)
 "dAb" = (
@@ -13691,7 +14597,10 @@
 "dAA" = (
 /obj/structure/table,
 /obj/item/toy/figure/qm,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "brown"
+	},
 /area/station/cargo/qm)
 "dAH" = (
 /turf/simulated/floor{
@@ -13787,7 +14696,10 @@
 /obj/structure/stool/bed/chair/metal/black{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/hallway/secondary/entry)
 "dDB" = (
 /obj/machinery/disposal,
@@ -13871,7 +14783,9 @@
 /area/station/solar/auxstarboard)
 "dEp" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "dEq" = (
 /obj/structure/sink{
@@ -13881,7 +14795,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
 /area/station/hallway/primary/central)
 "dEr" = (
 /obj/structure/cable{
@@ -13914,7 +14831,9 @@
 	c_tag = "Arrival Hallway West";
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "dEZ" = (
 /obj/machinery/door/poddoor{
@@ -13954,7 +14873,10 @@
 /area/station/civilian/chapel)
 "dFv" = (
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "brown"
+	},
 /area/station/cargo/qm)
 "dFV" = (
 /obj/structure/cable{
@@ -14041,7 +14963,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/station/engineering/chiefs_office)
 "dGY" = (
 /obj/effect/landmark/start/warden,
@@ -14085,7 +15010,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "dHJ" = (
 /obj/machinery/door/firedoor,
@@ -14143,7 +15068,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/storage/tech)
 "dIg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -14154,7 +15081,7 @@
 	},
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "dIp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -14166,11 +15093,12 @@
 	},
 /area/station/civilian/dormitories)
 "dID" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor{
-	dir = 6;
-	icon_state = "vault"
+	dir = 4;
+	icon_state = "caution"
 	},
-/area/station/rnd/hor)
+/area/station/engineering/atmos)
 "dIJ" = (
 /obj/item/weapon/flora/random,
 /obj/item/weapon/storage/secure/safe{
@@ -14187,7 +15115,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "dIV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -14206,7 +15134,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "bot"
+	icon_state = "neutralfull"
 	},
 /area/station/civilian/dormitories)
 "dJe" = (
@@ -14224,7 +15152,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
 "dJA" = (
 /obj/machinery/light/smart{
@@ -14323,7 +15251,10 @@
 	c_tag = "Arrival West";
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/hallway/secondary/exit)
 "dKQ" = (
 /obj/machinery/door/firedoor,
@@ -14366,7 +15297,9 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "dLx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on/atmos{
@@ -14378,7 +15311,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
 /area/station/engineering/engine)
 "dLG" = (
 /obj/structure/cable{
@@ -14397,6 +15332,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"dLV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "black"
+	},
+/area/station/civilian/chapel)
 "dMq" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -14499,7 +15441,7 @@
 	},
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "browncorner"
+	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/fore)
 "dOE" = (
@@ -14542,7 +15484,10 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/security/hos)
 "dPf" = (
 /obj/item/weapon/flora/random,
@@ -14556,6 +15501,11 @@
 	icon_state = "warndark"
 	},
 /area/station/aisat/ai_chamber)
+"dPh" = (
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/hallway/secondary/exit)
 "dPj" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -14594,9 +15544,15 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "neutralfull"
 	},
 /area/station/medical/storage)
+"dPL" = (
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "cautioncorner"
+	},
+/area/station/engineering/atmos)
 "dPT" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -14606,7 +15562,10 @@
 /area/station/cargo/storage)
 "dPZ" = (
 /obj/machinery/photocopier,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "brown"
+	},
 /area/station/cargo/qm)
 "dQa" = (
 /obj/machinery/computer/operating{
@@ -14624,6 +15583,11 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"dQD" = (
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/engine)
 "dQU" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -14740,7 +15704,10 @@
 	c_tag = "EVA";
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warning"
+	},
 /area/station/ai_monitored/eva)
 "dSL" = (
 /obj/structure/sign/departments/medbay/alt{
@@ -14782,7 +15749,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
 /area/station/rnd/xenobiology)
 "dTh" = (
 /turf/simulated/floor{
@@ -14838,6 +15808,20 @@
 	icon_state = "white"
 	},
 /area/station/medical/hallway)
+"dTR" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
+/area/station/medical/chemistry)
 "dTW" = (
 /obj/machinery/power/grounding_rod,
 /obj/structure/cable{
@@ -14932,7 +15916,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/security/brig)
 "dUJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -14945,7 +15931,10 @@
 	pixel_x = -28;
 	pixel_y = -6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "dUT" = (
 /obj/structure/cable{
@@ -14978,6 +15967,12 @@
 	icon_state = "warning"
 	},
 /area/station/engineering/atmos)
+"dVh" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/station/hallway/secondary/exit)
 "dVi" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -14994,10 +15989,10 @@
 /area/station/maintenance/cargo)
 "dVr" = (
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutral"
+	dir = 8;
+	icon_state = "warning"
 	},
-/area/station/maintenance/atmos)
+/area/station/rnd/tox_launch)
 "dVA" = (
 /obj/structure/stool/bed/chair/comfy/black,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -15034,7 +16029,7 @@
 	name = "KitchenShutters";
 	opacity = 0
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
 "dVL" = (
 /obj/structure/cable{
@@ -15074,7 +16069,7 @@
 	},
 /turf/simulated/floor{
 	dir = 5;
-	icon_state = "darkbrown"
+	icon_state = "brown"
 	},
 /area/station/engineering/engine)
 "dWD" = (
@@ -15098,6 +16093,15 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories)
+"dXa" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "dXf" = (
 /obj/structure/dispenser/oxygen,
 /obj/machinery/light/smart{
@@ -15110,7 +16114,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/window/northleft,
 /turf/simulated/floor{
-	icon_state = "redyellowfull"
+	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
 "dXr" = (
@@ -15229,6 +16233,19 @@
 	icon_state = "grimy"
 	},
 /area/station/aisat/antechamber_interior)
+"dYU" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
+/area/station/maintenance/chapel)
 "dZC" = (
 /obj/structure/lattice,
 /obj/structure/sign/nanotrasen{
@@ -15236,6 +16253,22 @@
 	},
 /turf/environment/space,
 /area/space)
+"dZK" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
+/obj/structure/window/thin{
+	dir = 8
+	},
+/obj/structure/window/thin{
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "black"
+	},
+/area/station/engineering/atmos)
 "eao" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -15331,7 +16364,10 @@
 "eaH" = (
 /obj/structure/table/reinforced,
 /obj/item/device/flashlight/lamp,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "brown"
+	},
 /area/station/cargo/qm)
 "eaU" = (
 /obj/structure/window/thin/reinforced{
@@ -15376,6 +16412,15 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/kitchen)
+"ebm" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/station/engineering/atmos)
 "ebo" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -15443,7 +16488,7 @@
 /area/station/hallway/primary/central)
 "ecm" = (
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "ecA" = (
 /obj/structure/table/reinforced,
@@ -15490,6 +16535,16 @@
 	icon_state = "bot"
 	},
 /area/station/rnd/robotics)
+"edm" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/cargo/qm)
 "edA" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -15532,7 +16587,9 @@
 /obj/machinery/alarm{
 	pixel_y = -32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/medical/sleeper)
 "eeb" = (
 /obj/structure/table/woodentable/poker,
@@ -15588,7 +16645,9 @@
 /area/station/security/vacantoffice)
 "eeF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "eeG" = (
 /obj/structure/disposalpipe/segment{
@@ -15605,7 +16664,8 @@
 "eeT" = (
 /obj/machinery/computer/operating,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/medical/surgeryobs)
 "eeX" = (
@@ -15618,7 +16678,9 @@
 /area/station/engineering/atmos)
 "eeZ" = (
 /obj/structure/filingcabinet/chestdrawer,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "efb" = (
 /obj/effect/landmark/start/assistant,
@@ -15643,7 +16705,10 @@
 /area/station/hallway/primary/starboard)
 "efE" = (
 /obj/machinery/computer,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/tcommsat/computer)
 "efR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -15686,8 +16751,21 @@
 	c_tag = "Chapel North";
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
 /area/station/civilian/chapel/mass_driver)
+"egy" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowfull"
+	},
+/area/station/engineering/engine)
 "egz" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 8
@@ -15702,11 +16780,16 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
 /area/station/engineering/atmos)
 "egQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/medical/reception)
 "egT" = (
 /obj/machinery/power/apc{
@@ -15764,7 +16847,8 @@
 	pixel_y = -22
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 9;
+	icon_state = "warndark"
 	},
 /area/station/engineering/engine)
 "ehY" = (
@@ -15787,7 +16871,10 @@
 "eig" = (
 /obj/structure/table/woodentable,
 /obj/item/device/taperecorder,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/security/hos)
 "eii" = (
 /obj/structure/cable{
@@ -15803,7 +16890,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 4;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/portsolar)
 "eiq" = (
 /turf/simulated/floor{
@@ -15840,7 +16930,9 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch_inv"
+	},
 /area/station/hallway/primary/central)
 "eiW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -15867,7 +16959,9 @@
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/office)
 "ejH" = (
 /obj/machinery/door/window/brigdoor{
@@ -15924,7 +17018,8 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 4;
+	icon_state = "warndark"
 	},
 /area/station/security/armoury)
 "ekd" = (
@@ -15935,7 +17030,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "warndark"
 	},
 /area/station/security/armoury)
 "ekl" = (
@@ -15984,7 +17080,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "red"
+	},
 /area/station/security/brig)
 "ekH" = (
 /obj/machinery/recharge_station,
@@ -16047,7 +17145,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor{
-	dir = 5;
+	dir = 8;
 	icon_state = "vault"
 	},
 /area/station/engineering/atmos)
@@ -16088,7 +17186,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "emw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -16209,6 +17310,15 @@
 	icon_state = "purplechecker"
 	},
 /area/station/rnd/lab)
+"eou" = (
+/obj/structure/stool/bed/chair{
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "green"
+	},
+/area/station/civilian/dormitories)
 "eow" = (
 /obj/structure/closet/emcloset,
 /obj/structure/cable{
@@ -16246,6 +17356,18 @@
 	icon_state = "warningcorner"
 	},
 /area/station/hallway/primary/central)
+"epa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "eph" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/light/smart{
@@ -16283,7 +17405,10 @@
 /obj/machinery/computer/HolodeckControl{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/civilian/gym)
 "eqy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16294,7 +17419,8 @@
 "eqC" = (
 /obj/machinery/light/smart,
 /turf/simulated/floor{
-	icon_state = "redcorner"
+	dir = 2;
+	icon_state = "bluecorner"
 	},
 /area/station/security/lobby)
 "eqG" = (
@@ -16377,6 +17503,12 @@
 	icon_state = "gcircuit"
 	},
 /area/station/bridge/nuke_storage)
+"esv" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warndarkcorners"
+	},
+/area/station/engineering/atmos)
 "esN" = (
 /obj/structure/sign/warning,
 /turf/simulated/wall/r_wall,
@@ -16403,7 +17535,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowfull"
+	},
 /area/station/engineering/engine)
 "etf" = (
 /obj/machinery/conveyor{
@@ -16444,7 +17578,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
 /area/station/civilian/dormitories)
 "etM" = (
 /obj/structure/disposaloutlet{
@@ -16485,12 +17622,18 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/chapel/mass_driver)
+"etT" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellowcorner"
+	},
+/area/station/engineering/atmos)
 "etX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "eui" = (
 /obj/structure/cable{
@@ -16534,11 +17677,16 @@
 /area/station/medical/sleeper)
 "euL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
 /area/station/engineering/singularity)
 "euO" = (
 /obj/structure/closet/jcloset,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/hallway/secondary/entry)
 "evk" = (
 /obj/machinery/door/airlock/security{
@@ -16699,7 +17847,9 @@
 	name = "Tank Monitor";
 	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous Oxide","waste_sensor"="Gas Mix Tank")
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/engineering/atmos)
 "ewO" = (
 /obj/effect/decal/cleanable/dirt,
@@ -16739,15 +17889,20 @@
 /area/station/maintenance/escape)
 "exf" = (
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "warning"
 	},
-/area/station/maintenance/atmos)
+/area/station/ai_monitored/eva)
 "exk" = (
 /obj/effect/landmark/start/botanist,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/civilian/hydroponics)
+"exw" = (
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
+/area/station/engineering/singularity)
 "exA" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
@@ -16810,7 +17965,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/office)
 "exM" = (
 /obj/machinery/door/firedoor,
@@ -16861,15 +18018,11 @@
 	},
 /area/station/aisat/teleport)
 "eyw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warning"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
-/area/station/maintenance/cargo)
+/area/station/hallway/secondary/entry)
 "eyD" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -16927,7 +18080,8 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/hallway/primary/starboard)
 "eza" = (
@@ -17053,7 +18207,10 @@
 /area/station/aisat)
 "eAS" = (
 /obj/structure/stool/bed/chair,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "red"
+	},
 /area/station/hallway/secondary/exit)
 "eAT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17089,7 +18246,10 @@
 	c_tag = "Mining Shuttle Preparation";
 	dir = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellow"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "eBv" = (
 /obj/structure/table,
@@ -17114,7 +18274,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 2;
+	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway)
 "eBT" = (
@@ -17170,7 +18331,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/primary/fore)
 "eDL" = (
 /obj/structure/table,
@@ -17189,7 +18352,9 @@
 /area/station/maintenance/atmos)
 "eDZ" = (
 /obj/machinery/door/firedoor,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/civilian/dormitories)
 "eEq" = (
 /obj/structure/cable{
@@ -17276,7 +18441,8 @@
 	},
 /obj/item/weapon/reagent_containers/blood/APlus,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/security/main)
 "eFK" = (
@@ -17307,13 +18473,18 @@
 "eFQ" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/camera_assembly,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "orange"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "eFW" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/medical/cryo)
 "eGg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -17329,7 +18500,9 @@
 /area/station/storage/tools)
 "eGn" = (
 /obj/structure/closet/firecloset,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
 /area/station/maintenance/atmos)
 "eGJ" = (
 /obj/structure/cable{
@@ -17361,7 +18534,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/miningoffice)
 "eHj" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -17417,7 +18592,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "eHY" = (
 /obj/structure/cable{
@@ -17484,7 +18659,10 @@
 	amount = 25
 	},
 /obj/item/weapon/storage/box/lights/mixed,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellow"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "eIH" = (
 /obj/effect/decal/cleanable/dirt,
@@ -17529,7 +18707,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/office)
 "eJm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -17586,7 +18766,8 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 4;
+	icon_state = "warndark"
 	},
 /area/station/security/armoury)
 "eKz" = (
@@ -17595,7 +18776,10 @@
 	dir = 4;
 	pixel_x = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "eKF" = (
 /obj/machinery/power/smes,
@@ -17670,12 +18854,14 @@
 	},
 /obj/machinery/light/smart,
 /turf/simulated/floor{
-	dir = 6;
-	icon_state = "whiteblue"
+	icon_state = "wooden"
 	},
 /area/station/medical/psych)
 "eLs" = (
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "eLM" = (
 /mob/living/carbon/monkey{
@@ -17691,11 +18877,14 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
 /area/station/engineering/engine)
 "eMm" = (
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "eMn" = (
 /obj/machinery/door/firedoor,
@@ -17731,6 +18920,10 @@
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
+"eNm" = (
+/obj/item/weapon/flora/random,
+/turf/simulated/floor/plating,
+/area/station/maintenance/atmos)
 "eNw" = (
 /obj/structure/barricade/wooden,
 /obj/structure/window/fulltile{
@@ -17791,12 +18984,46 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
+"eNG" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "vault"
+	},
+/area/station/rnd/xenobiology)
+"eNH" = (
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -32
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
+"eNI" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
+/area/station/maintenance/atmos)
 "eNV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/civilian/chapel/mass_driver)
 "eNW" = (
@@ -17851,7 +19078,9 @@
 /area/station/hallway/primary/fore)
 "eOx" = (
 /obj/structure/bookcase/manuals/medical,
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/medical/psych)
 "eOG" = (
 /obj/structure/table/woodentable,
@@ -17859,7 +19088,9 @@
 	pixel_y = 6
 	},
 /obj/item/weapon/storage/briefcase,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "blue"
+	},
 /area/station/civilian/dormitories)
 "eOJ" = (
 /obj/structure/table/reinforced,
@@ -17883,10 +19114,16 @@
 /obj/item/toy/figure/bartender,
 /obj/structure/table/woodentable,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/civilian/bar)
+"eOR" = (
+/obj/structure/closet,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "warning"
+	},
+/area/station/cargo/storage)
 "eOU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -17927,8 +19164,7 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor{
-	dir = 6;
-	icon_state = "red"
+	icon_state = "redfull"
 	},
 /area/station/medical/hallway)
 "ePN" = (
@@ -17987,7 +19223,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "blackcorner"
+	},
 /area/station/hallway/secondary/entry)
 "eQn" = (
 /obj/effect/decal/cleanable/dirt,
@@ -18022,7 +19261,10 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "eQU" = (
 /obj/structure/cable{
@@ -18083,11 +19325,16 @@
 /area/station/engineering/atmos)
 "eRn" = (
 /obj/machinery/chem_master,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "purple"
+	},
 /area/station/rnd/xenobiology)
 "eRS" = (
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
 /area/station/civilian/gym)
 "eRT" = (
 /turf/simulated/wall/r_wall,
@@ -18101,7 +19348,9 @@
 	pixel_x = -22
 	},
 /obj/effect/landmark/start/barber,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/hallway/primary/port)
 "eSi" = (
 /obj/machinery/telecomms/processor/preset_one,
@@ -18144,7 +19393,10 @@
 	dir = 9;
 	network = list("SS13","Research")
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "neutral"
+	},
 /area/station/rnd/xenobiology)
 "eSP" = (
 /obj/machinery/hologram/holopad,
@@ -18226,7 +19478,7 @@
 "eTM" = (
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "darkblue"
+	icon_state = "blue"
 	},
 /area/station/hallway/primary/starboard)
 "eTX" = (
@@ -18234,7 +19486,8 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "redcorner"
+	dir = 2;
+	icon_state = "bluecorner"
 	},
 /area/station/security/lobby)
 "eUf" = (
@@ -18301,7 +19554,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/storage/primary)
 "eUV" = (
 /obj/structure/table/reinforced,
@@ -18348,7 +19603,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowfull"
+	},
 /area/station/engineering/engine)
 "eWG" = (
 /turf/simulated/floor{
@@ -18391,7 +19648,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitebluecorner"
 	},
 /area/station/medical/hallway)
 "eXG" = (
@@ -18472,7 +19729,8 @@
 "eXY" = (
 /obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor{
-	icon_state = "bot"
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/station/civilian/dormitories)
 "eYc" = (
@@ -18483,8 +19741,7 @@
 	dir = 6
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/hallway/secondary/entry)
 "eYj" = (
@@ -18493,7 +19750,7 @@
 	dir = 5
 	},
 /turf/simulated/floor{
-	icon_state = "redyellowfull"
+	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
 "eYk" = (
@@ -18513,6 +19770,13 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/dormitories)
+"eYy" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/station/civilian/gym)
 "eYX" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
@@ -18526,8 +19790,7 @@
 /area/station/hallway/primary/central)
 "eZh" = (
 /turf/simulated/floor{
-	dir = 10;
-	icon_state = "red"
+	icon_state = "neutralfull"
 	},
 /area/station/security/main)
 "eZA" = (
@@ -18548,7 +19811,9 @@
 /obj/machinery/alarm{
 	pixel_y = -32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
 /area/station/rnd/hor)
 "eZH" = (
 /obj/structure/cable{
@@ -18579,7 +19844,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/engine)
 "eZV" = (
 /obj/machinery/door/firedoor,
@@ -18614,7 +19881,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "red"
+	},
 /area/station/hallway/secondary/exit)
 "fah" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -18698,7 +19968,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/security/brig)
 "fbg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -18801,7 +20073,10 @@
 /obj/structure/stool/bed/chair{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warning"
+	},
 /area/station/hallway/secondary/entry)
 "fcg" = (
 /obj/structure/table/reinforced,
@@ -18906,7 +20181,9 @@
 /area/shuttle/escape_pod2/station)
 "fdo" = (
 /obj/structure/closet/firecloset,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/hallway/secondary/exit)
 "fdt" = (
 /obj/machinery/door/firedoor,
@@ -18940,8 +20217,8 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "yellowcorner"
+	dir = 1;
+	icon_state = "yellow"
 	},
 /area/station/engineering/engine)
 "fdM" = (
@@ -18951,7 +20228,8 @@
 	},
 /obj/item/device/flashlight/lantern,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/civilian/chapel/mass_driver)
 "fdN" = (
@@ -19025,12 +20303,16 @@
 	pixel_x = 28;
 	pixel_y = -5
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/civilian/library)
 "feP" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/shoes/heels,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/storage)
 "ffe" = (
 /obj/structure/table/woodentable,
@@ -19099,8 +20381,8 @@
 /area/station/security/prison)
 "ffL" = (
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "black"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/station/storage/tech)
 "ffM" = (
@@ -19141,7 +20423,9 @@
 	dir = 4
 	},
 /obj/machinery/light/smart,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "cautioncorner"
+	},
 /area/station/engineering/atmos)
 "ffZ" = (
 /obj/structure/window/thin/reinforced{
@@ -19193,7 +20477,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "fgA" = (
 /obj/structure/cable{
@@ -19213,7 +20497,10 @@
 /area/station/rnd/hallway)
 "fgW" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/engineering/atmos)
 "fha" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19257,7 +20544,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "fiv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -19357,7 +20646,9 @@
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/suit/space/rig/atmos,
 /obj/item/clothing/head/helmet/space/rig/atmos,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/engineering/atmos)
 "fjO" = (
 /obj/structure/window/thin/reinforced{
@@ -19391,7 +20682,10 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warning"
+	},
 /area/station/hallway/secondary/entry)
 "fkc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -19456,8 +20750,8 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "redcorner"
+	dir = 1;
+	icon_state = "red"
 	},
 /area/station/security/brig)
 "fkz" = (
@@ -19478,7 +20772,10 @@
 /area/station/bridge)
 "fkM" = (
 /obj/machinery/iv_drip,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "bluecorner"
+	},
 /area/station/maintenance/chapel)
 "fkW" = (
 /obj/machinery/disposal,
@@ -19500,7 +20797,9 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "flh" = (
 /turf/simulated/wall/r_wall,
@@ -19610,13 +20909,18 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 8;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/chapel)
 "fnT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/storage)
 "fnU" = (
 /obj/structure/table/reinforced,
@@ -19659,7 +20963,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "red"
+	},
 /area/station/hallway/secondary/exit)
 "fpi" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -19714,7 +21020,10 @@
 /obj/machinery/light/smart{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "redcorner"
+	},
 /area/station/cargo/storage)
 "fqr" = (
 /obj/machinery/conveyor_switch/oneway{
@@ -19725,7 +21034,9 @@
 	dir = 4;
 	pixel_x = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/storage)
 "fqu" = (
 /obj/effect/decal/cleanable/dirt,
@@ -19760,7 +21071,7 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "fqK" = (
 /turf/simulated/floor{
@@ -19774,7 +21085,10 @@
 	pixel_x = -3;
 	pixel_y = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "browncorner"
+	},
 /area/station/cargo/storage)
 "fqR" = (
 /obj/machinery/meter,
@@ -19801,7 +21115,10 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
 /area/station/rnd/xenobiology)
 "frw" = (
 /obj/structure/stool/bar,
@@ -19851,6 +21168,15 @@
 	icon_state = "warndark"
 	},
 /area/station/security/brig)
+"frM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "whitehall"
+	},
+/area/station/rnd/hallway)
 "frU" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable,
@@ -19879,7 +21205,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "fsq" = (
 /obj/machinery/door/airlock/security{
@@ -19901,7 +21229,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "whitebluefull"
+	},
 /area/station/medical/sleeper)
 "fsz" = (
 /obj/structure/table,
@@ -19910,6 +21240,13 @@
 	icon_state = "vault"
 	},
 /area/station/hallway/primary/starboard)
+"fsC" = (
+/obj/item/weapon/flora/random,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "blackcorner"
+	},
+/area/station/hallway/secondary/exit)
 "fsG" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/book/manual/wiki/security_space_law,
@@ -19934,8 +21271,7 @@
 	pixel_y = 22
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "dark"
 	},
 /area/station/security/brig)
 "fsX" = (
@@ -20032,7 +21368,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "ftF" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
@@ -20045,7 +21381,10 @@
 /obj/structure/window/thin{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "blue"
+	},
 /area/station/engineering/atmos)
 "ftS" = (
 /obj/structure/filingcabinet/chestdrawer,
@@ -20054,14 +21393,19 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "brown"
+	},
 /area/station/cargo/qm)
 "ftZ" = (
 /obj/machinery/door/airlock/research{
 	name = "Ordnance Lab"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "whitepurplefull"
+	},
 /area/station/rnd/storage)
 "fuc" = (
 /obj/structure/table,
@@ -20106,7 +21450,9 @@
 /area/station/hallway/primary/central)
 "fuN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/civilian/library)
 "fuP" = (
 /obj/structure/cable{
@@ -20123,7 +21469,7 @@
 	sortType = "RnD Break Room"
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitepurplefull"
 	},
 /area/station/rnd/hallway)
 "fuV" = (
@@ -20139,7 +21485,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor{
-	icon_state = "bot"
+	icon_state = "delivery"
 	},
 /area/station/engineering/engine)
 "fvf" = (
@@ -20151,7 +21497,7 @@
 "fvs" = (
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "browncorner"
+	icon_state = "bluecorner"
 	},
 /area/station/security/lobby)
 "fvw" = (
@@ -20167,7 +21513,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/office)
 "fvA" = (
 /obj/machinery/portable_atmospherics/canister,
@@ -20175,12 +21523,15 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "warndark"
 	},
 /area/station/rnd/storage)
 "fvE" = (
 /obj/effect/landmark/start/assistant,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/civilian/gym)
 "fvH" = (
 /obj/item/device/radio/beacon,
@@ -20223,7 +21574,10 @@
 	network = list("SS13","Engineering");
 	dir = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "yellow"
+	},
 /area/station/engineering/engine)
 "fwl" = (
 /obj/machinery/light/smart{
@@ -20259,7 +21613,10 @@
 	pixel_x = 29;
 	pixel_y = -6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "fwL" = (
 /obj/structure/cable{
@@ -20312,7 +21669,10 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	name = "Air Outlet Pump"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/engineering/atmos)
 "fxe" = (
 /obj/machinery/door/firedoor,
@@ -20342,7 +21702,8 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "bar"
+	dir = 4;
+	icon_state = "bluered"
 	},
 /area/station/medical/medbreak)
 "fxQ" = (
@@ -20369,6 +21730,14 @@
 	icon_state = "darkblue"
 	},
 /area/station/medical/genetics)
+"fyx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/cargo/storage)
 "fyE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -20417,8 +21786,7 @@
 /obj/item/weapon/clipboard,
 /obj/item/weapon/pen,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/security/interrogation)
 "fzd" = (
@@ -20503,7 +21871,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/medical/reception)
 "fAf" = (
 /turf/simulated/floor{
@@ -20593,7 +21963,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
 /area/station/engineering/atmos)
 "fBm" = (
 /obj/machinery/computer,
@@ -20651,7 +22023,7 @@
 /obj/structure/stool/bed/roller,
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "darkbluecorners"
+	icon_state = "barber"
 	},
 /area/station/medical/surgeryobs)
 "fCg" = (
@@ -20671,9 +22043,27 @@
 	icon_state = "vault"
 	},
 /area/station/security/forensic_office)
+"fCu" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
+/obj/structure/window/thin{
+	dir = 8
+	},
+/obj/structure/window/thin{
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "purple"
+	},
+/area/station/engineering/atmos)
 "fCz" = (
 /obj/structure/table,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/civilian/dormitories)
 "fCH" = (
 /obj/structure/table/reinforced,
@@ -20691,7 +22081,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/office)
 "fDg" = (
 /obj/machinery/photocopier,
@@ -20747,7 +22139,10 @@
 /area/station/hallway/secondary/entry)
 "fDP" = (
 /obj/structure/stool/bed/chair,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "red"
+	},
 /area/station/civilian/dormitories)
 "fDV" = (
 /obj/structure/rack,
@@ -20856,14 +22251,19 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
 /area/station/engineering/singularity)
 "fFW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light/smart{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warning"
+	},
 /area/station/hallway/secondary/entry)
 "fGa" = (
 /obj/structure/cable{
@@ -20936,6 +22336,11 @@
 	icon_state = "dark"
 	},
 /area/station/bridge/nuke_storage)
+"fGy" = (
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
+/area/station/rnd/xenobiology)
 "fGG" = (
 /mob/living/carbon/monkey,
 /turf/simulated/floor{
@@ -20976,12 +22381,14 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "purple"
+	},
 /area/station/rnd/hor)
 "fHi" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
-	dir = 8;
+	dir = 10;
 	icon_state = "warning"
 	},
 /area/station/engineering/engine)
@@ -21137,7 +22544,10 @@
 	dir = 4;
 	name = "O2 to Airmix"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/engineering/atmos)
 "fJr" = (
 /obj/structure/closet{
@@ -21166,7 +22576,7 @@
 	},
 /turf/simulated/floor{
 	dir = 1;
-	icon_state = "yellowcorner"
+	icon_state = "yellow"
 	},
 /area/station/engineering/engine)
 "fJt" = (
@@ -21178,7 +22588,9 @@
 	name = "Station Intercom (General)";
 	pixel_y = -32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "fJD" = (
 /obj/structure/reagent_dispensers/aqueous_foam_tank,
@@ -21220,7 +22632,10 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "fJR" = (
 /obj/machinery/vending/assist,
@@ -21232,8 +22647,7 @@
 /obj/structure/table,
 /obj/item/device/flashlight/lamp,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/hallway/primary/fore)
 "fJU" = (
@@ -21304,8 +22718,8 @@
 "fKP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "warningcorner"
+	dir = 9;
+	icon_state = "red"
 	},
 /area/station/security/brig)
 "fKS" = (
@@ -21386,7 +22800,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 8;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/starboardsolar)
 "fLQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -21395,7 +22812,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
 /area/station/engineering/chiefs_office)
 "fLY" = (
 /turf/simulated/floor{
@@ -21417,7 +22836,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/security/checkpoint)
 "fMw" = (
 /turf/simulated/floor{
@@ -21436,7 +22857,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "fMP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -21454,7 +22877,10 @@
 /obj/structure/table/woodentable,
 /obj/item/weapon/folder/blue,
 /obj/item/weapon/pen,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "fNK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -21464,7 +22890,8 @@
 /area/station/cargo/office)
 "fOp" = (
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 3;
+	icon_state = "warndark"
 	},
 /area/station/security/armoury)
 "fOF" = (
@@ -21486,8 +22913,16 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
+"fOS" = (
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "orange"
+	},
+/area/station/hallway/secondary/mine_sci_shuttle)
 "fOV" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
@@ -21502,7 +22937,10 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/engineering/atmos)
 "fPf" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -21625,6 +23063,17 @@
 	icon_state = "vault"
 	},
 /area/station/security/armoury)
+"fRu" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "warning"
+	},
+/area/station/engineering/atmos)
 "fRG" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -21665,14 +23114,20 @@
 /obj/structure/stool/bed/chair/metal/black{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/hallway/secondary/entry)
 "fSb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
-/area/station/maintenance/atmos)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
+/area/station/hallway/secondary/entry)
 "fSd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -21697,14 +23152,20 @@
 	pixel_x = -3;
 	pixel_y = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/tcommsat/computer)
 "fSt" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/light/smart{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/station/engineering/atmos)
 "fSx" = (
 /obj/structure/table,
@@ -21796,7 +23257,9 @@
 /obj/structure/stool/bed/chair/office/light{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/chiefs_office)
 "fUz" = (
 /obj/structure/table/reinforced,
@@ -21810,7 +23273,7 @@
 "fUB" = (
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "darkred"
+	icon_state = "warndark"
 	},
 /area/station/security/armoury)
 "fUZ" = (
@@ -21872,7 +23335,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
 "fVJ" = (
@@ -21899,7 +23362,7 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "redyellowfull"
+	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
 "fVY" = (
@@ -21933,8 +23396,7 @@
 	pixel_y = -6
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/hallway/secondary/entry)
 "fWo" = (
@@ -21984,8 +23446,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"fWA" = (
+/turf/simulated/floor{
+	icon_state = "warningcorner"
+	},
+/area/station/maintenance/chapel)
 "fWT" = (
 /obj/machinery/smartfridge/chemistry,
 /turf/simulated/wall/r_wall,
@@ -22000,7 +23467,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/civilian/gym)
 "fXd" = (
 /obj/structure/cable{
@@ -22094,14 +23564,24 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/hallway/secondary/entry)
 "fYg" = (
 /obj/structure/closet/theatrecloset,
 /turf/simulated/floor/wood,
 /area/station/hallway/primary/fore)
+"fYv" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/mine_sci_shuttle)
 "fYD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -22113,7 +23593,10 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "fYG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -22144,7 +23627,10 @@
 "fYZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/station/engineering/chiefs_office)
 "fZz" = (
 /turf/simulated/floor{
@@ -22197,7 +23683,10 @@
 /area/station/security/prison)
 "fZQ" = (
 /obj/item/weapon/flora/random,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/primary/fore)
 "fZY" = (
 /obj/machinery/computer/aiupload,
@@ -22240,7 +23729,10 @@
 /area/station/cargo/storage)
 "gaJ" = (
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/primary/fore)
 "gaN" = (
 /obj/structure/cable{
@@ -22292,7 +23784,10 @@
 	c_tag = "Fore Port Solar Control";
 	network = list("SS13","Engineering")
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 5;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/auxsolarport)
 "gby" = (
 /obj/structure/rack,
@@ -22339,6 +23834,12 @@
 	icon_state = "vault"
 	},
 /area/station/rnd/xenobiology)
+"gbQ" = (
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warndark"
+	},
+/area/station/rnd/tox_launch)
 "gbY" = (
 /turf/simulated/wall/r_wall,
 /area/station/ai_monitored/storage_secure)
@@ -22358,7 +23859,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/maintenance/medbay)
 "gcf" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -22373,7 +23876,10 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/civilian/gym)
 "gcl" = (
 /obj/machinery/atmospherics/components/binary/valve/digital,
@@ -22382,6 +23888,12 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/storage)
+"gct" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "browncorner"
+	},
+/area/station/cargo/storage)
 "gcE" = (
 /obj/structure/table/reinforced,
 /obj/item/bodybag/cryobag,
@@ -22457,7 +23969,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "blackcorner"
+	},
 /area/station/hallway/secondary/exit)
 "gdS" = (
 /turf/simulated/floor{
@@ -22475,9 +23990,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "gdV" = (
 /obj/machinery/computer/prisoner,
@@ -22551,7 +24064,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "gex" = (
 /obj/structure/cable{
@@ -22559,7 +24072,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "geB" = (
 /obj/machinery/cell_charger,
@@ -22602,7 +24118,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/office)
 "gfs" = (
 /obj/structure/table,
@@ -22806,7 +24324,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
 "giN" = (
@@ -22832,8 +24351,7 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "red"
+	icon_state = "redyellowfull"
 	},
 /area/station/civilian/bar)
 "giW" = (
@@ -22884,7 +24402,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 8;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/auxsolarstarboard)
 "gjn" = (
 /obj/machinery/door/firedoor,
@@ -22912,12 +24433,18 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor{
-	icon_state = "bar"
+	icon_state = "redyellowfull"
 	},
 /area/station/rnd/scibreak)
 "gjC" = (
 /turf/simulated/floor/wood,
 /area/station/maintenance/science)
+"gjF" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "blackcorner"
+	},
+/area/station/civilian/gym)
 "gjJ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -22944,6 +24471,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"gjL" = (
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "warning"
+	},
+/area/station/hallway/secondary/entry)
 "gjS" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -22953,6 +24486,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison)
+"gjT" = (
+/obj/structure/filingcabinet/chestdrawer,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/station/civilian/dormitories)
 "gjY" = (
 /obj/structure/table,
 /obj/item/weapon/folder,
@@ -23020,7 +24560,9 @@
 	name = "Library Desk Door";
 	req_access = list(37)
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/civilian/library)
 "gkL" = (
 /obj/structure/cable{
@@ -23044,7 +24586,9 @@
 /obj/structure/table,
 /obj/item/weapon/storage/toolbox/mechanical,
 /obj/item/device/tagger/shop,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/storage)
 "gkV" = (
 /turf/simulated/wall,
@@ -23111,7 +24655,9 @@
 /obj/machinery/firealarm{
 	pixel_y = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
 /area/station/engineering/atmos)
 "glm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -23129,7 +24675,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "glH" = (
 /obj/effect/decal/cleanable/dirt,
@@ -23137,9 +24683,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
+/turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "glO" = (
 /obj/structure/closet/firecloset,
@@ -23157,7 +24701,10 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Pure to Mix"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "cautioncorner"
+	},
 /area/station/engineering/atmos)
 "gmg" = (
 /obj/structure/sign/poster/contraband/borg_fancy_1{
@@ -23197,7 +24744,9 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "gmw" = (
 /turf/simulated/wall,
@@ -23440,7 +24989,8 @@
 "gpz" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /turf/simulated/floor{
-	icon_state = "bot"
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/station/engineering/monitoring)
 "gpG" = (
@@ -23448,8 +24998,7 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "red"
+	icon_state = "redyellowfull"
 	},
 /area/station/civilian/bar)
 "gpM" = (
@@ -23507,7 +25056,10 @@
 /obj/structure/window/thin{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "arrival"
+	},
 /area/station/engineering/atmos)
 "gqH" = (
 /turf/simulated/floor{
@@ -23527,8 +25079,7 @@
 "gqT" = (
 /obj/structure/stool/bar,
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "red"
+	icon_state = "redyellowfull"
 	},
 /area/station/civilian/bar)
 "gqV" = (
@@ -23543,10 +25094,15 @@
 /obj/machinery/atmospherics/components/trinary/filter/m_filter{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
 /area/station/engineering/atmos)
 "gro" = (
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/storage/primary)
 "grP" = (
 /obj/machinery/door/firedoor,
@@ -23702,6 +25258,12 @@
 	},
 /turf/simulated/wall,
 /area/station/cargo/storage)
+"gtO" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	icon_state = "warning"
+	},
+/area/station/cargo/storage)
 "gtQ" = (
 /obj/machinery/teleport/station,
 /turf/simulated/floor{
@@ -23718,8 +25280,7 @@
 	pixel_y = -5
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "whiteblue"
+	icon_state = "wooden"
 	},
 /area/station/medical/psych)
 "gtW" = (
@@ -23811,6 +25372,12 @@
 	icon_state = "barber"
 	},
 /area/station/medical/cmo)
+"guK" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "black"
+	},
+/area/station/hallway/secondary/entry)
 "guM" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -23819,15 +25386,18 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "whitehall"
+	dir = 8;
+	icon_state = "warnwhite"
 	},
 /area/station/rnd/storage)
 "guO" = (
 /obj/structure/stool/bed/chair/metal{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/hallway/secondary/exit)
 "guR" = (
 /obj/structure/cable{
@@ -23875,6 +25445,27 @@
 	},
 /turf/simulated/floor/engine/oxygen,
 /area/station/engineering/atmos)
+"gvn" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "whiteredcorner"
+	},
+/area/station/medical/hallway)
+"gvr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "whitepurple"
+	},
+/area/station/rnd/hallway)
 "gvs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -23886,7 +25477,9 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "gvz" = (
 /obj/structure/stool/bed/chair/office/dark{
@@ -23900,16 +25493,22 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 5;
+	dir = 8;
 	icon_state = "vault"
 	},
 /area/station/engineering/atmos)
 "gvF" = (
-/turf/simulated/floor{
-	dir = 10;
-	icon_state = "red"
+/obj/structure/sign/nanotrasen{
+	pixel_y = 32
 	},
-/area/station/civilian/bar)
+/obj/machinery/light/smart{
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "gvN" = (
 /obj/machinery/door/airlock/external{
 	name = "Arrival Airlock"
@@ -23977,7 +25576,9 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/chiefs_office)
 "gwA" = (
 /obj/structure/cable{
@@ -24015,7 +25616,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "gxv" = (
 /obj/machinery/suit_storage_unit/standard_unit,
@@ -24037,8 +25641,16 @@
 	name = "Auxiliary E.V.A. Storage"
 	},
 /obj/structure/barricade/wooden,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"gxY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "warning"
+	},
+/area/station/maintenance/chapel)
 "gyf" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -24052,6 +25664,26 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
+"gyn" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "blackcorner"
+	},
+/area/station/hallway/secondary/exit)
 "gys" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -24245,7 +25877,10 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/engineering/atmos)
 "gAl" = (
 /obj/structure/stool/bed,
@@ -24263,13 +25898,19 @@
 /area/station/security/prison)
 "gAr" = (
 /obj/machinery/space_heater,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "gAG" = (
 /obj/machinery/firealarm{
 	pixel_y = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "blackcorner"
+	},
 /area/station/hallway/secondary/exit)
 "gAR" = (
 /obj/structure/stool/bed/chair/metal/blue{
@@ -24321,7 +25962,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "gBH" = (
 /obj/machinery/door/poddoor{
@@ -24377,7 +26018,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/engineering/engine)
 "gCE" = (
@@ -24569,7 +26211,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitepurplefull"
 	},
 /area/station/rnd/lab)
 "gFQ" = (
@@ -24676,7 +26318,10 @@
 	c_tag = "Arrival Hallway Second Docking North";
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warning"
+	},
 /area/station/hallway/secondary/entry)
 "gHx" = (
 /obj/structure/object_wall/pod{
@@ -24689,6 +26334,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories)
+"gHG" = (
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
+/area/station/security/main)
 "gHT" = (
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
@@ -24700,7 +26350,10 @@
 	dir = 4;
 	icon_state = "pipe-j2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/primary/fore)
 "gIb" = (
 /obj/structure/filingcabinet/chestdrawer,
@@ -24751,7 +26404,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warningcorner"
+	},
 /area/station/engineering/atmos)
 "gIJ" = (
 /obj/structure/cable{
@@ -24826,7 +26482,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/secondary/exit)
 "gKj" = (
 /obj/effect/decal/cleanable/dirt,
@@ -24852,6 +26510,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"gKo" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "blackcorner"
+	},
+/area/station/hallway/secondary/entry)
 "gKt" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -24978,7 +26643,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "yellow"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "gMz" = (
 /obj/machinery/light/small,
@@ -25003,6 +26671,14 @@
 /obj/structure/sign/warning,
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/science)
+"gMT" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "warning"
+	},
+/area/station/engineering/atmos)
 "gNf" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -25077,8 +26753,16 @@
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "warning"
+	},
 /area/station/engineering/atmos)
+"gOn" = (
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "whiteblue"
+	},
+/area/station/medical/hallway)
 "gOs" = (
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -25090,7 +26774,10 @@
 	dir = 4;
 	pixel_x = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "gOx" = (
 /obj/machinery/door/airlock/engineering/glass{
@@ -25105,15 +26792,27 @@
 	name = "Station Intercom (General)";
 	pixel_y = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "brown"
+	},
 /area/station/cargo/qm)
 "gOM" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
+"gPd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "bluecorner"
+	},
+/area/station/maintenance/chapel)
 "gPe" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -25124,7 +26823,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/singularity)
 "gPB" = (
 /obj/structure/cable{
@@ -25137,6 +26838,11 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
+"gPF" = (
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/engineering/atmos)
 "gPL" = (
 /obj/machinery/computer/rdconsole,
 /obj/structure/cable{
@@ -25381,7 +27087,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 29
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "gST" = (
 /obj/structure/stool/bed/chair/metal/green,
@@ -25480,7 +27189,9 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/maintenance/chapel)
 "gUd" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell{
@@ -25546,7 +27257,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "gUI" = (
 /turf/simulated/wall,
@@ -25556,7 +27269,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/engineering/atmos)
 "gUX" = (
 /obj/machinery/shieldwallgen,
@@ -25566,7 +27281,9 @@
 /area/station/bridge/teleporter)
 "gVe" = (
 /obj/effect/landmark/start/assistant,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/storage/primary)
 "gVg" = (
 /obj/structure/table/woodentable,
@@ -25574,6 +27291,14 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/library)
+"gVm" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "gVo" = (
 /obj/machinery/camera{
 	c_tag = "Misc Test Chamber";
@@ -25600,7 +27325,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitepurplefull"
 	},
 /area/station/rnd/hallway)
 "gVF" = (
@@ -25705,6 +27430,13 @@
 	icon_state = "red"
 	},
 /area/station/engineering/engine)
+"gWE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/station/civilian/dormitories)
 "gWP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -25773,7 +27505,10 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 4;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/starboardsolar)
 "gYk" = (
 /obj/structure/object_wall/mining{
@@ -25844,6 +27579,17 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/bridge/meeting_room)
+"gZd" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/station/rnd/hallway)
 "gZg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -25855,7 +27601,8 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "bot"
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/station/hallway/primary/port)
 "gZp" = (
@@ -25863,7 +27610,9 @@
 	dir = 1
 	},
 /obj/machinery/light/smart,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "gZz" = (
 /obj/structure/cable{
@@ -25884,7 +27633,10 @@
 /obj/machinery/door/airlock/engineering{
 	name = "Auxiliary Construction Zone"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warningcorner"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "gZV" = (
 /obj/structure/stool/bed/chair/office/dark,
@@ -25938,7 +27690,8 @@
 	dir = 9
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whitehall"
 	},
 /area/station/rnd/hallway)
 "haO" = (
@@ -26011,7 +27764,8 @@
 	dir = 6
 	},
 /turf/simulated/floor{
-	icon_state = "whitepurplefull"
+	dir = 4;
+	icon_state = "darkpurplefull"
 	},
 /area/station/rnd/hor)
 "hbE" = (
@@ -26050,6 +27804,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"hbR" = (
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/station/civilian/gym)
 "hbT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/alarm{
@@ -26068,7 +27828,7 @@
 "hcn" = (
 /obj/structure/stool,
 /turf/simulated/floor{
-	icon_state = "bar"
+	icon_state = "redyellowfull"
 	},
 /area/station/rnd/scibreak)
 "hcD" = (
@@ -26123,7 +27883,10 @@
 	name = "WARNING: EXTERNAL AIRLOCK";
 	pixel_y = 32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
 /area/station/hallway/secondary/entry)
 "hdu" = (
 /obj/effect/decal/cleanable/dirt,
@@ -26131,7 +27894,10 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 8;
+	icon_state = "warnplatecorner"
+	},
 /area/station/maintenance/chapel)
 "hdG" = (
 /obj/structure/cable{
@@ -26140,7 +27906,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "hdJ" = (
 /obj/machinery/status_display,
@@ -26170,10 +27938,7 @@
 "hdU" = (
 /obj/structure/table/reinforced,
 /obj/item/device/analyzer,
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "black"
-	},
+/turf/simulated/floor,
 /area/station/storage/tech)
 "hdV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -26198,7 +27963,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/security/checkpoint)
 "heu" = (
 /obj/structure/disposalpipe/segment,
@@ -26211,7 +27979,10 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "heK" = (
 /obj/structure/object_wall/pod{
@@ -26313,6 +28084,13 @@
 	icon_state = "dark"
 	},
 /area/station/maintenance/cargo)
+"hgH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "warning"
+	},
+/area/station/hallway/secondary/entry)
 "hgU" = (
 /obj/structure/sign/poster/official/no_erp{
 	pixel_x = -30
@@ -26347,7 +28125,10 @@
 /area/station/civilian/chapel/mass_driver)
 "hhG" = (
 /obj/machinery/computer/export,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "brown"
+	},
 /area/station/cargo/storage)
 "hhJ" = (
 /obj/structure/barricade/wooden,
@@ -26394,7 +28175,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/security/prison)
 "hiv" = (
 /obj/structure/cable{
@@ -26498,7 +28281,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "brown"
+	},
 /area/station/cargo/qm)
 "hkt" = (
 /obj/structure/rack,
@@ -26584,7 +28369,9 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "hle" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -26607,13 +28394,19 @@
 /obj/item/weapon/clipboard,
 /obj/item/weapon/folder/red,
 /obj/item/weapon/pen,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/security/hos)
 "hlq" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 28
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "hlv" = (
 /turf/simulated/wall,
@@ -26653,7 +28446,10 @@
 /turf/simulated/floor,
 /area/station/security/main)
 "hlQ" = (
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warning"
+	},
 /area/station/ai_monitored/eva)
 "hlU" = (
 /obj/structure/table/reinforced,
@@ -26722,7 +28518,8 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "bot"
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/station/security/hos)
 "hmR" = (
@@ -26741,7 +28538,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "hno" = (
 /turf/simulated/floor{
@@ -26768,6 +28568,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/space)
+"hnu" = (
+/obj/item/weapon/flora/random,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "hnX" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -26803,7 +28610,10 @@
 	pixel_x = -28;
 	pixel_y = -6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellow"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "hoM" = (
 /obj/structure/rack,
@@ -26832,7 +28642,6 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
-	dir = 8;
 	icon_state = "neutralcorner"
 	},
 /area/station/civilian/dormitories)
@@ -26840,7 +28649,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
 	dir = 1;
-	icon_state = "red"
+	icon_state = "whitered"
 	},
 /area/station/security/main)
 "hpd" = (
@@ -26930,6 +28739,7 @@
 	},
 /obj/machinery/light/smart,
 /turf/simulated/floor{
+	dir = 6;
 	icon_state = "red"
 	},
 /area/station/medical/hallway)
@@ -27050,7 +28860,9 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/gateway)
 "hqS" = (
 /obj/structure/window/thin/reinforced{
@@ -27082,8 +28894,7 @@
 "hqT" = (
 /obj/machinery/color_mixer,
 /turf/simulated/floor{
-	dir = 6;
-	icon_state = "escape"
+	icon_state = "redchecker"
 	},
 /area/station/hallway/primary/port)
 "hrj" = (
@@ -27130,7 +28941,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "hrO" = (
 /turf/simulated/floor{
@@ -27216,6 +29027,12 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"htg" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "blackcorner"
+	},
+/area/station/civilian/chapel)
 "htC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -27273,8 +29090,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "escape"
+	icon_state = "redchecker"
 	},
 /area/station/civilian/kitchen)
 "htM" = (
@@ -27291,7 +29107,9 @@
 	dir = 1;
 	name = "Air to Ports"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "hud" = (
 /obj/machinery/shower/free{
@@ -27303,10 +29121,14 @@
 /obj/structure/window/thin{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/medical/cryo)
 "hue" = (
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/auxsolarstarboard)
 "hug" = (
 /obj/structure/cable{
@@ -27324,8 +29146,8 @@
 /area/station/maintenance/science)
 "hur" = (
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "darkredcorners"
+	dir = 8;
+	icon_state = "warndark"
 	},
 /area/station/security/armoury)
 "huv" = (
@@ -27378,10 +29200,10 @@
 /area/station/civilian/hydroponics)
 "huZ" = (
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkbluecorners"
+	dir = 1;
+	icon_state = "black"
 	},
-/area/station/medical/surgeryobs)
+/area/station/civilian/chapel)
 "hva" = (
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor{
@@ -27464,7 +29286,10 @@
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "hwe" = (
 /obj/structure/disposalpipe/segment,
@@ -27491,13 +29316,16 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
 /area/station/hallway/secondary/entry)
 "hwE" = (
 /obj/machinery/door/airlock/external{
 	name = "Arrival Airlock"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/security/brig)
 "hwF" = (
 /obj/structure/table/woodentable/poker,
@@ -27650,7 +29478,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 8;
 	icon_state = "neutralcorner"
 	},
 /area/station/civilian/dormitories)
@@ -27670,7 +29497,10 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
 /area/station/engineering/atmos)
 "hyD" = (
 /obj/item/stack/cable_coil,
@@ -27727,7 +29557,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "hyY" = (
 /obj/structure/cable{
@@ -27777,7 +29609,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "purplechecker"
+	dir = 1;
+	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/hor)
 "hzw" = (
@@ -27793,7 +29626,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 10
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/engineering/atmos)
 "hzE" = (
 /obj/structure/cable{
@@ -27862,7 +29698,9 @@
 /area/station/maintenance/science)
 "hzP" = (
 /obj/machinery/light/smart,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "warning"
+	},
 /area/station/cargo/storage)
 "hzS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -27889,7 +29727,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor{
-	dir = 6;
+	dir = 4;
 	icon_state = "warning"
 	},
 /area/station/engineering/engine)
@@ -27910,7 +29748,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/civilian/chapel/mass_driver)
 "hAs" = (
@@ -27962,7 +29801,10 @@
 /area/station/hallway/primary/fore)
 "hAR" = (
 /obj/item/weapon/flora/random,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "hAU" = (
 /obj/machinery/alarm{
@@ -27986,8 +29828,17 @@
 /obj/machinery/computer/cargo{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
+	},
 /area/station/cargo/qm)
+"hBl" = (
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/station/hallway/secondary/entry)
 "hBo" = (
 /obj/structure/closet/crate/bin,
 /obj/item/clothing/shoes/orange/candals,
@@ -28003,8 +29854,7 @@
 "hBA" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/maintenance/chapel)
 "hBH" = (
@@ -28059,18 +29909,36 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"hCo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
+/area/station/maintenance/chapel)
 "hCq" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/engineering/atmos)
 "hCD" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"hCG" = (
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "yellow"
+	},
+/area/station/engineering/engine)
 "hCJ" = (
 /obj/machinery/atmospherics/components/binary/valve,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warning"
+	},
 /area/station/maintenance/chapel)
 "hCO" = (
 /obj/structure/grille,
@@ -28089,7 +29957,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "hDc" = (
 /obj/structure/stool/bed/chair/office/light{
@@ -28122,7 +29990,8 @@
 	dir = 5
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/hallway/primary/starboard)
 "hDI" = (
@@ -28131,18 +30000,23 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitepurplefull"
 	},
 /area/station/rnd/hallway)
 "hDL" = (
 /obj/effect/landmark/start/cargo_technician,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/office)
 "hDN" = (
 /obj/structure/table/woodentable,
 /obj/item/device/radio/intercom,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "blue"
+	},
 /area/station/civilian/dormitories)
 "hDP" = (
 /obj/machinery/door/airlock/atmos{
@@ -28171,7 +30045,9 @@
 /area/station/rnd/xenobiology)
 "hEv" = (
 /obj/structure/stool,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/security/prison)
 "hER" = (
 /obj/machinery/porta_turret/station_default{
@@ -28237,7 +30113,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/civilian/dormitories)
 "hFB" = (
 /obj/item/weapon/flora/random,
@@ -28250,6 +30128,12 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/fore)
+"hFG" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/station/cargo/storage)
 "hFR" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -28270,7 +30154,10 @@
 	id = "aftport";
 	name = "Port Quarter Solar Control"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 10;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/portsolar)
 "hGm" = (
 /obj/structure/sign/warning,
@@ -28363,7 +30250,8 @@
 "hGZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whitebluecorner"
 	},
 /area/station/medical/hallway)
 "hHc" = (
@@ -28478,7 +30366,10 @@
 	dir = 8
 	},
 /obj/structure/window/thin,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "red"
+	},
 /area/station/engineering/atmos)
 "hIQ" = (
 /obj/structure/sign/nanotrasen{
@@ -28522,7 +30413,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/hallway/primary/central)
 "hJG" = (
 /obj/machinery/light/smart{
@@ -28542,7 +30435,7 @@
 	name = "E.V.A. Storage Shutters"
 	},
 /obj/structure/barricade/wooden,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "hJJ" = (
 /obj/structure/cable{
@@ -28593,7 +30486,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
 /area/station/maintenance/atmos)
 "hKs" = (
 /obj/structure/object_wall/pod{
@@ -28639,7 +30534,9 @@
 	dir = 5
 	},
 /obj/machinery/light/smart,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "hLL" = (
 /obj/structure/cable{
@@ -28661,7 +30558,10 @@
 /obj/effect/landmark/start/paramedic,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/station/medical/storage)
 "hMb" = (
 /obj/structure/closet/wardrobe/red,
@@ -28682,7 +30582,9 @@
 /obj/structure/table,
 /obj/item/toy/ammo/gun,
 /obj/item/toy/gun,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
 /area/station/civilian/gym)
 "hMC" = (
 /obj/effect/decal/cleanable/dirt,
@@ -28706,7 +30608,9 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/landmark/start/barber,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/hallway/primary/port)
 "hMR" = (
 /obj/structure/cable{
@@ -28720,7 +30624,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "hMZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -28738,7 +30645,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "whitehall"
 	},
 /area/station/rnd/hallway)
 "hNp" = (
@@ -28800,6 +30708,16 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
+"hOl" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
+/area/station/rnd/xenobiology)
 "hOq" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
@@ -28934,11 +30852,15 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/starboard)
 "hPP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor,
-/area/station/civilian/kitchen)
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "hPY" = (
 /turf/simulated/floor{
 	icon_state = "grimy"
@@ -28974,7 +30896,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitepurplefull"
 	},
 /area/station/rnd/xenobiology)
 "hQl" = (
@@ -29010,6 +30932,15 @@
 	icon_state = "arrival"
 	},
 /area/station/hallway/primary/port)
+"hQX" = (
+/obj/machinery/light/smart{
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "hRb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -29037,7 +30968,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "arrival"
+	dir = 1;
+	icon_state = "whiteblue"
 	},
 /area/station/medical/reception)
 "hRn" = (
@@ -29077,7 +31009,10 @@
 /obj/structure/window/thin/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "purple"
+	},
 /area/station/rnd/xenobiology)
 "hSR" = (
 /obj/machinery/door/airlock{
@@ -29110,7 +31045,10 @@
 /area/station/medical/cmo)
 "hTc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellowcorner"
+	},
 /area/station/hallway/primary/central)
 "hTg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -29246,11 +31184,6 @@
 	},
 /area/station/civilian/chapel/office)
 "hVg" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
@@ -29258,7 +31191,15 @@
 	dir = 10
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "hVo" = (
 /obj/structure/filingcabinet/chestdrawer,
@@ -29282,6 +31223,11 @@
 	icon_state = "platebotc"
 	},
 /area/station/cargo/recycleroffice)
+"hVy" = (
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/singularity)
 "hVD" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/folder/blue,
@@ -29292,6 +31238,12 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
+"hVJ" = (
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/station/engineering/atmos)
 "hVK" = (
 /obj/structure/closet,
 /turf/simulated/floor/plating,
@@ -29475,7 +31427,9 @@
 	pixel_x = 22
 	},
 /obj/machinery/computer,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
 /area/station/storage/tools)
 "hXC" = (
 /obj/machinery/door/firedoor,
@@ -29543,6 +31497,12 @@
 	icon_state = "vault"
 	},
 /area/station/security/execution)
+"hYm" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "whiteblue"
+	},
+/area/station/medical/hallway)
 "hYI" = (
 /obj/machinery/camera{
 	c_tag = "Library Mid";
@@ -29583,10 +31543,16 @@
 	pixel_y = -6
 	},
 /turf/simulated/floor{
-	dir = 10;
+	dir = 8;
 	icon_state = "warning"
 	},
 /area/station/security/brig)
+"hYY" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warningcorner"
+	},
+/area/station/hallway/secondary/exit)
 "hZe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -29639,8 +31605,26 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/maintenance/cargo)
+"hZu" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "whitepurplefull"
+	},
+/area/station/rnd/hallway)
 "hZB" = (
 /obj/machinery/smartfridge/chemistry,
 /turf/simulated/wall,
@@ -29649,7 +31633,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "hZU" = (
 /turf/simulated/floor/wood,
@@ -29665,7 +31651,9 @@
 	name = "Creature Pen";
 	req_access = list(8)
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
 /area/station/rnd/xenobiology)
 "iau" = (
 /obj/machinery/light/small{
@@ -29748,7 +31736,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
-	icon_state = "purplechecker"
+	dir = 1;
+	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/hor)
 "ibe" = (
@@ -29816,7 +31805,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
 "ibP" = (
 /obj/structure/cable{
@@ -29905,7 +31894,10 @@
 	pixel_x = -28;
 	pixel_y = -5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/hallway/secondary/entry)
 "idF" = (
 /obj/machinery/clonepod,
@@ -29942,7 +31934,9 @@
 /obj/structure/window/thin/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "redfull"
+	},
 /area/station/hallway/secondary/exit)
 "ieu" = (
 /obj/machinery/hologram/holopad,
@@ -30052,6 +32046,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"ifz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "ifH" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -30171,7 +32173,9 @@
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/storage)
 "igM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -30269,7 +32273,10 @@
 /obj/structure/mirror{
 	pixel_y = 32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "purple"
+	},
 /area/station/rnd/hor)
 "ihP" = (
 /obj/structure/cable{
@@ -30280,7 +32287,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
 /area/station/engineering/chiefs_office)
 "ihW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -30337,7 +32347,9 @@
 	name = "Station Intercom (General)";
 	pixel_y = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/storage)
 "iir" = (
 /obj/structure/cable{
@@ -30365,13 +32377,17 @@
 /area/station/rnd/hallway)
 "iiQ" = (
 /obj/random/vending/cola,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/hallway/secondary/exit)
 "ije" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Cooling Bypass"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
 /area/station/engineering/singularity)
 "ijf" = (
 /obj/machinery/shieldgen,
@@ -30421,7 +32437,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
 /area/station/maintenance/chapel)
 "ikr" = (
 /obj/structure/cable{
@@ -30450,15 +32468,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "yellowfull"
-	},
+/turf/simulated/floor,
 /area/station/hallway/primary/port)
 "ikW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "red"
+	},
 /area/station/security/brig)
 "ikZ" = (
 /obj/machinery/vending/clothing,
@@ -30487,7 +32505,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "ilq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -30524,7 +32544,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "warningcorner"
+	},
 /area/station/maintenance/chapel)
 "ilA" = (
 /turf/simulated/floor/plating,
@@ -30643,7 +32665,7 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 5;
+	dir = 8;
 	icon_state = "vault"
 	},
 /area/station/engineering/atmos)
@@ -30856,7 +32878,10 @@
 /obj/machinery/status_display{
 	pixel_x = 32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warning"
+	},
 /area/station/hallway/secondary/entry)
 "ipN" = (
 /obj/machinery/door/unpowered/shuttle/pod{
@@ -30872,13 +32897,19 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
 /area/station/rnd/xenobiology)
 "iqg" = (
 /obj/machinery/computer/security/mining{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
+	},
 /area/station/cargo/qm)
 "iqh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -30917,7 +32948,10 @@
 /obj/machinery/light/smart{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/station/civilian/gym)
 "iqI" = (
 /turf/simulated/floor{
@@ -30990,7 +33024,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "red"
+	},
 /area/station/hallway/secondary/exit)
 "irO" = (
 /obj/structure/easel,
@@ -31071,19 +33108,26 @@
 "isW" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	icon_state = "left";
+	name = "Chemistry Desk";
+	req_access = list(33)
+	},
 /turf/simulated/floor/plating,
 /area/station/medical/chemistry)
 "isX" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "itb" = (
 /obj/structure/stool/bar,
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "escape"
+	icon_state = "redchecker"
 	},
 /area/station/civilian/kitchen)
 "itg" = (
@@ -31127,7 +33171,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
 /area/station/hallway/primary/central)
 "itF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -31200,14 +33247,18 @@
 /area/station/bridge/hop_office)
 "iuv" = (
 /obj/structure/closet/emcloset,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/hallway/secondary/exit)
 "iuC" = (
 /obj/structure/table/reinforced,
 /obj/structure/sign/poster/official/space_cops{
 	pixel_x = -32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "redfull"
+	},
 /area/station/hallway/secondary/exit)
 "ivc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -31238,15 +33289,15 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "neutral"
 	},
 /area/station/civilian/dormitories)
 "ivp" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/item/weapon/storage/wallet,
 /turf/simulated/floor{
-	icon_state = "bot"
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/station/civilian/dormitories)
 "ivs" = (
@@ -31282,6 +33333,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
+"ivG" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "ivS" = (
 /obj/structure/closet/cabinet,
 /obj/item/weapon/storage/briefcase,
@@ -31359,12 +33418,15 @@
 /area/station/security/brig)
 "ixC" = (
 /obj/item/target/syndicate,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/rnd/hallway)
 "ixG" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor{
-	icon_state = "bot"
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/station/engineering/monitoring)
 "ixJ" = (
@@ -31408,7 +33470,10 @@
 	c_tag = "Cargo Bay South-West";
 	dir = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warningcorner"
+	},
 /area/station/cargo/storage)
 "iys" = (
 /obj/effect/decal/cleanable/dirt,
@@ -31423,7 +33488,8 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor{
-	icon_state = "bot"
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/station/civilian/dormitories)
 "iyu" = (
@@ -31470,6 +33536,15 @@
 /obj/item/weapon/storage/box/lights/mixed,
 /turf/simulated/floor,
 /area/station/storage/primary)
+"iyK" = (
+/obj/machinery/light/smart{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/hallway/secondary/exit)
 "iyV" = (
 /turf/simulated/floor/plating{
 	dir = 10;
@@ -31493,7 +33568,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/gateway)
 "izt" = (
 /obj/structure/window/thin/reinforced{
@@ -31506,6 +33583,13 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
+"izG" = (
+/obj/effect/landmark/start/station_engineer,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellow"
+	},
+/area/station/engineering/engine)
 "izH" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -31660,7 +33744,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "iBG" = (
 /obj/machinery/light/small,
@@ -31685,7 +33771,10 @@
 	pixel_x = 28;
 	pixel_y = -5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warning"
+	},
 /area/station/hallway/secondary/entry)
 "iCx" = (
 /obj/structure/cable{
@@ -31751,7 +33840,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/engineering/atmos)
 "iDw" = (
 /obj/item/weapon/flora/random,
@@ -31814,7 +33906,9 @@
 	dir = 5
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/storage/primary)
 "iDV" = (
 /obj/item/weapon/airlock_painter,
@@ -31868,12 +33962,17 @@
 	icon_state = "greenblue"
 	},
 /area/station/civilian/hydroponics)
+"iEF" = (
+/turf/simulated/floor/plating{
+	dir = 8;
+	icon_state = "warnplate"
+	},
+/area/station/security/brig)
 "iEL" = (
 /obj/effect/landmark/start/janitor,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/hallway/secondary/entry)
 "iES" = (
@@ -31972,7 +34071,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitepurplefull"
 	},
 /area/station/rnd/hallway)
 "iGf" = (
@@ -32061,6 +34160,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"iGB" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/station/security/brig)
 "iGF" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/computer/general_air_control/large_tank_control{
@@ -32074,7 +34184,10 @@
 /obj/structure/window/thin{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "arrival"
+	},
 /area/station/engineering/atmos)
 "iGG" = (
 /obj/structure/table,
@@ -32097,7 +34210,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "iGO" = (
 /obj/structure/sign/warning/securearea{
@@ -32149,8 +34262,23 @@
 /obj/machinery/firealarm{
 	pixel_y = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
+"iHJ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
+/area/station/maintenance/science)
 "iHP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -32159,6 +34287,18 @@
 	icon_state = "dark"
 	},
 /area/station/security/interrogation)
+"iIq" = (
+/obj/item/device/radio/intercom{
+	frequency = 1485;
+	name = "Station Intercom (Medbay)";
+	pixel_x = 28;
+	pixel_y = -5
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "whitebluecorner"
+	},
+/area/station/medical/hallway)
 "iIt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -32322,7 +34462,7 @@
 	name = "Atmospherics Auxiliary Port"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "iKW" = (
 /obj/structure/cable{
@@ -32336,7 +34476,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
+	},
 /area/station/cargo/qm)
 "iKX" = (
 /obj/structure/cable{
@@ -32354,7 +34497,10 @@
 	network = list("SS13","Security");
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/security/hos)
 "iKZ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -32370,7 +34516,9 @@
 /area/station/civilian/gym)
 "iLk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowfull"
+	},
 /area/station/engineering/engine)
 "iLo" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -32390,6 +34538,19 @@
 	icon_state = "dark"
 	},
 /area/station/aisat/antechamber_interior)
+"iLM" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "warning"
+	},
+/area/station/engineering/engine)
 "iLP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -32404,7 +34565,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "iMa" = (
 /obj/structure/closet/cabinet,
@@ -32448,7 +34611,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
-	icon_state = "whiteyellowcorner"
+	dir = 4;
+	icon_state = "yellowcorner"
 	},
 /area/station/medical/chemistry)
 "iMj" = (
@@ -32477,8 +34641,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "warning"
+	dir = 1;
+	icon_state = "brown"
 	},
 /area/station/cargo/storage)
 "iMQ" = (
@@ -32519,13 +34683,18 @@
 	c_tag = "Arrival Hallway Second Docking South";
 	dir = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
 /area/station/hallway/secondary/entry)
 "iNz" = (
 /obj/structure/stool/bed/chair{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/civilian/dormitories)
 "iNE" = (
 /obj/structure/rack,
@@ -32563,6 +34732,14 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/civilian/holodeck/alphadeck)
+"iNR" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "bluecorner"
+	},
+/area/station/maintenance/chapel)
 "iOa" = (
 /obj/item/stack/cable_coil,
 /turf/simulated/floor/plating/airless/catwalk,
@@ -32605,7 +34782,10 @@
 	name = "apc right";
 	pixel_x = 28
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 6;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/portsolar)
 "iOK" = (
 /obj/structure/stool/bed/chair/metal/yellow{
@@ -32640,7 +34820,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
 	dir = 1;
-	icon_state = "red"
+	icon_state = "whitered"
 	},
 /area/station/security/main)
 "iPD" = (
@@ -32655,7 +34835,7 @@
 	},
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "red"
+	icon_state = "whitered"
 	},
 /area/station/security/main)
 "iPP" = (
@@ -32670,6 +34850,14 @@
 	icon_state = "delivery"
 	},
 /area/station/storage/primary)
+"iPW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/cargo/storage)
 "iPX" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -32714,6 +34902,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories)
+"iQp" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/station/engineering/atmos)
 "iQv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -32789,7 +34986,7 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitebluecorner"
 	},
 /area/station/medical/hallway)
 "iRb" = (
@@ -32863,10 +35060,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
+/turf/simulated/floor,
 /area/station/maintenance/atmos)
 "iRZ" = (
 /obj/machinery/door/firedoor,
@@ -32912,7 +35106,8 @@
 /obj/structure/stool/bed,
 /obj/item/weapon/bedsheet/medical,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/security/main)
 "iSo" = (
@@ -32947,7 +35142,9 @@
 /area/station/security/vacantoffice)
 "iTb" = (
 /obj/machinery/computer/cargo,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/storage)
 "iTl" = (
 /turf/simulated/wall,
@@ -33060,6 +35257,22 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/singularity)
+"iVc" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/exit)
 "iVe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -33098,7 +35311,8 @@
 	pixel_x = 3
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/medical/morgue)
 "iVU" = (
@@ -33108,7 +35322,10 @@
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "neutral"
+	},
 /area/station/rnd/hor)
 "iWg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -33220,7 +35437,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/office)
 "iXa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -33234,7 +35453,10 @@
 /turf/simulated/wall/r_wall,
 /area/station/security/range)
 "iXs" = (
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
 /area/station/rnd/hor)
 "iXC" = (
 /obj/structure/cable{
@@ -33252,6 +35474,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
+	dir = 1;
 	icon_state = "neutral"
 	},
 /area/station/civilian/dormitories)
@@ -33267,8 +35490,17 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 1;
+	icon_state = "warnplate"
+	},
 /area/station/hallway/secondary/entry)
+"iYj" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "vault"
+	},
+/area/station/engineering/atmos)
 "iYp" = (
 /obj/machinery/door/window/southleft,
 /turf/simulated/floor/plating,
@@ -33357,7 +35589,8 @@
 	sortType = "Chemistry Lab"
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whiteyellowcorner"
 	},
 /area/station/medical/hallway)
 "iZo" = (
@@ -33448,7 +35681,10 @@
 /obj/structure/window/thin{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "black"
+	},
 /area/station/engineering/atmos)
 "jaJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -33501,7 +35737,7 @@
 	freq = 1400;
 	location = "Hydroponics"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "jbM" = (
 /obj/machinery/light/smart,
@@ -33559,11 +35795,34 @@
 	},
 /turf/simulated/floor,
 /area/station/security/main)
+"jcC" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "bluecorner"
+	},
+/area/station/engineering/engine)
 "jcE" = (
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "4-5"
 	},
 /area/shuttle/mining/station)
+"jcJ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "whiteblue"
+	},
+/area/station/medical/hallway)
 "jcM" = (
 /obj/machinery/power/grounding_rod,
 /obj/structure/cable{
@@ -33592,7 +35851,10 @@
 /turf/simulated/floor/wood,
 /area/station/security/blueshield)
 "jde" = (
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "blackcorner"
+	},
 /area/station/civilian/chapel)
 "jdg" = (
 /obj/structure/cable{
@@ -33623,7 +35885,10 @@
 /area/station/aisat/ai_chamber)
 "jdG" = (
 /obj/structure/closet/crate/bin,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "blackcorner"
+	},
 /area/station/hallway/secondary/exit)
 "jdH" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -33642,7 +35907,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "whiteyellowcorner"
+	dir = 4;
+	icon_state = "yellowcorner"
 	},
 /area/station/medical/chemistry)
 "jee" = (
@@ -33663,7 +35929,8 @@
 /obj/item/clothing/suit/bio_suit/particle_protection,
 /obj/item/clothing/head/bio_hood/particle_protection,
 /turf/simulated/floor{
-	icon_state = "delivery"
+	dir = 4;
+	icon_state = "yellow"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "jeq" = (
@@ -33671,7 +35938,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "warningcorner"
+	},
 /area/station/hallway/secondary/entry)
 "jeB" = (
 /obj/structure/cable{
@@ -33693,7 +35962,7 @@
 "jeG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
-	dir = 4;
+	dir = 8;
 	icon_state = "neutral"
 	},
 /area/station/civilian/dormitories)
@@ -33713,7 +35982,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 5;
+	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
 "jfg" = (
@@ -33824,7 +36094,8 @@
 	},
 /obj/item/weapon/reagent_containers/food/snacks/sliceable/pizza/margherita,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/medical/medbreak)
 "jgd" = (
@@ -33878,7 +36149,9 @@
 	name = "OnlineShop";
 	sortType = "OnlineShop"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/office)
 "jgJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -33894,6 +36167,13 @@
 	icon_state = "delivery"
 	},
 /area/station/engineering/engine)
+"jhc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "jhj" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/book/manual/wiki/security_space_law,
@@ -33967,7 +36247,10 @@
 /obj/machinery/light/smart{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/station/civilian/gym)
 "jie" = (
 /obj/structure/table/reinforced,
@@ -34001,9 +36284,7 @@
 /obj/structure/table/woodentable,
 /obj/item/device/tagger/shop,
 /obj/item/weapon/packageWrap,
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
+/turf/simulated/floor/plating,
 /area/station/storage/tools)
 "jiS" = (
 /obj/machinery/computer/area_atmos{
@@ -34016,7 +36297,9 @@
 	dir = 8;
 	pixel_x = -22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "warnwhite"
+	},
 /area/station/rnd/storage)
 "jiU" = (
 /obj/structure/cable{
@@ -34236,7 +36519,8 @@
 "jlJ" = (
 /obj/effect/landmark/start/research_director,
 /turf/simulated/floor{
-	icon_state = "purplechecker"
+	dir = 2;
+	icon_state = "whitepurple"
 	},
 /area/station/rnd/hor)
 "jlK" = (
@@ -34250,12 +36534,24 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/civilian/toilet)
+"jlU" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "brown"
+	},
+/area/station/cargo/qm)
 "jmd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /turf/simulated/floor{
-	icon_state = "bot"
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/station/security/checkpoint)
 "jmu" = (
@@ -34274,7 +36570,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowfull"
+	},
 /area/station/engineering/engine)
 "jmY" = (
 /turf/simulated/floor{
@@ -34350,7 +36648,10 @@
 	name = "Station Intercom (General)";
 	pixel_y = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "purple"
+	},
 /area/station/rnd/xenobiology)
 "jom" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black{
@@ -34362,7 +36663,10 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/station/hallway/secondary/entry)
 "jos" = (
 /obj/structure/cable{
@@ -34487,7 +36791,10 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/primary/fore)
 "jqd" = (
 /obj/structure/table/glass,
@@ -34540,7 +36847,10 @@
 /area/station/security/brig/solitary_confinement)
 "jqN" = (
 /obj/structure/dresser,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "red"
+	},
 /area/station/security/hos)
 "jqQ" = (
 /obj/machinery/door/firedoor,
@@ -34591,6 +36901,15 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
+"jrs" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor{
+	icon_state = "browncorner"
+	},
+/area/station/cargo/storage)
 "jrt" = (
 /obj/structure/closet/wardrobe/atmospherics_yellow,
 /obj/machinery/firealarm{
@@ -34612,7 +36931,10 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "jrA" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on,
@@ -34623,12 +36945,19 @@
 	icon_state = "vault"
 	},
 /area/station/security/execution)
+"jrT" = (
+/turf/simulated/floor{
+	icon_state = "blue"
+	},
+/area/station/hallway/secondary/entry)
 "jrW" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/light/smart{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/storage)
 "jrY" = (
 /obj/machinery/door/airlock{
@@ -34654,7 +36983,9 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/medical/cryo)
 "jsa" = (
 /obj/effect/decal/cleanable/dirt,
@@ -34680,7 +37011,7 @@
 "jsw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "jsI" = (
 /obj/structure/table,
@@ -34691,7 +37022,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "redchecker"
+	},
 /area/station/civilian/kitchen)
 "jsL" = (
 /obj/structure/cable{
@@ -34708,7 +37041,8 @@
 /area/station/hallway/secondary/entry)
 "jtc" = (
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/medical/morgue)
 "jtd" = (
@@ -34756,7 +37090,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "red"
+	},
 /area/station/hallway/secondary/exit)
 "jtB" = (
 /obj/machinery/light/small{
@@ -34820,7 +37157,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitebluefull"
 	},
 /area/station/medical/surgeryobs)
 "jum" = (
@@ -34933,6 +37270,15 @@
 	icon_state = "cautioncorner"
 	},
 /area/station/hallway/primary/port)
+"jvb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/station/cargo/storage)
 "jvd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -34952,7 +37298,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "redyellowfull"
+	},
 /area/station/civilian/bar)
 "jvm" = (
 /obj/structure/dumbbells_rack,
@@ -34993,7 +37341,9 @@
 /area/station/storage/primary)
 "jvF" = (
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/office)
 "jwn" = (
 /obj/machinery/power/terminal,
@@ -35003,7 +37353,10 @@
 	pixel_y = -5
 	},
 /obj/structure/cable,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 8;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/auxsolarport)
 "jwp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -35014,7 +37367,10 @@
 /area/station/security/vacantoffice)
 "jwq" = (
 /obj/machinery/door/firedoor,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "jwD" = (
 /obj/structure/cable{
@@ -35034,7 +37390,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 8;
 	icon_state = "neutralcorner"
 	},
 /area/station/civilian/dormitories)
@@ -35070,7 +37425,7 @@
 	dir = 6
 	},
 /turf/simulated/floor{
-	icon_state = "whitebluefull"
+	icon_state = "darkbluefull"
 	},
 /area/station/medical/cmo)
 "jwW" = (
@@ -35106,13 +37461,18 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/primary/fore)
 "jxm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
 /area/station/rnd/xenobiology)
 "jxn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -35228,7 +37588,9 @@
 	pixel_x = 29;
 	pixel_y = -6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
 /area/station/engineering/atmos)
 "jyK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -35244,15 +37606,25 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/office)
 "jzd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/highsecurity{
 	name = "Engineering Auxiliary Storage"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"jze" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 10
+	},
+/turf/simulated/floor{
+	icon_state = "warning"
+	},
+/area/station/engineering/atmos)
 "jzj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -35263,7 +37635,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "jzq" = (
 /obj/machinery/power/apc{
@@ -35272,7 +37646,8 @@
 	},
 /obj/structure/cable,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/medical/morgue)
 "jzs" = (
@@ -35295,7 +37670,8 @@
 	req_access = list(22)
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/civilian/chapel/office)
 "jzV" = (
@@ -35358,7 +37734,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
 /area/station/engineering/singularity)
 "jBf" = (
 /obj/effect/decal/cleanable/greenglow,
@@ -35464,7 +37842,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitebluefull"
 	},
 /area/station/medical/sleeper)
 "jBY" = (
@@ -35493,8 +37871,7 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "blackcorner"
+	icon_state = "blackchecker"
 	},
 /area/station/hallway/primary/port)
 "jCI" = (
@@ -35507,11 +37884,18 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge/captain_quarters)
+"jDf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warningcorner"
+	},
+/area/station/hallway/secondary/entry)
 "jDw" = (
 /obj/machinery/portable_atmospherics/powered/scrubber/huge,
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "vault"
+	icon_state = "warndark"
 	},
 /area/station/rnd/storage)
 "jDM" = (
@@ -35601,15 +37985,16 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 10
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "jFs" = (
 /obj/machinery/door/airlock/external{
 	name = "Arrival Airlock"
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "jFu" = (
 /obj/machinery/ai_slipper{
@@ -35635,7 +38020,7 @@
 	freq = 1400;
 	location = "Bar"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "jFP" = (
 /obj/machinery/power/terminal{
@@ -35645,14 +38030,19 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
 /area/station/engineering/engine)
 "jFR" = (
 /turf/simulated/floor/carpet/green,
 /area/station/civilian/dormitories)
 "jFS" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "jFX" = (
 /obj/machinery/portable_atmospherics/powered/pump,
@@ -35667,6 +38057,12 @@
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
+"jGc" = (
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/station/hallway/secondary/entry)
 "jGd" = (
 /obj/machinery/door/airlock/hatch{
 	name = "MiniSat Transit Tube Access"
@@ -35717,7 +38113,7 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor{
-	dir = 9;
+	dir = 1;
 	icon_state = "black"
 	},
 /area/station/hallway/primary/fore)
@@ -35733,8 +38129,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/civilian/bar)
 "jGU" = (
@@ -35884,7 +38279,8 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/civilian/chapel)
 "jIP" = (
@@ -35933,7 +38329,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/maintenance/chapel)
 "jJo" = (
 /obj/structure/cable{
@@ -35944,7 +38342,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/medical/sleeper)
 "jJr" = (
 /obj/effect/landmark/start/quartermaster,
@@ -35977,7 +38377,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/qm)
 "jJs" = (
 /obj/machinery/door/firedoor,
@@ -36011,8 +38413,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor{
-	dir = 6;
-	icon_state = "red"
+	icon_state = "dark"
 	},
 /area/station/security/brig)
 "jJK" = (
@@ -36103,7 +38504,10 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 1;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/auxsolarstarboard)
 "jKI" = (
 /obj/machinery/door/firedoor,
@@ -36157,8 +38561,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "redchecker"
+	},
 /area/station/civilian/kitchen)
+"jKS" = (
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "warning"
+	},
+/area/station/hallway/secondary/entry)
 "jKT" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 1
@@ -36179,13 +38591,24 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "redyellowfull"
+	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
 "jLa" = (
 /obj/machinery/vending/coffee,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/hallway/secondary/exit)
+"jLh" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "jLq" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -36195,7 +38618,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "jLF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -36221,7 +38646,10 @@
 	dir = 8
 	},
 /obj/structure/window/thin,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "purple"
+	},
 /area/station/engineering/atmos)
 "jLW" = (
 /obj/structure/table,
@@ -36250,7 +38678,9 @@
 	pixel_x = 6;
 	pixel_y = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/medical/chemistry)
 "jMd" = (
 /turf/simulated/floor{
@@ -36271,15 +38701,28 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"jMv" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "whitebluecorner"
+	},
+/area/station/medical/hallway)
+"jMy" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "redcorner"
+	},
+/area/station/hallway/secondary/entry)
 "jMB" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "bot"
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/station/engineering/monitoring)
 "jMG" = (
@@ -36287,7 +38730,8 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/medical/morgue)
 "jMU" = (
@@ -36374,7 +38818,9 @@
 	dir = 4
 	},
 /obj/machinery/light/smart,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "jNT" = (
 /obj/machinery/door/firedoor,
@@ -36445,7 +38891,7 @@
 	pixel_x = 28
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "warndark"
 	},
 /area/station/rnd/tox_launch)
 "jOJ" = (
@@ -36496,8 +38942,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "blackcorner"
+	icon_state = "blackchecker"
 	},
 /area/station/hallway/primary/port)
 "jPt" = (
@@ -36552,7 +38997,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "redyellowfull"
+	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
 "jPQ" = (
@@ -36561,7 +39006,7 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "bot"
 	},
 /area/station/medical/storage)
 "jPR" = (
@@ -36608,6 +39053,16 @@
 	icon_state = "darkbluecorners"
 	},
 /area/station/medical/genetics)
+"jQj" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/singularity)
 "jQo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -36615,7 +39070,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "jQp" = (
 /obj/effect/decal/cleanable/dirt,
@@ -36678,10 +39135,17 @@
 "jQT" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/civilian/bar)
+"jRa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "neutral"
+	},
+/area/station/civilian/gym)
 "jRh" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -36726,9 +39190,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "jSU" = (
 /obj/structure/table,
@@ -36741,8 +39203,7 @@
 	pixel_y = -22
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/hallway/secondary/entry)
 "jSW" = (
@@ -36787,7 +39248,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
 /area/station/engineering/singularity)
 "jTu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -36873,8 +39336,8 @@
 	dir = 5
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "red"
+	dir = 8;
+	icon_state = "yellowcorner"
 	},
 /area/station/engineering/engine)
 "jUy" = (
@@ -36902,8 +39365,21 @@
 /obj/machinery/firealarm{
 	pixel_y = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
+"jUW" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
+/area/station/maintenance/science)
 "jVh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/stool/bed/chair/wood/normal{
@@ -36922,7 +39398,10 @@
 "jVl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 1;
+	icon_state = "warnplatecorner"
+	},
 /area/station/maintenance/chapel)
 "jVn" = (
 /obj/structure/cable{
@@ -37020,7 +39499,9 @@
 /area/station/hallway/primary/fore)
 "jWH" = (
 /obj/effect/landmark/start/shaft_miner,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/miningoffice)
 "jWM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -37055,6 +39536,14 @@
 	icon_state = "dark"
 	},
 /area/station/bridge/nuke_storage)
+"jXb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
+/area/station/maintenance/chapel)
 "jXd" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -37063,7 +39552,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/gateway)
 "jXj" = (
 /obj/structure/cable{
@@ -37077,8 +39568,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 10;
-	icon_state = "arrival"
+	dir = 4;
+	icon_state = "whitebluecorner"
 	},
 /area/station/medical/reception)
 "jXo" = (
@@ -37124,7 +39615,8 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/medical/morgue)
 "jXT" = (
@@ -37150,6 +39642,14 @@
 /obj/structure/grille,
 /turf/simulated/wall/r_wall,
 /area/station/engineering/atmos)
+"jXZ" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 10
+	},
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/singularity)
 "jYb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -37165,7 +39665,10 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 10;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/auxsolarport)
 "jYs" = (
 /obj/structure/table/reinforced,
@@ -37224,8 +39727,7 @@
 	},
 /obj/structure/stool/bed/chair/barber,
 /turf/simulated/floor{
-	dir = 6;
-	icon_state = "escape"
+	icon_state = "redchecker"
 	},
 /area/station/hallway/primary/port)
 "jYV" = (
@@ -37248,7 +39750,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/station/civilian/library)
 "jZs" = (
@@ -37281,7 +39784,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/gateway)
 "kaf" = (
 /obj/structure/table,
@@ -37364,7 +39869,8 @@
 	dir = 9
 	},
 /turf/simulated/floor{
-	icon_state = "bot"
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/station/civilian/dormitories)
 "kco" = (
@@ -37400,7 +39906,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "kdf" = (
 /turf/simulated/floor{
@@ -37410,14 +39919,18 @@
 "kdi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "whitehall"
 	},
 /area/station/rnd/hallway)
 "kdq" = (
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "kdy" = (
 /obj/structure/stool/bed/chair/comfy/black,
@@ -37463,7 +39976,18 @@
 	dir = 1;
 	name = "Port to Filter"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
+"kdU" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "kdW" = (
 /obj/machinery/navbeacon{
@@ -37474,7 +39998,7 @@
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "kdY" = (
 /obj/machinery/flasher/portable,
@@ -37552,7 +40076,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "warndark"
 	},
 /area/station/rnd/storage)
 "kfd" = (
@@ -37578,7 +40102,10 @@
 /obj/structure/window/thin{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "purple"
+	},
 /area/station/engineering/atmos)
 "kfl" = (
 /obj/structure/cable{
@@ -37732,7 +40259,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "kgk" = (
 /obj/structure/table/reinforced,
@@ -37740,7 +40270,10 @@
 	pixel_x = -28;
 	pixel_y = -6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "orange"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "kgH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -37777,6 +40310,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
+	dir = 1;
 	icon_state = "neutral"
 	},
 /area/station/civilian/dormitories)
@@ -37806,7 +40340,9 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "khY" = (
 /obj/machinery/door/airlock/highsecurity{
@@ -37826,7 +40362,10 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "kid" = (
 /obj/structure/sink{
@@ -37842,6 +40381,12 @@
 	icon_state = "bot"
 	},
 /area/station/rnd/robotics)
+"kin" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	icon_state = "whitehall"
+	},
+/area/station/rnd/hallway)
 "kiy" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -37881,6 +40426,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/hor)
+"kiP" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "blackcorner"
+	},
+/area/station/hallway/secondary/entry)
+"kiT" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "kiX" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -37960,7 +40523,9 @@
 /obj/item/clothing/glasses/meson,
 /obj/item/weapon/tank/emergency_oxygen/engi,
 /obj/item/clothing/suit/storage/hazardvest,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
 /area/station/engineering/engine)
 "kjZ" = (
 /obj/structure/disposalpipe/segment,
@@ -38030,6 +40595,15 @@
 	icon_state = "dark"
 	},
 /area/station/ai_monitored/eva)
+"kkH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
+/area/station/engineering/atmos)
 "kkN" = (
 /obj/structure/table/woodentable,
 /obj/item/device/flashlight/lamp,
@@ -38055,8 +40629,7 @@
 	dir = 7
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "escape"
+	icon_state = "redchecker"
 	},
 /area/station/civilian/kitchen)
 "klj" = (
@@ -38103,6 +40676,12 @@
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall,
 /area/station/engineering/chiefs_office)
+"kma" = (
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/station/hallway/secondary/entry)
 "kms" = (
 /obj/structure/closet/firecloset,
 /obj/structure/cable{
@@ -38145,6 +40724,12 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/warden)
+"kmP" = (
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warndark"
+	},
+/area/station/engineering/atmos)
 "kmW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
@@ -38164,7 +40749,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitebluefull"
 	},
 /area/station/medical/hallway)
 "kna" = (
@@ -38212,7 +40797,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/primary/central)
 "koj" = (
 /obj/structure/cable{
@@ -38245,7 +40832,10 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos)
 "kou" = (
 /obj/structure/cable{
@@ -38262,7 +40852,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor,
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-y"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "koy" = (
 /obj/structure/closet/secure_closet/forensics,
@@ -38306,13 +40902,10 @@
 	},
 /area/station/rnd/storage)
 "kpf" = (
-/obj/machinery/iv_drip,
-/obj/structure/stool/bed/roller,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "darkbluecorners"
+	icon_state = "neutralfull"
 	},
-/area/station/medical/surgeryobs)
+/area/station/hallway/secondary/exit)
 "kpg" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -38335,7 +40928,10 @@
 	network = list("SS13","Engineering");
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
 /area/station/engineering/engine)
 "kpr" = (
 /turf/simulated/wall,
@@ -38429,7 +41025,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/medical/morgue)
 "kqh" = (
@@ -38463,7 +41060,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/medical/sleeper)
 "kqT" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -38472,7 +41071,10 @@
 /obj/machinery/firealarm{
 	pixel_y = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "kqY" = (
 /obj/structure/cable{
@@ -38487,12 +41089,16 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
-	icon_state = "purplechecker"
+	dir = 8;
+	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/hor)
 "kqZ" = (
 /obj/effect/landmark/start/recycler,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "krl" = (
 /obj/machinery/recharge_station,
@@ -38527,13 +41133,22 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
 /area/station/medical/reception)
+"krR" = (
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/civilian/library)
 "ksc" = (
 /obj/structure/sign/painting{
 	pixel_y = -30
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/civilian/library)
 "ksl" = (
 /turf/simulated/floor{
@@ -38586,7 +41201,8 @@
 "ksz" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway)
 "ksB" = (
@@ -38608,13 +41224,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/bridge/meeting_room)
+"ksG" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "whitepurple"
+	},
+/area/station/rnd/hallway)
 "ksI" = (
 /obj/machinery/door/airlock{
 	name = "Auxiliary Storage Closet"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "ksR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -38706,7 +41331,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "orange"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "ktM" = (
 /obj/machinery/alarm{
@@ -38745,7 +41372,9 @@
 /area/station/bridge/hop_office)
 "kvb" = (
 /obj/random/vending/snack,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/hallway/secondary/exit)
 "kvh" = (
 /obj/structure/disposalpipe/segment{
@@ -38866,7 +41495,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
-	icon_state = "warning"
+	icon_state = "warningcorner"
 	},
 /area/station/engineering/atmos)
 "kxr" = (
@@ -38879,6 +41508,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/civilian/toilet)
+"kxu" = (
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "kxB" = (
 /obj/structure/grille,
 /turf/environment/space,
@@ -38886,7 +41523,10 @@
 "kxC" = (
 /obj/structure/table,
 /obj/item/weapon/storage/box/lights/bulbs,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "brown"
+	},
 /area/station/cargo/storage)
 "kxE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -38929,7 +41569,9 @@
 	pixel_x = 8;
 	pixel_y = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/qm)
 "kyf" = (
 /obj/effect/decal/cleanable/dirt,
@@ -39064,7 +41706,7 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 8;
+	dir = 4;
 	icon_state = "neutral"
 	},
 /area/station/civilian/dormitories)
@@ -39078,7 +41720,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "warndarkcorners"
 	},
 /area/station/rnd/mixing)
 "kAz" = (
@@ -39102,7 +41745,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warningcorner"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "kAI" = (
 /obj/structure/cable{
@@ -39200,7 +41846,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
 "kBT" = (
 /obj/item/weapon/flora/random,
@@ -39223,8 +41869,7 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "escape"
+	icon_state = "redchecker"
 	},
 /area/station/civilian/kitchen)
 "kCw" = (
@@ -39240,7 +41885,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/civilian/chapel/office)
 "kCx" = (
@@ -39261,7 +41907,10 @@
 	pixel_x = 28;
 	pixel_y = -5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warning"
+	},
 /area/station/engineering/atmos)
 "kCI" = (
 /obj/structure/sign/directions/supply{
@@ -39288,7 +41937,9 @@
 	c_tag = "Cargo Bay Center";
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/storage)
 "kCR" = (
 /obj/structure/cable{
@@ -39314,6 +41965,17 @@
 	icon_state = "greenblue"
 	},
 /area/station/civilian/hydroponics)
+"kDi" = (
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/station/medical/chemistry)
+"kDj" = (
+/turf/simulated/floor{
+	icon_state = "warndark"
+	},
+/area/station/rnd/tox_launch)
 "kDn" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/camera{
@@ -39381,11 +42043,15 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "kEH" = (
 /obj/structure/bookcase/manuals/engineering,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/engineering/atmos)
 "kET" = (
 /obj/structure/stool/bed/chair{
@@ -39409,6 +42075,12 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
+"kFc" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "kFd" = (
 /turf/simulated/wall,
 /area/station/rnd/scibreak)
@@ -39441,7 +42113,8 @@
 "kFI" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor{
-	icon_state = "bot"
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/station/engineering/monitoring)
 "kFJ" = (
@@ -39505,6 +42178,12 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard)
+"kGc" = (
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warningcorner"
+	},
+/area/station/hallway/secondary/exit)
 "kGq" = (
 /obj/structure/sign/warning/vacuum,
 /turf/simulated/wall/r_wall,
@@ -39512,7 +42191,7 @@
 "kGr" = (
 /obj/machinery/computer/prisoner,
 /turf/simulated/floor{
-	icon_state = "red"
+	icon_state = "dark"
 	},
 /area/station/security/brig)
 "kGu" = (
@@ -39526,13 +42205,18 @@
 	name = "Treatment Center APC";
 	pixel_y = 28
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/medical/sleeper)
 "kGC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "kGI" = (
 /turf/simulated/wall,
@@ -39575,7 +42259,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "cafeteria"
+	},
 /area/station/engineering/singularity)
 "kHp" = (
 /obj/machinery/computer/secure_data{
@@ -39688,7 +42374,8 @@
 	},
 /obj/machinery/light/smart,
 /turf/simulated/floor{
-	icon_state = "warningcorner"
+	dir = 8;
+	icon_state = "yellowcorner"
 	},
 /area/station/engineering/atmos)
 "kHU" = (
@@ -39706,6 +42393,13 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/hydroponics)
+"kHZ" = (
+/obj/structure/rack,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warningcorner"
+	},
+/area/station/maintenance/chapel)
 "kIf" = (
 /obj/structure/window/shuttle/reinforced/mining{
 	icon_state = "5-4"
@@ -39726,9 +42420,23 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitepurplefull"
 	},
 /area/station/rnd/hallway)
+"kIu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
+/area/station/maintenance/engineering)
 "kIw" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -39755,7 +42463,9 @@
 	pixel_y = 8
 	},
 /obj/item/weapon/pen/red,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/qm)
 "kIG" = (
 /obj/machinery/door/firedoor,
@@ -39803,7 +42513,9 @@
 	dir = 8
 	},
 /obj/structure/window/thin,
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/civilian/library)
 "kJd" = (
 /obj/structure/table/reinforced,
@@ -39917,13 +42629,19 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "red"
+	},
 /area/station/hallway/secondary/exit)
 "kKx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
 /area/station/civilian/chapel)
 "kKz" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
@@ -39969,7 +42687,9 @@
 	density = 0;
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "black"
+	},
 /area/station/civilian/gym)
 "kLq" = (
 /obj/machinery/r_n_d/protolathe,
@@ -40025,12 +42745,37 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/robotics)
+"kLT" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/atmos)
 "kLU" = (
 /obj/structure/table,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
 /area/station/rnd/tox_launch)
+"kMa" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warndark"
+	},
+/area/station/rnd/xenobiology)
 "kMb" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
@@ -40071,7 +42816,7 @@
 	name = "Arrival Airlock";
 	req_one_access = list(65,48)
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/hallway/secondary/mine_sci_shuttle)
 "kMw" = (
 /obj/structure/sign/directions/engineering{
@@ -40201,6 +42946,11 @@
 	},
 /turf/environment/space,
 /area/space)
+"kOi" = (
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/dormitories)
 "kOk" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/red,
@@ -40258,7 +43008,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/office)
 "kPm" = (
 /obj/machinery/light/smart,
@@ -40298,7 +43050,10 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "brown"
+	},
 /area/station/cargo/qm)
 "kQC" = (
 /obj/machinery/computer/card,
@@ -40342,7 +43097,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "kRA" = (
 /obj/machinery/door/firedoor,
@@ -40363,7 +43118,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/bridge/teleporter)
 "kRL" = (
 /obj/structure/cable{
@@ -40391,7 +43148,9 @@
 	name = "Station Intercom (General)";
 	pixel_y = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
 /area/station/engineering/singularity)
 "kSj" = (
 /obj/structure/cable{
@@ -40497,7 +43256,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "kSI" = (
 /obj/effect/landmark/start/mime,
@@ -40542,6 +43301,12 @@
 /obj/structure/lattice,
 /turf/environment/space,
 /area/station/maintenance/chapel)
+"kSW" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "bluecorner"
+	},
+/area/station/maintenance/chapel)
 "kTi" = (
 /obj/structure/table,
 /obj/item/weapon/storage/box/bodybags{
@@ -40577,7 +43342,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/medical/medbreak)
 "kTC" = (
@@ -40611,7 +43377,9 @@
 	pixel_x = -3
 	},
 /obj/item/weapon/reagent_containers/food/condiment/peppermill,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "redchecker"
+	},
 /area/station/civilian/kitchen)
 "kUd" = (
 /obj/machinery/door/firedoor,
@@ -40665,8 +43433,8 @@
 "kUv" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
-	dir = 6;
-	icon_state = "vault"
+	dir = 4;
+	icon_state = "black"
 	},
 /area/station/civilian/chapel)
 "kUz" = (
@@ -40767,7 +43535,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/hallway/primary/central)
 "kVW" = (
 /turf/simulated/floor{
@@ -40793,7 +43563,10 @@
 /obj/structure/stool/bed/chair/metal{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/hallway/secondary/exit)
 "kWv" = (
 /obj/machinery/door/firedoor,
@@ -40823,7 +43596,7 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "redyellowfull"
+	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
 "kWA" = (
@@ -40880,7 +43653,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
 /area/station/maintenance/atmos)
 "kWX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -40933,7 +43708,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitebluefull"
 	},
 /area/station/medical/hallway)
 "kXg" = (
@@ -40945,7 +43720,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "orange"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "kXo" = (
 /obj/machinery/light/small,
@@ -40985,7 +43763,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "kXQ" = (
 /obj/structure/table/woodentable/fancy,
@@ -40994,7 +43772,9 @@
 	name = "Library Museum";
 	req_access = list(37)
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/civilian/library)
 "kXR" = (
 /obj/machinery/alarm{
@@ -41047,12 +43827,21 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/science)
+"kYf" = (
+/obj/machinery/light/smart,
+/turf/simulated/floor{
+	icon_state = "black"
+	},
+/area/station/hallway/secondary/exit)
 "kYs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/light/smart{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "black"
+	},
 /area/station/civilian/chapel)
 "kYt" = (
 /obj/item/weapon/flora/random,
@@ -41066,11 +43855,17 @@
 	dir = 4
 	},
 /obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "kYy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
 /area/station/civilian/chapel)
 "kYA" = (
 /obj/structure/cable{
@@ -41079,8 +43874,8 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "black"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/station/storage/tech)
 "kYE" = (
@@ -41105,7 +43900,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock,
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
 /area/station/civilian/library)
 "kYQ" = (
 /obj/structure/cable{
@@ -41134,6 +43931,11 @@
 /obj/structure/sign/warning/radiation,
 /turf/simulated/wall/r_wall,
 /area/station/engineering/engine)
+"kZj" = (
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/cargo/miningoffice)
 "kZp" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -41160,7 +43962,10 @@
 /obj/item/device/radio/headset,
 /obj/item/device/radio/headset,
 /obj/item/device/radio/headset,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "red"
+	},
 /area/station/security/brig)
 "kZU" = (
 /obj/machinery/light/smart{
@@ -41178,7 +43983,10 @@
 /area/station/rnd/hor)
 "lae" = (
 /obj/structure/closet/emcloset,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 1;
+	icon_state = "warnplate"
+	},
 /area/station/hallway/secondary/entry)
 "lat" = (
 /obj/structure/stool/bed/chair/metal/black{
@@ -41195,7 +44003,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor{
-	icon_state = "redcorner"
+	icon_state = "red"
 	},
 /area/station/security/brig)
 "laC" = (
@@ -41249,13 +44057,21 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "lbh" = (
 /obj/structure/lattice,
 /obj/structure/window/thin/reinforced,
 /turf/environment/space,
 /area/space)
+"lbj" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "warning"
+	},
+/area/station/hallway/secondary/entry)
 "lbo" = (
 /obj/machinery/flasher/portable,
 /turf/simulated/floor{
@@ -41265,7 +44081,10 @@
 /area/station/security/armoury)
 "lbB" = (
 /obj/machinery/door/firedoor,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
 /area/station/engineering/engine)
 "lbG" = (
 /obj/machinery/porta_turret/station_default{
@@ -41278,7 +44097,9 @@
 "lbT" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/security/prison)
 "lbX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -41323,8 +44144,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "cautioncorner"
+	dir = 1;
+	icon_state = "caution"
 	},
 /area/station/engineering/engine)
 "lcN" = (
@@ -41405,7 +44226,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "ldN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -41421,7 +44244,8 @@
 	dir = 9
 	},
 /turf/simulated/floor{
-	icon_state = "warning"
+	dir = 8;
+	icon_state = "warningcorner"
 	},
 /area/station/engineering/atmos)
 "les" = (
@@ -41553,9 +44377,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor,
 /area/station/rnd/hallway)
 "lgP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -41583,7 +44405,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/station/civilian/gym)
 "lhd" = (
 /turf/simulated/floor{
@@ -41626,7 +44451,7 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor{
-	dir = 8;
+	dir = 10;
 	icon_state = "whiteblue"
 	},
 /area/station/medical/psych)
@@ -41743,7 +44568,10 @@
 /area/station/hallway/primary/port)
 "ljH" = (
 /obj/item/weapon/flora/random,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "warning"
+	},
 /area/station/hallway/secondary/entry)
 "ljP" = (
 /obj/structure/table/woodentable,
@@ -41782,14 +44610,18 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
 "lkv" = (
 /obj/structure/stool/bed/chair{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "green"
+	},
 /area/station/civilian/dormitories)
 "lkw" = (
 /obj/item/weapon/flora/random,
@@ -41803,7 +44635,9 @@
 /obj/machinery/conveyor_switch/oneway{
 	id = "cargoload"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/storage)
 "lkD" = (
 /obj/effect/decal/cleanable/dirt,
@@ -41860,11 +44694,16 @@
 	network = list("SS13","Engineering");
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "lkN" = (
 /obj/machinery/atmospherics/components/binary/valve/digital,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "warning"
+	},
 /area/station/maintenance/chapel)
 "lkU" = (
 /turf/simulated/wall,
@@ -41876,9 +44715,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor{
-	icon_state = "delivery"
-	},
+/turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
 "llc" = (
 /obj/machinery/space_heater,
@@ -41894,7 +44731,10 @@
 /area/station/engineering/monitoring)
 "lli" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "llw" = (
 /obj/structure/closet/secure_closet/scientist,
@@ -42028,7 +44868,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "redcorner"
 	},
 /area/station/security/lobby)
 "lmX" = (
@@ -42036,7 +44876,9 @@
 /obj/item/weapon/reagent_containers/spray/extinguisher{
 	pixel_y = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/singularity)
 "lnd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -42138,7 +44980,10 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 9;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/portsolar)
 "lpq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -42148,6 +44993,19 @@
 	icon_state = "warndark"
 	},
 /area/station/engineering/drone_fabrication)
+"lpw" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/monitoring)
 "lpN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -42159,7 +45017,9 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/hallway/primary/central)
 "lpX" = (
 /obj/machinery/door/airlock/research{
@@ -42186,7 +45046,9 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "whitepurplefull"
+	},
 /area/station/rnd/hallway)
 "lqr" = (
 /obj/structure/cable{
@@ -42215,7 +45077,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/maintenance/atmos)
 "lqF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -42260,7 +45124,9 @@
 /area/station/ai_monitored/storage_secure)
 "lqU" = (
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/hallway/primary/central)
 "lrh" = (
 /obj/structure/closet/secure_closet/security/science,
@@ -42370,8 +45236,7 @@
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/backpack/satchel/withwallet,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/maintenance/chapel)
 "lsy" = (
@@ -42390,7 +45255,8 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 6;
+	icon_state = "warndark"
 	},
 /area/station/security/armoury)
 "lsB" = (
@@ -42410,7 +45276,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "lsP" = (
 /obj/structure/window/thin/reinforced,
@@ -42515,7 +45381,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/engine)
 "luV" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
@@ -42547,7 +45415,10 @@
 "lva" = (
 /obj/structure/table,
 /obj/item/weapon/clipboard,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "brown"
+	},
 /area/station/cargo/qm)
 "lvb" = (
 /obj/machinery/washing_machine,
@@ -42683,11 +45554,16 @@
 	name = "Station Intercom (General)";
 	pixel_y = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "blackcorner"
+	},
 /area/station/hallway/secondary/exit)
 "lxv" = (
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/storage)
 "lxG" = (
 /obj/machinery/door/firedoor,
@@ -42700,7 +45576,10 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "neutral"
+	},
 /area/station/rnd/hallway)
 "lyg" = (
 /obj/structure/stool/bed/chair/office/light{
@@ -42922,7 +45801,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/hallway/primary/central)
 "lBJ" = (
 /obj/machinery/door/firedoor,
@@ -42956,6 +45837,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
+	dir = 1;
 	icon_state = "neutral"
 	},
 /area/station/civilian/dormitories)
@@ -42977,6 +45859,11 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
+"lCj" = (
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
+/area/station/civilian/gym)
 "lCq" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -43105,6 +45992,12 @@
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"lEA" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellow"
+	},
+/area/station/engineering/engine)
 "lEC" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -43185,7 +46078,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "lFs" = (
 /obj/item/device/radio/intercom{
@@ -43218,16 +46111,21 @@
 	},
 /area/station/engineering/monitoring)
 "lFS" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
+/obj/structure/window/thin{
+	dir = 8
+	},
+/obj/structure/window/thin{
+	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "cautioncorner"
+	dir = 9;
+	icon_state = "escape"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/atmos)
 "lGc" = (
 /obj/machinery/camera{
 	c_tag = "Enginnering Lobby"
@@ -43241,7 +46139,9 @@
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/bag/bookbag,
 /obj/structure/window/thin,
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/civilian/library)
 "lGl" = (
 /obj/machinery/door/firedoor,
@@ -43276,7 +46176,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/station/maintenance/chapel)
+"lGF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/maintenance/chapel)
 "lGG" = (
 /turf/simulated/floor{
@@ -43288,7 +46202,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/hallway/primary/central)
 "lGS" = (
 /obj/structure/cable{
@@ -43318,11 +46234,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
 /area/station/hallway/secondary/entry)
 "lHG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
 /area/station/engineering/engine)
 "lId" = (
 /obj/machinery/chem_master,
@@ -43348,7 +46270,7 @@
 /area/station/medical/genetics)
 "lIf" = (
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "lIj" = (
 /obj/structure/rack,
@@ -43414,7 +46336,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
 /area/station/civilian/library)
 "lIG" = (
 /turf/simulated/floor{
@@ -43431,7 +46355,10 @@
 	dir = 8
 	},
 /obj/structure/window/thin,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "black"
+	},
 /area/station/engineering/atmos)
 "lIQ" = (
 /obj/machinery/light/smart{
@@ -43492,7 +46419,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "lKf" = (
 /obj/structure/cable{
@@ -43673,7 +46603,10 @@
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
 /area/station/hallway/secondary/entry)
 "lMq" = (
 /obj/structure/sign/warning/securearea{
@@ -43724,6 +46657,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
+"lMA" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 5
+	},
+/obj/machinery/light/smart,
+/turf/simulated/floor{
+	icon_state = "caution"
+	},
+/area/station/engineering/atmos)
 "lMB" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -43766,6 +46708,29 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/engine)
+"lMM" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
+"lNc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
+"lNi" = (
+/obj/machinery/light/smart{
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "lNk" = (
 /turf/simulated/floor{
 	dir = 5;
@@ -43789,16 +46754,11 @@
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
 "lNr" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor{
-	dir = 9;
-	icon_state = "warning"
+	dir = 1;
+	icon_state = "blackcorner"
 	},
-/area/station/security/brig)
+/area/station/civilian/gym)
 "lNt" = (
 /obj/item/clothing/mask/cigarette/pipe,
 /obj/structure/table/woodentable/poker,
@@ -43841,7 +46801,10 @@
 	pixel_y = -5
 	},
 /obj/item/weapon/flora/random,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "warning"
+	},
 /area/station/hallway/secondary/entry)
 "lNP" = (
 /obj/machinery/firealarm{
@@ -43905,7 +46868,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "lOt" = (
 /obj/machinery/r_n_d/server/core,
@@ -43975,7 +46941,10 @@
 	c_tag = "Cargo Bay South-East";
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "brown"
+	},
 /area/station/cargo/storage)
 "lPl" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
@@ -44012,7 +46981,9 @@
 /obj/structure/table/reinforced,
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/chiefs_office)
 "lPP" = (
 /obj/machinery/computer/atmos_alert{
@@ -44040,7 +47011,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "lQz" = (
 /obj/machinery/door_control{
@@ -44078,7 +47051,10 @@
 /area/station/civilian/gym)
 "lQP" = (
 /obj/structure/rack,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "orange"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "lQT" = (
 /obj/structure/table/woodentable,
@@ -44107,7 +47083,9 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/medical/reception)
 "lRm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -44144,7 +47122,10 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 8;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/chapel)
 "lRY" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -44168,7 +47149,9 @@
 /area/station/engineering/atmos)
 "lSb" = (
 /obj/item/weapon/flora/random,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "lSs" = (
 /obj/structure/cable{
@@ -44201,7 +47184,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/civilian/dormitories)
 "lTd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -44218,9 +47204,18 @@
 /area/station/hallway/secondary/exit)
 "lTt" = (
 /turf/simulated/floor{
-	icon_state = "bar"
+	dir = 5;
+	icon_state = "bluered"
 	},
 /area/station/medical/medbreak)
+"lTw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "lTH" = (
 /obj/machinery/camera{
 	c_tag = "Dormitories Locker Room West";
@@ -44240,7 +47235,9 @@
 "lTQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/engine)
 "lTU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -44261,7 +47258,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "warning"
+	},
 /area/station/engineering/atmos)
 "lUh" = (
 /obj/machinery/firealarm{
@@ -44306,7 +47306,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "warning"
+	},
 /area/station/maintenance/chapel)
 "lUY" = (
 /obj/machinery/door/firedoor,
@@ -44345,6 +47347,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/bridge/nuke_storage)
+"lVs" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/exit)
 "lVA" = (
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
@@ -44369,7 +47381,10 @@
 	network = list("SS13","Engineering");
 	dir = 7
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "lWv" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -44433,7 +47448,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "lXA" = (
 /obj/machinery/door/airlock/engineering{
@@ -44447,7 +47462,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/starboardsolar)
 "lXB" = (
 /obj/machinery/door/firedoor,
@@ -44508,7 +47523,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 4;
 	icon_state = "warning"
 	},
 /area/station/engineering/engine)
@@ -44558,7 +47572,8 @@
 	auto_patrol = 0
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 10;
+	icon_state = "warndark"
 	},
 /area/station/security/armoury)
 "lZx" = (
@@ -44573,6 +47588,12 @@
 	icon_state = "caution"
 	},
 /area/station/hallway/primary/port)
+"map" = (
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "whiteblue"
+	},
+/area/station/medical/hallway)
 "maC" = (
 /obj/structure/ore_box,
 /turf/simulated/floor/plating,
@@ -44637,10 +47658,9 @@
 /area/station/engineering/atmos)
 "mbl" = (
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "escape"
+	icon_state = "neutralfull"
 	},
-/area/station/civilian/kitchen)
+/area/station/security/prison)
 "mbq" = (
 /obj/structure/bookcase/manuals/security,
 /turf/simulated/floor/wood,
@@ -44739,7 +47759,9 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "mcG" = (
 /obj/machinery/vending/theater,
@@ -44761,7 +47783,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/maintenance/chapel)
 "mdk" = (
 /obj/effect/decal/cleanable/dirt,
@@ -44786,8 +47810,7 @@
 /obj/item/clothing/under/waiter,
 /obj/item/clothing/under/waiter,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/hallway/primary/fore)
 "mdF" = (
@@ -44817,6 +47840,22 @@
 	icon_state = "vault"
 	},
 /area/station/security/armoury)
+"meu" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "blackcorner"
+	},
+/area/station/hallway/secondary/exit)
 "mev" = (
 /obj/structure/displaycase_chassis,
 /obj/effect/decal/cleanable/dirt,
@@ -44857,7 +47896,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/secondary/exit)
 "meX" = (
 /obj/structure/cable{
@@ -44871,7 +47912,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "mfa" = (
 /obj/structure/table/reinforced,
@@ -44895,7 +47939,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/civilian/chapel)
 "mfj" = (
@@ -44913,7 +47958,9 @@
 	dir = 4;
 	network = list("SS13","Medical")
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/medical/cryo)
 "mfz" = (
 /obj/structure/closet{
@@ -44965,13 +48012,17 @@
 	icon_state = "warning"
 	},
 /area/station/rnd/chargebay)
+"mga" = (
+/turf/simulated/floor{
+	icon_state = "warndark"
+	},
+/area/station/engineering/atmos)
 "mge" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/hallway/secondary/entry)
 "mgg" = (
@@ -44989,7 +48040,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "mgr" = (
 /obj/machinery/hydroponics/soil,
@@ -45040,6 +48094,15 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/singularity)
+"mgQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor{
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "mhb" = (
 /obj/structure/sign/directions/engineering{
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
@@ -45206,8 +48269,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/miningoffice)
+"mjl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	icon_state = "warningcorner"
+	},
+/area/station/hallway/secondary/entry)
 "mjD" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -45274,8 +48346,29 @@
 /area/station/engineering/drone_fabrication)
 "mko" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
+"mkS" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
+"mkT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "mkV" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -45305,7 +48398,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "mly" = (
 /obj/machinery/ai_status_display{
@@ -45329,7 +48422,8 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/medical/surgeryobs)
 "mlG" = (
@@ -45370,7 +48464,7 @@
 	},
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "redcorner"
 	},
 /area/station/security/lobby)
 "mlT" = (
@@ -45421,7 +48515,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "brown"
+	},
 /area/station/cargo/qm)
 "mmq" = (
 /obj/structure/stool/bed/chair/metal/white,
@@ -45436,6 +48532,18 @@
 	icon_state = "warning"
 	},
 /area/station/gateway)
+"mmN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "whiteblue"
+	},
+/area/station/medical/hallway)
 "mmP" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
@@ -45505,7 +48613,7 @@
 "mnH" = (
 /obj/random/vending/cola,
 /turf/simulated/floor{
-	icon_state = "redyellowfull"
+	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
 "mnK" = (
@@ -45543,7 +48651,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "browncorner"
+	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/fore)
 "mnY" = (
@@ -45674,7 +48782,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "redyellowfull"
+	},
 /area/station/civilian/bar)
 "mpR" = (
 /obj/machinery/light/small{
@@ -45698,7 +48808,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/storage)
 "mqe" = (
 /obj/machinery/door/firedoor,
@@ -45843,6 +48955,13 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"mrP" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
+/area/station/engineering/atmos)
 "msf" = (
 /obj/structure/table/reinforced,
 /obj/item/device/aicard,
@@ -45881,8 +49000,16 @@
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "bluecorner"
+	},
 /area/station/engineering/engine)
+"msR" = (
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "warndark"
+	},
+/area/station/engineering/atmos)
 "msS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
@@ -45909,14 +49036,17 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "mtn" = (
 /obj/machinery/light/smart{
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "redyellowfull"
+	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
 "mtp" = (
@@ -45934,7 +49064,9 @@
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil,
 /obj/item/weapon/tank/emergency_oxygen/engi,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/engine)
 "mtu" = (
 /obj/effect/decal/cleanable/dirt,
@@ -45951,7 +49083,8 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 2;
+	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway)
 "mtF" = (
@@ -45998,7 +49131,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "mue" = (
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/hallway/primary/central)
 "muh" = (
 /obj/structure/table,
@@ -46006,7 +49141,10 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "mum" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/green{
@@ -46096,7 +49234,10 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "mvE" = (
 /obj/structure/stool,
@@ -46127,7 +49268,8 @@
 	req_access = list("chapel_office")
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/civilian/chapel/mass_driver)
 "mvZ" = (
@@ -46145,6 +49287,14 @@
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/space)
+"mwy" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/cargo/storage)
 "mwT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -46174,6 +49324,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"mxb" = (
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "warndark"
+	},
+/area/station/security/armoury)
 "mxg" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -46234,7 +49390,9 @@
 "mxQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/maintenance/engineering)
 "mxZ" = (
 /obj/machinery/power/port_gen/pacman,
@@ -46280,7 +49438,7 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor{
-	icon_state = "redyellowfull"
+	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
 "myI" = (
@@ -46309,7 +49467,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 28
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "warning"
+	},
 /area/station/engineering/engine)
 "mzd" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -46321,6 +49482,15 @@
 	icon_state = "warnwhite"
 	},
 /area/station/medical/cryo)
+"mzF" = (
+/obj/machinery/hologram/holopad{
+	pixel_y = -16
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/station/security/main)
 "mzL" = (
 /obj/structure/table/woodentable,
 /obj/structure/cable{
@@ -46373,11 +49543,15 @@
 	pixel_x = -22
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "mzV" = (
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/security/main)
 "mAe" = (
@@ -46443,6 +49617,11 @@
 	icon_state = "dark"
 	},
 /area/station/security/interrogation)
+"mAQ" = (
+/turf/simulated/floor{
+	icon_state = "purple"
+	},
+/area/station/rnd/xenobiology)
 "mAZ" = (
 /obj/item/device/radio/beacon,
 /obj/structure/cable{
@@ -46730,7 +49909,9 @@
 "mEc" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/engine)
 "mEi" = (
 /obj/structure/stool/bed/chair/office/dark,
@@ -46759,7 +49940,9 @@
 /obj/machinery/light/smart{
 	dir = 1
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/civilian/library)
 "mEB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -46787,8 +49970,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor{
-	dir = 6;
-	icon_state = "red"
+	icon_state = "redyellowfull"
 	},
 /area/station/civilian/bar)
 "mEY" = (
@@ -46801,6 +49983,17 @@
 	icon_state = "warning"
 	},
 /area/station/engineering/engine)
+"mFh" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "brown"
+	},
+/area/station/cargo/qm)
 "mFs" = (
 /obj/structure/stool,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -46831,7 +50024,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
-	icon_state = "redcorner"
+	dir = 4;
+	icon_state = "yellowcorner"
 	},
 /area/station/engineering/engine)
 "mFD" = (
@@ -46840,7 +50034,10 @@
 	pixel_x = 29;
 	pixel_y = -6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warning"
+	},
 /area/station/hallway/secondary/entry)
 "mFM" = (
 /obj/structure/easel,
@@ -46880,7 +50077,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowfull"
+	},
 /area/station/engineering/engine)
 "mGu" = (
 /obj/structure/sign/departments/science,
@@ -46934,9 +50133,16 @@
 /obj/machinery/computer/card,
 /obj/machinery/light/smart,
 /turf/simulated/floor{
-	icon_state = "red"
+	icon_state = "dark"
 	},
 /area/station/security/brig)
+"mHC" = (
+/obj/structure/closet/toolcloset,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "orange"
+	},
+/area/station/hallway/secondary/mine_sci_shuttle)
 "mHM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -46953,7 +50159,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/engine)
 "mIL" = (
 /obj/machinery/door/firedoor,
@@ -47019,7 +50227,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/storage/tech)
 "mJM" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -47029,7 +50239,9 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "mKd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -47049,13 +50261,12 @@
 "mKv" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor{
-	icon_state = "bot"
+	icon_state = "neutralfull"
 	},
 /area/station/engineering/chiefs_office)
 "mKy" = (
 /turf/simulated/floor{
-	dir = 10;
-	icon_state = "vault"
+	icon_state = "dark"
 	},
 /area/station/rnd/hor)
 "mKB" = (
@@ -47116,8 +50327,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "black"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/station/storage/tech)
 "mLL" = (
@@ -47185,15 +50396,24 @@
 	name = "Station Intercom (General)";
 	pixel_y = -32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/singularity)
+"mMv" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/turf/simulated/floor{
+	icon_state = "cautioncorner"
+	},
+/area/station/engineering/atmos)
 "mMz" = (
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -22
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/civilian/chapel/office)
 "mMA" = (
@@ -47233,7 +50453,7 @@
 "mNx" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor{
-	icon_state = "whitebluefull"
+	icon_state = "bluefull"
 	},
 /area/station/medical/reception)
 "mNB" = (
@@ -47241,14 +50461,17 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "mNC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 3;
+	icon_state = "warndark"
 	},
 /area/station/security/armoury)
 "mNU" = (
@@ -47276,7 +50499,9 @@
 	dir = 5
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/maintenance/engineering)
 "mOq" = (
 /obj/machinery/door/firedoor,
@@ -47311,7 +50536,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/security/prison)
 "mOv" = (
 /obj/machinery/iv_drip,
@@ -47357,7 +50584,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
 "mPw" = (
@@ -47370,6 +50597,13 @@
 	icon_state = "darkblue"
 	},
 /area/station/security/iaa_office)
+"mPx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	icon_state = "yellowfull"
+	},
+/area/station/engineering/engine)
 "mPC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -47382,7 +50616,9 @@
 	dir = 8;
 	icon_state = "pipe-j2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/maintenance/chapel)
 "mPV" = (
 /turf/simulated/floor{
@@ -47425,7 +50661,10 @@
 "mQf" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/atmospherics/pipe/simple/visible/red,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/engineering/atmos)
 "mQh" = (
 /obj/machinery/door/firedoor,
@@ -47492,9 +50731,16 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/chapel/mass_driver)
+"mQE" = (
+/turf/simulated/floor{
+	icon_state = "whitehall"
+	},
+/area/station/rnd/hallway)
 "mQH" = (
 /obj/structure/stool/bed/chair/comfy/brown,
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/civilian/library)
 "mQP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -47511,7 +50757,10 @@
 	name = "recycler's rubber stamp";
 	stamp_message = "Recycler"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "mRc" = (
 /obj/structure/table/glass,
@@ -47594,8 +50843,19 @@
 	dir = 8
 	},
 /obj/structure/window/thin,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "arrival"
+	},
 /area/station/engineering/atmos)
+"mRB" = (
+/obj/structure/table,
+/obj/item/clothing/mask/gas,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warningcorner"
+	},
+/area/station/maintenance/chapel)
 "mRE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
@@ -47676,7 +50936,10 @@
 /obj/machinery/computer/message_monitor{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/tcommsat/computer)
 "mSW" = (
 /obj/structure/bookcase{
@@ -47771,7 +51034,9 @@
 /obj/structure/window/thin/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
 /area/station/rnd/xenobiology)
 "mTV" = (
 /obj/machinery/camera{
@@ -47790,6 +51055,21 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/fore)
+"mTY" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
+/area/station/hallway/secondary/exit)
+"mTZ" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/folder/red,
+/obj/item/weapon/pen,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "neutral"
+	},
+/area/station/civilian/dormitories)
 "mUb" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -47823,7 +51103,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/secondary/exit)
 "mUO" = (
 /obj/structure/disposalpipe/segment{
@@ -47863,8 +51145,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
+	dir = 1;
+	icon_state = "warndark"
 	},
 /area/station/rnd/xenobiology)
 "mVh" = (
@@ -47894,7 +51176,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/security/prison)
 "mVu" = (
 /obj/structure/cable{
@@ -47910,6 +51194,15 @@
 	icon_state = "warning"
 	},
 /area/station/tcommsat/chamber)
+"mVv" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/folder/blue,
+/obj/item/weapon/pen,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "red"
+	},
+/area/station/civilian/dormitories)
 "mVw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -47983,7 +51276,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/medical/morgue)
 "mXl" = (
@@ -48004,7 +51298,10 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/engineering/atmos)
 "mXZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -48060,7 +51357,10 @@
 /obj/structure/window/thin{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "red"
+	},
 /area/station/engineering/atmos)
 "mYS" = (
 /obj/structure/table/glass,
@@ -48069,7 +51369,8 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/medical/surgeryobs)
 "mYW" = (
@@ -48094,6 +51395,17 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/chapel/office)
+"mZg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "warning"
+	},
+/area/station/hallway/secondary/entry)
 "mZi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -48104,7 +51416,10 @@
 /obj/machinery/ai_status_display{
 	pixel_y = -32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "mZo" = (
 /obj/machinery/photocopier,
@@ -48137,7 +51452,9 @@
 /area/station/security/brig)
 "mZB" = (
 /obj/effect/landmark/start/assistant,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/secondary/exit)
 "mZC" = (
 /turf/simulated/shuttle/floor/mining{
@@ -48184,7 +51501,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "red"
+	},
 /area/station/hallway/secondary/exit)
 "nac" = (
 /obj/structure/drain{
@@ -48205,8 +51524,15 @@
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Auxiliary Power"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"nav" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "blackcorner"
+	},
+/area/station/hallway/secondary/exit)
 "naA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/atmos/glass{
@@ -48234,6 +51560,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
@@ -48284,7 +51611,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "whitehall"
 	},
 /area/station/rnd/hallway)
 "ncg" = (
@@ -48354,7 +51682,8 @@
 "ndh" = (
 /obj/machinery/disposal,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/station/civilian/library)
 "nds" = (
@@ -48363,7 +51692,8 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "bot"
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/station/engineering/monitoring)
 "ndu" = (
@@ -48382,7 +51712,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whitebluecorner"
 	},
 /area/station/medical/hallway)
 "ndF" = (
@@ -48495,7 +51826,10 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/photocopier,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "vault"
+	},
 /area/station/security/hos)
 "nfy" = (
 /obj/machinery/cell_charger,
@@ -48574,7 +51908,9 @@
 /obj/structure/sign/warning/enginesafety{
 	pixel_y = -32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowcorner"
+	},
 /area/station/engineering/engine)
 "nhe" = (
 /obj/structure/stool/bed/chair{
@@ -48654,6 +51990,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/computer/secure_data{
+	dir = 8
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "red"
@@ -48676,7 +52015,10 @@
 	pixel_x = 29;
 	pixel_y = -6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos)
 "niq" = (
 /obj/structure/cable{
@@ -48705,7 +52047,9 @@
 	network = list("SS13","Engineering");
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
 /area/station/engineering/atmos)
 "nix" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -48743,7 +52087,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "redchecker"
+	},
 /area/station/civilian/kitchen)
 "niX" = (
 /obj/structure/cable{
@@ -48786,7 +52132,10 @@
 /obj/machinery/light/smart{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "nkc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -48795,7 +52144,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowfull"
+	},
 /area/station/engineering/engine)
 "nkf" = (
 /obj/machinery/camera{
@@ -48812,7 +52163,8 @@
 	pixel_y = -4
 	},
 /turf/simulated/floor{
-	icon_state = "whiteyellowcorner"
+	dir = 8;
+	icon_state = "yellowcorner"
 	},
 /area/station/medical/chemistry)
 "nkK" = (
@@ -48864,6 +52216,15 @@
 	icon_state = "red"
 	},
 /area/station/security/main)
+"nln" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "nlp" = (
 /obj/structure/closet/l3closet/scientist,
 /turf/simulated/floor{
@@ -48890,7 +52251,10 @@
 	dir = 4
 	},
 /obj/machinery/disposal,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "purple"
+	},
 /area/station/rnd/xenobiology)
 "nma" = (
 /obj/structure/sign/warning/securearea,
@@ -48944,6 +52308,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/monitoring)
+"nmH" = (
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warningcorner"
+	},
+/area/station/cargo/storage)
 "nna" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -48990,7 +52360,10 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/engineering/atmos)
 "nnI" = (
 /obj/machinery/porta_turret/station_default{
@@ -49014,7 +52387,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/engineering/atmos)
 "noh" = (
 /obj/structure/table/woodentable/fancy,
@@ -49065,7 +52440,10 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 5;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/starboardsolar)
 "noZ" = (
 /obj/structure/sign/warning/radiation,
@@ -49096,7 +52474,10 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/primary/fore)
 "npo" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
@@ -49106,7 +52487,10 @@
 	output_tag = "waste_out";
 	sensors = list("waste_sensor"="Tank")
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "green"
+	},
 /area/station/engineering/atmos)
 "npv" = (
 /obj/structure/table/glass,
@@ -49139,8 +52523,7 @@
 	name = "Lizzy"
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/hallway/secondary/entry)
 "npF" = (
@@ -49152,6 +52535,12 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/robotics)
+"npG" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warndark"
+	},
+/area/station/engineering/atmos)
 "npW" = (
 /obj/machinery/gateway,
 /turf/simulated/floor{
@@ -49183,7 +52572,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
 /area/station/engineering/chiefs_office)
 "nqk" = (
 /obj/structure/stool/bed/chair/office/dark,
@@ -49196,8 +52588,7 @@
 	pixel_y = 22
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/security/interrogation)
 "nqz" = (
@@ -49216,16 +52607,23 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "yellow"
+	},
 /area/station/engineering/engine)
 "nqD" = (
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "nqE" = (
 /obj/structure/table,
 /obj/item/toy/crossbow,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
 /area/station/civilian/gym)
 "nqJ" = (
 /obj/structure/cable{
@@ -49340,6 +52738,15 @@
 "nsa" = (
 /turf/simulated/wall/r_wall,
 /area/station/engineering/engine)
+"nsh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "nsl" = (
 /obj/structure/closet/secure_closet/hos,
 /turf/simulated/floor{
@@ -49419,7 +52826,10 @@
 	dir = 8
 	},
 /obj/structure/window/thin,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "blue"
+	},
 /area/station/engineering/atmos)
 "ntw" = (
 /obj/structure/table/woodentable,
@@ -49431,6 +52841,26 @@
 /obj/item/weapon/folder/white,
 /turf/simulated/floor/carpet/blue2,
 /area/station/bridge/meeting_room)
+"ntM" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "whitegreen"
+	},
+/area/station/medical/hallway)
 "ntO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 6
@@ -49452,13 +52882,22 @@
 	icon_state = "vault"
 	},
 /area/station/maintenance/science)
+"nul" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "nuA" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/alarm{
 	pixel_x = 29;
 	pixel_y = -6
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/civilian/library)
 "nuP" = (
 /obj/machinery/disposal,
@@ -49505,7 +52944,8 @@
 "nve" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway)
 "nvi" = (
@@ -49584,7 +53024,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/maintenance/atmos)
 "nwo" = (
 /obj/item/weapon/flora/random,
@@ -49621,14 +53063,19 @@
 	network = list("SS13","Engineering");
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "nwM" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "nxa" = (
 /obj/structure/cable{
@@ -49666,17 +53113,15 @@
 /area/station/rnd/hallway)
 "nxi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/landmark/start/recycler,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "nxl" = (
 /obj/machinery/requests_console/bridge{
@@ -49710,7 +53155,10 @@
 	pixel_x = 29;
 	pixel_y = -6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
 /area/station/hallway/primary/central)
 "nyd" = (
 /obj/machinery/iv_drip,
@@ -49819,7 +53267,9 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/storage/tech)
 "nzE" = (
 /obj/structure/transit_tube{
@@ -49907,7 +53357,8 @@
 	sortType = "Medbay Storage"
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
 "nAv" = (
@@ -49979,7 +53430,9 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/office)
 "nBf" = (
 /obj/structure/table/reinforced,
@@ -49991,7 +53444,9 @@
 	network = list("SS13","Engineering");
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "warning"
+	},
 /area/station/engineering/engine)
 "nBv" = (
 /obj/item/clothing/accessory/armband/hydro,
@@ -50012,7 +53467,10 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "nBQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -50146,7 +53604,10 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 1;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/starboardsolar)
 "nEe" = (
 /obj/structure/cable{
@@ -50188,7 +53649,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/storage)
 "nEw" = (
 /obj/structure/cable{
@@ -50211,7 +53674,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/office)
 "nEC" = (
 /obj/structure/window/thin/reinforced{
@@ -50275,7 +53740,10 @@
 /area/station/maintenance/medbay)
 "nEU" = (
 /obj/machinery/light/smart,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "nFa" = (
 /obj/effect/decal/cleanable/dirt,
@@ -50320,6 +53788,11 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"nFZ" = (
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/singularity)
 "nGb" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Atmospherics Emergency Access"
@@ -50344,7 +53817,9 @@
 /obj/machinery/computer/station_alert{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
 /area/station/maintenance/chapel)
 "nGr" = (
 /obj/structure/table/glass,
@@ -50502,7 +53977,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/office)
 "nHO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -50525,10 +54002,21 @@
 	icon_state = "grimy"
 	},
 /area/station/maintenance/chapel)
+"nIu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/fore)
 "nIB" = (
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/hallway/secondary/entry)
 "nIE" = (
@@ -50536,11 +54024,14 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/engineering/atmos)
 "nIL" = (
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "nIT" = (
 /obj/machinery/hydroponics/constructable,
@@ -50565,7 +54056,10 @@
 /area/station/civilian/chapel/mass_driver)
 "nJn" = (
 /obj/machinery/light/smart,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/civilian/gym)
 "nJq" = (
 /obj/structure/cable{
@@ -50700,7 +54194,7 @@
 	name = "KitchenShutters";
 	opacity = 0
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
 "nLe" = (
 /obj/structure/table,
@@ -50719,7 +54213,9 @@
 	},
 /area/station/engineering/atmos)
 "nLP" = (
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "warnwhite"
+	},
 /area/station/rnd/storage)
 "nMg" = (
 /turf/simulated/wall,
@@ -50752,7 +54248,9 @@
 /obj/machinery/light/smart{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
 /area/station/rnd/xenobiology)
 "nMT" = (
 /obj/structure/cable{
@@ -50760,7 +54258,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "neutral"
+	},
 /area/station/medical/chemistry)
 "nNa" = (
 /obj/machinery/door/firedoor,
@@ -50784,7 +54285,7 @@
 	pixel_y = -6
 	},
 /turf/simulated/floor{
-	icon_state = "bar"
+	icon_state = "redyellowfull"
 	},
 /area/station/rnd/scibreak)
 "nNp" = (
@@ -50825,7 +54326,8 @@
 /area/station/engineering/engine)
 "nOh" = (
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/civilian/chapel/mass_driver)
 "nOJ" = (
@@ -50924,7 +54426,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/hallway/primary/central)
 "nPH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -50991,7 +54495,9 @@
 	pixel_x = 28;
 	pixel_y = -5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "nQo" = (
 /obj/structure/cable{
@@ -51000,18 +54506,25 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/hallway/primary/central)
 "nQq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
 /area/station/hallway/secondary/entry)
 "nQr" = (
 /obj/machinery/light/smart,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "brown"
+	},
 /area/station/cargo/qm)
 "nQx" = (
 /obj/machinery/power/apc{
@@ -51042,7 +54555,10 @@
 /obj/machinery/computer/telecomms/monitor{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/tcommsat/computer)
 "nQG" = (
 /obj/machinery/vending/cigarette,
@@ -51050,7 +54566,10 @@
 /area/station/security/prison)
 "nQI" = (
 /obj/machinery/pipedispenser,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "nQL" = (
 /obj/structure/cable{
@@ -51103,10 +54622,7 @@
 /obj/structure/table/reinforced,
 /obj/item/device/assembly/timer,
 /obj/item/device/assembly/voice,
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "black"
-	},
+/turf/simulated/floor,
 /area/station/storage/tech)
 "nRk" = (
 /obj/effect/landmark/start/head_of_security,
@@ -51167,13 +54683,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "brown"
+	},
 /area/station/cargo/qm)
 "nRG" = (
 /obj/machinery/light/smart{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/civilian/gym)
 "nRM" = (
 /obj/structure/cable{
@@ -51197,7 +54719,9 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "nRY" = (
 /obj/structure/girder,
@@ -51338,6 +54862,14 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/primary/central)
+"nTg" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/singularity)
 "nTu" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
@@ -51370,7 +54902,10 @@
 /obj/structure/table/woodentable,
 /obj/item/weapon/folder/red,
 /obj/item/weapon/pen,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "green"
+	},
 /area/station/civilian/dormitories)
 "nTU" = (
 /obj/machinery/optable/skill_scanner,
@@ -51407,7 +54942,8 @@
 /obj/item/weapon/gun/energy/laser,
 /obj/item/weapon/gun/energy/laser,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "warndark"
 	},
 /area/station/security/armoury)
 "nUv" = (
@@ -51426,7 +54962,9 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
 /area/station/engineering/atmos)
 "nUw" = (
 /turf/simulated/floor{
@@ -51623,7 +55161,10 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/station/civilian/gym)
 "nXi" = (
 /obj/item/weapon/flora/random,
@@ -51692,7 +55233,10 @@
 /area/station/hallway/primary/fore)
 "nYg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
 /area/station/hallway/secondary/entry)
 "nYh" = (
 /obj/structure/table/reinforced,
@@ -51734,6 +55278,11 @@
 "nYz" = (
 /turf/simulated/wall/r_wall,
 /area/station/rnd/test_area)
+"nYJ" = (
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
+/area/station/security/prison)
 "nYL" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -51750,7 +55299,10 @@
 /area/station/maintenance/medbay)
 "nYM" = (
 /obj/structure/closet/wardrobe/engineering_yellow,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellow"
+	},
 /area/station/engineering/engine)
 "nYN" = (
 /obj/structure/cable{
@@ -51768,7 +55320,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "nYQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
@@ -51819,7 +55371,8 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor{
-	icon_state = "purplechecker"
+	dir = 4;
+	icon_state = "whitepurple"
 	},
 /area/station/rnd/hor)
 "nZW" = (
@@ -51958,6 +55511,12 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/hallway)
+"obI" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
+/area/station/hallway/secondary/exit)
 "obL" = (
 /obj/structure/stacklifter,
 /turf/simulated/floor{
@@ -51989,7 +55548,7 @@
 	},
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "red"
+	icon_state = "whitered"
 	},
 /area/station/security/main)
 "ocl" = (
@@ -51997,7 +55556,8 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/civilian/chapel/mass_driver)
 "ocs" = (
@@ -52045,7 +55605,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/medical/morgue)
 "odu" = (
@@ -52067,7 +55628,9 @@
 /area/station/engineering/monitoring)
 "odD" = (
 /obj/machinery/atmospherics/components/binary/valve,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "odS" = (
 /obj/structure/table,
@@ -52082,7 +55645,7 @@
 	pixel_x = -22
 	},
 /turf/simulated/floor{
-	icon_state = "whiteyellowcorner"
+	icon_state = "yellowpatch_inv"
 	},
 /area/station/medical/chemistry)
 "oee" = (
@@ -52097,6 +55660,11 @@
 "oeh" = (
 /turf/simulated/floor{
 	icon_state = "dark"
+	},
+/area/station/medical/chemistry)
+"oen" = (
+/turf/simulated/floor{
+	icon_state = "neutral"
 	},
 /area/station/medical/chemistry)
 "oer" = (
@@ -52193,6 +55761,12 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/kitchen)
+"ogc" = (
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/station/cargo/storage)
 "oge" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 4;
@@ -52265,7 +55839,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway)
 "ogP" = (
@@ -52275,7 +55850,9 @@
 /area/station/hallway/primary/central)
 "ogZ" = (
 /obj/decal/boxingrope,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "black"
+	},
 /area/station/civilian/gym)
 "ohf" = (
 /obj/structure/table/reinforced,
@@ -52288,7 +55865,10 @@
 	dir = 4;
 	pixel_x = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "brown"
+	},
 /area/station/cargo/qm)
 "ohm" = (
 /obj/structure/table,
@@ -52297,7 +55877,7 @@
 	},
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "browncorner"
+	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/fore)
 "ohp" = (
@@ -52324,15 +55904,38 @@
 /turf/simulated/floor,
 /area/station/civilian/hydroponics)
 "ohw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/simulated/floor,
-/area/station/security/brig)
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "browncorner"
+	},
+/area/station/cargo/storage)
 "ohG" = (
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "yellow"
 	},
 /area/station/storage/primary)
+"ohP" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "whiteyellowcorner"
+	},
+/area/station/medical/hallway)
 "ohU" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -52345,7 +55948,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warning"
+	},
 /area/station/engineering/atmos)
 "ohV" = (
 /obj/structure/closet/secure_closet/personal/cabinet{
@@ -52354,6 +55963,19 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
+"ohW" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/atmos)
 "ohZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -52426,15 +56048,16 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
-"ojt" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
+"ojm" = (
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "warning"
 	},
-/area/station/maintenance/atmos)
+/area/station/cargo/storage)
+"ojt" = (
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/cargo/storage)
 "oju" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -52477,7 +56100,9 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
 /area/station/engineering/engine)
 "oki" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -52547,7 +56172,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/civilian/dormitories)
 "omd" = (
 /obj/machinery/firealarm{
@@ -52629,7 +56256,10 @@
 "onG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
 /area/station/civilian/gym)
 "onK" = (
 /obj/effect/spawner/lootdrop/maintenance,
@@ -52668,7 +56298,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	dir = 10;
+	dir = 8;
 	icon_state = "warning"
 	},
 /area/station/security/brig)
@@ -52702,7 +56332,9 @@
 	network = list("SS13","Security");
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "red"
+	},
 /area/station/security/hos)
 "oqc" = (
 /obj/machinery/door/firedoor,
@@ -52710,7 +56342,9 @@
 	name = "Gateway Atrium"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/gateway)
 "oqg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -52741,7 +56375,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/medical/morgue)
 "oqt" = (
@@ -52790,7 +56425,10 @@
 /area/station/hallway/primary/port)
 "ord" = (
 /obj/structure/cable,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 10;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/starboardsolar)
 "orf" = (
 /turf/simulated/floor{
@@ -52904,7 +56542,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
 /area/station/engineering/chiefs_office)
 "oti" = (
 /obj/structure/cable{
@@ -52917,6 +56558,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "vault"
@@ -52969,7 +56611,10 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
 /area/station/civilian/chapel)
 "otI" = (
 /obj/structure/cable{
@@ -53014,7 +56659,9 @@
 /area/station/engineering/engine)
 "oub" = (
 /obj/structure/closet/emcloset,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "ouf" = (
 /obj/structure/cable{
@@ -53066,7 +56713,8 @@
 /obj/structure/table,
 /obj/item/weapon/pen,
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
 "ouH" = (
@@ -53115,7 +56763,10 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 9;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/starboardsolar)
 "ovz" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -53133,7 +56784,10 @@
 "ovN" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor/plating,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "blue"
+	},
 /area/station/maintenance/chapel)
 "owz" = (
 /obj/structure/stool/bed/chair/office/dark{
@@ -53144,7 +56798,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/qm)
 "owL" = (
 /obj/structure/table/reinforced,
@@ -53205,7 +56861,10 @@
 /obj/item/stack/sheet/glass{
 	amount = 30
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellow"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "oyu" = (
 /obj/structure/cable{
@@ -53225,7 +56884,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/engineering/engine)
 "oyB" = (
@@ -53291,6 +56951,7 @@
 	},
 /area/station/hallway/primary/port)
 "ozC" = (
+/obj/machinery/computer,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "red"
@@ -53340,7 +57001,7 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
 	dir = 5;
-	icon_state = "vault"
+	icon_state = "warndark"
 	},
 /area/station/rnd/xenobiology)
 "oAJ" = (
@@ -53380,7 +57041,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowfull"
+	},
 /area/station/engineering/engine)
 "oBd" = (
 /obj/structure/disposalpipe/segment{
@@ -53400,6 +57063,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"oBr" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/central)
 "oBy" = (
 /obj/effect/landmark/start/assistant,
 /obj/structure/stool/bed/chair/metal/blue{
@@ -53497,6 +57166,12 @@
 "oCZ" = (
 /turf/simulated/wall,
 /area/station/bridge/teleporter)
+"oDg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "oDh" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -53518,7 +57193,9 @@
 /obj/machinery/door/window/brigdoor{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "redfull"
+	},
 /area/station/hallway/secondary/exit)
 "oDS" = (
 /obj/machinery/door/firedoor,
@@ -53536,7 +57213,7 @@
 /obj/machinery/door/airlock/external{
 	name = "Arrival Airlock"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "oDZ" = (
 /obj/machinery/door/firedoor,
@@ -53544,7 +57221,8 @@
 	name = "Engine Room"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/engineering/engine)
 "oEf" = (
@@ -53556,7 +57234,10 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "purple"
+	},
 /area/station/rnd/xenobiology)
 "oEo" = (
 /obj/item/weapon/flora/random,
@@ -53692,6 +57373,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"oGh" = (
+/obj/item/weapon/flora/random,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "neutral"
+	},
+/area/station/civilian/dormitories)
 "oGi" = (
 /obj/structure/table/glass,
 /obj/item/device/healthanalyzer,
@@ -53729,13 +57417,14 @@
 /obj/item/device/gps/engineering,
 /obj/item/device/gps/engineering,
 /obj/item/device/gps/engineering,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/engine)
 "oGK" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
+	icon_state = "dark"
 	},
 /area/station/rnd/xenobiology)
 "oGY" = (
@@ -53743,7 +57432,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "oHe" = (
 /obj/structure/cable{
@@ -53829,7 +57520,10 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "purple"
+	},
 /area/station/rnd/xenobiology)
 "oHN" = (
 /obj/structure/window/thin/reinforced{
@@ -53900,7 +57594,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/security/checkpoint)
 "oJt" = (
 /obj/machinery/door/firedoor,
@@ -53933,14 +57629,16 @@
 	name = "Dormitory APC";
 	pixel_y = -28
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "oJD" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor{
-	icon_state = "yellowfull"
+	icon_state = "neutralfull"
 	},
-/area/station/hallway/primary/port)
+/area/station/engineering/atmos)
 "oJI" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor,
@@ -53959,7 +57657,7 @@
 	pixel_y = -6
 	},
 /turf/simulated/floor{
-	icon_state = "redyellowfull"
+	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
 "oJP" = (
@@ -53992,7 +57690,8 @@
 	name = "Engine Room"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/engineering/engine)
 "oKR" = (
@@ -54012,7 +57711,9 @@
 "oKV" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold4w/visible/fuel,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "oKX" = (
 /obj/machinery/conveyor{
@@ -54041,11 +57742,23 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/station/cargo/miningoffice)
+"oLp" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/mine_sci_shuttle)
 "oLy" = (
 /obj/machinery/recharge_station,
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "whitepurplecorner"
+	icon_state = "yellow"
 	},
 /area/station/rnd/hallway)
 "oLB" = (
@@ -54088,7 +57801,9 @@
 	dir = 1;
 	name = "Mix to Ports"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "oLK" = (
 /obj/structure/cable{
@@ -54106,7 +57821,10 @@
 /turf/simulated/floor,
 /area/station/cargo/storage)
 "oLS" = (
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "orange"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "oLT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -54216,9 +57934,7 @@
 /obj/structure/window/thin{
 	dir = 1
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor,
 /area/station/civilian/chapel/mass_driver)
 "oMK" = (
 /obj/structure/sign/nanotrasen{
@@ -54306,14 +58022,17 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "black"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/station/storage/tech)
 "oOj" = (
 /obj/structure/table,
 /obj/item/weapon/paper/carbon,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/civilian/gym)
 "oOk" = (
 /obj/structure/closet/secure_closet/cargotech,
@@ -54334,7 +58053,10 @@
 	c_tag = "Quartermaster's Quarters";
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
+	},
 /area/station/cargo/qm)
 "oOy" = (
 /obj/structure/sign/nanotrasen{
@@ -54350,7 +58072,9 @@
 	dir = 4
 	},
 /obj/machinery/light/smart,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "oOJ" = (
 /obj/machinery/door/airlock/external{
@@ -54364,7 +58088,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/starboardsolar)
 "oOP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -54410,12 +58134,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/security/prison)
 "oPi" = (
 /obj/structure/table/reinforced,
 /obj/item/device/radio/beacon,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellow"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "oPD" = (
 /obj/machinery/computer/security/telescreen{
@@ -54433,15 +58162,17 @@
 	},
 /area/station/security/prison)
 "oPF" = (
-/obj/structure/closet/firecloset,
-/turf/simulated/floor,
-/area/station/maintenance/engineering)
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
+/area/station/engineering/atmos)
 "oPI" = (
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "arrival"
+	dir = 4;
+	icon_state = "black"
 	},
-/area/station/medical/reception)
+/area/station/hallway/secondary/exit)
 "oQd" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -54513,7 +58244,10 @@
 	pixel_x = -28;
 	pixel_y = -5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "brown"
+	},
 /area/station/cargo/storage)
 "oRy" = (
 /turf/simulated/wall,
@@ -54561,6 +58295,7 @@
 	dir = 5
 	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
 "oSI" = (
@@ -54573,6 +58308,12 @@
 /obj/structure/sign/warning/radiation,
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/science)
+"oSO" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/green,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/singularity)
 "oSU" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -54585,7 +58326,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "whitebluecorner"
 	},
 /area/station/medical/hallway)
 "oTt" = (
@@ -54617,6 +58359,20 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/carpet/red,
 /area/station/hallway/primary/fore)
+"oTI" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "whiteredcorner"
+	},
+/area/station/medical/hallway)
 "oTP" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Atmospherics HFR Room"
@@ -54668,6 +58424,13 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"oUF" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "warning"
+	},
+/area/station/maintenance/chapel)
 "oUW" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -54675,7 +58438,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "neutralfull"
 	},
 /area/station/medical/storage)
 "oVc" = (
@@ -54683,7 +58446,10 @@
 	pixel_x = -28;
 	pixel_y = -6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
 /area/station/engineering/engine)
 "oVg" = (
 /obj/machinery/door/morgue{
@@ -54692,7 +58458,8 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/civilian/chapel/office)
 "oVj" = (
@@ -54734,7 +58501,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/storage/tech)
 "oVZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -54812,8 +58581,18 @@
 	name = "Misc Researcg APC";
 	pixel_y = -28
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "neutral"
+	},
 /area/station/rnd/hallway)
+"oWH" = (
+/obj/structure/stool/bed/chair,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "red"
+	},
+/area/station/civilian/dormitories)
 "oWQ" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor,
@@ -54865,21 +58644,16 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/storage/primary)
 "oXA" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
-/area/station/security/brig)
+/area/station/civilian/gym)
 "oXQ" = (
 /obj/structure/stool/bed/chair/wood/normal{
 	dir = 4
@@ -54897,6 +58671,13 @@
 	icon_state = "darkblue"
 	},
 /area/station/bridge)
+"oXV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "oYa" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -54918,7 +58699,10 @@
 	dir = 4;
 	name = "N2 to Airmix"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/engineering/atmos)
 "oYl" = (
 /obj/structure/table/glass,
@@ -55004,7 +58788,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "white"
+	},
 /area/station/security/main)
 "oZa" = (
 /turf/simulated/wall/r_wall,
@@ -55051,7 +58837,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "oZK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -55149,7 +58935,8 @@
 	dir = 9
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway)
 "pbk" = (
@@ -55168,7 +58955,10 @@
 /area/station/cargo/recycleroffice)
 "pbm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
 /area/station/engineering/atmos)
 "pbn" = (
 /turf/simulated/floor/plating,
@@ -55213,6 +59003,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"pcI" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/station/rnd/xenobiology)
 "pcJ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -55230,9 +59027,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
+/turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "pcU" = (
 /obj/structure/window/thin/reinforced{
@@ -55333,6 +59128,13 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/singularity)
+"pey" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "pez" = (
 /obj/structure/stacklifter,
 /turf/simulated/floor,
@@ -55350,7 +59152,10 @@
 	dir = 10
 	},
 /obj/item/weapon/flora/random,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellow"
+	},
 /area/station/engineering/engine)
 "peS" = (
 /obj/machinery/light/smart{
@@ -55368,7 +59173,7 @@
 	},
 /turf/simulated/floor{
 	dir = 9;
-	icon_state = "red"
+	icon_state = "whitered"
 	},
 /area/station/security/main)
 "pff" = (
@@ -55415,7 +59220,8 @@
 	dir = 10
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/medical/morgue)
 "pfv" = (
@@ -55471,7 +59277,7 @@
 	},
 /obj/structure/barricade/wooden,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "pgt" = (
 /obj/item/clothing/mask/cigarette/cigar/cohiba{
@@ -55513,7 +59319,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/security/brig)
 "phj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -55540,7 +59348,9 @@
 	name = "Library Museum";
 	req_access = list(37)
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/civilian/library)
 "phG" = (
 /turf/simulated/floor{
@@ -55562,6 +59372,11 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/singularity)
+"phV" = (
+/turf/simulated/floor{
+	icon_state = "yellowcorner"
+	},
+/area/station/engineering/atmos)
 "pio" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -55592,7 +59407,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/storage)
 "piz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -55754,7 +59571,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellow"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "pkt" = (
 /obj/effect/decal/cleanable/dirt,
@@ -55774,10 +59594,7 @@
 "pkv" = (
 /obj/structure/table/reinforced,
 /obj/item/device/paicard,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "black"
-	},
+/turf/simulated/floor,
 /area/station/storage/tech)
 "pkL" = (
 /obj/item/stack/sheet/glass{
@@ -55812,7 +59629,8 @@
 	dir = 5
 	},
 /turf/simulated/floor{
-	icon_state = "whiteyellowcorner"
+	dir = 8;
+	icon_state = "yellowcorner"
 	},
 /area/station/medical/chemistry)
 "pkS" = (
@@ -55828,7 +59646,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "pkU" = (
 /obj/structure/cable{
@@ -55894,7 +59712,8 @@
 	pixel_y = -25
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/civilian/chapel/mass_driver)
 "ply" = (
@@ -56008,6 +59827,18 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/reception)
+"pnn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "whitehall"
+	},
+/area/station/rnd/hallway)
 "pno" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -56057,7 +59888,7 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "red"
+	icon_state = "redfull"
 	},
 /area/station/medical/hallway)
 "pnH" = (
@@ -56069,7 +59900,10 @@
 /area/station/hallway/primary/central)
 "pnL" = (
 /obj/machinery/vending/cigarette,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/bridge/captain_quarters)
 "pnO" = (
 /obj/machinery/door/firedoor,
@@ -56124,8 +59958,8 @@
 /area/station/civilian/chapel)
 "pnZ" = (
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "neutral"
+	dir = 8;
+	icon_state = "neutralcorner"
 	},
 /area/station/civilian/dormitories)
 "pod" = (
@@ -56196,7 +60030,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/office)
 "ppb" = (
 /obj/structure/cable{
@@ -56253,6 +60089,13 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/hallway)
+"ppz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "black"
+	},
+/area/station/civilian/chapel)
 "ppD" = (
 /obj/structure/stool/bed,
 /turf/simulated/floor{
@@ -56319,6 +60162,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
+"pqN" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "pre" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -56405,7 +60255,9 @@
 /obj/machinery/door/airlock/security/glass{
 	name = "Permabrig Visitation"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/security/prison)
 "pss" = (
 /obj/machinery/door/firedoor,
@@ -56432,6 +60284,12 @@
 "pst" = (
 /turf/simulated/floor/plating,
 /area/station/bridge/captain_quarters)
+"psz" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
+/area/station/hallway/secondary/entry)
 "psH" = (
 /obj/machinery/light/smart,
 /obj/structure/disposalpipe/segment{
@@ -56523,7 +60381,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "pux" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -56560,6 +60418,12 @@
 "puP" = (
 /turf/simulated/floor,
 /area/station/rnd/scibreak)
+"puT" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
+/area/station/hallway/secondary/entry)
 "pvg" = (
 /obj/structure/window/thin/reinforced,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -56590,7 +60454,9 @@
 	network = list("SS13","Engineering");
 	dir = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "pwa" = (
 /obj/structure/stool/bed/chair/office/dark{
@@ -56618,7 +60484,10 @@
 	dir = 8;
 	pixel_x = -22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "yellow"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "pwl" = (
 /obj/machinery/ai_slipper{
@@ -56651,7 +60520,9 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/storage)
 "pwt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -56698,7 +60569,9 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/office)
 "pwQ" = (
 /obj/machinery/photocopier,
@@ -56709,7 +60582,8 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/civilian/chapel)
 "pwT" = (
@@ -56730,6 +60604,12 @@
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"pxn" = (
+/turf/simulated/floor{
+	dir = 2;
+	icon_state = "bluecorner"
+	},
+/area/station/maintenance/chapel)
 "pxq" = (
 /obj/machinery/photocopier,
 /obj/structure/sign/poster/official/work_for_a_future{
@@ -56823,6 +60703,13 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"pyv" = (
+/obj/structure/stool/bed/chair,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "red"
+	},
+/area/station/hallway/secondary/exit)
 "pyw" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -56833,15 +60720,16 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "pyy" = (
 /obj/structure/mopbucket,
 /obj/item/weapon/mop,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/hallway/secondary/entry)
 "pyz" = (
@@ -56891,7 +60779,9 @@
 /area/shuttle/syndicate/north)
 "pyO" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/green,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
 /area/station/engineering/singularity)
 "pyX" = (
 /obj/machinery/light/small,
@@ -56917,7 +60807,10 @@
 	c_tag = "Arrival Hallway Third Docking South";
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warning"
+	},
 /area/station/hallway/secondary/entry)
 "pzr" = (
 /obj/structure/table,
@@ -56946,7 +60839,6 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "pzD" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -57044,6 +60936,13 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"pBb" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "pBf" = (
 /obj/structure/sign/nanotrasen,
 /turf/simulated/wall,
@@ -57330,7 +61229,10 @@
 	name = "Atmospherics APC";
 	pixel_y = 28
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos)
 "pFa" = (
 /turf/simulated/floor{
@@ -57391,7 +61293,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitepurplefull"
 	},
 /area/station/medical/hallway)
 "pFE" = (
@@ -57414,7 +61316,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "warning"
+	},
 /area/station/rnd/xenobiology)
 "pFO" = (
 /obj/structure/table/reinforced,
@@ -57439,6 +61344,15 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/lab)
+"pGs" = (
+/obj/machinery/light/smart{
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "caution"
+	},
+/area/station/engineering/atmos)
 "pGv" = (
 /turf/simulated/floor{
 	icon_state = "yellowcorner"
@@ -57471,7 +61385,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitebluefull"
 	},
 /area/station/medical/reception)
 "pGM" = (
@@ -57502,6 +61416,12 @@
 	icon_state = "white"
 	},
 /area/station/rnd/hallway)
+"pGR" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	icon_state = "bluecorner"
+	},
+/area/station/engineering/engine)
 "pHa" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
@@ -57510,6 +61430,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/port)
+"pHc" = (
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/rnd/hallway)
 "pHv" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -57617,6 +61542,16 @@
 	icon_state = "dark"
 	},
 /area/station/aisat/ai_chamber)
+"pJa" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "QMLoad"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
+/area/station/cargo/storage)
 "pJk" = (
 /obj/structure/table/woodentable/poker,
 /obj/item/device/flashlight/lamp,
@@ -57679,7 +61614,10 @@
 /area/station/rnd/hor)
 "pKo" = (
 /obj/structure/big_bell,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
 /area/station/civilian/chapel)
 "pKu" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -57692,7 +61630,9 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/maintenance/chapel)
 "pKx" = (
 /obj/machinery/firealarm{
@@ -57700,7 +61640,8 @@
 	pixel_x = -22
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/security/main)
 "pKL" = (
@@ -57718,7 +61659,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "pKX" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -57770,7 +61711,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/security/prison)
 "pLx" = (
 /obj/effect/spawner/lootdrop/maintenance,
@@ -57787,6 +61730,12 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/science)
+"pLy" = (
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "warndark"
+	},
+/area/station/engineering/atmos)
 "pLB" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/light/smart{
@@ -57806,7 +61755,9 @@
 /obj/machinery/newscaster{
 	pixel_y = 28
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/civilian/library)
 "pMd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -57817,7 +61768,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/starboardsolar)
 "pMl" = (
 /obj/structure/cable{
@@ -57883,7 +61834,9 @@
 	name = "OnlineShop";
 	sortType = "OnlineShop"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/miningoffice)
 "pNq" = (
 /obj/structure/sign/poster/official/ion_rifle{
@@ -57921,8 +61874,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "black"
+	dir = 4;
+	icon_state = "neutral"
 	},
 /area/station/storage/tech)
 "pNT" = (
@@ -57936,7 +61889,9 @@
 	},
 /area/station/medical/chemistry)
 "pOh" = (
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/medical/cryo)
 "pOj" = (
 /obj/structure/disposalpipe/segment,
@@ -57948,8 +61903,7 @@
 /obj/structure/table/woodentable,
 /obj/item/clothing/head/bowler,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/maintenance/chapel)
 "pOr" = (
@@ -57963,7 +61917,8 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway)
 "pOR" = (
@@ -57978,7 +61933,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
 "pPd" = (
 /obj/machinery/light/smart,
@@ -57998,7 +61953,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/security/checkpoint)
 "pPp" = (
 /turf/simulated/floor/wood,
@@ -58069,7 +62026,10 @@
 	name = "Quartermaster APC";
 	pixel_y = 28
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "brown"
+	},
 /area/station/cargo/qm)
 "pPV" = (
 /obj/structure/table/reinforced,
@@ -58089,7 +62049,7 @@
 "pPW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "pPY" = (
 /obj/structure/cable{
@@ -58221,7 +62181,10 @@
 /obj/structure/stool/bed/chair/wheelchair{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "blue"
+	},
 /area/station/medical/hallway)
 "pQU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -58253,6 +62216,25 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/cmo)
+"pRj" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/civilian/dormitories)
 "pRs" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/camera{
@@ -58296,9 +62278,16 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "redyellowfull"
+	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
+"pSP" = (
+/obj/structure/table,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/station/maintenance/chapel)
 "pSU" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -58313,7 +62302,7 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "yellowcorner"
+	icon_state = "yellow"
 	},
 /area/station/engineering/engine)
 "pSX" = (
@@ -58334,7 +62323,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "blackcorner"
+	},
 /area/station/hallway/secondary/exit)
 "pTk" = (
 /obj/structure/table,
@@ -58345,7 +62337,7 @@
 	network = list("SS13","Security","Interrogation")
 	},
 /turf/simulated/floor{
-	icon_state = "redyellowfull"
+	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
 "pTm" = (
@@ -58364,8 +62356,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "escape"
+	icon_state = "redchecker"
 	},
 /area/station/civilian/kitchen)
 "pTE" = (
@@ -58406,7 +62397,10 @@
 	network = list("SS13","Engineering");
 	dir = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/engineering/atmos)
 "pUp" = (
 /obj/structure/cable{
@@ -58442,8 +62436,7 @@
 /area/station/security/lobby)
 "pUP" = (
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "whiteyellowfull"
+	icon_state = "yellowfull"
 	},
 /area/station/medical/chemistry)
 "pVb" = (
@@ -58451,7 +62444,8 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "warndark"
 	},
 /area/station/rnd/tox_launch)
 "pVj" = (
@@ -58461,7 +62455,9 @@
 	name = "Library";
 	sortType = "Library"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
 /area/station/civilian/dormitories)
 "pVo" = (
 /obj/structure/object_wall/pod{
@@ -58543,7 +62539,10 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "red"
+	},
 /area/station/hallway/secondary/exit)
 "pWD" = (
 /obj/effect/decal/cleanable/dirt,
@@ -58565,6 +62564,12 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
+"pWG" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/rnd/hallway)
 "pWS" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/packageWrap,
@@ -58573,7 +62578,10 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/engineering/atmos)
 "pWW" = (
 /obj/machinery/hydroponics/constructable,
@@ -58601,7 +62609,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/starboardsolar)
 "pXL" = (
 /obj/structure/stool/bed/chair/comfy/beige{
@@ -58715,9 +62723,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor,
 /area/station/rnd/hallway)
 "pYQ" = (
 /obj/item/weapon/flora/random,
@@ -58725,7 +62731,10 @@
 	name = "Station Intercom (General)";
 	pixel_y = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "bluecorner"
+	},
 /area/station/engineering/engine)
 "pYU" = (
 /obj/effect/decal/cleanable/dirt,
@@ -58794,6 +62803,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/cargo/storage)
+"pZC" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 10
+	},
+/turf/simulated/floor{
+	icon_state = "caution"
+	},
+/area/station/engineering/atmos)
 "pZG" = (
 /obj/structure/stool/bed/chair/metal/red{
 	dir = 8
@@ -58843,8 +62860,18 @@
 	pixel_x = 29;
 	pixel_y = -6
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 6;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/auxsolarport)
+"qaU" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
+/area/station/engineering/atmos)
 "qaY" = (
 /obj/item/stack/rods{
 	amount = 23
@@ -58853,6 +62880,12 @@
 /obj/structure/rack,
 /turf/simulated/floor,
 /area/station/maintenance/science)
+"qba" = (
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "warning"
+	},
+/area/station/hallway/secondary/entry)
 "qbe" = (
 /obj/structure/closet{
 	name = "Evidence Closet"
@@ -58951,7 +62984,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "qbw" = (
 /obj/structure/cable{
@@ -58968,7 +63001,10 @@
 "qby" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "qbA" = (
 /obj/machinery/door/firedoor,
@@ -58997,13 +63033,14 @@
 	pixel_y = -4
 	},
 /turf/simulated/floor{
-	icon_state = "purplechecker"
+	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/hor)
 "qbF" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "warndark"
 	},
 /area/station/engineering/engine)
 "qbR" = (
@@ -59014,7 +63051,10 @@
 /obj/machinery/light/smart{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellow"
+	},
 /area/station/engineering/engine)
 "qca" = (
 /obj/structure/table/woodentable,
@@ -59052,7 +63092,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
 /area/station/cargo/qm)
 "qdl" = (
 /obj/machinery/door/airlock/engineering/glass{
@@ -59064,6 +63107,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"qdn" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "qdq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
@@ -59124,15 +63173,17 @@
 /obj/effect/landmark/start/janitor,
 /obj/structure/stool,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/hallway/secondary/entry)
 "qee" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/black,
 /obj/item/clothing/gloves/black,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "brown"
+	},
 /area/station/cargo/storage)
 "qeh" = (
 /obj/item/device/radio/beacon,
@@ -59155,8 +63206,7 @@
 	name = "Reading Bay"
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
+	icon_state = "grimy"
 	},
 /area/station/civilian/library)
 "qeL" = (
@@ -59207,6 +63257,18 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/toilet)
+"qfJ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	icon_state = "yellowfull"
+	},
+/area/station/engineering/engine)
 "qfR" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -59239,7 +63301,10 @@
 /area/station/rnd/robotics)
 "qgt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "qgy" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -59276,7 +63341,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "qhh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -59291,6 +63358,12 @@
 /obj/structure/stool/bed,
 /turf/simulated/floor/wood,
 /area/station/maintenance/medbay)
+"qhu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	icon_state = "blackcorner"
+	},
+/area/station/civilian/gym)
 "qhx" = (
 /obj/structure/sign/poster/official/report_crimes{
 	pixel_y = -32
@@ -59421,7 +63494,9 @@
 /area/station/engineering/engine)
 "qiW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/storage/primary)
 "qjc" = (
 /obj/structure/cable{
@@ -59462,7 +63537,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "qjw" = (
 /obj/machinery/door/morgue{
@@ -59495,6 +63572,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
@@ -59531,6 +63609,20 @@
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/space)
+"qkH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
+/area/station/hallway/secondary/entry)
+"qkK" = (
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellowcorner"
+	},
+/area/station/engineering/atmos)
 "qkN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -59574,7 +63666,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
 /area/station/engineering/singularity)
 "qls" = (
 /obj/decal/boxingrope{
@@ -59619,7 +63713,10 @@
 	name = "crate return conveyor";
 	pixel_x = -8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "browncorner"
+	},
 /area/station/cargo/storage)
 "qlO" = (
 /obj/structure/table/woodentable,
@@ -59644,9 +63741,15 @@
 	sortType = "RD Office"
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitehall"
 	},
 /area/station/rnd/hallway)
+"qms" = (
+/obj/machinery/light/smart,
+/turf/simulated/floor{
+	icon_state = "blackcorner"
+	},
+/area/station/hallway/secondary/exit)
 "qmx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
@@ -59713,16 +63816,16 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "qnj" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/aiModule/reset,
 /obj/item/device/flash,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "black"
-	},
+/turf/simulated/floor,
 /area/station/storage/tech)
 "qnq" = (
 /obj/structure/closet/secure_closet/security/med,
@@ -59785,7 +63888,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 1;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/auxsolarport)
 "qnY" = (
 /obj/structure/cable{
@@ -59955,7 +64061,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "escape"
+	icon_state = "redchecker"
 	},
 /area/station/civilian/kitchen)
 "qqG" = (
@@ -60096,14 +64202,19 @@
 "qsr" = (
 /obj/structure/table,
 /obj/item/clothing/mask/gas,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warningcorner"
+	},
 /area/station/maintenance/chapel)
 "qsy" = (
 /obj/structure/table/woodentable/fancy,
 /obj/structure/window/thin/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/civilian/library)
 "qsA" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/green{
@@ -60199,12 +64310,17 @@
 	pixel_x = 29;
 	pixel_y = -6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
 /area/station/engineering/atmos)
 "qtj" = (
 /obj/structure/table,
 /obj/item/weapon/pen,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/security/prison)
 "qtm" = (
 /obj/machinery/door/window/brigdoor{
@@ -60229,6 +64345,12 @@
 	icon_state = "floor"
 	},
 /area/shuttle/escape_pod3/station)
+"qtS" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellow"
+	},
+/area/station/hallway/secondary/mine_sci_shuttle)
 "qtT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
@@ -60240,7 +64362,8 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/medical/medbreak)
 "qtX" = (
@@ -60251,7 +64374,7 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "bot"
 	},
 /area/station/rnd/lab)
 "qua" = (
@@ -60272,7 +64395,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/storage/tech)
 "quf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -60298,7 +64423,7 @@
 /obj/structure/table,
 /obj/item/weapon/clipboard,
 /turf/simulated/floor{
-	icon_state = "redyellowfull"
+	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
 "qup" = (
@@ -60388,7 +64513,10 @@
 "qvQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/alarmlock,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/civilian/gym)
 "qwb" = (
 /obj/structure/table/reinforced,
@@ -60465,6 +64593,20 @@
 /mob/living/simple_animal/mouse,
 /turf/simulated/floor,
 /area/station/security/prison)
+"qxK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "loadingareadirty2"
+	},
+/area/station/maintenance/atmos)
 "qxQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -60499,6 +64641,12 @@
 	icon_state = "dark"
 	},
 /area/station/bridge/ai_upload)
+"qyx" = (
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "warndark"
+	},
+/area/station/engineering/atmos)
 "qyR" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -60592,7 +64740,10 @@
 	},
 /area/station/storage/tech)
 "qAl" = (
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/station/engineering/chiefs_office)
 "qAA" = (
 /obj/structure/rack,
@@ -60600,6 +64751,11 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"qAK" = (
+/turf/simulated/floor{
+	icon_state = "warndarkcorners"
+	},
+/area/station/engineering/atmos)
 "qAM" = (
 /obj/item/weapon/flora/random,
 /obj/structure/cable{
@@ -60637,6 +64793,19 @@
 	icon_state = "darkbluecorners"
 	},
 /area/station/bridge/captain_quarters)
+"qBI" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	icon_state = "whitepurplefull"
+	},
+/area/station/rnd/hallway)
 "qBN" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -60679,7 +64848,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "redchecker"
+	},
 /area/station/civilian/kitchen)
 "qCK" = (
 /obj/structure/closet/lasertag/red,
@@ -60698,7 +64869,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "bot"
+	dir = 4;
+	icon_state = "yellow"
 	},
 /area/station/engineering/atmos)
 "qDi" = (
@@ -60788,7 +64960,6 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 8;
 	icon_state = "neutralcorner"
 	},
 /area/station/civilian/dormitories)
@@ -60815,12 +64986,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
+"qDS" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "whiteblue"
+	},
+/area/station/medical/hallway)
 "qDW" = (
 /obj/machinery/light/smart,
 /obj/structure/sign/painting{
 	pixel_y = -30
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/civilian/library)
 "qEa" = (
 /obj/machinery/vending/coffee,
@@ -60836,7 +65015,10 @@
 	c_tag = "Arrival Hallway First Docking North";
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warning"
+	},
 /area/station/hallway/secondary/entry)
 "qEl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -60907,7 +65089,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowfull"
+	},
 /area/station/engineering/engine)
 "qFs" = (
 /obj/machinery/door/firedoor,
@@ -60956,6 +65140,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"qGp" = (
+/obj/machinery/light/smart{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/engineering/engine)
 "qGy" = (
 /obj/machinery/recycler,
 /turf/simulated/floor/plating,
@@ -61021,12 +65211,25 @@
 /obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor,
 /area/station/maintenance/brig)
+"qHP" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/engine)
 "qHR" = (
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "qIe" = (
 /obj/structure/closet,
@@ -61122,13 +65325,18 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos)
 "qJk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
 /area/station/engineering/engine)
 "qJp" = (
 /obj/structure/cable{
@@ -61142,8 +65350,8 @@
 /area/station/security/iaa_office)
 "qJx" = (
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "warningcorner"
+	dir = 10;
+	icon_state = "red"
 	},
 /area/station/security/brig)
 "qJA" = (
@@ -61156,7 +65364,10 @@
 	name = "Asteroid Shuttle Hallway APC";
 	pixel_x = -28
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellow"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "qJI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -61219,7 +65430,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/storage/primary)
 "qKB" = (
 /obj/item/device/radio/intercom{
@@ -61268,7 +65481,7 @@
 /area/station/maintenance/escape)
 "qLr" = (
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "qLu" = (
 /obj/structure/window/thin/reinforced{
@@ -61286,14 +65499,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/hallway/primary/central)
 "qLO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "qLW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -61389,7 +65606,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/security/brig)
 "qNE" = (
 /obj/structure/table/glass,
@@ -61439,15 +65658,16 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "redyellowfull"
 	},
 /area/station/civilian/bar)
 "qNX" = (
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "blue"
+	},
 /area/station/civilian/dormitories)
 "qOd" = (
 /obj/structure/cable{
@@ -61510,7 +65730,10 @@
 "qOY" = (
 /obj/structure/stool/bed,
 /obj/item/weapon/bedsheet/brown,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "brown"
+	},
 /area/station/cargo/qm)
 "qPa" = (
 /obj/structure/sign/warning/biohazard,
@@ -61570,15 +65793,15 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/hallway/secondary/entry)
 "qQp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
 "qQq" = (
@@ -61610,12 +65833,24 @@
 	icon_state = "purplefull"
 	},
 /area/station/hallway/primary/central)
+"qQy" = (
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "warning"
+	},
+/area/station/hallway/secondary/entry)
 "qQA" = (
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/sleeper)
+"qQK" = (
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "whitebluecorner"
+	},
+/area/station/medical/hallway)
 "qQL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -61635,7 +65870,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "whitepurplefull"
+	},
 /area/station/rnd/scibreak)
 "qQY" = (
 /turf/simulated/floor{
@@ -61648,7 +65885,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "whitepurplefull"
+	},
 /area/station/rnd/hallway)
 "qRh" = (
 /obj/structure/cable{
@@ -61668,7 +65907,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 6;
+	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
 "qRi" = (
@@ -61693,7 +65933,10 @@
 	pixel_x = 28;
 	pixel_y = -5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/civilian/gym)
 "qRA" = (
 /obj/machinery/conveyor_switch{
@@ -61724,7 +65967,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "qSi" = (
 /obj/item/device/radio/intercom{
@@ -61739,6 +65984,12 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"qSk" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "qSm" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
@@ -61750,7 +66001,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "qSx" = (
 /turf/simulated/floor/carpet/green,
@@ -61759,7 +66012,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/medical/cryo)
 "qSR" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -61798,7 +66053,9 @@
 	name = "Station Intercom (General)";
 	pixel_y = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
 /area/station/engineering/atmos)
 "qTm" = (
 /obj/structure/barricade/wooden,
@@ -61843,7 +66100,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/maintenance/atmos)
 "qTH" = (
 /obj/structure/stool/bed/chair/office/dark{
@@ -61869,7 +66128,9 @@
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage_secure)
 "qTM" = (
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/medical/sleeper)
 "qTS" = (
 /obj/structure/cable{
@@ -61898,10 +66159,16 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
+	dir = 8;
+	icon_state = "warndark"
 	},
 /area/station/rnd/xenobiology)
+"qTU" = (
+/turf/simulated/floor/plating{
+	dir = 8;
+	icon_state = "warnplate"
+	},
+/area/station/hallway/secondary/exit)
 "qTX" = (
 /turf/simulated/wall,
 /area/station/civilian/hydroponics)
@@ -61910,8 +66177,7 @@
 	pixel_y = 22
 	},
 /turf/simulated/floor{
-	dir = 9;
-	icon_state = "escape"
+	icon_state = "redchecker"
 	},
 /area/station/civilian/kitchen)
 "qUz" = (
@@ -61939,8 +66205,8 @@
 /area/station/security/main)
 "qVm" = (
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "black"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/station/storage/tech)
 "qVq" = (
@@ -61969,7 +66235,16 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/atmospherics/components/unary/portables_connector,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "warning"
+	},
+/area/station/maintenance/chapel)
+"qVx" = (
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "warning"
+	},
 /area/station/maintenance/chapel)
 "qVy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -62002,7 +66277,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/maintenance/chapel)
 "qVO" = (
 /obj/effect/decal/cleanable/dirt,
@@ -62040,6 +66318,14 @@
 	icon_state = "vault"
 	},
 /area/station/security/forensic_office)
+"qWm" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 10
+	},
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "qWs" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -62076,7 +66362,7 @@
 /obj/item/weapon/storage/box/ids,
 /obj/item/weapon/handcuffs,
 /turf/simulated/floor{
-	icon_state = "redcorner"
+	icon_state = "dark"
 	},
 /area/station/security/brig)
 "qXN" = (
@@ -62262,7 +66548,9 @@
 /area/station/engineering/engine)
 "raB" = (
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/medical/reception)
 "raD" = (
 /obj/structure/sign/directions/engineering{
@@ -62295,14 +66583,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "raR" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "raX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -62407,14 +66700,34 @@
 "rcy" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/belt/utility,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "brown"
+	},
 /area/station/cargo/storage)
+"rcz" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "whitebluecorner"
+	},
+/area/station/medical/hallway)
 "rcA" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
 	name = "Mix Outlet Pump"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "green"
+	},
 /area/station/engineering/atmos)
 "rcM" = (
 /obj/machinery/door/firedoor,
@@ -62551,7 +66864,10 @@
 /obj/structure/table/reinforced,
 /obj/item/weapon/clipboard,
 /obj/item/weapon/pen,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "red"
+	},
 /area/station/security/brig)
 "rfC" = (
 /obj/machinery/computer/forensic_scanning{
@@ -62642,7 +66958,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/station/medical/storage)
 "rgZ" = (
 /obj/structure/cable{
@@ -62701,7 +67020,8 @@
 	dir = 5
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/civilian/chapel/mass_driver)
 "rhs" = (
@@ -62753,7 +67073,9 @@
 /obj/machinery/atmospherics/components/trinary/filter/m_filter{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
 /area/station/engineering/singularity)
 "riq" = (
 /obj/structure/object_wall/pod{
@@ -62761,9 +67083,35 @@
 	},
 /turf/environment/space/shuttle,
 /area/shuttle/escape_pod3/station)
+"riw" = (
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "neutral"
+	},
+/area/station/civilian/dormitories)
 "riS" = (
 /turf/simulated/floor,
 /area/station/cargo/miningoffice)
+"riX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "whiteyellow"
+	},
+/area/station/medical/hallway)
 "rjb" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -62779,7 +67127,10 @@
 "rjz" = (
 /obj/structure/table,
 /obj/item/weapon/paper,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/civilian/gym)
 "rjD" = (
 /obj/structure/cable{
@@ -62833,7 +67184,10 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "warning"
+	},
 /area/station/engineering/engine)
 "rkE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -62892,9 +67246,15 @@
 	network = list("SS13","Security")
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/security/main)
+"rlG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance,
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "rlM" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -62979,12 +67339,19 @@
 "rmY" = (
 /turf/simulated/wall,
 /area/station/hallway/secondary/exit)
+"rnl" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warndark"
+	},
+/area/station/engineering/atmos)
 "rnn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway)
 "rnq" = (
@@ -63018,16 +67385,27 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "redyellowfull"
+	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
+"rot" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "warning"
+	},
+/area/station/engineering/atmos)
 "rov" = (
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "black"
+	},
 /area/station/hallway/secondary/entry)
 "rox" = (
 /obj/item/weapon/flora/random,
@@ -63083,14 +67461,16 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/qm)
 "rpj" = (
 /turf/simulated/floor{
-	dir = 9;
-	icon_state = "red"
+	dir = 4;
+	icon_state = "orange"
 	},
-/area/station/security/main)
+/area/station/hallway/secondary/mine_sci_shuttle)
 "rpu" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
@@ -63139,7 +67519,10 @@
 /obj/machinery/light/smart{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellow"
+	},
 /area/station/engineering/engine)
 "rpZ" = (
 /obj/machinery/computer/secure_data{
@@ -63151,8 +67534,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	dir = 9;
-	icon_state = "red"
+	icon_state = "redfull"
 	},
 /area/station/medical/hallway)
 "rqc" = (
@@ -63222,8 +67604,7 @@
 "rru" = (
 /obj/machinery/light/small,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "blackcorner"
+	icon_state = "blackchecker"
 	},
 /area/station/hallway/primary/port)
 "rrv" = (
@@ -63294,7 +67675,9 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/engineering/atmos)
 "rsx" = (
 /obj/structure/cable{
@@ -63311,7 +67694,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "rsB" = (
 /obj/structure/closet/crate{
@@ -63326,7 +67711,9 @@
 	name = "Station Intercom (General)";
 	pixel_y = -32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "warning"
+	},
 /area/station/engineering/engine)
 "rsE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -63342,7 +67729,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/station/civilian/gym)
 "rsN" = (
 /obj/structure/sign/poster/official/do_not_question{
@@ -63404,7 +67794,7 @@
 	name = "KitchenShutters";
 	opacity = 0
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
 "rtL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -63447,8 +67837,7 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
+	icon_state = "dark"
 	},
 /area/station/rnd/xenobiology)
 "rue" = (
@@ -63583,6 +67972,12 @@
 	icon_state = "neutralfull"
 	},
 /area/station/civilian/dormitories)
+"rwf" = (
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "whitepurple"
+	},
+/area/station/rnd/hallway)
 "rwh" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -63604,7 +67999,10 @@
 /area/station/security/brig)
 "rwr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
 /area/station/engineering/engine)
 "rwA" = (
 /obj/item/weapon/flora/random,
@@ -63612,7 +68010,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/engineering/atmos)
 "rwG" = (
 /obj/machinery/deepfryer,
@@ -63627,8 +68028,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor{
-	dir = 10;
-	icon_state = "escape"
+	icon_state = "redchecker"
 	},
 /area/station/hallway/primary/port)
 "rwJ" = (
@@ -63842,9 +68242,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor,
 /area/station/rnd/hallway)
 "rzs" = (
 /obj/structure/cable{
@@ -63882,7 +68280,8 @@
 	dir = 9
 	},
 /turf/simulated/floor{
-	icon_state = "purplechecker"
+	dir = 8;
+	icon_state = "whitepurple"
 	},
 /area/station/rnd/hor)
 "rzL" = (
@@ -63966,7 +68365,10 @@
 	pixel_y = -32
 	},
 /obj/machinery/light/smart,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "rAw" = (
 /obj/structure/cable{
@@ -64000,13 +68402,33 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "rAU" = (
 /obj/structure/stool/bed/chair/office/light,
 /obj/effect/landmark/start/xenobiologist,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "neutral"
+	},
 /area/station/rnd/xenobiology)
+"rAY" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/fore)
 "rBa" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -64020,6 +68442,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
+"rBd" = (
+/turf/simulated/floor{
+	icon_state = "whiteblue"
+	},
+/area/station/medical/hallway)
 "rBf" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -64046,13 +68473,15 @@
 	c_tag = "Arrival Hallway South";
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "rBo" = (
 /obj/structure/table,
 /obj/item/weapon/kitchen/utensil/pfork,
 /turf/simulated/floor{
-	icon_state = "redyellowfull"
+	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
 "rBp" = (
@@ -64091,7 +68520,10 @@
 	network = list("SS13","Engineering");
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "warning"
+	},
 /area/station/engineering/engine)
 "rCn" = (
 /turf/environment/space,
@@ -64129,7 +68561,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "rCU" = (
 /obj/structure/disposalpipe/segment{
@@ -64163,7 +68598,9 @@
 /turf/simulated/floor/plating/airless/catwalk,
 /area/space)
 "rDd" = (
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/storage/tech)
 "rDs" = (
 /obj/structure/table,
@@ -64171,7 +68608,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor{
-	icon_state = "redyellowfull"
+	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
 "rDR" = (
@@ -64251,6 +68688,18 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/qm)
+"rEz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "rEF" = (
 /obj/effect/landmark/start/station_engineer,
 /obj/structure/cable{
@@ -64263,7 +68712,9 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "warning"
+	},
 /area/station/engineering/engine)
 "rEP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -64295,7 +68746,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/maintenance/atmos)
 "rFp" = (
 /obj/machinery/door/firedoor,
@@ -64391,6 +68844,12 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge/hop_office)
+"rHh" = (
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "warndark"
+	},
+/area/station/engineering/atmos)
 "rHl" = (
 /obj/structure/closet/secure_closet/security/cargo,
 /obj/machinery/firealarm{
@@ -64410,6 +68869,13 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge/captain_quarters)
+"rHG" = (
+/obj/structure/closet/radiation,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "rHL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
 	dir = 10
@@ -64436,7 +68902,9 @@
 /area/station/medical/chemistry)
 "rHZ" = (
 /obj/machinery/door/firedoor,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/security/prison)
 "rIb" = (
 /obj/structure/cable{
@@ -64712,14 +69180,19 @@
 /obj/structure/disposalpipe/junction{
 	icon_state = "pipe-j2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/medical/sleeper)
 "rJE" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "warning"
+	},
 /area/station/engineering/atmos)
 "rJS" = (
 /obj/machinery/door/window/brigdoor{
@@ -64732,7 +69205,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
 /area/station/rnd/xenobiology)
 "rJU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -64744,14 +69219,13 @@
 "rJY" = (
 /obj/machinery/optable,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/medical/surgeryobs)
 "rJZ" = (
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor/plating,
 /area/station/hallway/primary/port)
 "rKp" = (
 /obj/machinery/door/firedoor,
@@ -64767,6 +69241,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/cargo/storage)
+"rKv" = (
+/obj/structure/table,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/hallway/secondary/exit)
 "rKw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -64834,7 +69315,7 @@
 /obj/machinery/door/airlock/external{
 	name = "Arrival Airlock"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "rKR" = (
 /obj/structure/stool/bed/chair/office/dark{
@@ -64910,7 +69391,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/hallway/primary/central)
 "rLY" = (
 /obj/machinery/power/terminal{
@@ -64924,7 +69407,10 @@
 	c_tag = "Fore Starboard Solars";
 	dir = 6
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 5;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/auxsolarstarboard)
 "rMn" = (
 /obj/structure/table/reinforced,
@@ -64934,7 +69420,9 @@
 	network = list("SS13","Research");
 	dir = 10
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
 /area/station/rnd/hor)
 "rMI" = (
 /obj/structure/cable{
@@ -65147,7 +69635,10 @@
 /area/station/medical/surgeryobs)
 "rPA" = (
 /obj/structure/closet/emcloset,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
+	},
 /area/station/cargo/storage)
 "rPB" = (
 /obj/machinery/door/firedoor,
@@ -65226,7 +69717,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/miningoffice)
 "rQM" = (
 /obj/structure/cable{
@@ -65234,7 +69727,10 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
 /area/station/engineering/atmos)
 "rQV" = (
 /obj/machinery/telecomms/receiver/preset_right,
@@ -65263,7 +69759,10 @@
 	dir = 4;
 	pixel_x = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "rRh" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -65272,13 +69771,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "rRo" = (
 /obj/machinery/recharger,
@@ -65327,7 +69824,10 @@
 	pixel_y = 5
 	},
 /obj/item/clothing/suit/storage/hazardvest,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/engineering/atmos)
 "rSm" = (
 /obj/structure/extinguisher_cabinet{
@@ -65495,6 +69995,11 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/singularity)
+"rUL" = (
+/turf/simulated/floor{
+	icon_state = "black"
+	},
+/area/station/hallway/secondary/exit)
 "rUR" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -65539,7 +70044,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "whiteyellowcorner"
+	dir = 4;
+	icon_state = "yellowcorner"
 	},
 /area/station/medical/chemistry)
 "rVw" = (
@@ -65570,6 +70076,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
+	dir = 1;
 	icon_state = "neutral"
 	},
 /area/station/civilian/dormitories)
@@ -65593,7 +70100,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
 /area/station/engineering/atmos)
 "rVN" = (
 /obj/structure/cable{
@@ -65653,6 +70162,23 @@
 /obj/structure/sign/warning/nosmoking,
 /turf/simulated/wall/r_wall,
 /area/station/ai_monitored/storage_secure)
+"rWL" = (
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/cargo/qm)
+"rWY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warndark"
+	},
+/area/station/rnd/xenobiology)
 "rXo" = (
 /obj/machinery/door/airlock/medical{
 	name = "Medical Break Room"
@@ -65672,7 +70198,9 @@
 	name = "Medbay Biohazard Blast Doors";
 	opacity = 0
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "whitebluefull"
+	},
 /area/station/medical/medbreak)
 "rXz" = (
 /turf/simulated/wall,
@@ -65682,8 +70210,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/hallway/secondary/entry)
 "rXM" = (
@@ -65691,11 +70218,16 @@
 /obj/structure/stool/bed/chair{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "redchecker"
+	},
 /area/station/civilian/kitchen)
 "rXN" = (
 /obj/machinery/light/smart,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "redcorner"
+	},
 /area/station/hallway/secondary/exit)
 "rXS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -65711,7 +70243,9 @@
 	dir = 4
 	},
 /obj/machinery/light/smart,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "rYj" = (
 /obj/effect/decal/cleanable/generic,
@@ -65723,7 +70257,7 @@
 "rYl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
-	icon_state = "whitebluefull"
+	icon_state = "bluefull"
 	},
 /area/station/medical/reception)
 "rYm" = (
@@ -65758,7 +70292,7 @@
 	pixel_y = -30
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitebluecorner"
 	},
 /area/station/medical/hallway)
 "rYV" = (
@@ -65834,14 +70368,18 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/medical/morgue)
 "rZM" = (
 /obj/machinery/conveyor{
 	id = "cargounload"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
 /area/station/cargo/storage)
 "rZO" = (
 /obj/structure/table/reinforced,
@@ -65850,6 +70388,11 @@
 	icon_state = "vault"
 	},
 /area/station/engineering/atmos)
+"rZU" = (
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/engine)
 "sac" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -65894,8 +70437,7 @@
 "sbi" = (
 /obj/structure/closet/secure_closet/engineering_welding,
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "warning"
+	icon_state = "bot"
 	},
 /area/station/engineering/engine)
 "sbk" = (
@@ -65909,7 +70451,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitebluecorner"
 	},
 /area/station/medical/hallway)
 "sbp" = (
@@ -65938,7 +70480,8 @@
 	dir = 5
 	},
 /turf/simulated/floor{
-	icon_state = "bar"
+	dir = 8;
+	icon_state = "bluered"
 	},
 /area/station/medical/medbreak)
 "sbV" = (
@@ -66046,8 +70589,7 @@
 	dir = 7
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "red"
+	icon_state = "redyellowfull"
 	},
 /area/station/civilian/bar)
 "sdW" = (
@@ -66103,7 +70645,10 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "brown"
+	},
 /area/station/cargo/qm)
 "seF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -66118,7 +70663,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "seJ" = (
 /obj/structure/table/woodentable/poker,
@@ -66135,6 +70683,19 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/singularity)
+"seV" = (
+/obj/machinery/shieldwallgen{
+	req_access = list(55)
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating{
+	dir = 5;
+	icon_state = "warnplate"
+	},
+/area/station/rnd/xenobiology)
 "sfe" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -66222,7 +70783,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/qm)
 "sgr" = (
 /obj/structure/cable{
@@ -66279,7 +70842,9 @@
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "shs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -66305,7 +70870,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
 /area/station/engineering/atmos)
 "shE" = (
 /obj/machinery/hydroponics/soil,
@@ -66318,7 +70885,9 @@
 	pixel_x = 1;
 	pixel_y = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/engine)
 "shI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -66374,7 +70943,10 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
 /area/station/rnd/xenobiology)
 "siI" = (
 /obj/machinery/door/airlock/security/glass{
@@ -66475,8 +71047,17 @@
 	c_tag = "Recycler Office";
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
+"sjx" = (
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "whitehall"
+	},
+/area/station/rnd/hallway)
 "sjA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -66489,8 +71070,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 6;
-	icon_state = "escape"
+	icon_state = "redchecker"
 	},
 /area/station/civilian/kitchen)
 "sjK" = (
@@ -66537,7 +71117,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "warning"
+	},
 /area/station/maintenance/chapel)
 "sjQ" = (
 /obj/effect/landmark/start/station_engineer,
@@ -66546,7 +71129,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/engine)
 "sjU" = (
 /obj/machinery/computer/security{
@@ -66558,8 +71143,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "red"
+	icon_state = "redfull"
 	},
 /area/station/medical/hallway)
 "sjW" = (
@@ -66605,7 +71189,9 @@
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Treatment Center"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "whitebluefull"
+	},
 /area/station/medical/sleeper)
 "skA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -66656,7 +71242,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/engineering/atmos)
 "skY" = (
 /obj/structure/cable{
@@ -66680,11 +71269,16 @@
 /area/station/hallway/primary/central)
 "slb" = (
 /mob/living/simple_animal/fox/Renault,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/bridge/captain_quarters)
 "sld" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/office)
 "slo" = (
 /obj/structure/sign/nanotrasen{
@@ -66697,7 +71291,10 @@
 	dir = 4
 	},
 /obj/machinery/light/smart,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "slw" = (
 /obj/structure/cable{
@@ -66750,6 +71347,14 @@
 	icon_state = "greenblue"
 	},
 /area/station/civilian/hydroponics)
+"smh" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/cargo/storage)
 "smi" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor/wood,
@@ -66758,7 +71363,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
 /area/station/maintenance/chapel)
 "smA" = (
 /obj/structure/table,
@@ -66785,7 +71393,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/office)
 "smU" = (
 /obj/item/device/radio/intercom{
@@ -66812,7 +71422,10 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/primary/fore)
 "snA" = (
 /obj/structure/cable{
@@ -66848,7 +71461,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
 /area/station/cargo/storage)
 "soh" = (
 /obj/effect/landmark/start/scientist,
@@ -66864,6 +71479,20 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/lab)
+"som" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/rnd/hallway)
 "sow" = (
 /turf/simulated/floor/engine/oxygen,
 /area/station/engineering/atmos)
@@ -66873,6 +71502,14 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"soD" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/singularity)
 "soF" = (
 /obj/structure/object_wall/pod{
 	dir = 1;
@@ -66941,7 +71578,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 5;
+	dir = 8;
 	icon_state = "vault"
 	},
 /area/station/rnd/xenobiology)
@@ -66954,7 +71591,10 @@
 	dir = 8
 	},
 /obj/structure/window/thin,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "escape"
+	},
 /area/station/engineering/atmos)
 "spN" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -67046,6 +71686,13 @@
 /obj/machinery/computer/reconstitutor/animal,
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
+"srS" = (
+/obj/structure/table/woodentable,
+/obj/item/device/radio/intercom,
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
+/area/station/civilian/dormitories)
 "srW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -67055,9 +71702,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor,
 /area/station/rnd/xenobiology)
 "srY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -67073,7 +71718,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "sse" = (
 /obj/structure/table/woodentable,
@@ -67092,7 +71737,9 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/office)
 "ssF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -67139,7 +71786,9 @@
 	pixel_x = 29;
 	pixel_y = -6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/engineering/atmos)
 "sts" = (
 /obj/machinery/pipedispenser/disposal,
@@ -67181,7 +71830,10 @@
 "stM" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "stP" = (
 /obj/structure/cable{
@@ -67205,7 +71857,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
 /area/station/rnd/xenobiology)
 "stW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -67214,6 +71868,13 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
+"sua" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warning"
+	},
+/area/station/hallway/secondary/entry)
 "suf" = (
 /obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt,
@@ -67227,6 +71888,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
+"suB" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/security/brig)
 "suL" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/brig/solitary_confinement)
@@ -67264,7 +71942,7 @@
 	dir = 9
 	},
 /turf/simulated/floor{
-	icon_state = "warning"
+	icon_state = "yellowfull"
 	},
 /area/station/engineering/engine)
 "svw" = (
@@ -67272,7 +71950,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "svE" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -67292,6 +71972,11 @@
 	icon_state = "warnwhite"
 	},
 /area/station/rnd/hallway)
+"svS" = (
+/turf/simulated/floor{
+	icon_state = "bluecorner"
+	},
+/area/station/engineering/engine)
 "swq" = (
 /obj/machinery/vending/clothing,
 /turf/simulated/floor{
@@ -67304,7 +71989,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "swv" = (
 /obj/structure/cable{
@@ -67387,8 +72074,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/storage/primary)
+"syl" = (
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "blackcorner"
+	},
+/area/station/hallway/secondary/exit)
 "syn" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -67411,7 +72106,7 @@
 /obj/structure/table/reinforced,
 /obj/item/weapon/paper/monitorkey,
 /turf/simulated/floor{
-	icon_state = "purplechecker"
+	icon_state = "white"
 	},
 /area/station/rnd/hor)
 "syI" = (
@@ -67498,7 +72193,10 @@
 	name = "Recycler Buffer";
 	pixel_y = 26
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "browncorner"
+	},
 /area/station/cargo/storage)
 "szw" = (
 /turf/simulated/floor/bluegrid{
@@ -67525,7 +72223,9 @@
 /obj/item/weapon/wrench,
 /obj/item/weapon/tank/emergency_oxygen/engi,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/engineering/atmos)
 "sAh" = (
 /obj/structure/cable{
@@ -67552,7 +72252,9 @@
 	c_tag = "Auxiliary Tool Storage";
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
 /area/station/storage/tools)
 "sAQ" = (
 /obj/structure/stool/bed/chair/pew/right,
@@ -67632,8 +72334,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "cautioncorner"
+	icon_state = "caution"
 	},
 /area/station/engineering/engine)
 "sBT" = (
@@ -67713,7 +72414,9 @@
 /area/station/civilian/kitchen)
 "sCr" = (
 /obj/machinery/computer,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos)
 "sCO" = (
 /obj/structure/closet,
@@ -67722,8 +72425,7 @@
 	},
 /obj/item/stack/cable_coil,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/civilian/bar)
 "sCS" = (
@@ -67764,8 +72466,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"sDa" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "whitegreen"
+	},
+/area/station/medical/hallway)
 "sDs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -67778,6 +72486,12 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/robotics)
+"sDu" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	icon_state = "blackcorner"
+	},
+/area/station/hallway/secondary/entry)
 "sDx" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -67796,7 +72510,9 @@
 	c_tag = "Quartermaster's Office";
 	dir = 10
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "brown"
+	},
 /area/station/cargo/qm)
 "sDU" = (
 /obj/machinery/conveyor{
@@ -67809,7 +72525,10 @@
 /obj/machinery/conveyor{
 	id = "stationscrap"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
 /area/station/cargo/storage)
 "sEi" = (
 /obj/structure/closet/secure_closet/brig{
@@ -67821,6 +72540,13 @@
 	icon_state = "darkred"
 	},
 /area/station/medical/hallway)
+"sEp" = (
+/obj/item/weapon/flora/random,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "black"
+	},
+/area/station/civilian/chapel)
 "sEr" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -67870,8 +72596,7 @@
 /area/station/hallway/primary/fore)
 "sEJ" = (
 /turf/simulated/floor{
-	dir = 10;
-	icon_state = "escape"
+	icon_state = "redchecker"
 	},
 /area/station/civilian/kitchen)
 "sEV" = (
@@ -67892,6 +72617,14 @@
 	icon_state = "neutral"
 	},
 /area/station/hallway/primary/fore)
+"sEX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "sEY" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/snacks/baguette,
@@ -67919,7 +72652,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitebluefull"
 	},
 /area/station/medical/sleeper)
 "sFd" = (
@@ -68073,7 +72806,8 @@
 	},
 /obj/machinery/light/small,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/medical/medbreak)
 "sHG" = (
@@ -68105,7 +72839,10 @@
 "sHZ" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "warning"
+	},
 /area/station/maintenance/chapel)
 "sIa" = (
 /obj/effect/decal/cleanable/dirt,
@@ -68123,6 +72860,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/maintenance/science)
+"sId" = (
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "yellow"
+	},
+/area/station/engineering/engine)
 "sIe" = (
 /turf/simulated/floor/plating{
 	dir = 4;
@@ -68136,7 +72879,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitepurplefull"
 	},
 /area/station/rnd/hallway)
 "sIq" = (
@@ -68173,7 +72916,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "bot"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/security/hos)
 "sIE" = (
@@ -68204,7 +72948,9 @@
 	density = 0;
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "black"
+	},
 /area/station/civilian/gym)
 "sJa" = (
 /obj/structure/cable{
@@ -68215,7 +72961,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "yellow"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "sJk" = (
 /obj/structure/cable{
@@ -68563,14 +73312,17 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	dir = 8;
+	dir = 9;
 	icon_state = "red"
 	},
 /area/station/medical/hallway)
 "sOp" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/folder/brown,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "blue"
+	},
 /area/station/civilian/dormitories)
 "sOu" = (
 /obj/structure/stool,
@@ -68579,18 +73331,29 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor{
-	icon_state = "redyellowfull"
+	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
+"sOD" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
+/area/station/rnd/xenobiology)
 "sOK" = (
 /obj/item/cardboard_cutout{
 	icon_state = "cutout_clown"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "neutral"
+	},
 /area/station/civilian/gym)
 "sOU" = (
 /obj/machinery/light/smart,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "sPk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -68664,7 +73427,9 @@
 	name = "Brig Desk";
 	req_access = list(63)
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/security/brig)
 "sPU" = (
 /obj/structure/table/reinforced,
@@ -68691,11 +73456,13 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/chiefs_office)
 "sQd" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "arrival"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
-/area/station/medical/reception)
+/turf/simulated/floor{
+	icon_state = "whitebluecorner"
+	},
+/area/station/medical/hallway)
 "sQq" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/window/thin{
@@ -68715,7 +73482,9 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/hallway/primary/central)
 "sQF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -68756,7 +73525,8 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 9;
+	icon_state = "warndark"
 	},
 /area/station/security/armoury)
 "sRk" = (
@@ -68795,7 +73565,8 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
 "sSh" = (
@@ -68803,7 +73574,8 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "warndark"
 	},
 /area/station/rnd/tox_launch)
 "sSj" = (
@@ -68828,10 +73600,23 @@
 /obj/item/weapon/crowbar/red,
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories)
+"sSE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "whitepurplefull"
+	},
+/area/station/rnd/hallway)
 "sSH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/maintenance/engineering)
 "sSQ" = (
 /turf/simulated/floor{
@@ -68887,8 +73672,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "browncorner"
+	icon_state = "yellowpatch_inv"
 	},
 /area/station/hallway/primary/fore)
 "sTo" = (
@@ -68911,7 +73695,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway)
 "sTE" = (
@@ -68961,13 +73746,22 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/theatre)
+"sUm" = (
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
+/area/station/engineering/engine)
 "sUt" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = -28;
 	pixel_y = -5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "warning"
+	},
 /area/station/hallway/secondary/entry)
 "sUP" = (
 /obj/machinery/shower/free{
@@ -68977,7 +73771,9 @@
 	drainage = 2
 	},
 /obj/structure/window/thin,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/medical/cryo)
 "sUT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -68990,7 +73786,10 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "sUX" = (
 /obj/machinery/door/firedoor,
@@ -69018,7 +73817,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "sVa" = (
 /turf/simulated/wall/r_wall,
@@ -69083,7 +73884,10 @@
 /obj/machinery/light/smart{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/engineering/atmos)
 "sWq" = (
 /obj/item/weapon/flora/random,
@@ -69124,7 +73928,10 @@
 	dir = 4;
 	pixel_x = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos)
 "sWL" = (
 /obj/item/weapon/flora/random,
@@ -69147,7 +73954,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "red"
+	},
 /area/station/hallway/secondary/exit)
 "sXj" = (
 /obj/machinery/firealarm{
@@ -69223,6 +74033,14 @@
 	icon_state = "wooden-2"
 	},
 /area/station/civilian/gym)
+"sYc" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/singularity)
 "sYm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -69270,7 +74088,10 @@
 	c_tag = "Holodeck Controls";
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/civilian/gym)
 "sYI" = (
 /obj/structure/filingcabinet/chestdrawer/black,
@@ -69295,6 +74116,15 @@
 	icon_state = "vault"
 	},
 /area/station/hallway/primary/starboard)
+"sZe" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "whitepurple"
+	},
+/area/station/rnd/hallway)
 "sZk" = (
 /obj/structure/sign/poster/official/report_crimes{
 	pixel_y = 32
@@ -69396,6 +74226,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
+	dir = 1;
 	icon_state = "neutral"
 	},
 /area/station/civilian/dormitories)
@@ -69435,7 +74266,8 @@
 	dir = 9
 	},
 /turf/simulated/floor{
-	icon_state = "arrival"
+	dir = 1;
+	icon_state = "whiteblue"
 	},
 /area/station/medical/reception)
 "taL" = (
@@ -69446,14 +74278,17 @@
 	dir = 6
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "whitebluecorner"
 	},
 /area/station/medical/hallway)
 "tbt" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "tbx" = (
 /obj/machinery/light/smart{
@@ -69462,7 +74297,10 @@
 /obj/machinery/ai_status_display{
 	pixel_x = -32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "bluecorner"
+	},
 /area/station/engineering/engine)
 "tbH" = (
 /obj/structure/cable{
@@ -69473,7 +74311,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "white"
+	},
 /area/station/security/main)
 "tbR" = (
 /obj/structure/dresser,
@@ -69542,7 +74382,9 @@
 /area/station/hallway/primary/central)
 "tcE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/qm)
 "tcM" = (
 /obj/item/clothing/glasses/welding,
@@ -69576,7 +74418,9 @@
 /obj/structure/table,
 /obj/item/weapon/clipboard,
 /obj/item/weapon/pen/blue,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch_inv"
+	},
 /area/station/hallway/primary/central)
 "tdk" = (
 /obj/structure/table/glass,
@@ -69633,7 +74477,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "teo" = (
 /obj/effect/decal/cleanable/dirt,
@@ -69661,7 +74508,10 @@
 "teE" = (
 /obj/structure/table,
 /obj/item/weapon/folder/brown,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "teH" = (
 /obj/structure/table,
@@ -69814,7 +74664,10 @@
 	c_tag = "Arrival Entry";
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "blackcorner"
+	},
 /area/station/hallway/secondary/exit)
 "tgI" = (
 /obj/structure/disposalpipe/junction{
@@ -69836,7 +74689,10 @@
 	c_tag = "Arrival Hallway First Docking South";
 	dir = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
 /area/station/hallway/secondary/entry)
 "tgP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -69857,7 +74713,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/engineering/atmos)
 "thi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -69868,14 +74727,11 @@
 	},
 /area/station/civilian/kitchen)
 "thA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "escape"
+	dir = 8;
+	icon_state = "neutral"
 	},
-/area/station/civilian/kitchen)
+/area/station/hallway/secondary/entry)
 "thB" = (
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -69974,11 +74830,16 @@
 	},
 /area/station/hallway/primary/central)
 "tiN" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 5
+/turf/simulated/floor{
+	icon_state = "yellow"
 	},
-/turf/simulated/floor,
 /area/station/engineering/atmos)
+"tiS" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "blackcorner"
+	},
+/area/station/hallway/secondary/exit)
 "tjk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -70019,7 +74880,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "tjx" = (
 /obj/item/device/radio/intercom{
@@ -70162,7 +75023,10 @@
 	},
 /area/station/bridge/ai_upload)
 "tlS" = (
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/security/hos)
 "tmb" = (
 /obj/structure/cable{
@@ -70175,7 +75039,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/medical/cryo)
 "tmk" = (
 /obj/machinery/light/smart{
@@ -70194,12 +75060,26 @@
 /area/shuttle/escape_pod3/station)
 "tmK" = (
 /obj/item/weapon/flora/random,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "blackcorner"
+	},
 /area/station/hallway/secondary/exit)
 "tmQ" = (
 /obj/structure/closet/radiation,
 /obj/item/device/analyzer,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "caution"
+	},
+/area/station/engineering/atmos)
+"tmX" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos)
 "tne" = (
 /obj/structure/cable{
@@ -70210,7 +75090,10 @@
 /obj/machinery/firealarm{
 	pixel_y = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos)
 "tnf" = (
 /obj/machinery/door/window/southright{
@@ -70234,9 +75117,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "browncorner"
+	icon_state = "bluecorner"
 	},
 /area/station/security/lobby)
+"tnq" = (
+/turf/simulated/floor{
+	icon_state = "warning"
+	},
+/area/station/maintenance/chapel)
 "tnt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -70258,6 +75146,12 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
+"tnz" = (
+/obj/structure/barricade/wooden,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/hallway/primary/port)
 "top" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -70290,7 +75184,9 @@
 /area/station/security/brig)
 "tov" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowfull"
+	},
 /area/station/engineering/engine)
 "toJ" = (
 /obj/structure/cable{
@@ -70340,7 +75236,10 @@
 	c_tag = "Dormitories North";
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "tpx" = (
 /obj/structure/disposalpipe/segment{
@@ -70378,7 +75277,10 @@
 	c_tag = "Arrival Hallway Third Docking North";
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warning"
+	},
 /area/station/hallway/secondary/entry)
 "tpH" = (
 /obj/item/weapon/flora/random,
@@ -70427,7 +75329,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
 /area/station/engineering/singularity)
 "tqF" = (
 /obj/structure/window/thin/reinforced,
@@ -70453,7 +75357,10 @@
 /obj/machinery/ai_status_display{
 	pixel_x = 32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warning"
+	},
 /area/station/hallway/secondary/entry)
 "trd" = (
 /obj/machinery/shower/free{
@@ -70643,7 +75550,7 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "cautioncorner"
+	icon_state = "caution"
 	},
 /area/station/engineering/engine)
 "tuv" = (
@@ -70677,7 +75584,7 @@
 	},
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "browncorner"
+	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/fore)
 "tuE" = (
@@ -70748,12 +75655,16 @@
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/belt/utility,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/engineering/atmos)
 "tvu" = (
 /obj/structure/morgue,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/civilian/chapel/mass_driver)
 "tvw" = (
@@ -70904,8 +75815,7 @@
 /obj/effect/landmark/start/janitor,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/hallway/secondary/entry)
 "txp" = (
@@ -71089,7 +75999,10 @@
 	id = "aftstarboard";
 	name = "Starboard Quarter Solar Control"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 6;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/starboardsolar)
 "tzR" = (
 /obj/structure/disposalpipe/segment{
@@ -71219,7 +76132,6 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor{
-	dir = 6;
 	icon_state = "darkred"
 	},
 /area/station/security/armoury)
@@ -71253,7 +76165,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/station/civilian/gym)
 "tBy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -71326,7 +76241,9 @@
 /area/station/maintenance/cargo)
 "tCz" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/cyan,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "tCI" = (
 /obj/structure/rack,
@@ -71386,8 +76303,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
+	dir = 8;
+	icon_state = "warndark"
 	},
 /area/station/rnd/xenobiology)
 "tDn" = (
@@ -71395,7 +76312,10 @@
 	pixel_x = 16;
 	pixel_y = -16
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "tDu" = (
 /obj/structure/table,
@@ -71452,7 +76372,6 @@
 /obj/effect/landmark/start/assistant,
 /obj/structure/stool,
 /turf/simulated/floor{
-	dir = 1;
 	icon_state = "neutral"
 	},
 /area/station/civilian/dormitories)
@@ -71472,7 +76391,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
 /area/station/engineering/chiefs_office)
 "tEF" = (
 /turf/simulated/wall/r_wall,
@@ -71530,7 +76452,10 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/security/hos)
 "tEY" = (
 /obj/structure/closet/l3closet/scientist,
@@ -71540,6 +76465,11 @@
 	icon_state = "warning"
 	},
 /area/station/medical/hallway)
+"tFn" = (
+/turf/simulated/floor{
+	icon_state = "blackcorner"
+	},
+/area/station/hallway/secondary/exit)
 "tFz" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -71682,11 +76612,20 @@
 	icon_state = "boxing"
 	},
 /area/station/civilian/gym)
+"tHA" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "black"
+	},
+/area/station/civilian/chapel)
 "tHI" = (
 /obj/machinery/computer/telecomms/server{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/tcommsat/computer)
 "tHY" = (
 /obj/machinery/door/firedoor,
@@ -71767,7 +76706,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/office)
 "tJP" = (
 /obj/structure/table/reinforced,
@@ -71805,7 +76746,10 @@
 	network = list("SS13","Engineering");
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/engineering/atmos)
 "tKs" = (
 /obj/effect/decal/cleanable/dirt,
@@ -71923,8 +76867,7 @@
 	network = list("SS13","Security")
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "red"
+	icon_state = "dark"
 	},
 /area/station/security/brig)
 "tMh" = (
@@ -72009,7 +76952,9 @@
 /obj/structure/window/thin/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
 /area/station/rnd/xenobiology)
 "tMS" = (
 /obj/structure/closet/secure_closet/hydroponics,
@@ -72028,7 +76973,10 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 4;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/auxsolarport)
 "tNj" = (
 /obj/structure/table/reinforced,
@@ -72050,14 +76998,19 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock,
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
 /area/station/civilian/library)
 "tNE" = (
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = 12
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "purple"
+	},
 /area/station/rnd/xenobiology)
 "tNG" = (
 /obj/random/vending/cola,
@@ -72117,7 +77070,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "tPt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -72146,7 +77102,10 @@
 "tPT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "neutral"
+	},
 /area/station/medical/storage)
 "tPU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -72217,7 +77176,9 @@
 /obj/item/toy/figure/md{
 	pixel_y = 14
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/medical/psych)
 "tRu" = (
 /turf/simulated/floor{
@@ -72249,6 +77210,12 @@
 	icon_state = "greenblue"
 	},
 /area/station/civilian/hydroponics)
+"tRY" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellow"
+	},
+/area/station/hallway/secondary/mine_sci_shuttle)
 "tSi" = (
 /obj/structure/closet/crate/bin,
 /obj/item/toy/figure/syndie,
@@ -72283,7 +77250,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/station/civilian/gym)
 "tSH" = (
 /obj/structure/window/thin/reinforced,
@@ -72307,8 +77277,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "arrival"
+	dir = 4;
+	icon_state = "whiteblue"
 	},
 /area/station/medical/reception)
 "tTd" = (
@@ -72334,7 +77304,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/security/brig)
 "tTn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -72399,7 +77371,8 @@
 	dir = 9
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whitebluecorner"
 	},
 /area/station/medical/hallway)
 "tUl" = (
@@ -72413,6 +77386,17 @@
 	},
 /turf/simulated/floor,
 /area/station/storage/primary)
+"tUm" = (
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 28;
+	pixel_y = -5
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "tUn" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/camera{
@@ -72420,7 +77404,10 @@
 	network = list("SS13","Engineering");
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos)
 "tUo" = (
 /obj/structure/disposalpipe/segment{
@@ -72462,7 +77449,9 @@
 "tUJ" = (
 /obj/structure/table/reinforced,
 /obj/item/device/flashlight/lamp,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/chiefs_office)
 "tUL" = (
 /obj/structure/cable{
@@ -72486,7 +77475,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 9;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/auxsolarport)
 "tVc" = (
 /obj/structure/cable{
@@ -72524,10 +77516,10 @@
 /area/station/security/brig)
 "tVy" = (
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkred"
+	dir = 4;
+	icon_state = "black"
 	},
-/area/station/security/armoury)
+/area/station/hallway/secondary/entry)
 "tVF" = (
 /obj/structure/stool/bed,
 /obj/item/device/radio/intercom{
@@ -72609,7 +77601,9 @@
 /obj/structure/window/thin{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/civilian/library)
 "tWC" = (
 /obj/structure/cable{
@@ -72646,7 +77640,9 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
 /area/station/engineering/atmos)
 "tWR" = (
 /obj/effect/landmark/start/medical_doctor,
@@ -72690,7 +77686,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
 "tXy" = (
 /obj/structure/table/reinforced,
@@ -72736,12 +77732,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "warning"
+	},
 /area/station/rnd/xenobiology)
 "tYh" = (
 /obj/structure/stool,
 /turf/simulated/floor{
-	dir = 1;
 	icon_state = "neutral"
 	},
 /area/station/civilian/dormitories)
@@ -72760,7 +77757,9 @@
 	dir = 8;
 	name = "Port Mix to Engine"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "tYu" = (
 /obj/structure/cable{
@@ -72809,13 +77808,20 @@
 	},
 /area/station/security/iaa_office)
 "tYA" = (
-/obj/structure/stool/bed/chair/comfy/brown{
-	dir = 8
+/turf/simulated/floor/plating{
+	dir = 1;
+	icon_state = "warnplate"
+	},
+/area/station/hallway/secondary/entry)
+"tYI" = (
+/obj/machinery/door/airlock/external{
+	name = "Arrival Airlock"
 	},
 /turf/simulated/floor{
-	icon_state = "red"
+	dir = 5;
+	icon_state = "vault"
 	},
-/area/station/civilian/bar)
+/area/station/engineering/atmos)
 "tYK" = (
 /turf/simulated/floor{
 	icon_state = "yellowcorner"
@@ -72832,7 +77838,9 @@
 /area/station/civilian/dormitories)
 "tZe" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
 /area/station/medical/chemistry)
 "tZl" = (
 /obj/structure/table/woodentable/fancy,
@@ -72907,7 +77915,7 @@
 "uac" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "ual" = (
 /obj/machinery/power/apc{
@@ -73007,13 +78015,19 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "neutral"
+	},
 /area/station/medical/chemistry)
 "uch" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "black"
+	},
 /area/station/civilian/chapel)
 "uck" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -73042,7 +78056,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
 /area/station/engineering/chiefs_office)
 "ucP" = (
 /obj/machinery/door/airlock{
@@ -73157,7 +78173,10 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "red"
+	},
 /area/station/hallway/secondary/exit)
 "uep" = (
 /turf/simulated/floor/plating{
@@ -73196,7 +78215,10 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/security/hos)
 "ufi" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
@@ -73207,7 +78229,9 @@
 /area/station/rnd/storage)
 "ufr" = (
 /obj/machinery/light/smart,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "ufx" = (
 /turf/simulated/floor{
@@ -73226,15 +78250,17 @@
 	dir = 8
 	},
 /obj/machinery/disposal,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
 /area/station/hallway/secondary/entry)
 "ugc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "black"
+	dir = 8;
+	icon_state = "neutral"
 	},
 /area/station/storage/tech)
 "ugf" = (
@@ -73293,6 +78319,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/main)
+"uhk" = (
+/turf/simulated/floor{
+	icon_state = "whitepurplefull"
+	},
+/area/station/rnd/hallway)
 "uhm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -73326,7 +78357,9 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "blackcorner"
+	},
 /area/station/hallway/secondary/exit)
 "uhz" = (
 /obj/structure/cable{
@@ -73371,7 +78404,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "redyellowfull"
+	},
 /area/station/civilian/bar)
 "uib" = (
 /obj/structure/sign/nanotrasen,
@@ -73397,7 +78432,10 @@
 /area/station/hallway/primary/fore)
 "uiq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "black"
+	},
 /area/station/civilian/chapel)
 "uix" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -73461,7 +78499,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/engineering/atmos)
 "ujc" = (
 /obj/structure/table/reinforced,
@@ -73488,7 +78529,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whitegreencorner"
 	},
 /area/station/medical/hallway)
 "ujB" = (
@@ -73513,8 +78555,7 @@
 "ujY" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/civilian/bar)
 "ukc" = (
@@ -73530,6 +78571,12 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/tox_launch)
+"uki" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warndarkcorners"
+	},
+/area/station/engineering/atmos)
 "ukm" = (
 /turf/simulated/wall,
 /area/station/gateway)
@@ -73679,14 +78726,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "umc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway)
 "umi" = (
@@ -73709,14 +78757,19 @@
 "umn" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/box/lights/mixed,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/engineering/atmos)
 "umE" = (
 /obj/machinery/camera{
 	c_tag = "Dormitories South";
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "umH" = (
 /obj/item/device/radio/beacon/interaction_watcher,
@@ -73750,7 +78803,10 @@
 	pixel_x = 2;
 	pixel_y = 2
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/security/hos)
 "umV" = (
 /obj/machinery/shieldgen,
@@ -73765,7 +78821,10 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 6;
+	icon_state = "warnplate"
+	},
 /area/station/rnd/xenobiology)
 "unp" = (
 /obj/machinery/door/firedoor,
@@ -73823,17 +78882,18 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "blackcorner"
+	},
 /area/station/hallway/secondary/exit)
 "unD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "escape"
+	icon_state = "neutralfull"
 	},
-/area/station/civilian/kitchen)
+/area/station/security/prison)
 "unI" = (
 /obj/structure/table/woodentable,
 /obj/structure/cable{
@@ -73911,7 +78971,8 @@
 "uot" = (
 /obj/machinery/vending/assist,
 /turf/simulated/floor{
-	icon_state = "whitepurplecorner"
+	dir = 4;
+	icon_state = "yellow"
 	},
 /area/station/rnd/hallway)
 "uoF" = (
@@ -73965,7 +79026,8 @@
 "upe" = (
 /obj/structure/table,
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "whitebluecorner"
 	},
 /area/station/medical/hallway)
 "upq" = (
@@ -73976,7 +79038,10 @@
 /obj/machinery/camera{
 	c_tag = "Arrival Hallway Mid"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "upG" = (
 /obj/structure/table,
@@ -74012,10 +79077,10 @@
 /area/station/bridge/cmf_room)
 "uqt" = (
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "warning"
 	},
-/area/station/security/lobby)
+/area/station/hallway/secondary/entry)
 "uqv" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -74059,7 +79124,9 @@
 	name = "Delivery Office APC";
 	pixel_x = 28
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "browncorner"
+	},
 /area/station/cargo/storage)
 "urd" = (
 /obj/machinery/door/firedoor,
@@ -74085,20 +79152,33 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "urm" = (
 /obj/structure/stool,
 /obj/effect/landmark/start/technical_assistant,
 /turf/simulated/floor,
 /area/station/hallway/primary/port)
+"urv" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "blackcorner"
+	},
+/area/station/hallway/secondary/entry)
 "urE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
 /area/station/hallway/secondary/entry)
 "urF" = (
 /obj/structure/closet/secure_closet/recycler,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "urI" = (
 /obj/structure/cable{
@@ -74108,6 +79188,16 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/singularity)
+"urO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/station/maintenance/chapel)
 "urQ" = (
 /obj/item/weapon/flora/random,
 /obj/item/device/radio/intercom{
@@ -74116,20 +79206,24 @@
 	pixel_y = -5
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/hallway/primary/starboard)
 "urR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellow"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "usj" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Emergency Access"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "usl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -74173,7 +79267,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/qm)
 "usJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -74193,7 +79289,10 @@
 	dir = 4;
 	pixel_x = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
+	},
 /area/station/cargo/storage)
 "usP" = (
 /obj/machinery/space_heater,
@@ -74227,11 +79326,16 @@
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/storage)
 "utf" = (
 /obj/structure/filingcabinet/filingcabinet,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "brown"
+	},
 /area/station/cargo/storage)
 "utn" = (
 /obj/machinery/portable_atmospherics/canister,
@@ -74273,8 +79377,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "redcorner"
+	icon_state = "dark"
 	},
 /area/station/security/brig)
 "utL" = (
@@ -74291,7 +79394,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/security/prison)
 "uub" = (
 /obj/structure/cable{
@@ -74314,7 +79419,10 @@
 /area/station/cargo/recycler)
 "uui" = (
 /obj/machinery/atmospherics/components/unary/portables_connector,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "warning"
+	},
 /area/station/maintenance/chapel)
 "uum" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -74364,7 +79472,9 @@
 "uuG" = (
 /obj/structure/table,
 /obj/item/toy/figure/chemist,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/medical/chemistry)
 "uuH" = (
 /turf/simulated/floor{
@@ -74499,6 +79609,12 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/primary/port)
+"uwt" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellow"
+	},
+/area/station/engineering/engine)
 "uwA" = (
 /obj/structure/table,
 /obj/item/device/tagger/shop,
@@ -74506,8 +79622,19 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
 /area/station/hallway/primary/central)
+"uwB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/engine)
 "uwE" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -74520,7 +79647,10 @@
 /obj/machinery/light/smart{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "uwI" = (
 /obj/machinery/portable_atmospherics/canister,
@@ -74560,7 +79690,7 @@
 /obj/machinery/computer/cargo/request,
 /turf/simulated/floor{
 	dir = 9;
-	icon_state = "darkbrown"
+	icon_state = "brown"
 	},
 /area/station/engineering/engine)
 "uxh" = (
@@ -74635,7 +79765,10 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/tcommsat/computer)
 "uzw" = (
 /turf/simulated/floor{
@@ -74687,7 +79820,10 @@
 /obj/machinery/light/smart{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "uAM" = (
 /obj/structure/sign/directions/engineering{
@@ -74755,6 +79891,26 @@
 	icon_state = "darkbrown"
 	},
 /area/station/medical/chemistry)
+"uBz" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/atmos)
 "uBC" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -74770,7 +79926,9 @@
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
 /area/station/engineering/atmos)
 "uBG" = (
 /turf/simulated/shuttle/floor/mining{
@@ -74801,7 +79959,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/maintenance/atmos)
 "uCj" = (
 /obj/machinery/firealarm{
@@ -74829,7 +79989,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "brown"
+	},
 /area/station/cargo/storage)
 "uDb" = (
 /obj/structure/table/reinforced,
@@ -74869,7 +80031,9 @@
 /area/station/engineering/engine)
 "uDp" = (
 /obj/effect/landmark/start/atmospheric_technician,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "uDx" = (
 /obj/effect/landmark/start/assistant,
@@ -74924,7 +80088,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "uEC" = (
 /obj/machinery/door/firedoor,
@@ -74956,7 +80122,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/medical/cryo)
 "uER" = (
 /obj/structure/disposalpipe/trunk{
@@ -74980,7 +80148,8 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/medical/medbreak)
 "uFj" = (
@@ -75108,7 +80277,9 @@
 /obj/machinery/light/smart{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "redfull"
+	},
 /area/station/hallway/secondary/exit)
 "uHA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -75131,7 +80302,10 @@
 	network = list("Research","Toxins Test Area","Robots","Anomaly Isolation");
 	pixel_x = 32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "neutral"
+	},
 /area/station/rnd/hor)
 "uHX" = (
 /turf/simulated/floor/wood,
@@ -75168,9 +80342,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison)
+"uJe" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "caution"
+	},
+/area/station/engineering/atmos)
 "uJi" = (
 /turf/simulated/wall,
 /area/station/rnd/chargebay)
+"uJK" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/binary/valve,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warning"
+	},
+/area/station/maintenance/chapel)
 "uJO" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -75199,7 +80388,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitepurplefull"
 	},
 /area/station/rnd/xenobiology)
 "uJW" = (
@@ -75247,7 +80436,8 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
-	icon_state = "bar"
+	dir = 10;
+	icon_state = "bluered"
 	},
 /area/station/medical/medbreak)
 "uKi" = (
@@ -75268,6 +80458,13 @@
 /obj/structure/stool/bed/chair/office/dark,
 /turf/simulated/floor,
 /area/station/civilian/hydroponics)
+"uKt" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warningcorner"
+	},
+/area/station/maintenance/chapel)
 "uKL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -75294,7 +80491,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/security/brig)
 "uLf" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -75303,7 +80502,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/station/engineering/chiefs_office)
 "uLo" = (
 /obj/structure/cable{
@@ -75314,7 +80516,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "uLr" = (
 /obj/structure/cable{
@@ -75380,6 +80584,13 @@
 	icon_state = "red"
 	},
 /area/station/engineering/engine)
+"uLP" = (
+/obj/machinery/computer/cargo,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "uLX" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -75392,7 +80603,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/security/brig)
 "uMd" = (
 /obj/structure/closet/l3closet/scientist,
@@ -75455,7 +80668,10 @@
 "uNd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "uNl" = (
 /obj/machinery/door/firedoor,
@@ -75484,7 +80700,9 @@
 /obj/structure/closet/fireaxecabinet{
 	pixel_x = 32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/engineering/atmos)
 "uNH" = (
 /obj/structure/disposalpipe/segment,
@@ -75500,7 +80718,7 @@
 "uOc" = (
 /turf/simulated/floor{
 	dir = 9;
-	icon_state = "darkred"
+	icon_state = "warndark"
 	},
 /area/station/security/armoury)
 "uOe" = (
@@ -75603,13 +80821,18 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/maintenance/atmos)
 "uPk" = (
 /obj/machinery/firealarm{
 	pixel_y = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "uPs" = (
 /obj/structure/cable{
@@ -75637,8 +80860,8 @@
 /area/station/hallway/primary/central)
 "uPV" = (
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "arrival"
+	dir = 8;
+	icon_state = "whitebluecorner"
 	},
 /area/station/medical/reception)
 "uPZ" = (
@@ -75661,7 +80884,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor{
-	icon_state = "red"
+	icon_state = "redyellowfull"
 	},
 /area/station/civilian/bar)
 "uQo" = (
@@ -75693,7 +80916,10 @@
 "uQI" = (
 /obj/structure/table,
 /obj/machinery/light/smart,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "uQR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -75747,8 +80973,8 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "cautioncorner"
+	dir = 1;
+	icon_state = "caution"
 	},
 /area/station/engineering/engine)
 "uRF" = (
@@ -75773,7 +80999,9 @@
 "uSg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "uSD" = (
 /obj/structure/object_wall/mining{
@@ -75788,7 +81016,9 @@
 	},
 /area/station/medical/hallway)
 "uSN" = (
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "redyellowfull"
+	},
 /area/station/civilian/bar)
 "uST" = (
 /obj/structure/sign/poster/official/obey{
@@ -75806,7 +81036,10 @@
 /area/station/security/prison)
 "uSY" = (
 /obj/machinery/vending/boozeomat,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/bridge/captain_quarters)
 "uSZ" = (
 /obj/effect/landmark/start/assistant,
@@ -75864,7 +81097,8 @@
 "uTH" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/civilian/chapel/mass_driver)
 "uTY" = (
@@ -75982,7 +81216,10 @@
 /area/station/rnd/tox_launch)
 "uUW" = (
 /obj/machinery/power/port_gen/pacman/scrap,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "uVc" = (
 /obj/structure/cable{
@@ -75993,7 +81230,7 @@
 /obj/structure/table/reinforced,
 /obj/item/weapon/book/manual/wiki/security_space_law,
 /turf/simulated/floor{
-	dir = 4;
+	dir = 5;
 	icon_state = "red"
 	},
 /area/station/security/brig)
@@ -76017,6 +81254,25 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway)
+"uVF" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "whitebluecorner"
+	},
+/area/station/medical/hallway)
 "uVP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
@@ -76079,7 +81335,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellowcorner"
+	},
 /area/station/hallway/primary/central)
 "uWL" = (
 /obj/structure/cable,
@@ -76087,7 +81346,10 @@
 	name = "apc down";
 	pixel_y = -28
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 10;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/auxsolarstarboard)
 "uWZ" = (
 /obj/structure/table/reinforced,
@@ -76098,11 +81360,16 @@
 	amount = 5;
 	layer = 2.9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "purple"
+	},
 /area/station/rnd/xenobiology)
 "uXz" = (
 /obj/structure/closet/emcloset,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "uXI" = (
 /obj/structure/cable{
@@ -76138,12 +81405,15 @@
 /obj/machinery/light/smart{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
 /area/station/cargo/storage)
 "uYb" = (
 /obj/structure/stool,
 /turf/simulated/floor{
-	icon_state = "redyellowfull"
+	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
 "uYf" = (
@@ -76158,7 +81428,7 @@
 "uYh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "uYj" = (
 /obj/structure/closet/blueshield,
@@ -76246,12 +81516,15 @@
 	},
 /area/station/civilian/dormitories)
 "uYY" = (
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "warning"
+	},
 /area/station/cargo/qm)
 "uZe" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	icon_state = "blackcorner"
+	icon_state = "blackchecker"
 	},
 /area/station/hallway/primary/port)
 "uZl" = (
@@ -76272,6 +81545,12 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/kitchen)
+"uZz" = (
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "whitehall"
+	},
+/area/station/rnd/hallway)
 "uZA" = (
 /obj/machinery/portable_atmospherics/canister/hydrogen,
 /turf/simulated/floor{
@@ -76351,7 +81630,7 @@
 	pixel_y = -2
 	},
 /turf/simulated/floor{
-	icon_state = "purplechecker"
+	icon_state = "white"
 	},
 /area/station/rnd/hor)
 "vaT" = (
@@ -76364,7 +81643,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
 "vbc" = (
 /obj/machinery/door/airlock{
@@ -76413,6 +81692,12 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge)
+"vbS" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/tox_launch)
 "vbZ" = (
 /obj/machinery/computer/atmos_alert,
 /turf/simulated/floor{
@@ -76423,7 +81708,10 @@
 "vch" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/box/lights/mixed,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "yellow"
+	},
 /area/station/engineering/engine)
 "vct" = (
 /obj/structure/cable{
@@ -76443,7 +81731,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
 /area/station/engineering/singularity)
 "vcL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -76543,7 +81833,7 @@
 	},
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor{
-	icon_state = "bot"
+	icon_state = "neutralfull"
 	},
 /area/station/bridge/teleporter)
 "vev" = (
@@ -76713,10 +82003,28 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "red"
+	icon_state = "redyellowfull"
 	},
 /area/station/civilian/bar)
+"vhK" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
+/area/station/maintenance/engineering)
 "vhL" = (
 /obj/structure/object_wall/mining{
 	icon_state = "5-3"
@@ -76735,7 +82043,10 @@
 /obj/machinery/light/smart{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "vhU" = (
 /obj/effect/decal/cleanable/dirt,
@@ -76797,7 +82108,10 @@
 /obj/machinery/light/smart{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/tcommsat/computer)
 "viI" = (
 /obj/machinery/firealarm{
@@ -76869,7 +82183,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/primary/fore)
 "vje" = (
 /obj/structure/cable{
@@ -76880,7 +82197,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/storage)
 "vjq" = (
 /obj/machinery/door/firedoor,
@@ -76921,15 +82240,24 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	icon_state = "redyellowfull"
+	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
 "vjZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/civilian/gym)
+"vke" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
+/area/station/cargo/storage)
 "vkh" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -76980,7 +82308,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "browncorner"
+	},
 /area/station/cargo/miningoffice)
 "vlv" = (
 /obj/machinery/firealarm{
@@ -77020,7 +82351,10 @@
 "vlH" = (
 /obj/structure/table,
 /obj/item/toy/carpplushie,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "neutral"
+	},
 /area/station/civilian/gym)
 "vlJ" = (
 /turf/simulated/floor{
@@ -77046,7 +82380,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "warning"
+	},
 /area/station/rnd/xenobiology)
 "vmq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -77145,7 +82482,7 @@
 /obj/structure/closet/crate,
 /obj/item/weapon/storage/box/drinkingglasses,
 /turf/simulated/floor{
-	icon_state = "redyellowfull"
+	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
 "vof" = (
@@ -77174,10 +82511,14 @@
 /obj/item/device/tagger/shop,
 /obj/item/weapon/packageWrap,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/hallway/primary/fore)
+"vow" = (
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
+/area/station/maintenance/engineering)
 "voI" = (
 /obj/machinery/disposal,
 /turf/simulated/floor{
@@ -77226,7 +82567,10 @@
 /obj/structure/window/thin{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "escape"
+	},
 /area/station/engineering/atmos)
 "voY" = (
 /obj/machinery/light/small{
@@ -77259,7 +82603,10 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
 /area/station/hallway/secondary/entry)
 "vpT" = (
 /turf/simulated/floor{
@@ -77271,7 +82618,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
 /area/station/rnd/hor)
 "vqz" = (
 /obj/machinery/door/airlock/research{
@@ -77286,7 +82636,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "whitepurplefull"
+	},
 /area/station/medical/genetics)
 "vqB" = (
 /obj/structure/cable{
@@ -77355,7 +82707,8 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/medical/medbreak)
 "vrC" = (
@@ -77384,7 +82737,9 @@
 /area/station/maintenance/science)
 "vsl" = (
 /obj/item/target/alien,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/rnd/hallway)
 "vsr" = (
 /obj/structure/cable{
@@ -77488,7 +82843,10 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "brown"
+	},
 /area/station/cargo/storage)
 "vtN" = (
 /obj/effect/decal/cleanable/dirt,
@@ -77679,10 +83037,19 @@
 	icon_state = "gcircuit"
 	},
 /area/station/aisat/ai_chamber)
+"vwv" = (
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "warning"
+	},
+/area/station/engineering/atmos)
 "vwz" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/clipboard,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "blue"
+	},
 /area/station/civilian/dormitories)
 "vwJ" = (
 /obj/structure/cable{
@@ -77690,7 +83057,10 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "vwM" = (
 /obj/machinery/light/smart,
@@ -77803,7 +83173,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
 /area/station/engineering/singularity)
 "vzc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -78021,8 +83393,8 @@
 /area/station/bridge)
 "vBe" = (
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "whitehall"
+	dir = 8;
+	icon_state = "warnwhite"
 	},
 /area/station/rnd/storage)
 "vBg" = (
@@ -78059,7 +83431,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/engine)
 "vBV" = (
 /obj/structure/table/woodentable,
@@ -78153,7 +83527,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitepurplefull"
 	},
 /area/station/rnd/lab)
 "vDf" = (
@@ -78210,13 +83584,18 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/engineering/atmos)
 "vEp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/miningoffice)
 "vEq" = (
 /obj/structure/table,
@@ -78254,7 +83633,9 @@
 /area/station/engineering/atmos)
 "vEB" = (
 /obj/structure/table/reinforced,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos)
 "vEF" = (
 /obj/machinery/door/airlock{
@@ -78298,7 +83679,8 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/medical/morgue)
 "vES" = (
@@ -78313,8 +83695,7 @@
 	name = "formal wardrobe"
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/civilian/bar)
 "vEZ" = (
@@ -78345,12 +83726,34 @@
 	icon_state = "dark"
 	},
 /area/station/bridge/ai_upload)
+"vFo" = (
+/obj/structure/table,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "blue"
+	},
+/area/station/maintenance/chapel)
+"vFy" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	icon_state = "red"
+	},
+/area/station/hallway/secondary/exit)
 "vFz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/station/civilian/gym)
 "vFF" = (
 /obj/machinery/camera{
@@ -78429,7 +83832,10 @@
 /area/station/rnd/xenobiology)
 "vGp" = (
 /obj/structure/closet/toolcloset,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "orange"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "vGv" = (
 /obj/machinery/camera{
@@ -78453,8 +83859,17 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
 /area/station/engineering/engine)
+"vHf" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warndark"
+	},
+/area/station/rnd/xenobiology)
 "vHR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/window/northright,
@@ -78506,7 +83921,10 @@
 /area/station/maintenance/cargo)
 "vIz" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "vID" = (
 /turf/simulated/floor{
@@ -78610,7 +84028,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "red"
+	},
 /area/station/hallway/secondary/exit)
 "vKc" = (
 /obj/machinery/hologram/holopad,
@@ -78733,7 +84154,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "vLC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -78764,7 +84185,7 @@
 	},
 /turf/simulated/floor{
 	dir = 1;
-	icon_state = "bluecorner"
+	icon_state = "greencorner"
 	},
 /area/station/hallway/primary/fore)
 "vMc" = (
@@ -78774,7 +84195,7 @@
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "darkblue"
+	icon_state = "blue"
 	},
 /area/station/hallway/primary/starboard)
 "vMf" = (
@@ -78920,8 +84341,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
+"vOB" = (
+/turf/simulated/floor{
+	icon_state = "warning"
+	},
+/area/station/engineering/atmos)
 "vOQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -78971,6 +84400,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -78982,14 +84412,16 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitepurplefull"
 	},
 /area/station/rnd/hallway)
 "vPd" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "vPk" = (
 /turf/simulated/wall/r_wall,
@@ -79017,6 +84449,17 @@
 	icon_state = "bluecorner"
 	},
 /area/station/civilian/hydroponics)
+"vPR" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/station/engineering/atmos)
 "vPV" = (
 /obj/structure/closet/radiation,
 /obj/item/device/radio/intercom{
@@ -79049,8 +84492,7 @@
 	},
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "red"
+	icon_state = "redyellowfull"
 	},
 /area/station/civilian/bar)
 "vQC" = (
@@ -79179,7 +84621,9 @@
 	pixel_x = 3;
 	pixel_y = -7
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch_inv"
+	},
 /area/station/hallway/primary/central)
 "vSz" = (
 /obj/structure/cable{
@@ -79280,7 +84724,10 @@
 /obj/machinery/requests_console/rd{
 	pixel_x = -32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "neutral"
+	},
 /area/station/rnd/hor)
 "vTS" = (
 /obj/structure/cable{
@@ -79299,14 +84746,24 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/bridge/teleporter)
 "vTX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "red"
+	},
 /area/station/security/brig)
+"vUe" = (
+/turf/simulated/floor{
+	icon_state = "warning"
+	},
+/area/station/hallway/secondary/entry)
 "vUh" = (
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -79421,7 +84878,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "vWv" = (
 /obj/structure/closet/crate/hydroponics,
@@ -79437,6 +84896,12 @@
 	icon_state = "greenblue"
 	},
 /area/station/civilian/hydroponics)
+"vWF" = (
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warndarkcorners"
+	},
+/area/station/engineering/atmos)
 "vWI" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor{
@@ -79518,7 +84983,10 @@
 "vXq" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/folder/blue,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "blue"
+	},
 /area/station/civilian/dormitories)
 "vXB" = (
 /obj/machinery/door/airlock/maintenance_hatch{
@@ -79533,6 +85001,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
+"vXE" = (
+/turf/simulated/floor{
+	icon_state = "bluecorner"
+	},
+/area/station/hallway/secondary/entry)
 "vXG" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 29
@@ -79629,7 +85102,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "vYs" = (
 /obj/machinery/portable_atmospherics/canister,
@@ -79643,13 +85119,18 @@
 /obj/structure/window/thin{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "blue"
+	},
 /area/station/medical/hallway)
 "vYv" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/packageWrap,
 /obj/item/device/tagger/shop,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "warning"
+	},
 /area/station/engineering/engine)
 "vYy" = (
 /obj/structure/lattice,
@@ -79715,7 +85196,8 @@
 	dir = 10
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/civilian/chapel/mass_driver)
 "vZv" = (
@@ -79743,8 +85225,8 @@
 /area/station/civilian/hydroponics)
 "vZA" = (
 /turf/simulated/floor{
-	dir = 6;
-	icon_state = "arrival"
+	dir = 1;
+	icon_state = "whitebluecorner"
 	},
 /area/station/medical/reception)
 "vZD" = (
@@ -79894,7 +85376,7 @@
 	req_access = list(5)
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitebluefull"
 	},
 /area/station/medical/reception)
 "wcD" = (
@@ -79905,7 +85387,8 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/medical/surgeryobs)
 "wcJ" = (
@@ -79993,7 +85476,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "wdr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -80004,7 +85487,9 @@
 "wdt" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/clipboard,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/storage)
 "wdw" = (
 /obj/structure/sign/directions/engineering{
@@ -80036,7 +85521,10 @@
 /obj/structure/stool/bed/chair/metal{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/hallway/secondary/exit)
 "wdN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -80078,7 +85566,10 @@
 "wek" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/components/unary/portables_connector,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "warning"
+	},
 /area/station/maintenance/chapel)
 "weB" = (
 /obj/machinery/computer/crew{
@@ -80103,7 +85594,7 @@
 /obj/item/weapon/reagent_containers/dropper/precision,
 /obj/item/weapon/razor,
 /turf/simulated/floor{
-	icon_state = "escape"
+	icon_state = "redchecker"
 	},
 /area/station/hallway/primary/port)
 "wfw" = (
@@ -80247,7 +85738,10 @@
 /obj/machinery/ai_status_display{
 	pixel_y = 32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "wil" = (
 /obj/item/weapon/flora/random,
@@ -80321,7 +85815,8 @@
 	dir = 6
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "whitehall"
 	},
 /area/station/rnd/hallway)
 "wja" = (
@@ -80351,13 +85846,22 @@
 	icon_state = "bluecorner"
 	},
 /area/station/hallway/primary/starboard)
+"wjf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "wjj" = (
 /obj/machinery/camera{
 	c_tag = "Chapel Office";
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/civilian/chapel/office)
 "wjl" = (
@@ -80428,7 +85932,9 @@
 	},
 /area/station/engineering/monitoring)
 "wjK" = (
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/starboardsolar)
 "wjL" = (
 /obj/structure/table,
@@ -80461,7 +85967,9 @@
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "wkd" = (
 /obj/machinery/firealarm{
@@ -80499,13 +86007,17 @@
 	dir = 5
 	},
 /turf/simulated/floor{
-	icon_state = "bot"
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/station/civilian/dormitories)
 "wlk" = (
 /obj/structure/table/woodentable,
 /obj/item/device/flashlight/lamp,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "red"
+	},
 /area/station/security/hos)
 "wln" = (
 /obj/structure/table,
@@ -80513,7 +86025,10 @@
 	charge = 100;
 	maxcharge = 15000
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "dark"
+	},
 /area/station/cargo/recycleroffice)
 "wlq" = (
 /obj/structure/table/glass,
@@ -80550,7 +86065,9 @@
 "wlz" = (
 /obj/structure/table,
 /obj/item/toy/katana,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
 /area/station/civilian/gym)
 "wlQ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -80582,7 +86099,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "purplechecker"
+	dir = 1;
+	icon_state = "whitepurple"
 	},
 /area/station/rnd/hor)
 "wmd" = (
@@ -80628,7 +86146,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
 /area/station/civilian/gym)
 "wmC" = (
 /obj/structure/sink{
@@ -80672,7 +86193,7 @@
 "wmV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
-	icon_state = "vault"
+	icon_state = "dark"
 	},
 /area/station/rnd/hor)
 "wmZ" = (
@@ -80693,8 +86214,17 @@
 "wnb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/binary/valve,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
 /area/station/maintenance/chapel)
+"wnj" = (
+/obj/machinery/light/smart,
+/turf/simulated/floor{
+	icon_state = "warning"
+	},
+/area/station/engineering/engine)
 "wno" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -80800,7 +86330,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/office)
 "wpm" = (
 /obj/machinery/door/firedoor,
@@ -80820,7 +86352,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/secondary/exit)
 "wpM" = (
 /obj/structure/table/woodentable,
@@ -80842,7 +86376,9 @@
 	c_tag = "Librarian Workspace";
 	dir = 6
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/civilian/library)
 "wqs" = (
 /obj/structure/stool/bed/chair/metal/red{
@@ -80872,16 +86408,19 @@
 	},
 /area/station/rnd/robotics)
 "wrg" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "blue"
 	},
-/turf/simulated/floor,
-/area/station/civilian/kitchen)
+/area/station/civilian/dormitories)
 "wri" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "wrq" = (
 /obj/structure/table/glass,
@@ -80926,7 +86465,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/cargo/miningoffice)
 "wse" = (
 /obj/structure/cable{
@@ -80966,15 +86505,16 @@
 	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor{
-	dir = 9;
-	icon_state = "arrival"
+	icon_state = "whitebluecorner"
 	},
 /area/station/medical/reception)
 "wsv" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 10
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/singularity)
 "wsw" = (
 /obj/structure/table/reinforced,
@@ -80994,7 +86534,9 @@
 /area/station/security/warden)
 "wsS" = (
 /obj/structure/table/reinforced,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/chiefs_office)
 "wtb" = (
 /turf/simulated/floor{
@@ -81014,6 +86556,11 @@
 	icon_state = "vault"
 	},
 /area/station/bridge)
+"wtr" = (
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "wtC" = (
 /turf/simulated/wall,
 /area/station/maintenance/engineering)
@@ -81058,7 +86605,10 @@
 	pixel_x = 28;
 	pixel_y = -5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/station/civilian/gym)
 "wug" = (
 /obj/machinery/shieldgen,
@@ -81163,7 +86713,8 @@
 	pixel_x = -3
 	},
 /turf/simulated/floor{
-	icon_state = "purplechecker"
+	dir = 8;
+	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/hor)
 "www" = (
@@ -81171,7 +86722,9 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "wwR" = (
 /obj/structure/disposalpipe/segment,
@@ -81233,7 +86786,7 @@
 	},
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "browncorner"
+	icon_state = "bluecorner"
 	},
 /area/station/security/lobby)
 "wxH" = (
@@ -81366,6 +86919,15 @@
 	icon_state = "red"
 	},
 /area/station/security/prison)
+"wzu" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Central Access"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "wzI" = (
 /obj/item/weapon/flora/random,
 /obj/structure/disposalpipe/segment{
@@ -81377,6 +86939,17 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/lab)
+"wzP" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/engineering/chiefs_office)
 "wzZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -81396,8 +86969,7 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "escape"
+	icon_state = "redchecker"
 	},
 /area/station/civilian/kitchen)
 "wAn" = (
@@ -81455,7 +87027,10 @@
 /obj/structure/stool/bed/chair{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warning"
+	},
 /area/station/hallway/secondary/entry)
 "wAH" = (
 /obj/machinery/firealarm{
@@ -81487,7 +87062,10 @@
 	c_tag = "Recreation Room";
 	dir = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/station/civilian/gym)
 "wAP" = (
 /obj/structure/stool,
@@ -81502,7 +87080,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/security/prison)
 "wAR" = (
 /obj/item/weapon/flora/random,
@@ -81518,7 +87098,10 @@
 	c_tag = "Arrival Hallway Mid";
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "wBa" = (
 /obj/machinery/door/firedoor,
@@ -81544,8 +87127,8 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
-	dir = 10;
-	icon_state = "neutral"
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
 /area/station/civilian/dormitories)
 "wBi" = (
@@ -81557,7 +87140,10 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 4;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/auxsolarstarboard)
 "wBm" = (
 /obj/item/weapon/flora/random,
@@ -81580,7 +87166,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "red"
+	},
 /area/station/hallway/secondary/exit)
 "wBF" = (
 /obj/machinery/mech_bay_recharge_port{
@@ -81615,7 +87204,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "wBR" = (
 /turf/simulated/wall/r_wall,
@@ -81688,8 +87277,7 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
+	icon_state = "dark"
 	},
 /area/station/rnd/xenobiology)
 "wCC" = (
@@ -81791,12 +87379,21 @@
 "wDO" = (
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/mine_sci_shuttle)
+"wDR" = (
+/obj/effect/landmark/start/station_engineer,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/engine)
 "wDZ" = (
 /turf/simulated/wall,
 /area/station/medical/chemistry)
 "wEc" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "wEp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -81840,6 +87437,17 @@
 	icon_state = "vault"
 	},
 /area/station/tcommsat/chamber)
+"wFj" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "wFq" = (
 /obj/structure/rack,
 /turf/simulated/floor{
@@ -81916,7 +87524,9 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/miningoffice)
 "wGe" = (
 /obj/machinery/door/firedoor,
@@ -81946,9 +87556,7 @@
 /area/station/hallway/primary/central)
 "wGs" = (
 /obj/structure/closet/wardrobe/white,
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/floor,
 /area/station/civilian/chapel/mass_driver)
 "wGW" = (
 /obj/structure/cable{
@@ -81981,6 +87589,14 @@
 	icon_state = "warning"
 	},
 /area/station/civilian/cold_room)
+"wHm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warning"
+	},
+/area/station/hallway/secondary/entry)
 "wHp" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -82012,7 +87628,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	icon_state = "warningcorner"
+	icon_state = "neutralfull"
 	},
 /area/station/engineering/engine)
 "wHy" = (
@@ -82037,13 +87653,14 @@
 "wHE" = (
 /obj/structure/stool/bed/roller,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/security/main)
 "wHR" = (
 /obj/machinery/vending/sustenance,
 /turf/simulated/floor{
-	icon_state = "redyellowfull"
+	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
 "wIf" = (
@@ -82094,7 +87711,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/hallway/primary/starboard)
 "wIW" = (
@@ -82333,7 +87951,10 @@
 	name = "Station Intercom (General)";
 	pixel_y = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "yellow"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "wMl" = (
 /obj/effect/landmark/start/geneticist,
@@ -82386,7 +88007,9 @@
 	pixel_x = 3;
 	pixel_y = 12
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
 /area/station/civilian/gym)
 "wNl" = (
 /obj/item/weapon/flora/random,
@@ -82396,6 +88019,11 @@
 /obj/structure/easel,
 /turf/simulated/floor,
 /area/station/security/prison)
+"wNt" = (
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/atmos)
 "wNM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/light/small{
@@ -82423,7 +88051,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "wOp" = (
 /obj/item/weapon/flora/random,
@@ -82447,7 +88075,9 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "whitepurplefull"
+	},
 /area/station/rnd/hallway)
 "wOT" = (
 /obj/structure/table/reinforced,
@@ -82484,7 +88114,9 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/office)
 "wPt" = (
 /turf/simulated/floor{
@@ -82627,8 +88259,7 @@
 "wRM" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "escape"
+	icon_state = "redchecker"
 	},
 /area/station/hallway/primary/port)
 "wRP" = (
@@ -82647,7 +88278,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/bridge/teleporter)
 "wRX" = (
 /obj/structure/table,
@@ -82742,6 +88375,15 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/brig)
+"wTU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/cargo/storage)
 "wTX" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/item/device/radio/intercom{
@@ -82801,7 +88443,8 @@
 /obj/item/ammo_box/magazine/plasma,
 /obj/item/ammo_box/magazine/plasma,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "warndark"
 	},
 /area/station/security/armoury)
 "wUH" = (
@@ -82845,7 +88488,9 @@
 	network = list("SS13","Engineering");
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "wVg" = (
 /obj/structure/stool,
@@ -82853,7 +88498,7 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "redyellowfull"
+	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
 "wVh" = (
@@ -82935,7 +88580,7 @@
 "wWa" = (
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "browncorner"
+	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/fore)
 "wWj" = (
@@ -82955,8 +88600,7 @@
 /obj/structure/table/woodentable,
 /obj/item/weapon/wrench,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/maintenance/chapel)
 "wWD" = (
@@ -83036,11 +88680,16 @@
 /area/station/rnd/hallway)
 "wYB" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "orange"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "wYD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/office)
 "wYF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -83208,7 +88857,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/gateway)
 "xai" = (
 /obj/structure/closet/secure_closet/medical3,
@@ -83223,13 +88874,12 @@
 	},
 /area/station/medical/storage)
 "xao" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutral"
+	dir = 4;
+	icon_state = "blackcorner"
 	},
-/area/station/maintenance/atmos)
+/area/station/hallway/secondary/entry)
 "xas" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /turf/simulated/floor{
@@ -83292,14 +88942,25 @@
 	dir = 5
 	},
 /obj/machinery/door/airlock/alarmlock,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/civilian/gym)
+"xbm" = (
+/turf/simulated/floor{
+	icon_state = "yellowfull"
+	},
+/area/station/engineering/engine)
 "xby" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/firealarm{
 	pixel_y = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
 /area/station/civilian/chapel/mass_driver)
 "xbG" = (
 /obj/machinery/door/firedoor,
@@ -83320,7 +88981,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor{
-	dir = 4;
+	dir = 6;
 	icon_state = "red"
 	},
 /area/station/security/brig)
@@ -83348,13 +89009,16 @@
 	dir = 4;
 	pixel_x = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
 /area/station/hallway/primary/central)
 "xcD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/barricade/wooden,
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "xcH" = (
 /obj/machinery/iv_drip,
@@ -83454,7 +89118,9 @@
 	name = "Station Intercom (Medbay)";
 	pixel_y = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/medical/chemistry)
 "xdV" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -83514,7 +89180,10 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 9;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/auxsolarstarboard)
 "xeB" = (
 /obj/machinery/door/firedoor,
@@ -83585,7 +89254,10 @@
 /obj/machinery/computer/cargo/request{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "browncorner"
+	},
 /area/station/cargo/office)
 "xfI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -83601,7 +89273,7 @@
 "xfJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "warndark"
 	},
 /area/station/rnd/tox_launch)
 "xfO" = (
@@ -83637,6 +89309,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"xfY" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "bluecorner"
+	},
+/area/station/engineering/engine)
 "xgd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -83662,7 +89341,10 @@
 	pixel_x = 28;
 	pixel_y = -5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos)
 "xgC" = (
 /mob/living/simple_animal/mouse,
@@ -83700,7 +89382,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/secondary/exit)
 "xgY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -83754,13 +89438,18 @@
 	name = "Kitchen";
 	sortType = "Kitchen"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/primary/fore)
 "xhQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/medical/cryo)
 "xhV" = (
 /obj/machinery/light/small{
@@ -83792,7 +89481,9 @@
 	},
 /area/station/rnd/mixing)
 "xiM" = (
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/office)
 "xiS" = (
 /obj/structure/rack,
@@ -83806,7 +89497,8 @@
 	},
 /obj/structure/window/thin,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 10;
+	icon_state = "warndark"
 	},
 /area/station/security/armoury)
 "xiZ" = (
@@ -83882,6 +89574,13 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge/hop_office)
+"xjX" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/station/engineering/atmos)
 "xkd" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -83894,7 +89593,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/storage)
 "xkn" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -83916,6 +89617,12 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"xlc" = (
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "black"
+	},
+/area/station/hallway/secondary/exit)
 "xlj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -83951,7 +89658,10 @@
 /obj/machinery/requests_console/hos{
 	pixel_y = 32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/security/hos)
 "xlX" = (
 /obj/structure/lattice,
@@ -84003,7 +89713,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "xmU" = (
 /obj/structure/stool,
@@ -84012,6 +89724,18 @@
 	icon_state = "vault"
 	},
 /area/station/security/forensic_office)
+"xmW" = (
+/obj/structure/stool/bed/chair,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "red"
+	},
+/area/station/hallway/secondary/exit)
 "xmZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -84067,6 +89791,18 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/medbay)
+"xnt" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "greencorner"
+	},
+/area/station/hallway/primary/fore)
+"xnu" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/engineering/atmos)
 "xnv" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -84114,7 +89850,7 @@
 "xob" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/cargo/office)
 "xoc" = (
 /obj/structure/disposalpipe/segment{
@@ -84122,10 +89858,20 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/hallway/secondary/entry)
+"xoe" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellow"
+	},
+/area/station/engineering/engine)
 "xom" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
 /turf/simulated/floor{
@@ -84180,7 +89926,9 @@
 /obj/structure/window/thin/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "brown"
+	},
 /area/station/cargo/storage)
 "xoX" = (
 /obj/structure/disposalpipe/segment{
@@ -84229,8 +89977,19 @@
 	id = "forestarboard";
 	name = "Starboard Bow Solar Control"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 6;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/auxsolarstarboard)
+"xpQ" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "whitehall"
+	},
+/area/station/rnd/hallway)
 "xpT" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/fancy/candle_box/red,
@@ -84251,7 +90010,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitebluefull"
 	},
 /area/station/bridge/cmf_room)
 "xqi" = (
@@ -84323,7 +90082,9 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "xqX" = (
 /obj/structure/stool/bed/chair/janitorialcart,
@@ -84336,8 +90097,7 @@
 	pixel_y = -5
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/hallway/secondary/entry)
 "xqY" = (
@@ -84357,6 +90117,19 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/science)
+"xrx" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
+/area/station/maintenance/engineering)
 "xry" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -84379,7 +90152,9 @@
 	name = "Station Intercom (General)";
 	pixel_y = -32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "xrB" = (
 /obj/machinery/door/firedoor,
@@ -84462,7 +90237,8 @@
 /area/station/maintenance/cargo)
 "xss" = (
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 8;
+	icon_state = "vault"
 	},
 /area/station/security/forensic_office)
 "xsw" = (
@@ -84483,7 +90259,7 @@
 	},
 /turf/simulated/floor{
 	dir = 5;
-	icon_state = "red"
+	icon_state = "whitered"
 	},
 /area/station/security/main)
 "xsJ" = (
@@ -84565,10 +90341,15 @@
 	name = "Cargo Bay APC";
 	pixel_x = -28
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "browncorner"
+	},
 /area/station/cargo/storage)
 "xtY" = (
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/portsolar)
 "xut" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -84609,7 +90390,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/storage)
 "xuT" = (
 /turf/simulated/floor/wood,
@@ -84620,7 +90403,10 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	dir = 5;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/portsolar)
 "xuY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -84653,6 +90439,13 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/rnd/scibreak)
+"xvu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "blackcorner"
+	},
+/area/station/civilian/gym)
 "xvB" = (
 /obj/machinery/status_display{
 	pixel_x = -32
@@ -84660,7 +90453,10 @@
 /obj/machinery/light/smart{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
 /area/station/hallway/secondary/entry)
 "xvF" = (
 /obj/structure/table/woodentable,
@@ -84746,7 +90542,9 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/security/brig)
 "xxd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -84793,7 +90591,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	icon_state = "whiteyellowcorner"
+	icon_state = "yellowpatch_inv"
 	},
 /area/station/medical/chemistry)
 "xxm" = (
@@ -84810,6 +90608,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
+"xxv" = (
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "xxE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -84835,7 +90639,10 @@
 	name = "EXTERNAL AIRLOCK";
 	pixel_x = -32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "bluecorner"
+	},
 /area/station/engineering/engine)
 "xyb" = (
 /obj/structure/cable{
@@ -84861,7 +90668,8 @@
 /area/station/rnd/hallway)
 "xyt" = (
 /turf/simulated/floor{
-	icon_state = "whiteyellowcorner"
+	dir = 8;
+	icon_state = "yellowcorner"
 	},
 /area/station/medical/chemistry)
 "xyx" = (
@@ -84984,7 +90792,10 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
 /area/station/civilian/chapel)
 "xzP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -85089,6 +90900,16 @@
 	icon_state = "white"
 	},
 /area/station/medical/chemistry)
+"xAT" = (
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = 22
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/station/cargo/storage)
 "xAU" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/box/ids,
@@ -85176,7 +90997,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	dir = 15;
+	dir = 5;
 	icon_state = "vault"
 	},
 /area/station/civilian/chapel)
@@ -85228,7 +91049,9 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/monitoring)
 "xCc" = (
 /obj/structure/disposaloutlet,
@@ -85243,7 +91066,7 @@
 	pixel_x = 12
 	},
 /turf/simulated/floor{
-	icon_state = "redyellowfull"
+	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
 "xCJ" = (
@@ -85254,12 +91077,14 @@
 /obj/structure/stool/bed/chair{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "redchecker"
+	},
 /area/station/civilian/kitchen)
 "xCO" = (
 /turf/simulated/floor{
 	dir = 5;
-	icon_state = "darkred"
+	icon_state = "warndark"
 	},
 /area/station/security/armoury)
 "xCW" = (
@@ -85269,7 +91094,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "xCZ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -85297,7 +91125,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/singularity)
 "xDD" = (
 /obj/machinery/atmospherics/components/binary/pump,
@@ -85435,8 +91265,8 @@
 /area/station/medical/genetics)
 "xFi" = (
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "darkbluecorners"
+	dir = 8;
+	icon_state = "barber"
 	},
 /area/station/medical/surgeryobs)
 "xFn" = (
@@ -85452,7 +91282,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/secondary/exit)
 "xFB" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
@@ -85561,7 +91393,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
 /area/station/engineering/atmos)
 "xHN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -85592,6 +91426,12 @@
 	icon_state = "delivery"
 	},
 /area/station/engineering/singularity)
+"xIq" = (
+/turf/simulated/floor/plating{
+	dir = 1;
+	icon_state = "warnplate"
+	},
+/area/station/maintenance/chapel)
 "xIs" = (
 /obj/structure/dispenser,
 /obj/machinery/light/small,
@@ -85634,7 +91474,10 @@
 /obj/machinery/light/smart{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "orange"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "xJb" = (
 /turf/simulated/floor,
@@ -85649,9 +91492,14 @@
 	},
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "blackcorner"
+	icon_state = "greenblue"
 	},
 /area/station/hallway/primary/fore)
+"xJv" = (
+/turf/simulated/floor/plating{
+	icon_state = "warnplate"
+	},
+/area/station/maintenance/chapel)
 "xJC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -85662,7 +91510,9 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/storage)
 "xJS" = (
 /turf/simulated/floor{
@@ -85685,7 +91535,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
 /area/station/engineering/atmos)
 "xKc" = (
 /obj/structure/cable{
@@ -85710,7 +91562,10 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
 /area/station/civilian/dormitories)
 "xKk" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
@@ -85736,7 +91591,7 @@
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "xKJ" = (
 /obj/structure/stool/bed/roller,
@@ -85779,7 +91634,10 @@
 /obj/machinery/light/smart{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
 /area/station/civilian/chapel)
 "xLs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -85794,7 +91652,8 @@
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/medical/medbreak)
 "xLE" = (
@@ -85889,11 +91748,15 @@
 /area/station/rnd/lab)
 "xMz" = (
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/storage/primary)
 "xMC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/civilian/dormitories)
 "xMD" = (
 /obj/item/stack/sheet/cardboard,
@@ -85936,7 +91799,10 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
 "xNJ" = (
 /obj/machinery/shower/free{
@@ -85952,7 +91818,9 @@
 "xNK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/gateway)
 "xNR" = (
 /obj/machinery/door/firedoor,
@@ -86015,7 +91883,7 @@
 	},
 /turf/simulated/floor{
 	dir = 1;
-	icon_state = "cautioncorner"
+	icon_state = "caution"
 	},
 /area/station/engineering/engine)
 "xOr" = (
@@ -86033,7 +91901,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "xPl" = (
 /obj/structure/cable{
@@ -86105,16 +91975,13 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor{
-	icon_state = "white"
-	},
+/turf/simulated/floor,
 /area/station/rnd/hallway)
 "xPY" = (
 /obj/structure/closet,
 /obj/item/clothing/under/sundress,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/hallway/primary/fore)
 "xPZ" = (
@@ -86146,7 +92013,10 @@
 /obj/structure/stool/bed/chair/metal/white{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
 /area/station/civilian/gym)
 "xQx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -86169,7 +92039,9 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
 /area/station/engineering/atmos)
 "xQz" = (
 /obj/machinery/door/firedoor,
@@ -86199,7 +92071,10 @@
 	pixel_x = 29;
 	pixel_y = -6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
+	},
 /area/station/cargo/qm)
 "xRq" = (
 /obj/machinery/washing_machine,
@@ -86289,7 +92164,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "blackchecker"
+	},
 /area/station/hallway/secondary/entry)
 "xSd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -86317,7 +92194,9 @@
 	name = "Library Museum";
 	req_access = list(37)
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/civilian/library)
 "xSS" = (
 /obj/structure/cable{
@@ -86431,7 +92310,7 @@
 /area/station/cargo/office)
 "xUE" = (
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "warndark"
 	},
 /area/station/rnd/storage)
 "xUM" = (
@@ -86801,6 +92680,18 @@
 	icon_state = "gcircuit"
 	},
 /area/station/rnd/chargebay)
+"xYB" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "xYD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -86824,7 +92715,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor{
-	dir = 5;
+	dir = 8;
 	icon_state = "vault"
 	},
 /area/station/engineering/atmos)
@@ -86852,7 +92743,10 @@
 	c_tag = "Miscellaneous Research";
 	dir = 9
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
 /area/station/rnd/xenobiology)
 "xZm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -86861,6 +92755,23 @@
 	icon_state = "cafeteria"
 	},
 /area/station/maintenance/science)
+"xZn" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "whitebluecorner"
+	},
+/area/station/medical/hallway)
 "xZC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -86883,7 +92794,10 @@
 	name = "Fitness Room APC";
 	pixel_x = -28
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/station/civilian/gym)
 "yam" = (
 /obj/structure/closet/secure_closet/personal/patient,
@@ -86906,7 +92820,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/miningoffice)
 "yaE" = (
 /obj/machinery/door/firedoor,
@@ -86931,7 +92847,8 @@
 "yaY" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "vault"
 	},
 /area/station/civilian/chapel/mass_driver)
 "yaZ" = (
@@ -86996,7 +92913,7 @@
 	name = "KitchenShutters";
 	opacity = 0
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
 "ybL" = (
 /obj/effect/landmark/start/head_of_security,
@@ -87018,7 +92935,8 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	icon_state = "redcorner"
+	dir = 2;
+	icon_state = "bluecorner"
 	},
 /area/station/security/lobby)
 "ybX" = (
@@ -87029,7 +92947,9 @@
 /area/shuttle/escape_pod2/station)
 "ybY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
 /area/station/civilian/library)
 "ycb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -87087,7 +93007,9 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "ycy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -87144,6 +93066,14 @@
 	icon_state = "red"
 	},
 /area/station/cargo/office)
+"ydm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "yellowfull"
+	},
+/area/station/engineering/engine)
 "yds" = (
 /obj/structure/stool/bed,
 /obj/machinery/alarm{
@@ -87169,7 +93099,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 10
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
 /area/station/engineering/singularity)
 "ydI" = (
 /obj/machinery/door/firedoor,
@@ -87207,7 +93139,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
 /area/station/civilian/chapel)
 "yeb" = (
 /turf/simulated/floor/bluegrid,
@@ -87224,8 +93159,7 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "escape"
+	icon_state = "redchecker"
 	},
 /area/station/civilian/kitchen)
 "yeo" = (
@@ -87268,7 +93202,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
 "yfb" = (
@@ -87424,7 +93358,10 @@
 	dir = 6
 	},
 /obj/machinery/door/airlock/alarmlock,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
 /area/station/civilian/gym)
 "yid" = (
 /obj/structure/rack,
@@ -87437,6 +93374,13 @@
 	icon_state = "warndark"
 	},
 /area/station/engineering/engine)
+"yig" = (
+/obj/structure/closet/emcloset,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "warning"
+	},
+/area/station/maintenance/chapel)
 "yij" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/window/thin{
@@ -87468,7 +93412,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos)
 "yjy" = (
 /obj/machinery/door/airlock/atmos/glass{
@@ -87529,7 +93475,10 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "red"
+	},
 /area/station/hallway/secondary/exit)
 "yky" = (
 /turf/environment/space,
@@ -87576,6 +93525,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"ylb" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/civilian/chapel)
 "ylh" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -87598,7 +93553,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/civilian/dormitories)
 "ylo" = (
 /obj/effect/decal/cleanable/dirt,
@@ -87611,7 +93568,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "red"
+	},
 /area/station/hallway/secondary/exit)
 "ylt" = (
 /obj/structure/cable{
@@ -107043,7 +113003,7 @@ plf
 plf
 mIP
 lLE
-cOU
+jcC
 wMu
 ghA
 hso
@@ -107087,7 +113047,7 @@ xRM
 cjx
 gVW
 tZY
-fRJ
+eNG
 fRJ
 spu
 tZY
@@ -107300,10 +113260,10 @@ lgc
 kHU
 mIP
 lLE
-cOU
+jcC
 jiU
 cOU
-lbB
+pGR
 nsa
 qVq
 ksR
@@ -107331,7 +113291,7 @@ ije
 euL
 aXN
 euL
-fKT
+oSO
 xwj
 oSJ
 ilA
@@ -107348,7 +113308,7 @@ bbc
 bFR
 eGJ
 bbc
-unh
+seV
 gMM
 cjx
 cjx
@@ -107557,7 +113517,7 @@ amw
 amw
 psX
 lLE
-rwr
+xfY
 fEV
 eLR
 nsa
@@ -107814,7 +113774,7 @@ jXX
 jXX
 kHU
 lLE
-cOU
+jcC
 jiU
 awS
 kZh
@@ -107858,9 +113818,9 @@ gVW
 uwI
 vme
 ach
-mhk
-mhk
-mhk
+sOD
+sOD
+sOD
 jxm
 pFJ
 dbo
@@ -108290,7 +114250,7 @@ svE
 iBG
 vPk
 udN
-uNw
+cSH
 vPk
 plf
 jXX
@@ -108328,7 +114288,7 @@ ddJ
 jXX
 kHU
 lLE
-cOU
+jcC
 plm
 wod
 xBC
@@ -108364,7 +114324,7 @@ xkn
 cjx
 ilb
 fVu
-pis
+jUW
 cjx
 wCA
 oAI
@@ -108372,9 +114332,9 @@ gVW
 uhT
 frn
 aAZ
-fRJ
+vHf
 tDm
-fRJ
+vHf
 xZd
 siE
 gVW
@@ -108547,7 +114507,7 @@ oXk
 gqt
 vPk
 udN
-uNw
+cSH
 vPk
 nHd
 jXX
@@ -108585,9 +114545,9 @@ bIc
 jXX
 plf
 lLE
-cOU
+jcC
 jiU
-cOU
+svS
 nsa
 flj
 hHS
@@ -108799,12 +114759,12 @@ kHU
 gcf
 nHd
 vPk
-uwG
+pGs
 vCv
 fiP
 mKP
 dtg
-uNw
+cSH
 vPk
 iOt
 jXX
@@ -108842,9 +114802,9 @@ jSZ
 jXX
 kHU
 lLE
-cOU
+jcC
 jiU
-cOU
+svS
 kZh
 nUN
 rmd
@@ -108886,9 +114846,9 @@ fRJ
 fRJ
 fXd
 bJD
-fRJ
-tDm
-fRJ
+kMa
+rWY
+kMa
 ecA
 hTC
 fRJ
@@ -109061,7 +115021,7 @@ rCs
 dPj
 dPj
 wUK
-uNw
+cSH
 oxO
 dRh
 kHU
@@ -109099,7 +115059,7 @@ gvV
 kHU
 kHU
 lLE
-cOU
+jcC
 jiU
 msK
 nsa
@@ -109133,7 +115093,7 @@ pev
 rii
 dfK
 gQM
-dsj
+exw
 usj
 ara
 crH
@@ -109145,7 +115105,7 @@ rIz
 stV
 iqa
 sjW
-iqa
+hOl
 iag
 jum
 mph
@@ -109313,10 +115273,10 @@ kHU
 gcf
 vPk
 tmQ
-uNw
+hVJ
 uja
 nnA
-nqD
+xjX
 gAh
 ckv
 vPk
@@ -109358,7 +115318,7 @@ kHU
 nsa
 dwo
 jiU
-cOU
+svS
 lLE
 plf
 kHU
@@ -109400,9 +115360,9 @@ fGG
 idF
 rNV
 srI
-eMU
+pcI
 osF
-mhk
+fGy
 tMM
 cUf
 qkA
@@ -109569,44 +115529,44 @@ plf
 kHU
 wVj
 pLb
-xFB
-xFB
+uJe
+biK
 grm
-uyQ
-uNw
+kkH
+lIG
 lTZ
 vEB
 mOt
 aBv
 sVH
-vCv
+aIO
 fJh
-ubT
+iQp
 tKg
-vCv
+aIO
 oYf
-ubT
+iQp
 sVH
-uaN
-uNw
-uaN
-dkZ
+ebm
+hVJ
+ebm
+iTw
 tpy
 fxd
 nIE
-dEp
+kSO
 iDp
 anD
 nIE
-dEp
+kSO
 iDp
 pUh
 nIE
-dEp
+kSO
 iDp
-tiN
+gRR
 pte
-uNw
+dPL
 aaj
 npo
 rcA
@@ -109657,9 +115617,9 @@ nCm
 nCm
 mBU
 jie
-mhk
+ccq
 sdC
-mhk
+fGy
 afj
 uUJ
 nCm
@@ -109850,15 +115810,15 @@ mRz
 aIv
 fVB
 aIv
-mYJ
+dZK
 jaG
 lIJ
 fgW
-mYJ
+lFS
 voX
 spw
 vDX
-mYJ
+fCu
 kfj
 jLR
 rwA
@@ -109901,7 +115861,7 @@ uZD
 iJA
 iJA
 qrq
-wsv
+jXZ
 kOk
 jwI
 vLF
@@ -109916,7 +115876,7 @@ inR
 bGW
 iqa
 oju
-iqa
+hOl
 rJS
 mBw
 mph
@@ -110085,13 +116045,13 @@ plf
 vPk
 udX
 dzq
-udN
+vPR
 drM
 uNw
-fiP
-hLs
+jze
+lMA
 tGM
-hZG
+jLh
 uNw
 sox
 xKk
@@ -110104,9 +116064,9 @@ xFB
 fqi
 xFB
 bQj
-xFB
+cKf
 wQz
-xFB
+pqN
 bQj
 xFB
 xFB
@@ -110118,7 +116078,7 @@ tfQ
 bQj
 bCr
 xFB
-xKk
+cFh
 wQz
 gmf
 gis
@@ -110138,7 +116098,7 @@ cNb
 qAl
 qAl
 qAl
-tED
+wzP
 tlv
 ehA
 jKa
@@ -110171,9 +116131,9 @@ fRJ
 vpb
 oaA
 mTN
-mhk
+ccq
 sdC
-mhk
+fGy
 tMM
 rhI
 qkA
@@ -110345,10 +116305,10 @@ fTJ
 rQM
 uyQ
 uNw
-uNw
+vOB
 yjl
 mOt
-hZG
+jLh
 lQn
 bTG
 dkZ
@@ -110359,34 +116319,34 @@ hqD
 dEp
 dEp
 ilj
-uNw
-uNw
-uNw
+aWD
+aWD
+tiN
 tGM
 lWs
 qQY
-uNw
-uNw
-uNw
-uNw
-uNw
+aWD
+aWD
+aWD
+aWD
+aWD
 vPd
 qhd
-uNw
+aWD
 oGY
-uNw
+aWD
 flf
 oMm
 ddG
 cKe
 uNw
-ubT
+tmX
 vPk
 xFF
 xFG
 flb
 uDn
-cOU
+rZU
 ude
 ehA
 geB
@@ -110405,7 +116365,7 @@ vmP
 vmP
 gbd
 pgL
-neS
+cQq
 fKT
 dsj
 dsj
@@ -110428,9 +116388,9 @@ nCm
 nCm
 czg
 lNl
-mhk
+ccq
 sdC
-mhk
+fGy
 jrf
 qxf
 nCm
@@ -110602,22 +116562,22 @@ jQF
 pbm
 hsW
 aIJ
-whA
-fiP
+gMT
+pZC
 mbj
 gxk
 jLz
 aAr
-mKP
-mKP
-mKP
-mKP
-mKP
-mKP
-mKP
-mKP
-mKP
-mKP
+cmG
+cmG
+cmG
+cmG
+cmG
+cmG
+cmG
+cmG
+cmG
+cmG
 hLs
 csb
 uwG
@@ -110625,17 +116585,17 @@ bfg
 bfg
 utn
 utn
-uNw
-uNw
+aWD
+aWD
 tYo
-uNw
-uNw
-vCv
+aWD
+aWD
+kdU
 kEA
 sws
 fVB
-fgW
-fgW
+mMv
+dID
 nim
 xgt
 vPk
@@ -110643,7 +116603,7 @@ qnQ
 hEd
 fDg
 jiU
-cOU
+rZU
 hkb
 ehA
 fUz
@@ -110663,17 +116623,17 @@ jUd
 jUd
 oex
 tqB
-phs
-dsj
-dsj
-dsj
-ptT
-dsj
-dsj
+soD
+nFZ
+nFZ
+nFZ
+nTg
+nFZ
+nFZ
 vcG
-urI
+jQj
 wjb
-dsj
+hVy
 bmQ
 lmX
 jwI
@@ -110687,7 +116647,7 @@ nJq
 bGW
 iqa
 oju
-iqa
+hOl
 iag
 siZ
 mph
@@ -110856,10 +116816,10 @@ plf
 oRS
 eQM
 fTJ
-dPj
+fRu
 ohU
 kCA
-uNw
+vwv
 sWI
 mOt
 jFr
@@ -110871,11 +116831,11 @@ wEc
 eKz
 qCV
 wEc
-wEc
-wEc
+qaU
+qSk
 qSh
-uNw
-fiP
+aWD
+qWm
 eZV
 bOJ
 oKV
@@ -110883,12 +116843,12 @@ dup
 dup
 nRV
 bOD
-mKP
+cmG
 bYx
 bme
-xFB
+oJD
 isX
-ubT
+gVm
 rYi
 vPk
 pte
@@ -110930,7 +116890,7 @@ iFu
 nGB
 qrR
 wjb
-ptT
+sYc
 kHn
 mMu
 jwI
@@ -110942,9 +116902,9 @@ fRJ
 vpb
 vYM
 mTN
-mhk
+ccq
 sdC
-mhk
+fGy
 tMM
 uWb
 qkA
@@ -111129,22 +117089,22 @@ tGM
 tGM
 tGM
 yec
-uNw
+aWD
 hZG
-uNw
-uNw
+aWD
+tiN
 pte
-uNw
-gOl
-uNw
+cfD
+kxu
+aWD
 uDp
-uNw
-uNw
-uNw
+aWD
+aWD
+aWD
 dnD
 oLJ
-fgW
-fgW
+kFc
+kFc
 cEO
 flf
 azQ
@@ -111199,9 +117159,9 @@ nCm
 nCm
 kSz
 aog
-mhk
+ccq
 sdC
-mhk
+fGy
 goU
 qWU
 nCm
@@ -111377,19 +117337,19 @@ vPk
 cgu
 gza
 cCw
-syn
+ohW
 shx
-syn
-syn
-syn
-syn
+ohW
+ohW
+ohW
+ohW
 nUv
 tGM
 nWR
-uNw
+aWD
 dLs
-wEc
-wEc
+qSk
+qdn
 naA
 kdJ
 nRV
@@ -111397,7 +117357,7 @@ xqQ
 fmh
 mNB
 bfy
-mKP
+cmG
 dup
 htY
 dEp
@@ -111458,7 +117418,7 @@ qob
 bGW
 iqa
 vGh
-iqa
+hOl
 iag
 gbO
 mph
@@ -111631,7 +117591,7 @@ jIZ
 kou
 kFq
 mrj
-syn
+ohW
 syn
 pjj
 uNw
@@ -111643,9 +117603,9 @@ uNw
 fBl
 tGM
 ckm
-uNw
+aWD
 hZG
-uNw
+phV
 hAR
 tGM
 nQI
@@ -111654,9 +117614,9 @@ nLs
 aKu
 nLs
 bTE
-kCA
-uNw
-uNw
+tUm
+oPF
+aWD
 rSb
 umn
 svw
@@ -111666,7 +117626,7 @@ rZO
 iIJ
 vPk
 fPg
-cOU
+sUm
 oLl
 kDq
 ifq
@@ -111686,9 +117646,9 @@ abX
 rvC
 jDO
 gRV
-fuV
-aKa
-jDO
+sUm
+ifQ
+qGp
 sbi
 nsa
 tlb
@@ -111700,7 +117660,7 @@ nsa
 xBg
 cOU
 cOU
-cOU
+rZU
 wkD
 ugv
 fHi
@@ -111713,7 +117673,7 @@ fRJ
 vpb
 vFZ
 mTN
-fRJ
+vHf
 qTT
 aJg
 tMM
@@ -111888,19 +117848,19 @@ bjK
 aqy
 nFq
 vPk
+wNt
 uNw
+aWD
+aWD
+aWD
+aWD
+aWD
+aWD
 uNw
-uNw
-uNw
-uNw
-uNw
-uNw
-uNw
-uNw
-kiy
+kLT
 tGM
 lkH
-uNw
+aWD
 hZG
 xrz
 tGM
@@ -111912,8 +117872,8 @@ tGM
 pte
 tGM
 tGM
-hAR
-xvk
+hnu
+oDg
 skN
 tvr
 gOM
@@ -111943,21 +117903,21 @@ gKu
 bZA
 cOU
 elw
-cOU
+sUm
 mts
-cOU
+dQD
 gqH
 kLE
 bau
-cOU
+xbm
 gpM
-cOU
+xbm
 elw
 xKm
 gqH
-cOU
+dQD
 mEc
-cOU
+rZU
 bau
 cmi
 vYv
@@ -112147,30 +118107,30 @@ vPk
 vPk
 qTl
 uNw
-uNw
-uNw
+aWD
+phV
 kic
+mkS
+oPF
+aWD
 uNw
-uNw
-uNw
-uNw
-kiy
+kLT
 bwm
-uNw
+cfD
 bTG
 hZG
 ufr
 tGM
 jrt
-uNw
+bLn
 fSt
-uNw
+bLn
 wYP
 dwK
 dwK
 tGM
 kqT
-wEc
+qSk
 qjv
 khK
 fif
@@ -112198,11 +118158,11 @@ bVH
 pUu
 jgS
 bZA
-cOU
+xbm
 elw
-cOU
+sUm
 shG
-cOU
+dQD
 ksU
 nsa
 fGh
@@ -112212,9 +118172,9 @@ hmC
 wyP
 nsa
 gUA
-ifQ
+wDR
 oGF
-cOU
+rZU
 jyK
 oBb
 nBf
@@ -112398,25 +118358,25 @@ mqw
 gcE
 fWb
 qua
-nnA
+cbk
 hyA
 vNa
 vPk
+wNt
 uNw
-uNw
-uNw
-uNw
+aWD
+tiN
 tGM
 gUl
-uNw
-uNw
+cfD
+aWD
 uNw
 xKb
 szc
-aIJ
+oXV
 sUZ
 jzl
-aIJ
+bsZ
 fZH
 cTK
 whA
@@ -112424,13 +118384,13 @@ uNw
 uNw
 uNw
 uNw
-uNw
+xnu
 pte
-hZG
-uNw
+jLh
+aWD
 fMO
 hZG
-ubT
+gVm
 kHT
 vPk
 vPk
@@ -112455,11 +118415,11 @@ lzo
 ehA
 jgS
 bZA
-xaA
+uwB
 elw
-cOU
+sUm
 caP
-ifQ
+wDR
 bie
 nsa
 hyN
@@ -112469,9 +118429,9 @@ bKu
 hyN
 nsa
 hXd
-cOU
+dQD
 bxE
-cOU
+rZU
 bau
 cmi
 rsB
@@ -112481,7 +118441,7 @@ wTL
 sgS
 jwI
 tAS
-mhk
+mAQ
 svI
 uJP
 srW
@@ -112489,7 +118449,7 @@ cNE
 hQk
 wXp
 oHG
-mhk
+fGy
 wcV
 cjx
 lUT
@@ -112651,35 +118611,35 @@ kHU
 vPk
 vPk
 pvz
-uNw
-uNw
-uNw
-uNw
-uyQ
+aWD
+aWD
+aWD
+aWD
+ifz
 aQP
 nUT
 vPk
 gll
 uNw
-uNw
+aWD
 wUS
 tGM
 xNJ
+cfD
+aWD
 uNw
-uNw
-uNw
-kiy
+kLT
 bwm
-uNw
-uNw
+cfD
+aWD
 mJM
-iEf
+pBb
 yjy
 qcT
-iEf
-iEf
-iEf
-iEf
+mrP
+daq
+daq
+daq
 egG
 iEf
 yjy
@@ -112714,10 +118674,10 @@ azf
 dkO
 cbc
 elw
-cOU
-ifQ
-cOU
-cOU
+nPn
+izG
+lEA
+lEA
 qbR
 fwj
 jvA
@@ -112725,20 +118685,20 @@ rVN
 sFd
 vch
 rpW
-cOU
-cOU
-ifQ
-cOU
+lEA
+lEA
+izG
+hCG
 vej
 eWb
-awS
+wnj
 jwI
 ijY
 buY
 ldN
 jwI
 hVD
-mhk
+mAQ
 ooG
 tME
 wbu
@@ -112907,23 +118867,23 @@ kHU
 plf
 vPk
 dwK
-uNw
-uNw
-jQF
-jQF
-jQF
+aWD
+aWD
+pLy
+rnl
+msR
 gms
 nqD
 apm
 bcW
+wNt
 uNw
-uNw
-uNw
+aWD
 ufr
 tGM
 tGM
 uwG
-uNw
+aWD
 uNw
 uBC
 lXB
@@ -112938,7 +118898,7 @@ fjH
 hCq
 nFr
 gRS
-uNw
+gPF
 pte
 aGB
 lQn
@@ -112961,7 +118921,7 @@ iGx
 kHU
 iGx
 wdN
-cOU
+rZU
 evV
 hiE
 pUK
@@ -112978,7 +118938,7 @@ fuV
 fuV
 aKa
 coy
-gpM
+egy
 eTg
 fuV
 fuV
@@ -113163,30 +119123,30 @@ plf
 lgc
 kHU
 oRS
-uNw
-uNw
-jQF
-jQF
-jQF
-jQF
-jQF
-uNw
-uyQ
+aWD
+aWD
+pLy
+vWF
+iYj
+uki
+msR
+aWD
+rot
 ryS
+wNt
 uNw
-uNw
-uNw
-uNw
+aWD
+tiN
 cBU
 tGM
 nwH
+aWD
 uNw
-uNw
-kiy
+kLT
 bwm
 gAr
-cwt
-uNw
+ivG
+aWD
 bmj
 tGM
 stm
@@ -113221,26 +119181,26 @@ hdV
 qJk
 evV
 oKM
-vKa
 wCx
-vKa
+wCx
+wCx
 oDZ
 bau
 nkc
 dij
-wod
-wod
+qfJ
+blI
 mGk
-wod
-wod
-wod
+blI
+qfJ
+blI
 qFo
 vGK
 jmX
 lTQ
+mPx
 lTQ
-lTQ
-lTQ
+mPx
 lTQ
 ete
 lTQ
@@ -113420,31 +119380,31 @@ kHU
 lgc
 plf
 oRS
-uNw
-uNw
-jQF
-jQF
-jQF
-jQF
-jQF
-uNw
-uyQ
+aWD
+aWD
+kmP
+iYj
+iYj
+iYj
+mga
+aWD
+rot
 bcW
+wNt
 uNw
-uNw
-uNw
-uNw
+aWD
+tiN
 gUl
 tGM
+cfD
+aWD
 uNw
-uNw
-uNw
-kiy
+kLT
 tGM
 gOw
 kic
-uNw
-bmj
+mkS
+rHG
 tEF
 tEF
 tEF
@@ -113455,8 +119415,8 @@ bQW
 pte
 tGM
 kcY
-udN
-ubT
+dff
+buf
 kGC
 qtc
 leb
@@ -113469,7 +119429,7 @@ vPk
 aPN
 xxe
 sBQ
-lFS
+uRD
 cOU
 xEE
 mre
@@ -113492,7 +119452,7 @@ qER
 qER
 qER
 drK
-cOU
+xbm
 qYD
 qER
 qER
@@ -113677,24 +119637,24 @@ plf
 lgc
 kHU
 oRS
-uNw
-uNw
-jQF
-jQF
-jQF
-jQF
-jQF
-uNw
-uyQ
+aWD
+aWD
+rHh
+esv
+iYj
+qAK
+qyx
+aWD
+rot
 ryS
+wNt
 uNw
-uNw
-uNw
-uNw
-uNw
-sVH
-uNw
-uNw
+aWD
+etT
+lMM
+hQX
+qkK
+aWD
 uNw
 rVK
 tGM
@@ -113732,7 +119692,7 @@ cOU
 aaV
 cOU
 wdN
-gpM
+qHP
 evV
 rSA
 sVD
@@ -113740,11 +119700,11 @@ szf
 gLd
 lcN
 jQc
-eZT
+ydm
 mEY
-cOU
-cOU
-gpM
+sId
+uwt
+xoe
 nYM
 hdJ
 kjY
@@ -113935,25 +119895,25 @@ kHU
 plf
 vPk
 jEa
-uNw
-uNw
-jQF
-jQF
-jQF
-uNw
-uNw
-uyQ
+aWD
+aWD
+rHh
+npG
+qyx
+aWD
+aWD
+rot
 bcW
+wNt
 uNw
+aWD
+aWD
+aWD
+aWD
+aWD
+aWD
 uNw
-uNw
-uNw
-uNw
-uNw
-uNw
-uNw
-uNw
-kiy
+kLT
 jQF
 tEF
 dsQ
@@ -113997,10 +119957,10 @@ ndF
 cvI
 azf
 fYT
-auG
+bhh
 mEY
-cOU
-cOU
+sUm
+dQD
 sjQ
 fuX
 nsa
@@ -114193,14 +120153,15 @@ kHU
 vPk
 vPk
 nQk
-uNw
-uNw
-uNw
+aWD
+aWD
+aWD
 shj
-uNw
+aWD
 lQn
 bHz
 vPk
+wNt
 uNw
 uNw
 uNw
@@ -114209,8 +120170,7 @@ uNw
 uNw
 uNw
 uNw
-uNw
-kiy
+kLT
 rNm
 tEF
 baP
@@ -114223,7 +120183,7 @@ kop
 tEF
 cPf
 dPE
-xvk
+oDg
 xmO
 cdv
 ubT
@@ -114268,11 +120228,11 @@ inM
 tiI
 nsa
 yid
-cOU
-cOU
-cmi
-cOU
-cOU
+sUm
+dQD
+azT
+dQD
+rZU
 hUk
 jwI
 les
@@ -114458,16 +120418,16 @@ jFS
 mcx
 vPk
 vPk
-uNw
+wNt
 uNw
 uNw
 ozK
-syn
+ohW
 cxI
-syn
-syn
+ohW
+ohW
 xQy
-pjj
+uBz
 rNm
 tEF
 faL
@@ -114491,7 +120451,7 @@ ixG
 ixG
 ixG
 wjD
-gPB
+lpw
 vKc
 bfD
 inT
@@ -114714,8 +120674,8 @@ vPk
 vPk
 vPk
 vPk
-uNw
-uNw
+diQ
+wNt
 uNw
 uNw
 kiy
@@ -114768,7 +120728,7 @@ gZV
 eAD
 nsa
 pem
-jFP
+iLM
 rkz
 bDP
 jwI
@@ -114782,24 +120742,24 @@ fRP
 gLD
 nsa
 hoM
-cOU
-cOU
-cOU
-cOU
-cOU
+sUm
+dQD
+xbm
+dQD
+rZU
 bFm
 jwI
 ajw
 nyw
 lGS
 uTY
-lGS
+xrx
 fWz
 xOb
 ePN
 nxa
 ftA
-sIc
+iHJ
 uDL
 mYv
 uDL
@@ -114970,8 +120930,8 @@ nHd
 nHd
 jFs
 ahU
-jFs
-uNw
+tYI
+wNt
 jyl
 tWL
 sTo
@@ -115527,9 +121487,9 @@ pEO
 hQQ
 hQQ
 qTx
-oJD
+gUo
 iky
-oJD
+gUo
 qTx
 abU
 ryx
@@ -115796,7 +121756,7 @@ mhm
 doE
 mnD
 wtC
-oPF
+flE
 bXL
 jyh
 ijY
@@ -116053,7 +122013,7 @@ clJ
 xSf
 rSn
 ulW
-dzl
+dmK
 uGq
 moI
 moI
@@ -116106,8 +122066,8 @@ vee
 plf
 eWN
 pOr
-pOr
-hLq
+kDj
+dVr
 pVb
 mRQ
 gvl
@@ -116338,7 +122298,7 @@ aWq
 aIW
 wtC
 mTr
-bzw
+iGZ
 oqY
 tJr
 tJr
@@ -116363,7 +122323,7 @@ vee
 kHU
 eWN
 kLU
-pOr
+kDj
 hLq
 sSh
 mjh
@@ -116595,7 +122555,7 @@ wtC
 jyh
 wtC
 eRa
-bzw
+atN
 aTn
 agq
 ihB
@@ -116609,8 +122569,8 @@ pTY
 obC
 fgI
 qtm
-fsX
-fsX
+pHc
+pHc
 ixC
 tUP
 cjx
@@ -116802,7 +122762,7 @@ nXl
 kop
 mFM
 wwi
-exB
+eNI
 wwi
 plf
 kHU
@@ -116841,7 +122801,7 @@ lud
 wtC
 ijY
 jyh
-jyh
+vow
 hBT
 hBT
 wtC
@@ -116866,8 +122826,8 @@ dnt
 top
 oIX
 sBO
-fsX
-fsX
+pHc
+pHc
 vsl
 tUP
 cjx
@@ -116877,10 +122837,10 @@ vee
 kHU
 eWN
 pOr
-pOr
+kDj
 elZ
-pOr
-pOr
+gbQ
+vbS
 quE
 eRT
 hHr
@@ -117038,7 +122998,7 @@ wJu
 wwi
 cEz
 kFU
-wFw
+cFz
 kRw
 uBY
 wwi
@@ -117090,7 +123050,7 @@ ajw
 ylt
 ylt
 omz
-omz
+kIu
 ylt
 tGJ
 omz
@@ -117109,7 +123069,7 @@ jbr
 jbr
 rkx
 aqm
-bzw
+nCa
 gWl
 agq
 bJu
@@ -117134,9 +123094,9 @@ vee
 plf
 eWN
 pOr
-pOr
+kDj
 elZ
-kLU
+aOG
 lyg
 dfH
 eRT
@@ -117393,7 +123353,7 @@ oIK
 rvA
 jOD
 bQP
-kLU
+aOG
 ukc
 kLU
 eRT
@@ -117571,7 +123531,7 @@ eDO
 lXM
 iIz
 lqt
-bpv
+qxK
 liK
 kWH
 qlc
@@ -117606,7 +123566,7 @@ sgS
 dNl
 sHo
 bCV
-les
+bFD
 ijY
 ijY
 ijY
@@ -117827,7 +123787,7 @@ gUI
 gUI
 wwi
 wwi
-cmG
+pug
 bZz
 wwi
 ieA
@@ -117858,7 +123818,7 @@ vIN
 wtC
 jyh
 kCR
-gat
+rlG
 uQR
 teo
 hxU
@@ -118108,13 +124068,13 @@ bjc
 ksv
 gKG
 rJZ
-sWW
+tnz
 isB
 nRf
 uwq
 wtC
 sgS
-ksn
+vhK
 wtC
 ncC
 jwI
@@ -118396,9 +124356,9 @@ mkl
 svQ
 vxf
 kiL
-dID
-dID
-hzm
+mKy
+mKy
+blq
 syE
 qbC
 uHN
@@ -118822,7 +124782,7 @@ maK
 aHs
 miE
 mVU
-fSb
+qdU
 miE
 fAo
 wwi
@@ -119069,9 +125029,9 @@ yaE
 yaE
 yaE
 ffS
-gHT
-gHT
-rxk
+hkD
+hkD
+mkT
 ksI
 mVU
 mVU
@@ -119172,9 +125132,9 @@ hrO
 nCa
 hRy
 tQM
-cyt
-aTn
-rSG
+lVE
+hrO
+hRy
 tQM
 sCS
 avV
@@ -119305,13 +125265,13 @@ plf
 yaE
 iYf
 yaE
-gHT
-gHT
-gHT
+qQy
+uqt
+uqt
 lMn
-gHT
-gHT
-dtY
+uqt
+uqt
+fSb
 nYg
 nYg
 nYg
@@ -119319,12 +125279,12 @@ nYg
 nYg
 nYg
 nQq
-iMs
-iMs
+qkH
+qkH
 tgM
-iMs
-iMs
-iMs
+qkH
+qkH
+lbj
 eAW
 iMs
 iMs
@@ -119424,7 +125384,7 @@ rkx
 frF
 rzd
 iFV
-jfv
+gZd
 aVf
 qlT
 bIg
@@ -119560,9 +125520,9 @@ plf
 plf
 plf
 hGn
-qYg
+tYA
 hGn
-gHT
+kma
 fYS
 fYS
 fYS
@@ -119581,7 +125541,7 @@ fYS
 fYS
 fYS
 fYS
-gHT
+vUe
 alc
 gHT
 rsE
@@ -119592,7 +125552,7 @@ buR
 ban
 ban
 abs
-xao
+mVU
 qdU
 miE
 fob
@@ -119681,13 +125641,13 @@ cMg
 ibP
 sIn
 cqW
-aTn
-mtD
-aTn
+uhk
+pWG
+cyt
 rjL
 tQM
 cyt
-aTn
+fsX
 lyC
 tQM
 qUN
@@ -119820,36 +125780,36 @@ yaE
 lae
 yaE
 lNN
-gHT
-gHT
+eyw
+eyw
 qEc
-gHT
-gHT
-gHT
-gHT
-gHT
-gHT
-gHT
-gHT
-gHT
-gHT
-gHT
-gHT
+eyw
+eyw
+eyw
+eyw
+eyw
+eyw
+eyw
+eyw
+eyw
+eyw
+eyw
+eyw
 ipy
-gHT
-gHT
-gHT
+eyw
+eyw
+gjL
 alc
 gHT
 fYS
 uDS
 wwi
 kAU
-ojt
-exf
-exf
+fhT
+auA
+auA
 iRS
-rdK
+eNm
 wwi
 wwi
 bOT
@@ -119868,16 +125828,16 @@ pLk
 tJq
 ohm
 vIX
-sTk
+rAY
 tJq
 qUi
-mbl
+sEJ
 itb
 itb
 itb
 aRK
 itb
-mbl
+sEJ
 kCk
 sEJ
 dqA
@@ -119944,7 +125904,7 @@ pqw
 kYt
 vCH
 apt
-aTn
+uhk
 fVY
 oRy
 wST
@@ -120097,17 +126057,17 @@ yaE
 yaE
 ffS
 eVM
-coT
+lNi
 fYS
 uDS
 wwi
 kAU
-exf
+auA
 rdK
 rdK
-dVr
-dVr
-dVr
+auA
+auA
+auA
 wwi
 iGs
 wwi
@@ -120130,7 +126090,7 @@ tJq
 kli
 xCL
 rXM
-wrg
+qqF
 xCL
 jKQ
 qCA
@@ -120201,7 +126161,7 @@ vCH
 vCH
 vCH
 guz
-aTn
+fsX
 viI
 vCH
 nNa
@@ -120390,7 +126350,7 @@ kUa
 niP
 dkf
 jsI
-hPP
+pTB
 dkf
 kUa
 ano
@@ -120458,7 +126418,7 @@ vDQ
 yjQ
 ciQ
 eFq
-aTn
+uhk
 lyC
 nNa
 iDy
@@ -120611,7 +126571,7 @@ mTn
 mTn
 mTn
 dhU
-gHT
+csG
 fYS
 gUH
 wwi
@@ -120644,10 +126604,10 @@ jGD
 pTB
 wAl
 yel
-thA
+niP
 yel
 htK
-unD
+pTB
 yel
 yel
 sjA
@@ -120702,10 +126662,10 @@ sTD
 wiV
 pbh
 kdi
-kdi
+gvr
 kdi
 rnn
-aTn
+frF
 rSG
 bXK
 lrH
@@ -120713,9 +126673,9 @@ uFu
 ubg
 wOD
 cyt
-aTn
-ciD
-rnn
+uZz
+bcO
+dfa
 veU
 vCH
 ahJ
@@ -120868,7 +126828,7 @@ mTn
 mTn
 mTn
 iQE
-gHT
+csG
 fYS
 dEP
 wwi
@@ -120890,7 +126850,7 @@ fLh
 fLh
 fLh
 vLX
-vIX
+xnt
 xJf
 thU
 thU
@@ -120898,15 +126858,15 @@ thU
 thU
 hMZ
 dQU
-uyK
-vIX
-vIX
+lNc
+hXb
+hXb
 eDr
-vIX
-kvx
-uyK
-vIX
-vIX
+hXb
+wjf
+lNc
+hXb
+hXb
 cIH
 bvI
 jxg
@@ -120953,16 +126913,16 @@ mnY
 mnY
 wPL
 cyt
-mtD
-aTn
+ksG
+axy
 umc
-xfI
-aTn
-aTn
-aTn
-aTn
-eBS
-aTn
+pnn
+hrO
+axy
+hrO
+axy
+sZe
+cyt
 rSG
 cvc
 cxG
@@ -120970,7 +126930,7 @@ dqb
 vKj
 cvc
 cyt
-aTn
+rSG
 cIT
 hDI
 lyC
@@ -121125,7 +127085,7 @@ mTn
 mTn
 mTn
 yaE
-gHT
+csG
 fYS
 oOy
 ffS
@@ -121165,7 +127125,7 @@ snp
 gaJ
 gaJ
 gHU
-vIX
+gNR
 npk
 wwi
 dIg
@@ -121218,8 +127178,8 @@ wix
 dqy
 wJi
 aTn
-eBS
-aTn
+frM
+mQE
 rSG
 bXK
 oJe
@@ -121227,7 +127187,7 @@ vtX
 srf
 wOD
 cyt
-aTn
+sjx
 nve
 lgD
 lyC
@@ -121385,7 +127345,7 @@ yaE
 vwJ
 fBK
 mgg
-eQj
+kiP
 rov
 rov
 rov
@@ -121423,9 +127383,9 @@ dhg
 vNc
 pzc
 vIX
-vIX
+gNR
 fZQ
-fsf
+nIu
 qMb
 fuM
 jxa
@@ -121446,7 +127406,7 @@ dka
 aVs
 aVs
 tLU
-gUo
+bed
 iYt
 kGI
 pHa
@@ -121476,7 +127436,7 @@ oRy
 oRy
 wAR
 eBS
-aTn
+cyt
 fuc
 vDQ
 tjH
@@ -121486,7 +127446,7 @@ vDQ
 aea
 iVr
 frF
-xfI
+sSE
 lyC
 nNa
 cQN
@@ -121639,7 +127599,7 @@ mTn
 mTn
 mTn
 yaE
-rCP
+hPP
 fYS
 fYD
 qDi
@@ -121732,8 +127692,8 @@ vpT
 njw
 oRy
 frF
-eBS
-aTn
+frM
+mQE
 qPO
 ofJ
 ofJ
@@ -121743,7 +127703,7 @@ ofJ
 ofJ
 ofJ
 qDG
-xfI
+cAb
 hHB
 vCH
 vCH
@@ -121911,7 +127871,7 @@ teD
 kEp
 teD
 dkQ
-xXt
+wzu
 hXb
 hXb
 hXb
@@ -121990,7 +127950,7 @@ vpT
 tQM
 cyt
 mtD
-aTn
+cyt
 rSG
 xVQ
 vRy
@@ -122000,7 +127960,7 @@ mGK
 gAU
 fes
 cyt
-xfI
+sSE
 akL
 kFd
 iwd
@@ -122153,9 +128113,9 @@ mTn
 mTn
 mTn
 yaE
-rCP
+wFj
 fYS
-uDS
+epa
 alc
 gHT
 gHT
@@ -122246,8 +128206,8 @@ bhS
 ayO
 hXC
 dNL
-ksz
-ksz
+xpQ
+kin
 wbH
 wgu
 soh
@@ -122257,7 +128217,7 @@ mXZ
 mvj
 fes
 cyt
-xfI
+cAb
 lyC
 rYZ
 pwE
@@ -122413,15 +128373,15 @@ yaE
 rCP
 fYS
 uDS
-alc
-gHT
-gHT
-gHT
-gHT
-gHT
-gHT
-alc
-gHT
+sDu
+tVy
+tVy
+tVy
+tVy
+tVy
+tVy
+xao
+csG
 fDL
 gHT
 ufV
@@ -122503,8 +128463,8 @@ ogP
 vpT
 exM
 cyt
-aTn
-aTn
+rjL
+cyt
 rSG
 xVQ
 wzI
@@ -122678,9 +128638,9 @@ acf
 dDs
 aSq
 ffS
-uAC
+gvF
 fDL
-gHT
+vDr
 whB
 ffS
 ffS
@@ -122771,7 +128731,7 @@ dhs
 mbI
 fes
 cyt
-bzw
+iGZ
 wYl
 kFd
 kFd
@@ -123006,9 +128966,9 @@ qdX
 aVg
 ssF
 sfX
-hlQ
-hlQ
-hlQ
+exf
+exf
+exf
 aZe
 amN
 aVg
@@ -123028,7 +128988,7 @@ hXw
 mbI
 fes
 cyt
-bzw
+atN
 aTn
 aTn
 csz
@@ -123183,7 +129143,7 @@ mTn
 dhU
 rCP
 fYS
-uDS
+rEz
 yaE
 kHU
 plf
@@ -123192,9 +129152,9 @@ plf
 plf
 kHU
 yaE
-gHT
+hkD
 hss
-heu
+ctc
 hSR
 xoc
 fWg
@@ -123214,7 +129174,7 @@ fjB
 qSx
 dtr
 czE
-gvF
+uSN
 kvu
 gIl
 rdY
@@ -123286,10 +129246,10 @@ xMv
 gFD
 ucX
 xPV
-jfv
-jfv
+qBI
+gZd
 gVz
-jfv
+gZd
 ogL
 nAF
 wBR
@@ -123440,7 +129400,7 @@ mTn
 ffS
 nBB
 fYS
-uDS
+rEz
 yaE
 kHU
 kHU
@@ -123449,7 +129409,7 @@ plf
 kHU
 kHU
 yaE
-gHT
+hkD
 fYS
 nEU
 ffS
@@ -123520,9 +129480,9 @@ pea
 aVg
 wqk
 baa
-hlQ
-hlQ
-hlQ
+exf
+exf
+exf
 rTk
 qbf
 unR
@@ -123542,7 +129502,7 @@ tAO
 klG
 fes
 gLF
-iAz
+hZu
 uzK
 eSq
 eSq
@@ -123706,9 +129666,9 @@ plf
 kHU
 plf
 yaE
-gHT
+wtr
 rsE
-nYg
+jhc
 epk
 pyy
 rXC
@@ -123799,7 +129759,7 @@ wVL
 enN
 fes
 gLF
-iAz
+som
 oRg
 xxm
 hOR
@@ -123932,11 +129892,11 @@ yaE
 iYf
 yaE
 sUt
-gHT
-gHT
+uqt
+uqt
 lMn
-gHT
-gHT
+uqt
+uqt
 lHD
 urE
 urE
@@ -123945,12 +129905,12 @@ urE
 urE
 urE
 vpk
-iMs
-iMs
+qkH
+qkH
 iNv
-iMs
-iMs
-iMs
+qkH
+qkH
+lbj
 eAW
 iMs
 vJG
@@ -123963,9 +129923,9 @@ plf
 kHU
 plf
 yaE
-gHT
+vDr
 fYS
-gHT
+hkD
 alc
 nIB
 iEL
@@ -123985,7 +129945,7 @@ qSx
 qSx
 uSN
 aam
-tYA
+bqI
 kvu
 bRX
 rbL
@@ -124056,7 +130016,7 @@ fes
 ofJ
 ofJ
 dTt
-iAz
+hZu
 oRg
 xek
 lrh
@@ -124186,9 +130146,9 @@ plf
 plf
 plf
 hGn
-qYg
+tYA
 hGn
-gHT
+kma
 fYS
 fYS
 fYS
@@ -124207,11 +130167,11 @@ fYS
 fYS
 fYS
 fYS
-gHT
+vUe
 alc
 gHT
 fYS
-dUJ
+lTw
 yaE
 kHU
 kHU
@@ -124220,9 +130180,9 @@ plf
 kHU
 kHU
 yaE
-gHT
+csG
 fYS
-gHT
+wtr
 ffS
 npC
 txi
@@ -124446,29 +130406,29 @@ yaE
 lae
 yaE
 ljH
-gHT
-gHT
+eyw
+eyw
 gHs
-gHT
-gHT
-gHT
-gHT
-gHT
-gHT
-gHT
-gHT
-gHT
-gHT
-gHT
-gHT
+eyw
+eyw
+eyw
+eyw
+eyw
+eyw
+eyw
+eyw
+eyw
+eyw
+eyw
+eyw
 ipy
-gHT
-gHT
-gHT
+eyw
+eyw
+gjL
 alc
 gHT
 fYS
-dUJ
+lTw
 yaE
 kHU
 plf
@@ -124477,9 +130437,9 @@ plf
 plf
 kHU
 yaE
-gHT
+csG
 fYS
-gHT
+wtr
 ffS
 bCJ
 euO
@@ -124565,9 +130525,9 @@ vJT
 aMG
 fMG
 ydI
-cyt
-aTn
-aTn
+rwf
+wix
+frF
 fQf
 eSq
 eSq
@@ -124993,7 +130953,7 @@ ryG
 ffS
 uAC
 fYS
-gHT
+wtr
 tJq
 iga
 dXT
@@ -125237,18 +131197,18 @@ kHU
 kHU
 kHU
 yaE
-gHT
+csG
 fYS
-dUJ
-alc
-gHT
-gHT
-gHT
-gHT
-gHT
-gHT
-alc
-gHT
+nln
+gKo
+guK
+guK
+guK
+guK
+guK
+guK
+urv
+hkD
 fYS
 raR
 tJq
@@ -125494,7 +131454,7 @@ plf
 kHU
 yaE
 yaE
-gHT
+csG
 fYS
 dUJ
 alc
@@ -125507,7 +131467,7 @@ gHT
 alc
 gHT
 fYS
-gHT
+wtr
 tJq
 nXN
 rVS
@@ -125612,16 +131572,16 @@ qFs
 nWN
 qFs
 vzs
-ftg
-pxa
-pxa
-eXp
+bCv
+sDa
+sDa
+dmc
 ffG
 blp
-pxa
-pxa
-gRg
-pxa
+cnr
+sDa
+ntM
+sDa
 ujr
 gJC
 gJC
@@ -125751,7 +131711,7 @@ plf
 kHU
 eeB
 mlH
-gHT
+csG
 fYS
 kBx
 vjq
@@ -125866,9 +131826,9 @@ oqm
 nMg
 upe
 ouz
-gRg
-pxa
-pxa
+ahh
+hYm
+qQK
 pxa
 sAh
 dTO
@@ -126008,7 +131968,7 @@ plf
 yaE
 yaE
 yaE
-gHT
+csG
 fYS
 gHT
 alc
@@ -126021,7 +131981,7 @@ gHT
 alc
 gHT
 fYS
-mYW
+sEX
 srs
 srs
 srs
@@ -126109,7 +132069,7 @@ nvX
 sew
 taL
 giF
-pxa
+map
 qGQ
 kEm
 xxm
@@ -126130,13 +132090,13 @@ dTO
 uiQ
 pxa
 eXp
-pxa
-pxa
+qDS
+qDS
 tUk
 uYo
 qKB
-pxa
-yey
+cAq
+jcJ
 amR
 ftg
 hqd
@@ -126265,20 +132225,20 @@ plf
 hGn
 qYg
 hGn
-gHT
+hBl
 fYS
-gHT
-alc
-gHT
-gHT
-gHT
-gHT
-gHT
-gHT
-alc
-gHT
+wtr
+sDu
+tVy
+tVy
+tVy
+tVy
+tVy
+tVy
+xao
+csG
 fYS
-mYW
+sEX
 srs
 rzN
 hSq
@@ -126364,15 +132324,15 @@ jdS
 pUP
 xyt
 fWT
-sAh
+ohP
 mGd
-dTO
-dTO
-dTO
+rcz
+cvs
+cvs
 aEZ
-dTO
+oTI
 cyh
-dTO
+gvn
 iDX
 ilZ
 oSU
@@ -126407,11 +132367,11 @@ hqd
 hqd
 plf
 sug
-yaN
-yaN
+qTU
+qTU
 sug
-yaN
-yaN
+qTU
+qTU
 sug
 kHU
 sug
@@ -126522,7 +132482,7 @@ plf
 yaE
 yaE
 yaE
-gHT
+hkD
 fYS
 rAq
 omV
@@ -126535,7 +132495,7 @@ paD
 omV
 uAC
 fYS
-mYW
+sEX
 srs
 nyv
 nyv
@@ -126615,33 +132575,33 @@ nyL
 vof
 rHU
 uuG
-xJb
-xJb
+kDi
+oen
 bCH
 vyx
 xyt
 isW
-gRg
-mvQ
-pxa
-pxa
-qKB
-pxa
-pxa
-giF
-pxa
+riX
+sQd
+qDS
+qDS
+iIq
+cAq
+qDS
+mmN
+jMv
 iQV
-pxa
+qDS
 sRN
 lkn
+jMv
+pxa
+cAq
+qDS
+jMv
 pxa
 pxa
-pxa
-pxa
-pxa
-pxa
-pxa
-gRg
+uVF
 kpr
 eOb
 kmx
@@ -126677,8 +132637,8 @@ mqe
 uHv
 iuC
 djE
-eAS
-mRu
+pyv
+dVh
 uei
 hpu
 plf
@@ -126779,7 +132739,7 @@ plf
 kHU
 aev
 dVZ
-gHT
+hkD
 fYS
 bNF
 omV
@@ -126790,7 +132750,7 @@ cbP
 xbG
 omV
 omV
-gHT
+csG
 kuh
 jQo
 srs
@@ -126872,14 +132832,14 @@ lNz
 muK
 sew
 xdM
-xJb
+kDi
 tZe
 iMh
-xxl
+dTR
 xxl
 ado
 iZg
-pxa
+rBd
 vYu
 pQP
 mne
@@ -126920,22 +132880,22 @@ pku
 kbr
 vEG
 gdJ
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
+hYY
+obI
+obI
+obI
+obI
+obI
+kGc
 ier
-mRu
-mRu
-mRu
+dVh
+dVh
+dVh
 pWA
 aAI
 hpu
 eAS
-mRu
+kpf
 foK
 hpu
 plf
@@ -127036,9 +132996,9 @@ plf
 kHU
 yaE
 yaE
-gHT
+hkD
 fYS
-gHT
+vDr
 omV
 vCQ
 cEE
@@ -127047,7 +133007,7 @@ jhj
 hfB
 aST
 omV
-gHT
+jMy
 fYS
 uDS
 srs
@@ -127154,7 +133114,7 @@ hqS
 lRD
 lRD
 sBD
-pxa
+jMv
 yey
 hZB
 rPr
@@ -127177,12 +133137,12 @@ hqd
 hqd
 hqd
 pTf
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
 mSl
 oDn
 uVq
@@ -127295,7 +133255,7 @@ kHU
 yaE
 dtY
 sTt
-gHT
+vDr
 hje
 sjK
 oJr
@@ -127304,7 +133264,7 @@ fMs
 aZA
 sqq
 cDr
-gHT
+jGc
 rxk
 hkW
 srs
@@ -127428,25 +133388,25 @@ hqd
 pku
 dTj
 hqd
-mRu
-mRu
-mRu
+syl
+syl
+syl
 ckw
-mRu
+syl
 pTf
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
+dPh
 ier
 mRu
-mRu
+mTY
 lTd
 kOx
-gJZ
+vFy
 bYq
 irL
 wps
@@ -127562,7 +133522,7 @@ poH
 rIM
 srs
 srs
-eyw
+boA
 srs
 srs
 fKS
@@ -127668,8 +133628,8 @@ wDh
 fMw
 leI
 sBD
-pxa
-yey
+qQK
+xZn
 kpr
 adj
 jmY
@@ -127685,11 +133645,11 @@ hqd
 pku
 dTj
 hqd
-mRu
-mRu
-mRu
-mRu
-mRu
+syl
+kpf
+kpf
+kpf
+kpf
 bLC
 gJZ
 gJZ
@@ -127697,7 +133657,7 @@ gJZ
 gJZ
 gJZ
 gJZ
-gJZ
+vFy
 moM
 wBB
 wBB
@@ -127706,7 +133666,7 @@ fab
 ykx
 hpu
 sWY
-vKb
+lVs
 cea
 djE
 plf
@@ -127807,9 +133767,9 @@ yaE
 yaE
 ffS
 cmm
-mYW
+nsh
 fYS
-raR
+eNH
 omV
 omV
 qGe
@@ -127929,7 +133889,7 @@ hdN
 sbk
 kpr
 wcD
-huZ
+xFi
 xFi
 eSA
 beJ
@@ -127942,18 +133902,18 @@ hqd
 pku
 dTj
 hqd
-mRu
-mRu
+syl
+kpf
 guO
 guO
 guO
 dKO
-mRu
+kpf
 guO
 guO
 guO
 guO
-mRu
+kpf
 rXN
 djE
 ljh
@@ -127962,7 +133922,7 @@ ljh
 ljh
 ljh
 djE
-sWY
+xmW
 vKb
 jtA
 djE
@@ -128043,30 +134003,30 @@ soF
 qNL
 xrO
 bjl
-gHT
-gHT
-gHT
+qQy
+uqt
+uqt
 xvB
-gHT
-gHT
-gHT
-gHT
-gHT
-gHT
-gHT
-gHT
-gHT
-gHT
-gHT
-gHT
+uqt
+uqt
+uqt
+uqt
+uqt
+uqt
+uqt
+uqt
+uqt
+uqt
+uqt
+uqt
 hwD
-gHT
-gHT
-gHT
+uqt
+uqt
+qba
 alc
 mYW
 fYS
-gHT
+vXE
 omV
 sNm
 wxH
@@ -128186,7 +134146,7 @@ pxa
 yey
 meR
 cRa
-huZ
+xFi
 xFi
 mYS
 beJ
@@ -128199,19 +134159,19 @@ hqd
 fyI
 dTj
 hqd
-mRu
-mRu
+syl
+kpf
 rmY
 oVL
 lJd
 rmY
-mRu
+kpf
 yfC
 nKi
 nKi
 lJd
-mRu
-mRu
+kpf
+rUL
 sug
 plf
 plf
@@ -128319,11 +134279,11 @@ oaP
 fYS
 fYS
 fYS
-gHT
+vUe
 alc
 mYW
 fYS
-gHT
+jrT
 cfk
 whM
 jmd
@@ -128414,7 +134374,7 @@ eQI
 vof
 bRY
 mSs
-oPI
+kzl
 adn
 hRl
 kzl
@@ -128443,7 +134403,7 @@ ing
 yey
 meR
 rJY
-huZ
+xFi
 xFi
 rJY
 beJ
@@ -128456,19 +134416,19 @@ hqd
 pku
 dTj
 hqd
-mRu
-mRu
+syl
+kpf
 kWl
 kWl
 kWl
 kWl
-mRu
+kpf
 kWl
 kWl
 kWl
 kWl
-mRu
-mRu
+kpf
+rUL
 sug
 plf
 plf
@@ -128557,7 +134517,7 @@ hcZ
 iaJ
 sRk
 yaE
-gHT
+jKS
 fcd
 wAG
 tqX
@@ -128565,22 +134525,22 @@ mFD
 tpD
 fkb
 iCe
-iMs
-iMs
-iMs
-iMs
-iMs
-iMs
-iMs
+wHm
+jDf
+mjl
+wHm
+wHm
+wHm
+jDf
 jeq
-nYg
+sua
 fFW
 pzf
-nYg
+hgH
 epk
 wdr
 gHT
-gHT
+psz
 omV
 xAU
 sTZ
@@ -128671,7 +134631,7 @@ xag
 vof
 tDl
 wLF
-oPI
+kzl
 xzh
 hRl
 kzl
@@ -128697,11 +134657,11 @@ fMw
 bOW
 sBD
 qjH
-yey
+xZn
 kpr
 eeT
 fBQ
-kpf
+fBQ
 mlF
 beJ
 vEK
@@ -128713,19 +134673,19 @@ hqd
 pku
 dTj
 hqd
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
+syl
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
+rUL
 sug
 plf
 plf
@@ -128823,13 +134783,13 @@ lgb
 lgb
 lgb
 mlH
-gHT
-gHT
+kma
+vUe
 cPu
 cPu
 cPu
-gHT
-uDS
+kma
+mZg
 mlH
 srs
 srs
@@ -128928,7 +134888,7 @@ azV
 psH
 nPb
 add
-oPI
+kzl
 ljv
 hRl
 ugB
@@ -128970,19 +134930,19 @@ hqd
 hqd
 xXS
 hqd
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
+syl
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
+rUL
 sug
 plf
 plf
@@ -129068,10 +135028,10 @@ plf
 plf
 ffS
 oub
-gHT
-gHT
+puT
+puT
 jor
-gHT
+csG
 lgb
 oLS
 eFQ
@@ -129185,7 +135145,7 @@ bhS
 uzP
 tDl
 ulr
-oPI
+kzl
 mNx
 hRl
 sNe
@@ -129210,7 +135170,7 @@ kdH
 qxl
 qxl
 vUq
-pxa
+gOn
 yey
 jwW
 npd
@@ -129221,25 +135181,25 @@ jfS
 vrA
 qtV
 npd
-mRu
+syl
 tmK
 unB
-mRu
-xgV
+syl
+gyn
 ckw
-mRu
-mRu
+syl
+kpf
+guO
+guO
+guO
+guO
+kpf
 guO
 guO
 guO
 guO
 mRu
-guO
-guO
-guO
-guO
-mRu
-mRu
+rUL
 sug
 plf
 plf
@@ -129325,24 +135285,24 @@ plf
 plf
 ffS
 kYu
-gHT
-gHT
-gHT
-gHT
+thA
+thA
+thA
+hkD
 lgb
-oLS
+fOS
 uLo
-ktC
-ktC
+fYv
+fYv
 ktC
 cMb
 sJa
 urR
-oLS
+tRY
 eBe
 qJA
 hoj
-oLS
+tRY
 aex
 pwd
 srs
@@ -129442,7 +135402,7 @@ ogP
 mso
 bRY
 mSs
-oPI
+kzl
 xzh
 hRl
 pSX
@@ -129478,24 +135438,24 @@ sbN
 uKh
 sHC
 npd
-mRu
+syl
 djc
 mUL
 meW
 bQo
-mRu
-mRu
-mRu
+kpf
+kpf
+kpf
 yfC
 nKi
 nKi
 lJd
-mRu
+kpf
 yfC
 nKi
 nKi
 lJd
-rXN
+kYf
 rmY
 rmY
 plf
@@ -129589,17 +135549,17 @@ yaE
 lgb
 wYB
 kXg
-oLS
-vGp
+rpj
+mHC
 vGp
 lgb
 vhM
 cQi
-gMy
-gMy
+oLp
+oLp
 vWh
-gMy
-gMy
+oLp
+oLp
 xOH
 gZp
 srs
@@ -129699,7 +135659,7 @@ ogP
 mso
 bRY
 mSs
-oPI
+kzl
 ljv
 hRl
 kzl
@@ -129735,24 +135695,24 @@ fxH
 cde
 kTm
 xLC
-tjB
+nav
 bAQ
-mRu
+kpf
 guO
 guO
 guO
 guO
-mRu
+kpf
 kWl
 kWl
 kWl
 kWl
-mRu
+kpf
 kWl
 kWl
 kWl
 kWl
-mRu
+rUL
 sug
 kHU
 plf
@@ -129856,7 +135816,7 @@ oyh
 eIE
 ayB
 jej
-oLS
+qtS
 pkm
 gMy
 dHA
@@ -129902,7 +135862,7 @@ sht
 sht
 sht
 utf
-osg
+dXa
 qlM
 osg
 pxS
@@ -129956,7 +135916,7 @@ ogP
 mso
 tDl
 mSs
-oPI
+kzl
 rYl
 taG
 kzl
@@ -129999,17 +135959,17 @@ eHc
 qPo
 qPo
 lTn
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
+rUL
 sug
 kHU
 plf
@@ -130122,7 +136082,7 @@ srs
 hrn
 hrn
 srs
-eyw
+boA
 srs
 srs
 pnq
@@ -130144,13 +136104,13 @@ quG
 snQ
 cpR
 hVo
-gaF
-gaF
-gaF
+hFG
+hFG
+hFG
 fqo
 iyr
-gaF
-gaF
+aOO
+xxv
 xtV
 oLK
 edQ
@@ -130158,9 +136118,9 @@ tpx
 nuP
 cpR
 oRv
-gaF
+ohw
 osg
-gaF
+ojt
 tpx
 gtB
 ejv
@@ -130214,7 +136174,7 @@ mso
 nPb
 gQq
 uPV
-sQd
+bUf
 vZA
 kzl
 nlc
@@ -130256,17 +136216,17 @@ fJU
 ryF
 ryF
 kiX
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
+rUL
 sug
 kHU
 plf
@@ -130406,18 +136366,18 @@ gaF
 gaF
 qQc
 gaF
-gaF
+ojm
 qee
 feP
-gaF
+ojt
 pit
 dmP
-gaF
+aUg
 tiC
 kxC
 kgH
 snW
-qQc
+smh
 gaF
 xoS
 uOv
@@ -130506,24 +136466,24 @@ npd
 npd
 tmK
 ckw
-mRu
+syl
 xgV
-mRu
+kpf
 kWl
 wdH
 kWl
 kWl
-mRu
+kpf
 guO
 guO
 guO
 guO
-mRu
+kpf
 dnT
 guO
 guO
 guO
-mRu
+rUL
 rmY
 rmY
 plf
@@ -130650,33 +136610,33 @@ eLs
 uQI
 aGL
 udw
-gaF
+ogc
 gaF
 vNs
 fED
 gRk
 aBY
 tII
-gaF
-gaF
-gaF
-gaF
+ojt
+ojt
+ojt
+ojt
 xuQ
-gaF
-gaF
+ojt
+ojm
 rcy
-gaF
+ojt
 igK
 xkd
 nEo
-nEo
+xYB
 rKp
 vtt
 mpS
 diU
 vje
 uqZ
-gaF
+snQ
 mEi
 hqz
 bzv
@@ -130712,7 +136672,7 @@ hEr
 hEr
 xCJ
 pAS
-hOf
+kRo
 mMA
 rZn
 rZn
@@ -130761,27 +136721,27 @@ eyY
 hDo
 ciN
 rmY
-mRu
+syl
 mRu
 mRu
 xgV
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
 yfC
 nKi
 nKi
 lJd
-mRu
+kpf
 rmY
 oVL
 lJd
 rmY
 mRu
-mRu
+rUL
 sug
 plf
 plf
@@ -130907,26 +136867,26 @@ eLs
 eLs
 aGL
 qZv
-gaF
+ogc
 kgH
 pre
 pre
 pre
 pre
 gaF
-gaF
+ojt
 miA
-gaF
+ojt
 onK
 xuQ
 oMj
-gaF
-gaF
-gaF
-gaF
-gaF
-gaF
-gaF
+ojm
+uuH
+ojt
+ojt
+ojt
+ojt
+gct
 tiC
 iMO
 dSx
@@ -131022,23 +136982,23 @@ tjB
 tjB
 tjB
 bjM
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
 kWl
 kWl
 kWl
 kWl
-mRu
+kpf
 kWl
 kWl
 kWl
 kWl
-mRu
-mRu
+kpf
+rUL
 sug
 plf
 plf
@@ -131164,25 +137124,25 @@ vOw
 vOw
 xze
 igj
-luA
+jvb
 pZs
 luA
 qwv
 luA
 luA
 luA
-luA
+fyx
 rUr
-luA
+fyx
 rha
 usV
 gsa
-lxv
-lxv
+gtO
+nul
 lxv
 pws
 rGA
-gaF
+ojt
 kIR
 cpR
 xCc
@@ -131278,24 +137238,24 @@ xeB
 mRu
 mRu
 mRu
-pTf
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
+iVc
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
+kpf
 mZB
-mRu
-mRu
-mRu
-mRu
+kpf
+kpf
+kpf
+rUL
 sug
 plf
 plf
@@ -131420,26 +137380,26 @@ seH
 eLs
 vIz
 aGL
-gaF
-gaF
-gaF
-gaF
+aUs
+nmH
+ojt
+ojt
 xuQ
-gaF
-gaF
-gaF
-gaF
-gaF
-gaF
-gaF
+ojt
+ojt
+ojt
+ojt
+ojt
+ojt
+ojt
 fnT
-gaF
-gaF
-iTb
-gaF
-osg
-gaF
-gaF
+ojt
+ojm
+uLP
+ojt
+iPW
+ojt
+ojt
 gng
 cpR
 cpR
@@ -131535,24 +137495,24 @@ xeB
 mRu
 mRu
 mRu
-pTf
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-mRu
-ngu
-ngu
-mRu
-mRu
-uhy
-mRu
-mRu
-mRu
+iVc
+kpf
+kpf
+kpf
+kpf
+kpf
+tFn
+oPI
+oPI
+oPI
+rKv
+rKv
+oPI
+oPI
+iyK
+oPI
+oPI
+xlc
 sug
 plf
 plf
@@ -131677,27 +137637,27 @@ seH
 eLs
 sjq
 aGL
-iij
+xAT
 gaF
-gaF
+ojt
 beO
 xuQ
 miA
-gaF
+ojt
 kNa
-gaF
+ojt
 kNa
-gaF
+ojt
 miA
 fnT
 kNa
-gaF
+ojm
 hhG
 igK
-tpx
+wTU
 lxv
 lxv
-pws
+jrs
 xqF
 smA
 oDh
@@ -131792,13 +137752,13 @@ rmY
 lxd
 mRu
 mRu
-pTf
+meu
 uhy
-mRu
-mRu
-mRu
-mRu
-rXN
+tFn
+tFn
+tFn
+tFn
+qms
 rmY
 rmY
 rmY
@@ -131936,31 +137896,31 @@ aGL
 aGL
 aED
 gaF
-gaF
+ojt
 dDF
 xuQ
 miA
-gaF
+ojt
 dDF
-gaF
+ojt
 miA
-gaF
+ojt
 beO
 fnT
 kNa
-gaF
+ojm
 cRT
 wdt
-gaF
-gaF
-qQc
-tpx
+ojt
+ojt
+smh
+mgQ
 eoI
 dcY
 vKm
-vKm
+bGg
 pMY
-vKm
+bGg
 hiv
 tCI
 lGt
@@ -132046,10 +138006,10 @@ hPN
 efB
 vNi
 rmY
-tmK
+fsC
 jdG
-mRu
-pTf
+tiS
+meu
 rmY
 iuv
 fdo
@@ -132190,22 +138150,22 @@ fTz
 cvE
 fTz
 fTz
-idI
+eOR
+nmH
 gaF
-gaF
-gaF
+ojt
 kNa
 xuQ
 dPT
-gaF
+ojt
 kNa
-gaF
+ojt
 luW
-gaF
+ojt
 miA
 fnT
 miA
-gaF
+ojm
 lPc
 gaF
 gaF
@@ -132293,7 +138253,7 @@ lHk
 bSq
 ahz
 aZF
-wJU
+bkq
 jis
 wOB
 lhw
@@ -132448,17 +138408,17 @@ wnv
 juQ
 fTz
 uXY
-gaF
-gaF
-gaF
+ojt
+ojt
+ojt
 adb
-vPX
+mwy
 bGb
-gaF
+ojt
 bGb
-gaF
+ojt
 bGb
-gaF
+ojt
 onK
 fVh
 adb
@@ -132518,7 +138478,7 @@ hoQ
 hBZ
 uwA
 nxQ
-vSe
+oBr
 xbZ
 vSv
 dEq
@@ -132565,12 +138525,12 @@ scJ
 cUU
 tpQ
 eiH
-kqE
-jde
+kUv
+ylb
 xzO
 kYy
 ydP
-kqE
+kUv
 eiH
 eiH
 mUR
@@ -132706,9 +138666,9 @@ xLK
 liC
 sDX
 sDX
-sDU
-gaF
-gaF
+pJa
+vke
+vke
 rZM
 rZM
 rZM
@@ -132719,7 +138679,7 @@ rZM
 rZM
 rZM
 rZM
-bGb
+vke
 twC
 qSZ
 qSZ
@@ -132962,20 +138922,20 @@ cie
 yhv
 fTz
 szt
-gaF
+ojt
 sDU
-gaF
-gaF
+ojt
+ojt
 wmd
-gaF
-gaF
-gaF
-gaF
-gaF
-gaF
-gaF
-gaF
-gaF
+ojt
+ojt
+ojt
+ojt
+ojt
+ojt
+ojt
+ojt
+ojt
 adb
 qSZ
 dAA
@@ -132988,7 +138948,7 @@ aAF
 iqI
 jWH
 riS
-riS
+kZj
 eCr
 lDY
 lGt
@@ -133028,7 +138988,7 @@ mKd
 xUx
 pIp
 aiy
-orJ
+pRj
 bYH
 fTi
 vJf
@@ -133086,9 +139046,9 @@ sAQ
 jky
 vNd
 dFs
-uiq
+ppz
 kKx
-jde
+htg
 mUR
 plf
 kHU
@@ -133218,34 +139178,34 @@ pjX
 cie
 kTj
 oWa
-gaF
-gaF
+uuH
+ojt
 uRa
-gaF
-gaF
+ojt
+ojt
 wmd
 xJI
 fqr
 kCL
 bbY
 bbY
-gaF
-gaF
-gaF
+ojt
+ojt
+ojt
 xJI
 qIe
 qSZ
 lva
-uYY
+rWL
 usB
-uYY
+rWL
 nQr
 twC
 iWT
 oOR
+kZj
 riS
-riS
-riS
+kZj
 wtb
 aBP
 lGt
@@ -133345,7 +139305,7 @@ cUU
 mtw
 gEt
 cUU
-jde
+huZ
 mUR
 mUR
 kHU
@@ -133475,11 +139435,11 @@ pjX
 kTj
 xwa
 oWa
-gaF
-gaF
+uuH
+ojt
 sDU
-gaF
-gaF
+ojt
+ojt
 fgh
 cpR
 cpR
@@ -133500,9 +139460,9 @@ sDB
 twC
 nsI
 oOR
-riS
-riS
-riS
+kZj
+kZj
+kZj
 wTB
 rut
 lGt
@@ -133530,10 +139490,10 @@ cTd
 xUx
 cOr
 fDP
-nTT
-vKG
+mTZ
+lCq
 caD
-vKG
+lCq
 fNC
 lkv
 lSb
@@ -133563,9 +139523,9 @@ bmM
 van
 akS
 fSl
-bZx
-bZx
-bZx
+krR
+krR
+krR
 qDW
 sfm
 xln
@@ -133602,7 +139562,7 @@ cUU
 mtw
 cUU
 cUU
-jde
+huZ
 kqE
 mUR
 plf
@@ -133732,11 +139692,11 @@ dmY
 olk
 fTz
 fTz
-gaF
-gaF
+ohw
+ojt
 sDU
-gaF
-gaF
+ojt
+ojt
 fgh
 cpR
 vZU
@@ -133781,18 +139741,18 @@ aUh
 xss
 fAN
 gmw
-uqt
+xWN
 emV
 pMC
 xUx
-eeZ
-fDP
-hDN
-vKG
+gjT
+oWH
+cox
+aiy
 dIW
-vKG
-hDN
-lkv
+aiy
+srS
+eou
 eeZ
 pBD
 gfQ
@@ -133990,10 +139950,10 @@ rNd
 eSt
 fTz
 ulA
-gaF
+ojt
 sDU
-gaF
-gaF
+ojt
+ojt
 fgh
 gsX
 vZU
@@ -134006,10 +139966,10 @@ vZU
 vZU
 kHU
 mTB
-mmg
-mmg
+jlU
+edm
 jJr
-mmg
+edm
 mmg
 jYV
 qIP
@@ -134038,19 +139998,19 @@ xmU
 mlK
 fCi
 gmw
-uqt
+xWN
 emV
 lVA
 xUx
 uPk
-aJo
-bAH
+jfQ
+gWE
 bAH
 yll
 xMC
-xMC
+aOp
 bce
-vKG
+hdR
 tdQ
 gfQ
 xUx
@@ -134116,7 +140076,7 @@ cUU
 mtw
 cUU
 cUU
-jde
+huZ
 kqE
 mUR
 plf
@@ -134247,10 +140207,10 @@ rNd
 rNd
 fTz
 gkS
-gaF
+ojt
 sDU
-gaF
-gaF
+ojt
+ojt
 fgh
 sVi
 vZU
@@ -134300,14 +140260,14 @@ emV
 fLY
 xUx
 heI
-vKG
-vKG
+aiy
+rgg
 sOp
 vXq
 hDN
-vKG
-vKG
-vKG
+hdR
+aiy
+hdR
 xpq
 gfQ
 xUx
@@ -134373,7 +140333,7 @@ cUU
 mtw
 gEt
 cUU
-jde
+huZ
 mUR
 mUR
 kHU
@@ -134504,11 +140464,11 @@ rNd
 rNd
 fTz
 jrW
-gaF
+ojt
 sDU
-gaF
-gaF
-gaF
+ojt
+ojt
+ojt
 pQj
 vZU
 vZU
@@ -134556,15 +140516,15 @@ xWN
 emV
 fLY
 aLa
-vKG
-vKG
-fNC
+rgg
+lCq
+mVv
 vwz
 iNz
 eOG
 nTT
-vKG
-vKG
+lCq
+hdR
 pBD
 gfQ
 xUx
@@ -134628,8 +140588,8 @@ eCe
 chl
 kxE
 udi
-kYy
-jde
+dLV
+tHA
 jde
 mUR
 plf
@@ -134761,10 +140721,10 @@ rNd
 sKT
 fTz
 cmY
-gaF
+ojt
 sDU
-gaF
-gaF
+ojt
+ojt
 iTb
 jqQ
 vZU
@@ -134778,7 +140738,7 @@ vZU
 kHU
 mTB
 ftS
-mmg
+mFh
 nRu
 caY
 jYV
@@ -134814,14 +140774,14 @@ tTA
 fLY
 xUx
 cQU
-vKG
+sSQ
 fwI
-vKG
+wrg
 cjy
 qNX
-iNz
+aip
 hlq
-vKG
+riw
 uaL
 kwI
 xUx
@@ -134848,9 +140808,9 @@ bmM
 iKm
 akS
 fSl
-bZx
-bZx
-bZx
+krR
+krR
+krR
 qDW
 sfm
 mUb
@@ -134859,7 +140819,7 @@ sfm
 ikm
 qSm
 bls
-kkE
+tnq
 mfb
 xRL
 bwO
@@ -135018,11 +140978,11 @@ rNd
 dAe
 fTz
 fTz
-gaF
+ojt
 sDU
 lkz
-gaF
-gaF
+ojt
+ojt
 pQj
 vZU
 vZU
@@ -135135,12 +141095,12 @@ mDI
 ctU
 cUU
 eiH
-kqE
-jde
+sEp
+tHA
 kYs
 uiq
 uch
-kqE
+sEp
 eiH
 eiH
 mUR
@@ -135275,7 +141235,7 @@ rNd
 rNd
 guW
 fTz
-gaF
+ojt
 etf
 sxQ
 sxQ
@@ -135325,7 +141285,7 @@ maQ
 hJf
 nOU
 sgr
-fLY
+dnn
 fJg
 uER
 hUR
@@ -135371,9 +141331,9 @@ xln
 oRY
 sfm
 qVv
-wnb
+uJK
 ark
-qsr
+mRB
 sfm
 vDC
 gas
@@ -135533,10 +141493,10 @@ rNd
 jcc
 fTz
 iij
-gaF
-gaF
-gaF
-gaF
+ojt
+ojt
+ojt
+ojt
 gsX
 vZU
 vZU
@@ -135790,9 +141750,9 @@ rNd
 clc
 fTz
 rPA
-gaF
+quG
 usK
-gaF
+quG
 rPA
 cpR
 vZU
@@ -135853,7 +141813,7 @@ vst
 vst
 vst
 oxx
-hjc
+cAF
 kAb
 wBb
 fnk
@@ -136096,7 +142056,7 @@ fsG
 xyC
 dny
 jXs
-fLY
+dnn
 aEr
 wPw
 jQy
@@ -136336,11 +142296,11 @@ kHU
 kHU
 kHU
 mBz
-kJs
+iEF
 jxX
 kHU
 jxX
-kJs
+iEF
 mBz
 kHU
 gUI
@@ -136353,7 +142313,7 @@ mjM
 xyC
 xWN
 jXs
-fLY
+dnn
 fJg
 eUf
 pwT
@@ -136365,9 +142325,9 @@ wzd
 eYX
 vst
 olT
-vKG
+kOi
 rgg
-rgg
+hdR
 fCz
 lBQ
 hdR
@@ -136399,7 +142359,7 @@ xln
 rkZ
 dIO
 lGE
-qDN
+gxY
 aqn
 lUU
 nau
@@ -136652,12 +142612,12 @@ mRE
 eqn
 uoV
 kXH
-tCo
+dYU
 itP
 sfm
-oHD
-bwO
-bwO
+kHZ
+xIq
+xJv
 bhy
 sfm
 iIt
@@ -136854,7 +142814,7 @@ opt
 kms
 cHH
 eow
-lNr
+opt
 goK
 hYT
 nsn
@@ -136881,7 +142841,7 @@ vst
 xUx
 xUx
 ize
-rgg
+hdR
 axb
 iXC
 hdR
@@ -136897,11 +142857,11 @@ imd
 gYm
 hgd
 jlH
-vKG
+hjc
 cAr
-vKG
-vKG
-lSb
+lCq
+lCq
+oGh
 kbS
 rzL
 bZx
@@ -137106,11 +143066,11 @@ poe
 leA
 cHH
 adG
-wcO
+iGB
 qJx
 tTk
 qMX
-oXA
+utF
 fKP
 vTX
 dhy
@@ -137128,7 +143088,7 @@ flQ
 pUN
 oCd
 bNq
-kJs
+tVx
 mQb
 ujC
 pHC
@@ -137186,10 +143146,10 @@ nPK
 nPK
 pne
 xby
-jzW
-tkH
+byH
+cJd
 egu
-tkH
+cJd
 dfI
 pne
 plf
@@ -137368,7 +143328,7 @@ ikW
 qXE
 rjb
 utF
-ohw
+bDv
 uLd
 lat
 nsn
@@ -137393,7 +143353,7 @@ wzd
 pHC
 vst
 hFn
-vKG
+kOi
 rgg
 tEg
 fCz
@@ -137412,7 +143372,7 @@ fek
 hWA
 lFK
 hMR
-vKG
+hdR
 sfm
 sfm
 tjw
@@ -137621,12 +143581,12 @@ sta
 cHH
 tSE
 fbb
-kJs
+gFh
 mHj
 cHH
 fsP
 kZT
-vSz
+suB
 cQR
 cHH
 uRO
@@ -137669,7 +143629,7 @@ xUx
 xUx
 xUx
 hMR
-vKG
+hdR
 sfm
 kkE
 tkF
@@ -137883,7 +143843,7 @@ kGr
 rjb
 bXA
 rfz
-vSz
+vzx
 gvj
 cHH
 pQo
@@ -137931,12 +143891,12 @@ sfm
 bwO
 pKu
 bJr
-lOw
+jXb
 lOw
 iUi
 jAu
 bJr
-lOw
+jXb
 iUi
 ycg
 yjE
@@ -138440,7 +144400,7 @@ vqQ
 mvv
 xUx
 xKj
-vKG
+hdR
 sfm
 glO
 kEZ
@@ -138451,7 +144411,7 @@ hCD
 sfm
 sfm
 ovN
-fbX
+vFo
 sfm
 fbX
 kEZ
@@ -138460,7 +144420,7 @@ xln
 kkE
 pyA
 sfm
-uiV
+aoy
 bwO
 sfm
 ogy
@@ -138670,7 +144630,7 @@ dGp
 kJs
 tRo
 gca
-vSz
+vzx
 aEM
 apq
 oYL
@@ -138697,18 +144657,18 @@ xUx
 xUx
 xUx
 hMR
-vKG
+hdR
 sfm
 tyb
 kEZ
 sfm
 mUb
 bwO
-xln
-xln
-whI
-kkE
-kkE
+gPd
+gPd
+acP
+beX
+fWA
 sfm
 qsr
 bTp
@@ -138938,21 +144898,21 @@ pWq
 oYL
 vst
 gSP
-vKG
-vKG
-vKG
-vKG
-vKG
+lCq
+lCq
+lCq
+lCq
+lCq
 tpp
 byk
-vKG
-vKG
-vKG
-vKG
+lCq
+lCq
+lCq
+lCq
 byk
-vKG
+lCq
 wri
-vKG
+lCq
 etv
 oJA
 sfm
@@ -138965,9 +144925,9 @@ gCM
 mUb
 nKx
 gzt
-kkE
+tnq
 ecm
-xln
+cQO
 mUb
 lAe
 ohZ
@@ -139194,7 +145154,7 @@ gYo
 uBW
 iBx
 vst
-lSb
+hIf
 kgj
 uNd
 sUU
@@ -139211,7 +145171,7 @@ mti
 tPs
 uNd
 cfY
-vKG
+hdR
 sfm
 iZy
 qMB
@@ -139224,7 +145184,7 @@ qDN
 nFa
 bwO
 sfm
-xln
+uKt
 mUb
 mUb
 bwO
@@ -139473,13 +145433,13 @@ sfm
 kkE
 kEZ
 sfm
-nKx
+iNR
 whI
 whI
-kkE
-kkE
+kSW
+kSW
 qMB
-kkE
+pxn
 sfm
 fbX
 fbX
@@ -139982,7 +145942,7 @@ lzO
 crz
 xUx
 gex
-vKG
+hdR
 sfm
 bwO
 kEZ
@@ -139992,7 +145952,7 @@ kkE
 kkE
 bwO
 kkE
-kEZ
+lGF
 kkE
 kkE
 bwO
@@ -140496,10 +146456,10 @@ wgL
 rDT
 xUx
 gex
-vKG
+hdR
 sfm
 bwO
-uiV
+aoy
 bwO
 sfm
 xsw
@@ -140679,8 +146639,8 @@ qZx
 aXC
 ieR
 pLw
-oAx
-oAx
+unD
+unD
 oAx
 ulK
 eyO
@@ -140702,7 +146662,7 @@ afw
 afw
 mxH
 sck
-rpj
+eZh
 eZh
 pjw
 qqG
@@ -140763,11 +146723,11 @@ kSQ
 sfm
 mXp
 qVM
-kkE
-tyb
+aTU
+yig
 wkj
 sfm
-voR
+vah
 sfm
 aeo
 jWr
@@ -140937,7 +146897,7 @@ kNn
 kyX
 wAP
 gfl
-bZu
+mbl
 pez
 wjC
 iun
@@ -140959,8 +146919,8 @@ afw
 nHb
 wGW
 pNw
-rbY
-rbY
+eZh
+eZh
 rbY
 luP
 krl
@@ -141018,11 +146978,11 @@ vlH
 dJL
 plf
 sfm
-whI
-ohZ
-kkE
+pSP
+urO
+qVx
 mUb
-xln
+oUF
 sfm
 bAC
 sfm
@@ -141194,7 +147154,7 @@ uic
 yhj
 oPc
 qtj
-bZu
+mbl
 neO
 wjC
 wJR
@@ -141215,10 +147175,10 @@ kHU
 ugF
 nQR
 pmn
-rbY
+gHG
 jax
 aHY
-rbY
+mzF
 luP
 bzN
 jGU
@@ -141232,8 +147192,8 @@ ilq
 uKd
 sxG
 uOc
-tVy
-tVy
+hur
+hur
 hur
 ekd
 lZw
@@ -141258,15 +147218,15 @@ ncp
 ncp
 ncp
 ncp
-mWz
+hbR
 mWz
 jFj
-dAh
-dAh
-dAh
-dAh
-dAh
-dAh
+qhu
+pey
+pey
+pey
+pey
+xvu
 lQK
 mWz
 eRS
@@ -141275,10 +147235,10 @@ hMc
 adB
 kHU
 xsw
-whI
+pSP
+cNp
 mUb
-mUb
-rNY
+hCo
 mUb
 xsw
 hFR
@@ -141472,10 +147432,10 @@ plf
 ugF
 hxi
 hbh
-rbY
+gHG
 ozC
 ybL
-rbY
+chf
 luP
 nEe
 iTl
@@ -141515,7 +147475,7 @@ obL
 ncp
 ncp
 ncp
-mWz
+hbR
 mWz
 mmq
 kLd
@@ -141708,7 +147668,7 @@ vVM
 onb
 wAP
 hEv
-bZu
+mbl
 akB
 wjC
 wjC
@@ -141772,7 +147732,7 @@ ncp
 ncp
 ncp
 tDV
-mWz
+hbR
 mWz
 tun
 ogZ
@@ -141785,7 +147745,7 @@ ram
 mWz
 ucd
 mWz
-mWz
+lCj
 adB
 kHU
 kHU
@@ -141964,8 +147924,8 @@ vtZ
 hcP
 nWz
 mOu
-bZu
-bZu
+mbl
+mbl
 qpW
 wVg
 qum
@@ -142007,7 +147967,7 @@ fUB
 fUB
 fUB
 fUB
-fUB
+mxb
 tAW
 uKd
 cHH
@@ -142029,7 +147989,7 @@ ncp
 ncp
 ncp
 tDV
-mWz
+hbR
 mWz
 mmq
 ogZ
@@ -142042,7 +148002,7 @@ ram
 mWz
 qnB
 mWz
-mWz
+lCj
 adB
 kHU
 kHU
@@ -142286,7 +148246,7 @@ ige
 ncp
 ncp
 ncp
-mWz
+hbR
 mWz
 mmq
 sIY
@@ -142543,15 +148503,15 @@ ncp
 ncp
 ncp
 ncp
-mWz
+hbR
 mWz
 oKH
-mWz
-mWz
-mWz
-mWz
-mWz
-mWz
+gjF
+kiT
+kiT
+kiT
+kiT
+lNr
 tPt
 dAh
 mMt
@@ -142800,15 +148760,15 @@ iLa
 xEl
 nvA
 qCm
-onG
+jRa
 onG
 wmz
 onG
 onG
-onG
-onG
+aJo
+aJo
 vFz
-onG
+aJo
 lgZ
 wud
 oTT
@@ -143316,8 +149276,8 @@ fMh
 plf
 dJL
 nRG
-mWz
-mWz
+oXA
+oXA
 nJn
 dJL
 plf
@@ -144034,7 +149994,7 @@ uix
 vnX
 hUq
 dhY
-bZu
+nYJ
 dYQ
 ffr
 dYQ
@@ -146657,8 +152617,8 @@ fMh
 plf
 dJL
 nRG
-mWz
-mWz
+oXA
+oXA
 nJn
 dJL
 plf
@@ -147429,7 +153389,7 @@ kHU
 dJL
 gcj
 fvE
-mWz
+eYy
 sYC
 dJL
 kHU


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Подтянуты новые плиточки из палитры Тапора и теперь почти везде используется оригинальная покраска с ТГ. Мало трогал техи так как там надо будет думать когда будет задача их наполнить. Также не создавал декали в местах "полуразрушенных", так как вставка там плиток игроками на нашем билде не "починит картинку", оставляя обрывки цветов на своих местах. Или может я чего-то не знаю.

![2023 05 28-15 58 40](https://github.com/TauCetiStation/TauCetiClassic/assets/96499407/374d8358-53bc-4b0d-b4b0-f0fac4257bf2)

## Почему и что этот ПР улучшит
Выполнение пункта TODO для дельты из закрепов мап-канала
## Авторство

## Чеинжлог
