### PR TITLE
Replicator Mines Don't Give Out Nearby Replicators

### DIFF
--- a/code/controllers/subsystem/mobs/chunks.dm
+++ b/code/controllers/subsystem/mobs/chunks.dm
@@ -87,11 +87,10 @@ SUBSYSTEM_DEF(chunks)
 /datum/chunk/proc/has_enemy_faction(faction)
 	update()
 
-	for(var/other_faction in factions)
-		if(other_faction != faction)
-			return TRUE
+	if(length(factions) == 1 && !LAZYACCESS(factions, faction))
+		return TRUE
 
-	return FALSE
+	return length(factions) >= 2
 
 /datum/chunk/proc/has_ally_faction(faction)
 	update()

--- a/code/controllers/subsystem/mobs/chunks.dm
+++ b/code/controllers/subsystem/mobs/chunks.dm
@@ -39,11 +39,11 @@ SUBSYSTEM_DEF(chunks)
 
 	zone.add_faction(L.faction)
 
-/datum/controller/subsystem/chunks/proc/has_enemy_faction(atom/A, faction ,range)
+/datum/controller/subsystem/chunks/proc/get_chunks_in_range(atom/A, range)
 	var/turf/T = get_turf(A)
 
 	if(!T || T.z > grid.len)
-		return FALSE
+		return null
 
 	var/z_grid = grid[T.z]
 	var/x_start = GRID_ELEM(max(1, (T.x - range)))
@@ -51,43 +51,57 @@ SUBSYSTEM_DEF(chunks)
 	var/y_start = GRID_ELEM(max(1, (T.y - range)))
 	var/y_end = GRID_ELEM(min(world.maxx, T.y + range))
 
+	. = list()
 	for(var/x_ in x_start to x_end)
 		for(var/y_ in y_start to y_end)
 			var/datum/chunk/chunk = z_grid[x_][y_]
+			. += chunk
 
-			if(chunk.has_enemy_faction(faction))
-				return TRUE
+/datum/controller/subsystem/chunks/proc/has_enemy_faction(atom/A, faction ,range)
+	for(var/datum/chunk/chunk as anything in get_chunks_in_range(A, range))
+		if(chunk.has_enemy_faction(faction))
+			return TRUE
 
 	return FALSE
 
+/datum/controller/subsystem/chunks/proc/has_ally_faction(atom/A, faction ,range)
+	for(var/datum/chunk/chunk as anything in get_chunks_in_range(A, range))
+		if(chunk.has_ally_faction(faction))
+			return TRUE
+
+	return FALSE
+
+
 /datum/chunk
 	var/last_updated
-	var/faction = null
-	var/conflict = FALSE
+
+	var/list/factions
 
 /datum/chunk/proc/update()
-	if (last_updated == SSchunks.tick)
+	if(last_updated == SSchunks.tick)
 		return
 
 	last_updated = SSchunks.tick
-	faction = null
-	conflict = FALSE
+	factions = null
 
 /datum/chunk/proc/has_enemy_faction(faction)
 	update()
 
-	if(conflict)
-		return conflict
+	for(var/other_faction in factions)
+		if(other_faction != faction)
+			return TRUE
 
-	return src.faction && (src.faction != faction)
+	return FALSE
+
+/datum/chunk/proc/has_ally_faction(faction)
+	update()
+
+	return LAZYACCESS(factions, faction)
 
 /datum/chunk/proc/add_faction(faction)
 	update()
 
-	if(!src.faction)
-		src.faction = faction
-	else if(src.faction != faction)
-		conflict = TRUE
+	LAZYSET(factions, faction, TRUE)
 
 #undef GRID_ELEM
 #undef GRID_STEP


### PR DESCRIPTION
## Описание изменений

https://github.com/TauCetiStation/TauCetiClassic/pull/11435

Ожидание: Репликаторы юзают мины чтобы экипаж запутался и бегал за несуществующим репликатором
Реальность: Репликатор ставит мину чтобы прикрыть подходы к нему, и этим палится

Этот ПР делает так, что если в пределах видимости репликатора есть мина она не будет пиликать (если он хочет пиликать он может что-то поразбирать)

## Почему и что этот ПР улучшит

Репликаторы имеют инструмент "стелса" который не делает им же хуже

## Чеинжлог
:cl: Luduk
- tweak: Репликаторские мины не бибикают если рядом есть репликатор.