### PR TITLE
cargo starting money

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -470,7 +470,7 @@ SUBSYSTEM_DEF(job)
 			H.forceMove(spawn_mark.loc, keep_buckled = TRUE)
 
 	//give them an account in the station database
-	var/datum/money_account/M = create_random_account_and_store_in_mind(H, job.salary, job.department_stocks)	//starting funds = salary
+	var/datum/money_account/M = create_random_account_and_store_in_mind(H, job.salary + job.starting_money, job.department_stocks)	//starting funds = salary
 
 	// If they're head, give them the account info for their department
 	if(H.mind && job.head_position)

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -11,6 +11,7 @@
 	idtype = /obj/item/weapon/card/id/cargoGold
 	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mint, access_mining, access_mining_station, access_recycler)
 	salary = 0
+	starting_money = 60
 	minimal_player_ingame_minutes = 960
 	outfit = /datum/outfit/job/qm
 	skillsets = list("Quartermaster" = /datum/skillset/quartermaster)
@@ -37,6 +38,7 @@
 	idtype = /obj/item/weapon/card/id/cargo
 	access = list(access_maint_tunnels, access_cargo, access_cargo_bot, access_mailsorting)
 	salary = 0
+	starting_money = 25
 	minimal_player_ingame_minutes = 480
 	outfit = /datum/outfit/job/cargo_tech
 	skillsets = list("Cargo Technician" = /datum/skillset/cargotech)
@@ -56,6 +58,7 @@
 	idtype = /obj/item/weapon/card/id/cargo
 	access = list(access_mining, access_mint, access_mining_station, access_mailsorting)
 	salary = 0
+	starting_money = 30
 	minimal_player_ingame_minutes = 480
 	outfit = /datum/outfit/job/mining
 	skillsets = list("Shaft Miner" = /datum/skillset/miner)
@@ -75,6 +78,7 @@
 	idtype = /obj/item/weapon/card/id/cargo
 	access = list(access_mailsorting, access_recycler)
 	salary = 0
+	starting_money = 20
 	minimal_player_ingame_minutes = 480
 	outfit = /datum/outfit/job/recycler
 	skillsets = list("Recycler" = /datum/skillset/recycler)

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -54,6 +54,8 @@
 	var/salary = 0
 	//salary ratio - for global salary changes
 	var/salary_ratio = 1
+	// Some jobs don't have a salary but still would like to eat roundstart. They have some starting money.
+	var/starting_money = 0
 
 	/*
 		HEY YOU!


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Каргонцы из-за отсутствия зарплат спавнятся совсем без денег но при этом могут приехать голодными, что как мне кажется не очень честно/интересно

Изначально думал что это может побуждать каргонцев продавать свои стартовые акции в обмен на раундстарт еду но:
а) никто так не делает
б) звучит как-то глупо

Поэтому каргонцам вопреки отсутствию зарплаты даётся стартовых денег на покушать.

## Почему и что этот ПР улучшит

QoL

## Чеинжлог
:cl: Luduk
- tweak: Вопреки отсутствию зарплат каргонцы прилетают с небольшой деньгой.