### PR TITLE
Closets nerf

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -67,12 +67,12 @@
 	for(var/obj/effect/dummy/chameleon/AD in src)
 		AD.forceMove(src.loc)
 
-	for(var/obj/I in src)
-		I.forceMove(src.loc)
-
 	for(var/mob/M in src)
 		M.forceMove(src.loc)
 		M.instant_vision_update(0)
+
+	for(var/obj/I in src)
+		I.forceMove(src.loc)
 
 /obj/structure/closet/proc/collect_contents()
 	var/itemcount = 0

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -32,12 +32,7 @@
 
 	playsound(src, 'sound/machines/click.ogg', VOL_EFFECTS_MASTER, 15, FALSE, null, -3)
 
-	for(var/obj/O in src)
-		O.forceMove(get_turf(src))
-
-	for(var/mob/M in src)
-		M.forceMove(src.loc)
-		M.instant_vision_update(0)
+	dump_contents()
 
 	icon_state = icon_opened
 	src.opened = 1


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Шкафы теперь выбрасывают сначала людей, а потом уже вещи. Должно пофиксить абузы с тригером всяких OnEntered ловушек закрытием/открытием шкафов с людьми. 

Отчасти связано с #11366

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог

:cl: 
 - tweak: Шкафы больше не тригерят различные ловушки на людей постоянным открытием/закрытием.