### PR TITLE
Insurance fixes

### DIFF
--- a/code/controllers/subsystem/economy.dm
+++ b/code/controllers/subsystem/economy.dm
@@ -13,6 +13,7 @@ SUBSYSTEM_DEF(economy)
 	var/list/department_dividends
 	var/list/stock_splits
 	var/list/insurance_prices = list(INSURANCE_NONE = 0, INSURANCE_STANDARD = 10, INSURANCE_PREMIUM = 40)
+	var/list/roundstart_insurance_prices = list(INSURANCE_NONE = 0, INSURANCE_STANDARD = 10, INSURANCE_PREMIUM = 40)
 	var/list/insurance_quality_decreasing = list(INSURANCE_PREMIUM, INSURANCE_STANDARD, INSURANCE_NONE)
 
 
@@ -171,20 +172,20 @@ SUBSYSTEM_DEF(economy)
 	return R.fields["insurance_type"]
 
 
-/proc/get_next_insurance_type(current_insurance_type, datum/money_account/MA)
+/proc/get_next_insurance_type(current_insurance_type, datum/money_account/MA, list/insurance_prices=SSeconomy.insurance_prices)
 	if(MA.suspended)
 		return INSURANCE_NONE
 
-	var/current_insurance_price = SSeconomy.insurance_prices[current_insurance_type]
+	var/current_insurance_price = insurance_prices[current_insurance_type]
 	if(current_insurance_type == MA.owner_preferred_insurance_type && MA.money >= current_insurance_price  && MA.owner_max_insurance_payment >= current_insurance_price)
 		return current_insurance_type
 
-	var/prefprice = SSeconomy.insurance_prices[MA.owner_preferred_insurance_type]
+	var/prefprice = insurance_prices[MA.owner_preferred_insurance_type]
 	if(MA.money >= prefprice && MA.owner_max_insurance_payment >= prefprice)
 		return MA.owner_preferred_insurance_type
 
 	for(var/insurance_type in SSeconomy.insurance_quality_decreasing)
-		var/insprice = SSeconomy.insurance_prices[insurance_type]
+		var/insprice = insurance_prices[insurance_type]
 		if(MA.money >= insprice && MA.owner_max_insurance_payment >= insprice)
 			return insurance_type
 

--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -588,13 +588,11 @@ SUBSYSTEM_DEF(job)
 				C.associated_account_number = MA.account_number
 				MA.set_salary(job.salary, job.salary_ratio)	//set the salary equal to job
 				MA.owner_preferred_insurance_type = job.is_head ? SSeconomy.insurance_quality_decreasing[1] : H.roundstart_insurance
-				MA.owner_max_insurance_payment = SSeconomy.insurance_prices[H.roundstart_insurance]
-
-				var/insurance_type = get_next_insurance_type(H.roundstart_insurance, MA)
+				MA.owner_max_insurance_payment = job.is_head ? SSeconomy.roundstart_insurance_prices[MA.owner_preferred_insurance_type] : SSeconomy.roundstart_insurance_prices[H.roundstart_insurance]
+				var/insurance_type = get_next_insurance_type(H.roundstart_insurance, MA, SSeconomy.roundstart_insurance_prices)
 				H.roundstart_insurance = insurance_type
-
 				var/med_account_number = global.department_accounts["Medical"].account_number
-				var/insurance_price = SSeconomy.insurance_prices[insurance_type]
+				var/insurance_price = SSeconomy.roundstart_insurance_prices[insurance_type]
 				charge_to_account(med_account_number, med_account_number, "[insurance_type] Insurance payment", "NT Insurance", insurance_price)
 				charge_to_account(MA.account_number, "Medical", "[insurance_type] Insurance payment", "NT Insurance", -insurance_price)
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Исправил недочёт с премиум страховкой у глав (они просто с префом на премиум спавнились, без самого премиума) #11477 

Теперь есть 2 списка цен страховок:
1-основной (эти цены будут списываться у игроков в процессе раунда, и их СМО может менять)
2-список базовых цен (этот список хранит раундстартовые цены страховок и в процессе раунда не меняется)

зачем второй список?
допустим начальная цена Premium страховки равна 40, а СМО в процессе раунда поменяет её цену на 500 кредитов. У зашедших после этого в раунд игроков с префом на Premium страховку всёравно спишется 40 (т.е непредвиденных трат при заходе в раунд не будет).
## Почему и что этот ПР улучшит
фича с премиум страховкой у глав заработает
у хуманов не будет списываться больше, чем должно при заходе в раунд
## Авторство

## Чеинжлог
