### PR TITLE
Living shileds refactoring

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -321,7 +321,7 @@
 #define COMSIG_XENO_TURF_CLICK_CTRL "xeno_turf_click_alt"
 /// from monkey CtrlClickOn(): (/mob)
 #define COMSIG_XENO_MONKEY_CLICK_CTRL "xeno_monkey_click_ctrl"
-/// from mob/living/check_shields(): (atom/attacker, damage, attack_text, hit_dir)
+/// from mob/living/prob_shields(): (atom/attacker, damage, attack_text, hit_dir)
 #define COMSIG_LIVING_CHECK_SHIELDS "check_shields"
 	#define COMPONENT_ATTACK_SHIELDED 1
 // from mob/living/learn_combo(): (datum/combat_combo/combo, datum/combat_moveset/moveset)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -233,7 +233,7 @@
 
 	if(user != M)
 		user.do_attack_animation(M)
-		if(M.check_shields(src, force, "the [name]", get_dir(user, M) ))
+		if(M.prob_shields(src, force, "the [name]", get_dir(user, M) ))
 			return FALSE
 
 	. = M.attacked_by(src, user, def_zone, power)

--- a/code/datums/components/forcefield.dm
+++ b/code/datums/components/forcefield.dm
@@ -52,7 +52,7 @@
  * After destroying shield waits for reactivate_time before beggining to rechage.
  * Shields require recharge_time amount of ticks to get fully charged from 0 health to max_health.
  *
- * Currently only /mob-s utilize the check_shields() mechanic, but forcefields can be applied to any /atom.
+ * Currently only /mob-s utilize the prob_shields() mechanic, but forcefields can be applied to any /atom.
  */
 /datum/component/forcefield
 	/// The name of the shield.

--- a/code/datums/components/swiping.dm
+++ b/code/datums/components/swiping.dm
@@ -338,7 +338,7 @@
 	else if(def_zone == BP_R_ARM && istype(target.r_hand, /obj/item/weapon/shield))
 		S = target.r_hand
 
-	if(S && prob(S.Get_shield_chance()))
+	if(S && prob(S.get_shield_chance()))
 		user.visible_message("<span class='warning'>[user] knocks [target] down with \a [src]!</span>", "<span class='warning'>You knock [target] down with \a [src]!</span>")
 		if(target.buckled)
 			target.buckled.user_unbuckle_mob(target)

--- a/code/game/gamemodes/modes_gameplays/changeling/powers/mutations.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/mutations.dm
@@ -187,7 +187,7 @@
 		if(C.absorbedcount)
 			remaining_uses +=  C.absorbedcount
 
-/obj/item/weapon/shield/changeling/Get_shield_chance()
+/obj/item/weapon/shield/changeling/get_shield_chance()
 	if(!remaining_uses)
 		if(ishuman(loc))
 			var/mob/living/carbon/human/H = loc

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -775,7 +775,7 @@
 /obj/item/proc/IsReflect(def_zone, hol_dir, hit_dir) //This proc determines if and at what% an object will reflect energy projectiles if it's in l_hand,r_hand or wear_suit
 	return FALSE
 
-/obj/item/proc/Get_shield_chance()
+/obj/item/proc/get_shield_chance()
 	return 0
 
 /obj/item/proc/get_loc_turf()

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -28,7 +28,7 @@
 
 	melee_attack_chain(target, user)
 
-	if(isliving(target) && prob(Get_shield_chance())) // Better shields have more chance to stun.
+	if(isliving(target) && prob(get_shield_chance())) // Better shields have more chance to stun.
 		var/mob/living/M = target
 		user.visible_message("<span class='warning'>[M] is stunned by [user] with [src]!</span>", "<span class='warning'>You stun [M] with [src]!</span>")
 		if(M.buckled)
@@ -115,7 +115,7 @@
 	if(wall_of_shield_on)
 		disable_wallshield(user)
 
-/obj/item/weapon/shield/Get_shield_chance()
+/obj/item/weapon/shield/get_shield_chance()
 	var/mob/living/carbon/human/M = loc
 	if(!M || !M.is_in_hands(src) || !wall_of_shield_on)
 		return block_chance
@@ -270,7 +270,7 @@
 /obj/item/weapon/shield/riot/tele/proc/can_sweep_push(mob/user)
 	return active
 
-/obj/item/weapon/shield/riot/tele/Get_shield_chance()
+/obj/item/weapon/shield/riot/tele/get_shield_chance()
 	if(active)
 		return ..()
 	return 0

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -19,7 +19,7 @@
 /*
  * Sword
  */
-/obj/item/weapon/melee/energy/sword/Get_shield_chance()
+/obj/item/weapon/melee/energy/sword/get_shield_chance()
 	if(active)
 		return 40
 	return 0
@@ -289,7 +289,7 @@
 /*
  * Energy Shield
  */
-/obj/item/weapon/shield/energy/Get_shield_chance()
+/obj/item/weapon/shield/energy/get_shield_chance()
 	if(active)
 		return block_chance
 	return 0

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -156,7 +156,7 @@
 				user.set_dir(i)
 				sleep(1)
 
-/obj/item/weapon/dualsaber/Get_shield_chance()
+/obj/item/weapon/dualsaber/get_shield_chance()
 	if(HAS_TRAIT(src, TRAIT_DOUBLE_WIELDED) && !slicing)
 		return reflect_chance * DUALSABER_BLOCK_CHANCE_MODIFIER - 5
 	else

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -33,7 +33,7 @@
 	w_class = SIZE_SMALL
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 
-/obj/item/weapon/claymore/Get_shield_chance()
+/obj/item/weapon/claymore/get_shield_chance()
 	return 50
 
 /obj/item/weapon/claymore/suicide_act(mob/user)
@@ -63,7 +63,7 @@
 	to_chat(viewers(user), "<span class='warning'><b>[user] is slitting \his stomach open with the [src.name]! It looks like \he's trying to commit seppuku.</b></span>")
 	return(BRUTELOSS)
 
-/obj/item/weapon/katana/Get_shield_chance()
+/obj/item/weapon/katana/get_shield_chance()
 		return 50
 
 /obj/item/weapon/harpoon

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -242,7 +242,7 @@
 	slowdown = 0.5
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
 
-/obj/item/clothing/suit/armor/reactive/Get_shield_chance()
+/obj/item/clothing/suit/armor/reactive/get_shield_chance()
 	if(active)
 		return 35
 	return 0

--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -121,7 +121,7 @@
 	. = ..()
 	blade_color = "red"
 
-/obj/item/weapon/holo/esword/Get_shield_chance()
+/obj/item/weapon/holo/esword/get_shield_chance()
 	if(active)
 		return 50
 	return 0

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -646,3 +646,13 @@
 			bad = 1
 		if(!bad)
 			to_chat(user, "<span class='notice'>[H]'s skin is normal.</span>")
+
+// mob as shield, should be less effective than real shields
+/obj/item/weapon/grab/get_shield_chance()
+	if(state < GRAB_NECK)
+		return 0
+
+	if(affecting.lying) // we need it?
+		return 0
+
+	return (affecting.w_class * 5) // 5% to block with mouse (squeek!), 35% for humans

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -85,20 +85,6 @@
 	shot_from = null
 	return ..()
 
-
-/obj/item/projectile/proc/check_living_shield(mob/living/carbon/human/H)
-	var/obj/item/weapon/grab/grab = null
-	if(istype(H.r_hand,/obj/item/weapon/grab))
-		grab = H.r_hand
-	else if(istype(H.l_hand,/obj/item/weapon/grab))
-		grab = H.l_hand
-	if(!grab)
-		return H
-	if(grab.state >= GRAB_NECK && !grab.affecting.lying)
-		if(is_the_opposite_dir(H.dir, dir))
-			return grab.affecting
-	return H
-
 /obj/item/projectile/proc/on_hit(atom/target, def_zone = BP_CHEST, blocked = 0) // why we have this and on_impact at the same time
 	if(!isliving(target))
 		return 0
@@ -110,7 +96,7 @@
 		L.IgniteMob(target)
 	return L.apply_effects(stun, weaken, paralyze, irradiate, stutter, eyeblur, drowsy, agony, blocked) // add in AGONY!
 
-	//called when the projectile stops flying because it collided with something
+//called when the projectile stops flying because it collided with something
 /obj/item/projectile/proc/on_impact(atom/A)
 	impact_effect(effect_transform)		// generate impact effect
 	if(proj_impact_sound)
@@ -185,9 +171,10 @@
 			forcedodge = PROJECTILE_FORCE_MISS
 
 	if(!forcedodge)
-		if(M && ishuman(M))
+		/*if(M && ishuman(M))
 			M = check_living_shield(A)
 			A = M
+		*/
 
 		forcedodge = A.bullet_act(src, def_zone) // searches for return value
 
@@ -205,7 +192,7 @@
 
 		return FALSE
 
-	else if(M)
+	else if(M) // todo: move to bullet_act; todo2: def_zone == null?
 		if(silenced)
 			to_chat(M, "<span class='userdanger'>You've been shot in the [parse_zone(def_zone)] by the [src.name]!</span>")
 		else if(!fake)
@@ -224,7 +211,7 @@
 			Mob.bullet_act(src, def_zone)
 
 	//stop flying
-	on_impact(A)
+	on_impact(A) // todo: merge with on_hit
 
 	density = FALSE
 	invisibility = 101

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -185,7 +185,7 @@
 	if(target.try_inject(user, FALSE, TRUE))
 		target.log_combat(user, "stabbed with [name] (INTENT: [uppertext(user.a_intent)])")
 
-		if((user != target) && target.check_shields(src, 7, "the [src.name]", get_dir(user,target)))
+		if((user != target) && target.prob_shields(src, 7, "the [src.name]", get_dir(user,target)))
 			return
 
 		if(ishuman(target))

--- a/code/modules/unarmed_combat/living_procs_defines.dm
+++ b/code/modules/unarmed_combat/living_procs_defines.dm
@@ -144,7 +144,7 @@
 		return FALSE
 
 	var/list/attack_obj = attacker.get_unarmed_attack()
-	if((attacker != src) && check_shields(attacker, attack_obj["damage"], attacker.name, get_dir(attacker, src)))
+	if((attacker != src) && prob_shields(attacker, attack_obj["damage"], attacker.name, get_dir(attacker, src)))
 		attacker.do_attack_animation(src)
 		visible_message("<span class='warning bold'>[attacker] attempted to touch [src]!</span>")
 		return FALSE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Для обсуждения, по мотивам #11389. Живой щит сейчас реализован очень тупо и криво, его нужно или выпиливать, или фиксить.

Для начала, это вообще была не система живого щита, а просто прикрывание грабом любым мобом. В случае живого щита опасность должна исходить прежде всего не из того, что случайно при стрельбе заденут щит, а из того, что этого заложника пристрелит держащий его человоек. У нас такого механа нету, не впилили, и я впиливать тоже не буду - инстакиллы это отдельный, сложный вопрос баланса.

В ПР-е просто рефакторинг под уже существующую систему щитов, буквально добавление ``/obj/item/weapon/grab/get_shield_chance()``. Человек в грабе не будет отличаться от специального щита, и (новая фича) будет с определенным шансом блокировать не только выстрелы, но и летающие тулбоксы и удары балоном (редирект урона еще не везде сделан).

Добавлена зависимость шанса от размера моба, мыши-щиты станут фичей, а не багом.

Теперь только встаёт вопрос, может нужно добавить ``get_shield_chance()`` и для всех остальных предметов в руках, с небольшим шансом в зависимости от размера...

И на будущее, для более корректной работы, следовало бы впилить изменение размера моба при отсутствии у него конечностей.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
