### PR TITLE
нерф дуалсейбера

### DIFF
--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -155,6 +155,7 @@
 				sleep(1)
 
 /obj/item/weapon/dualsaber/Get_shield_chance()
+	if(HAS_TRAIT(src, TRAIT_DOUBLE_WIELDED) && !slicing)
 		return reflect_chance
 	else
 		return 0

--- a/code/game/objects/items/weapons/twohanded.dm
+++ b/code/game/objects/items/weapons/twohanded.dm
@@ -1,5 +1,3 @@
-#define DUALSABER_BLOCK_CHANCE_MODIFIER 1.2
-
 /obj/item/weapon/fireaxe
 	icon_state = "fireaxe0"
 	name = "fire axe"
@@ -71,7 +69,7 @@
 
 /obj/item/weapon/dualsaber/atom_init()
 	. = ..()
-	reflect_chance = rand(50, 65)
+	reflect_chance = rand(20, 35)
 	blade_color = pick("red", "blue", "green", "purple","yellow","pink","black")
 	switch(blade_color)
 		if("red")
@@ -157,8 +155,7 @@
 				sleep(1)
 
 /obj/item/weapon/dualsaber/Get_shield_chance()
-	if(HAS_TRAIT(src, TRAIT_DOUBLE_WIELDED) && !slicing)
-		return reflect_chance * DUALSABER_BLOCK_CHANCE_MODIFIER - 5
+		return reflect_chance
 	else
 		return 0
 
@@ -207,5 +204,3 @@
 	if(slicing)
 		return
 	..()
-
-#undef DUALSABER_BLOCK_CHANCE_MODIFIER


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
в раунде солонюкер вынес почти всю станцию с использованием двойного меча, поэтому мне кажется что его следует занерфить
непонятно зачем нужная формула высчитывания шанса блока удалена, теперь шанс 20-35 процентов
## Почему и что этот ПР улучшит
дуалсейбер - самое мощное оружие ближнего боя на станции - 45 урона (а со скиллами ещё больше!), отсутствие замедления, имбовые свайпы и возможный шанс блока выстрела в **!72!** процента делали его ну тупо нечестным. поэтому так
## Авторство

## Чеинжлог
:cl:
- balance: Шанс блока выстрела у двойного лазерного меча значительно снижен.
