### PR TITLE
fixes #11519

### DIFF
--- a/code/game/machinery/podmen.dm
+++ b/code/game/machinery/podmen.dm
@@ -49,7 +49,7 @@ Growing it to term with nothing injected will grab a ghost from the observers. *
 	priveleged_player = null
 
 /obj/item/seeds/replicapod/proc/replicate_blood_data(list/data, mob/living/user)
-	blood_source = data["donor"]
+	blood_source = locate(data["donor"])
 	if(!istype(blood_source) || !blood_source.mind)
 		blood_source = null
 		if(user)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

в ишуе описан мыслительный процесс. донор сейчас это ref() строка а не ссылка.

## Почему и что этот ПР улучшит

fixes #11519 

## Авторство

## Чеинжлог
:cl: Luduk
- bugfix: Семенам подмен снова можно колоть кровь.