### PR TITLE
[Fixes] Текст при смене настроения

### DIFF
--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -275,9 +275,9 @@
 	update_mood_client_color()
 
 	if(spirit_level > prev_spirit_level)
-		to_chat(parent, "<span class='notice'>Ваше настроение ухудшилось.</span>")
+		to_chat(parent, "<span class='warning'>Ваше настроение ухудшилось.</span>")
 	if(spirit_level < prev_spirit_level)
-		to_chat(parent, "<span class='warning'>Ваше настроение улучшилось.</span>")
+		to_chat(parent, "<span class='notice'>Ваше настроение улучшилось.</span>")
 
 // Category will override any events in the same category, should be unique unless the event is based on the same thing like hunger.
 /datum/component/mood/proc/add_event(datum/source, category, type, ...)

--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -275,9 +275,9 @@
 	update_mood_client_color()
 
 	if(spirit_level > prev_spirit_level)
-		to_chat(parent, "<span class='notice'>Ваше настроение улучшилось.</span>")
+		to_chat(parent, "<span class='notice'>Ваше настроение ухудшилось.</span>")
 	if(spirit_level < prev_spirit_level)
-		to_chat(parent, "<span class='warning'>Ваше настроение ухудшилось.</span>")
+		to_chat(parent, "<span class='warning'>Ваше настроение улучшилось.</span>")
 
 // Category will override any events in the same category, should be unique unless the event is based on the same thing like hunger.
 /datum/component/mood/proc/add_event(datum/source, category, type, ...)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Сейчас при повышении настроения тебе выдает текс что он наоборот ухудшается. Так что поменял местами слова
## Почему и что этот ПР улучшит
Это fixes для корректного вывода текста при смене настроения
## Авторство
Я
## Чеинжлог
-