### PR TITLE
Фиксы Тыквяка

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -243,5 +243,5 @@ var/global/list/toilet_overlay_cache = list()
 	var/mob/living/L = AM
 	if(L.get_species() == UNATHI)
 		return
-	if(L.crawling)
+	if(L.lying || L.crawling)
 		L.vomit()

--- a/code/game/objects/items/weapons/hydroponics.dm
+++ b/code/game/objects/items/weapons/hydroponics.dm
@@ -212,19 +212,20 @@ var/global/gourd_name = null
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/gourd/attackby(obj/item/I, mob/user)
 	if(I.get_quality(QUALITY_CUTTING))
-		var/turf/T = I.loc
+		var/turf/T = loc
 		if(!isturf(T))
 			T = T.loc
 		if(!isturf(T))
 			return ..()
 
-		user.drop_from_inventory(I)
+		user.drop_from_inventory(src)
 		var/obj/item/weapon/reagent_containers/food/drinks/bottle/gourd/G = new /obj/item/weapon/reagent_containers/food/drinks/bottle/gourd(T)
 		G.volume = reagents.maximum_volume * 3
 		G.reagents.maximum_volume = reagents.maximum_volume * 3
 
 		if(user.in_interaction_vicinity(G))
 			user.put_in_hands(G)
+
 		qdel(src)
 		return
 


### PR DESCRIPTION
## Описание изменений

См. ченжлог

## Почему и что этот ПР улучшит

Фиксит баги которые противоречат задумке тыквяка, делая тыквяк смешней, а игроков счастливее.

## Чеинжлог
:cl: Luduk
- bugfix: Тыквяк вызывает рвоту у лежащих как добровольно так и подскользнувшихся.
- bugfix: При нарезке бутылок из тыквяка нож не падает из рук.