### PR TITLE
Uplink discounts

### DIFF
--- a/code/datums/components/gamemodes/syndicate.dm
+++ b/code/datums/components/gamemodes/syndicate.dm
@@ -121,6 +121,8 @@
 		total_TC += R.hidden_uplink.uses
 		R.hidden_uplink.uplink_type = uplink_type
 
+	R.hidden_uplink.extra_purchasable += create_uplink_sales(rand(2,3), "Discounts", TRUE, get_uplink_items(R.hidden_uplink))
+
 /datum/component/gamemode/syndicate/proc/give_codewords()
 	var/mob/traitor_mob = get_current()
 	if(!traitor_mob)

--- a/code/datums/uplinks_items.dm
+++ b/code/datums/uplinks_items.dm
@@ -1,4 +1,41 @@
-//var/list/uplink_items = list()
+/// Selects a set number of unique items from the uplink, and deducts a percentage discount from them
+/proc/create_uplink_sales(num, category = "Discounts", limited_stock, list/sale_items)
+	var/list/sales = list()
+	var/list/sale_items_copy = sale_items.Copy()
+	for (var/i in 1 to num)
+		var/picked_category = pick(sale_items_copy)
+		var/datum/uplink_item/taken_item = pick_n_take(sale_items_copy[picked_category])
+		if(taken_item.cant_discount || taken_item.cost < 2)
+			continue
+		var/datum/uplink_item/uplink_item = new taken_item.type()
+		var/discount = uplink_item.get_discount()
+		var/list/disclaimer = list("Void where prohibited.", "Not recommended for children.", "Contains small parts.", "Check local laws for legality in region.", "Do not taunt.", "Not responsible for direct, indirect, incidental or consequential damages resulting from any defect, error or failure to perform.", "Keep away from fire or flames.", "Product is provided \"as is\" without any implied or expressed warranties.", "As seen on TV.", "For recreational use only.", "Use only as directed.", "16% sales tax will be charged for orders originating within Space Nebraska.")
+		uplink_item.limited_stock = limited_stock
+		if(uplink_item.cost >= 20) //Tough love for nuke ops
+			discount *= 0.5
+		uplink_item.category = category
+		uplink_item.cost = max(round(uplink_item.cost * (1 - discount)),1)
+		uplink_item.name += " ([round(((initial(uplink_item.cost)-uplink_item.cost)/initial(uplink_item.cost))*100)]% off!)"
+		uplink_item.desc += " Normally costs [initial(uplink_item.cost)] TC. All sales final. [pick(disclaimer)]"
+		uplink_item.item = taken_item.item
+		sales += uplink_item
+	return sales
+
+/// Returns by how much percentage do we reduce the price of the selected item
+/datum/uplink_item/proc/get_discount()
+	var/static/list/discount_types = list(
+		"small" = 4,
+		"medium" = 2,
+		"big" = 1,
+	)
+
+	switch(pickweight(discount_types))
+		if(1)
+			return 0.75
+		if(2)
+			return 0.5
+		else
+			return 0.25
 
 /proc/get_uplink_items(obj/item/device/uplink/uplink)
 	// If not already initialized..
@@ -35,6 +72,11 @@
 
 			uplink.uplink_items[I.category] += I
 
+		for(var/datum/uplink_item/I in uplink.extra_purchasable)
+			if(!uplink.uplink_items[I.category])
+				uplink.uplink_items[I.category] = list()
+			uplink.uplink_items[I.category] += I
+
 	return uplink.uplink_items
 
 // You can change the order of the list by putting datums before/after one another OR
@@ -47,6 +89,8 @@
 	var/item = null
 	var/cost = 0
 	var/last = 0 // Appear last
+	var/cant_discount = FALSE
+	var/limited_stock = FALSE
 	var/list/uplink_types = list() //Empty list means that the object will be available in all types of uplinks. Alias you will need to state its type.
 
 	// used for dealer items
@@ -960,6 +1004,7 @@
 	The ability for an agent to open an uplink after their posessions have been stripped from them makes this implant excellent for escaping confinement."
 	item = /obj/item/weapon/storage/box/syndie_kit/imp_uplink
 	cost = 20
+	cant_discount = TRUE
 	uplink_types = list("traitor")
 
 /datum/uplink_item/implants/storage
@@ -999,6 +1044,7 @@
 
 /datum/uplink_item/telecrystals
 	category = "Telecrystals"
+	cant_discount = TRUE
 
 /datum/uplink_item/telecrystals/one
 	name = "1 Telecrystal"
@@ -1029,12 +1075,14 @@
 	desc = "Syndicate Bundles are specialised groups of items that arrive in a plain box. These items are collectively worth more than 10 telecrystals, but you do not know which specialisation you will receive."
 	item = /obj/item/weapon/storage/box/syndicate
 	cost = 20
+	cant_discount = TRUE
 
 /datum/uplink_item/badass/merch
 	name = "Syndicate Merchandise"
 	desc = "To show your loalty to the Syndicate! Contains new red t-shirt with Syndicate logo, red cap and a fancy baloon!"
 	item = /obj/item/weapon/storage/box/syndie_kit/merch
 	cost = 20
+	cant_discount = TRUE
 
 /datum/uplink_item/badass/syndiecigs
 	name = "Syndicate Smokes"
@@ -1060,6 +1108,7 @@
 	desc = "Picking this choice will send you a random item from the list. Useful for when you cannot think of a strategy to finish your objectives with."
 	item = /obj/item/weapon/storage/box/syndicate
 	cost = 0
+	cant_discount = TRUE
 
 /datum/uplink_item/badass/random/spawn_item(turf/loc, obj/item/device/uplink/U, mob/user)
 
@@ -1087,6 +1136,7 @@
 	desc = "A crate containing 40 telecrystals worth of random syndicate leftovers."
 	item = /obj/item/weapon/storage/box/syndicate
 	cost = 20
+	cant_discount = TRUE
 	uplink_types = list("traitor")
 	var/crate_value = 40
 

--- a/code/datums/uplinks_items.dm
+++ b/code/datums/uplinks_items.dm
@@ -30,9 +30,9 @@
 	)
 
 	switch(pickweight(discount_types))
-		if(1)
+		if("big" )
 			return 0.75
-		if(2)
+		if("medium")
 			return 0.5
 		else
 			return 0.25

--- a/code/game/gamemodes/factions/syndicate.dm
+++ b/code/game/gamemodes/factions/syndicate.dm
@@ -17,6 +17,8 @@
 
 	var/nuke_code
 
+	var/list/team_discounts = list()
+
 /datum/faction/nuclear/AdminPanelEntry()
 	var/dat = ..()
 	var/obj/item/weapon/disk/nuclear/nukedisk

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -13,6 +13,7 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 	var/active = 0
 	var/uplink_type = "traitor" //0 - traitor uplink, 1 - nuke
 	var/list/uplink_items = list()
+	var/list/extra_purchasable = list()
 
 // Interaction code. Gathers a list of items purchasable from the paren't uplink and displays it. It also adds a lock button.
 /obj/item/device/uplink/interact(mob/user)
@@ -88,6 +89,9 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 				var/datum/uplink_item/I = uplink[number]
 				if(I)
 					I.buy(src, usr)
+					if(I.limited_stock)
+						buyable_items -= I
+						extra_purchasable -= I
 					interact(usr)
 
 
@@ -172,6 +176,15 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 	. = ..()
 	hidden_uplink = new(src)
 	hidden_uplink.uplink_type = "nuclear"
+
+	hidden_uplink.extra_purchasable += create_uplink_sales(rand(2,3), "Discounts", TRUE, get_uplink_items(hidden_uplink))
+
+	var/datum/faction/nuclear/F = find_faction_by_type(/datum/faction/nuclear)
+	if(!F)
+		return
+	if(!F.team_discounts.len)
+		F.team_discounts += create_uplink_sales(rand(3,5), "Team Discounts", FALSE, get_uplink_items(hidden_uplink))
+	hidden_uplink.extra_purchasable += F.team_discounts
 
 /obj/item/device/radio/uplink/attack_self(mob/user)
 	if(hidden_uplink)


### PR DESCRIPTION

## Описание изменений
На ТГ есть прикольная система: у всех трейторов есть несколько вещей по скидке вплоть до 75%. Как это работает?

Вот, у нас спавнится предатель. Он может не получить вообще скидок, а может и **до** 3 вещей со скидкой. Скидка бывает 25%, 50%, 75% с шансами в 4, 2, 1 соответственно. Предложение после покупки исчезает.

У нюки ситуация похожая, до 3 вещей, **НО** есть ещё **до** 5 предметов, которые общие для всех команды (в каждом аплинке нюки). Вещи, которые стоят больше 20 ТК, получают уполовиненную скидку, т.е. максимальная скидка у маулера - 38%. **Предложения для команды не исчезают после покупки**.

Конечно же, бандлов, телекристаллов, ящиков, а главное, мерча, по скидке не бывает.

![image](https://github.com/TauCetiStation/TauCetiClassic/assets/50750952/2aba239c-a486-4c94-81ff-494ed2a703f5)

## Почему и что этот ПР улучшит
Некоторые вещи станут (возможно) брать
Смешные ситуации с сквадом нюкеров из ближников
Также, возможно, подтолкнёт к некой креативности
## Авторство
Порт с ТГ
Идея порта из ПРа со скидками
Напоминание Малевича о скидках
## Чеинжлог
:cl:
- add: Синдикат начинает распродажу завалявшихся товаров в своих аплинках