### PR TITLE
SSstation_coloring now respects mappers color choice

### DIFF
--- a/code/controllers/subsystem/station_coloring.dm
+++ b/code/controllers/subsystem/station_coloring.dm
@@ -45,8 +45,12 @@ SUBSYSTEM_DEF(station_coloring)
 /datum/controller/subsystem/station_coloring/proc/color_area_objects(list/possible_areas, color) // paint in areas
 	for(var/type in possible_areas)
 		for(var/obj/structure/window/W in get_area_by_type(type)) //for in area is slow by refs, but we have a time while in lobby so just to-do-sometime
+			if(W.color) // has already been set by mapper
+				continue
 			W.change_color(color)
 		for(var/obj/machinery/door/window/D in get_area_by_type(type))
+			if(D.color)
+				continue
 			D.color = color
 
 /datum/controller/subsystem/station_coloring/proc/get_default_color()

--- a/code/game/objects/structures/windows/window_fulltile.dm
+++ b/code/game/objects/structures/windows/window_fulltile.dm
@@ -36,7 +36,8 @@
 	if(grill)
 		grilled = TRUE
 
-	var/new_color = SSstation_coloring.get_default_color()
+	var/new_color = color || SSstation_coloring.get_default_color()
+	color = null
 	if(glass_color_blend_to_color && glass_color_blend_to_ratio)
 		glass_color = BlendRGB(new_color, glass_color_blend_to_color, glass_color_blend_to_ratio)
 	else


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

По реквестам, мапперы смогут устанавливать окнам и стеклянным дверям ``color``, и он не будет переопределяться при инициализации в игре. Но я не рекомендую очень сильно увлекаться с разнообразными разноцветными фуллтайл окнами.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
