### PR TITLE
User pincode input

### DIFF
--- a/code/__DEFINES/accounts.dm
+++ b/code/__DEFINES/accounts.dm
@@ -1,0 +1,3 @@
+#define ACCOUNT_SECURITY_LEVEL_NONE 0       // auto-identify from worn ID, require only account number
+#define ACCOUNT_SECURITY_LEVEL_STANDARD 1   // require manual login / account number and pin
+#define ACCOUNT_SECURITY_LEVEL_MAXIMUM 2    // require card and manual login

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -287,18 +287,8 @@
 		if(check_accounts)
 			if(vendor_account)
 				var/datum/money_account/D = get_account(C.associated_account_number)
-				var/attempt_pin = 0
 				if(D)
-					if(D.security_level > 0)
-						if(usr.mind.get_key_memory(MEM_ACCOUNT_NUMBER) == D.account_number && usr.mind.get_key_memory(MEM_ACCOUNT_PIN) == D.remote_access_pin)
-							attempt_pin = usr.mind.get_key_memory(MEM_ACCOUNT_PIN)
-						else
-							attempt_pin = input("Enter pin code", "Vendor transaction") as num
-						if(isnull(attempt_pin))
-							to_chat(usr, "[bicon(src)]<span class='warning'>You entered wrong account PIN!</span>")
-							return
-						D = attempt_account_access(C.associated_account_number, attempt_pin, 2)
-
+					D = attempt_account_access_with_user_input(C.associated_account_number, 2, usr)
 					if(D)
 						var/transaction_amount = currently_vending.price
 						if(transaction_amount <= D.money)

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -288,7 +288,9 @@
 			if(vendor_account)
 				var/datum/money_account/D = get_account(C.associated_account_number)
 				if(D)
-					D = attempt_account_access_with_user_input(C.associated_account_number, 2, usr)
+					D = attempt_account_access_with_user_input(C.associated_account_number, ACCOUNT_SECURITY_LEVEL_MAXIMUM, usr)
+					if(usr.incapacitated() || !Adjacent(usr))
+						return
 					if(D)
 						var/transaction_amount = currently_vending.price
 						if(transaction_amount <= D.money)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -676,23 +676,10 @@
 	qdel(src)
 
 /obj/lot_holder/proc/scan_card(obj/item/weapon/card/id/Card, mob/user)
-	var/datum/money_account/Buyer = get_account(Card.associated_account_number)
-
-	var/attempt_pin = 0
-	if(Buyer.security_level > 0)
-		if(user.mind.get_key_memory(MEM_ACCOUNT_NUMBER) == Buyer.account_number && user.mind.get_key_memory(MEM_ACCOUNT_PIN) == Buyer.remote_access_pin)
-			attempt_pin = user.mind.get_key_memory(MEM_ACCOUNT_PIN)
-		else
-			attempt_pin = input("Введите ПИН-код", "Прилавок") as num
-		if(isnull(attempt_pin))
-			to_chat(user, "[bicon(table_attached_to)]<span class='warning'>Неверный ПИН-код!</span>")
-			return
-		Buyer = attempt_account_access(Card.associated_account_number, attempt_pin, 2)
-
-		if(!Buyer)
-			to_chat(user, "[bicon(table_attached_to)]<span class='warning'>Неверный ПИН-код!</span>")
-			return
-
+	var/datum/money_account/Buyer = attempt_account_access_with_user_input(Card.associated_account_number, 2, user)
+	if(!Buyer)
+		to_chat(user, "[bicon(table_attached_to)]<span class='warning'>Неверный ПИН-код!</span>")
+		return
 	pay_with_account(Buyer, user)
 
 /obj/lot_holder/proc/scan_ewallet(obj/item/weapon/ewallet/EW, mob/user)

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -676,7 +676,9 @@
 	qdel(src)
 
 /obj/lot_holder/proc/scan_card(obj/item/weapon/card/id/Card, mob/user)
-	var/datum/money_account/Buyer = attempt_account_access_with_user_input(Card.associated_account_number, 2, user)
+	var/datum/money_account/Buyer = attempt_account_access_with_user_input(Card.associated_account_number, ACCOUNT_SECURITY_LEVEL_MAXIMUM, user)
+	if(user.incapacitated() || !Adjacent(user))
+		return
 	if(!Buyer)
 		to_chat(user, "[bicon(table_attached_to)]<span class='warning'>Неверный ПИН-код!</span>")
 		return

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -431,7 +431,9 @@ ADD_TO_GLOBAL_LIST(/obj/structure/toilet, toilet_list)
 				var/obj/item/weapon/card/C = I
 				visible_message("<span class='info'>[usr] swipes a card through [src].</span>")
 				if(station_account)
-					var/datum/money_account/D = attempt_account_access_with_user_input(C.associated_account_number, 2, usr)
+					var/datum/money_account/D = attempt_account_access_with_user_input(C.associated_account_number, ACCOUNT_SECURITY_LEVEL_MAXIMUM, user)
+					if(user.incapacitated() || !Adjacent(user))
+						return
 					if(D)
 						var/transaction_amount = cost_per_activation
 						if(transaction_amount <= D.money)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -431,12 +431,7 @@ ADD_TO_GLOBAL_LIST(/obj/structure/toilet, toilet_list)
 				var/obj/item/weapon/card/C = I
 				visible_message("<span class='info'>[usr] swipes a card through [src].</span>")
 				if(station_account)
-					var/datum/money_account/D = get_account(C.associated_account_number)
-					var/attempt_pin = 0
-					if(D.security_level > 0)
-						attempt_pin = input("Enter pin code", "Transaction") as num
-					if(attempt_pin)
-						D = attempt_account_access(C.associated_account_number, attempt_pin, 2)
+					var/datum/money_account/D = attempt_account_access_with_user_input(C.associated_account_number, 2, usr)
 					if(D)
 						var/transaction_amount = cost_per_activation
 						if(transaction_amount <= D.money)

--- a/code/modules/economy/ATM.dm
+++ b/code/modules/economy/ATM.dm
@@ -397,13 +397,12 @@ log transactions
 					if(!MA)
 						to_chat(usr, "[bicon(src)]<span class='warning'>Unable to find your money account!</span>")
 						return
-					var/tried_pin = 0
-					if(!href_list["account_pin"] && usr.mind.get_key_memory(MEM_ACCOUNT_NUMBER) == MA.account_number && usr.mind.get_key_memory(MEM_ACCOUNT_PIN) == MA.remote_access_pin)
-						tried_pin = usr.mind.get_key_memory(MEM_ACCOUNT_PIN)
+					var/security_level_passed = held_card && held_card.associated_account_number == tried_account_num ? 2 : 1
+					if(href_list["account_pin"])
+						authenticated_account = attempt_account_access(tried_account_num, text2num(href_list["account_pin"]), security_level_passed)
 					else
-						tried_pin = text2num(href_list["account_pin"])
+						authenticated_account = attempt_account_access_with_user_input(tried_account_num, security_level_passed, usr)
 
-					authenticated_account = attempt_account_access(tried_account_num, tried_pin, held_card && held_card.associated_account_number == tried_account_num ? 2 : 1)
 					if(!authenticated_account)
 						number_incorrect_tries++
 						if(previous_account_number == tried_account_num)

--- a/code/modules/economy/ATM.dm
+++ b/code/modules/economy/ATM.dm
@@ -397,11 +397,14 @@ log transactions
 					if(!MA)
 						to_chat(usr, "[bicon(src)]<span class='warning'>Unable to find your money account!</span>")
 						return
-					var/security_level_passed = held_card && held_card.associated_account_number == tried_account_num ? 2 : 1
+						
+					var/security_level_passed = held_card && held_card.associated_account_number == tried_account_num ? ACCOUNT_SECURITY_LEVEL_MAXIMUM : ACCOUNT_SECURITY_LEVEL_STANDARD
 					if(href_list["account_pin"])
 						authenticated_account = attempt_account_access(tried_account_num, text2num(href_list["account_pin"]), security_level_passed)
 					else
 						authenticated_account = attempt_account_access_with_user_input(tried_account_num, security_level_passed, usr)
+					if(usr.incapacitated() || !Adjacent(usr))
+						return
 
 					if(!authenticated_account)
 						number_incorrect_tries++

--- a/code/modules/economy/Accounts.dm
+++ b/code/modules/economy/Accounts.dm
@@ -239,13 +239,17 @@
 
 //this returns the first account datum that matches the supplied accnum/pin combination, it returns null if the combination did not match any account
 /proc/attempt_account_access(attempt_account_number, attempt_pin_number, security_level_passed = 0)
-	var/datum/money_account/D = get_account(attempt_account_number)	
+	var/datum/money_account/D = get_account(attempt_account_number)
+	if(!D)
+		return
 	if( D.security_level <= security_level_passed && (!D.security_level || D.remote_access_pin == attempt_pin_number) )
 		return D
 
 //for ATM, cardpay, watercloset, table_rack, vendomat
 /proc/attempt_account_access_with_user_input(attempt_account_number, security_level_passed = 0, mob/user)
 	var/datum/money_account/MA = get_account(attempt_account_number)
+	if(!MA)
+		return
 	if(MA.security_level == 0)
 		return MA
 	var/attempt_pin = 0

--- a/code/modules/economy/Accounts.dm
+++ b/code/modules/economy/Accounts.dm
@@ -16,9 +16,7 @@
 	var/list/transaction_log = list()
 	var/obj/item/device/pda/owner_PDA = null	//contains a PDA linked to an account
 	var/suspended = 0
-	var/security_level = 1	//0 - auto-identify from worn ID, require only account number
-							//1 - require manual login / account number and pin
-							//2 - require card and manual login
+	var/security_level = ACCOUNT_SECURITY_LEVEL_STANDARD
 	// Whether this account is hidden from databases. In the future, if required, abstract to Database ID, and make the financial database connect to said ID and view accounts only for that ID.
 	var/hidden = FALSE
 
@@ -238,7 +236,7 @@
 	return FALSE
 
 //this returns the first account datum that matches the supplied accnum/pin combination, it returns null if the combination did not match any account
-/proc/attempt_account_access(attempt_account_number, attempt_pin_number, security_level_passed = 0)
+/proc/attempt_account_access(attempt_account_number, attempt_pin_number, security_level_passed = ACCOUNT_SECURITY_LEVEL_NONE)
 	var/datum/money_account/D = get_account(attempt_account_number)
 	if(!D)
 		return
@@ -246,11 +244,11 @@
 		return D
 
 //for ATM, cardpay, watercloset, table_rack, vendomat
-/proc/attempt_account_access_with_user_input(attempt_account_number, security_level_passed = 0, mob/user)
+/proc/attempt_account_access_with_user_input(attempt_account_number, security_level_passed = ACCOUNT_SECURITY_LEVEL_NONE, mob/user)
 	var/datum/money_account/MA = get_account(attempt_account_number)
 	if(!MA)
 		return
-	if(MA.security_level == 0)
+	if(MA.security_level == ACCOUNT_SECURITY_LEVEL_NONE)
 		return MA
 	var/attempt_pin = 0
 	if(user.mind.get_key_memory(MEM_ACCOUNT_NUMBER) == MA.account_number && user.mind.get_key_memory(MEM_ACCOUNT_PIN) == MA.remote_access_pin)

--- a/code/modules/economy/Accounts.dm
+++ b/code/modules/economy/Accounts.dm
@@ -239,11 +239,21 @@
 
 //this returns the first account datum that matches the supplied accnum/pin combination, it returns null if the combination did not match any account
 /proc/attempt_account_access(attempt_account_number, attempt_pin_number, security_level_passed = 0)
-	for(var/datum/money_account/D in all_money_accounts)
-		if(D.account_number == attempt_account_number)
-			if( D.security_level <= security_level_passed && (!D.security_level || D.remote_access_pin == attempt_pin_number) )
-				return D
-			break
+	var/datum/money_account/D = get_account(attempt_account_number)	
+	if( D.security_level <= security_level_passed && (!D.security_level || D.remote_access_pin == attempt_pin_number) )
+		return D
+
+//for ATM, cardpay, watercloset, table_rack, vendomat
+/proc/attempt_account_access_with_user_input(attempt_account_number, security_level_passed = 0, mob/user)
+	var/datum/money_account/MA = get_account(attempt_account_number)
+	if(MA.security_level == 0)
+		return MA
+	var/attempt_pin = 0
+	if(user.mind.get_key_memory(MEM_ACCOUNT_NUMBER) == MA.account_number && user.mind.get_key_memory(MEM_ACCOUNT_PIN) == MA.remote_access_pin)
+		attempt_pin = user.mind.get_key_memory(MEM_ACCOUNT_PIN)
+	else
+		attempt_pin = input("Enter pin code", "Money transaction") as num
+	return attempt_account_access(attempt_account_number, attempt_pin, security_level_passed)
 
 /proc/get_account(account_number)
 	for(var/datum/money_account/D in all_money_accounts)

--- a/code/modules/economy/cardpay.dm
+++ b/code/modules/economy/cardpay.dm
@@ -134,27 +134,18 @@
 	addtimer(CALLBACK(src, .proc/make_transaction, D, pay_holder), 3 SECONDS)
 
 /obj/item/device/cardpay/proc/check_pincode(datum/money_account/Acc)
-	var/attempt_pin = 0
-	if(Acc.security_level > 0)
-		var/time_for_pin = world.time
-		if(usr.mind.get_key_memory(MEM_ACCOUNT_PIN) == Acc.remote_access_pin)
-			attempt_pin = usr.mind.get_key_memory(MEM_ACCOUNT_PIN)
-		else
-			attempt_pin = input("Введите ПИН-код", "Терминал оплаты") as num
-		if(!usr || !usr.Adjacent(src))
-			return FALSE
-		if(world.time - time_for_pin > 300)
-			to_chat(usr, "[bicon(src)] [name] <span class='warning'>Время операции истекло!</span>")
-			return FALSE
-		if(isnull(attempt_pin))
-			to_chat(usr, "[bicon(src)] [name] <span class='warning'>Неверный ПИН-код!</span>")
-			return FALSE
-		Acc = attempt_account_access(Acc.account_number, attempt_pin, 2)
-		if(!Acc)
-			to_chat(usr, "[bicon(src)] [name] <span class='warning'>Неверный ПИН-код!</span>")
-			return FALSE
-
-	return TRUE
+    var/time_for_pin = world.time
+    Acc = attempt_account_access_with_user_input(Acc.account_number, 2, usr)
+    if(!usr || !usr.Adjacent(src))
+        return FALSE
+    if(world.time - time_for_pin > 300)
+        to_chat(usr, "[bicon(src)] [name] <span class='warning'>Время операции истекло!</span>")
+        return FALSE
+    if(!Acc)
+        to_chat(usr, "[bicon(src)] [name] <span class='warning'>Неверный ПИН-код!</span>")
+        return FALSE
+		
+    return TRUE
 
 /obj/item/device/cardpay/proc/make_transaction(datum/money_account/Acc, amount)
 	if(!src || !Acc)

--- a/code/modules/economy/cardpay.dm
+++ b/code/modules/economy/cardpay.dm
@@ -135,8 +135,8 @@
 
 /obj/item/device/cardpay/proc/check_pincode(datum/money_account/Acc)
     var/time_for_pin = world.time
-    Acc = attempt_account_access_with_user_input(Acc.account_number, 2, usr)
-    if(!usr || !usr.Adjacent(src))
+    Acc = attempt_account_access_with_user_input(Acc.account_number, ACCOUNT_SECURITY_LEVEL_MAXIMUM, usr)
+    if(usr.incapacitated() || !usr.Adjacent())
         return FALSE
     if(world.time - time_for_pin > 300)
         to_chat(usr, "[bicon(src)] [name] <span class='warning'>Время операции истекло!</span>")

--- a/code/modules/economy/cardpay.dm
+++ b/code/modules/economy/cardpay.dm
@@ -136,7 +136,7 @@
 /obj/item/device/cardpay/proc/check_pincode(datum/money_account/Acc)
     var/time_for_pin = world.time
     Acc = attempt_account_access_with_user_input(Acc.account_number, ACCOUNT_SECURITY_LEVEL_MAXIMUM, usr)
-    if(usr.incapacitated() || !usr.Adjacent())
+    if(usr.incapacitated() || !Adjacent(usr))
         return FALSE
     if(world.time - time_for_pin > 300)
         to_chat(usr, "[bicon(src)] [name] <span class='warning'>Время операции истекло!</span>")

--- a/taucetistation.dme
+++ b/taucetistation.dme
@@ -21,6 +21,7 @@
 #include "code\__DEFINES\_readme.dm"
 #include "code\__DEFINES\_tick.dm"
 #include "code\__DEFINES\_util.dm"
+#include "code\__DEFINES\accounts.dm"
 #include "code\__DEFINES\admin.dm"
 #include "code\__DEFINES\animations.dm"
 #include "code\__DEFINES\atmos.dm"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
банкомат, прилавок, душ, вендомат, ефтпос используют одинаковый код для входа юзера в money_account (или из мемов берём, или инпутом)

вынес это в отдельный прок

## Почему и что этот ПР улучшит
меньше копипасты

душ перестанет требовать пинкод у владельцев аккаунтов
## Авторство

## Чеинжлог
:cl: Kandrey
- bugfix: Душ перестал требовать пинкод у владельца карты