### PR TITLE
Выселяем всех с карго. Закрываем проходной двор.

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -27,7 +27,7 @@
 		SSStatistics.score.captain += H.real_name
 
 /datum/job/captain/get_access()
-	return get_all_accesses()
+	return get_all_accesses() - get_region_accesses(7)
 
 /datum/job/hop
 	title = "Head of Personnel"

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -48,9 +48,9 @@
 		access_security, access_sec_doors, access_brig, access_forensics_lockers,
 		access_medical, access_change_ids, access_ai_upload, access_eva, access_heads,
 		access_all_personal_lockers, access_maint_tunnels, access_bar, access_janitor, access_construction, access_morgue,
-		access_crematorium, access_kitchen, access_cargo, access_cargo_bot, access_mailsorting, access_qm, access_hydroponics, access_lawyer,
-		access_theatre, access_chapel_office, access_library, access_research, access_mining, access_heads_vault, access_mining_station,
-		access_clown, access_mime, access_hop, access_RC_announce, access_keycard_auth, access_gateway, access_recycler, access_detective, access_barber
+		access_crematorium, access_kitchen, access_hydroponics, access_lawyer,
+		access_theatre, access_chapel_office, access_library, access_research, access_heads_vault,
+		access_clown, access_mime, access_hop, access_RC_announce, access_keycard_auth, access_gateway, access_detective, access_barber
 	)
 	outfit = /datum/outfit/job/hop
 	/*
@@ -73,7 +73,7 @@
 	selection_color = "#ddddff"
 	idtype = /obj/item/weapon/card/id/blueshield
 	access = list(access_blueshield, access_heads, access_maint_tunnels,
-				  access_sec_doors, access_medical, access_research, access_mailsorting, access_engineering_lobby,
+				  access_sec_doors, access_medical, access_research, access_engineering_lobby,
 				  access_security, access_engine) // needed accesses to reach heads
 	salary = 200
 	minimal_player_age = 14

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -27,7 +27,7 @@
 		SSStatistics.score.captain += H.real_name
 
 /datum/job/captain/get_access()
-	return get_all_accesses() - get_region_accesses(7)
+	return get_all_accesses()
 
 /datum/job/hop
 	title = "Head of Personnel"

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -171,7 +171,7 @@
 	supervisors = "the head of personnel"
 	selection_color = "#bbe291"
 	idtype = /obj/item/weapon/card/id/civ
-	access = list(access_janitor, access_maint_tunnels, access_sec_doors, access_research, access_mailsorting, access_medical, access_engineering_lobby)
+	access = list(access_janitor, access_maint_tunnels, access_sec_doors, access_research, access_medical, access_engineering_lobby)
 	salary = 50
 	minimal_player_ingame_minutes = 120
 	outfit = /datum/outfit/job/janitor
@@ -226,7 +226,7 @@
 	supervisors = "The Central Command"
 	selection_color = "#dddddd"
 	idtype = /obj/item/weapon/card/id/int
-	access = list(access_lawyer, access_sec_doors, access_medical, access_research, access_mailsorting, access_engineering_lobby)
+	access = list(access_lawyer, access_sec_doors, access_medical, access_research, access_engineering_lobby)
 	salary = 200
 	minimal_player_ingame_minutes = 1560
 	outfit = /datum/outfit/job/lawyer

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -76,7 +76,7 @@
 	supervisors = "the chief medical officer"
 	selection_color = "#ffeef0"
 	idtype = /obj/item/weapon/card/id/med
-	access = list(access_medical, access_morgue, access_paramedic, access_maint_tunnels, access_external_airlocks, access_sec_doors, access_research, access_mailsorting, access_medbay_storage, access_engineering_lobby)
+	access = list(access_medical, access_morgue, access_paramedic, access_maint_tunnels, access_external_airlocks, access_sec_doors, access_research, access_medbay_storage, access_engineering_lobby)
 	salary = 120
 	minimal_player_ingame_minutes = 1500 //they have too much access, so you have to play more to unlock it
 	outfit = /datum/outfit/job/paramedic

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -13,7 +13,7 @@
 	access = list(
 		access_security, access_sec_doors, access_brig, access_armory,
 		access_forensics_lockers, access_morgue, access_maint_tunnels, access_all_personal_lockers,
-		access_research, access_mining, access_medical, access_construction, access_mailsorting,
+		access_research, access_medical, access_construction,
 		access_heads, access_hos, access_RC_announce, access_keycard_auth, access_gateway, access_detective
 	)
 	salary = 250


### PR DESCRIPTION
## Описание изменений
Убираем доступы в карго у всех кроме карго. Проходной двор тут устроили, ей-богу. За доступом к ГП, блеат!

## Почему и что этот ПР улучшит
Закрываем проходной двор в карго и даём карго немного самостоятельности. Пусть живут.

## Авторство
AndreyGysev и все все все кто помогал в дискорде.

## Чеинжлог
 :cl:
 - tweak: изменены доступы в карго у различных профессий.