### PR TITLE
Чуть передвинул терминалы оплаты на 5 пикселей вверх на боковых столах чтобы меньше занимали места на столе.

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -36107,7 +36107,7 @@
 /obj/item/weapon/bell,
 /obj/item/device/cardpay{
 	dir = 8;
-	pixel_y = 10;
+	pixel_y = 15;
 	pixel_x = -3
 	},
 /turf/simulated/floor,
@@ -46469,7 +46469,7 @@
 /obj/item/weapon/reagent_containers/dropper,
 /obj/item/device/cardpay{
 	dir = 8;
-	pixel_y = 10;
+	pixel_y = 15;
 	pixel_x = -3
 	},
 /turf/simulated/floor{
@@ -68864,7 +68864,7 @@
 	},
 /obj/item/device/cardpay{
 	dir = 4;
-	pixel_y = 10;
+	pixel_y = 15;
 	pixel_x = 5
 	},
 /obj/structure/table/reinforced/stall,
@@ -82485,7 +82485,7 @@
 /obj/item/weapon/bell,
 /obj/item/device/cardpay{
 	dir = 4;
-	pixel_y = 10
+	pixel_y = 15
 	},
 /obj/structure/table/reinforced/stall,
 /turf/simulated/floor{


### PR DESCRIPTION
## Описание изменений
Чуть передвинул терминалы оплаты на 5 пикселей вверх на боковых столах...

## Почему и что этот ПР улучшит
...чтобы меньше занимали места на столе.

## Авторство
AndreyGysev и все все все кто помогал в дискорде

## Чеинжлог
 :cl:
  - tweak: Чуть передвинул терминалы оплаты на 5 пикселей вверх на боковых столах чтобы меньше занимали места на столе.