### PR TITLE
Crew help in blob mode

### DIFF
--- a/code/__DEFINES/gamemodes.dm
+++ b/code/__DEFINES/gamemodes.dm
@@ -75,10 +75,11 @@
 ///////////////// FACTION STAGES //////////////////////
 #define FS_DEFEATED    -1
 #define FS_DORMANT      0
-#define FS_ACTIVE       1
-#define FS_MIDGAME      2
-#define FS_ENDGAME      3
-#define FS_VICTORY      4
+#define FS_START        1
+#define FS_ACTIVE       2
+#define FS_MIDGAME      3
+#define FS_ENDGAME      4
+#define FS_VICTORY      5
 
 /////////////////////// OTHERS ////////////////////////
 

--- a/code/__DEFINES/gamemodes.dm
+++ b/code/__DEFINES/gamemodes.dm
@@ -76,8 +76,9 @@
 #define FS_DEFEATED    -1
 #define FS_DORMANT      0
 #define FS_ACTIVE       1
-#define FS_ENDGAME      2
-#define FS_VICTORY      3
+#define FS_MIDGAME      2
+#define FS_ENDGAME      3
+#define FS_VICTORY      4
 
 /////////////////////// OTHERS ////////////////////////
 

--- a/code/datums/announcements/gamemode.dm
+++ b/code/datums/announcements/gamemode.dm
@@ -12,6 +12,16 @@
 			"Персонал должен предотвратить распространение заражения. " + \
 			"Активирован протокол изоляции экипажа станции."
 
+/datum/announcement/centcomm/blob/half
+	name = "Blob: Dangerous Level Spread"
+	subtitle = "Распространение биоугрозы"
+	sound = "commandreport"
+
+/datum/announcement/centcomm/blob/half/New()
+	message = "Биоугроза продолжает своё распространение на [station_name_ru()]. \
+			Персоналу предписывается любой ценой остановить распространение заражения по станции. \
+			Высылаем через шаттл карго дополнительные средства по борьбе с угрозой."
+
 /datum/announcement/centcomm/blob/critical
 	name = "Blob: Blob Critical Mass"
 	subtitle = "Тревога. Биоугроза"

--- a/code/game/gamemodes/factions/blob.dm
+++ b/code/game/gamemodes/factions/blob.dm
@@ -68,7 +68,7 @@
 /datum/faction/blob_conglomerate/OnPostSetup()
 	start = new()
 	start.count()
-	announcement_timer = addtimer(CALLBACK(src, .proc/stage, FS_START), rand(2 * INTERCEPT_TIME_LOW, 1.5 * INTERCEPT_TIME_HIGH), TIMER_STOPPABLE)//world.time + rand(INTERCEPT_TIME_LOW, 2 * INTERCEPT_TIME_HIGH)
+	announcement_timer = addtimer(CALLBACK(src, .proc/stage, FS_START), rand(2 * INTERCEPT_TIME_LOW, 1.5 * INTERCEPT_TIME_HIGH), TIMER_STOPPABLE)
 	spawn_blob_mice()
 	return ..()
 

--- a/code/game/gamemodes/factions/blob.dm
+++ b/code/game/gamemodes/factions/blob.dm
@@ -54,8 +54,8 @@
 	. = ..()
 	if(!blobwincount || !detect_overminds())
 		return .
-	if(0.2 * blobwincount < blobs.len && stage <= FS_DORMANT) // Announcement
-		stage(FS_DORMANT)
+	if(0.2 * blobwincount < blobs.len && stage < FS_START) // Announcement
+		stage(FS_START)
 		if(announcement_timer)
 			deltimer(announcement_timer)
 	if(0.3 * blobwincount < blobs.len && stage < FS_ACTIVE) // AI law
@@ -68,7 +68,7 @@
 /datum/faction/blob_conglomerate/OnPostSetup()
 	start = new()
 	start.count()
-	announcement_timer = addtimer(CALLBACK(src, .proc/stage, FS_DORMANT), rand(2 * INTERCEPT_TIME_LOW, 1.5 * INTERCEPT_TIME_HIGH), TIMER_STOPPABLE)//world.time + rand(INTERCEPT_TIME_LOW, 2 * INTERCEPT_TIME_HIGH)
+	announcement_timer = addtimer(CALLBACK(src, .proc/stage, FS_START), rand(2 * INTERCEPT_TIME_LOW, 1.5 * INTERCEPT_TIME_HIGH), TIMER_STOPPABLE)//world.time + rand(INTERCEPT_TIME_LOW, 2 * INTERCEPT_TIME_HIGH)
 	spawn_blob_mice()
 	return ..()
 
@@ -99,7 +99,7 @@
 /datum/faction/blob_conglomerate/stage(new_stage)
 	stage = new_stage
 	switch(new_stage)
-		if(FS_DORMANT)
+		if(FS_START)
 			var/datum/announcement/centcomm/blob/outbreak5/announcement = new
 			announcement.play()
 			return

--- a/code/game/gamemodes/modes_gameplays/blob/blobs/core.dm
+++ b/code/game/gamemodes/modes_gameplays/blob/blobs/core.dm
@@ -30,6 +30,16 @@ var/global/list/blob_nodes = list()
 	blob_cores -= src
 	QDEL_NULL(OV)
 	STOP_PROCESSING(SSobj, src)
+
+	var/dead_faction = TRUE
+	var/datum/faction/F = find_faction_by_type(/datum/faction/blob_conglomerate)
+	for(var/datum/role/R in F.members)
+		if(R.antag.current && R.antag.current.is_dead())
+			continue
+		dead_faction = FALSE
+	if(dead_faction)
+		F.stage(FS_DEFEATED)
+
 	return ..()
 //	return
 
@@ -99,8 +109,6 @@ var/global/list/blob_nodes = list()
 					ded = FALSE
 					break
 		add_faction_member(conglomerate, B, !ded)
-
-	conglomerate.declared = TRUE
 
 	B.b_congl = conglomerate
 	notify_ghosts("[B] in [get_area(B)]!", source=B, action=NOTIFY_ORBIT, header="Blob")

--- a/code/game/gamemodes/modes_gameplays/blob/blobs/core.dm
+++ b/code/game/gamemodes/modes_gameplays/blob/blobs/core.dm
@@ -31,13 +31,8 @@ var/global/list/blob_nodes = list()
 	QDEL_NULL(OV)
 	STOP_PROCESSING(SSobj, src)
 
-	var/dead_faction = TRUE
-	var/datum/faction/F = find_faction_by_type(/datum/faction/blob_conglomerate)
-	for(var/datum/role/R in F.members)
-		if(R.antag.current && R.antag.current.is_dead())
-			continue
-		dead_faction = FALSE
-	if(dead_faction)
+	var/datum/faction/blob_conglomerate/F = find_faction_by_type(/datum/faction/blob_conglomerate)
+	if(!F.detect_overminds())
 		F.stage(FS_DEFEATED)
 
 	return ..()

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1957,7 +1957,10 @@ var/global/list/all_supply_groups = list("Operations","Security","Hospitality","
 					/obj/item/ammo_box/magazine/glock,
 					/obj/item/ammo_box/magazine/glock,
 					/obj/item/weapon/storage/box/flashbangs,
-					/obj/item/weapon/gun/energy/laser/cutter)
+					/obj/item/weapon/gun/energy/laser/cutter,
+					/obj/machinery/power/emitter,
+					/obj/machinery/power/emitter)
+	crate_type = /obj/structure/closet/crate/secure/large
 	access = access_mint
 	additional_costs = 9300
 	crate_name = "Anti-blob equipment: Group supply"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1919,6 +1919,50 @@ var/global/list/all_supply_groups = list("Operations","Security","Hospitality","
 	hidden = TRUE
 
 //----------------------------------------------
+//-----------------BLOB THREAT-------------------
+//----------------------------------------------
+/datum/supply_pack/blob_equipment
+	name = "Anti-blob equipment: Personal set"
+	contains = list(/obj/item/clothing/suit/space/rig/atmos,
+					/obj/item/clothing/head/helmet/space/rig/atmos,
+					/obj/item/clothing/shoes/magboots,
+					/obj/item/clothing/mask/breath,
+					/obj/item/weapon/tank/oxygen,
+					/obj/item/weapon/gun/energy/laser,
+					/obj/item/weapon/gun/projectile/automatic/glock,
+					/obj/item/ammo_box/magazine/glock,
+					/obj/item/ammo_box/magazine/glock,
+					/obj/item/weapon/gun/energy/gun/nuclear,
+					/obj/item/weapon/storage/firstaid/small_firstaid_kit/space)
+	additional_costs = 9300
+	crate_name = "Anti-blob equipment: Personal set"
+	group = "blob"	//there is no such category, so these crates will not be visible in the console
+	hidden = TRUE
+
+/datum/supply_pack/blob_equipment/group
+	name = "Anti-blob equipment: Group supply"
+	contains = list(/obj/item/weapon/gun/energy/laser,
+					/obj/item/weapon/gun/energy/laser,
+					/obj/item/weapon/gun/energy/laser,
+					/obj/machinery/recharger,
+					/obj/machinery/recharger,
+					/obj/machinery/recharger,
+					/obj/item/weapon/storage/firstaid/small_firstaid_kit/space,
+					/obj/item/weapon/storage/firstaid/small_firstaid_kit/space,
+					/obj/item/weapon/storage/firstaid/small_firstaid_kit/space,
+					/obj/item/weapon/gun/projectile/automatic/glock,
+					/obj/item/weapon/gun/projectile/automatic/glock,
+					/obj/item/ammo_box/magazine/glock,
+					/obj/item/ammo_box/magazine/glock,
+					/obj/item/ammo_box/magazine/glock,
+					/obj/item/ammo_box/magazine/glock,
+					/obj/item/weapon/storage/box/flashbangs,
+					/obj/item/weapon/gun/energy/laser/cutter)
+	access = access_mint
+	additional_costs = 9300
+	crate_name = "Anti-blob equipment: Group supply"
+
+//----------------------------------------------
 //-------------SMARTLIGHT PROGRAMMS-------------
 //----------------------------------------------
 


### PR DESCRIPTION

## Описание изменений
1) Теперь анонс от ИИ с изменением законов не может быть перед анонсом о блобе
2) Прибрался в коде
4) Ставит красный код при критической массе
3) Когда блоб набирает более половины массы, экипажу высылают помощь в виде:
   - 2 персональных набора.
     - Риг атмостеха. Для атаки из космоса ИЛИ для защиты от форона И потому что он лёгкий
     - Аеган. Даже два не переломят ход боя, но помогут в бою в космосе.
     - Лазерка. Бери зарядник.
     - Глок с магазинами. Рефлекторы.
     - Аптечка. Право на ошибку.
   - 1 набор для группы
     - 3 лазера. Дополнительное к тому, что есть у станции.
     - 3 аптечки. Для помощи на поле боя
     - 3 зарядника. Что бы люди задумались.
     - 2 глока. На рефлекты
     - 2 эмиттера. В прямых руках нелпохое оружие.
     - 1 коробка флешбенгов
     - Резак. В купе с эмиттерами, может что-то сделать в прямых руках.
 В общем и целом. Персональные наборы своеобразная "плата" за доставку более тяжёлой посылки. Да, пройдёт не мало времени, прежде чем это поймут, но тем не менее.
 
## Почему и что этот ПР улучшит
Это создаёт дополнительную точку интереса для блобов. Так, 2 блоба не смогут закрыть одновременно и бриг, и РнД, и карго. 

ПР не призван идеально сбалансировать режим, а лишь сгладить неровности при перевесе сил. Да и если блоб разросся, значит он сильнее станции.
## Авторство

## Чеинжлог
:cl: 
- balance: ЦК присылает помощь в карго в случае распространении блоба.