### PR TITLE
Необходимый навык инженерного дела для использования SMES'а и консолей соляр понижен до нуля

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -17,6 +17,8 @@
 
 	process_last = TRUE
 
+	required_skills = list(/datum/skill/engineering = SKILL_LEVEL_NONE)
+
 	var/capacity = 0 // Maximum charge
 	var/charge = 0 // Actual charge
 
@@ -35,7 +37,6 @@
 
 	var/obj/machinery/power/terminal/terminal = null
 	var/power_failure = FALSE
-	required_skills = list(/datum/skill/engineering = SKILL_LEVEL_NOVICE)
 
 /obj/machinery/power/smes/atom_init()
 	. = ..()

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -17,7 +17,7 @@
 
 	process_last = TRUE
 
-	required_skills = list(/datum/skill/engineering = SKILL_LEVEL_NONE)
+	required_skills = null
 
 	var/capacity = 0 // Maximum charge
 	var/charge = 0 // Actual charge

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -240,7 +240,7 @@
 	max_integrity = 200
 	integrity_failure = 0.5
 
-	required_skills = list(/datum/skill/engineering = SKILL_LEVEL_NONE)
+	required_skills = null
 
 	var/light_range_on = 1.5
 	var/light_power_on = 3

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -240,6 +240,8 @@
 	max_integrity = 200
 	integrity_failure = 0.5
 
+	required_skills = list(/datum/skill/engineering = SKILL_LEVEL_NONE)
+
 	var/light_range_on = 1.5
 	var/light_power_on = 3
 	var/id = 0
@@ -250,6 +252,8 @@
 	var/trackrate = 60		// Measured in tenths of degree per minute (i.e. defaults to 6.0 deg/min)
 	var/trackdir = 1		// -1=CCW, 1=CW
 	var/nexttime = 0		// Next clock time that manual tracking will move the array
+
+
 
 /obj/machinery/power/solar_control/atom_init()
 	. = ..()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Если у инженеров будут забирать эту работу, то они ведь не расстроятся?
## Почему и что этот ПР улучшит
читать первый пункт плана https://github.com/TauCetiStation/TauCetiClassic/issues/11575
ноль скила на смес ещё увеличивает удобность саботажа инженерного отсека, что безусловно хорошо.
## Авторство
Luduk
## Чеинжлог
:cl: Deahaka, Luduk
- del: Навыки для управления SMES и солнечными панелями больше не требуются.