### PR TITLE
Увеличение отдачи энергии солнечных панелей

### DIFF
--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -1,5 +1,5 @@
 #define SOLAR_MAX_DIST 40
-#define SOLARGENRATE 1500
+#define SOLARGENRATE 1800
 
 // This will choose whether to get the solar list from the powernet or the powernet nodes,
 // depending on the size of the nodes.
@@ -136,11 +136,16 @@
 
 	if(obscured)	return
 
-	var/sgen = SOLARGENRATE * sunfrac
+	var/sgen = calculate_energy_incoming()
 	add_avail(sgen)
 	if(powernet && control)
 		if(powernet.nodes[control])
 			control.gen += sgen
+
+//override this if you want more/less power incoming from solars
+/obj/machinery/power/solar/proc/calculate_energy_incoming()
+	//Enough for supply NSS Exodus
+	return SOLARGENRATE * sunfrac
 
 /obj/machinery/power/solar/fake/atom_init(mapload, obj/item/solar_assembly/S)
 	. = ..(mapload, S, 0)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Теперь солнечные двигатели выдают полное обеспечение станции энергией. При подпитывании всех АПЦ ещё останется 40 кВт на нужды станции.
![0000000000000000000000000000000000](https://github.com/TauCetiStation/TauCetiClassic/assets/96499407/330f5d48-532c-4ccd-806a-ce6647ee565e)


Не советую ставить их без двигателя, если не перекласть проводку в двигательном отсеке.
## Почему и что этот ПР улучшит
читать первый пункт https://github.com/TauCetiStation/TauCetiClassic/issues/11575
## Авторство
Luduk
## Чеинжлог
:cl: Deahaka, Luduk
- tweak: Солнечные панели стали давать значительно больше энергии.