### PR TITLE
removes mood double slow

### DIFF
--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -124,7 +124,6 @@
 		if(MOOD_LEVEL_HAPPY4 to INFINITY)
 			mood_level = 9
 	update_mood_icon()
-	update_mood_client_color()
 
 /datum/component/mood/proc/update_mood_icon()
 	if(!screen_obj)
@@ -176,30 +175,6 @@
 		if(abs(event.mood_change) == highest_absolute_mood)
 			screen_obj.icon_state = "[event.special_screen_obj]"
 			break
-
-/datum/component/mood/proc/update_mood_client_color()
-	var/mob/living/carbon/human/H = parent
-	if(!istype(H))
-		return
-
-	H.moody_color = null
-
-	if(H.stat == DEAD)
-		return
-
-	if(spirit_level < 4)
-		return
-
-	var/dissapointment
-	switch(spirit_level)
-		if(6)
-			dissapointment = 0.8
-		if(5)
-			dissapointment = 0.4
-		if(4)
-			dissapointment = 0.2
-
-	H.moody_color = SADNESS_COLOR(dissapointment)
 
 ///Called on SSmood process
 /datum/component/mood/process(delta_time)
@@ -272,7 +247,6 @@
 			master.mood_multiplicative_actionspeed_modifier = -0.1
 			spirit_level = 1
 	update_mood_icon()
-	update_mood_client_color()
 
 	if(spirit_level > prev_spirit_level)
 		to_chat(parent, "<span class='warning'>Ваше настроение ухудшилось.</span>")
@@ -340,7 +314,6 @@
 	RegisterSignal(screen_obj, COMSIG_CLICK, .proc/hud_click)
 
 	update_mood_icon()
-	update_mood_client_color()
 
 /datum/component/mood/proc/unmodify_hud(datum/source)
 	SIGNAL_HANDLER

--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -124,6 +124,7 @@
 		if(MOOD_LEVEL_HAPPY4 to INFINITY)
 			mood_level = 9
 	update_mood_icon()
+	update_mood_client_color()
 
 /datum/component/mood/proc/update_mood_icon()
 	if(!screen_obj)
@@ -175,6 +176,30 @@
 		if(abs(event.mood_change) == highest_absolute_mood)
 			screen_obj.icon_state = "[event.special_screen_obj]"
 			break
+
+/datum/component/mood/proc/update_mood_client_color()
+	var/mob/living/carbon/human/H = parent
+	if(!istype(H))
+		return
+
+	H.moody_color = null
+
+	if(H.stat == DEAD)
+		return
+
+	if(spirit_level < 4)
+		return
+
+	var/dissapointment
+	switch(spirit_level)
+		if(6)
+			dissapointment = 0.8
+		if(5)
+			dissapointment = 0.4
+		if(4)
+			dissapointment = 0.2
+
+	H.moody_color = SADNESS_COLOR(dissapointment)
 
 ///Called on SSmood process
 /datum/component/mood/process(delta_time)
@@ -241,6 +266,7 @@
 			master.mood_multiplicative_actionspeed_modifier = -0.1
 			spirit_level = 1
 	update_mood_icon()
+	update_mood_client_color()
 
 	if(spirit_level > prev_spirit_level)
 		to_chat(parent, "<span class='warning'>Ваше настроение ухудшилось.</span>")
@@ -308,6 +334,7 @@
 	RegisterSignal(screen_obj, COMSIG_CLICK, .proc/hud_click)
 
 	update_mood_icon()
+	update_mood_client_color()
 
 /datum/component/mood/proc/unmodify_hud(datum/source)
 	SIGNAL_HANDLER

--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -223,27 +223,21 @@
 	var/mob/living/master = parent
 	switch(spirit)
 		if(SPIRIT_BAD to SPIRIT_LOW)
-			master.mood_additive_speed_modifier = 1.0
 			master.mood_multiplicative_actionspeed_modifier = 0.25
 			spirit_level = 6
 		if(SPIRIT_LOW to SPIRIT_POOR)
-			master.mood_additive_speed_modifier = 0.5
 			master.mood_multiplicative_actionspeed_modifier = 0.25
 			spirit_level = 5
 		if(SPIRIT_POOR to SPIRIT_DISTURBED)
-			master.mood_additive_speed_modifier = 0.25
 			master.mood_multiplicative_actionspeed_modifier = 0.25
 			spirit_level = 4
 		if(SPIRIT_DISTURBED to SPIRIT_NEUTRAL)
-			master.mood_additive_speed_modifier = 0.0
 			master.mood_multiplicative_actionspeed_modifier = 0.0
 			spirit_level = 3
 		if(SPIRIT_NEUTRAL + 1 to SPIRIT_HIGH + 1) //shitty hack but +1 to prevent it from responding to super small differences
-			master.mood_additive_speed_modifier = 0.0
 			master.mood_multiplicative_actionspeed_modifier = -0.1
 			spirit_level = 2
 		if(SPIRIT_HIGH + 1 to INFINITY)
-			master.mood_additive_speed_modifier = 0.0
 			master.mood_multiplicative_actionspeed_modifier = -0.1
 			spirit_level = 1
 	update_mood_icon()

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -139,9 +139,6 @@
 	if(get_species() == UNATHI && bodytemperature > species.body_temperature)
 		tally -= min((bodytemperature - species.body_temperature) / 10, 1) //will be on the border of heat_level_1
 
-	if(mood_additive_speed_modifier < 0 || !nullify_debuffs)
-		tally += mood_additive_speed_modifier
-
 	return (tally + config.human_delay)
 
 /mob/living/carbon/human/Process_Spacemove(movement_dir = 0)


### PR DESCRIPTION
## Описание изменений

Убирает замедление от муда.

#11125 некорректен потому-что не с той стороны подходит к проблеме. замедление от голода универсально для всех антаг, хуман, спу и делается чтобы куклы взаимодействовали с голодом

настроение к сожалению тоже замедляло потому-что нужен был дебафф связывающий игрока и куклу. но замедление это некорректный дебафф потому-что перечит задумке муда:
- наказывать набегаторов (то есть муд должен мешать драться но не мешать убегать)
- наказывать асоциальных типов (в итоге муд не даёт возможность социализироваться так как тебе нужно ползти к коллеге)

~~В будущем кто-то обязательно добавит другой дебафф на муд. Который не будет мешать убежать от набегатора и социализироваться. Я предпологаю что такой дебафф может быть связан с тем что субъективно неприятно игроку, как оверлей экрана. Возможно этот оверлей будет смешного цвета чтобы игроки подшучивали друг над другом и подталкивали играться с этой системой. Другой альтернативой было бы добавить шансы промаха при низком настроении. Это бы не грифонило убегающих от набегатора, но грифонило бы набегаторов.~~

## Почему и что этот ПР улучшит

муд работает согласно задумке и не грифонит игроков мешая им социализироваться

## Чеинжлог
:cl: Luduk
- rscdel: Настроение больше не замедляет.