### PR TITLE
Ящики охраны можно разрушать оружием 15+ урона

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -221,6 +221,7 @@ ADD_TO_GLOBAL_LIST(/obj/structure/closet/secure_closet/security, sec_closets_lis
 	icon_opened = "secopen"
 	icon_broken = "secbroken"
 	icon_off = "secoff"
+	damage_deflection = 15
 
 /obj/structure/closet/secure_closet/security/PopulateContents()
 	if(prob(50))


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Я думал, смотря на ящики с пушками из карго, что с полной разрушаемостью наконец-то не нужно дрочить эмиттеры для лута снаряги СБ. Но в недавнем раунде, оказалось, что ящики охраны на КПП имеют ту же броню, что и ящики глав. Если с главами понятно - чтобы не легко было воровать хайриск предметы, то с шмотом СБ не понятно, так как он хайриском не является. На КПП лежат ящики специально чтобы их воровали и вскрывали. Воровать отлично, вскрывать оказалось даже копьё не способно.
## Почему и что этот ПР улучшит
боланс и геймплей. Контент в первую очередь для революции, где снаряга для голожопиков это единственное условие дать сдачи и выжить после этого. Для остальных режимов на всё это скорее насрать.
## Авторство

## Чеинжлог
:cl: Deahaka
- balance: Ящики охраны теперь можно сломать оружием с уроном равному сварочному инструменту и больше.