### PR TITLE
Lifted mood debuffs: screen overlay and slowdown

### DIFF
--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -248,27 +248,21 @@
 	var/mob/living/master = parent
 	switch(spirit)
 		if(SPIRIT_BAD to SPIRIT_LOW)
-			master.mood_additive_speed_modifier = 1.0
 			master.mood_multiplicative_actionspeed_modifier = 0.25
 			spirit_level = 6
 		if(SPIRIT_LOW to SPIRIT_POOR)
-			master.mood_additive_speed_modifier = 0.5
 			master.mood_multiplicative_actionspeed_modifier = 0.25
 			spirit_level = 5
 		if(SPIRIT_POOR to SPIRIT_DISTURBED)
-			master.mood_additive_speed_modifier = 0.25
 			master.mood_multiplicative_actionspeed_modifier = 0.25
 			spirit_level = 4
 		if(SPIRIT_DISTURBED to SPIRIT_NEUTRAL)
-			master.mood_additive_speed_modifier = 0.0
 			master.mood_multiplicative_actionspeed_modifier = 0.0
 			spirit_level = 3
 		if(SPIRIT_NEUTRAL + 1 to SPIRIT_HIGH + 1) //shitty hack but +1 to prevent it from responding to super small differences
-			master.mood_additive_speed_modifier = 0.0
 			master.mood_multiplicative_actionspeed_modifier = -0.1
 			spirit_level = 2
 		if(SPIRIT_HIGH + 1 to INFINITY)
-			master.mood_additive_speed_modifier = 0.0
 			master.mood_multiplicative_actionspeed_modifier = -0.1
 			spirit_level = 1
 	update_mood_icon()

--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -124,7 +124,6 @@
 		if(MOOD_LEVEL_HAPPY4 to INFINITY)
 			mood_level = 9
 	update_mood_icon()
-	update_mood_client_color()
 
 /datum/component/mood/proc/update_mood_icon()
 	if(!screen_obj)
@@ -176,30 +175,6 @@
 		if(abs(event.mood_change) == highest_absolute_mood)
 			screen_obj.icon_state = "[event.special_screen_obj]"
 			break
-
-/datum/component/mood/proc/update_mood_client_color()
-	var/mob/living/carbon/human/H = parent
-	if(!istype(H))
-		return
-
-	H.moody_color = null
-
-	if(H.stat == DEAD)
-		return
-
-	if(spirit_level < 4)
-		return
-
-	var/dissapointment
-	switch(spirit_level)
-		if(6)
-			dissapointment = 0.8
-		if(5)
-			dissapointment = 0.4
-		if(4)
-			dissapointment = 0.2
-
-	H.moody_color = SADNESS_COLOR(dissapointment)
 
 ///Called on SSmood process
 /datum/component/mood/process(delta_time)
@@ -266,7 +241,6 @@
 			master.mood_multiplicative_actionspeed_modifier = -0.1
 			spirit_level = 1
 	update_mood_icon()
-	update_mood_client_color()
 
 	if(spirit_level > prev_spirit_level)
 		to_chat(parent, "<span class='warning'>Ваше настроение ухудшилось.</span>")
@@ -334,7 +308,6 @@
 	RegisterSignal(screen_obj, COMSIG_CLICK, PROC_REF(hud_click))
 
 	update_mood_icon()
-	update_mood_client_color()
 
 /datum/component/mood/proc/unmodify_hud(datum/source)
 	SIGNAL_HANDLER

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -139,9 +139,6 @@
 	if(get_species() == UNATHI && bodytemperature > species.body_temperature)
 		tally -= min((bodytemperature - species.body_temperature) / 10, 1) //will be on the border of heat_level_1
 
-	if(mood_additive_speed_modifier < 0 || !nullify_debuffs)
-		tally += mood_additive_speed_modifier
-
 	return (tally + config.human_delay)
 
 /mob/living/carbon/human/Process_Spacemove(movement_dir = 0)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

#11590, но в первоначальном варианте. Автор собрал кучу фидбека на гитхабе (на данный момент - 4 залайканный ПР из всех, что были), без особого пиара, за день, всего лишь за иронично вкинутую ссылку во флудилке на форума. А потом сдал назад и отменил наиболее критичную, на мой взгляд, половину изменений.

Даже если не брать во внимание фидбек, бодаться против которого уже как-то не прилично. Я просто предлагаю считать систему настроений бета-версией того, чем оно могло бы быть. Пока регулярно что-то ломается, пока игроки банально не видят своих муд-модификаторов, пока у нас нету инструментов для дебага, сбора и отслеживания изменений муда, я считаю наказывать игроков противным фильтром в таких обстоятельствах излишним. Вернутся к вопросу можно будет в будущем, когда будут исправлены уже все известные проблемы и система будет более устоявшейся и стабильной.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог

:cl:
- rscdel: До переработки системы настроения, дебаффы настроения больше не замедляют и не вешают фильтр на экран. Всё еще остаётся небольшое влияние на скорость действий (с прогрессбаром).