### PR TITLE
Fix for bugged overlays?

### DIFF
--- a/code/game/objects/structures/chapel.dm
+++ b/code/game/objects/structures/chapel.dm
@@ -339,9 +339,9 @@ ADD_TO_GLOBAL_LIST(/obj/effect/effect/bell, bells)
 
 	var/obj/item/weapon/storage/internal/book
 
-	var/image/lectern_overlay
-	var/image/book_overlay
-	var/image/emblem_overlay
+	var/mutable_appearance/lectern_overlay
+	var/mutable_appearance/book_overlay
+	var/mutable_appearance/emblem_overlay
 
 /obj/structure/stool/bed/chair/lectern/atom_init()
 	. = ..()
@@ -359,13 +359,13 @@ ADD_TO_GLOBAL_LIST(/obj/effect/effect/bell, bells)
 	RegisterSignal(book, list(COMSIG_STORAGE_ENTERED), PROC_REF(add_book))
 	RegisterSignal(book, list(COMSIG_STORAGE_EXITED), PROC_REF(remove_book))
 
-	lectern_overlay = image(icon, "lectern_overlay")
+	lectern_overlay = mutable_appearance(icon, "lectern_overlay")
 	lectern_overlay.layer = INFRONT_MOB_LAYER
 
-	book_overlay = image(icon, "book")
+	book_overlay = mutable_appearance(icon, "book")
 	book_overlay.layer = INFRONT_MOB_LAYER
 
-	emblem_overlay = image(icon, "general")
+	emblem_overlay = mutable_appearance(icon, "general")
 	emblem_overlay.layer = INFRONT_MOB_LAYER
 	lectern_overlay.add_overlay(emblem_overlay)
 	add_overlay(emblem_overlay)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -124,11 +124,11 @@ Please contact me on #coderbus IRC. ~Carn x
 			if("[t_state]_fem" in icon_states(def_icon_path))
 				fem = "_fem"
 
-	var/image/I = image(icon = icon_path, icon_state = "[t_state][fem][icon_state_appendix]", layer = layer)
+	var/mutable_appearance/I = mutable_appearance(icon = icon_path, icon_state = "[t_state][fem][icon_state_appendix]", layer = layer)
 	I.color = color
 
 	if(dirt_overlay && bloodied_icon_state)
-		var/image/bloodsies = image(icon = 'icons/effects/blood.dmi', icon_state = bloodied_icon_state)
+		var/mutable_appearance/bloodsies = mutable_appearance(icon = 'icons/effects/blood.dmi', icon_state = bloodied_icon_state)
 		bloodsies.color = dirt_overlay.color
 		I.add_overlay(bloodsies)
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Залипающие оверели багуются по каким-то только бьенду ведомым причинам, похоже что-то связанное с тем, как он внутренне работает с appearance-ами, и как именно бьенд линкует их при обновлении списка оверлеев.

В процессе отладки попробовал использовать mutable_appearance (это всё равно нужно было сделать), и... баг чудесным образом перестал воспроизводиться!

Но может быть мне показалось, конечно. Баг изначально какой-то, мягко говоря, сложно воспроизводимый.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог

:cl: 
  - fix: Вроде как исправлены залипающие на кукле оверлеи одежды/оружия, оверлеи кафедры.