### PR TITLE
Delta Station Map Edit. Supermatter Destroying. Singularity and Tesla returns.

### DIFF
--- a/code/game/area/delta_areas.dm
+++ b/code/game/area/delta_areas.dm
@@ -1,0 +1,8 @@
+/area/station/engineering/atmos/supermatter
+	name = "Supermatter Construction Area"
+	power_equip = 0
+	power_light = 0
+	power_environ = 0
+
+/area/station/engineering/minisat_secure_area
+	name = "Minisat Access Area"

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -45419,7 +45419,7 @@
 "bFr" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Delivery Office";
-	req_one_access = list(50, 70)
+	req_one_access = list(50,70)
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -301,7 +301,9 @@
 /area/station/medical/hallway)
 "abU" = (
 /obj/structure/closet/emcloset,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
 /area/station/hallway/primary/port)
 "abX" = (
 /obj/machinery/atmospherics/components/unary/portables_connector,
@@ -1678,6 +1680,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "yellowpatch"
 	},
@@ -2344,10 +2351,10 @@
 	},
 /area/station/rnd/xenobiology)
 "atL" = (
-/obj/machinery/camera{
-	c_tag = "Drone Fabrication";
-	network = list("SS13","Engineering");
-	dir = 4
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "apc left";
+	pixel_x = -28
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -2776,17 +2783,16 @@
 	},
 /area/station/hallway/primary/fore)
 "aAr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/camera{
+	c_tag = "Drone Fabrication";
+	network = list("SS13","Engineering");
 	dir = 5
 	},
 /turf/simulated/floor{
-	icon_state = "neutralfull"
+	dir = 8;
+	icon_state = "darkyellow"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/drone_fabrication)
 "aAt" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3998,10 +4004,11 @@
 "aQc" = (
 /obj/structure/rack,
 /obj/machinery/light/smart,
-/obj/item/device/multitool,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/weapon/storage/belt/utility,
+/obj/item/device/multitool,
 /obj/item/device/multitool,
 /turf/simulated/floor{
 	dir = 8;
@@ -4605,6 +4612,11 @@
 	},
 /obj/machinery/door/airlock/atmos{
 	name = "Supermatter Construction Area"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "yellowfull"
@@ -5545,6 +5557,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
@@ -9303,6 +9320,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
+"cbS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "cce" = (
 /obj/structure/closet/wardrobe/white,
 /turf/simulated/floor{
@@ -17804,11 +17838,16 @@
 /turf/simulated/floor,
 /area/station/rnd/tox_launch)
 "emc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -22839,6 +22878,11 @@
 	pixel_y = -32
 	},
 /obj/item/weapon/flora/random,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "yellowpatch"
 	},
@@ -26006,6 +26050,11 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -37342,6 +37391,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "jcC" = (
@@ -39570,6 +39624,11 @@
 "jEa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	icon_state = "yellowpatch"
 	},
@@ -40263,12 +40322,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "jLz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -47037,7 +47101,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/primary/port)
 "lsm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -47137,6 +47203,11 @@
 "ltv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	icon_state = "darkyellow"
 	},
@@ -48656,6 +48727,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "yellow"
@@ -49462,6 +49538,11 @@
 /obj/machinery/door/airlock/atmos{
 	name = "Supermatter Construction Area"
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	icon_state = "yellowfull"
 	},
@@ -49634,7 +49715,7 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/device/flashlight/lamp{
-	pixel_x = -4;
+	on = 0;
 	pixel_y = 6
 	},
 /turf/simulated/floor{
@@ -50318,6 +50399,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -54474,6 +54560,11 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	icon_state = "yellowpatch"
 	},
@@ -57155,6 +57246,11 @@
 /obj/structure/table/reinforced,
 /obj/item/weapon/module/power_control,
 /obj/item/device/analyzer,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor{
 	icon_state = "yellowpatch"
 	},
@@ -62904,6 +63000,11 @@
 /obj/structure/rack,
 /obj/item/weapon/weldingtool,
 /obj/item/clothing/head/welding,
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 28;
+	pixel_y = -5
+	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/supermatter)
 "pwa" = (
@@ -64363,10 +64464,11 @@
 /area/station/maintenance/medbay)
 "pMJ" = (
 /obj/structure/rack,
-/obj/item/weapon/storage/box/lights/bulbs,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 29
 	},
+/obj/item/clothing/gloves/black,
+/obj/item/weapon/storage/box/lights/bulbs,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "vault"
@@ -65564,6 +65666,11 @@
 /area/shuttle/supply/station)
 "qby" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "yellow"
@@ -67319,6 +67426,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
@@ -71059,7 +71171,9 @@
 /area/station/maintenance/escape)
 "ryx" = (
 /obj/structure/closet/firecloset,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
 /area/station/hallway/primary/port)
 "ryF" = (
 /obj/machinery/door/airlock{
@@ -72694,6 +72808,11 @@
 /area/station/cargo/miningoffice)
 "rQM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "darkyellow"
@@ -73347,6 +73466,10 @@
 /area/station/cargo/storage)
 "rZO" = (
 /obj/structure/table/reinforced,
+/obj/item/weapon/crowbar,
+/obj/item/weapon/wrench{
+	pixel_y = -6
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -73844,6 +73967,11 @@
 	dir = 10
 	},
 /obj/structure/grille,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor{
 	icon_state = "yellowpatch"
 	},
@@ -78105,6 +78233,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "yellowpatch"
 	},
@@ -78164,6 +78297,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/atmos{
 	name = "Drone Fabrication"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "darkyellowfull"
@@ -81799,6 +81937,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -82871,6 +83014,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -83031,6 +83179,11 @@
 	dir = 1
 	},
 /obj/structure/grille,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor{
 	icon_state = "yellowpatch"
 	},
@@ -87211,7 +87364,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/light/smart,
+/obj/machinery/light_construct,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -87626,6 +87779,11 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -90007,6 +90165,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -91080,12 +91243,16 @@
 	},
 /area/station/security/brig)
 "wJN" = (
-/obj/structure/table/reinforced,
-/obj/machinery/computer/skills,
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/item/weapon/paper/depacc{
+	department_name = "Engineering"
+	},
+/obj/structure/filingcabinet/chestdrawer/black{
+	req_access = list(56)
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -91848,6 +92015,11 @@
 /obj/structure/cable/yellow{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -28;
+	pixel_y = -5
 	},
 /turf/simulated/floor{
 	icon_state = "yellowpatch"
@@ -95009,6 +95181,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "yellowpatch"
 	},
@@ -96543,6 +96720,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -119301,7 +119483,7 @@ kAl
 kAl
 kAl
 kAl
-gII
+aAr
 rDL
 atL
 rDL
@@ -120080,7 +120262,7 @@ pbm
 vPk
 gYu
 jLz
-aAr
+qSk
 qSk
 qSk
 qSk
@@ -120336,7 +120518,7 @@ vwv
 sWI
 vPk
 jFr
-bFn
+cbS
 emc
 bFn
 npG

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -372,7 +372,6 @@
 	},
 /area/station/medical/sleeper)
 "acq" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/structure/transit_tube{
 	icon_state = "D-SE"
 	},
@@ -841,14 +840,6 @@
 	icon_state = "orange"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
-"aeC" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "bot"
-	},
-/area/station/engineering/singularity)
 "aeD" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -1654,8 +1645,10 @@
 	},
 /area/station/hallway/primary/central)
 "amw" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/turf/simulated/floor/plating/airless/catwalk,
+/turf/simulated/floor/plating/airless{
+	dir = 8;
+	icon_state = "warnplate"
+	},
 /area/space)
 "amy" = (
 /obj/structure/table/reinforced,
@@ -1777,19 +1770,6 @@
 	icon_state = "darkbrown"
 	},
 /area/station/bridge)
-"anr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating{
-	dir = 4;
-	icon_state = "warnplate"
-	},
-/area/station/engineering/singularity)
 "anD" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/light/smart{
@@ -2194,10 +2174,13 @@
 	},
 /area/station/civilian/hydroponics)
 "arF" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 8
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating{
+	icon_state = "platebot"
+	},
 /area/station/engineering/singularity)
 "asj" = (
 /obj/structure/cable{
@@ -2244,12 +2227,6 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/kitchen)
-"asr" = (
-/obj/machinery/power/rad_collector{
-	anchored = 1
-	},
-/turf/simulated/floor/plating,
-/area/station/engineering/singularity)
 "ass" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -2640,12 +2617,6 @@
 	icon_state = "neutral"
 	},
 /area/station/security/main)
-"ayw" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/singularity)
 "ayB" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/breath,
@@ -2758,12 +2729,6 @@
 	icon_state = "blackchecker"
 	},
 /area/station/hallway/primary/fore)
-"aAn" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 10
-	},
-/turf/simulated/floor/plating/airless/catwalk,
-/area/space)
 "aAr" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2895,15 +2860,6 @@
 	icon_state = "warning"
 	},
 /area/station/rnd/xenobiology)
-"aBb" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "bot"
-	},
-/area/station/engineering/singularity)
 "aBc" = (
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -3806,12 +3762,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
-"aNw" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 5
-	},
-/turf/simulated/floor/plating/airless/catwalk,
-/area/space)
 "aNE" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -4158,15 +4108,6 @@
 	icon_state = "grimy"
 	},
 /area/station/storage/tools)
-"aRY" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "bot"
-	},
-/area/station/engineering/singularity)
 "aSh" = (
 /turf/simulated/floor{
 	icon_state = "bot"
@@ -4490,10 +4431,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/medical/genetics)
-"aWh" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/turf/simulated/wall/r_wall,
-/area/station/engineering/singularity)
 "aWq" = (
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
@@ -4543,13 +4480,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/atmos)
-"aXN" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/turf/simulated/floor{
-	icon_state = "yellowpatch"
-	},
-/area/station/engineering/singularity)
 "aXP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -5339,14 +5269,11 @@
 	},
 /area/station/engineering/engine)
 "bhn" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
+/turf/simulated/floor/plating/airless{
+	dir = 8;
+	icon_state = "warnplate"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/singularity)
+/area/station/maintenance/science)
 "bhp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -5382,16 +5309,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
-"bie" = (
-/obj/structure/closet/radiation,
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -32
-	},
-/turf/simulated/floor{
-	icon_state = "bot"
-	},
-/area/station/engineering/engine)
 "biv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -5857,12 +5774,14 @@
 	},
 /area/station/civilian/library)
 "bmQ" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	id_tag = "engineering_east_outer";
+	locked = 1;
+	name = "Engineering External Access";
+	req_access = list(10,13)
 	},
-/turf/simulated/floor{
-	icon_state = "cafeteria"
-	},
+/turf/simulated/floor/plating,
 /area/station/engineering/singularity)
 "bmU" = (
 /obj/effect/decal/cleanable/blood/splatter,
@@ -6090,15 +6009,6 @@
 	icon_state = "bot"
 	},
 /area/station/bridge)
-"bqi" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/singularity)
 "bqn" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -6370,8 +6280,8 @@
 /turf/simulated/floor,
 /area/station/civilian/chapel/mass_driver)
 "btC" = (
-/obj/machinery/power/rad_collector,
-/turf/simulated/floor/plating,
+/obj/machinery/power/emitter,
+/turf/simulated/floor/plating/airless,
 /area/station/engineering/singularity)
 "btE" = (
 /obj/structure/bookcase{
@@ -6549,21 +6459,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
-"bvK" = (
-/obj/item/weapon/flora/random,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 28
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/singularity)
 "bvL" = (
 /turf/simulated/floor{
 	icon_state = "bot"
@@ -6931,18 +6826,10 @@
 	},
 /area/station/hallway/primary/central)
 "bAA" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/turf/simulated/floor/plating{
+	dir = 8;
+	icon_state = "warnplate"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor,
 /area/station/engineering/singularity)
 "bAC" = (
 /obj/structure/cable{
@@ -8043,14 +7930,6 @@
 	icon_state = "redyellowfull"
 	},
 /area/station/civilian/bar)
-"bKW" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "bot"
-	},
-/area/station/engineering/singularity)
 "bLg" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 29
@@ -9053,12 +8932,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
-"bYx" = (
-/obj/machinery/atmospherics/pipe/manifold4w/visible/fuel,
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "bYy" = (
 /obj/structure/rack,
 /obj/structure/window/thin/reinforced{
@@ -9118,15 +8991,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
-"bZA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "warning"
-	},
-/area/station/engineering/engine)
 "bZN" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -9251,7 +9115,12 @@
 	},
 /area/station/cargo/qm)
 "cbc" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "yellowfull"
 	},
@@ -9676,21 +9545,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
-"cgh" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_access = list(10)
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/station/engineering/singularity)
 "cgu" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor{
@@ -10396,14 +10250,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
-"coV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light/smart{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "cpc" = (
 /obj/structure/table,
 /obj/machinery/alarm{
@@ -10440,16 +10286,6 @@
 "cpR" = (
 /turf/simulated/wall,
 /area/station/cargo/storage)
-"cqb" = (
-/obj/structure/closet/radiation,
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "caution"
-	},
-/area/station/engineering/singularity)
 "cqB" = (
 /obj/item/weapon/flora/random,
 /obj/item/device/radio/intercom{
@@ -11624,12 +11460,6 @@
 	icon_state = "delivery"
 	},
 /area/station/engineering/monitoring)
-"cGo" = (
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/turf/simulated/floor{
-	icon_state = "bot"
-	},
-/area/station/engineering/atmos)
 "cGA" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -12153,8 +11983,10 @@
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
 "cNU" = (
-/obj/machinery/power/tesla_coil,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/airless{
+	dir = 10;
+	icon_state = "warnplate"
+	},
 /area/station/engineering/singularity)
 "cNX" = (
 /obj/structure/closet/emcloset,
@@ -12329,23 +12161,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
-"cQq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor{
-	icon_state = "yellowpatch"
-	},
-/area/station/engineering/singularity)
 "cQt" = (
 /obj/item/device/flash,
 /obj/item/clothing/glasses/sunglasses,
@@ -12467,16 +12282,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
-"cRn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/plating{
-	dir = 4;
-	icon_state = "warnplate"
-	},
-/area/station/engineering/singularity)
 "cRp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -12573,13 +12378,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"cSu" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/obj/machinery/light/smart{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "cSB" = (
 /obj/structure/object_wall/mining{
 	icon_state = "1-8"
@@ -12913,13 +12711,6 @@
 	icon_state = "grimy"
 	},
 /area/station/tcommsat/computer)
-"cWS" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/visible/green{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "cWT" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13213,13 +13004,11 @@
 	},
 /area/station/aisat/ai_chamber)
 "ddt" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -28;
-	pixel_y = -5
+/turf/simulated/floor/plating/airless{
+	dir = 9;
+	icon_state = "warnplate"
 	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
+/area/space)
 "ddy" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13257,12 +13046,6 @@
 	oxygen = 0.01
 	},
 /area/station/engineering/atmos)
-"ddK" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 6
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/singularity)
 "ddT" = (
 /obj/machinery/computer/atmos_alert,
 /obj/structure/cable{
@@ -13396,10 +13179,10 @@
 	},
 /area/station/civilian/chapel/mass_driver)
 "dfK" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 4
+/turf/simulated/floor/plating/airless{
+	dir = 9;
+	icon_state = "warnplate"
 	},
-/turf/simulated/floor,
 /area/station/engineering/singularity)
 "dfS" = (
 /obj/item/weapon/flora/random,
@@ -13920,13 +13703,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/brig)
-"dkA" = (
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/turf/simulated/floor/plating/airless/catwalk,
-/area/space)
 "dkB" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
@@ -13948,9 +13724,6 @@
 "dkO" = (
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -14174,12 +13947,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/monitoring)
-"dpd" = (
-/obj/structure/rack,
-/obj/item/clothing/gloves/orange,
-/obj/item/weapon/wirecutters,
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "dpi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -14436,7 +14203,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "dsj" = (
-/turf/simulated/floor,
+/turf/simulated/floor/plating/airless{
+	dir = 6;
+	icon_state = "warnplate"
+	},
 /area/station/engineering/singularity)
 "dsq" = (
 /obj/machinery/access_button{
@@ -14687,18 +14457,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
-"dvx" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor{
-	icon_state = "yellowpatch"
-	},
-/area/station/engineering/singularity)
 "dvy" = (
 /obj/effect/landmark/start/bartender,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -15115,10 +14873,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/hallway/primary/central)
-"dBV" = (
-/obj/machinery/constructable_frame/machine_frame,
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "dBW" = (
 /obj/machinery/camera{
 	c_tag = "Dormitories Toilets";
@@ -15817,10 +15571,9 @@
 	},
 /area/station/engineering/atmos)
 "dLx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on/atmos{
-	dir = 1
+/turf/simulated/floor/plating/airless{
+	icon_state = "platebot"
 	},
-/turf/simulated/floor/engine,
 /area/station/engineering/singularity)
 "dLz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -16337,14 +16090,6 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/medical/chemistry)
-"dTW" = (
-/obj/machinery/power/grounding_rod,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/singularity)
 "dTZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -18058,12 +17803,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/toilet)
-"erS" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 6
-	},
-/turf/simulated/floor/plating/airless/catwalk,
-/area/space)
 "erV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on/atmos{
 	dir = 4;
@@ -18303,12 +18042,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/sleeper)
-"euL" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/turf/simulated/floor{
-	icon_state = "yellowpatch"
-	},
-/area/station/engineering/singularity)
 "euO" = (
 /obj/structure/closet/jcloset,
 /turf/simulated/floor{
@@ -18536,10 +18269,10 @@
 /turf/simulated/floor,
 /area/station/civilian/hydroponics)
 "exw" = (
-/turf/simulated/floor{
-	icon_state = "bot"
+/turf/simulated/floor/plating/airless{
+	icon_state = "warnplate"
 	},
-/area/station/engineering/singularity)
+/area/station/maintenance/engineering)
 "exA" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
@@ -19837,13 +19570,6 @@
 	},
 /turf/simulated/shuttle/floor/wagon,
 /area/shuttle/supply/station)
-"eOU" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/turf/simulated/floor/plating/airless/catwalk,
-/area/space)
 "ePG" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -20969,12 +20695,6 @@
 	icon_state = "red"
 	},
 /area/station/security/brig)
-"feb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/maintenance/science)
 "feh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -22268,12 +21988,6 @@
 	icon_state = "delivery"
 	},
 /area/station/engineering/engine)
-"fvf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/engineering/singularity)
 "fvs" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -22376,10 +22090,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/tox_launch)
-"fwv" = (
-/obj/machinery/light/small,
-/turf/simulated/floor/engine,
-/area/station/engineering/singularity)
 "fwH" = (
 /mob/living/simple_animal/corgi/borgi,
 /turf/simulated/floor{
@@ -22575,15 +22285,8 @@
 	},
 /area/station/security/interrogation)
 "fzd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/plating{
-	dir = 4;
+/turf/simulated/floor/plating/airless{
+	dir = 1;
 	icon_state = "warnplate"
 	},
 /area/station/engineering/singularity)
@@ -23041,15 +22744,6 @@
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/starboard)
-"fFF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/turf/simulated/floor{
-	icon_state = "yellowpatch"
-	},
-/area/station/engineering/singularity)
 "fFW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light/smart{
@@ -23078,10 +22772,9 @@
 	},
 /area/station/civilian/library)
 "fGh" = (
-/obj/structure/closet/radiation,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	dir = 5;
-	icon_state = "warning"
+	icon_state = "warnplate"
 	},
 /area/station/engineering/engine)
 "fGm" = (
@@ -23182,13 +22875,6 @@
 	icon_state = "purple"
 	},
 /area/station/rnd/hor)
-"fHi" = (
-/obj/item/weapon/flora/random,
-/turf/simulated/floor{
-	dir = 10;
-	icon_state = "warning"
-	},
-/area/station/engineering/engine)
 "fHs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -23530,8 +23216,10 @@
 	},
 /area/station/maintenance/cargo)
 "fKT" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/green,
-/turf/simulated/floor,
+/turf/simulated/floor/plating/airless{
+	dir = 4;
+	icon_state = "warnplate"
+	},
 /area/station/engineering/singularity)
 "fKV" = (
 /obj/structure/rack,
@@ -23745,11 +23433,9 @@
 	},
 /area/station/engineering/atmos)
 "fPf" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Atmos to Loop"
-	},
-/turf/simulated/floor{
-	icon_state = "bot"
+/turf/simulated/floor/plating/airless{
+	dir = 1;
+	icon_state = "warnplatecorner"
 	},
 /area/station/engineering/singularity)
 "fPg" = (
@@ -23921,9 +23607,11 @@
 	},
 /area/station/rnd/xenobiology)
 "fRP" = (
-/obj/machinery/the_singularitygen/tesla,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
 /turf/simulated/floor{
-	icon_state = "bot"
+	icon_state = "warning"
 	},
 /area/station/engineering/engine)
 "fRR" = (
@@ -24584,15 +24272,6 @@
 	icon_state = "delivery"
 	},
 /area/station/storage/primary)
-"gbd" = (
-/obj/machinery/atmospherics/components/binary/pump,
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -28;
-	pixel_y = -5
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/singularity)
 "gbj" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/pen,
@@ -24745,9 +24424,9 @@
 	},
 /area/station/engineering/atmos)
 "gcG" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/blue,
-/turf/simulated/floor{
-	icon_state = "delivery"
+/turf/simulated/floor/plating/airless{
+	dir = 8;
+	icon_state = "warnplatecorner"
 	},
 /area/station/engineering/singularity)
 "gcK" = (
@@ -25001,12 +24680,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "gfO" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/structure/transit_tube{
+	icon_state = "D-NW"
 	},
-/turf/simulated/floor/plating,
-/area/station/engineering/singularity)
+/obj/structure/lattice,
+/turf/environment/space,
+/area/space)
 "gfQ" = (
 /obj/structure/stool/bed/chair{
 	dir = 1
@@ -25107,13 +24786,6 @@
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/auxport)
-"ghM" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 1
-	},
-/obj/machinery/power/supermatter/shard,
-/turf/simulated/floor/engine,
-/area/station/engineering/singularity)
 "ghN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 9
@@ -25694,16 +25366,10 @@
 	},
 /area/station/cargo/storage)
 "gnl" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/floor/plating{
+	dir = 10;
+	icon_state = "warnplate"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor,
 /area/station/engineering/singularity)
 "gnv" = (
 /obj/structure/cable{
@@ -25814,12 +25480,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
-"gom" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/manifold4w/visible,
-/obj/structure/window/fulltile/reinforced/phoron,
-/turf/simulated/floor/engine,
-/area/station/engineering/singularity)
 "goK" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -25930,7 +25590,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/obj/structure/particle_accelerator/end_cap{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "gqd" = (
 /obj/structure/table/woodentable,
@@ -25994,11 +25657,6 @@
 	icon_state = "arrival"
 	},
 /area/station/engineering/atmos)
-"gqH" = (
-/turf/simulated/floor{
-	icon_state = "delivery"
-	},
-/area/station/engineering/engine)
 "gqK" = (
 /obj/structure/lattice,
 /obj/structure/window/thin/reinforced{
@@ -26942,21 +26600,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "gBi" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/power/tesla_coil,
+/turf/simulated/floor/plating/airless{
+	icon_state = "platebot"
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "Singularity";
-	layer = 2.8;
-	name = "Singularity Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
 /area/station/engineering/singularity)
 "gBj" = (
 /obj/machinery/firealarm{
@@ -27823,14 +27470,6 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/atmos)
-"gOx" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_access = list(10)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/engineering/singularity)
 "gOB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/item/device/radio/intercom{
@@ -27864,14 +27503,6 @@
 	},
 /turf/simulated/floor/engine/carbon_dioxide,
 /area/station/engineering/atmos)
-"gPk" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 5
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/singularity)
 "gPy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -27987,14 +27618,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
-"gQM" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Emergency Access";
-	req_access = list(10)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "gRg" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -28028,15 +27651,10 @@
 /turf/environment/space,
 /area/shuttle/supply/station)
 "gRp" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/floor/plating/airless{
+	dir = 8;
+	icon_state = "warnplate"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/turf/simulated/floor,
 /area/station/engineering/singularity)
 "gRz" = (
 /turf/simulated/floor{
@@ -28312,10 +27930,10 @@
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/port)
 "gUA" = (
-/obj/structure/closet/toolcloset,
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/closet/radiation,
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
@@ -28803,20 +28421,6 @@
 	icon_state = "whitehall"
 	},
 /area/station/rnd/hallway)
-"haO" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/station/engineering/singularity)
-"haU" = (
-/obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
-/turf/simulated/floor/plating,
-/area/station/engineering/singularity)
 "hba" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28891,13 +28495,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry)
-"hbF" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/obj/structure/transit_tube{
-	icon_state = "D-NW"
-	},
-/turf/simulated/floor/plating/airless/catwalk,
-/area/space)
 "hbM" = (
 /obj/structure/window/fulltile/reinforced/phoron{
 	grilled = 1;
@@ -29500,12 +29097,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
-"hle" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/singularity)
 "hlh" = (
 /obj/structure/table/woodentable,
 /obj/structure/cable{
@@ -29621,7 +29212,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
@@ -29634,10 +29225,9 @@
 	},
 /area/station/civilian/kitchen)
 "hmC" = (
-/obj/structure/closet/firecloset,
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	dir = 4;
-	icon_state = "warning"
+	icon_state = "warnplate"
 	},
 /area/station/engineering/engine)
 "hmN" = (
@@ -29849,31 +29439,20 @@
 	pixel_y = -25;
 	req_one_access = list(13,45,1)
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "hpC" = (
-/obj/structure/closet/crate{
-	name = "solar pack crate"
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 10
 	},
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/solar_assembly,
-/obj/item/weapon/circuitboard/solar_control,
-/obj/item/weapon/tracker_electronics,
-/obj/item/weapon/paper/solar,
-/turf/simulated/floor,
-/area/station/engineering/singularity)
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "yellow"
+	},
+/area/station/engineering/engine)
 "hpD" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -30434,12 +30013,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
-"hvL" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/turf/simulated/floor/plating,
-/area/station/engineering/singularity)
 "hvR" = (
 /obj/structure/closet/secure_closet/captains,
 /turf/simulated/floor{
@@ -30577,15 +30150,10 @@
 /turf/simulated/floor,
 /area/station/security/main)
 "hxo" = (
-/obj/item/weapon/flora/random,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/floor/plating{
+	dir = 1;
+	icon_state = "warnplate"
 	},
-/turf/simulated/floor,
 /area/station/engineering/singularity)
 "hxr" = (
 /obj/structure/cable{
@@ -30743,17 +30311,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
-"hyY" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/light/smart{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "hzh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -31641,12 +31198,6 @@
 	icon_state = "wooden"
 	},
 /area/station/hallway/primary/central)
-"hJG" = (
-/obj/machinery/light/smart{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/station/engineering/singularity)
 "hJH" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/fancy/crayons,
@@ -31673,17 +31224,15 @@
 	},
 /area/station/hallway/primary/central)
 "hKj" = (
-/obj/machinery/meter,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/status_display{
+	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 9
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "warning"
 	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
+/area/station/engineering/engine)
 "hKk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -32303,10 +31852,7 @@
 /area/station/hallway/primary/central)
 "hTd" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall/r_wall,
 /area/station/maintenance/science)
 "hTg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -32481,10 +32027,13 @@
 	},
 /area/station/cargo/recycleroffice)
 "hVy" = (
-/turf/simulated/floor{
-	icon_state = "neutralfull"
+/obj/machinery/power/rad_collector{
+	anchored = 1
 	},
-/area/station/engineering/singularity)
+/turf/simulated/floor/plating/airless{
+	icon_state = "platebot"
+	},
+/area/space)
 "hVD" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/folder/blue,
@@ -32643,11 +32192,7 @@
 /turf/environment/space,
 /area/shuttle/mining/station)
 "hXd" = (
-/obj/structure/closet/toolcloset,
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 22
-	},
+/obj/machinery/vending/tool,
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
@@ -33280,11 +32825,11 @@
 	},
 /area/station/civilian/bar)
 "ieI" = (
-/obj/machinery/space_heater,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -22
 	},
+/obj/machinery/power/rad_collector,
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
@@ -33373,7 +32918,10 @@
 /area/station/civilian/library)
 "ifQ" = (
 /obj/effect/landmark/start/station_engineer,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellow"
+	},
 /area/station/engineering/engine)
 "ifR" = (
 /obj/machinery/computer/secure_data,
@@ -33673,14 +33221,6 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/secondary/exit)
-"ije" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Cooling Bypass"
-	},
-/turf/simulated/floor{
-	icon_state = "yellowpatch"
-	},
-/area/station/engineering/singularity)
 "ijf" = (
 /obj/machinery/shieldgen,
 /obj/effect/decal/cleanable/dirt,
@@ -33786,11 +33326,9 @@
 	},
 /area/station/civilian/theatre)
 "ilb" = (
-/obj/structure/rack,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
+/turf/simulated/floor/plating/airless{
+	dir = 6;
+	icon_state = "warnplate"
 	},
 /area/station/maintenance/science)
 "ilc" = (
@@ -34704,11 +34242,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
-"iwx" = (
-/obj/machinery/constructable_frame/machine_frame,
-/obj/item/device/multitool,
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "iwy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -35359,23 +34892,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway)
-"iFu" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
-/area/station/engineering/singularity)
-"iFv" = (
-/obj/machinery/light/smart{
-	dir = 1
-	},
-/obj/machinery/power/rad_collector,
-/turf/simulated/floor/plating,
-/area/station/engineering/singularity)
 "iFw" = (
 /obj/item/weapon/flora/random,
 /obj/structure/cable{
@@ -35784,14 +35300,6 @@
 /obj/structure/displaycase,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
-"iJA" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "delivery"
-	},
-/area/station/engineering/singularity)
 "iJP" = (
 /obj/structure/dresser,
 /obj/machinery/light/small{
@@ -35932,14 +35440,12 @@
 	},
 /area/station/engineering/engine)
 "iLP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+/obj/machinery/power/rad_collector{
+	anchored = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/turf/simulated/floor/plating{
+	icon_state = "platebot"
 	},
-/obj/item/weapon/flora/random,
-/turf/simulated/floor,
 /area/station/engineering/singularity)
 "iLV" = (
 /obj/structure/extinguisher_cabinet{
@@ -36210,10 +35716,10 @@
 /turf/simulated/floor/plating,
 /area/station/security/brig/solitary_confinement)
 "iPv" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 9
+/turf/simulated/floor/plating{
+	dir = 9;
+	icon_state = "warnplate"
 	},
-/turf/simulated/floor,
 /area/station/engineering/singularity)
 "iPB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -37259,14 +36765,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
-"jcM" = (
-/obj/machinery/power/grounding_rod,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/singularity)
 "jcO" = (
 /obj/structure/rack,
 /obj/item/weapon/circuitboard/rdconsole,
@@ -37329,13 +36827,6 @@
 	icon_state = "blackcorner"
 	},
 /area/station/hallway/primary/starboard)
-"jdH" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/obj/machinery/light/smart,
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "jdS" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -37638,14 +37129,6 @@
 	icon_state = "red"
 	},
 /area/station/security/checkpoint)
-"jhE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "jhH" = (
 /obj/machinery/telecomms/bus/preset_two,
 /turf/simulated/floor/bluegrid{
@@ -39112,11 +38595,6 @@
 	icon_state = "warning"
 	},
 /area/station/engineering/atmos)
-"jzj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "jzl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
@@ -39237,16 +38715,14 @@
 /turf/simulated/floor,
 /area/station/engineering/engine)
 "jBe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/spray/extinguisher{
+	pixel_y = 6
 	},
 /turf/simulated/floor{
-	icon_state = "yellowpatch"
+	icon_state = "bot"
 	},
-/area/station/engineering/singularity)
+/area/station/maintenance/engineering)
 "jBf" = (
 /obj/effect/decal/cleanable/greenglow,
 /obj/structure/cable{
@@ -39418,8 +38894,11 @@
 	},
 /area/station/engineering/atmos)
 "jDO" = (
-/obj/machinery/light/smart{
-	dir = 8
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -39565,7 +39044,7 @@
 	},
 /area/station/engineering/atmos)
 "jFX" = (
-/obj/machinery/portable_atmospherics/powered/pump,
+/obj/machinery/power/rad_collector,
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
@@ -39812,7 +39291,6 @@
 	},
 /area/shuttle/supply/station)
 "jIT" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/machinery/access_button{
 	command = "cycle_exterior";
 	frequency = 1379;
@@ -39957,17 +39435,6 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge/captain_quarters)
-"jKa" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_access = list(10)
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "jKp" = (
 /turf/simulated/floor{
 	dir = 5;
@@ -40278,14 +39745,11 @@
 	},
 /area/station/civilian/dormitories)
 "jNg" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6
+/obj/structure/closet/secure_closet/engineering_electrical,
+/turf/simulated/floor{
+	icon_state = "delivery"
 	},
-/obj/structure/window/fulltile/reinforced/phoron,
-/obj/structure/sign/warning/radiation,
-/turf/simulated/floor/engine,
-/area/station/engineering/singularity)
+/area/station/maintenance/engineering)
 "jNo" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -40613,15 +40077,15 @@
 	},
 /area/station/medical/genetics)
 "jQj" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/ai_status_display{
+	pixel_x = -32
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor{
-	icon_state = "yellowpatch"
+	dir = 10;
+	icon_state = "warning"
 	},
-/area/station/engineering/singularity)
+/area/station/engineering/engine)
 "jQo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -40807,14 +40271,9 @@
 /turf/simulated/floor/wood,
 /area/station/maintenance/science)
 "jTp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/turf/simulated/floor{
-	icon_state = "yellowpatch"
-	},
-/area/station/engineering/singularity)
+/obj/machinery/particle_accelerator/control_box,
+/turf/simulated/floor/plating,
+/area/station/engineering/engine)
 "jTu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -40857,7 +40316,19 @@
 /turf/simulated/wall/r_wall,
 /area/station/engineering/engine)
 "jUd" = (
-/turf/simulated/floor/engine,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	id_tag = "engineering_west_outer";
+	locked = 1;
+	name = "Engineering External Access";
+	req_access = list(10,13)
+	},
+/turf/simulated/floor/plating,
 /area/station/engineering/singularity)
 "jUj" = (
 /obj/structure/stool/bed/chair/comfy/brown,
@@ -41234,14 +40705,6 @@
 /obj/structure/grille,
 /turf/simulated/wall/r_wall,
 /area/station/engineering/atmos)
-"jXZ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 10
-	},
-/turf/simulated/floor{
-	icon_state = "yellowpatch"
-	},
-/area/station/engineering/singularity)
 "jYb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -42212,13 +41675,16 @@
 	},
 /area/station/civilian/library)
 "kkY" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/green{
-	dir = 1
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor{
-	icon_state = "delivery"
+/turf/simulated/floor/plating{
+	dir = 4;
+	icon_state = "warnplate"
 	},
-/area/station/engineering/singularity)
+/area/station/engineering/engine)
 "kli" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -43178,15 +42644,6 @@
 	icon_state = "chapel"
 	},
 /area/station/civilian/chapel)
-"kxQ" = (
-/obj/structure/table/reinforced,
-/obj/item/device/analyzer,
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 22
-	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "kxX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -43923,14 +43380,6 @@
 	},
 /turf/environment/space,
 /area/space)
-"kHn" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "cafeteria"
-	},
-/area/station/engineering/singularity)
 "kHp" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -44137,13 +43586,11 @@
 	},
 /area/station/cargo/qm)
 "kIG" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10
+/obj/machinery/the_singularitygen/tesla,
+/turf/simulated/floor/plating/airless{
+	dir = 1;
+	icon_state = "warnplate"
 	},
-/obj/structure/window/fulltile/reinforced/phoron,
-/obj/structure/sign/warning/radiation,
-/turf/simulated/floor/engine,
 /area/station/engineering/singularity)
 "kIM" = (
 /obj/item/clothing/suit/storage/labcoat/winterlabcoat,
@@ -44410,7 +43857,17 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "Singularity";
+	layer = 2.8;
+	name = "Engine Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/engineering/engine)
 "kLF" = (
 /turf/simulated/floor{
@@ -44541,18 +43998,6 @@
 	temperature = 80
 	},
 /area/station/tcommsat/chamber)
-"kMS" = (
-/obj/item/stack/sheet/glass{
-	amount = 20;
-	pixel_x = -3;
-	pixel_y = 6
-	},
-/obj/structure/rack,
-/obj/item/stack/sheet/metal{
-	amount = 12
-	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "kNa" = (
 /obj/structure/closet/crate,
 /obj/item/clothing/head/fedora/white,
@@ -44643,11 +44088,6 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/dormitories)
-"kOk" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/visible/red,
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "kOx" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -44797,17 +44237,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
-"kRA" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 4
-	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Engine Room";
-	req_access = list(10)
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/singularity)
 "kRI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -44841,25 +44270,10 @@
 /turf/environment/space,
 /area/shuttle/supply/station)
 "kRY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor/plating/airless{
+	icon_state = "warnplate"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 22
-	},
-/turf/simulated/floor{
-	icon_state = "yellowpatch"
-	},
-/area/station/engineering/singularity)
+/area/station/maintenance/science)
 "kSj" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -46614,15 +46028,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/lobby)
-"lmX" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/spray/extinguisher{
-	pixel_y = 6
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/singularity)
 "lnd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -49228,13 +48633,6 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/atmos)
-"lWv" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/turf/simulated/floor/plating/airless/catwalk,
-/area/space)
 "lWC" = (
 /obj/structure/stool,
 /obj/machinery/light/small,
@@ -49929,16 +49327,6 @@
 	icon_state = "warning"
 	},
 /area/station/hallway/primary/central)
-"mgL" = (
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/obj/structure/closet/crate/radiation{
-	desc = "A crate with a radiation sign on it. For the love of god, use protection.";
-	name = "Radiation Suit Crate";
-	req_access = list(56)
-	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "mgQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -50940,6 +50328,7 @@
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil,
 /obj/item/weapon/tank/emergency_oxygen/engi,
+/obj/item/stack/cable_coil,
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -50993,18 +50382,16 @@
 /turf/simulated/floor/plating,
 /area/station/aisat/ai_chamber)
 "mtH" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_access = list(10)
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	id_tag = "engineering_east_inner";
+	locked = 1;
+	name = "Engineering External Access";
+	req_access = list(10,13)
 	},
+/obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/engineering/singularity)
 "mtI" = (
 /turf/simulated/floor{
@@ -51031,12 +50418,6 @@
 	},
 /turf/environment/space,
 /area/shuttle/supply/station)
-"mum" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/green{
-	dir = 8
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/singularity)
 "mun" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "scicell";
@@ -51650,6 +51031,9 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/station/maintenance/science)
 "mBC" = (
@@ -51784,7 +51168,8 @@
 /area/station/civilian/dormitories)
 "mEc" = (
 /obj/structure/table/reinforced,
-/obj/item/stack/cable_coil,
+/obj/item/device/tagger/shop,
+/obj/item/weapon/packageWrap,
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -52041,29 +51426,14 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/engine)
-"mIL" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "Singularity";
-	layer = 2.8;
-	name = "Singularity Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/singularity)
 "mIP" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 4
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
 	},
-/turf/simulated/floor/plating/airless/catwalk,
-/area/space)
+/area/station/maintenance/science)
 "mIU" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -52157,15 +51527,8 @@
 	},
 /area/station/rnd/hallway)
 "mKD" = (
-/obj/machinery/shower/free{
-	dir = 4
-	},
-/obj/structure/drain{
-	drainage = 2
-	},
-/turf/simulated/floor{
-	dir = 10;
-	icon_state = "warning"
+/turf/simulated/floor/plating{
+	icon_state = "warnplate"
 	},
 /area/station/engineering/engine)
 "mKJ" = (
@@ -52266,18 +51629,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/civilian/gym)
-"mMu" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/head/welding,
-/obj/item/weapon/wrench,
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -32
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/singularity)
 "mMv" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor{
@@ -52308,15 +51659,6 @@
 	icon_state = "warning"
 	},
 /area/station/engineering/engine)
-"mMV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/floor/plating{
-	dir = 4;
-	icon_state = "warnplate"
-	},
-/area/station/engineering/singularity)
 "mMZ" = (
 /turf/simulated/floor{
 	icon_state = "white"
@@ -53536,15 +52878,6 @@
 	icon_state = "vault"
 	},
 /area/station/maintenance/engineering)
-"ncZ" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "bot"
-	},
-/area/station/engineering/singularity)
 "nda" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/toolbox/mechanical,
@@ -53693,21 +53026,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
-"neS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "nff" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/machinery/power/terminal{
@@ -54068,11 +53386,11 @@
 	},
 /area/station/cargo/storage)
 "nkc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "yellowfull"
@@ -54186,10 +53504,6 @@
 	icon_state = "purple"
 	},
 /area/station/rnd/xenobiology)
-"nma" = (
-/obj/structure/sign/warning/securearea,
-/turf/simulated/wall/r_wall,
-/area/station/engineering/singularity)
 "nmd" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -54660,6 +53974,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 2;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/simulated/floor/plating{
 	icon_state = "foam_plating"
@@ -55397,18 +54714,15 @@
 	},
 /area/station/cargo/office)
 "nBf" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/spray/extinguisher{
-	pixel_y = 6
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/camera{
-	c_tag = "Enginnering Engine South";
-	network = list("SS13","Engineering");
-	dir = 1
+/obj/structure/particle_accelerator/fuel_chamber{
+	dir = 8
 	},
-/turf/simulated/floor{
-	icon_state = "warning"
-	},
+/turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "nBv" = (
 /obj/item/clothing/accessory/armband/hydro,
@@ -55754,9 +55068,8 @@
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "nFZ" = (
-/turf/simulated/floor{
-	icon_state = "yellowpatch"
-	},
+/obj/machinery/power/grounding_rod,
+/turf/simulated/floor/plating/airless,
 /area/station/engineering/singularity)
 "nGb" = (
 /obj/machinery/door/airlock/highsecurity{
@@ -55819,18 +55132,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
-"nGB" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "nGM" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Upper Cells";
@@ -56720,10 +56021,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
-"nRY" = (
-/obj/structure/girder,
-/turf/simulated/floor/plating,
-/area/station/maintenance/science)
 "nRZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -56752,22 +56049,6 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/primary/fore)
-"nSl" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "nSm" = (
 /obj/structure/sign/poster/official/cleanliness{
 	pixel_y = 32
@@ -56789,13 +56070,6 @@
 	},
 /turf/simulated/floor/carpet/black,
 /area/station/bridge)
-"nSt" = (
-/obj/structure/window/fulltile/reinforced/phoron{
-	grilled = 1;
-	icon_state = "gr_window_reinforced_phoron"
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/singularity)
 "nSC" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots,
@@ -56885,14 +56159,6 @@
 	icon_state = "black"
 	},
 /area/station/hallway/primary/starboard)
-"nTg" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "yellowpatch"
-	},
-/area/station/engineering/singularity)
 "nTu" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
@@ -57406,11 +56672,9 @@
 	},
 /area/station/hallway/primary/starboard)
 "nZC" = (
-/obj/machinery/camera{
-	c_tag = "Engine Room Storage";
-	network = list("SS13","Engineering")
+/turf/simulated/floor/plating{
+	icon_state = "platebotc"
 	},
-/turf/simulated/floor,
 /area/station/engineering/singularity)
 "nZH" = (
 /obj/structure/table/reinforced,
@@ -57733,12 +56997,7 @@
 /turf/simulated/wall/r_wall,
 /area/station/bridge/ai_upload)
 "oex" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_access = list(10)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/engine,
+/turf/simulated/floor/plating/airless,
 /area/station/engineering/singularity)
 "oeN" = (
 /obj/structure/cable{
@@ -58369,17 +57628,10 @@
 	},
 /area/station/cargo/storage)
 "oos" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_access = list(10)
+/obj/structure/particle_accelerator/power_box{
+	dir = 8
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/engineering/singularity)
 "ooG" = (
 /turf/simulated/floor{
@@ -58869,11 +58121,14 @@
 	},
 /area/station/maintenance/starboardsolar)
 "ovz" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 9
 	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "yellow"
+	},
+/area/station/engineering/engine)
 "ovK" = (
 /obj/structure/table/glass,
 /obj/item/weapon/folder/white,
@@ -58989,13 +58244,6 @@
 	icon_state = "vault"
 	},
 /area/station/engineering/engine)
-"oyB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating{
-	dir = 4;
-	icon_state = "warnplate"
-	},
-/area/station/engineering/singularity)
 "oyG" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -60484,11 +59732,8 @@
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/science)
 "oSO" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/green,
-/turf/simulated/floor{
-	icon_state = "yellowpatch"
-	},
-/area/station/engineering/singularity)
+/turf/simulated/floor/plating/airless,
+/area/station/maintenance/science)
 "oSU" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -60706,15 +59951,6 @@
 /obj/random/misc/all,
 /turf/simulated/floor/plating,
 /area/station/cargo/recycler)
-"oWg" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/visible/blue{
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "delivery"
-	},
-/area/station/engineering/singularity)
 "oWo" = (
 /obj/machinery/light/smart{
 	dir = 1
@@ -61260,17 +60496,6 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
-"pdl" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_access = list(10)
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "pdv" = (
 /obj/structure/table/reinforced,
 /obj/item/device/tagger/shop,
@@ -61332,17 +60557,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
-"pev" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "pey" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
@@ -61527,15 +60741,6 @@
 	},
 /turf/simulated/floor/carpet/red,
 /area/station/security/detectives_office)
-"pgL" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
-/turf/simulated/floor/plating,
-/area/station/engineering/singularity)
 "pgT" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -61579,12 +60784,6 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/secondary/exit)
-"phs" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "pht" = (
 /obj/structure/table/woodentable/fancy/black,
 /obj/structure/window/thin/reinforced{
@@ -61605,20 +60804,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/reception)
-"phP" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
-	},
-/obj/machinery/light/smart{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "phV" = (
 /turf/simulated/floor{
 	icon_state = "yellowcorner"
@@ -61639,6 +60824,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/maintenance/science)
@@ -62150,39 +61338,6 @@
 	icon_state = "vault"
 	},
 /area/station/bridge/captain_quarters)
-"pnO" = (
-/obj/machinery/door/firedoor,
-/obj/item/weapon/wrench,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "Singularity";
-	layer = 2.8;
-	name = "Singularity Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/singularity)
 "pnR" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -62459,11 +61614,10 @@
 	},
 /area/station/engineering/drone_fabrication)
 "pry" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 6
+/turf/simulated/floor/plating/airless{
+	icon_state = "warnplatecorner"
 	},
-/turf/simulated/floor/plating/airless/catwalk,
-/area/space)
+/area/station/engineering/singularity)
 "prC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -62598,12 +61752,6 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
-"psX" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 9
-	},
-/turf/simulated/floor/plating/airless/catwalk,
-/area/space)
 "pte" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
@@ -62673,12 +61821,6 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/chapel/mass_driver)
-"ptT" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "pug" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -63115,12 +62257,6 @@
 "pyL" = (
 /turf/environment/space,
 /area/shuttle/syndicate/north)
-"pyO" = (
-/obj/machinery/atmospherics/pipe/manifold4w/visible/green,
-/turf/simulated/floor{
-	icon_state = "yellowpatch"
-	},
-/area/station/engineering/singularity)
 "pyX" = (
 /obj/machinery/light/small,
 /turf/simulated/floor{
@@ -64038,15 +63174,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
-"pKX" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
-/turf/simulated/floor/plating{
-	dir = 4;
-	icon_state = "warnplate"
-	},
-/area/station/engineering/singularity)
 "pLb" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
@@ -64817,9 +63944,6 @@
 /area/station/rnd/hallway)
 "pUh" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 4
-	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics West";
 	network = list("SS13","Engineering");
@@ -65116,23 +64240,10 @@
 	},
 /area/station/gateway)
 "pYC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
+/obj/structure/particle_accelerator/particle_emitter/center{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/engineering/singularity)
 "pYK" = (
 /obj/item/weapon/flora/random,
@@ -65200,13 +64311,11 @@
 /turf/simulated/floor/plating,
 /area/station/civilian/toilet)
 "pZb" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/turf/simulated/floor/plating/airless{
+	dir = 8;
+	icon_state = "warnplate"
 	},
-/turf/simulated/floor/plating,
-/area/station/engineering/singularity)
+/area/station/maintenance/engineering)
 "pZo" = (
 /obj/item/weapon/flora/random,
 /obj/structure/cable{
@@ -65492,6 +64601,17 @@
 /obj/machinery/light/smart{
 	dir = 8
 	},
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_y = 5
+	},
+/obj/item/weapon/storage/toolbox/mechanical{
+	pixel_y = 5
+	},
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -28;
+	pixel_y = -5
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "yellow"
@@ -65555,17 +64675,6 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/atmos)
-"qdq" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
-	dir = 8
-	},
-/obj/structure/window/fulltile/reinforced/phoron{
-	grilled = 1;
-	icon_state = "gr_window_reinforced_phoron"
-	},
-/turf/simulated/floor/plating,
-/area/station/engineering/singularity)
 "qdu" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -65798,12 +64907,29 @@
 	},
 /area/station/engineering/engine)
 "qgD" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 22
+/obj/structure/closet/crate{
+	name = "solar pack crate"
 	},
-/turf/simulated/floor/plating,
-/area/station/engineering/singularity)
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/solar_assembly,
+/obj/item/weapon/circuitboard/solar_control,
+/obj/item/weapon/tracker_electronics,
+/obj/item/weapon/paper/solar,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
+/area/station/engineering/engine)
 "qhc" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 4;
@@ -65812,15 +64938,6 @@
 	name = "N2 air injector"
 	},
 /turf/simulated/floor/engine/nitrogen,
-/area/station/engineering/atmos)
-"qhd" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 9
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
 /area/station/engineering/atmos)
 "qhh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -66080,12 +65197,6 @@
 	icon_state = "vault"
 	},
 /area/station/rnd/xenobiology)
-"qkG" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 1
-	},
-/turf/simulated/floor/plating/airless/catwalk,
-/area/space)
 "qkH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -66140,12 +65251,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "qlj" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "yellowpatch"
-	},
+/turf/environment/space,
 /area/station/engineering/singularity)
 "qls" = (
 /obj/decal/boxingrope{
@@ -66428,17 +65534,6 @@
 	icon_state = "vault"
 	},
 /area/station/rnd/xenobiology)
-"qor" = (
-/obj/machinery/power/tesla_coil,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/singularity)
 "qox" = (
 /obj/structure/rack,
 /obj/item/weapon/storage/briefcase,
@@ -66604,17 +65699,6 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/library)
-"qrq" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "qrx" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -66641,20 +65725,6 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/library)
-"qrR" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "qrX" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
@@ -66703,12 +65773,6 @@
 	icon_state = "wooden"
 	},
 /area/station/civilian/library)
-"qsA" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/green{
-	dir = 1
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/singularity)
 "qsC" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable{
@@ -67223,13 +66287,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
-"qzM" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/machinery/light/smart{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "qzO" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/toolbox/electrical,
@@ -67694,12 +66751,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"qGp" = (
-/obj/machinery/light/smart{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/engineering/engine)
 "qGy" = (
 /obj/machinery/recycler,
 /turf/simulated/floor/plating,
@@ -67754,12 +66805,6 @@
 	icon_state = "grimy"
 	},
 /area/station/security/detectives_office)
-"qHt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "qHu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/stool/bed/chair/wood/normal{
@@ -69629,13 +68674,6 @@
 	icon_state = "bot"
 	},
 /area/station/cargo/storage)
-"rhc" = (
-/obj/structure/closet/radiation,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "warning"
-	},
-/area/station/engineering/engine)
 "rhh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -69671,8 +68709,18 @@
 	},
 /area/station/civilian/chapel/mass_driver)
 "rhs" = (
-/obj/structure/sign/warning/nosmoking,
-/turf/simulated/wall/r_wall,
+/obj/machinery/atmospherics/pipe/simple/hidden/red{
+	dir = 4
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "Singularity";
+	layer = 2.8;
+	name = "Engine Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
 /area/station/engineering/singularity)
 "rhI" = (
 /obj/structure/cable{
@@ -69716,12 +68764,8 @@
 	},
 /area/station/medical/hallway)
 "rii" = (
-/obj/machinery/atmospherics/components/trinary/filter/m_filter{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "yellowpatch"
-	},
+/obj/structure/lattice,
+/turf/environment/space,
 /area/station/engineering/singularity)
 "riq" = (
 /obj/structure/object_wall/pod{
@@ -70036,8 +69080,10 @@
 	},
 /area/station/solar/auxstarboard)
 "rnA" = (
-/obj/structure/sign/warning/radiation,
-/turf/simulated/wall/r_wall,
+/obj/machinery/power/emitter{
+	dir = 1
+	},
+/turf/simulated/floor/plating/airless,
 /area/station/maintenance/engineering)
 "rnH" = (
 /obj/item/device/radio/intercom{
@@ -70153,12 +69199,6 @@
 	icon_state = "orange"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
-"rpu" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/singularity)
 "rpF" = (
 /obj/structure/table/woodentable,
 /obj/item/stack/sheet/cloth{
@@ -70189,10 +69229,26 @@
 /area/station/cargo/storage)
 "rpW" = (
 /obj/structure/table/reinforced,
-/obj/item/clothing/gloves/yellow,
 /obj/machinery/light/smart{
 	dir = 8
 	},
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -28;
+	pixel_y = -5
+	},
+/obj/item/device/radio/off{
+	pixel_y = 6
+	},
+/obj/item/device/radio/off{
+	pixel_x = -6;
+	pixel_y = 4
+	},
+/obj/item/device/radio/off{
+	pixel_x = 6;
+	pixel_y = 4
+	},
+/obj/item/device/radio/off,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "yellow"
@@ -70373,17 +69429,14 @@
 	},
 /area/station/engineering/atmos)
 "rsB" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/item/weapon/caution/cone,
-/obj/item/weapon/caution/cone,
-/obj/item/weapon/caution/cone,
-/obj/item/weapon/caution/cone,
-/obj/item/weapon/caution/cone,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -32
+	},
+/obj/machinery/camera{
+	c_tag = "Enginnering Engine South";
+	network = list("SS13","Engineering");
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "warning"
@@ -70471,12 +69524,22 @@
 /turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
 "rtL" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 4
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
 	},
-/obj/structure/sign/warning/secure_area,
-/turf/simulated/wall/r_wall,
-/area/station/engineering/atmos)
+/obj/item/weapon/caution/cone,
+/obj/item/weapon/caution/cone{
+	pixel_x = 6
+	},
+/obj/item/weapon/caution/cone{
+	pixel_x = -6
+	},
+/obj/item/weapon/caution/cone,
+/obj/item/weapon/caution/cone,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
+/area/station/maintenance/engineering)
 "rtQ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -70610,15 +69673,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/tox_launch)
-"rvC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 9;
-	icon_state = "warning"
-	},
-/area/station/engineering/engine)
 "rvM" = (
 /obj/structure/table/woodentable,
 /obj/item/device/paicard,
@@ -71328,7 +70382,6 @@
 	},
 /area/station/security/warden)
 "rCY" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/structure/transit_tube{
 	icon_state = "NE-SW"
 	},
@@ -72743,17 +71796,6 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/bar)
-"rTi" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 4
-	},
-/obj/structure/window/fulltile/reinforced/phoron{
-	grilled = 1;
-	icon_state = "gr_window_reinforced_phoron"
-	},
-/turf/simulated/floor/plating,
-/area/station/engineering/singularity)
 "rTk" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -72820,24 +71862,6 @@
 	icon_state = "delivery"
 	},
 /area/station/cargo/storage)
-"rUw" = (
-/obj/machinery/door/firedoor,
-/obj/item/weapon/crowbar,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "Singularity";
-	layer = 2.8;
-	name = "Singularity Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/singularity)
 "rUL" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/simulated/floor{
@@ -72863,6 +71887,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -73285,12 +72310,6 @@
 	icon_state = "red"
 	},
 /area/station/security/brig)
-"sap" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "saw" = (
 /obj/machinery/light/smart{
 	dir = 1
@@ -73323,12 +72342,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
-"sbi" = (
-/obj/structure/closet/secure_closet/engineering_welding,
-/turf/simulated/floor{
-	icon_state = "bot"
-	},
-/area/station/engineering/engine)
 "sbk" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -73356,13 +72369,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/storage)
-"sbM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/science)
 "sbN" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/structure/stool,
@@ -73413,11 +72419,14 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "scw" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/turf/simulated/floor/engine,
-/area/station/engineering/singularity)
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/station/maintenance/science)
 "scI" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -73585,14 +72594,10 @@
 /turf/simulated/floor/wood,
 /area/station/maintenance/science)
 "seP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/particle_accelerator/particle_emitter/left{
+	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/engineering/singularity)
 "seU" = (
 /obj/effect/landmark/start/cargo_technician,
@@ -73813,12 +72818,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/fore)
-"shK" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 5
-	},
-/turf/simulated/floor/plating/airless/catwalk,
-/area/space)
 "shX" = (
 /obj/item/weapon/storage/firstaid/regular,
 /obj/structure/table,
@@ -74443,14 +73442,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
-"soD" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "yellowpatch"
-	},
-/area/station/engineering/singularity)
 "soF" = (
 /obj/structure/object_wall/pod{
 	dir = 1;
@@ -74537,12 +73528,6 @@
 	icon_state = "escape"
 	},
 /area/station/engineering/atmos)
-"spN" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/singularity)
 "sqb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 4
@@ -75178,10 +74163,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/medical/morgue)
-"szT" = (
-/obj/machinery/status_display,
-/turf/simulated/wall/r_wall,
-/area/station/engineering/singularity)
 "szY" = (
 /obj/structure/rack,
 /obj/item/device/lightreplacer,
@@ -75352,37 +74333,8 @@
 	},
 /area/station/rnd/robotics)
 "sCh" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "Singularity";
-	layer = 2.8;
-	name = "Singularity Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/singularity)
+/turf/simulated/floor/plating/airless,
+/area/station/maintenance/engineering)
 "sCp" = (
 /obj/machinery/chem_master/condimaster{
 	name = "CondiMaster Neo"
@@ -75587,10 +74539,6 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
 /area/station/security/blueshield)
-"sED" = (
-/obj/machinery/power/emitter,
-/turf/simulated/floor/plating,
-/area/station/engineering/singularity)
 "sEI" = (
 /obj/structure/window/thin{
 	dir = 1
@@ -75831,18 +74779,6 @@
 "sHQ" = (
 /turf/simulated/wall/r_wall,
 /area/station/engineering/monitoring)
-"sHS" = (
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	dir = 4
-	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -32
-	},
-/turf/simulated/floor{
-	icon_state = "bot"
-	},
-/area/station/engineering/singularity)
 "sHZ" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
@@ -77034,13 +75970,11 @@
 /turf/simulated/wall/r_wall,
 /area/station/medical/chemistry)
 "sXQ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/turf/simulated/floor/plating/airless{
+	dir = 4;
+	icon_state = "warnplate"
 	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
+/area/station/maintenance/science)
 "sXT" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/light/smart{
@@ -77065,11 +75999,9 @@
 	},
 /area/station/civilian/gym)
 "sYc" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
+/turf/simulated/floor/plating/airless{
+	dir = 4;
+	icon_state = "warnplatecorner"
 	},
 /area/station/engineering/singularity)
 "sYm" = (
@@ -77531,16 +76463,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
-"tew" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/machinery/door_control{
-	id = "Singularity";
-	name = "Shutters Control";
-	pixel_x = -25;
-	req_access = list(10)
-	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "teD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
@@ -77642,13 +76564,6 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/chapel/mass_driver)
-"tfQ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/engineering/atmos)
 "tfV" = (
 /obj/machinery/firealarm{
 	pixel_y = 22
@@ -77868,12 +76783,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "tiK" = (
-/obj/structure/sign/nanotrasen{
-	pixel_x = 32
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/lattice,
-/turf/environment/space,
-/area/space)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/engineering/engine)
 "tiL" = (
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway East";
@@ -78023,18 +76940,9 @@
 /turf/environment/space,
 /area/shuttle/supply/station)
 "tlb" = (
-/obj/machinery/shower/free{
-	dir = 4
-	},
-/obj/structure/drain{
-	drainage = 2
-	},
-/obj/machinery/light/smart{
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 9;
-	icon_state = "warning"
+/turf/simulated/floor/plating{
+	dir = 1;
+	icon_state = "warnplate"
 	},
 /area/station/engineering/engine)
 "tlq" = (
@@ -78406,22 +77314,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
-"tqB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor{
-	icon_state = "yellowpatch"
-	},
-/area/station/engineering/singularity)
 "tqF" = (
 /obj/structure/window/thin/reinforced,
 /turf/simulated/floor/wood,
@@ -78625,23 +77517,6 @@
 /obj/effect/landmark/start/assistant,
 /turf/simulated/floor,
 /area/station/civilian/gym)
-"tup" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "Singularity";
-	layer = 2.8;
-	name = "Singularity Shutters";
-	opacity = 0
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/singularity)
 "tur" = (
 /obj/machinery/light/smart{
 	dir = 8
@@ -78699,23 +77574,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/engineering/engine)
-"tuQ" = (
-/obj/structure/closet/firecloset,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/simulated/floor{
-	icon_state = "delivery"
-	},
-/area/station/engineering/singularity)
 "tvg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -79315,6 +78173,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "tCo" = (
@@ -79902,13 +78763,6 @@
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"tKt" = (
-/obj/machinery/camera{
-	c_tag = "Engine Room Storage";
-	network = list("SS13","Engineering")
-	},
-/turf/simulated/floor/plating,
-/area/station/engineering/singularity)
 "tKx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -79980,8 +78834,21 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/hop_office)
 "tLA" = (
-/obj/structure/sign/warning/secure_area,
-/turf/simulated/wall/r_wall,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	id_tag = "engineering_west_inner";
+	locked = 1;
+	name = "Engineering External Access";
+	req_access = list(10,13)
+	},
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
 /area/station/engineering/singularity)
 "tLS" = (
 /obj/structure/table/woodentable,
@@ -80186,10 +79053,6 @@
 /obj/item/weapon/storage/box,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
-"tOn" = (
-/obj/item/weapon/flora/random,
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "tOH" = (
 /obj/structure/sign/directions/evac{
 	pixel_x = -32;
@@ -80589,17 +79452,6 @@
 	icon_state = "bot"
 	},
 /area/station/storage/tech)
-"tUz" = (
-/obj/structure/rack,
-/obj/item/clothing/glasses/meson,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 22
-	},
-/turf/simulated/floor{
-	icon_state = "bot"
-	},
-/area/station/engineering/singularity)
 "tUJ" = (
 /obj/structure/table/reinforced,
 /obj/item/device/flashlight/lamp,
@@ -80899,15 +79751,6 @@
 "tYn" = (
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/auxsolarstarboard)
-"tYo" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Port Mix to Engine"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "tYu" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -81457,9 +80300,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "warning"
@@ -81795,15 +80636,6 @@
 	icon_state = "brownold"
 	},
 /area/station/rnd/robotics)
-"ukK" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/blue,
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "ukM" = (
 /obj/machinery/newscaster{
 	pixel_y = -28
@@ -82380,14 +81212,6 @@
 	icon_state = "dark"
 	},
 /area/station/cargo/recycleroffice)
-"urI" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "urO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -82419,14 +81243,6 @@
 	icon_state = "yellow"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
-"usj" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Emergency Access";
-	req_access = list(10)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/maintenance/engineering)
 "usl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 10
@@ -82769,10 +81585,10 @@
 	},
 /area/station/security/prison)
 "uwk" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 1
+/obj/machinery/the_singularitygen,
+/turf/simulated/floor/plating/airless{
+	icon_state = "warnplate"
 	},
-/turf/simulated/floor/engine,
 /area/station/engineering/singularity)
 "uwq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -82801,7 +81617,10 @@
 	},
 /area/station/hallway/primary/central)
 "uwB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -83543,17 +82362,6 @@
 	icon_state = "warning"
 	},
 /area/station/maintenance/chapel)
-"uJO" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/blue{
-	dir = 6
-	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "uJP" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -83814,12 +82622,6 @@
 	icon_state = "solarpanel"
 	},
 /area/station/solar/port)
-"uMm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "uMS" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -84028,18 +82830,6 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/dormitories)
-"uPs" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "uPD" = (
 /obj/item/weapon/flora/random,
 /obj/structure/cable{
@@ -84330,10 +83120,8 @@
 /turf/simulated/floor,
 /area/station/medical/medbreak)
 "uUf" = (
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
-	dir = 4
-	},
-/turf/simulated/floor/plating/airless/catwalk,
+/obj/structure/grille,
+/turf/simulated/floor/plating/airless,
 /area/space)
 "uUk" = (
 /obj/structure/table/reinforced,
@@ -84835,9 +83623,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "val" = (
-/obj/structure/closet/toolcloset,
 /obj/item/weapon/storage/belt/utility,
-/obj/item/clothing/gloves/fyellow,
+/obj/structure/closet/secure_closet/engineering_welding,
+/obj/item/clothing/gloves/yellow,
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
@@ -84987,6 +83775,7 @@
 /area/station/engineering/engine)
 "vch" = (
 /obj/structure/table/reinforced,
+/obj/item/clothing/gloves/black,
 /obj/item/weapon/storage/box/lights/mixed,
 /turf/simulated/floor{
 	dir = 5;
@@ -85007,14 +83796,6 @@
 	icon_state = "darkbluefull"
 	},
 /area/station/engineering/engine)
-"vcG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "yellowpatch"
-	},
-/area/station/engineering/singularity)
 "vcL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
@@ -85239,18 +84020,8 @@
 	},
 /area/station/engineering/atmos)
 "vgR" = (
-/obj/structure/sign/directions/engineering{
-	desc = "A sign that shows there are doors here. There are doors everywhere!";
-	icon_state = "doors";
-	name = "WARNING: PRESSURIZED DOORS";
-	pixel_y = -32
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 4
-	},
-/obj/machinery/light/smart,
-/turf/simulated/floor,
-/area/station/engineering/singularity)
+/turf/simulated/floor/plating/airless,
+/area/space)
 "vhk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/window/brigdoor,
@@ -85571,8 +84342,15 @@
 	},
 /area/shuttle/supply/station)
 "vkK" = (
-/obj/machinery/ai_status_display,
-/turf/simulated/wall/r_wall,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "Singularity";
+	layer = 2.8;
+	name = "Engine Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
 /area/station/engineering/singularity)
 "vkR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -85717,10 +84495,6 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/reception)
-"vmP" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/turf/simulated/floor/engine,
-/area/station/engineering/singularity)
 "vmR" = (
 /turf/simulated/floor/plating,
 /area/station/civilian/toilet)
@@ -86113,13 +84887,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/miningoffice)
-"vss" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -22
-	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "vst" = (
 /turf/simulated/wall,
 /area/station/maintenance/brig)
@@ -86376,14 +85143,6 @@
 	icon_state = "dark"
 	},
 /area/station/maintenance/medbay)
-"vvR" = (
-/obj/machinery/power/tesla_coil,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/singularity)
 "vwl" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -86535,32 +85294,16 @@
 	},
 /area/station/medical/chemistry)
 "vyR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/machinery/power/emitter{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "yellowpatch"
-	},
-/area/station/engineering/singularity)
+/turf/simulated/floor/plating/airless,
+/area/station/maintenance/science)
 "vyY" = (
 /turf/simulated/shuttle/floor/cargo{
 	icon_state = "2,1"
 	},
 /area/shuttle/supply/station)
-"vzc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Engine Room West";
-	network = list("SS13","Engineering");
-	dir = 5
-	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "vzh" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
@@ -86644,15 +85387,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"vzE" = (
-/obj/machinery/power/tesla_coil,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/light/small,
-/turf/simulated/floor/engine,
-/area/station/engineering/singularity)
 "vzR" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -86804,6 +85538,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -86870,15 +85607,6 @@
 	icon_state = "darkred"
 	},
 /area/station/rnd/xenobiology)
-"vCV" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Engine Cooling Bypass"
-	},
-/turf/simulated/floor{
-	icon_state = "bot"
-	},
-/area/station/engineering/singularity)
 "vDb" = (
 /obj/machinery/door/airlock/research{
 	name = "Research and Development Lab";
@@ -86946,16 +85674,6 @@
 /obj/structure/sign/warning/securearea,
 /turf/simulated/wall/r_wall,
 /area/station/rnd/hallway)
-"vDX" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
-	},
-/area/station/engineering/atmos)
 "vEp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -87224,8 +85942,10 @@
 	},
 /area/station/hallway/primary/central)
 "vGC" = (
-/obj/structure/closet/radiation,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/airless{
+	dir = 10;
+	icon_state = "warnplate"
+	},
 /area/station/maintenance/science)
 "vGK" = (
 /obj/structure/cable{
@@ -87552,12 +86272,10 @@
 	},
 /area/station/hallway/primary/starboard)
 "vLF" = (
-/obj/effect/decal/remains/human{
-	desc = "They look like human remains. The bones are charred and burned.";
-	name = "charred remains"
+/turf/simulated/floor/plating/airless{
+	dir = 10;
+	icon_state = "warnplate"
 	},
-/obj/item/clothing/under/pants/gar/bandages,
-/turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "vLG" = (
 /obj/effect/decal/cleanable/dirt,
@@ -87681,16 +86399,6 @@
 	icon_state = "dark"
 	},
 /area/station/aisat/ai_chamber)
-"vNQ" = (
-/obj/structure/closet/firecloset,
-/obj/machinery/alarm{
-	pixel_x = 29;
-	pixel_y = -6
-	},
-/turf/simulated/floor{
-	icon_state = "delivery"
-	},
-/area/station/engineering/singularity)
 "vNW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -87798,14 +86506,6 @@
 	icon_state = "whitepurplefull"
 	},
 /area/station/rnd/hallway)
-"vPd" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "vPk" = (
 /turf/simulated/wall/r_wall,
 /area/station/engineering/atmos)
@@ -87843,17 +86543,6 @@
 	icon_state = "warning"
 	},
 /area/station/engineering/atmos)
-"vPV" = (
-/obj/structure/closet/radiation,
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 28;
-	pixel_y = -5
-	},
-/turf/simulated/floor{
-	icon_state = "delivery"
-	},
-/area/station/engineering/singularity)
 "vPX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -88075,17 +86764,6 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
-"vTI" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_access = list(10)
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "vTJ" = (
 /obj/machinery/disposal,
 /turf/simulated/floor{
@@ -88239,16 +86917,7 @@
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
 "vWf" = (
-/obj/machinery/shower/free{
-	dir = 4
-	},
-/obj/structure/drain{
-	drainage = 2
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "warning"
-	},
+/turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "vWh" = (
 /obj/structure/cable{
@@ -88507,14 +87176,6 @@
 	icon_state = "blue"
 	},
 /area/station/medical/hallway)
-"vYv" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/packageWrap,
-/obj/item/device/tagger/shop,
-/turf/simulated/floor{
-	icon_state = "warning"
-	},
-/area/station/engineering/engine)
 "vYy" = (
 /obj/structure/lattice,
 /obj/structure/window/thin/reinforced{
@@ -88746,16 +87407,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway)
-"wbI" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/window/fulltile/reinforced/phoron{
-	grilled = 1;
-	icon_state = "gr_window_reinforced_phoron"
-	},
-/turf/simulated/floor/plating,
-/area/station/engineering/singularity)
 "wcp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical/glass{
@@ -89129,13 +87780,9 @@
 	},
 /area/station/security/checkpoint)
 "whN" = (
-/obj/item/weapon/flora/random,
-/obj/machinery/camera{
-	c_tag = "Engine Room East";
-	network = list("SS13","Engineering");
-	dir = 8
+/turf/simulated/floor/plating{
+	icon_state = "warnplate"
 	},
-/turf/simulated/floor,
 /area/station/engineering/singularity)
 "wii" = (
 /obj/machinery/ai_status_display{
@@ -89267,19 +87914,6 @@
 	icon_state = "vault"
 	},
 /area/station/civilian/chapel/office)
-"wjl" = (
-/obj/machinery/power/tesla_coil,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/camera{
-	c_tag = "Engine Room Mid";
-	network = list("SS13","Engineering");
-	dir = 8
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/singularity)
 "wjm" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -89929,14 +88563,6 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/reception)
-"wsv" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 10
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/singularity)
 "wsw" = (
 /obj/structure/table/reinforced,
 /obj/item/toy/figure/warden{
@@ -90173,17 +88799,6 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge/captain_quarters)
-"wxa" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan{
-	dir = 6
-	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "wxc" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -90274,21 +88889,19 @@
 	},
 /area/station/hallway/primary/central)
 "wyP" = (
-/obj/structure/rack,
 /obj/machinery/light/smart,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -32
 	},
-/obj/item/device/analyzer,
 /obj/machinery/camera{
 	c_tag = "Enginnering Engine Access";
 	network = list("SS13","Engineering");
 	dir = 8
 	},
-/turf/simulated/floor{
+/turf/simulated/floor/plating{
 	dir = 6;
-	icon_state = "warning"
+	icon_state = "warnplate"
 	},
 /area/station/engineering/engine)
 "wzc" = (
@@ -90725,17 +89338,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/xenobiology)
-"wCC" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Engine Room South";
-	network = list("SS13","Engineering");
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "wCN" = (
 /obj/structure/table,
 /obj/item/clothing/under/color/white,
@@ -91148,10 +89750,13 @@
 	},
 /area/station/security/prison)
 "wIr" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 4
+/obj/machinery/field_generator{
+	anchored = 1;
+	state = 2
 	},
-/turf/simulated/floor,
+/turf/simulated/floor/plating/airless{
+	icon_state = "platebotc"
+	},
 /area/station/engineering/singularity)
 "wIy" = (
 /obj/structure/rack,
@@ -91876,12 +90481,12 @@
 	},
 /area/station/cargo/storage)
 "wTX" = (
-/obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = -28;
 	pixel_y = -5
 	},
+/obj/machinery/space_heater,
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
@@ -91916,13 +90521,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
-"wUs" = (
-/obj/machinery/light/smart{
-	dir = 8
-	},
-/obj/machinery/power/emitter,
-/turf/simulated/floor/plating,
-/area/station/engineering/singularity)
 "wUB" = (
 /obj/structure/rack,
 /obj/item/weapon/gun/plasma{
@@ -93145,13 +91743,10 @@
 	},
 /area/station/cargo/storage)
 "xkn" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 4
+/turf/simulated/floor/plating/airless{
+	dir = 5;
+	icon_state = "warnplate"
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/turf/simulated/floor,
 /area/station/engineering/singularity)
 "xkv" = (
 /obj/machinery/light/small,
@@ -93904,7 +92499,17 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "Singularity";
+	layer = 2.8;
+	name = "Engine Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/engineering/engine)
 "xtC" = (
 /obj/structure/table/reinforced,
@@ -94121,11 +92726,9 @@
 	},
 /area/station/cargo/office)
 "xwj" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 4
+/turf/simulated/floor/plating/airless{
+	icon_state = "warnplate"
 	},
-/obj/machinery/light/smart,
-/turf/simulated/floor,
 /area/station/engineering/singularity)
 "xwr" = (
 /obj/structure/cable{
@@ -94759,15 +93362,6 @@
 	icon_state = "darkred"
 	},
 /area/station/civilian/bar)
-"xDw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/singularity)
 "xDD" = (
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/simulated/floor{
@@ -95072,28 +93666,12 @@
 /obj/item/weapon/storage/firstaid/small_firstaid_kit/civilian/strike,
 /turf/simulated/floor/wood,
 /area/station/security/blueshield)
-"xIf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "delivery"
-	},
-/area/station/engineering/singularity)
 "xIq" = (
 /turf/simulated/floor/plating{
 	dir = 1;
 	icon_state = "warnplate"
 	},
 /area/station/maintenance/chapel)
-"xIs" = (
-/obj/structure/dispenser,
-/obj/machinery/light/small,
-/turf/simulated/floor,
-/area/station/engineering/singularity)
 "xIA" = (
 /obj/machinery/firealarm{
 	pixel_y = 22
@@ -95241,7 +93819,17 @@
 	req_access = list(10)
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "Singularity";
+	layer = 2.8;
+	name = "Engine Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
 /area/station/engineering/engine)
 "xKq" = (
 /turf/simulated/floor{
@@ -95947,16 +94535,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "xTZ" = (
-/obj/machinery/shower/free{
+/obj/structure/particle_accelerator/particle_emitter/right{
 	dir = 8
 	},
-/obj/structure/drain{
-	drainage = 2
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "caution"
-	},
+/turf/simulated/floor/plating,
 /area/station/engineering/singularity)
 "xUd" = (
 /obj/structure/stool/bed/chair/comfy/brown,
@@ -96797,14 +95379,6 @@
 /obj/item/weapon/stamp/hop,
 /turf/simulated/floor/wood,
 /area/station/bridge/hop_office)
-"ydF" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 10
-	},
-/turf/simulated/floor{
-	icon_state = "yellowpatch"
-	},
-/area/station/engineering/singularity)
 "ydI" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
@@ -109004,7 +107578,7 @@ plf
 lgc
 plf
 plf
-kHU
+plf
 plf
 plf
 plf
@@ -109259,9 +107833,9 @@ lgc
 lgc
 kHU
 lgc
-kHU
-kHU
-lgc
+plf
+plf
+plf
 plf
 plf
 plf
@@ -109498,7 +108072,7 @@ plf
 plf
 plf
 plf
-lgc
+kHU
 plf
 kHU
 plf
@@ -109516,9 +108090,9 @@ kHU
 plf
 plf
 plf
-kHU
 plf
-lgc
+plf
+plf
 plf
 plf
 plf
@@ -109755,9 +108329,9 @@ plf
 plf
 plf
 plf
-lgc
 kHU
-lgc
+kHU
+kHU
 plf
 kHU
 quq
@@ -109773,9 +108347,9 @@ kHU
 plf
 plf
 plf
-lgc
-kHU
-lgc
+plf
+plf
+plf
 plf
 plf
 plf
@@ -110012,9 +108586,9 @@ plf
 plf
 plf
 plf
-lgc
 plf
-lgc
+plf
+kHU
 kHU
 kHU
 kHU
@@ -110027,12 +108601,12 @@ vMQ
 uZG
 kHU
 kHU
-kHU
-kHU
-kHU
-lgc
 plf
-lgc
+plf
+plf
+plf
+plf
+plf
 plf
 plf
 plf
@@ -110269,9 +108843,9 @@ plf
 plf
 plf
 plf
-kHU
 plf
-lgc
+plf
+kHU
 plf
 kHU
 plf
@@ -110287,9 +108861,9 @@ kHU
 plf
 plf
 plf
-lgc
-kHU
-lgc
+plf
+plf
+plf
 plf
 plf
 plf
@@ -110526,9 +109100,9 @@ plf
 plf
 plf
 plf
-lgc
+plf
+plf
 kHU
-lgc
 plf
 kHU
 plf
@@ -110544,9 +109118,9 @@ kHU
 plf
 plf
 plf
-kHU
 plf
-lgc
+plf
+plf
 plf
 plf
 plf
@@ -110783,9 +109357,9 @@ plf
 plf
 plf
 plf
-lgc
 plf
-lgc
+plf
+kHU
 kHU
 kHU
 kHU
@@ -110798,12 +109372,12 @@ xRX
 kHU
 kHU
 kHU
-kHU
-kHU
-kHU
-lgc
 plf
-kHU
+plf
+plf
+plf
+plf
+plf
 plf
 plf
 plf
@@ -111040,7 +109614,7 @@ plf
 plf
 plf
 plf
-lgc
+plf
 plf
 kHU
 plf
@@ -111058,9 +109632,9 @@ kHU
 plf
 plf
 plf
-lgc
-kHU
-lgc
+plf
+plf
+plf
 plf
 plf
 plf
@@ -111292,14 +109866,14 @@ plf
 plf
 plf
 plf
-quq
+plf
+plf
+plf
 plf
 plf
 plf
 plf
 kHU
-plf
-lgc
 plf
 kHU
 plf
@@ -111315,9 +109889,9 @@ kHU
 plf
 plf
 plf
-lgc
 plf
-lgc
+plf
+plf
 plf
 plf
 plf
@@ -111554,9 +110128,9 @@ plf
 plf
 plf
 plf
-lgc
+plf
+plf
 kHU
-lgc
 plf
 kHU
 plf
@@ -111572,9 +110146,9 @@ kHU
 plf
 plf
 plf
-lgc
-kHU
-lgc
+plf
+plf
+plf
 plf
 plf
 plf
@@ -111811,9 +110385,9 @@ plf
 plf
 plf
 plf
-lgc
 plf
-lgc
+plf
+kHU
 kHU
 kHU
 kHU
@@ -111826,12 +110400,12 @@ xRX
 kHU
 kHU
 kHU
-kHU
-kHU
-kHU
-kHU
 plf
-lgc
+plf
+plf
+plf
+plf
+plf
 plf
 plf
 plf
@@ -112068,7 +110642,7 @@ plf
 plf
 plf
 plf
-lgc
+plf
 plf
 kHU
 plf
@@ -112086,9 +110660,9 @@ kHU
 plf
 plf
 plf
-lgc
-kHU
-lgc
+plf
+plf
+plf
 plf
 plf
 plf
@@ -112325,9 +110899,9 @@ plf
 plf
 plf
 plf
-lgc
+plf
+plf
 kHU
-lgc
 plf
 kHU
 plf
@@ -112343,9 +110917,9 @@ kHU
 plf
 plf
 plf
-lgc
 plf
-kHU
+plf
+plf
 plf
 plf
 plf
@@ -112582,9 +111156,9 @@ plf
 plf
 plf
 plf
-kHU
 plf
-lgc
+plf
+kHU
 kHU
 kHU
 kHU
@@ -112597,12 +111171,12 @@ xRX
 kHU
 kHU
 kHU
-kHU
-kHU
-kHU
-lgc
 plf
-lgc
+plf
+plf
+plf
+plf
+plf
 plf
 plf
 plf
@@ -112839,9 +111413,9 @@ plf
 plf
 plf
 plf
-pka
+plf
+plf
 kHU
-pka
 kHU
 kHU
 plf
@@ -112857,9 +111431,9 @@ kHU
 plf
 plf
 plf
-lgc
-kHU
-lgc
+plf
+plf
+plf
 plf
 plf
 plf
@@ -113096,7 +111670,7 @@ plf
 plf
 plf
 plf
-kHU
+plf
 plf
 kHU
 plf
@@ -113114,21 +111688,21 @@ kHU
 plf
 plf
 plf
-kHU
-plf
-lgc
 plf
 plf
 plf
-kHU
 plf
 plf
 plf
-kHU
 plf
 plf
 plf
-kHU
+plf
+plf
+plf
+plf
+plf
+plf
 plf
 plf
 plf
@@ -113353,7 +111927,7 @@ plf
 plf
 plf
 plf
-pka
+plf
 plf
 kHU
 kHU
@@ -113368,29 +111942,29 @@ xRX
 kHU
 kHU
 kHU
-kHU
-kHU
-kHU
-lgc
-kHU
-lgc
-kHU
-pka
-pka
-pka
-pka
-kHU
-pka
-pka
-pka
-pka
-kHU
-pka
-pka
-pka
-kHU
-kHU
-pka
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
 plf
 plf
 plf
@@ -113610,9 +112184,9 @@ plf
 plf
 plf
 plf
-pka
 plf
-pka
+plf
+kHU
 plf
 kHU
 plf
@@ -113628,26 +112202,26 @@ kHU
 plf
 plf
 plf
-lgc
-plf
-kHU
-plf
-plf
-kHU
 plf
 plf
 plf
 plf
 plf
-kHU
 plf
 plf
 plf
-kHU
 plf
 plf
 plf
-pka
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
 plf
 plf
 plf
@@ -113867,9 +112441,9 @@ plf
 plf
 plf
 plf
+plf
+plf
 kHU
-kHU
-pka
 plf
 kHU
 plf
@@ -113885,26 +112459,26 @@ kHU
 plf
 plf
 plf
-lgc
-plf
-lgc
-plf
-plf
-kHU
 plf
 plf
 plf
 plf
 plf
-kHU
 plf
 plf
 plf
-kHU
 plf
 plf
 plf
-kHU
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
 plf
 plf
 plf
@@ -114124,44 +112698,44 @@ plf
 plf
 plf
 plf
-pka
 plf
-pka
+plf
 kHU
-pka
-pka
-pka
+kHU
+kHU
+kHU
+kHU
 kHU
 nHd
 kHU
 kHU
 xRX
-pka
-pka
-pka
-kHU
-pka
-kHU
-lgc
-kHU
-lgc
-pka
-pka
-pka
-kHU
-pka
-pka
-pka
-kHU
-pka
-pka
-pka
-pka
-lgc
 kHU
 kHU
 kHU
-kHU
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
 plf
 plf
 plf
@@ -114375,13 +112949,13 @@ plf
 plf
 plf
 plf
-kHU
-kHU
-pka
-pka
-kHU
-pka
-pka
+plf
+plf
+plf
+plf
+plf
+plf
+plf
 plf
 kHU
 plf
@@ -114399,25 +112973,25 @@ kHU
 plf
 plf
 plf
-lgc
-plf
-lgc
-plf
-kHU
-plf
-plf
-kHU
 plf
 plf
 plf
-kHU
+plf
+plf
+plf
+plf
+plf
 plf
 plf
 plf
 kHU
-nHd
-plf
-plf
+kHU
+kHU
+kHU
+kHU
+kHU
+kHU
+kHU
 pka
 pka
 pka
@@ -114633,10 +113207,10 @@ plf
 plf
 plf
 plf
-kHU
 plf
 plf
-kHU
+plf
+plf
 plf
 plf
 plf
@@ -114656,23 +113230,23 @@ kHU
 plf
 plf
 plf
-lgc
-plf
-kHU
-plf
-kHU
-plf
-plf
-kHU
 plf
 plf
 plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
 kHU
-kHU
-kHU
-kHU
-pka
-nHd
+plf
+plf
+plf
+plf
+plf
 plf
 plf
 pka
@@ -114907,29 +113481,29 @@ nHd
 kHU
 qej
 nzE
-pka
 kHU
-pka
-pka
-pka
 kHU
-pka
+kHU
+kHU
+kHU
+kHU
+kHU
 plf
 kHU
-erS
-qkG
-qkG
-qkG
-qkG
-qkG
-qkG
-qkG
-qkG
-shK
-plf
-plf
-pka
-nHd
+kHU
+kHU
+kHU
+kHU
+kHU
+kHU
+kHU
+kHU
+kHU
+kHU
+kHU
+kHU
+kHU
+kHU
 kHU
 kHU
 kHU
@@ -115173,8 +113747,6 @@ plf
 kHU
 plf
 kHU
-uUf
-kHU
 plf
 kHU
 plf
@@ -115182,11 +113754,13 @@ kHU
 plf
 kHU
 plf
-uUf
+kHU
 plf
 plf
-pka
-nHd
+plf
+plf
+kHU
+kHU
 plf
 plf
 kHU
@@ -115406,31 +113980,29 @@ plf
 plf
 lgc
 kHU
-pry
-amw
-dkA
-amw
+kHU
+kHU
+bns
+nHd
 jIT
-amw
-dkA
-amw
-amw
-amw
-amw
+nHd
+bns
+nHd
+nHd
+nHd
+nHd
 acq
 rCY
-hbF
-amw
-amw
-aNw
-kHU
-pka
-pka
-pka
-pka
+pod
+nHd
 kHU
 kHU
-uUf
+kHU
+kHU
+kHU
+kHU
+kHU
+kHU
 kHU
 plf
 kHU
@@ -115439,7 +114011,9 @@ kHU
 plf
 kHU
 plf
-uUf
+kHU
+plf
+plf
 kHU
 kHU
 kHU
@@ -115663,31 +114237,25 @@ plf
 plf
 kHU
 plf
-mIP
+kHU
 kHU
 nsa
 nsa
 pzz
 nsa
 nsa
-nHd
-nHd
-nHd
+kHU
+kHU
+kHU
 kHU
 mwq
-pod
-nHd
+gfO
 kHU
-plf
-mIP
-plf
-plf
 kHU
 plf
 kHU
 plf
-kHU
-uUf
+plf
 kHU
 plf
 kHU
@@ -115696,14 +114264,20 @@ kHU
 plf
 kHU
 plf
-uUf
-nHd
+kHU
+plf
+kHU
+plf
+kHU
+plf
+plf
+kHU
 nHd
 nHd
 iuV
 bns
 nHd
-nHd
+plf
 vee
 xRM
 cjx
@@ -115920,7 +114494,7 @@ plf
 plf
 pka
 kHU
-mIP
+kHU
 kHU
 nsa
 xXN
@@ -115936,25 +114510,25 @@ hbP
 hbP
 nsa
 nsa
-mIP
 kHU
 kHU
 kHU
-nHd
-nHd
-nHd
-nHd
+kHU
+kHU
+kHU
+kHU
+kHU
+uUf
+uUf
+byu
+uUf
 uUf
 kHU
 plf
 kHU
 plf
-kHU
 plf
 kHU
-plf
-uUf
-nHd
 cjx
 cjx
 trR
@@ -116177,7 +114751,7 @@ plf
 plf
 kHU
 plf
-mIP
+kHU
 nsa
 nsa
 nsa
@@ -116193,25 +114767,25 @@ cTi
 dgY
 pFO
 nsa
-mIP
+kHU
 plf
 kHU
 plf
-nHd
-byu
-tiK
+kHU
+plf
 kHU
 uUf
-nHd
-nHd
-nHd
-nHd
-nHd
-nHd
-nHd
-nHd
 uUf
-tGR
+vgR
+hVy
+vgR
+uUf
+uUf
+kHU
+kHU
+kHU
+kHU
+kHU
 cjx
 vok
 fJS
@@ -116434,7 +115008,7 @@ kHU
 lgc
 lgc
 kHU
-mIP
+kHU
 nsa
 xxJ
 tbx
@@ -116450,25 +115024,25 @@ swv
 oFq
 ktv
 nsa
-mIP
+kHU
 plf
 kHU
 plf
-nHd
-uZD
-uZD
-wjb
-qdq
-wjb
-uZD
-tLA
-wjb
-wjb
-tLA
-uZD
-wjb
-qdq
-rTi
+kHU
+qlj
+dfK
+gRp
+gRp
+xkn
+fKT
+dsj
+gRp
+gRp
+cNU
+qlj
+rii
+qlj
+rii
 cjx
 aQr
 vnx
@@ -116691,7 +115265,7 @@ plf
 kHU
 plf
 plf
-mIP
+kHU
 lLE
 jcC
 wMu
@@ -116707,25 +115281,25 @@ fts
 nsa
 nsa
 nsa
-aAn
-amw
-amw
-amw
-amw
-aWh
-fPf
-ovz
-aeC
-tOn
-vss
-vzc
-ptT
-dsj
-dsj
+kHU
+plf
 ddt
-tOn
-bKW
-dfK
+amw
+amw
+gRp
+fPf
+oex
+rii
+rii
+rii
+rii
+rii
+oex
+gcG
+gRp
+gRp
+gRp
+cNU
 cjx
 fXg
 hpA
@@ -116948,7 +115522,7 @@ lgc
 lgc
 lgc
 kHU
-mIP
+kHU
 lLE
 jcC
 njz
@@ -116964,31 +115538,31 @@ cyQ
 nsa
 ear
 uZD
-uZD
-wjb
-uZD
-wjb
-uZD
-uZD
-kxQ
-ydF
-pyO
-euL
-aXN
-fFF
-jTp
-ije
-euL
-aXN
-euL
-oSO
+qlj
+qlj
+fzd
+oex
+rii
+qlj
+qlj
+qlj
+qlj
+oex
+oex
+oex
+qlj
+qlj
+qlj
+qlj
+rii
+oex
 xwj
 oSJ
 ilA
-sbM
+fVu
 tCf
-xRM
-lUT
+mIP
+scw
 flv
 awi
 cjx
@@ -117199,13 +115773,13 @@ kHU
 plf
 kHU
 kHU
-pry
-amw
-amw
-amw
-amw
-amw
-psX
+kHU
+kHU
+kHU
+kHU
+kHU
+kHU
+kHU
 lLE
 xfY
 fEV
@@ -117221,28 +115795,28 @@ nsa
 nsa
 nsa
 uZD
-sED
-sED
-wUs
-sED
-dyt
 uZD
 uZD
-vyR
-jhE
-coV
-jzj
-uPs
-gRp
-hyY
-sXQ
-uJO
-ukK
+fzd
+rii
 rii
 dfK
+gRp
+gRp
+gRp
+gRp
+gRp
+gRp
+gRp
+gRp
+gRp
+cNU
+rii
+rii
+xwj
 cjx
-nRY
-feb
+cjx
+cjx
 pis
 cjx
 cjx
@@ -117456,7 +116030,7 @@ jXX
 jXX
 jXX
 jXX
-mIP
+kHU
 jXX
 jXX
 jXX
@@ -117478,26 +116052,26 @@ jIF
 vKa
 vKa
 uZD
-iFv
+dfK
+gRp
 cNU
-cNU
-cNU
-dyt
-dyt
-gOx
-jBe
-phs
-uZD
-mIL
-pnO
-tup
-uZD
-oWg
-gcG
-urI
 qlj
 dfK
-cjx
+fPf
+gBi
+oex
+oex
+oex
+gBi
+oex
+oex
+gBi
+oex
+gcG
+cNU
+qlj
+dfK
+bhn
 vGC
 hTd
 hmp
@@ -117713,7 +116287,7 @@ iFl
 otq
 iFl
 jXX
-mIP
+kHU
 jXX
 ddJ
 xXk
@@ -117735,28 +116309,28 @@ ttr
 qVs
 vKa
 uZD
+fzd
 btC
-btC
-cNU
-cNU
-dyt
-hvL
-uZD
-jBe
-phs
-hNK
-vvR
-dTW
-vzE
-hNK
-ncZ
-ncZ
-wxa
-rii
-dfK
-oSJ
-xRM
-ilA
+xwj
+qlj
+fzd
+oex
+wIr
+qlj
+qlj
+wIr
+qlj
+qlj
+qlj
+qlj
+wIr
+oex
+xwj
+qlj
+fzd
+vyR
+kRY
+cjx
 hRb
 cjx
 rud
@@ -117970,7 +116544,7 @@ iFl
 bWB
 iFl
 jXX
-mIP
+kHU
 jXX
 ddJ
 ddJ
@@ -117992,28 +116566,28 @@ kHh
 aSl
 vKa
 hNK
-asr
-asr
-dyt
-dyt
-dyt
-dyt
-wjb
-jBe
-jdH
-uZD
-nSt
-nSt
-nSt
-uZD
-hNK
-uZD
-phP
+xkn
+fKT
+dsj
+qlj
+fzd
+gBi
+qlj
+qlj
+qlj
+rii
+qlj
+qlj
+qlj
+qlj
+qlj
+gBi
+xwj
 qlj
 xkn
-cjx
+sXQ
 ilb
-fVu
+hTd
 jUW
 cjx
 wCA
@@ -118227,7 +116801,7 @@ kkr
 iFl
 dCg
 jXX
-mIP
+kHU
 jXX
 oge
 ddJ
@@ -118249,27 +116823,27 @@ ttr
 fXa
 vKa
 uZD
-asr
-asr
-dyt
-dyt
-dyt
-dyt
-tLA
-jBe
-phs
-jNg
-dLx
-scw
-spN
-nSt
-qor
-rUw
-pev
+fzd
+oex
+qlj
 rii
-vgR
-cjx
-cjx
+fzd
+oex
+qlj
+qlj
+rii
+rii
+rii
+rii
+rii
+qlj
+qlj
+oex
+xwj
+rii
+qlj
+oSO
+kRY
 jwI
 eAC
 jwI
@@ -118484,7 +117058,7 @@ fqR
 qIC
 jSZ
 jXX
-mIP
+kHU
 jXX
 jSZ
 qIC
@@ -118506,28 +117080,28 @@ vqO
 gph
 lqF
 uZD
-tKt
-dyt
-dyt
-dyt
-gfO
-dyt
-wjb
-xIf
-kkY
-gom
-dLx
-ghM
-spN
-nSt
-jcM
-sCh
-nSl
+fzd
+oex
+rii
+rii
+fzd
+oex
 qlj
+qlj
+rii
 dfK
-hNK
-cqb
-fbL
+gRp
+cNU
+rii
+rii
+wIr
+oex
+xwj
+rii
+rii
+oex
+xwj
+jwI
 buY
 sgS
 ctb
@@ -118736,12 +117310,12 @@ kHU
 gcf
 kHU
 gvV
-pry
-lWv
-amw
-eOU
-amw
-psX
+plf
+gcf
+nHd
+gvV
+plf
+kHU
 kHU
 gvV
 kHU
@@ -118763,28 +117337,28 @@ nsa
 qBN
 nsa
 uZD
-hJG
-dyt
-dyt
-dyt
-pZb
-dyt
-tLA
-jBe
-phs
+fzd
+oex
+rii
+rii
+fzd
+gBi
+qlj
+qlj
+rii
 kIG
 dLx
 uwk
-spN
-nSt
-wjl
-gBi
-pev
 rii
-dfK
-gQM
-exw
-usj
+qlj
+qlj
+gBi
+xwj
+rii
+rii
+oex
+xwj
+jwI
 ara
 crH
 otI
@@ -118993,7 +117567,7 @@ oxO
 eMn
 bwm
 gmU
-rtL
+oxO
 eMn
 bwm
 gmU
@@ -119020,28 +117594,28 @@ plf
 kHU
 plf
 uZD
-qgD
-fvf
-dyt
-haO
-pZb
-dyt
-wjb
-jBe
-jdH
-uZD
-uZD
-kRA
-uZD
-uZD
-hNK
-uZD
-phP
+fzd
+oex
+rii
+rii
+fzd
+oex
+wIr
+rii
+rii
+xkn
+fKT
+dsj
+rii
 qlj
-wCC
-hNK
-xTZ
-fbL
+qlj
+oex
+xwj
+rii
+rii
+oex
+xwj
+jwI
 hBT
 cMM
 jwI
@@ -119277,27 +117851,27 @@ ehA
 bmZ
 klO
 ehA
-mMV
-pKX
-oyB
-cRn
 fzd
-anr
-cgh
-dvx
-phs
-uZD
-jUd
-rpu
-fwv
-uZD
-aRY
-aRY
-pev
+oex
+qlj
 rii
-sHS
-jwI
-jwI
+fzd
+oex
+qlj
+qlj
+rii
+rii
+rii
+rii
+rii
+qlj
+qlj
+oex
+xwj
+rii
+qlj
+sCh
+exw
 jwI
 aFy
 gPy
@@ -119507,7 +118081,7 @@ fgW
 lFS
 voX
 spw
-vDX
+fgW
 fCu
 kfj
 jLR
@@ -119534,26 +118108,26 @@ gRG
 pZo
 tJP
 ehA
-qHt
-dpd
-hpC
-dBV
-kMS
-mgL
-uZD
-kRY
-phs
-uZD
-nma
-kRA
-uZD
-uZD
-iJA
-iJA
-qrq
-jXZ
-kOk
-jwI
+dfK
+gRp
+cNU
+qlj
+fzd
+gBi
+qlj
+qlj
+qlj
+qlj
+qlj
+rii
+qlj
+qlj
+qlj
+gBi
+xwj
+qlj
+dfK
+pZb
 vLF
 jwI
 qMT
@@ -119764,7 +118338,7 @@ xFB
 qjC
 xFB
 xFB
-tfQ
+xFB
 bQj
 bCr
 xFB
@@ -119791,27 +118365,27 @@ qAl
 wzP
 tlv
 ehA
-jKa
-uZD
-haU
-haU
-haU
-uZD
-uZD
-tqB
-cWS
-cSu
-vCV
+fzd
+btC
+xwj
+qlj
+xkn
+sYc
 wIr
-tew
-qzM
+qlj
+qlj
+qlj
+qlj
 wIr
+qlj
+qlj
 wIr
-hKj
-uZD
-pdl
+pry
+dsj
+qlj
+fzd
 rnA
-jwI
+exw
 jwI
 hBT
 gPy
@@ -120020,8 +118594,8 @@ aWD
 aWD
 aWD
 aWD
-vPd
-qhd
+aWD
+aWD
 aWD
 oGY
 aWD
@@ -120048,27 +118622,27 @@ gws
 tED
 gWQ
 wtG
-uMm
-jUd
-ddK
-vmP
-vmP
-gbd
-pgL
-cQq
+xkn
 fKT
 dsj
+rii
+rii
+xkn
+fKT
+fKT
+fKT
+fKT
+fKT
+fKT
+fKT
+fKT
+fKT
 dsj
+rii
+rii
+xkn
+fKT
 dsj
-dsj
-dsj
-dsj
-dsj
-urI
-wjb
-wsv
-gPk
-bqi
 jwI
 sgS
 gPy
@@ -120277,7 +118851,7 @@ utn
 utn
 aWD
 aWD
-tYo
+aWD
 aWD
 aWD
 kdU
@@ -120305,27 +118879,27 @@ tUJ
 otd
 scX
 ehA
-sap
+uZD
 jUd
-hle
-jUd
-jUd
-jUd
+uZD
 oex
-tqB
-soD
-nFZ
-nFZ
-nFZ
-nTg
-nFZ
-nFZ
-vcG
-jQj
+oex
+oex
+oex
 wjb
-hVy
+wjb
+wjb
+wjb
+wjb
+wjb
+wjb
+nFZ
+oex
+oex
+nFZ
+uZD
 bmQ
-lmX
+uZD
 jwI
 hBT
 wTL
@@ -120534,7 +119108,7 @@ dup
 nRV
 bOD
 cmG
-bYx
+xqQ
 bme
 oJD
 isX
@@ -120563,26 +119137,26 @@ ihP
 ghY
 ehA
 nZC
-jUd
-qsA
-mum
-mum
-ayw
-pgL
-neS
-iPv
-dsj
-bAA
-iFu
-gnl
-iFu
-iFu
-nGB
-qrR
+oex
+uZD
+uZD
 wjb
-sYc
-kHn
-mMu
+wjb
+wjb
+wjb
+iPv
+bAA
+bAA
+bAA
+gnl
+wjb
+wjb
+wjb
+wjb
+uZD
+uZD
+oex
+nZC
 jwI
 ijY
 buY
@@ -120819,27 +119393,27 @@ ked
 gFB
 bQs
 ehA
-ptT
-iwx
-aBb
-arF
-arF
-xIs
+nZC
+oex
 uZD
-tuQ
+arF
+iLP
+iLP
+iLP
+wjb
 hxo
 seP
 pYC
-dsj
+xTZ
 whN
-vPV
-vNQ
-tUz
+wjb
 iLP
-wbI
-xDw
-bhn
-bvK
+iLP
+iLP
+arF
+uZD
+oex
+nZC
 jwI
 ijY
 wTL
@@ -121076,29 +119650,29 @@ kHq
 dAf
 ehA
 ehA
-vTI
+uZD
 tLA
-wjb
-wjb
-wjb
+uZD
+rhs
+vkK
+vkK
 vkK
 uZD
-uZD
-hNK
-wjb
+hxo
+dyt
 oos
-wjb
-hNK
+dyt
+whN
 uZD
-uZD
-uZD
-wjb
+vkK
+vkK
+vkK
 rhs
-szT
+uZD
 mtH
 uZD
 jwI
-hBT
+jwI
 cMM
 otI
 mph
@@ -121333,29 +119907,29 @@ vMk
 gwm
 ehA
 abX
-rvC
+wkD
 jDO
-gRV
-sUm
+jQj
+ovz
 ifQ
-qGp
-sbi
-nsa
+uwt
+uwt
+kZh
 tlb
-vWf
-rVN
+jTp
+nBf
 vWf
 mKD
-nsa
-xBg
-cOU
-cOU
-rZU
-wkD
+kZh
+uwt
+uwt
+uwt
+hpC
+hKj
 ugv
-fHi
+gRV
+jBe
 jwI
-ijY
 gPy
 ctb
 fRJ
@@ -121589,30 +120163,30 @@ xEt
 tya
 xEy
 pUu
-gKu
-bZA
-cOU
+qgD
+bau
+tiK
 elw
 sUm
 mts
 dQD
-gqH
+cOU
 kLE
-bau
-xbm
+tlb
+vWf
 gpM
-xbm
-elw
+vWf
+mKD
 xKm
-gqH
+cOU
 dQD
 mEc
 rZU
 bau
 cmi
-vYv
+elw
+rtL
 jwI
-jyh
 buY
 jwI
 jwI
@@ -121847,8 +120421,8 @@ oiI
 bVH
 pUu
 jgS
-bZA
-xbm
+bau
+cbc
 elw
 sUm
 shG
@@ -121856,8 +120430,8 @@ dQD
 ksU
 nsa
 fGh
-rhc
-nSK
+hmC
+kkY
 hmC
 wyP
 nsa
@@ -121867,9 +120441,9 @@ oGF
 rZU
 jyK
 oBb
-nBf
+elw
+jNg
 jwI
-ijY
 gPy
 sgS
 jwI
@@ -122104,13 +120678,13 @@ fti
 lzo
 ehA
 jgS
-bZA
+bau
 uwB
-elw
+fRP
 sUm
 caP
 wDR
-bie
+xBg
 nsa
 hyN
 bKu
@@ -122126,7 +120700,7 @@ bau
 cmi
 rsB
 jwI
-hBT
+jwI
 wTL
 sgS
 jwI
@@ -124428,7 +123002,7 @@ jwI
 eLj
 cJM
 cOU
-fRP
+gKu
 gLD
 nsa
 hoM
@@ -124629,9 +123203,9 @@ gjf
 wfx
 tGM
 wTX
-cGo
-cIt
 wNU
+cIt
+jFX
 ieI
 tEF
 wwi

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -96,11 +96,9 @@
 	},
 /area/station/cargo/office)
 "aaS" = (
-/obj/structure/disposaloutlet{
-	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/space)
+/obj/structure/closet/radiation,
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "aaT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -115,7 +113,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "aaW" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -228,6 +226,22 @@
 	icon_state = "redfull"
 	},
 /area/station/security/main)
+"abE" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating/airless{
+	dir = 1;
+	icon_state = "warnplate"
+	},
+/area/station/engineering/singularity)
 "abG" = (
 /obj/structure/rack,
 /obj/item/toy/figure/chef,
@@ -290,11 +304,8 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/port)
 "abX" = (
-/obj/structure/rack,
-/obj/item/weapon/storage/firstaid/regular{
-	pixel_x = -2;
-	pixel_y = 4
-	},
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/machinery/atmospherics/components/unary/portables_connector,
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
@@ -330,7 +341,7 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
 "acf" = (
-/obj/effect/landmark/start/assistant,
+/obj/effect/landmark/start/assistant/test_subject,
 /obj/structure/stool/bed/chair/metal/black{
 	dir = 8
 	},
@@ -601,11 +612,9 @@
 /turf/simulated/wall,
 /area/station/security/brig)
 "adu" = (
-/obj/structure/closet/radiation,
-/turf/simulated/floor{
-	icon_state = "warning"
-	},
-/area/station/engineering/atmos)
+/obj/structure/closet/l3closet/general,
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "adw" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/simulated/floor{
@@ -1121,13 +1130,14 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "ahx" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/red{
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = 32
 	},
-/area/station/engineering/atmos)
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "ahz" = (
 /obj/machinery/alarm{
 	pixel_x = -28;
@@ -1203,35 +1213,11 @@
 	},
 /area/station/civilian/theatre)
 "ahU" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 5
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
-	frequency = 1379;
-	id_tag = "atmospherics_pump";
-	name = "Atmospherics Large Air Vent"
-	},
-/obj/machinery/airlock_sensor{
-	id_tag = "atmospherics_sensor";
-	req_one_access = list(13,45,1);
-	pixel_x = -25;
-	pixel_y = 6
-	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	id_tag = "atmospherics_airlock";
-	tag_airpump = "atmospherics_pump";
-	tag_chamber_sensor = "atmospherics_sensor";
-	tag_exterior_door = "atmospherics_outer";
-	tag_interior_door = "atmospherics_inner";
-	pixel_x = -25;
-	pixel_y = -6;
-	req_one_access = list(10,24)
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
-	},
-/area/station/engineering/atmos)
+/turf/simulated/floor/plating/airless/catwalk,
+/area/station/engineering/atmos/supermatter)
 "ahV" = (
 /obj/structure/stool/bed/roller,
 /obj/structure/window/thin{
@@ -1337,6 +1323,16 @@
 	icon_state = "whitepurplefull"
 	},
 /area/station/rnd/hallway)
+"ajh" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/airless{
+	icon_state = "warnplate"
+	},
+/area/space)
 "ajk" = (
 /obj/structure/table,
 /obj/item/weapon/paper/pamphlet{
@@ -1630,6 +1626,23 @@
 	icon_state = "vault"
 	},
 /area/station/bridge)
+"amp" = (
+/obj/machinery/door_control{
+	id = "Singularity";
+	name = "Shutters Control";
+	req_access = list(10);
+	pixel_y = 25
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating{
+	dir = 1;
+	icon_state = "warnplate"
+	},
+/area/station/engineering/engine)
 "amv" = (
 /obj/structure/sign/directions/science{
 	pixel_x = -32
@@ -1645,11 +1658,12 @@
 	},
 /area/station/hallway/primary/central)
 "amw" = (
-/turf/simulated/floor/plating/airless{
-	dir = 8;
-	icon_state = "warnplate"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
 	},
-/area/space)
+/area/station/engineering/break_room)
 "amy" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil,
@@ -1658,6 +1672,17 @@
 /obj/item/device/multitool,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"amM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/atmos/supermatter)
 "amN" = (
 /obj/machinery/light/smart,
 /turf/simulated/floor{
@@ -1786,6 +1811,17 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/xenobiology)
+"anN" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "anO" = (
 /obj/structure/sign/nanotrasen{
 	pixel_y = -32
@@ -1933,14 +1969,11 @@
 	},
 /area/station/hallway/primary/central)
 "apm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/components/trinary/filter{
+	dir = 1
 	},
-/turf/simulated/floor{
-	icon_state = "warning"
-	},
-/area/station/engineering/atmos)
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "apq" = (
 /obj/machinery/door/firedoor,
 /obj/structure/plasticflaps{
@@ -1963,21 +1996,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway)
-"apR" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	id_tag = "solar_tool_outer";
-	locked = 1;
-	name = "Engineering External Access";
-	req_access = list(10,13)
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/auxsolarport)
 "apV" = (
 /turf/simulated/floor/carpet/blue2,
 /area/station/bridge/meeting_room)
@@ -2068,17 +2086,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "aqy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/turf/simulated/floor/plating{
+	dir = 1;
+	icon_state = "warnplate"
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "warning"
-	},
-/area/station/engineering/atmos)
+/area/station/maintenance/auxsolarport)
 "aqC" = (
 /turf/simulated/floor{
 	dir = 6;
@@ -2100,10 +2115,6 @@
 /area/station/security/hos)
 "aqK" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Atmospherics Project Room";
-	req_access = list(24)
-	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -2111,7 +2122,15 @@
 	name = "Atmos Blast Door";
 	opacity = 0
 	},
-/turf/simulated/floor,
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 4
+	},
+/obj/machinery/door/airlock/atmos{
+	name = "Supermatter Construction Area"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowfull"
+	},
 /area/station/engineering/atmos)
 "ara" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2174,14 +2193,14 @@
 	},
 /area/station/civilian/hydroponics)
 "arF" = (
-/obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 4
 	},
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating{
 	icon_state = "platebot"
 	},
-/area/station/engineering/singularity)
+/area/station/engineering/engine)
 "asj" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2324,6 +2343,17 @@
 	icon_state = "gcircuit"
 	},
 /area/station/rnd/xenobiology)
+"atL" = (
+/obj/machinery/camera{
+	c_tag = "Drone Fabrication";
+	network = list("SS13","Engineering");
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkyellow"
+	},
+/area/station/engineering/drone_fabrication)
 "atM" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
@@ -2385,6 +2415,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
+"auq" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating/airless{
+	dir = 4;
+	icon_state = "warnplate"
+	},
+/area/station/engineering/singularity)
 "aux" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -2400,7 +2446,7 @@
 	dir = 8
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "auM" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
@@ -2540,7 +2586,7 @@
 	dir = 8;
 	icon_state = "bluecorner"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "awU" = (
 /turf/simulated/floor{
 	icon_state = "purplefull"
@@ -2730,11 +2776,11 @@
 	},
 /area/station/hallway/primary/fore)
 "aAr" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
 /turf/simulated/floor{
@@ -3011,7 +3057,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "aDW" = (
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
@@ -3298,7 +3344,7 @@
 	},
 /area/station/security/prison)
 "aGB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -3448,9 +3494,11 @@
 	},
 /area/station/civilian/hydroponics)
 "aIJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
-/area/station/engineering/atmos)
+/obj/item/device/radio/beacon,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/drone_fabrication)
 "aIO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -3460,6 +3508,17 @@
 	icon_state = "vault"
 	},
 /area/station/engineering/atmos)
+"aIU" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/engineering/engine)
 "aIW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
@@ -3514,21 +3573,21 @@
 "aJG" = (
 /obj/structure/cable{
 	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 29
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 1
 	},
-/obj/machinery/camera{
-	c_tag = "Turbine Generator";
-	network = list("SS13","Engineering")
+/turf/simulated/floor/plating{
+	icon_state = "warnplate"
 	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
-/area/station/engineering/atmos)
+/area/station/maintenance/auxsolarport)
 "aJH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -3912,7 +3971,7 @@
 	dir = 1;
 	icon_state = "warning"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "aPP" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -3947,7 +4006,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "aQh" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -4000,13 +4059,11 @@
 	},
 /area/station/hallway/secondary/exit)
 "aQP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
 /turf/simulated/floor{
-	icon_state = "neutralfull"
+	dir = 4;
+	icon_state = "caution"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "aRb" = (
 /turf/simulated/floor{
 	icon_state = "boxing"
@@ -4119,7 +4176,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "aSo" = (
 /obj/structure/table/glass,
 /obj/item/weapon/paper_bin,
@@ -4318,7 +4375,7 @@
 	dir = 4;
 	icon_state = "warning"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "aUX" = (
 /obj/structure/table,
 /obj/item/device/flash,
@@ -4373,7 +4430,7 @@
 /turf/simulated/floor{
 	icon_state = "yellow"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "aVD" = (
 /obj/item/target,
 /turf/simulated/floor/plating/airless{
@@ -4474,12 +4531,27 @@
 /obj/structure/window/thin,
 /turf/simulated/floor,
 /area/station/security/prison)
-"aXH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on/atmos{
-	dir = 4
+"aXN" = (
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "Singularity";
+	layer = 2.8;
+	name = "Engine Shutters";
+	opacity = 0
 	},
-/turf/simulated/floor/engine,
-/area/station/engineering/atmos)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/engine)
 "aXP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -4517,10 +4589,6 @@
 /area/station/maintenance/medbay)
 "aYm" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Atmospherics Project Room";
-	req_access = list(24)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -4534,7 +4602,12 @@
 	name = "Atmos Blast Door";
 	opacity = 0
 	},
-/turf/simulated/floor,
+/obj/machinery/door/airlock/atmos{
+	name = "Supermatter Construction Area"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowfull"
+	},
 /area/station/engineering/atmos)
 "aYo" = (
 /obj/machinery/door/firedoor,
@@ -4613,6 +4686,17 @@
 	icon_state = "warning"
 	},
 /area/station/ai_monitored/eva)
+"bae" = (
+/obj/structure/rack,
+/obj/item/weapon/storage/firstaid/regular{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/item/bodybag/cryobag,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
+/area/station/engineering/engine)
 "ban" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
@@ -4878,7 +4962,7 @@
 	icon_state = "gr_window_reinforced_phoron"
 	},
 /turf/simulated/floor/plating,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "bcX" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8
@@ -4947,12 +5031,7 @@
 "bec" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Atmospherics Emergency Access";
-	req_one_access = list(10,24)
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	req_access = list(24)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -4964,6 +5043,10 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/barricade/wooden{
+	layer = 2.8;
+	name = "doorway barricade"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "bed" = (
@@ -5259,7 +5342,7 @@
 	dir = 5;
 	icon_state = "vault"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "bhh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -5269,11 +5352,10 @@
 	},
 /area/station/engineering/engine)
 "bhn" = (
-/turf/simulated/floor/plating/airless{
-	dir = 8;
-	icon_state = "warnplate"
+/turf/simulated/floor{
+	icon_state = "yellow"
 	},
-/area/station/maintenance/science)
+/area/station/engineering/break_room)
 "bhp" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -5360,13 +5442,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
-"biK" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/turf/simulated/floor{
-	dir = 9;
-	icon_state = "warning"
-	},
-/area/station/engineering/atmos)
 "biT" = (
 /obj/machinery/camera{
 	c_tag = "Vault";
@@ -5408,6 +5483,15 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/port)
+"bjg" = (
+/obj/machinery/power/grounding_rod,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/engineering/singularity)
 "bjl" = (
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
@@ -5452,11 +5536,17 @@
 	},
 /area/station/civilian/bar)
 "bjK" = (
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "warning"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/atmos)
 "bjM" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -5781,8 +5871,13 @@
 	name = "Engineering External Access";
 	req_access = list(10,13)
 	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
-/area/station/engineering/singularity)
+/area/station/engineering/engine)
 "bmU" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/structure/stool/bed/chair,
@@ -5897,6 +5992,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/bridge/nuke_storage)
+"bou" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "boA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -5958,7 +6057,7 @@
 	},
 /area/station/medical/psych)
 "bpO" = (
-/obj/effect/landmark/start/assistant,
+/obj/effect/landmark/start/assistant/test_subject,
 /obj/machinery/light/smart{
 	dir = 4
 	},
@@ -6184,7 +6283,7 @@
 /turf/simulated/floor{
 	icon_state = "caution"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "bsD" = (
 /turf/simulated/floor{
 	icon_state = "cafeteria"
@@ -6315,7 +6414,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "bua" = (
 /obj/item/weapon/storage/secure/safe{
 	pixel_x = 5;
@@ -6570,19 +6669,21 @@
 	},
 /area/station/medical/hallway)
 "bxl" = (
-/obj/structure/cable{
-	d1 = 2;
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 9
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
 	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/plating,
-/area/station/maintenance/atmos)
+/area/station/engineering/atmos/supermatter)
 "bxB" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/door_control{
@@ -6641,7 +6742,10 @@
 	},
 /area/station/civilian/dormitories)
 "byu" = (
-/turf/simulated/wall/r_wall,
+/turf/simulated/floor/plating/airless{
+	dir = 8;
+	icon_state = "warnplate"
+	},
 /area/space)
 "byw" = (
 /obj/machinery/door/firedoor,
@@ -6818,6 +6922,17 @@
 	icon_state = "platebotc"
 	},
 /area/station/cargo/recycleroffice)
+"bzS" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 10
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "bAn" = (
 /obj/structure/disposalpipe/junction,
 /turf/simulated/floor{
@@ -6830,7 +6945,7 @@
 	dir = 8;
 	icon_state = "warnplate"
 	},
-/area/station/engineering/singularity)
+/area/station/engineering/engine)
 "bAC" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -7069,7 +7184,7 @@
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "bCV" = (
 /obj/structure/window/fulltile{
 	grilled = 1;
@@ -7289,6 +7404,12 @@
 	icon_state = "bot"
 	},
 /area/station/engineering/engine)
+"bFn" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "bFo" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -7636,16 +7757,6 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/chapel)
-"bHz" = (
-/obj/machinery/light/smart,
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/atmos)
 "bHC" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/lipstick/jade,
@@ -8440,22 +8551,9 @@
 /turf/simulated/floor/wood,
 /area/station/storage/tools)
 "bSs" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 4
-	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1379;
-	master_tag = "atmospherics_airlock";
-	name = "interior access button";
-	pixel_x = 20;
-	req_one_access = list(10,24);
-	pixel_y = 12
-	},
-/turf/simulated/floor{
-	icon_state = "yellowpatch"
-	},
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/manifold/visible/yellow,
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "bSM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -8513,9 +8611,6 @@
 /obj/structure/table/reinforced,
 /obj/item/device/analyzer,
 /obj/item/weapon/wrench,
-/obj/machinery/light/smart{
-	dir = 4
-	},
 /turf/simulated/floor{
 	icon_state = "yellowcorner"
 	},
@@ -8605,7 +8700,7 @@
 	},
 /area/station/security/interrogation)
 "bUL" = (
-/obj/effect/landmark/start/assistant,
+/obj/effect/landmark/start/assistant/test_subject,
 /obj/structure/stool/bed/chair{
 	dir = 4
 	},
@@ -8623,7 +8718,7 @@
 /turf/simulated/floor{
 	icon_state = "caution"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "bUV" = (
 /obj/structure/table/reinforced,
 /obj/item/device/science_tool,
@@ -8927,6 +9022,17 @@
 	icon_state = "warning"
 	},
 /area/station/gateway)
+"bYp" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/airless{
+	dir = 5;
+	icon_state = "warnplate"
+	},
+/area/station/engineering/singularity)
 "bYu" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/cobweb,
@@ -9017,6 +9123,21 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/library)
+"cak" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/atmos/supermatter)
 "cal" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -9092,7 +9213,6 @@
 /area/station/rnd/robotics)
 "caP" = (
 /obj/structure/table/reinforced,
-/obj/item/clothing/mask/gas,
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -9125,16 +9245,6 @@
 	icon_state = "yellowfull"
 	},
 /area/station/engineering/engine)
-"cbk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "warning"
-	},
-/area/station/engineering/atmos)
 "cbo" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9145,11 +9255,12 @@
 	},
 /area/station/medical/chemistry)
 "cbA" = (
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA"
 	},
-/turf/simulated/floor/engine,
+/turf/simulated/wall/r_wall,
 /area/station/engineering/atmos)
 "cbM" = (
 /obj/structure/closet/crate,
@@ -9234,6 +9345,20 @@
 /obj/structure/sign/warning/fire,
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/science)
+"ccL" = (
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "Singularity";
+	layer = 2.8;
+	name = "Engine Shutters";
+	opacity = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/engine)
 "ccP" = (
 /obj/machinery/ai_status_display,
 /turf/simulated/wall,
@@ -9443,6 +9568,12 @@
 	icon_state = "bluefull"
 	},
 /area/station/security/checkpoint)
+"cfr" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "darkyellowcorners"
+	},
+/area/station/engineering/drone_fabrication)
 "cfA" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -9546,11 +9677,9 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "cgu" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor{
-	icon_state = "bot"
-	},
-/area/station/engineering/atmos)
+/obj/structure/window/thin/reinforced,
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "cgv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
@@ -9590,6 +9719,14 @@
 /obj/structure/curtain,
 /turf/simulated/floor/plating,
 /area/station/security/prison/toilet)
+"cha" = (
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA"
+	},
+/turf/simulated/wall/r_wall,
+/area/station/maintenance/auxsolarport)
 "che" = (
 /obj/machinery/light/smart{
 	dir = 4
@@ -9632,6 +9769,17 @@
 	icon_state = "chapel"
 	},
 /area/station/civilian/chapel)
+"chy" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/airless{
+	dir = 1;
+	icon_state = "warnplate"
+	},
+/area/space)
 "chB" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -9874,15 +10022,6 @@
 	icon_state = "wooden"
 	},
 /area/station/hallway/primary/central)
-"ckv" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "caution"
-	},
-/area/station/engineering/atmos)
 "ckw" = (
 /obj/machinery/light/smart{
 	dir = 8
@@ -9999,11 +10138,13 @@
 	},
 /area/station/cargo/office)
 "cmi" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -10081,7 +10222,7 @@
 /turf/simulated/floor,
 /area/station/civilian/kitchen)
 "cmX" = (
-/obj/effect/landmark/start/assistant,
+/obj/effect/landmark/start/assistant/test_subject,
 /obj/structure/stool/bed/chair/metal/black{
 	dir = 4
 	},
@@ -10397,6 +10538,21 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/theatre)
+"ctH" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/airless{
+	icon_state = "warnplate"
+	},
+/area/space)
 "ctR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -10436,6 +10592,24 @@
 	dir = 5;
 	icon_state = "warning"
 	},
+/area/station/engineering/engine)
+"cum" = (
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/machinery/embedded_controller/radio/airlock_controller{
+	id_tag = "engineering_west_airlock";
+	req_access = list(10,13);
+	tag_airpump = "engineering_west_pump";
+	tag_chamber_sensor = "engineering_west_sensor";
+	tag_exterior_door = "engineering_west_outer";
+	tag_interior_door = "engineering_west_inner";
+	pixel_y = -25
+	},
+/obj/machinery/airlock_sensor{
+	id_tag = "engineering_west_sensor";
+	pixel_x = -12;
+	pixel_y = -25
+	},
+/turf/simulated/floor/plating/airless,
 /area/station/engineering/engine)
 "cuw" = (
 /obj/structure/object_wall/mining{
@@ -10754,21 +10928,8 @@
 	},
 /area/station/rnd/hallway)
 "cxI" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/light/smart{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	icon_state = "yellowpatch"
-	},
-/area/station/engineering/atmos)
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "cxU" = (
 /obj/machinery/shower/free{
 	dir = 4
@@ -10825,6 +10986,31 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway)
+"cyw" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1379;
+	master_tag = "engineering_east_airlock";
+	name = "exterior access button";
+	pixel_x = 22;
+	pixel_y = 20;
+	req_access = list(10,13)
+	},
+/turf/simulated/floor/plating/airless{
+	dir = 5;
+	icon_state = "warnplate"
+	},
+/area/station/engineering/singularity)
 "cyx" = (
 /obj/machinery/computer/secure_data{
 	dir = 8
@@ -10880,7 +11066,7 @@
 	dir = 6;
 	icon_state = "darkblue"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "czd" = (
 /turf/simulated/floor{
 	dir = 6;
@@ -11101,16 +11287,19 @@
 /turf/simulated/wall/r_wall,
 /area/station/bridge/ai_upload)
 "cBU" = (
-/obj/machinery/shower/free{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/structure/window/fulltile/reinforced/phoron{
+	grilled = 1;
+	icon_state = "gr_window_reinforced_phoron"
 	},
-/obj/structure/drain{
-	drainage = 2
+/obj/machinery/meter{
+	frequency = 1444;
+	id = "out_sm_meter";
+	layer = 3.2;
+	name = "Out Supermatter"
 	},
-/turf/simulated/floor{
-	icon_state = "bot"
-	},
-/area/station/engineering/atmos)
+/turf/simulated/floor/engine,
+/area/station/engineering/atmos/supermatter)
 "cBY" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -11127,14 +11316,14 @@
 	},
 /area/station/medical/sleeper)
 "cCw" = (
-/obj/machinery/light/smart{
-	dir = 8
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/structure/closet/emcloset,
-/turf/simulated/floor{
-	icon_state = "bot"
+/turf/simulated/floor/plating{
+	icon_state = "platebot"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "cCx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -11443,6 +11632,19 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
+"cFP" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/atmos/supermatter)
 "cGi" = (
 /obj/structure/closet/bombcloset,
 /turf/simulated/floor{
@@ -11483,6 +11685,15 @@
 	icon_state = "warnwhite"
 	},
 /area/station/medical/cryo)
+"cGK" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "cGN" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -11643,7 +11854,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "cIy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -11987,7 +12198,7 @@
 	dir = 10;
 	icon_state = "warnplate"
 	},
-/area/station/engineering/singularity)
+/area/space)
 "cNX" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor{
@@ -12385,10 +12596,12 @@
 /turf/environment/space,
 /area/shuttle/mining/station)
 "cSH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	icon_state = "caution"
+	icon_state = "dark"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/drone_fabrication)
 "cTc" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -12455,7 +12668,7 @@
 /turf/simulated/floor{
 	icon_state = "darkbluefull"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "cTq" = (
 /obj/machinery/power/solar{
 	id = "auxsolareast";
@@ -12619,6 +12832,12 @@
 "cVA" = (
 /turf/simulated/floor,
 /area/station/rnd/robotics)
+"cVB" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "cVO" = (
 /obj/structure/object_wall/pod{
 	icon_state = "1,2"
@@ -12736,23 +12955,11 @@
 	},
 /area/station/bridge/hop_office)
 "cXC" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1
-	},
-/turf/simulated/floor/plating{
-	icon_state = "warnplate"
-	},
-/area/station/maintenance/auxsolarport)
+/turf/simulated/floor,
+/area/station/engineering/atmos)
 "cXP" = (
 /obj/machinery/shower/free{
 	dir = 8
@@ -12835,18 +13042,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "cZS" = (
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "Abandoned Room APC";
-	pixel_y = 28
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "caution"
+	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
 "daq" = (
@@ -12982,6 +13182,14 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/dormitories)
+"dcO" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/engine)
 "dcY" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -13004,11 +13212,11 @@
 	},
 /area/station/aisat/ai_chamber)
 "ddt" = (
-/turf/simulated/floor/plating/airless{
-	dir = 9;
-	icon_state = "warnplate"
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 9
 	},
-/area/space)
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "ddy" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13083,6 +13291,23 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge/captain_quarters)
+"dee" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
+"deM" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor,
+/area/station/engineering/engine)
 "deV" = (
 /obj/machinery/biogenerator,
 /turf/simulated/floor/plating,
@@ -13183,7 +13408,7 @@
 	dir = 9;
 	icon_state = "warnplate"
 	},
-/area/station/engineering/singularity)
+/area/space)
 "dfS" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor,
@@ -13285,7 +13510,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "dhb" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -13546,14 +13771,19 @@
 	},
 /area/station/hallway/primary/central)
 "diQ" = (
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor{
-	icon_state = "yellowpatch"
+/obj/machinery/light/smart{
+	dir = 1
 	},
-/area/station/engineering/atmos)
+/turf/simulated/floor/plating{
+	dir = 1;
+	icon_state = "warnplate"
+	},
+/area/station/engineering/engine)
 "diU" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13594,7 +13824,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "djG" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -13768,7 +13998,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "dlE" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -14190,13 +14420,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
-"drM" = (
-/obj/item/device/radio/beacon,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/engineering/atmos)
 "drY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/emcloset,
@@ -14207,19 +14430,13 @@
 	dir = 6;
 	icon_state = "warnplate"
 	},
-/area/station/engineering/singularity)
-"dsq" = (
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1379;
-	master_tag = "atmospherics_airlock";
-	name = "exterior access button";
-	pixel_x = 20;
-	pixel_y = -20;
-	req_one_access = list(10,24)
-	},
-/turf/simulated/floor/plating/airless/catwalk,
 /area/space)
+"dsq" = (
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "caution"
+	},
+/area/station/engineering/atmos/supermatter)
 "dsx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -14281,15 +14498,27 @@
 /area/station/security/prison)
 "dtg" = (
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1379;
+	master_tag = "solar_tool_airlock";
+	name = "interior access button";
+	pixel_x = 25;
+	pixel_y = 25;
+	req_access = list(13)
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
 	},
-/turf/simulated/floor,
-/area/station/engineering/atmos)
+/turf/simulated/floor/plating{
+	dir = 9;
+	icon_state = "warnplate"
+	},
+/area/station/maintenance/auxsolarport)
 "dtr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -14417,7 +14646,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "duM" = (
 /obj/structure/filingcabinet,
 /turf/simulated/floor{
@@ -14521,7 +14750,7 @@
 	dir = 8;
 	icon_state = "warning"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "dwn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/toolcloset,
@@ -14541,7 +14770,7 @@
 	dir = 4;
 	icon_state = "bluecorner"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "dwB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/visible{
@@ -14690,8 +14919,8 @@
 	},
 /area/station/bridge/meeting_room)
 "dyt" = (
-/turf/simulated/floor/plating,
-/area/station/engineering/singularity)
+/turf/simulated/wall/r_wall,
+/area/station/engineering/atmos/supermatter)
 "dyv" = (
 /obj/structure/table,
 /obj/item/weapon/storage/box/lights/mixed,
@@ -14763,14 +14992,13 @@
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
 "dzq" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8
+/obj/structure/sign/directions/engineering{
+	desc = "A sign that shows there are doors here. There are doors everywhere!";
+	icon_state = "doors";
+	name = "WARNING: EXTERNAL AIRLOCK"
 	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
-/area/station/engineering/atmos)
+/turf/simulated/wall/r_wall,
+/area/station/maintenance/auxsolarport)
 "dzK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
@@ -15035,6 +15263,22 @@
 	icon_state = "vault"
 	},
 /area/station/medical/genetics)
+"dEz" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating/airless{
+	dir = 1;
+	icon_state = "warnplate"
+	},
+/area/space)
 "dEP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -15335,25 +15579,29 @@
 	},
 /area/station/engineering/atmos)
 "dIE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor{
 	icon_state = "yellowpatch"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
+"dIH" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/engineering/break_room)
 "dIJ" = (
 /obj/item/weapon/flora/random,
 /obj/item/weapon/storage/secure/safe{
@@ -15574,7 +15822,7 @@
 /turf/simulated/floor/plating/airless{
 	icon_state = "platebot"
 	},
-/area/station/engineering/singularity)
+/area/space)
 "dLz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -15733,6 +15981,17 @@
 	icon_state = "warning"
 	},
 /area/station/civilian/cold_room)
+"dOV" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating/airless{
+	dir = 9;
+	icon_state = "warnplate"
+	},
+/area/station/engineering/singularity)
 "dPb" = (
 /obj/machinery/recharger{
 	pixel_y = 3
@@ -15770,13 +16029,16 @@
 	},
 /area/station/aisat/ai_chamber)
 "dPj" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "dPx" = (
 /obj/structure/disposalpipe/sortjunction/flipped{
 	dir = 8;
@@ -15867,11 +16129,14 @@
 /turf/simulated/wall/r_wall,
 /area/station/rnd/chargebay)
 "dRh" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/on{
+	dir = 4;
+	external_pressure_bound = 140;
+	external_pressure_bound_default = 140;
+	name = "(OUT) Space Large Air Vent"
 	},
 /turf/simulated/floor/plating/airless/catwalk,
-/area/space)
+/area/station/engineering/atmos)
 "dRG" = (
 /obj/machinery/door/window/brigdoor{
 	id = "cargocell";
@@ -15921,7 +16186,7 @@
 	},
 /area/station/aisat/antechamber_interior)
 "dSt" = (
-/obj/effect/landmark/start/assistant,
+/obj/effect/landmark/start/assistant/test_subject,
 /obj/structure/stool,
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -16331,7 +16596,7 @@
 	dir = 5;
 	icon_state = "brown"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "dWD" = (
 /obj/structure/table/woodentable/fancy,
 /obj/item/stack/sheet/wood{
@@ -16494,6 +16759,15 @@
 /obj/effect/decal/cleanable/vomit,
 /turf/simulated/floor/wood,
 /area/station/maintenance/medbay)
+"dYH" = (
+/obj/structure/window/thin/reinforced{
+	dir = 1
+	},
+/obj/item/weapon/flora/random,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/atmos/supermatter)
 "dYQ" = (
 /obj/machinery/door/airlock/external{
 	dock_tag = "pod3"
@@ -16616,7 +16890,7 @@
 	dir = 5;
 	icon_state = "vault"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "eax" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -16627,7 +16901,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "eay" = (
@@ -16709,16 +16989,19 @@
 	},
 /area/station/engineering/atmos)
 "ebo" = (
-/obj/structure/cable{
+/turf/simulated/floor/plating,
+/area/station/maintenance/auxsolarport)
+"ebv" = (
+/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/light/smart{
-	dir = 1
+/turf/simulated/floor/plating/airless{
+	dir = 1;
+	icon_state = "warnplate"
 	},
-/turf/simulated/floor,
-/area/station/engineering/atmos)
+/area/station/engineering/singularity)
 "ebD" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -16961,13 +17244,15 @@
 	},
 /area/station/medical/surgeryobs)
 "eeX" = (
-/obj/machinery/computer/area_atmos{
-	dir = 8
+/obj/machinery/power/emitter{
+	anchored = 1;
+	dir = 8;
+	state = 2
 	},
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "eeZ" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor{
@@ -16975,7 +17260,7 @@
 	},
 /area/station/civilian/dormitories)
 "efb" = (
-/obj/effect/landmark/start/assistant,
+/obj/effect/landmark/start/assistant/test_subject,
 /obj/structure/stool/bed/chair{
 	dir = 4
 	},
@@ -17145,11 +17430,11 @@
 /turf/simulated/floor/wood,
 /area/station/maintenance/medbay)
 "ehX" = (
-/obj/structure/reagent_dispensers/watertank,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "warndark"
@@ -17487,7 +17772,6 @@
 /turf/simulated/floor,
 /area/station/rnd/tox_launch)
 "emc" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -17576,7 +17860,7 @@
 /turf/simulated/floor{
 	icon_state = "warning"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "env" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -17635,6 +17919,15 @@
 	icon_state = "purplechecker"
 	},
 /area/station/rnd/lab)
+"eom" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/station/engineering/engine)
 "eou" = (
 /obj/structure/stool/bed/chair{
 	dir = 1
@@ -17803,6 +18096,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/toilet)
+"erQ" = (
+/obj/machinery/power/terminal,
+/obj/structure/cable,
+/turf/simulated/floor{
+	icon_state = "warning"
+	},
+/area/station/engineering/engine)
 "erV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on/atmos{
 	dir = 4;
@@ -17827,14 +18127,13 @@
 	},
 /area/station/bridge/nuke_storage)
 "esv" = (
-/obj/machinery/computer/drone_control{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "warndarkcorners"
+	icon_state = "yellowpatch"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "esN" = (
 /obj/structure/sign/warning,
 /turf/simulated/wall/r_wall,
@@ -17892,6 +18191,19 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
+"etj" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile/reinforced/phoron{
+	grilled = 1;
+	icon_state = "gr_window_reinforced_phoron"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/engine)
 "eto" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 1;
@@ -17900,7 +18212,7 @@
 	sortType = "CE Office"
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "etq" = (
 /turf/simulated/floor{
 	dir = 5;
@@ -17977,12 +18289,6 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/chapel/mass_driver)
-"etT" = (
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "yellowcorner"
-	},
-/area/station/engineering/atmos)
 "etX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18130,7 +18436,7 @@
 /turf/simulated/floor{
 	icon_state = "warning"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "evW" = (
 /obj/machinery/light/smart,
 /obj/item/weapon/flora/random,
@@ -18142,13 +18448,24 @@
 	icon_state = "dark"
 	},
 /area/station/bridge/ai_upload)
+"ewd" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating/airless{
+	dir = 9;
+	icon_state = "warnplate"
+	},
+/area/space)
 "ewi" = (
 /obj/structure/sign/warning/electricshock{
 	pixel_x = 32
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "ewn" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -18269,10 +18586,17 @@
 /turf/simulated/floor,
 /area/station/civilian/hydroponics)
 "exw" = (
-/turf/simulated/floor/plating/airless{
-	icon_state = "warnplate"
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/area/station/maintenance/engineering)
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/break_room)
 "exA" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
@@ -18296,11 +18620,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
-"exF" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor,
-/turf/simulated/floor/plating,
-/area/station/engineering/atmos)
 "exG" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -18461,7 +18780,7 @@
 /turf/simulated/floor{
 	icon_state = "blue"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "ezB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -18534,7 +18853,7 @@
 	},
 /obj/item/weapon/bell,
 /turf/simulated/floor/plating,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "eAx" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor,
@@ -19025,7 +19344,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "eIm" = (
 /obj/structure/window/thin/reinforced{
 	dir = 4
@@ -19195,11 +19514,11 @@
 	},
 /area/station/security/armoury)
 "eKz" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 22
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "yellow"
@@ -19260,10 +19579,10 @@
 /turf/simulated/floor,
 /area/station/civilian/chapel/mass_driver)
 "eLj" = (
-/obj/machinery/shieldgen,
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
 	},
+/obj/machinery/power/emitter,
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
@@ -19319,7 +19638,7 @@
 	dir = 8;
 	icon_state = "bluecorner"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "eMm" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -19392,7 +19711,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "eNy" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -19686,16 +20005,15 @@
 	},
 /area/station/hallway/primary/central)
 "eQM" = (
-/obj/machinery/power/smes,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/alarm{
+	pixel_x = 29;
+	pixel_y = -6
 	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "vault"
+/turf/simulated/floor/plating{
+	dir = 6;
+	icon_state = "warnplate"
 	},
-/area/station/engineering/atmos)
+/area/station/maintenance/auxsolarport)
 "eQO" = (
 /obj/machinery/status_display{
 	pixel_y = 32
@@ -20145,7 +20463,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "eXS" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
@@ -20372,6 +20690,12 @@
 "faL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA";
+	pixel_y = 32
+	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
 "faX" = (
@@ -20653,7 +20977,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "fdM" = (
 /obj/structure/table/woodentable,
 /obj/structure/window/thin{
@@ -21038,11 +21362,18 @@
 /turf/simulated/floor,
 /area/station/maintenance/cargo)
 "fiP" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 10
+/obj/machinery/camera{
+	c_tag = "Fore Port Solar Control";
+	network = list("SS13","Engineering")
 	},
-/turf/simulated/floor,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
+/turf/simulated/floor/plating{
+	dir = 1;
+	icon_state = "warnplate"
+	},
+/area/station/maintenance/auxsolarport)
 "fiZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -21263,7 +21594,7 @@
 /area/station/civilian/dormitories)
 "flb" = (
 /turf/simulated/floor/wood,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "flf" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 1
@@ -21285,7 +21616,7 @@
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "flv" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -21834,7 +22165,7 @@
 /turf/simulated/floor{
 	icon_state = "darkblue"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "fty" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -22021,7 +22352,7 @@
 	},
 /area/station/rnd/storage)
 "fvE" = (
-/obj/effect/landmark/start/assistant,
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
@@ -22126,7 +22457,7 @@
 	dir = 1;
 	icon_state = "warning"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "fxa" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Security's Quarters";
@@ -22438,12 +22769,14 @@
 /obj/structure/sign/departments/science,
 /turf/simulated/wall/r_wall,
 /area/station/medical/genetics)
-"fBl" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"fBh" = (
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "o2_sensor"
 	},
+/turf/simulated/floor/engine/oxygen,
+/area/station/engineering/atmos)
+"fBl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -22454,13 +22787,11 @@
 	name = "Station Intercom (General)";
 	pixel_y = -32
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/item/weapon/flora/random,
 /turf/simulated/floor{
 	icon_state = "yellowpatch"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "fBm" = (
 /obj/structure/computerframe{
 	dir = 8
@@ -22588,7 +22919,7 @@
 "fDg" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor/wood,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "fDm" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -22702,7 +23033,13 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
+"fFf" = (
+/obj/item/weapon/flora/random,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/atmos/supermatter)
 "fFk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -23067,7 +23404,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "fJt" = (
 /obj/machinery/computer/med_data,
 /turf/simulated/floor,
@@ -23433,11 +23770,16 @@
 	},
 /area/station/engineering/atmos)
 "fPf" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating/airless{
 	dir = 1;
 	icon_state = "warnplatecorner"
 	},
-/area/station/engineering/singularity)
+/area/space)
 "fPg" = (
 /obj/machinery/computer/station_alert,
 /obj/machinery/light/smart{
@@ -23446,7 +23788,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "fPv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -23469,7 +23811,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "fPH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -23566,16 +23908,12 @@
 	},
 /area/station/security/armoury)
 "fRu" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/machinery/disposal,
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "warning"
+	dir = 8;
+	icon_state = "vault"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/drone_fabrication)
 "fRG" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -23738,15 +24076,18 @@
 /turf/simulated/wall,
 /area/station/cargo/recycler)
 "fTJ" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Port Bow Solar Access";
+	req_access = list(10)
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/turf/simulated/floor/plating,
+/area/station/maintenance/auxsolarport)
 "fTK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/light/smart{
@@ -23884,13 +24225,11 @@
 	},
 /area/station/rnd/hallway)
 "fWb" = (
-/obj/machinery/computer/security/engineering/drone{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/visible/red,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "yellowpatch"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "fWg" = (
 /obj/structure/table,
 /obj/item/clothing/gloves/orange,
@@ -23973,7 +24312,7 @@
 	dir = 1;
 	icon_state = "vault"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "fXb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -24283,21 +24622,6 @@
 	icon_state = "vault"
 	},
 /area/station/civilian/dormitories)
-"gbs" = (
-/obj/machinery/camera{
-	c_tag = "Fore Port Solar Control";
-	network = list("SS13","Engineering")
-	},
-/obj/machinery/power/solar_control{
-	id = "auxsolareast";
-	name = "Fore Port Solar Control";
-	dir = 8
-	},
-/turf/simulated/floor/plating{
-	dir = 5;
-	icon_state = "warnplate"
-	},
-/area/station/maintenance/auxsolarport)
 "gby" = (
 /obj/structure/rack,
 /obj/item/weapon/storage/toolbox/mechanical,
@@ -24410,20 +24734,15 @@
 	},
 /area/station/cargo/storage)
 "gcE" = (
-/obj/structure/table/reinforced,
-/obj/item/bodybag/cryobag,
-/obj/machinery/alarm{
-	pixel_x = -28;
-	pixel_y = -6
-	},
-/obj/item/weapon/storage/fancy/glowsticks{
-	pixel_y = 4
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/components/trinary/filter/m_filter,
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "gcG" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor/plating/airless{
 	dir = 8;
 	icon_state = "warnplatecorner"
@@ -24515,25 +24834,12 @@
 	},
 /area/station/bridge)
 "gdY" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/window/fulltile/reinforced/phoron{
+	grilled = 1;
+	icon_state = "gr_window_reinforced_phoron"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "warning"
-	},
-/area/station/engineering/atmos)
+/turf/simulated/floor/engine,
+/area/station/engineering/atmos/supermatter)
 "gea" = (
 /turf/simulated/floor{
 	icon_state = "white"
@@ -24576,6 +24882,22 @@
 	icon_state = "vault"
 	},
 /area/station/maintenance/science)
+"get" = (
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "Singularity";
+	layer = 2.8;
+	name = "Engine Shutters";
+	opacity = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/engine)
 "gex" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -24665,7 +24987,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "gfI" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -24777,7 +25099,7 @@
 	icon_state = "2-4"
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "ghI" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable{
@@ -24899,23 +25221,28 @@
 	},
 /area/station/hallway/primary/central)
 "gjf" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "Atmospherics Emergency Access";
+	req_access = list(24)
+	},
+/obj/structure/barricade/wooden{
+	layer = 2.8;
+	name = "doorway barricade"
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "warning"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "gjl" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -24948,7 +25275,7 @@
 	dir = 1;
 	icon_state = "warning"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "gjo" = (
 /obj/effect/landmark/start/scientist,
 /obj/structure/cable{
@@ -25110,7 +25437,7 @@
 /turf/simulated/floor{
 	icon_state = "delivery"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "gkR" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -25182,16 +25509,13 @@
 	},
 /area/station/civilian/chapel/crematorium)
 "gll" = (
-/obj/machinery/light/smart{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on/atmos{
+	frequency = 1444;
+	id_tag = "sm_out";
+	name = "(A) SM Vent"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 22
-	},
-/turf/simulated/floor{
-	icon_state = "yellowpatch"
-	},
-/area/station/engineering/atmos)
+/turf/simulated/floor/engine,
+/area/station/engineering/atmos/supermatter)
 "glm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -25261,6 +25585,26 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
+"gma" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1379;
+	master_tag = "engineering_west_airlock";
+	name = "exterior access button";
+	pixel_x = 22;
+	pixel_y = -20;
+	req_access = list(10,13)
+	},
+/turf/simulated/floor/plating/airless{
+	dir = 6;
+	icon_state = "warnplate"
+	},
+/area/station/engineering/singularity)
 "gmf" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Pure to Mix"
@@ -25304,14 +25648,11 @@
 	},
 /area/station/bridge)
 "gms" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 6
 	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "gmw" = (
 /turf/simulated/wall,
 /area/station/security/forensic_office)
@@ -25370,7 +25711,7 @@
 	dir = 10;
 	icon_state = "warnplate"
 	},
-/area/station/engineering/singularity)
+/area/station/engineering/engine)
 "gnv" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -25548,7 +25889,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "gpo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -25585,11 +25926,6 @@
 	},
 /area/station/civilian/bar)
 "gpM" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/particle_accelerator/end_cap{
 	dir = 8
 	},
@@ -25615,15 +25951,13 @@
 	},
 /area/station/hallway/secondary/entry)
 "gqt" = (
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "gqx" = (
 /turf/simulated/floor{
@@ -25677,19 +26011,19 @@
 /turf/simulated/wall/r_wall,
 /area/station/rnd/scibreak)
 "grm" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/power/solar_control{
+	id = "auxsolareast";
+	name = "Fore Port Solar Control";
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/trinary/filter/m_filter{
+/obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "warning"
+/turf/simulated/floor/plating{
+	dir = 4;
+	icon_state = "warnplate"
 	},
-/area/station/engineering/atmos)
+/area/station/maintenance/auxsolarport)
 "gro" = (
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -26126,6 +26460,27 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
+"gvH" = (
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "Singularity";
+	layer = 2.8;
+	name = "Engine Shutters";
+	opacity = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/engine)
 "gvN" = (
 /obj/machinery/door/airlock/external{
 	name = "Arrival Airlock"
@@ -26230,15 +26585,24 @@
 	},
 /area/station/medical/reception)
 "gxk" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
+/obj/machinery/alarm{
+	pixel_x = -28;
+	pixel_y = -6
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "yellow"
+	icon_state = "yellowpatch"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "gxv" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /turf/simulated/floor{
@@ -26399,12 +26763,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/bridge)
-"gza" = (
-/obj/structure/closet/firecloset,
-/turf/simulated/floor{
-	icon_state = "bot"
-	},
-/area/station/engineering/atmos)
 "gzd" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -26515,16 +26873,6 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge/captain_quarters)
-"gAh" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
-	},
-/area/station/engineering/atmos)
 "gAj" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced/tinted{
@@ -26601,10 +26949,14 @@
 /area/station/maintenance/chapel)
 "gBi" = (
 /obj/machinery/power/tesla_coil,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
 /turf/simulated/floor/plating/airless{
 	icon_state = "platebot"
 	},
-/area/station/engineering/singularity)
+/area/space)
 "gBj" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -26816,7 +27168,7 @@
 	pixel_x = 22
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "gFo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -27040,6 +27392,20 @@
 	icon_state = "bot"
 	},
 /area/station/rnd/hor)
+"gIe" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "caution"
+	},
+/area/station/engineering/atmos/supermatter)
 "gIj" = (
 /obj/structure/stool/bed/chair/comfy/black{
 	dir = 1
@@ -27076,19 +27442,11 @@
 	},
 /area/station/tcommsat/chamber)
 "gII" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 9
-	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "warningcorner"
+	dir = 8;
+	icon_state = "darkyellow"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/drone_fabrication)
 "gIJ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -27209,6 +27567,7 @@
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
 "gKu" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
@@ -27363,13 +27722,10 @@
 /turf/environment/space,
 /area/shuttle/supply/station)
 "gMT" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /turf/simulated/floor{
-	icon_state = "warning"
+	icon_state = "dark"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/drone_fabrication)
 "gNf" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -27440,14 +27796,6 @@
 	icon_state = "warning"
 	},
 /area/station/gateway)
-"gOl" = (
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "warning"
-	},
-/area/station/engineering/atmos)
 "gOn" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -27714,6 +28062,11 @@
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "gRV" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "warning"
@@ -27812,6 +28165,10 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
+"gTw" = (
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "gTB" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -27898,11 +28255,9 @@
 	},
 /area/station/hallway/primary/central)
 "gUl" = (
-/obj/structure/closet/radiation,
-/turf/simulated/floor{
-	icon_state = "bot"
-	},
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
+/turf/simulated/floor/engine,
+/area/station/engineering/atmos/supermatter)
 "gUo" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
@@ -27930,14 +28285,12 @@
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/port)
 "gUA" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "n2_sensor"
 	},
-/obj/structure/closet/radiation,
-/turf/simulated/floor{
-	icon_state = "bot"
-	},
-/area/station/engineering/engine)
+/turf/simulated/floor/engine/nitrogen,
+/area/station/engineering/atmos)
 "gUC" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass,
@@ -27987,7 +28340,7 @@
 	},
 /area/station/bridge/teleporter)
 "gVe" = (
-/obj/effect/landmark/start/assistant,
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -28274,6 +28627,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/hos)
+"gYu" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 10
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "gYv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -28295,6 +28657,14 @@
 /obj/effect/decal/remains/human,
 /turf/simulated/floor/plating,
 /area/station/rnd/test_area)
+"gYL" = (
+/obj/machinery/light/smart{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "bluecorner"
+	},
+/area/station/engineering/minisat_secure_area)
 "gYU" = (
 /obj/machinery/light_switch{
 	pixel_y = -28
@@ -28404,6 +28774,14 @@
 	icon_state = "darkblue"
 	},
 /area/station/bridge)
+"hap" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/engineering/singularity)
 "haJ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -28516,7 +28894,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /turf/simulated/floor/plating,
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "hbR" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -28556,7 +28934,7 @@
 /turf/simulated/floor,
 /area/station/maintenance/medbay)
 "hcM" = (
-/obj/effect/landmark/start/assistant,
+/obj/effect/landmark/start/assistant/test_subject,
 /obj/structure/stool/bed/chair/metal/blue{
 	dir = 8
 	},
@@ -28664,7 +29042,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "hec" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -28685,6 +29063,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
+"heH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/atmos/supermatter)
 "heI" = (
 /obj/machinery/light/smart{
 	dir = 1
@@ -28723,6 +29110,13 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
+"hfc" = (
+/obj/machinery/power/tesla_coil,
+/obj/structure/cable,
+/turf/simulated/floor/plating/airless{
+	icon_state = "platebot"
+	},
+/area/space)
 "hfj" = (
 /obj/structure/window/thin{
 	dir = 8
@@ -28735,7 +29129,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "hfx" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -28919,7 +29313,7 @@
 "hiE" = (
 /obj/structure/sign/warning/nosmoking,
 /turf/simulated/wall,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "hjc" = (
 /turf/simulated/floor{
 	dir = 9;
@@ -28989,7 +29383,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "hke" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -29074,7 +29468,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "hkQ" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/clipboard,
@@ -29225,6 +29619,11 @@
 	},
 /area/station/civilian/kitchen)
 "hmC" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating{
 	dir = 4;
 	icon_state = "warnplate"
@@ -29261,6 +29660,17 @@
 /obj/structure/disposalpipe/junction,
 /turf/simulated/floor,
 /area/station/cargo/miningoffice)
+"hmY" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/airless{
+	dir = 6;
+	icon_state = "warnplate"
+	},
+/area/station/engineering/singularity)
 "hna" = (
 /obj/structure/object_wall/cargo{
 	icon_state = "7,7"
@@ -29304,6 +29714,9 @@
 /area/space)
 "hnu" = (
 /obj/item/weapon/flora/random,
+/obj/machinery/light/smart{
+	dir = 1
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "yellow"
@@ -29445,7 +29858,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "hpC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
 	},
 /turf/simulated/floor{
@@ -29558,7 +29976,7 @@
 	dir = 9;
 	icon_state = "darkblue"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "hqz" = (
 /obj/machinery/door/firedoor,
 /obj/item/weapon/bell,
@@ -29632,6 +30050,18 @@
 	icon_state = "redchecker"
 	},
 /area/station/hallway/primary/port)
+"hrc" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/smes,
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
+"hrg" = (
+/obj/structure/sign/warning/radiation,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/minisat_secure_area)
 "hrj" = (
 /obj/machinery/door/airlock/silver{
 	name = "Bathroom"
@@ -29671,6 +30101,12 @@
 	req_access = list(12)
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "hrO" = (
@@ -29716,7 +30152,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "hso" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -29734,7 +30170,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "hsq" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -29779,17 +30215,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "hsW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/turf/simulated/floor{
+	icon_state = "dark"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/engineering/atmos)
+/area/station/engineering/drone_fabrication)
 "htg" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -29836,7 +30268,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "htF" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/visuals/surgery/full,
@@ -30150,11 +30582,16 @@
 /turf/simulated/floor,
 /area/station/security/main)
 "hxo" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating{
 	dir = 1;
 	icon_state = "warnplate"
 	},
-/area/station/engineering/singularity)
+/area/station/engineering/engine)
 "hxr" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -30240,20 +30677,26 @@
 	},
 /area/station/medical/sleeper)
 "hyA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/components/trinary/filter/m_filter{
+	dir = 1
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "warning"
-	},
-/area/station/engineering/atmos)
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "hyD" = (
-/obj/item/stack/cable_coil,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	frequency = 1379;
+	master_tag = "solar_tool_airlock";
+	name = "exterior access button";
+	pixel_x = -25;
+	pixel_y = -25;
+	req_access = list(13)
+	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/auxport)
 "hyF" = (
@@ -30506,7 +30949,7 @@
 /area/station/civilian/dormitories)
 "hAz" = (
 /turf/simulated/floor/engine,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "hAH" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "cargocell";
@@ -30786,11 +31229,11 @@
 	dir = 5;
 	icon_state = "vault"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/break_room)
 "hEd" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/wood,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "hEr" = (
 /turf/simulated/wall/r_wall,
 /area/station/bridge/teleporter)
@@ -31089,7 +31532,7 @@
 	dir = 1;
 	icon_state = "warning"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "hIe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -31223,11 +31666,20 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"hKc" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "hKj" = (
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/light/smart{
+	dir = 8
+	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "warning"
@@ -31241,7 +31693,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "hKq" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -31303,14 +31755,13 @@
 /turf/simulated/floor,
 /area/station/rnd/tox_launch)
 "hLs" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
 	},
-/obj/machinery/light/smart,
 /turf/simulated/floor{
-	icon_state = "yellow"
+	icon_state = "yellowpatch"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "hLL" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -31470,9 +31921,8 @@
 	},
 /area/station/security/main)
 "hNK" = (
-/obj/structure/sign/warning/radiation,
-/turf/simulated/wall/r_wall,
-/area/station/engineering/singularity)
+/turf/simulated/wall,
+/area/station/engineering/atmos/supermatter)
 "hNT" = (
 /obj/machinery/flasher{
 	id = "Execution_flash";
@@ -31710,6 +32160,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"hQo" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating/airless{
+	dir = 5;
+	icon_state = "warnplate"
+	},
+/area/space)
 "hQz" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 4;
@@ -31729,14 +32190,11 @@
 	},
 /area/station/hallway/primary/port)
 "hQX" = (
-/obj/machinery/light/smart{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
 	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "yellow"
-	},
-/area/station/engineering/atmos)
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "hRb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -31853,7 +32311,7 @@
 "hTd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall/r_wall,
-/area/station/maintenance/science)
+/area/station/maintenance/engineering)
 "hTg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -31914,6 +32372,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
+"hUj" = (
+/obj/structure/window/thin/reinforced{
+	dir = 1
+	},
+/obj/machinery/computer/general_air_control/large_tank_control{
+	frequency = 1444;
+	input_tag = "sm_in";
+	name = "Supermatter Supply Control";
+	output_tag = "sm_out";
+	sensors = list("sm_sensor"="Supermatter")
+	},
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "hUk" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/status_display{
@@ -32030,10 +32501,14 @@
 /obj/machinery/power/rad_collector{
 	anchored = 1
 	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating/airless{
 	icon_state = "platebot"
 	},
-/area/space)
+/area/station/engineering/singularity)
 "hVD" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/folder/blue,
@@ -32290,7 +32765,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "hXZ" = (
 /obj/structure/curtain/open/shower/security,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -32399,14 +32874,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/genetics)
-"hZk" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 4;
-	frequency = 1443;
-	id = "air_in"
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/atmos)
 "hZs" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -32622,22 +33089,13 @@
 /turf/environment/space,
 /area/shuttle/syndicate/south)
 "ibG" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/machinery/meter,
+/obj/machinery/light/smart{
+	dir = 8
 	},
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	id_tag = "solar_tool_inner";
-	locked = 1;
-	name = "Engineering External Access";
-	req_access = list(13)
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
-/area/station/maintenance/auxsolarport)
+/area/station/engineering/atmos/supermatter)
 "ibP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -32716,7 +33174,7 @@
 	},
 /area/station/hallway/primary/starboard)
 "idn" = (
-/obj/effect/landmark/start/assistant,
+/obj/effect/landmark/start/assistant/test_subject,
 /obj/structure/stool/bed/chair/metal/black{
 	dir = 4
 	},
@@ -32754,6 +33212,18 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/port)
+"idM" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/minisat_secure_area)
 "idQ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -32833,7 +33303,7 @@
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "ieL" = (
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32
@@ -32868,7 +33338,7 @@
 	icon_state = "gr_window"
 	},
 /turf/simulated/floor/plating,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "ifx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -32881,14 +33351,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"ifz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "ifH" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -33311,6 +33773,17 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/port)
+"ikT" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/airless{
+	dir = 6;
+	icon_state = "warnplate"
+	},
+/area/station/engineering/singularity)
 "ikW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -33326,11 +33799,12 @@
 	},
 /area/station/civilian/theatre)
 "ilb" = (
+/obj/machinery/light/small,
 /turf/simulated/floor/plating/airless{
-	dir = 6;
+	dir = 4;
 	icon_state = "warnplate"
 	},
-/area/station/maintenance/science)
+/area/station/engineering/singularity)
 "ilc" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -33355,6 +33829,22 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
+"ilk" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating/airless{
+	dir = 4;
+	icon_state = "warnplate"
+	},
+/area/space)
 "ilq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -33650,12 +34140,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
-"ioF" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 9
-	},
-/turf/simulated/floor/plating/airless/catwalk,
-/area/space)
 "ioG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -33667,7 +34151,7 @@
 	dir = 8;
 	icon_state = "bluecorner"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "ioK" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -34622,13 +35106,6 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/dormitories)
-"iBG" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 4
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/atmos)
 "iBL" = (
 /obj/machinery/conveyor{
 	id = "QMLoad2";
@@ -35242,7 +35719,7 @@
 	dir = 5;
 	icon_state = "vault"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/break_room)
 "iIJ" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/mask/gas,
@@ -35258,6 +35735,15 @@
 	icon_state = "warnplate"
 	},
 /area/station/rnd/test_area)
+"iIT" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/power/grounding_rod,
+/turf/simulated/floor/plating/airless,
+/area/station/engineering/singularity)
 "iIW" = (
 /obj/structure/stool/bed/chair/office/dark,
 /turf/simulated/floor/plating,
@@ -35443,10 +35929,14 @@
 /obj/machinery/power/rad_collector{
 	anchored = 1
 	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating{
 	icon_state = "platebot"
 	},
-/area/station/engineering/singularity)
+/area/station/engineering/engine)
 "iLV" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -35516,6 +36006,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
+"iMK" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/station/engineering/engine)
 "iMO" = (
 /obj/structure/table,
 /obj/item/device/tagger,
@@ -35654,15 +36153,6 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
-"iOt" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/on{
-	dir = 4;
-	external_pressure_bound = 140;
-	external_pressure_bound_default = 140;
-	name = "(OUT) Space Large Air Vent"
-	},
-/turf/simulated/floor/plating/airless/catwalk,
-/area/space)
 "iOw" = (
 /obj/machinery/door/airlock/research/glass{
 	autoclose = 0;
@@ -35674,6 +36164,10 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/rnd/mixing)
+"iOz" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "iOB" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -35694,6 +36188,16 @@
 	icon_state = "delivery"
 	},
 /area/station/hallway/secondary/entry)
+"iOL" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 8
+	},
+/turf/simulated/floor/plating{
+	dir = 5;
+	icon_state = "warnplate"
+	},
+/area/station/maintenance/auxsolarport)
 "iOQ" = (
 /obj/structure/object_wall/cargo{
 	icon_state = "8,7"
@@ -35716,11 +36220,16 @@
 /turf/simulated/floor/plating,
 /area/station/security/brig/solitary_confinement)
 "iPv" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating{
 	dir = 9;
 	icon_state = "warnplate"
 	},
-/area/station/engineering/singularity)
+/area/station/engineering/engine)
 "iPB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -36165,6 +36674,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/chemistry)
+"iUS" = (
+/obj/machinery/door_control{
+	id = "Singularity";
+	name = "Shutters Control";
+	req_access = list(10);
+	pixel_y = 25
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellow"
+	},
+/area/station/engineering/engine)
 "iVc" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -36221,6 +36747,13 @@
 	icon_state = "vault"
 	},
 /area/station/medical/morgue)
+"iVQ" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 4
+	},
+/obj/machinery/meter,
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "iVU" = (
 /obj/machinery/computer/robotics{
 	dir = 8
@@ -36410,11 +36943,13 @@
 	},
 /area/station/hallway/secondary/entry)
 "iYj" = (
-/obj/machinery/drone_fabricator,
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8
 	},
-/area/station/engineering/atmos)
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/atmos/supermatter)
 "iYp" = (
 /obj/machinery/door/window/southleft,
 /turf/simulated/floor/plating,
@@ -36735,6 +37270,15 @@
 	req_access = list(24)
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "jcC" = (
@@ -36742,7 +37286,7 @@
 	dir = 4;
 	icon_state = "bluecorner"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "jcE" = (
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "4-5"
@@ -37057,6 +37601,14 @@
 	icon_state = "vault"
 	},
 /area/station/civilian/library)
+"jgq" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/item/apc_frame,
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "jgt" = (
 /obj/structure/stool/bed/chair/schair/wagon{
 	dir = 4
@@ -37236,7 +37788,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "jiY" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/stamp/captain,
@@ -37308,6 +37860,16 @@
 "jjS" = (
 /turf/simulated/floor/engine,
 /area/station/civilian/holodeck/alphadeck)
+"jjT" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating/airless{
+	icon_state = "warnplate"
+	},
+/area/station/engineering/singularity)
 "jjV" = (
 /obj/structure/table,
 /obj/item/clothing/head/welding,
@@ -37496,6 +38058,17 @@
 /obj/structure/dresser,
 /turf/simulated/floor/wood,
 /area/station/hallway/primary/fore)
+"jmS" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/airless{
+	dir = 10;
+	icon_state = "warnplate"
+	},
+/area/station/engineering/singularity)
 "jmW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -37550,14 +38123,9 @@
 	},
 /area/station/medical/storage)
 "jnQ" = (
-/obj/structure/stool/bed/chair/metal{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 9;
-	icon_state = "warndark"
-	},
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel,
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "jod" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -38296,18 +38864,16 @@
 	},
 /area/station/cargo/office)
 "jwn" = (
-/obj/machinery/power/terminal,
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -28;
-	pixel_y = -5
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 4
 	},
-/obj/structure/cable,
-/turf/simulated/floor/plating{
-	dir = 8;
-	icon_state = "warnplate"
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/station/maintenance/auxsolarport)
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "jwp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /mob/living/simple_animal/mouse,
@@ -38545,17 +39111,11 @@
 /turf/simulated/floor,
 /area/station/maintenance/cargo)
 "jyl" = (
-/obj/machinery/alarm{
-	pixel_x = 29;
-	pixel_y = -6
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "yellowpatch"
-	},
-/area/station/engineering/atmos)
+/turf/simulated/floor/plating/airless/catwalk,
+/area/station/engineering/atmos/supermatter)
 "jyz" = (
 /obj/random/vending/snack,
 /turf/simulated/floor{
@@ -38588,18 +39148,25 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "jze" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 10
+/obj/machinery/power/terminal,
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -28;
+	pixel_y = -5
 	},
-/turf/simulated/floor{
-	icon_state = "warning"
+/obj/structure/cable,
+/turf/simulated/floor/plating{
+	dir = 8;
+	icon_state = "warnplate"
 	},
-/area/station/engineering/atmos)
+/area/station/maintenance/auxsolarport)
 "jzl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -38639,6 +39206,19 @@
 	icon_state = "vault"
 	},
 /area/station/civilian/chapel/office)
+"jzv" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/atmos/supermatter)
 "jzV" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -38713,12 +39293,25 @@
 	dir = 9
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "jBe" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/reagent_containers/spray/extinguisher{
-	pixel_y = 6
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/item/weapon/caution/cone{
+	pixel_x = -6
+	},
+/obj/item/weapon/caution/cone{
+	pixel_x = 6
+	},
+/obj/item/weapon/caution/cone,
+/obj/item/weapon/caution/cone,
+/obj/item/weapon/caution/cone,
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
@@ -38894,11 +39487,17 @@
 	},
 /area/station/engineering/atmos)
 "jDO" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1379;
+	master_tag = "engineering_west_airlock";
+	name = "interior access button";
+	pixel_x = -20;
+	pixel_y = 20;
+	req_access = list(10,13)
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -38910,12 +39509,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "jEa" = (
-/obj/structure/closet/radiation,
-/obj/item/device/analyzer,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	icon_state = "bot"
+	icon_state = "yellowpatch"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "jEc" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
@@ -38940,6 +39539,18 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/sleeper)
+"jEB" = (
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "waste_sensor";
+	output = 63
+	},
+/turf/simulated/floor/engine{
+	name = "vacuum floor";
+	nitrogen = 0.01;
+	oxygen = 0.01
+	},
+/area/station/engineering/atmos)
 "jEM" = (
 /obj/machinery/camera{
 	c_tag = "Bridge East";
@@ -38976,23 +39587,10 @@
 	},
 /area/station/bridge/ai_upload)
 "jFr" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 10
-	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "yellow"
 	},
-/area/station/engineering/atmos)
-"jFs" = (
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	id_tag = "atmospherics_outer";
-	locked = 1;
-	name = "Atmospherics External Access";
-	req_one_access = list(10,24)
-	},
-/turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "jFu" = (
 /obj/machinery/ai_slipper{
@@ -39038,17 +39636,17 @@
 /turf/simulated/floor/carpet/green,
 /area/station/civilian/dormitories)
 "jFS" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
-/turf/simulated/floor{
-	icon_state = "neutralfull"
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 9
 	},
-/area/station/engineering/atmos)
+/turf/simulated/floor/plating/airless/catwalk,
+/area/station/engineering/atmos/supermatter)
 "jFX" = (
 /obj/machinery/power/rad_collector,
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "jFZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/light/small{
@@ -39077,7 +39675,7 @@
 /turf/simulated/floor{
 	icon_state = "darkbluefull"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "jGn" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/box/cups,
@@ -39259,7 +39857,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "jIL" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 8
@@ -39321,17 +39919,11 @@
 	},
 /area/station/rnd/server)
 "jIZ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/manifold/visible/green{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "warning"
-	},
-/area/station/engineering/atmos)
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "jJh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -39612,8 +40204,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "jLz" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /turf/simulated/floor{
@@ -39746,6 +40341,10 @@
 /area/station/civilian/dormitories)
 "jNg" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -32
+	},
 /turf/simulated/floor{
 	icon_state = "delivery"
 	},
@@ -39907,13 +40506,11 @@
 	},
 /area/station/hallway/primary/central)
 "jOT" = (
-/obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
+/obj/machinery/atmospherics/pipe/manifold/visible/red,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/auxsolarport)
+/area/station/engineering/atmos/supermatter)
 "jOY" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -40080,7 +40677,10 @@
 /obj/machinery/ai_status_display{
 	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/machinery/atmospherics/pipe/simple/visible,
+/obj/machinery/light/smart{
+	dir = 8
+	},
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "warning"
@@ -40126,11 +40726,6 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/bar)
-"jQF" = (
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/atmos)
 "jQJ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -40219,6 +40814,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"jSv" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating{
+	icon_state = "warnplate"
+	},
+/area/station/engineering/engine)
 "jSU" = (
 /obj/structure/table,
 /obj/item/weapon/storage/box/mousetraps,
@@ -40272,6 +40877,10 @@
 /area/station/maintenance/science)
 "jTp" = (
 /obj/machinery/particle_accelerator/control_box,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "jTu" = (
@@ -40329,7 +40938,7 @@
 	req_access = list(10,13)
 	},
 /turf/simulated/floor/plating,
-/area/station/engineering/singularity)
+/area/station/engineering/engine)
 "jUj" = (
 /obj/structure/stool/bed/chair/comfy/brown,
 /obj/machinery/light/smart{
@@ -40351,7 +40960,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "jUm" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -40380,7 +40989,7 @@
 	dir = 8;
 	icon_state = "yellowcorner"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "jUt" = (
 /obj/structure/stool/bed/chair/metal/red{
 	dir = 1
@@ -40715,15 +41324,21 @@
 	},
 /area/station/storage/primary)
 "jYh" = (
-/obj/machinery/power/smes,
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating{
-	dir = 10;
-	icon_state = "warnplate"
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	id_tag = "solar_tool_inner";
+	locked = 1;
+	name = "Engineering External Access";
+	req_access = list(13)
 	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
 "jYs" = (
 /obj/structure/table/reinforced,
@@ -40758,7 +41373,7 @@
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "jYO" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -41421,8 +42036,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/environment/space,
-/area/station/engineering/engine)
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/minisat_secure_area)
 "kic" = (
 /obj/machinery/light/smart{
 	dir = 4
@@ -41452,12 +42069,18 @@
 	icon_state = "whitehall"
 	},
 /area/station/rnd/hallway)
-"kiy" = (
-/obj/structure/cable{
+"kip" = (
+/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/turf/simulated/floor/plating/airless{
+	dir = 10;
+	icon_state = "warnplate"
+	},
+/area/station/engineering/singularity)
+"kiy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -41467,8 +42090,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/engineering/atmos)
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "warning"
+	},
+/area/station/engineering/atmos/supermatter)
 "kiI" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/closet/hydrant{
@@ -41657,15 +42283,6 @@
 	icon_state = "dark"
 	},
 /area/station/ai_monitored/eva)
-"kkH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "warning"
-	},
-/area/station/engineering/atmos)
 "kkN" = (
 /obj/structure/table/woodentable,
 /obj/item/device/flashlight/lamp,
@@ -41676,9 +42293,14 @@
 /area/station/civilian/library)
 "kkY" = (
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/plating{
 	dir = 4;
@@ -41711,6 +42333,10 @@
 	icon_state = "vault"
 	},
 /area/station/maintenance/science)
+"klu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "kly" = (
 /obj/structure/closet/crate,
 /obj/machinery/light/smart,
@@ -41789,12 +42415,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/warden)
-"kmP" = (
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "warndark"
-	},
-/area/station/engineering/atmos)
 "kmW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
@@ -41901,7 +42521,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "koo" = (
-/obj/effect/landmark/start/assistant,
+/obj/effect/landmark/start/assistant/test_subject,
 /obj/structure/stool/bed/chair/metal/green,
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -41925,26 +42545,18 @@
 "kou" = (
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/door/airlock/external{
+	frequency = 1379;
+	id_tag = "solar_tool_outer";
+	locked = 1;
+	name = "Engineering External Access";
+	req_access = list(10,13)
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-y"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
+/turf/simulated/floor/plating,
+/area/station/maintenance/auxsolarport)
 "koy" = (
 /obj/structure/closet/secure_closet/forensics,
 /turf/simulated/floor{
@@ -42026,7 +42638,7 @@
 	dir = 8;
 	icon_state = "bluecorner"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "kpr" = (
 /turf/simulated/wall,
 /area/station/medical/surgeryobs)
@@ -42058,7 +42670,7 @@
 	dir = 9;
 	icon_state = "warning"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "kpx" = (
 /obj/item/device/flashlight/lamp,
 /obj/structure/table/woodentable,
@@ -42225,7 +42837,7 @@
 	dir = 10;
 	icon_state = "darkblue"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "krw" = (
 /obj/structure/disposalpipe/sortjunction{
 	dir = 2;
@@ -42365,10 +42977,9 @@
 	dir = 4;
 	icon_state = "darkblue"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "ksU" = (
 /obj/structure/closet/radiation,
-/obj/machinery/light/small,
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
@@ -42418,7 +43029,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "ktB" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -42445,6 +43056,12 @@
 	icon_state = "orange"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
+"ktI" = (
+/obj/machinery/atmospherics/components/trinary/filter/m_filter{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "ktM" = (
 /obj/machinery/alarm{
 	pixel_x = 29;
@@ -42603,6 +43220,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/machinery/light/smart,
 /turf/simulated/floor{
 	icon_state = "warningcorner"
 	},
@@ -42855,7 +43473,7 @@
 	icon_state = "0-2"
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "kAA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -43044,11 +43662,14 @@
 	pixel_x = 28;
 	pixel_y = -5
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "warning"
+/obj/machinery/computer/drone_control{
+	dir = 8
 	},
-/area/station/engineering/atmos)
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "vault"
+	},
+/area/station/engineering/drone_fabrication)
 "kCI" = (
 /obj/structure/sign/directions/supply{
 	dir = 1;
@@ -43135,7 +43756,7 @@
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "kDr" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable{
@@ -43244,18 +43865,16 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "kFq" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	icon_state = "warning"
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/station/engineering/atmos)
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "kFI" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor{
@@ -43324,6 +43943,9 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard)
+"kGh" = (
+/turf/simulated/floor/plating/airless/catwalk,
+/area/station/engineering/atmos/supermatter)
 "kGq" = (
 /obj/structure/sign/warning/vacuum,
 /turf/simulated/wall/r_wall,
@@ -43373,7 +43995,7 @@
 /turf/simulated/floor/bluegrid{
 	icon_state = "gcircuit"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "kHi" = (
 /obj/structure/window/thin/reinforced{
 	dir = 8
@@ -43490,7 +44112,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/obj/machinery/light/smart,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "yellowcorner"
@@ -43591,7 +44212,7 @@
 	dir = 1;
 	icon_state = "warnplate"
 	},
-/area/station/engineering/singularity)
+/area/space)
 "kIM" = (
 /obj/item/clothing/suit/storage/labcoat/winterlabcoat,
 /obj/item/clothing/head/soft/paramed,
@@ -43680,7 +44301,7 @@
 	dir = 1
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "kJq" = (
 /obj/machinery/computer/secure_data/detective_computer,
 /turf/simulated/floor/carpet/red,
@@ -43865,6 +44486,11 @@
 	name = "Engine Shutters";
 	opacity = 0
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	icon_state = "delivery"
 	},
@@ -43886,24 +44512,13 @@
 	},
 /area/station/rnd/robotics)
 "kLT" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "yellowpatch"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "kLU" = (
 /obj/structure/table,
 /turf/simulated/floor{
@@ -44270,10 +44885,9 @@
 /turf/environment/space,
 /area/shuttle/supply/station)
 "kRY" = (
-/turf/simulated/floor/plating/airless{
-	icon_state = "warnplate"
-	},
-/area/station/maintenance/science)
+/obj/machinery/status_display,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/break_room)
 "kSj" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -44715,27 +45329,14 @@
 	},
 /area/station/hallway/secondary/exit)
 "kWv" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Turbine Generator Access";
-	req_one_access = list(10,24)
-	},
-/turf/simulated/floor,
-/area/station/engineering/atmos)
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "kWw" = (
 /obj/structure/table,
 /obj/item/trash/popcorn,
@@ -45236,7 +45837,7 @@
 	dir = 8;
 	icon_state = "bluecorner"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "lbG" = (
 /obj/machinery/porta_turret/station_default{
 	dir = 4
@@ -45298,7 +45899,7 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "lcN" = (
 /obj/structure/sign/warning/radiation,
 /turf/simulated/wall,
@@ -45526,6 +46127,12 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/hallway)
+"lgM" = (
+/obj/machinery/power/emitter,
+/turf/simulated/floor{
+	icon_state = "bot"
+	},
+/area/station/engineering/engine)
 "lgP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -45842,36 +46449,9 @@
 /turf/simulated/wall,
 /area/station/maintenance/starboardsolar)
 "lla" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/embedded_controller/radio/airlock_controller{
-	id_tag = "solar_tool_airlock";
-	pixel_x = 28;
-	pixel_y = 4;
-	req_access = list(13);
-	tag_airpump = "solar_tool_pump";
-	tag_chamber_sensor = "solar_tool_sensor";
-	tag_exterior_door = "solar_tool_outer";
-	tag_interior_door = "solar_tool_inner"
-	},
-/obj/machinery/airlock_sensor{
-	id_tag = "solar_tool_sensor";
-	layer = 3.3;
-	pixel_x = 28;
-	pixel_y = -8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
-	frequency = 1379;
-	id_tag = "solar_tool_pump";
-	name = "Solar Tool Large Air Vent"
-	},
-/turf/simulated/floor/plating{
-	icon_state = "platebotc"
-	},
-/area/station/maintenance/auxsolarport)
+/obj/machinery/atmospherics/pipe/simple/visible/green,
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "llc" = (
 /obj/machinery/space_heater,
 /obj/machinery/light/smart{
@@ -46238,7 +46818,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "lqH" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -46477,6 +47057,22 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
+"lts" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
+"ltv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	icon_state = "darkyellow"
+	},
+/area/station/engineering/drone_fabrication)
 "ltF" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -46650,6 +47246,21 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/mixing)
+"lvT" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/atmos/supermatter)
 "lvZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light/smart{
@@ -46718,6 +47329,17 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/storage)
+"lwK" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/airless{
+	dir = 4;
+	icon_state = "warnplate"
+	},
+/area/space)
 "lwN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -46877,13 +47499,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "lzv" = (
-/obj/structure/closet/firecloset,
-/obj/machinery/light/small,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "warning"
+/obj/structure/closet/hydrant{
+	pixel_y = -32
 	},
-/area/station/engineering/atmos)
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "lzx" = (
 /turf/simulated/floor{
 	dir = 5;
@@ -47807,7 +48427,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /turf/simulated/floor/plating,
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "lLH" = (
 /obj/structure/easel,
 /obj/item/canvas/twentythree_twentythree,
@@ -47888,14 +48508,11 @@
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
 "lMA" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 5
-	},
 /obj/machinery/light/smart,
 /turf/simulated/floor{
-	icon_state = "caution"
+	icon_state = "darkyellowcorners"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/drone_fabrication)
 "lMB" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -47938,13 +48555,24 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "lMM" = (
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "yellow"
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "Sm";
+	layer = 2.8;
+	name = "Supermatter Shutters";
+	opacity = 0
 	},
-/area/station/engineering/atmos)
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "lNc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -47953,6 +48581,17 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
+"lNd" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "lNi" = (
 /obj/machinery/light/smart{
 	dir = 1
@@ -48094,7 +48733,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "lOa" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -48219,6 +48858,13 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/chiefs_office)
+"lPO" = (
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "n2o_sensor"
+	},
+/turf/simulated/floor/engine/n20,
+/area/station/engineering/atmos)
 "lPP" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 1
@@ -48511,15 +49157,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
-"lTZ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 10;
-	icon_state = "warning"
-	},
-/area/station/engineering/atmos)
 "lUh" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -48590,6 +49227,23 @@
 	},
 /turf/simulated/floor,
 /area/station/security/blueshield)
+"lVc" = (
+/obj/machinery/light/smart,
+/turf/simulated/floor/plating{
+	icon_state = "warnplate"
+	},
+/area/station/engineering/engine)
+"lVh" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "lVq" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -48727,12 +49381,7 @@
 /area/station/maintenance/starboardsolar)
 "lXB" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Atmospherics Project Room";
-	req_access = list(24)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -48740,7 +49389,12 @@
 	name = "Atmos Blast Door";
 	opacity = 0
 	},
-/turf/simulated/floor,
+/obj/machinery/door/airlock/atmos{
+	name = "Supermatter Construction Area"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowfull"
+	},
 /area/station/engineering/atmos)
 "lXD" = (
 /obj/machinery/door/firedoor,
@@ -48776,7 +49430,7 @@
 	dir = 9;
 	icon_state = "darkblue"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "lYB" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -48903,21 +49557,20 @@
 	},
 /area/station/hallway/secondary/exit)
 "mbj" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Turbine Generator Access";
-	req_access = list(24)
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "atmos";
-	name = "Atmos Blast Door";
-	opacity = 0
+/obj/structure/table/reinforced,
+/obj/item/device/flashlight/lamp{
+	pixel_x = -4;
+	pixel_y = 6
 	},
-/turf/simulated/floor,
-/area/station/engineering/atmos)
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/atmos/supermatter)
 "mbl" = (
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -49014,18 +49667,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/chargebay)
-"mcx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "mcG" = (
 /obj/machinery/vending/theater,
 /turf/simulated/floor/plating,
@@ -49034,6 +49675,13 @@
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"mcN" = (
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "co2_sensor"
+	},
+/turf/simulated/floor/engine/carbon_dioxide,
+/area/station/engineering/atmos)
 "mcU" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -49250,11 +49898,6 @@
 	icon_state = "warning"
 	},
 /area/station/rnd/chargebay)
-"mga" = (
-/turf/simulated/floor{
-	icon_state = "warndark"
-	},
-/area/station/engineering/atmos)
 "mge" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -49336,14 +49979,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
-"mhb" = (
-/obj/structure/sign/directions/engineering{
-	desc = "A sign that shows there are doors here. There are doors everywhere!";
-	icon_state = "doors";
-	name = "WARNING: EXTERNAL AIRLOCK"
-	},
-/turf/simulated/wall/r_wall,
-/area/station/maintenance/auxsolarport)
 "mhe" = (
 /obj/structure/stool/bed/chair,
 /obj/machinery/light/small{
@@ -49497,6 +50132,15 @@
 	icon_state = "red"
 	},
 /area/station/medical/hallway)
+"mje" = (
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/station/engineering/engine)
 "mjh" = (
 /obj/structure/table,
 /obj/structure/window/thin/reinforced,
@@ -49596,6 +50240,15 @@
 	},
 /area/station/hallway/secondary/entry)
 "mkS" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "yellow"
@@ -49968,7 +50621,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "moM" = (
 /obj/structure/stool/bed/chair/metal/red{
 	dir = 1
@@ -50022,7 +50675,7 @@
 	},
 /area/station/storage/tech)
 "mpG" = (
-/obj/effect/landmark/start/assistant,
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor{
 	icon_state = "wooden-2"
 	},
@@ -50081,15 +50734,36 @@
 	},
 /area/station/gateway)
 "mqw" = (
-/obj/structure/table/reinforced,
-/obj/item/weapon/storage/firstaid/regular{
-	pixel_x = -2;
-	pixel_y = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/machinery/embedded_controller/radio/airlock_controller{
+	id_tag = "solar_tool_airlock";
+	pixel_x = 28;
+	pixel_y = 4;
+	req_access = list(13);
+	tag_airpump = "solar_tool_pump";
+	tag_chamber_sensor = "solar_tool_sensor";
+	tag_exterior_door = "solar_tool_outer";
+	tag_interior_door = "solar_tool_inner"
 	},
-/area/station/engineering/atmos)
+/obj/machinery/airlock_sensor{
+	id_tag = "solar_tool_sensor";
+	layer = 3.3;
+	pixel_x = 28;
+	pixel_y = -8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
+	frequency = 1379;
+	id_tag = "solar_tool_pump";
+	name = "Solar Tool Large Air Vent"
+	},
+/turf/simulated/floor/plating{
+	icon_state = "platebotc"
+	},
+/area/station/maintenance/auxsolarport)
 "mqB" = (
 /turf/environment/space,
 /area/shuttle/escape/station)
@@ -50135,23 +50809,15 @@
 	icon_state = "gr_window_reinforced"
 	},
 /turf/simulated/floor/plating,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "mrj" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/components/trinary/tvalve/mirrored/digital/bypass{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Atmospherics Project Room";
-	req_one_access = list(10,24)
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
 	},
-/turf/simulated/floor,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "mrl" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Auxiliary Tool Storage"
@@ -50210,7 +50876,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "mrP" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/structure/disposalpipe/segment,
@@ -50266,13 +50932,18 @@
 /turf/simulated/floor{
 	icon_state = "bluecorner"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "msR" = (
-/turf/simulated/floor{
-	dir = 10;
-	icon_state = "warndark"
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile/reinforced/phoron{
+	grilled = 1;
+	icon_state = "gr_window_reinforced_phoron"
 	},
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "msS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
@@ -50391,8 +51062,16 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
-/area/station/engineering/singularity)
+/area/station/engineering/engine)
 "mtI" = (
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -50920,6 +51599,16 @@
 	icon_state = "warndark"
 	},
 /area/station/ai_monitored/storage_secure)
+"mBg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
+	frequency = 1379;
+	id_tag = "engineering_west_pump";
+	name = "Engineering West Large Air Vent"
+	},
+/turf/simulated/floor/plating{
+	icon_state = "platebotc"
+	},
+/area/station/engineering/engine)
 "mBj" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil{
@@ -51289,7 +51978,20 @@
 	dir = 4;
 	icon_state = "yellowcorner"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
+"mFB" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/tank/phoron{
+	pixel_y = -12
+	},
+/obj/item/weapon/tank/phoron{
+	pixel_y = -6
+	},
+/obj/item/weapon/tank/phoron,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/atmos/supermatter)
 "mFD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/alarm{
@@ -51379,19 +52081,6 @@
 	icon_state = "red"
 	},
 /area/station/security/brig)
-"mGQ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
-/area/station/engineering/atmos)
 "mHj" = (
 /obj/machinery/computer/card,
 /obj/machinery/light/smart,
@@ -51467,6 +52156,31 @@
 	icon_state = "bot"
 	},
 /area/station/medical/surgeryobs)
+"mJd" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile/reinforced/phoron{
+	grilled = 1;
+	icon_state = "gr_window_reinforced_phoron"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/engine)
+"mJs" = (
+/obj/item/weapon/flora/random,
+/obj/structure/window/thin/reinforced,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/atmos/supermatter)
 "mJw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -51486,6 +52200,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -51512,6 +52229,17 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/chiefs_office)
+"mKw" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating/airless{
+	dir = 1;
+	icon_state = "warnplatecorner"
+	},
+/area/station/engineering/singularity)
 "mKy" = (
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -51527,6 +52255,12 @@
 	},
 /area/station/rnd/hallway)
 "mKD" = (
+/obj/machinery/door_control{
+	id = "Singularity";
+	name = "Shutters Control";
+	req_access = list(10);
+	pixel_y = -25
+	},
 /turf/simulated/floor/plating{
 	icon_state = "warnplate"
 	},
@@ -51549,9 +52283,11 @@
 	},
 /area/station/hallway/primary/central)
 "mKP" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 5
+	},
 /turf/simulated/floor,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "mKV" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
@@ -51732,20 +52468,17 @@
 /turf/simulated/floor/plating,
 /area/station/rnd/hallway)
 "mOt" = (
-/obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced/phoron{
-	grilled = 1;
-	icon_state = "gr_window_reinforced_phoron"
+/obj/machinery/computer/general_air_control{
+	frequency = 1444;
+	level = 3;
+	name = "Supermatter Monitor";
+	sensors = list("in_sm_meter"="Supermatter In","sm_sensor"="Supermatter","out_sm_meter"="Supermatter Out")
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "atmos";
-	name = "Atmos Blast Door";
-	opacity = 0
+/obj/structure/window/thin/reinforced{
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/station/engineering/atmos)
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "mOu" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -51867,7 +52600,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "mQb" = (
 /obj/structure/sign/nanotrasen{
 	pixel_y = -32
@@ -52009,7 +52742,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "mRj" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -52180,6 +52913,17 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
+/area/station/engineering/break_room)
+"mTb" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating{
+	dir = 8;
+	icon_state = "warnplate"
+	},
 /area/station/engineering/engine)
 "mTi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -52191,25 +52935,20 @@
 /turf/environment/space,
 /area/shuttle/arrival/station)
 "mTp" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-j2"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
@@ -52470,6 +53209,15 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/chapel)
+"mVR" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/power/grounding_rod,
+/turf/simulated/floor/plating/airless,
+/area/station/engineering/singularity)
 "mVU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -52703,7 +53451,7 @@
 	},
 /area/station/security/brig)
 "mZB" = (
-/obj/effect/landmark/start/assistant,
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "mZC" = (
@@ -52741,6 +53489,12 @@
 	icon_state = "neutral"
 	},
 /area/station/hallway/primary/central)
+"naa" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 10
+	},
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "nac" = (
 /obj/structure/drain{
 	drainage = 2
@@ -52819,6 +53573,19 @@
 "naK" = (
 /turf/simulated/floor/bluegrid,
 /area/station/rnd/xenobiology)
+"naO" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/tank/phoron,
+/obj/item/weapon/tank/phoron{
+	pixel_y = 6
+	},
+/obj/item/weapon/tank/phoron{
+	pixel_y = 12
+	},
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/atmos/supermatter)
 "naR" = (
 /obj/structure/table/woodentable,
 /obj/item/clothing/head/hairflower,
@@ -52911,7 +53678,7 @@
 	dir = 1;
 	icon_state = "warning"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "ndh" = (
 /obj/machinery/disposal,
 /turf/simulated/floor{
@@ -53082,6 +53849,14 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/storage)
+"nfY" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor,
+/area/station/engineering/engine)
 "ngn" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -53124,9 +53899,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "ngP" = (
@@ -53143,7 +53922,7 @@
 /turf/simulated/floor{
 	icon_state = "yellowcorner"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "nhe" = (
 /obj/structure/stool/bed/chair{
 	dir = 8
@@ -53274,15 +54053,12 @@
 	name = "Station Intercom (General)";
 	pixel_y = -32
 	},
-/obj/machinery/camera{
-	c_tag = "Project Room Access";
-	network = list("SS13","Engineering");
-	dir = 1
-	},
+/obj/item/weapon/flora/random,
 /turf/simulated/floor{
-	icon_state = "yellowpatch"
+	dir = 4;
+	icon_state = "warningcorner"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "nit" = (
 /obj/machinery/flasher_button{
 	id = "escapeshutflash";
@@ -53370,7 +54146,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "njC" = (
 /turf/simulated/floor/plating/airless{
 	dir = 5;
@@ -53479,6 +54255,23 @@
 	icon_state = "bot"
 	},
 /area/station/rnd/xenobiology)
+"nlx" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warndark"
+	},
+/area/station/maintenance/engineering)
 "nlJ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -53605,15 +54398,15 @@
 /turf/simulated/floor,
 /area/station/civilian/toilet)
 "nnA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
+	icon_state = "yellowpatch"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "nnI" = (
 /obj/machinery/porta_turret/station_default{
 	dir = 4
@@ -53673,6 +54466,17 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/bar)
+"nos" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/airless{
+	dir = 9;
+	icon_state = "warnplate"
+	},
+/area/station/engineering/singularity)
 "nou" = (
 /obj/machinery/door/window{
 	dir = 8;
@@ -53704,7 +54508,7 @@
 "noZ" = (
 /obj/structure/sign/warning/radiation,
 /turf/simulated/wall/r_wall,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "npc" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light/smart,
@@ -53722,7 +54526,7 @@
 	},
 /area/station/hallway/secondary/entry)
 "npk" = (
-/obj/effect/landmark/start/assistant,
+/obj/effect/landmark/start/assistant/test_subject,
 /obj/structure/stool/bed/chair/metal{
 	dir = 1
 	},
@@ -53796,9 +54600,12 @@
 /turf/simulated/floor,
 /area/station/rnd/robotics)
 "npG" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 6
+	},
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "warndark"
+	icon_state = "yellow"
 	},
 /area/station/engineering/atmos)
 "npW" = (
@@ -53851,6 +54658,31 @@
 	icon_state = "blackchecker"
 	},
 /area/station/security/interrogation)
+"nqo" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible{
+	dir = 1
+	},
+/obj/machinery/embedded_controller/radio/airlock_controller{
+	id_tag = "engineering_east_airlock";
+	req_access = list(10,13);
+	tag_airpump = "engineering_east_pump";
+	tag_chamber_sensor = "engineering_east_sensor";
+	tag_exterior_door = "engineering_east_outer";
+	tag_interior_door = "engineering_east_inner";
+	pixel_y = 25
+	},
+/obj/machinery/airlock_sensor{
+	id_tag = "engineering_east_sensor";
+	pixel_x = -12;
+	pixel_y = 25
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/engineering/engine)
 "nqz" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -53871,7 +54703,7 @@
 	dir = 6;
 	icon_state = "yellow"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "nqD" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -53932,18 +54764,18 @@
 	},
 /area/station/civilian/kitchen)
 "nrh" = (
-/obj/machinery/power/terminal{
-	dir = 4
-	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "vault"
+/obj/machinery/power/apc{
+	name = "apc down";
+	pixel_y = -28
 	},
-/area/station/engineering/atmos)
+/turf/simulated/floor/plating{
+	icon_state = "warnplate"
+	},
+/area/station/maintenance/auxsolarport)
 "nrj" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -54124,12 +54956,6 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/hallway)
-"ntO" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 6
-	},
-/turf/simulated/floor/plating/airless/catwalk,
-/area/space)
 "nub" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -54334,16 +55160,39 @@
 	},
 /area/station/security/warden)
 "nwH" = (
-/obj/machinery/camera{
-	c_tag = "Project Room South";
-	network = list("SS13","Engineering");
-	dir = 6
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/structure/window/fulltile/reinforced/phoron{
+	grilled = 1;
+	icon_state = "gr_window_reinforced_phoron"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "Sm";
+	layer = 2.8;
+	name = "Supermatter Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/station/engineering/atmos/supermatter)
+"nwK" = (
+/obj/machinery/door_control{
+	id = "Singularity";
+	name = "Shutters Control";
+	req_access = list(10);
+	pixel_y = -25
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	dir = 1;
+	dir = 8;
 	icon_state = "yellow"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/engine)
 "nwM" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -54534,7 +55383,7 @@
 	dir = 1;
 	icon_state = "darkblue"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "nzk" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -54714,11 +55563,6 @@
 	},
 /area/station/cargo/office)
 "nBf" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/particle_accelerator/fuel_chamber{
 	dir = 8
 	},
@@ -55051,15 +55895,19 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "nFq" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -32
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	dir = 6;
-	icon_state = "warning"
+	dir = 8;
+	icon_state = "caution"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "nFr" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/structure/stool/bed/chair/office/dark{
@@ -55069,18 +55917,14 @@
 /area/station/engineering/atmos)
 "nFZ" = (
 /obj/machinery/power/grounding_rod,
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/singularity)
 "nGb" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Atmospherics Emergency Access";
-	req_one_access = list(10,24)
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -55090,8 +55934,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/engineering/atmos)
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/station/engineering/atmos/supermatter)
 "nGh" = (
 /obj/machinery/computer/station_alert{
 	dir = 4
@@ -55722,7 +56569,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "nPK" = (
 /obj/structure/closet/coffin,
 /turf/simulated/floor/plating,
@@ -55773,19 +56620,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
-"nQk" = (
-/obj/machinery/light/smart{
-	dir = 1
-	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 28;
-	pixel_y = -5
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "nQo" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -56237,25 +57071,19 @@
 	},
 /area/station/security/armoury)
 "nUv" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
+/obj/structure/table/reinforced,
+/obj/item/weapon/module/power_control,
+/obj/item/device/analyzer,
 /turf/simulated/floor{
 	icon_state = "yellowpatch"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "nUw" = (
 /turf/simulated/floor{
 	dir = 9;
@@ -56293,22 +57121,7 @@
 	pixel_x = 22
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
-"nUT" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/rglass{
-	amount = 20;
-	pixel_x = 2;
-	pixel_y = -2
-	},
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/machinery/light/smart,
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/atmos)
+/area/station/engineering/minisat_secure_area)
 "nUY" = (
 /obj/structure/bookcase,
 /obj/effect/decal/cleanable/cobweb2,
@@ -56672,10 +57485,17 @@
 	},
 /area/station/hallway/primary/starboard)
 "nZC" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
+	frequency = 1379;
+	id_tag = "engineering_east_pump";
+	name = "Engineering East Large Air Vent";
+	dir = 1
+	},
+/obj/machinery/light/small,
 /turf/simulated/floor/plating{
 	icon_state = "platebotc"
 	},
-/area/station/engineering/singularity)
+/area/station/engineering/engine)
 "nZH" = (
 /obj/structure/table/reinforced,
 /obj/item/device/aicard,
@@ -56766,7 +57586,7 @@
 	dir = 10
 	},
 /turf/simulated/floor,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "oaP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -56813,6 +57633,27 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/library)
+"obx" = (
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "Singularity";
+	layer = 2.8;
+	name = "Engine Shutters";
+	opacity = 0
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/engine)
 "obC" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -56953,11 +57794,11 @@
 	},
 /area/station/engineering/monitoring)
 "odD" = (
-/obj/machinery/atmospherics/components/binary/valve,
 /turf/simulated/floor{
-	icon_state = "neutralfull"
+	dir = 1;
+	icon_state = "darkyellowcorners"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/drone_fabrication)
 "odS" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/glass/beaker/large,
@@ -57265,25 +58106,14 @@
 	},
 /area/station/medical/hallway)
 "ohU" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/computer/security/engineering/drone{
+	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "warning"
+	dir = 8;
+	icon_state = "vault"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/drone_fabrication)
 "ohV" = (
 /obj/structure/closet/secure_closet/personal/cabinet{
 	name = "clown's closet"
@@ -57292,18 +58122,13 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "ohW" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	icon_state = "yellowpatch"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "ohZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -57377,7 +58202,7 @@
 /turf/simulated/floor,
 /area/station/maintenance/cargo)
 "ojc" = (
-/obj/effect/landmark/start/assistant,
+/obj/effect/landmark/start/assistant/test_subject,
 /obj/structure/stool/bed/chair/metal/blue{
 	dir = 8
 	},
@@ -57440,7 +58265,7 @@
 /turf/simulated/floor{
 	icon_state = "yellow"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "ojS" = (
 /obj/machinery/computer/arcade,
 /turf/simulated/floor{
@@ -57516,7 +58341,7 @@
 	},
 /area/station/civilian/bar)
 "olT" = (
-/obj/effect/landmark/start/assistant,
+/obj/effect/landmark/start/assistant/test_subject,
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -57632,7 +58457,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/station/engineering/singularity)
+/area/station/engineering/engine)
 "ooG" = (
 /turf/simulated/floor{
 	dir = 5;
@@ -58007,7 +58832,7 @@
 	dir = 9;
 	icon_state = "yellow"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "oub" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor{
@@ -58121,7 +58946,7 @@
 	},
 /area/station/maintenance/starboardsolar)
 "ovz" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
+/obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
 	},
 /turf/simulated/floor{
@@ -58144,6 +58969,20 @@
 	icon_state = "blue"
 	},
 /area/station/maintenance/chapel)
+"owf" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/engineering/break_room)
 "owz" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 4
@@ -58308,11 +59147,6 @@
 	},
 /area/station/security/main)
 "ozK" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -58323,8 +59157,15 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
-/area/station/engineering/atmos)
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/atmos/supermatter)
 "ozQ" = (
 /obj/machinery/camera{
 	c_tag = "Chapel North";
@@ -58340,6 +59181,12 @@
 	},
 /turf/simulated/wall,
 /area/station/civilian/kitchen)
+"oAn" = (
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
+/area/station/engineering/break_room)
 "oAx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -58385,10 +59232,9 @@
 	},
 /area/station/security/vacantoffice)
 "oBb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor{
 	icon_state = "yellowfull"
 	},
@@ -58428,7 +59274,7 @@
 	},
 /area/station/hallway/secondary/exit)
 "oBy" = (
-/obj/effect/landmark/start/assistant,
+/obj/effect/landmark/start/assistant/test_subject,
 /obj/structure/stool/bed/chair/metal/blue{
 	dir = 1
 	},
@@ -58702,7 +59548,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "oFu" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -58814,6 +59660,17 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/xenobiology)
+"oGO" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/plating/airless{
+	dir = 6;
+	icon_state = "warnplate"
+	},
+/area/space)
 "oGY" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
@@ -59097,7 +59954,7 @@
 	dir = 5;
 	icon_state = "vault"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "oKR" = (
 /obj/machinery/computer/security{
 	dir = 4
@@ -59141,7 +59998,7 @@
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "oLo" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -59518,6 +60375,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboardsolar)
+"oON" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
+	frequency = 1379;
+	id_tag = "engineering_west_pump";
+	name = "Engineering West Large Air Vent"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating{
+	icon_state = "platebotc"
+	},
+/area/station/engineering/engine)
 "oOP" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -59680,7 +60550,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /turf/simulated/floor/plating,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "oRY" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -59730,10 +60600,15 @@
 "oSJ" = (
 /obj/structure/sign/warning/radiation,
 /turf/simulated/wall/r_wall,
-/area/station/maintenance/science)
+/area/station/maintenance/engineering)
 "oSO" = (
-/turf/simulated/floor/plating/airless,
-/area/station/maintenance/science)
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA"
+	},
+/turf/simulated/wall/r_wall,
+/area/station/engineering/atmos/supermatter)
 "oSU" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -59794,19 +60669,11 @@
 	},
 /area/station/medical/hallway)
 "oTP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Atmospherics HFR Room";
-	req_one_access = list(10,24)
-	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "oTR" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -59846,7 +60713,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "oUF" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
@@ -59873,7 +60740,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "oVg" = (
 /obj/machinery/door/morgue{
 	name = "Confession Booth (Chaplain)";
@@ -60035,17 +60902,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor,
 /area/station/maintenance/medbay)
-"oXk" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Turbine Generator Access";
-	req_one_access = list(10,24)
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/atmos)
 "oXr" = (
 /obj/item/toy/figure/detective,
 /obj/structure/table/woodentable,
@@ -60398,12 +61254,11 @@
 /turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
 "pbm" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "warning"
+	dir = 8;
+	icon_state = "darkyellowcorners"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/drone_fabrication)
 "pbn" = (
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/port)
@@ -60585,7 +61440,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "peS" = (
 /obj/machinery/light/smart{
 	dir = 8
@@ -60594,6 +61449,21 @@
 	icon_state = "wooden-2"
 	},
 /area/station/civilian/gym)
+"peZ" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/airless{
+	icon_state = "warnplate"
+	},
+/area/station/engineering/singularity)
 "pfc" = (
 /obj/machinery/iv_drip,
 /obj/structure/stool/bed/roller,
@@ -60759,6 +61629,16 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/brig)
+"pgW" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel,
+/obj/machinery/meter,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "phc" = (
 /turf/simulated/shuttle/floor/cargo{
 	icon_state = "0,2"
@@ -60899,16 +61779,17 @@
 /turf/simulated/floor/carpet/green,
 /area/station/civilian/library)
 "pjj" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/door_control{
+	id = "Sm";
+	name = "Shutters Control";
+	req_access = list(10);
+	pixel_y = 28
+	},
 /turf/simulated/floor,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "pjl" = (
 /obj/structure/rack,
 /obj/item/device/radio/intercom{
@@ -60941,7 +61822,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /turf/simulated/floor/plating,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "pjw" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/folder/blue,
@@ -61138,7 +62019,7 @@
 	dir = 1
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "plp" = (
 /obj/structure/stool/bed/chair,
 /turf/simulated/floor{
@@ -61399,6 +62280,16 @@
 	icon_state = "dark"
 	},
 /area/station/security/interrogation)
+"pom" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/engine)
 "poA" = (
 /obj/machinery/light/smart{
 	dir = 4
@@ -61614,10 +62505,15 @@
 	},
 /area/station/engineering/drone_fabrication)
 "pry" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating/airless{
 	icon_state = "warnplatecorner"
 	},
-/area/station/engineering/singularity)
+/area/space)
 "prC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -61718,7 +62614,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /turf/simulated/floor/plating,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "pst" = (
 /turf/simulated/floor/plating,
 /area/station/bridge/captain_quarters)
@@ -61903,18 +62799,11 @@
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
 "pvz" = (
-/obj/machinery/light/smart{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "HFR Room";
-	network = list("SS13","Engineering");
-	dir = 5
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
+/obj/structure/rack,
+/obj/item/weapon/weldingtool,
+/obj/item/clothing/head/welding,
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "pwa" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 8
@@ -62019,7 +62908,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "pwE" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/box/donkpockets,
@@ -62108,6 +62997,13 @@
 	icon_state = "vault"
 	},
 /area/station/gateway)
+"pxK" = (
+/obj/machinery/atmospherics/components/binary/pump,
+/obj/machinery/light/smart{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "pxL" = (
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
@@ -62316,7 +63212,7 @@
 	req_one_access = list(11,24)
 	},
 /turf/simulated/floor/plating,
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "pzD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -62333,20 +63229,53 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
+"pzQ" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/atmos/supermatter)
 "pAm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/vending/snack,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "pAq" = (
-/obj/machinery/portable_atmospherics/powered/scrubber/huge,
+/obj/structure/closet/crate{
+	name = "TEG crate"
+	},
+/obj/item/weapon/circuitboard/teg,
+/obj/item/weapon/circuitboard/circulator,
+/obj/item/weapon/circuitboard/circulator,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/capacitor,
+/obj/item/weapon/stock_parts/console_screen,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/weapon/stock_parts/matter_bin,
+/obj/item/stack/cable_coil,
 /obj/machinery/light/small{
 	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "pAG" = (
 /obj/structure/table/reinforced,
 /obj/item/device/taperecorder,
@@ -62401,7 +63330,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "pAS" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -62829,7 +63758,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "pGn" = (
 /turf/simulated/wall/r_wall,
 /area/station/aisat/teleport)
@@ -62845,14 +63774,9 @@
 	},
 /area/station/rnd/lab)
 "pGs" = (
-/obj/machinery/light/smart{
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "caution"
-	},
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/simple/visible,
+/turf/simulated/floor/plating,
+/area/station/maintenance/auxsolarport)
 "pGv" = (
 /turf/simulated/floor{
 	icon_state = "yellowcorner"
@@ -62927,7 +63851,7 @@
 /turf/simulated/floor{
 	icon_state = "bluecorner"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "pHa" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
@@ -62981,7 +63905,7 @@
 /turf/simulated/floor{
 	icon_state = "blue"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "pHP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -63174,15 +64098,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
-"pLb" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
-/turf/simulated/floor/plating,
-/area/station/engineering/atmos)
 "pLk" = (
 /obj/machinery/hydroponics/constructable,
 /turf/simulated/floor{
@@ -63202,7 +64117,7 @@
 	},
 /obj/structure/transit_tube,
 /turf/simulated/floor/plating,
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "pLw" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -63235,11 +64150,22 @@
 /turf/simulated/floor,
 /area/station/maintenance/science)
 "pLy" = (
-/turf/simulated/floor{
-	dir = 9;
-	icon_state = "warndark"
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
+/obj/structure/window/fulltile/reinforced/phoron{
+	grilled = 1;
+	icon_state = "gr_window_reinforced_phoron"
 	},
-/area/station/engineering/atmos)
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "Sm";
+	layer = 2.8;
+	name = "Supermatter Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/engine,
+/area/station/engineering/atmos/supermatter)
 "pLB" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/light/smart{
@@ -63344,7 +64270,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "pML" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -63485,7 +64411,7 @@
 	pixel_y = 6
 	},
 /turf/simulated/floor/wood,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "pPk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -63853,7 +64779,7 @@
 	dir = 4;
 	icon_state = "yellow"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "pSX" = (
 /obj/structure/stool/bed/roller,
 /turf/simulated/floor{
@@ -64244,7 +65170,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/station/engineering/singularity)
+/area/station/engineering/engine)
 "pYK" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/firealarm{
@@ -64287,7 +65213,7 @@
 	dir = 4;
 	icon_state = "bluecorner"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "pYU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -64311,11 +65237,11 @@
 /turf/simulated/floor/plating,
 /area/station/civilian/toilet)
 "pZb" = (
-/turf/simulated/floor/plating/airless{
-	dir = 8;
-	icon_state = "warnplate"
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "yellow"
 	},
-/area/station/maintenance/engineering)
+/area/station/engineering/break_room)
 "pZo" = (
 /obj/item/weapon/flora/random,
 /obj/structure/cable{
@@ -64350,13 +65276,11 @@
 	},
 /area/station/cargo/storage)
 "pZC" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "caution"
-	},
-/area/station/engineering/atmos)
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "pZG" = (
 /obj/structure/stool/bed/chair/metal/red{
 	dir = 8
@@ -64399,25 +65323,14 @@
 	},
 /area/station/hallway/primary/starboard)
 "qaF" = (
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
+/obj/machinery/atmospherics/pipe/manifold/visible/red,
+/obj/machinery/meter,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
 	},
-/obj/machinery/power/apc{
-	name = "apc down";
-	pixel_y = -28
-	},
-/obj/machinery/alarm{
-	pixel_x = 29;
-	pixel_y = -6
-	},
-/turf/simulated/floor/plating{
-	dir = 6;
-	icon_state = "warnplate"
-	},
-/area/station/maintenance/auxsolarport)
+/area/station/engineering/atmos/supermatter)
 "qaU" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "yellowcorner"
@@ -64550,7 +65463,6 @@
 /area/shuttle/supply/station)
 "qby" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "yellow"
@@ -64668,7 +65580,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "qdn" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor{
@@ -64926,6 +65838,9 @@
 /obj/item/weapon/circuitboard/solar_control,
 /obj/item/weapon/tracker_electronics,
 /obj/item/weapon/paper/solar,
+/obj/machinery/light/small{
+	dir = 8
+	},
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
@@ -65142,6 +66057,22 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/station/civilian/chapel/office)
+"qjA" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/airless{
+	dir = 8;
+	icon_state = "warnplate"
+	},
+/area/space)
 "qjC" = (
 /obj/machinery/atmospherics/components/trinary/mixer{
 	color = "#ffff00";
@@ -65206,11 +66137,9 @@
 	},
 /area/station/hallway/secondary/entry)
 "qkK" = (
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "yellowcorner"
-	},
-/area/station/engineering/atmos)
+/obj/structure/window/thin/reinforced,
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "qkN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -65251,8 +66180,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "qlj" = (
-/turf/environment/space,
-/area/station/engineering/singularity)
+/turf/simulated/wall,
+/area/station/engineering/break_room)
 "qls" = (
 /obj/decal/boxingrope{
 	density = 0;
@@ -65470,16 +66399,17 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/wood,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "qnU" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 10
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume/on{
+	external_pressure_bound = 140;
+	external_pressure_bound_default = 140;
+	name = "(OUT) Space Large Air Vent"
 	},
-/turf/simulated/floor/plating{
-	dir = 1;
-	icon_state = "warnplate"
+/turf/simulated/floor/plating/airless{
+	icon_state = "platebot"
 	},
-/area/station/maintenance/auxsolarport)
+/area/station/engineering/atmos/supermatter)
 "qnY" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -65704,7 +66634,7 @@
 	dir = 1
 	},
 /turf/simulated/floor,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "qrH" = (
 /obj/structure/object_wall/pod{
 	dir = 1;
@@ -65928,17 +66858,6 @@
 	icon_state = "bot"
 	},
 /area/station/rnd/lab)
-"qua" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -28;
-	pixel_y = -5
-	},
-/obj/machinery/recharge_station,
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/atmos)
 "qud" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -66210,11 +67129,13 @@
 	},
 /area/station/bridge/ai_upload)
 "qyx" = (
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "warndark"
+/obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	frequency = 1444;
+	id = "sm_in";
+	name = "SM air injector"
 	},
-/area/station/engineering/atmos)
+/turf/simulated/floor/engine,
+/area/station/engineering/atmos/supermatter)
 "qyR" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -66285,6 +67206,15 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
 "qzO" = (
@@ -66312,11 +67242,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
-"qAK" = (
-/turf/simulated/floor{
-	icon_state = "warndarkcorners"
-	},
-/area/station/engineering/atmos)
 "qAM" = (
 /obj/item/weapon/flora/random,
 /obj/structure/cable{
@@ -66437,10 +67362,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "qCV" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/light/smart{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "yellow"
@@ -66579,6 +67504,12 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
+"qDT" = (
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/engineering/engine)
 "qDV" = (
 /obj/machinery/driver_button{
 	id = "chapelgun";
@@ -66830,7 +67761,7 @@
 /turf/simulated/floor{
 	icon_state = "yellow"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "qHR" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/effect/landmark/start/recycler,
@@ -66943,18 +67874,17 @@
 	icon_state = "barber"
 	},
 /area/station/medical/cmo)
-"qIT" = (
-/obj/machinery/alarm{
-	pixel_y = 22
+"qJd" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 6
+/turf/simulated/floor/plating/airless{
+	dir = 10;
+	icon_state = "warnplate"
 	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "caution"
-	},
-/area/station/engineering/atmos)
+/area/space)
 "qJe" = (
 /obj/structure/object_wall/cargo{
 	icon_state = "8,1"
@@ -66968,7 +67898,7 @@
 /turf/simulated/floor{
 	icon_state = "yellow"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "qJp" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -67344,23 +68274,6 @@
 	icon_state = "bot"
 	},
 /area/station/maintenance/chapel)
-"qOG" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/access_button{
-	command = "cycle_exterior";
-	frequency = 1379;
-	master_tag = "solar_tool_airlock";
-	name = "exterior access button";
-	pixel_x = -25;
-	pixel_y = -25;
-	req_access = list(13)
-	},
-/turf/simulated/floor/plating/airless/catwalk,
-/area/station/solar/auxport)
 "qOV" = (
 /obj/structure/table,
 /obj/item/seeds/appleseed,
@@ -67467,7 +68380,7 @@
 	dir = 8;
 	icon_state = "yellow"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "qQu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -67482,6 +68395,17 @@
 	icon_state = "warning"
 	},
 /area/station/hallway/secondary/entry)
+"qQz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
+	dir = 1;
+	frequency = 1379;
+	id_tag = "engineering_east_pump";
+	name = "Engineering East Large Air Vent"
+	},
+/turf/simulated/floor/plating{
+	icon_state = "platebotc"
+	},
+/area/station/engineering/engine)
 "qQA" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -67707,14 +68631,16 @@
 /turf/simulated/floor/plating,
 /area/station/cargo/qm)
 "qTl" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 22
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 10
 	},
-/turf/simulated/floor{
-	icon_state = "yellowpatch"
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/station/engineering/atmos)
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "qTm" = (
 /obj/structure/barricade/wooden,
 /turf/simulated/floor{
@@ -67877,13 +68803,13 @@
 	dir = 5;
 	icon_state = "darkblue"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "qVs" = (
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "vault"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "qVu" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 8
@@ -67981,9 +68907,7 @@
 	},
 /area/station/security/forensic_office)
 "qWm" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /turf/simulated/floor{
 	icon_state = "yellow"
 	},
@@ -67994,6 +68918,24 @@
 	icon_state = "chapel"
 	},
 /area/station/civilian/chapel)
+"qWH" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/atmos/supermatter)
 "qWU" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -68127,6 +69069,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "qYJ" = (
@@ -68155,6 +69098,18 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard)
+"qZe" = (
+/obj/machinery/power/terminal{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating{
+	icon_state = "platebot"
+	},
+/area/station/engineering/atmos/supermatter)
 "qZv" = (
 /obj/structure/table,
 /obj/item/weapon/storage/toolbox/mechanical,
@@ -68211,7 +69166,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/wood,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "raz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -68240,6 +69195,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "raJ" = (
@@ -68311,6 +69267,15 @@
 /obj/item/weapon/storage/fancy/candle_box,
 /turf/simulated/floor,
 /area/station/civilian/chapel)
+"rbD" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "rbK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -68597,6 +69562,16 @@
 	icon_state = "showroomfloor"
 	},
 /area/station/civilian/cold_room)
+"rfM" = (
+/obj/machinery/power/tesla_coil,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor/plating/airless{
+	icon_state = "platebot"
+	},
+/area/space)
 "rfV" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/toilet{
@@ -68665,7 +69640,7 @@
 	dir = 8;
 	icon_state = "darkblue"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "rha" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -68709,9 +69684,6 @@
 	},
 /area/station/civilian/chapel/mass_driver)
 "rhs" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	dir = 4
-	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -68720,8 +69692,16 @@
 	name = "Engine Shutters";
 	opacity = 0
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
-/area/station/engineering/singularity)
+/area/station/engineering/engine)
 "rhI" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -68764,9 +69744,22 @@
 	},
 /area/station/medical/hallway)
 "rii" = (
-/obj/structure/lattice,
-/turf/environment/space,
-/area/station/engineering/singularity)
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/break_room)
 "riq" = (
 /obj/structure/object_wall/pod{
 	icon_state = "0,0"
@@ -69020,7 +70013,7 @@
 	dir = 5;
 	icon_state = "warning"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "rmh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -69055,12 +70048,9 @@
 /turf/simulated/wall,
 /area/station/hallway/secondary/exit)
 "rnl" = (
-/obj/machinery/drone_fabricator,
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "warndark"
-	},
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/turf/simulated/floor/engine,
+/area/station/engineering/atmos/supermatter)
 "rnn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -69080,11 +70070,13 @@
 	},
 /area/station/solar/auxstarboard)
 "rnA" = (
-/obj/machinery/power/emitter{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/plating/airless,
-/area/station/maintenance/engineering)
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/break_room)
 "rnH" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -69117,13 +70109,14 @@
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "rot" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "warning"
+	dir = 8;
+	icon_state = "caution"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "rov" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -69170,7 +70163,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "roY" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -69429,14 +70422,13 @@
 	},
 /area/station/engineering/atmos)
 "rsB" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -32
-	},
 /obj/machinery/camera{
 	c_tag = "Enginnering Engine South";
 	network = list("SS13","Engineering");
 	dir = 1
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
 	},
 /turf/simulated/floor{
 	icon_state = "warning"
@@ -69509,6 +70501,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "rtx" = (
@@ -69524,18 +70520,11 @@
 /turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
 "rtL" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
+/obj/machinery/power/smes,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
 	},
-/obj/item/weapon/caution/cone,
-/obj/item/weapon/caution/cone{
-	pixel_x = 6
-	},
-/obj/item/weapon/caution/cone{
-	pixel_x = -6
-	},
-/obj/item/weapon/caution/cone,
-/obj/item/weapon/caution/cone,
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
@@ -69740,13 +70729,23 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/brig)
+"rwn" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/atmos/supermatter)
 "rwr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "rwA" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/atmospherics/pipe/simple/visible/green,
@@ -69973,14 +70972,6 @@
 	icon_state = "delivery"
 	},
 /area/station/hallway/secondary/entry)
-"ryS" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Atmospherics HFR Room";
-	req_one_access = list(10,24)
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor,
-/area/station/engineering/atmos)
 "rzd" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -70021,7 +71012,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "rzy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -70087,7 +71078,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "rzP" = (
 /obj/machinery/light/smart,
 /turf/simulated/floor{
@@ -70314,22 +71305,6 @@
 "rCn" = (
 /turf/environment/space,
 /area/shuttle/vox/southeast_solars)
-"rCs" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/engineering/atmos)
 "rCx" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/machinery/status_display{
@@ -70401,6 +71376,13 @@
 	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
+"rDL" = (
+/obj/machinery/drone_fabricator,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkyellow"
+	},
+/area/station/engineering/drone_fabrication)
 "rDR" = (
 /obj/machinery/computer/cargo{
 	dir = 4
@@ -70538,6 +71520,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "delivery"
 	},
@@ -70637,11 +71625,11 @@
 	},
 /area/station/bridge/hop_office)
 "rHh" = (
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "warndark"
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 4
 	},
-/area/station/engineering/atmos)
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "rHl" = (
 /obj/structure/closet/secure_closet/security/cargo,
 /obj/machinery/firealarm{
@@ -70992,16 +71980,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/medical/sleeper)
-"rJE" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/visible/yellow{
-	dir = 8
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "warning"
-	},
-/area/station/engineering/atmos)
 "rJS" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 1;
@@ -71089,7 +72067,7 @@
 	},
 /area/station/hallway/primary/central)
 "rKy" = (
-/obj/effect/landmark/start/assistant,
+/obj/effect/landmark/start/assistant/test_subject,
 /obj/structure/stool/bed/chair{
 	dir = 4
 	},
@@ -71143,7 +72121,7 @@
 /turf/simulated/floor{
 	icon_state = "darkbluefull"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "rKH" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -71325,11 +72303,11 @@
 /turf/simulated/floor/plating,
 /area/station/cargo/recycler)
 "rNm" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/structure/reagent_dispensers/aqueous_foam_tank,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "rNn" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -71385,6 +72363,10 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/cargo)
+"rNN" = (
+/obj/structure/sign/warning/secure_area,
+/turf/simulated/wall,
+/area/station/engineering/break_room)
 "rNQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -71444,7 +72426,7 @@
 	dir = 1;
 	icon_state = "warndark"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "rOF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -71600,16 +72582,12 @@
 	},
 /area/station/cargo/miningoffice)
 "rQM" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
 	dir = 1;
-	icon_state = "warning"
+	icon_state = "darkyellow"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/drone_fabrication)
 "rQV" = (
 /obj/machinery/telecomms/receiver/preset_right,
 /turf/simulated/floor/bluegrid{
@@ -71936,23 +72914,9 @@
 	},
 /area/station/rnd/mixing)
 "rVz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /turf/simulated/floor,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "rVB" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -71980,29 +72944,14 @@
 	},
 /area/station/civilian/dormitories)
 "rVK" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/light/smart,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor{
 	icon_state = "yellowpatch"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "rVN" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -72120,10 +73069,10 @@
 	},
 /area/station/hallway/secondary/entry)
 "rXM" = (
-/obj/effect/landmark/start/assistant,
 /obj/structure/stool/bed/chair{
 	dir = 4
 	},
+/obj/effect/landmark/start/assistant/waiter,
 /turf/simulated/floor{
 	icon_state = "redchecker"
 	},
@@ -72149,7 +73098,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/obj/machinery/light/smart,
 /turf/simulated/floor{
 	icon_state = "yellow"
 	},
@@ -72386,6 +73334,13 @@
 	icon_state = "bluered"
 	},
 /area/station/medical/medbreak)
+"sbT" = (
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "tox_sensor"
+	},
+/turf/simulated/floor/engine/phoron,
+/area/station/engineering/atmos)
 "sbV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -72449,7 +73404,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/wood,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "scX" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -72598,7 +73553,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/station/engineering/singularity)
+/area/station/engineering/engine)
 "seU" = (
 /obj/effect/landmark/start/cargo_technician,
 /turf/simulated/floor{
@@ -72752,13 +73707,13 @@
 /turf/simulated/floor,
 /area/station/maintenance/cargo)
 "shj" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/vault{
+	name = "Supermatter";
+	req_access = list(24)
 	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
+/turf/simulated/floor/engine,
+/area/station/engineering/atmos/supermatter)
 "shs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -72771,22 +73726,16 @@
 /turf/simulated/wall,
 /area/station/cargo/office)
 "shx" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	icon_state = "yellowpatch"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "shy" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/door_control{
@@ -72972,7 +73921,7 @@
 	dir = 6;
 	icon_state = "darkblue"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "sjq" = (
 /turf/simulated/shuttle/floor/cargo{
 	icon_state = "2,5"
@@ -73528,6 +74477,16 @@
 	icon_state = "escape"
 	},
 /area/station/engineering/atmos)
+"spB" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/atmos/supermatter)
 "sqb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red{
 	dir = 4
@@ -73620,6 +74579,13 @@
 /obj/machinery/computer/reconstitutor/animal,
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
+"srP" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 9
+	},
+/obj/machinery/meter,
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "srS" = (
 /obj/structure/table/woodentable,
 /obj/item/device/radio/intercom,
@@ -73815,6 +74781,10 @@
 	icon_state = "warning"
 	},
 /area/station/hallway/secondary/entry)
+"sud" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor,
+/area/station/engineering/break_room)
 "suf" = (
 /obj/structure/dresser,
 /obj/effect/decal/cleanable/dirt,
@@ -73869,6 +74839,17 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/grass,
 /area/station/hallway/primary/fore)
+"svn" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/airless{
+	dir = 5;
+	icon_state = "warnplate"
+	},
+/area/station/engineering/singularity)
 "svo" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -73894,12 +74875,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
-"svE" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/atmos)
 "svI" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -73916,6 +74891,19 @@
 /turf/simulated/floor{
 	icon_state = "bluecorner"
 	},
+/area/station/engineering/minisat_secure_area)
+"svZ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "swq" = (
 /obj/machinery/vending/clothing,
@@ -73946,7 +74934,7 @@
 	dir = 10;
 	icon_state = "darkblue"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "swz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /turf/simulated/floor{
@@ -74024,23 +75012,21 @@
 	icon_state = "neutralfull"
 	},
 /area/station/storage/primary)
+"syg" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/atmos/supermatter)
 "syl" = (
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "blackcorner"
 	},
 /area/station/hallway/primary/starboard)
-"syn" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor,
-/area/station/engineering/atmos)
 "syC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -74094,10 +75080,6 @@
 /area/station/gateway)
 "szc" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/atmos/glass{
-	name = "Atmospherics Project Room";
-	req_access = list(24)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -74106,7 +75088,12 @@
 	name = "Atmos Blast Door";
 	opacity = 0
 	},
-/turf/simulated/floor,
+/obj/machinery/door/airlock/atmos{
+	name = "Supermatter Construction Area"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowfull"
+	},
 /area/station/engineering/atmos)
 "szf" = (
 /turf/simulated/floor{
@@ -74165,7 +75152,6 @@
 /area/station/medical/morgue)
 "szY" = (
 /obj/structure/rack,
-/obj/item/device/lightreplacer,
 /obj/item/weapon/wrench,
 /obj/item/weapon/tank/emergency_oxygen/engi,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -74293,7 +75279,7 @@
 /turf/simulated/floor{
 	icon_state = "caution"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "sBT" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -74333,8 +75319,9 @@
 	},
 /area/station/rnd/robotics)
 "sCh" = (
-/turf/simulated/floor/plating/airless,
-/area/station/maintenance/engineering)
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "sCp" = (
 /obj/machinery/chem_master/condimaster{
 	name = "CondiMaster Neo"
@@ -74348,14 +75335,6 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/kitchen)
-"sCr" = (
-/obj/structure/computerframe{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "caution"
-	},
-/area/station/engineering/atmos)
 "sCO" = (
 /obj/structure/closet,
 /obj/item/stack/sheet/glass{
@@ -74530,7 +75509,7 @@
 	name = "HIGH VOLTAGE"
 	},
 /turf/simulated/wall/r_wall,
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "sEz" = (
 /obj/machinery/door_control{
 	id = "bsentry";
@@ -74680,6 +75659,12 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
+"sFM" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "sGc" = (
 /obj/structure/sign/directions/engineering{
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
@@ -75024,14 +76009,11 @@
 	},
 /area/station/rnd/mixing)
 "sKN" = (
-/obj/structure/stool/bed/chair/metal{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 9
 	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "warndark"
-	},
-/area/station/engineering/atmos)
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "sKR" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor{
@@ -75226,6 +76208,15 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/reception)
+"sNl" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating/airless{
+	dir = 4;
+	icon_state = "warnplate"
+	},
+/area/station/engineering/singularity)
 "sNm" = (
 /obj/structure/closet,
 /obj/item/weapon/storage/briefcase/centcomm,
@@ -75277,6 +76268,12 @@
 	icon_state = "redfull"
 	},
 /area/station/security/main)
+"sNY" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/engineering/minisat_secure_area)
 "sOe" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/box/cups,
@@ -75474,7 +76471,7 @@
 	dir = 5
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "sQI" = (
 /obj/machinery/computer/mine_sci_shuttle/flight_comp{
 	dir = 8
@@ -75659,12 +76656,6 @@
 	icon_state = "yellowpatch_inv"
 	},
 /area/station/hallway/primary/fore)
-"sTo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor{
-	icon_state = "warningcorner"
-	},
-/area/station/engineering/atmos)
 "sTt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -75798,7 +76789,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /turf/simulated/floor/plating,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "sUZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -75907,11 +76898,12 @@
 	dir = 4;
 	pixel_x = 22
 	},
+/obj/machinery/recharge_station,
 /turf/simulated/floor{
-	dir = 6;
-	icon_state = "caution"
+	dir = 8;
+	icon_state = "vault"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/drone_fabrication)
 "sWL" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/light/small{
@@ -75970,11 +76962,8 @@
 /turf/simulated/wall/r_wall,
 /area/station/medical/chemistry)
 "sXQ" = (
-/turf/simulated/floor/plating/airless{
-	dir = 4;
-	icon_state = "warnplate"
-	},
-/area/station/maintenance/science)
+/turf/simulated/floor,
+/area/station/engineering/break_room)
 "sXT" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/light/smart{
@@ -75999,11 +76988,16 @@
 	},
 /area/station/civilian/gym)
 "sYc" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating/airless{
 	dir = 4;
 	icon_state = "warnplatecorner"
 	},
-/area/station/engineering/singularity)
+/area/space)
 "sYm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -76258,13 +77252,12 @@
 	},
 /area/station/medical/hallway)
 "tbt" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 6
+/obj/machinery/door/airlock/vault{
+	name = "Supermatter";
+	req_access = list(24)
 	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
+/turf/simulated/floor/engine,
+/area/station/engineering/atmos/supermatter)
 "tbx" = (
 /obj/machinery/light/smart{
 	dir = 8
@@ -76279,7 +77272,7 @@
 	dir = 1;
 	icon_state = "bluecorner"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "tbH" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -76770,27 +77763,28 @@
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "tiI" = (
-/obj/machinery/light/small{
-	dir = 8
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor{
-	icon_state = "bot"
-	},
-/area/station/engineering/engine)
+/turf/simulated/floor/plating/airless,
+/area/station/engineering/singularity)
 "tiJ" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "tiK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor/plating/airless{
+	dir = 8;
+	icon_state = "warnplate"
 	},
-/turf/simulated/floor,
-/area/station/engineering/engine)
+/area/space)
 "tiL" = (
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway East";
@@ -76818,6 +77812,12 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/secondary/exit)
+"tji" = (
+/turf/simulated/floor/plating/airless{
+	dir = 4;
+	icon_state = "warnplate"
+	},
+/area/space)
 "tjk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -76940,6 +77940,16 @@
 /turf/environment/space,
 /area/shuttle/supply/station)
 "tlb" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating{
 	dir = 1;
 	icon_state = "warnplate"
@@ -76985,6 +77995,17 @@
 	icon_state = "dark"
 	},
 /area/station/bridge/ai_upload)
+"tlM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/atmos/supermatter)
 "tlS" = (
 /turf/simulated/floor{
 	dir = 5;
@@ -77028,11 +78049,21 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/starboard)
 "tmQ" = (
-/obj/structure/closet/radiation,
-/obj/item/device/analyzer,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "atmos";
+	name = "Atmos Blast Door";
+	opacity = 0
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/atmos{
+	name = "Drone Fabrication"
+	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "caution"
+	icon_state = "darkyellowfull"
 	},
 /area/station/engineering/atmos)
 "tmX" = (
@@ -77425,7 +78456,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "ttx" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -77514,7 +78545,7 @@
 /area/station/medical/cmo)
 "tun" = (
 /obj/structure/stool/bed/chair/metal/white,
-/obj/effect/landmark/start/assistant,
+/obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor,
 /area/station/civilian/gym)
 "tur" = (
@@ -77524,7 +78555,7 @@
 /turf/simulated/floor{
 	icon_state = "caution"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "tuv" = (
 /obj/structure/table/reinforced,
 /obj/item/toy/figure/engineer{
@@ -77534,7 +78565,7 @@
 	pixel_x = 6
 	},
 /turf/simulated/floor/wood,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "tuy" = (
 /obj/effect/landmark/start/scientist,
 /obj/structure/stool/bed/chair{
@@ -77573,7 +78604,7 @@
 	dir = 1;
 	icon_state = "darkblue"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "tvg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -77615,6 +78646,9 @@
 	icon_state = "vault"
 	},
 /area/station/engineering/atmos)
+"tvt" = (
+/turf/simulated/wall/r_wall,
+/area/station/engineering/minisat_secure_area)
 "tvu" = (
 /obj/structure/morgue,
 /turf/simulated/floor{
@@ -77843,6 +78877,18 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge/hop_office)
+"txU" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/minisat_secure_area)
 "tya" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -77909,6 +78955,11 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet/blue2,
 /area/station/security/vacantoffice)
+"tyI" = (
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/machinery/atmospherics/components/unary/portables_connector,
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "tzh" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/lockbox/vials,
@@ -78225,6 +79276,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/bridge/hop_office)
+"tCV" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 5
+	},
+/obj/machinery/light/smart,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "vault"
+	},
+/area/station/engineering/atmos)
 "tCX" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor{
@@ -78335,7 +79396,7 @@
 	},
 /area/station/civilian/gym)
 "tEg" = (
-/obj/effect/landmark/start/assistant,
+/obj/effect/landmark/start/assistant/test_subject,
 /obj/structure/stool,
 /turf/simulated/floor{
 	icon_state = "neutral"
@@ -78558,12 +79619,6 @@
 	icon_state = "whitered"
 	},
 /area/station/civilian/library)
-"tGR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on/atmos{
-	dir = 4
-	},
-/turf/simulated/floor/plating,
-/area/space)
 "tGX" = (
 /obj/structure/table,
 /turf/simulated/floor{
@@ -78688,12 +79743,6 @@
 "tJr" = (
 /turf/simulated/wall/r_wall,
 /area/station/rnd/server)
-"tJv" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 4
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/atmos)
 "tJH" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -78846,10 +79895,12 @@
 	name = "Engineering External Access";
 	req_access = list(10,13)
 	},
-/obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
-/area/station/engineering/singularity)
+/area/station/engineering/engine)
 "tLS" = (
 /obj/structure/table/woodentable,
 /obj/machinery/alarm{
@@ -78984,18 +80035,14 @@
 /turf/simulated/floor/wood,
 /area/station/hallway/primary/port)
 "tMY" = (
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/structure/window/fulltile/reinforced/phoron{
+	grilled = 1;
+	icon_state = "gr_window_reinforced_phoron"
 	},
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/plating{
-	dir = 4;
-	icon_state = "warnplate"
-	},
-/area/station/maintenance/auxsolarport)
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "tNj" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/rods{
@@ -79130,6 +80177,17 @@
 	icon_state = "warning"
 	},
 /area/station/medical/hallway)
+"tQu" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "tQx" = (
 /obj/structure/rack,
 /obj/item/clothing/under/bathtowel,
@@ -79240,11 +80298,11 @@
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "tSt" = (
-/obj/machinery/atmospherics/pipe/manifold/visible{
-	dir = 8
+/obj/machinery/light/smart,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
 	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/auxsolarport)
+/area/station/engineering/atmos/supermatter)
 "tSE" = (
 /obj/machinery/computer/security,
 /obj/machinery/light/smart{
@@ -79409,6 +80467,7 @@
 	pixel_x = 28;
 	pixel_y = -5
 	},
+/obj/machinery/pipedispenser/disposal,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "yellow"
@@ -79472,29 +80531,6 @@
 	icon_state = "warning"
 	},
 /area/station/rnd/hallway)
-"tUY" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/access_button{
-	command = "cycle_interior";
-	frequency = 1379;
-	master_tag = "solar_tool_airlock";
-	name = "interior access button";
-	pixel_x = 25;
-	pixel_y = 25;
-	req_access = list(13)
-	},
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5
-	},
-/turf/simulated/floor/plating{
-	dir = 9;
-	icon_state = "warnplate"
-	},
-/area/station/maintenance/auxsolarport)
 "tVc" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -79620,7 +80656,7 @@
 	sortType = "Engineering Break Room"
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "tWH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -79634,14 +80670,8 @@
 	name = "WARNING: PRESSURIZED DOORS";
 	pixel_x = 32
 	},
-/obj/machinery/light/smart{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
-/turf/simulated/floor{
-	icon_state = "yellowpatch"
-	},
-/area/station/engineering/atmos)
+/turf/simulated/wall/r_wall,
+/area/station/engineering/atmos/supermatter)
 "tWR" = (
 /obj/effect/landmark/start/medical_doctor,
 /turf/simulated/floor{
@@ -79675,18 +80705,14 @@
 /turf/environment/space,
 /area/shuttle/escape_pod2/station)
 "tXv" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Port Bow Solar Access";
-	req_access = list(10)
+/obj/machinery/atmospherics/pipe/manifold/visible/green{
+	dir = 1
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/meter,
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/turf/simulated/floor/plating,
-/area/station/maintenance/auxsolarport)
+/area/station/engineering/atmos/supermatter)
 "tXy" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/tank/oxygen,
@@ -79804,20 +80830,11 @@
 	},
 /area/station/hallway/secondary/entry)
 "tYI" = (
-/obj/machinery/atmospherics/pipe/simple/visible,
-/obj/machinery/door/airlock/external{
-	frequency = 1379;
-	id_tag = "atmospherics_inner";
-	locked = 1;
-	name = "Atmospherics External Access";
-	req_one_access = list(10,24)
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 6
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
-	},
-/area/station/engineering/atmos)
+/turf/simulated/floor/plating/airless/catwalk,
+/area/station/engineering/atmos/supermatter)
 "tYK" = (
 /turf/simulated/floor{
 	icon_state = "yellowcorner"
@@ -80095,7 +81112,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "udi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
@@ -80132,14 +81149,6 @@
 	icon_state = "vault"
 	},
 /area/station/hallway/primary/starboard)
-"udN" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor,
-/area/station/engineering/atmos)
 "udW" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
@@ -80151,17 +81160,16 @@
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
 "udX" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
-	dir = 8
+/obj/machinery/power/smes,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
-/obj/machinery/light/smart{
-	dir = 1
+/turf/simulated/floor/plating{
+	dir = 10;
+	icon_state = "warnplate"
 	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "vault"
-	},
-/area/station/engineering/atmos)
+/area/station/maintenance/auxsolarport)
 "uef" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -80209,7 +81217,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "ueD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -80297,10 +81305,21 @@
 	},
 /area/station/engineering/engine)
 "ugv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/visible,
+/obj/machinery/access_button{
+	command = "cycle_interior";
+	frequency = 1379;
+	master_tag = "engineering_east_airlock";
+	name = "interior access button";
+	pixel_x = -20;
+	pixel_y = -20;
+	req_access = list(10,13)
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "warning"
@@ -80353,6 +81372,21 @@
 	icon_state = "white"
 	},
 /area/station/medical/sleeper)
+"uhp" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/atmos/supermatter)
 "uhv" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -80411,7 +81445,7 @@
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
 "uhY" = (
-/obj/effect/landmark/start/assistant,
+/obj/effect/landmark/start/assistant/test_subject,
 /obj/structure/stool/bed/chair/comfy/brown{
 	dir = 4
 	},
@@ -80505,19 +81539,13 @@
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
 "uja" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
-	},
-/area/station/engineering/atmos)
+/turf/simulated/floor/plating,
+/area/station/maintenance/auxsolarport)
 "ujc" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/aiModule/reset,
@@ -80591,11 +81619,11 @@
 	},
 /area/station/rnd/tox_launch)
 "uki" = (
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "warndarkcorners"
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 8
 	},
-/area/station/engineering/atmos)
+/turf/simulated/floor/plating/airless/catwalk,
+/area/station/engineering/atmos/supermatter)
 "ukm" = (
 /turf/simulated/wall,
 /area/station/gateway)
@@ -80665,6 +81693,20 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/hor)
+"ula" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "ulc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
@@ -80882,29 +81924,16 @@
 /turf/simulated/floor/plating,
 /area/station/bridge/nuke_storage)
 "uns" = (
-/obj/structure/closet/crate{
-	name = "TEG crate"
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/item/weapon/circuitboard/teg,
-/obj/item/weapon/circuitboard/circulator,
-/obj/item/weapon/circuitboard/circulator,
-/obj/item/weapon/stock_parts/capacitor,
-/obj/item/weapon/stock_parts/capacitor,
-/obj/item/weapon/stock_parts/capacitor,
-/obj/item/weapon/stock_parts/console_screen,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/matter_bin,
-/obj/item/weapon/stock_parts/matter_bin,
-/obj/item/stack/cable_coil,
-/turf/simulated/floor{
-	icon_state = "bot"
+/turf/simulated/floor/plating/airless{
+	dir = 8;
+	icon_state = "warnplate"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/singularity)
 "unt" = (
 /turf/simulated/floor{
 	icon_state = "grimy"
@@ -81160,15 +82189,15 @@
 /area/station/cargo/storage)
 "urd" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/visible/red{
+/obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
-/obj/structure/window/fulltile/reinforced{
+/obj/structure/window/fulltile/reinforced/phoron{
 	grilled = 1;
-	icon_state = "gr_window_reinforced"
+	icon_state = "gr_window_reinforced_phoron"
 	},
 /turf/simulated/floor/plating,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "urf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -81454,7 +82483,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "uuy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -81589,7 +82618,7 @@
 /turf/simulated/floor/plating/airless{
 	icon_state = "warnplate"
 	},
-/area/station/engineering/singularity)
+/area/space)
 "uwq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -81617,11 +82646,11 @@
 	},
 /area/station/hallway/primary/central)
 "uwB" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -81684,7 +82713,7 @@
 	dir = 9;
 	icon_state = "brown"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "uxh" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -81742,11 +82771,14 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/fore)
 "uyQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/turf/simulated/floor,
-/area/station/engineering/atmos)
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/drone_fabrication)
 "uzb" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/phone{
@@ -81890,17 +82922,6 @@
 	},
 /area/station/medical/chemistry)
 "uBz" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
@@ -81908,26 +82929,15 @@
 /turf/simulated/floor{
 	icon_state = "yellowpatch"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "uBC" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
-	},
-/obj/structure/disposalpipe/junction{
-	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "yellowpatch"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "uBG" = (
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "4-4,6"
@@ -82026,7 +83036,7 @@
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "uDp" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/simulated/floor{
@@ -82034,7 +83044,7 @@
 	},
 /area/station/engineering/atmos)
 "uDx" = (
-/obj/effect/landmark/start/assistant,
+/obj/effect/landmark/start/assistant/test_subject,
 /obj/structure/stool/bed/chair/metal/red{
 	dir = 8
 	},
@@ -82116,7 +83126,7 @@
 /obj/structure/toilet{
 	dir = 8
 	},
-/obj/effect/landmark/start/assistant,
+/obj/effect/landmark/start/assistant/test_subject,
 /obj/machinery/light/small,
 /turf/simulated/floor{
 	icon_state = "bot"
@@ -82345,12 +83355,13 @@
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "uJe" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "caution"
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
-/area/station/engineering/atmos)
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/drone_fabrication)
 "uJi" = (
 /turf/simulated/wall,
 /area/station/rnd/chargebay)
@@ -82807,6 +83818,14 @@
 	icon_state = "darkbrown"
 	},
 /area/station/bridge)
+"uOU" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 5
+	},
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/atmos/supermatter)
 "uOV" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -82962,7 +83981,7 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "uRF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -83028,8 +84047,8 @@
 	},
 /area/station/bridge/captain_quarters)
 "uSZ" = (
-/obj/effect/landmark/start/assistant,
 /obj/structure/stool/bar,
+/obj/effect/landmark/start/assistant/waiter,
 /turf/simulated/floor/carpet/green,
 /area/station/civilian/bar)
 "uTh" = (
@@ -83122,12 +84141,16 @@
 "uUf" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating/airless,
-/area/space)
+/area/station/engineering/singularity)
 "uUk" = (
 /obj/structure/table/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"uUs" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "uUy" = (
 /obj/structure/stool/bed/chair{
 	dir = 4
@@ -83629,7 +84652,7 @@
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "van" = (
 /obj/structure/bookcase{
 	name = "bookcase (Religious)"
@@ -83772,7 +84795,7 @@
 	dir = 8;
 	icon_state = "vault"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "vch" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/black,
@@ -83795,7 +84818,7 @@
 /turf/simulated/floor{
 	icon_state = "darkbluefull"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "vcL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
@@ -83816,7 +84839,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "vdq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
@@ -83944,11 +84967,11 @@
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
 "vfU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/siphon/on/atmos{
-	dir = 8
+/obj/item/weapon/flora/random,
+/turf/simulated/floor{
+	icon_state = "warningcorner"
 	},
-/turf/simulated/floor/plating/airless/catwalk,
-/area/space)
+/area/station/engineering/atmos/supermatter)
 "vgf" = (
 /obj/machinery/photocopier,
 /obj/structure/cable{
@@ -84130,7 +85153,7 @@
 	dir = 8;
 	icon_state = "bluecorner"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "vic" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -84350,8 +85373,18 @@
 	name = "Engine Shutters";
 	opacity = 0
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/plating,
-/area/station/engineering/singularity)
+/area/station/engineering/engine)
 "vkR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -84521,6 +85554,15 @@
 	icon_state = "vault"
 	},
 /area/station/engineering/drone_fabrication)
+"vnf" = (
+/obj/structure/cable/yellow{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating{
+	icon_state = "platebot"
+	},
+/area/station/engineering/atmos/supermatter)
 "vnt" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/firstaid/regular,
@@ -84768,6 +85810,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"vqL" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating{
+	dir = 8;
+	icon_state = "warnplate"
+	},
+/area/station/engineering/engine)
 "vqO" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -84781,7 +85834,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "vqQ" = (
 /obj/machinery/door_control{
 	id = "Dorm5";
@@ -84851,7 +85904,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "vrV" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -84911,7 +85964,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "vsX" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -85164,11 +86217,12 @@
 	},
 /area/station/aisat/ai_chamber)
 "vwv" = (
+/obj/machinery/recharge_station,
 /turf/simulated/floor{
-	dir = 6;
-	icon_state = "warning"
+	dir = 8;
+	icon_state = "vault"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/drone_fabrication)
 "vwz" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/clipboard,
@@ -85227,6 +86281,19 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway)
+"vxg" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/atmos/supermatter)
 "vxj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -85298,7 +86365,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/airless,
-/area/station/maintenance/science)
+/area/station/engineering/singularity)
 "vyY" = (
 /turf/simulated/shuttle/floor/cargo{
 	icon_state = "2,1"
@@ -85528,6 +86595,17 @@
 	icon_state = "dark"
 	},
 /area/station/medical/chemistry)
+"vBB" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating/airless{
+	dir = 8;
+	icon_state = "warnplatecorner"
+	},
+/area/space)
 "vBL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
@@ -85574,11 +86652,9 @@
 	},
 /area/station/civilian/library)
 "vCv" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/engineering/atmos)
+/obj/structure/sign/warning/fire,
+/turf/simulated/wall/r_wall,
+/area/station/engineering/atmos/supermatter)
 "vCH" = (
 /turf/simulated/wall/r_wall,
 /area/station/rnd/hallway)
@@ -85714,12 +86790,6 @@
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "vault"
-	},
-/area/station/engineering/atmos)
-"vEB" = (
-/obj/structure/table/reinforced,
-/turf/simulated/floor{
-	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
 "vEF" = (
@@ -85942,11 +87012,16 @@
 	},
 /area/station/hallway/primary/central)
 "vGC" = (
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating/airless{
-	dir = 10;
+	dir = 9;
 	icon_state = "warnplate"
 	},
-/area/station/maintenance/science)
+/area/station/engineering/singularity)
 "vGK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -86076,6 +87151,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/bridge/hop_office)
+"vJD" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/engineering/singularity)
 "vJG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -86121,7 +87204,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "vKb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -86228,16 +87311,19 @@
 	},
 /area/station/civilian/chapel)
 "vLk" = (
-/obj/machinery/light/small,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -22
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
+/obj/structure/window/fulltile/reinforced/phoron{
+	grilled = 1;
+	icon_state = "gr_window_reinforced_phoron"
 	},
-/turf/simulated/floor{
-	dir = 10;
-	icon_state = "warning"
+/obj/machinery/meter{
+	frequency = 1444;
+	id = "in_sm_meter";
+	layer = 3.2;
+	name = "In Supermatter"
 	},
-/area/station/engineering/atmos)
+/turf/simulated/floor/engine,
+/area/station/engineering/atmos/supermatter)
 "vLs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -86272,11 +87358,16 @@
 	},
 /area/station/hallway/primary/starboard)
 "vLF" = (
-/turf/simulated/floor/plating/airless{
-	dir = 10;
-	icon_state = "warnplate"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/station/maintenance/engineering)
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "warning"
+	},
+/area/station/engineering/engine)
 "vLG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
@@ -86346,16 +87437,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/drone_fabrication)
-"vNa" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/sheet/glass{
-	amount = 50
-	},
-/obj/item/weapon/storage/briefcase/inflatable,
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/atmos)
 "vNc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
@@ -86393,6 +87474,14 @@
 	icon_state = "1,6"
 	},
 /area/shuttle/supply/station)
+"vNC" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/engineering/singularity)
 "vNN" = (
 /obj/machinery/light/smart,
 /turf/simulated/floor{
@@ -86436,10 +87525,14 @@
 	},
 /area/station/cargo/recycleroffice)
 "vOB" = (
-/turf/simulated/floor{
-	icon_state = "warning"
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/drone_fabrication)
 "vOQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -86506,6 +87599,12 @@
 	icon_state = "whitepurplefull"
 	},
 /area/station/rnd/hallway)
+"vPc" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "vPk" = (
 /turf/simulated/wall/r_wall,
 /area/station/engineering/atmos)
@@ -86533,16 +87632,13 @@
 	},
 /area/station/civilian/hydroponics)
 "vPR" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/stool/bed/chair/metal{
+	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "warning"
+	icon_state = "dark"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/drone_fabrication)
 "vPX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -86722,11 +87818,16 @@
 /turf/simulated/wall/r_wall,
 /area/station/aisat/antechamber_interior)
 "vSO" = (
-/turf/simulated/floor{
-	dir = 9;
-	icon_state = "warning"
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 5
 	},
-/area/station/engineering/atmos)
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "vTl" = (
 /obj/structure/table/woodentable,
 /obj/item/device/camera_film{
@@ -86854,6 +87955,17 @@
 	icon_state = "vault"
 	},
 /area/station/rnd/xenobiology)
+"vVi" = (
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/plating/airless{
+	dir = 10;
+	icon_state = "warnplate"
+	},
+/area/station/engineering/singularity)
 "vVj" = (
 /turf/simulated/floor{
 	dir = 5;
@@ -86882,7 +87994,7 @@
 /turf/simulated/floor{
 	icon_state = "darkblue"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "vVL" = (
 /obj/structure/closet/crate,
 /obj/item/stack/rods{
@@ -86936,6 +88048,12 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
+"vWq" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 5
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "vWv" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/item/weapon/reagent_containers/glass/bucket,
@@ -86951,14 +88069,11 @@
 	},
 /area/station/civilian/hydroponics)
 "vWF" = (
-/obj/machinery/computer/drone_control{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 10
 	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "warndarkcorners"
-	},
-/area/station/engineering/atmos)
+/turf/simulated/floor/plating/airless/catwalk,
+/area/station/engineering/atmos/supermatter)
 "vWH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -87586,7 +88701,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "wdO" = (
 /turf/simulated/floor,
 /area/station/maintenance/escape)
@@ -87659,16 +88774,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
-"wfx" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "warningcorner"
-	},
-/area/station/engineering/atmos)
 "wfH" = (
 /obj/structure/sign/nanotrasen,
 /turf/simulated/wall,
 /area/station/bridge/hop_office)
+"wfI" = (
+/obj/machinery/air_sensor{
+	frequency = 1443;
+	id_tag = "air_sensor";
+	output = 7
+	},
+/turf/simulated/floor/engine/airmix,
+/area/station/engineering/atmos)
 "wfK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -87679,7 +88796,7 @@
 	dir = 1;
 	icon_state = "yellowcorner"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "wfP" = (
 /obj/machinery/photocopier,
 /obj/machinery/camera{
@@ -87783,7 +88900,7 @@
 /turf/simulated/floor/plating{
 	icon_state = "warnplate"
 	},
-/area/station/engineering/singularity)
+/area/station/engineering/engine)
 "wii" = (
 /obj/machinery/ai_status_display{
 	pixel_y = 32
@@ -87883,13 +89000,8 @@
 	},
 /area/shuttle/escape_pod2/station)
 "wjb" = (
-/obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced/phoron{
-	grilled = 1;
-	icon_state = "gr_window_reinforced_phoron"
-	},
-/turf/simulated/floor/plating,
-/area/station/engineering/singularity)
+/turf/simulated/wall/r_wall,
+/area/station/engineering/break_room)
 "wjc" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -88049,6 +89161,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "wkD" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 5
+	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "warning"
@@ -88184,14 +89299,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/bridge)
-"wms" = (
-/obj/machinery/camera{
-	c_tag = "Turbine Generator Room";
-	network = list("SS13","Engineering");
-	dir = 5
-	},
-/turf/simulated/floor/engine,
-/area/station/engineering/atmos)
 "wmz" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -88225,7 +89332,7 @@
 	dir = 1;
 	icon_state = "yellow"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "wmM" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -88271,11 +89378,11 @@
 	},
 /area/station/maintenance/chapel)
 "wnj" = (
-/obj/machinery/light/smart,
-/turf/simulated/floor{
-	icon_state = "warning"
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging{
+	dir = 1
 	},
-/area/station/engineering/engine)
+/turf/simulated/floor/plating/airless/catwalk,
+/area/station/engineering/atmos/supermatter)
 "wno" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -88342,7 +89449,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "woA" = (
 /obj/machinery/computer/prisoner{
 	dir = 8
@@ -88399,6 +89506,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories)
+"wpR" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/atmos/supermatter)
 "wpS" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -88416,6 +89531,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
+"wqg" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "caution"
+	},
+/area/station/engineering/atmos/supermatter)
 "wqk" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
@@ -88506,6 +89630,14 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/hydroponics)
+"wrI" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/atmos/supermatter)
 "wrS" = (
 /obj/machinery/door/airlock/mining{
 	name = "Mining Dock";
@@ -88778,7 +89910,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -89020,10 +90151,10 @@
 /turf/simulated/floor,
 /area/station/civilian/toilet)
 "wAl" = (
-/obj/effect/landmark/start/assistant,
 /obj/structure/stool/bed/chair{
 	dir = 8
 	},
+/obj/effect/landmark/start/assistant/waiter,
 /turf/simulated/floor{
 	icon_state = "redchecker"
 	},
@@ -89440,7 +90571,7 @@
 /turf/simulated/wall,
 /area/station/medical/chemistry)
 "wEc" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "yellow"
@@ -89757,7 +90888,7 @@
 /turf/simulated/floor/plating/airless{
 	icon_state = "platebotc"
 	},
-/area/station/engineering/singularity)
+/area/space)
 "wIy" = (
 /obj/structure/rack,
 /obj/item/weapon/storage/toolbox/mechanical,
@@ -90073,10 +91204,11 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "wNt" = (
-/turf/simulated/floor{
-	icon_state = "yellowpatch"
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4
 	},
-/area/station/engineering/atmos)
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "wNM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/light/small{
@@ -90085,11 +91217,16 @@
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "wNU" = (
-/obj/machinery/space_heater,
-/turf/simulated/floor{
-	icon_state = "bot"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/engine)
 "wNY" = (
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_y = -32
@@ -90486,11 +91623,11 @@
 	pixel_x = -28;
 	pixel_y = -5
 	},
-/obj/machinery/space_heater,
+/obj/machinery/power/rad_collector,
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "wUb" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -90554,16 +91691,12 @@
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
 "wUK" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/air_sensor{
+	frequency = 1444;
+	id_tag = "sm_sensor"
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/engineering/atmos)
+/turf/simulated/floor/engine,
+/area/station/engineering/atmos/supermatter)
 "wUR" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
@@ -90572,15 +91705,21 @@
 	},
 /area/station/rnd/hallway)
 "wUS" = (
-/obj/machinery/camera{
-	c_tag = "Project Room North";
-	network = list("SS13","Engineering");
-	dir = 1
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile/reinforced/phoron{
+	grilled = 1;
+	icon_state = "gr_window_reinforced_phoron"
 	},
-/turf/simulated/floor{
-	icon_state = "yellow"
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "Sm";
+	layer = 2.8;
+	name = "Supermatter Shutters";
+	opacity = 0
 	},
-/area/station/engineering/atmos)
+/turf/simulated/floor/engine,
+/area/station/engineering/atmos/supermatter)
 "wVg" = (
 /obj/structure/stool,
 /obj/structure/window/thin{
@@ -90604,11 +91743,17 @@
 /turf/simulated/floor/plating,
 /area/station/medical/hallway)
 "wVj" = (
-/obj/machinery/atmospherics/pipe/simple/visible/yellow{
-	dir = 10
+/obj/machinery/computer/monitor{
+	dir = 4
 	},
-/turf/simulated/floor/plating/airless/catwalk,
-/area/space)
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowpatch"
+	},
+/area/station/engineering/atmos/supermatter)
 "wVt" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -91005,7 +92150,7 @@
 	dir = 4
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "xaF" = (
 /turf/simulated/floor,
 /area/station/civilian/hydroponics)
@@ -91092,7 +92237,7 @@
 	dir = 1
 	},
 /turf/simulated/floor,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "xbY" = (
 /turf/simulated/floor,
 /area/station/maintenance/medbay)
@@ -91145,11 +92290,15 @@
 	},
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Atmospherics Project Closet";
-	req_one_access = list(10,24)
+	req_access = list(24)
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/barricade/wooden{
+	layer = 2.8;
+	name = "doorway barricade"
+	},
 /turf/simulated/floor,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "xcZ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -91445,7 +92594,7 @@
 	dir = 4;
 	icon_state = "bluecorner"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "xgd" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -91636,6 +92785,10 @@
 	icon_state = "warndark"
 	},
 /area/station/security/armoury)
+"xiX" = (
+/obj/machinery/light/small,
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "xiZ" = (
 /obj/random/foods/food_trash,
 /turf/simulated/floor/airless/ceiling,
@@ -91666,7 +92819,7 @@
 	dir = 10;
 	icon_state = "blue"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "xjG" = (
 /obj/structure/stool/bed/chair{
 	dir = 8
@@ -91719,13 +92872,6 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge/hop_office)
-"xjX" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "vault"
-	},
-/area/station/engineering/atmos)
 "xkd" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -91747,7 +92893,7 @@
 	dir = 5;
 	icon_state = "warnplate"
 	},
-/area/station/engineering/singularity)
+/area/space)
 "xkv" = (
 /obj/machinery/light/small,
 /obj/machinery/embedded_controller/radio/airlock_controller{
@@ -91762,7 +92908,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "xkE" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -92650,7 +93796,7 @@
 "xvk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor,
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "xvs" = (
 /obj/structure/toilet{
 	dir = 8
@@ -92787,7 +93933,7 @@
 	req_access = list(24)
 	},
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "xxh" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -92868,7 +94014,7 @@
 	dir = 4;
 	icon_state = "bluecorner"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "xyb" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -93247,7 +94393,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "xBG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -93454,7 +94600,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /turf/simulated/floor/plating,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "xEL" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/light/small{
@@ -93555,17 +94701,23 @@
 	pixel_y = 22
 	},
 /turf/simulated/floor/wood,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "xFG" = (
 /obj/structure/stool/bar,
 /turf/simulated/floor/wood,
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "xFH" = (
 /obj/machinery/vending/engivend,
 /turf/simulated/floor{
 	icon_state = "delivery"
 	},
 /area/station/engineering/engine)
+"xFL" = (
+/obj/structure/cable,
+/turf/simulated/floor{
+	icon_state = "delivery"
+	},
+/area/station/engineering/atmos/supermatter)
 "xFM" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -93757,24 +94909,16 @@
 	},
 /area/station/storage/primary)
 "xKb" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/simulated/floor{
 	icon_state = "yellowpatch"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "xKc" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -93826,6 +94970,11 @@
 	layer = 2.8;
 	name = "Engine Shutters";
 	opacity = 0
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor{
 	icon_state = "delivery"
@@ -94064,16 +95213,9 @@
 	},
 /area/station/hallway/secondary/entry)
 "xNJ" = (
-/obj/machinery/shower/free{
-	pixel_y = 24
-	},
-/obj/structure/drain{
-	drainage = 2
-	},
-/turf/simulated/floor{
-	icon_state = "bot"
-	},
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/components/binary/valve,
+/turf/simulated/floor/engine,
+/area/station/engineering/atmos/supermatter)
 "xNK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -94144,7 +95286,7 @@
 	dir = 1;
 	icon_state = "caution"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "xOr" = (
 /obj/structure/window/thin/reinforced,
 /turf/simulated/floor{
@@ -94284,7 +95426,7 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/starboard)
 "xQv" = (
-/obj/effect/landmark/start/assistant,
+/obj/effect/landmark/start/assistant/test_subject,
 /obj/structure/stool/bed/chair/metal/white{
 	dir = 1
 	},
@@ -94302,22 +95444,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "xQy" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /turf/simulated/floor{
 	icon_state = "yellowpatch"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/atmos/supermatter)
 "xQz" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -94381,7 +95518,7 @@
 	dir = 8;
 	icon_state = "blue"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/break_room)
 "xRz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -94534,12 +95671,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
+"xTO" = (
+/turf/simulated/floor,
+/area/station/engineering/atmos/supermatter)
 "xTZ" = (
 /obj/structure/particle_accelerator/particle_emitter/right{
 	dir = 8
 	},
 /turf/simulated/floor/plating,
-/area/station/engineering/singularity)
+/area/station/engineering/engine)
 "xUd" = (
 /obj/structure/stool/bed/chair/comfy/brown,
 /obj/structure/cable{
@@ -94677,6 +95817,15 @@
 /obj/item/weapon/storage/box/cdeathalarm_kit,
 /turf/simulated/floor/wood,
 /area/station/security/blueshield)
+"xVu" = (
+/obj/machinery/atmospherics/pipe/simple/visible/yellow,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "xVv" = (
 /obj/structure/table/glass,
 /obj/item/device/antibody_scanner,
@@ -94903,7 +96052,7 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/engineering/engine)
+/area/station/engineering/minisat_secure_area)
 "xXS" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/soda{
@@ -95292,10 +96441,14 @@
 	},
 /area/station/medical/reception)
 "ycv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -95512,6 +96665,17 @@
 	icon_state = "bot"
 	},
 /area/station/storage/primary)
+"yfy" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/turf/simulated/floor/plating{
+	dir = 4;
+	icon_state = "warnplate"
+	},
+/area/station/engineering/engine)
 "yfN" = (
 /obj/structure/displaycase/labcage,
 /turf/simulated/floor{
@@ -95687,15 +96851,6 @@
 	icon_state = "dark"
 	},
 /area/station/bridge)
-"yjl" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "caution"
-	},
-/area/station/engineering/atmos)
 "yjy" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Atmospherics Storage";
@@ -113151,13 +114306,13 @@ plf
 plf
 plf
 plf
-pka
-kHU
-pka
-kHU
-pka
-pka
-pka
+plf
+plf
+plf
+plf
+plf
+plf
+plf
 plf
 plf
 plf
@@ -113404,21 +114559,21 @@ plf
 plf
 plf
 plf
-pka
-pka
-kHU
-pka
-pka
 plf
-kHU
 plf
-kHU
 plf
-pka
-pka
-kHU
-pka
-pka
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
 plf
 plf
 plf
@@ -113661,21 +114816,21 @@ plf
 plf
 plf
 plf
-pka
 plf
-kHU
 plf
-kHU
 plf
-cTq
-uXR
-njm
 plf
-kHU
 plf
-kHU
 plf
-pka
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
 plf
 plf
 plf
@@ -113918,21 +115073,21 @@ plf
 plf
 plf
 plf
-pka
 plf
-cTq
-uXR
-njm
 plf
-cTq
-uXR
-njm
 plf
-cTq
-uXR
-njm
 plf
-kHU
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
 plf
 plf
 plf
@@ -114175,21 +115330,6 @@ plf
 plf
 plf
 plf
-kHU
-plf
-cTq
-uXR
-njm
-plf
-cTq
-uXR
-njm
-plf
-cTq
-uXR
-njm
-plf
-pka
 plf
 plf
 plf
@@ -114235,15 +115375,30 @@ plf
 plf
 plf
 plf
-kHU
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
 plf
 kHU
+plf
 kHU
-nsa
-nsa
+kHU
+tvt
+tvt
 pzz
-nsa
-nsa
+tvt
+tvt
 kHU
 kHU
 kHU
@@ -114432,20 +115587,16 @@ plf
 plf
 plf
 plf
+plf
+plf
+plf
+plf
 pka
 kHU
-cTq
-uXR
-njm
+pka
 kHU
-cTq
-uXR
-njm
-kHU
-cTq
-uXR
-njm
-kHU
+pka
+pka
 pka
 plf
 plf
@@ -114492,15 +115643,19 @@ plf
 plf
 plf
 plf
+plf
+plf
+plf
+plf
 pka
 kHU
 kHU
 kHU
-nsa
+tvt
 xXN
 rOC
 xkv
-nsa
+tvt
 hbP
 hbP
 hbP
@@ -114508,8 +115663,8 @@ sEx
 pLs
 hbP
 hbP
-nsa
-nsa
+tvt
+tvt
 kHU
 kHU
 kHU
@@ -114520,7 +115675,7 @@ kHU
 kHU
 uUf
 uUf
-byu
+uZD
 uUf
 uUf
 kHU
@@ -114690,83 +115845,83 @@ plf
 plf
 plf
 pka
+pka
+kHU
+pka
+pka
 plf
-cTq
-uXR
-njm
+kHU
 plf
-cTq
-uXR
-njm
+kHU
 plf
-cTq
-uXR
-njm
+pka
+pka
+kHU
+pka
+pka
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
 plf
 kHU
 plf
 plf
 plf
-plf
-kHU
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-kHU
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-kHU
-plf
-plf
-plf
 kHU
 plf
 kHU
-nsa
-nsa
-nsa
+tvt
+tvt
+tvt
 uer
-nsa
-nsa
+tvt
+tvt
 btY
 mQa
 jUl
-nsa
+tvt
 vct
 cTi
 dgY
 pFO
-nsa
+tvt
 kHU
 plf
 kHU
@@ -114776,9 +115931,9 @@ plf
 kHU
 uUf
 uUf
-vgR
+oex
 hVy
-vgR
+oex
 uUf
 uUf
 kHU
@@ -114943,53 +116098,41 @@ plf
 plf
 plf
 plf
+plf
+plf
+plf
 pka
+plf
 kHU
-pka
-pka
+plf
+kHU
 plf
 cTq
 uXR
 njm
 plf
 kHU
-sqE
-kHU
-plf
-cTq
-uXR
-njm
 plf
 kHU
+plf
 pka
-lgc
-lgc
-pka
-lgc
-kHU
-pka
-kHU
-kHU
-pka
-pka
-pka
-kHU
-lgc
-lgc
-lgc
-kHU
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
 lgc
 lgc
 lgc
 kHU
-lgc
-lgc
-lgc
-lgc
-kHU
-kHU
-lgc
-lgc
 lgc
 lgc
 lgc
@@ -114998,6 +116141,18 @@ lgc
 lgc
 lgc
 lgc
+kHU
+kHU
+lgc
+lgc
+lgc
+lgc
+lgc
+kHU
+lgc
+lgc
+lgc
+lgc
 lgc
 kHU
 lgc
@@ -115009,12 +116164,12 @@ lgc
 lgc
 kHU
 kHU
-nsa
+tvt
 xxJ
 tbx
 jAI
 lbB
-nsa
+tvt
 hqw
 rgZ
 krn
@@ -115023,26 +116178,26 @@ lYm
 swv
 oFq
 ktv
-nsa
+tvt
 kHU
 plf
 kHU
 plf
 kHU
-qlj
-dfK
-gRp
-gRp
-xkn
-fKT
-dsj
-gRp
-gRp
-cNU
-qlj
-rii
-qlj
-rii
+plf
+dOV
+uns
+uns
+svn
+auq
+ikT
+uns
+uns
+jmS
+plf
+kHU
+plf
+kHU
 cjx
 aQr
 vnx
@@ -115200,33 +116355,33 @@ plf
 plf
 plf
 plf
+plf
+plf
+plf
 pka
 plf
-kHU
-kHU
+cTq
+uXR
+njm
 plf
-kHU
-sqE
-kHU
-kHU
-kHU
-hSk
-kHU
-kHU
-kHU
-sqE
-kHU
-kHU
-kHU
+cTq
+uXR
+njm
 plf
+cTq
+uXR
+njm
 plf
 kHU
 plf
 plf
-kHU
 plf
 plf
-kHU
+plf
+plf
+plf
+plf
+plf
 plf
 plf
 plf
@@ -115268,7 +116423,7 @@ plf
 kHU
 lLE
 jcC
-wMu
+sNY
 ghA
 hso
 jGd
@@ -115278,29 +116433,29 @@ vVG
 rKF
 nzd
 fts
-nsa
-nsa
-nsa
+tvt
+tvt
+tvt
 kHU
 plf
-ddt
-amw
-amw
-gRp
-fPf
+dOV
+uns
+uns
+uns
+mKw
 oex
-rii
-rii
-rii
-rii
-rii
+kHU
+kHU
+kHU
+kHU
+kHU
 oex
 gcG
-gRp
-gRp
-gRp
-cNU
-cjx
+uns
+uns
+uns
+jmS
+jwI
 fXg
 hpA
 mBA
@@ -115457,37 +116612,37 @@ plf
 plf
 plf
 plf
+plf
+plf
+plf
+kHU
+plf
+cTq
+uXR
+njm
+plf
+cTq
+uXR
+njm
+plf
+cTq
+uXR
+njm
+plf
 pka
-kHU
-ghI
-uvL
-hSk
-hSk
-hSk
-hSk
-hSk
-hSk
-hSk
-hSk
-hSk
-hSk
-hSk
-hSk
-hSk
-hSk
 plf
 plf
-kHU
 plf
 plf
-kHU
-vPk
-exF
-vPk
-vPk
-oRS
-vPk
-vPk
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+lgc
+lgc
 kHU
 lgc
 lgc
@@ -115528,35 +116683,35 @@ jcC
 njz
 fPC
 pGR
-nsa
+tvt
 qVq
 ksR
 sjd
-qBN
+idM
 qVq
 cyQ
-nsa
+tvt
 ear
-uZD
-qlj
-qlj
-fzd
+tvt
+plf
+plf
+ebv
 oex
-rii
-qlj
-qlj
-qlj
-qlj
+kHU
+plf
+plf
+plf
+plf
+vgR
+vgR
+vgR
+plf
+plf
+plf
+plf
+kHU
 oex
-oex
-oex
-qlj
-qlj
-qlj
-qlj
-rii
-oex
-xwj
+jjT
 oSJ
 ilA
 fVu
@@ -115714,37 +116869,37 @@ plf
 plf
 plf
 plf
+plf
+plf
+plf
+pka
+kHU
+cTq
+uXR
+njm
+kHU
+cTq
+uXR
+njm
+kHU
+cTq
+uXR
+njm
+kHU
+pka
+kHU
 pka
 plf
-kHU
-kHU
 plf
-kHU
-oyu
-kHU
-kHU
-kHU
-hSk
-kHU
-kHU
-kHU
-oyu
-kHU
-kHU
-hSk
-kHU
-kHU
-kHU
-kHU
-nHd
-nHd
-vPk
-hZk
-aXH
-wms
-cbA
-hAz
-oRS
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+pka
+plf
 kHU
 kHU
 kHU
@@ -115784,39 +116939,39 @@ lLE
 xfY
 fEV
 eLR
-nsa
-nsa
-nsa
-nsa
-nsa
-nsa
-nsa
-nsa
-nsa
-nsa
+tvt
+tvt
+tvt
+tvt
+tvt
+tvt
+tvt
+tvt
+tvt
+tvt
+tvt
 uZD
 uZD
-uZD
-fzd
-rii
-rii
-dfK
-gRp
-gRp
-gRp
-gRp
-gRp
-gRp
-gRp
-gRp
-gRp
-cNU
-rii
-rii
-xwj
-cjx
-cjx
-cjx
+ebv
+kHU
+kHU
+ewd
+qjA
+tiK
+tiK
+tiK
+qjA
+tiK
+tiK
+qjA
+tiK
+qJd
+kHU
+kHU
+jjT
+jwI
+jwI
+jwI
 pis
 cjx
 cjx
@@ -115971,38 +117126,38 @@ plf
 plf
 plf
 plf
+plf
+plf
+plf
 pka
-pka
-kHU
-kHU
 plf
 cTq
-fiZ
+uXR
+njm
+plf
+cTq
+uXR
+njm
+plf
+cTq
+uXR
 njm
 plf
 kHU
-oyu
-kHU
-plf
-cTq
-fiZ
-njm
-kHU
-hSk
-plf
 plf
 kHU
-nHd
-tGR
-aaS
-vPk
-svE
-tJv
-vPk
-mGQ
-vPk
-vPk
-nHd
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+kHU
+kHU
+kHU
 jXX
 jXX
 jXX
@@ -116041,38 +117196,38 @@ lLE
 jcC
 jiU
 awS
-kZh
+hrg
 kAz
 kpw
 dwf
-rwR
+txU
 lMI
 roV
 jIF
 vKa
 vKa
-uZD
-dfK
+tvt
 gRp
-cNU
-qlj
-dfK
+vVi
+mKw
+kHU
+ewd
 fPf
-gBi
-oex
-oex
-oex
-gBi
-oex
-oex
-gBi
-oex
+rfM
+vgR
+vgR
+vgR
+rfM
+vgR
+vgR
+rfM
+vgR
+vBB
+qJd
+kHU
 gcG
-cNU
-qlj
-dfK
-bhn
-vGC
+nos
+gRp
 hTd
 hmp
 cjx
@@ -116228,37 +117383,37 @@ plf
 plf
 plf
 plf
+pka
+kHU
+pka
+pka
+plf
+cTq
+uXR
+njm
+plf
+kHU
+sqE
+kHU
+plf
+cTq
+uXR
+njm
+plf
+kHU
+plf
+pka
+plf
+plf
+plf
+plf
+plf
+plf
 plf
 plf
 plf
 pka
 plf
-cTq
-fiZ
-njm
-plf
-cTq
-fiZ
-njm
-plf
-cTq
-fiZ
-njm
-plf
-hSk
-plf
-plf
-kHU
-ntO
-ioF
-nHd
-vPk
-oXk
-gqt
-vPk
-ebo
-sCr
-oRS
 kHU
 jXX
 sow
@@ -116294,43 +117449,43 @@ xXk
 ddJ
 jXX
 plf
-nsa
+tvt
 pYQ
 kJm
 kpo
-nsa
+tvt
 jYE
 hHS
 xaA
-rwR
+txU
 aDk
 fXa
 ttr
 qVs
 vKa
-uZD
-fzd
+tvt
 btC
-xwj
-qlj
-fzd
-oex
+peZ
+kHU
+kHU
+chy
+vgR
 wIr
-qlj
-qlj
+plf
+plf
 wIr
-qlj
-qlj
-qlj
-qlj
+plf
+plf
+plf
+plf
 wIr
-oex
-xwj
-qlj
-fzd
+vgR
+ajh
+kHU
+kHU
+abE
 vyR
-kRY
-cjx
+jwI
 hRb
 cjx
 rud
@@ -116485,38 +117640,38 @@ plf
 plf
 plf
 plf
+pka
+plf
+kHU
+kHU
+plf
+kHU
+sqE
+kHU
+kHU
+kHU
+hSk
+kHU
+kHU
+kHU
+sqE
+kHU
+kHU
+kHU
+plf
+pka
+plf
+plf
+plf
+plf
+plf
+plf
 plf
 plf
 plf
 pka
-kHU
-cTq
-fiZ
-njm
-plf
-cTq
-fiZ
-njm
-kHU
-cTq
-fiZ
-njm
-plf
-hSk
-plf
 plf
 kHU
-gcf
-plf
-plf
-oRS
-svE
-iBG
-vPk
-udN
-cSH
-vPk
-plf
 jXX
 sow
 xqi
@@ -116565,28 +117720,28 @@ ttr
 kHh
 aSl
 vKa
-hNK
-xkn
+hrg
 fKT
-dsj
-qlj
-fzd
+hmY
+plf
+plf
+dEz
+hfc
+plf
+plf
+plf
+kHU
+plf
+plf
+plf
+plf
+plf
 gBi
-qlj
-qlj
-qlj
-rii
-qlj
-qlj
-qlj
-qlj
-qlj
-gBi
-xwj
-qlj
-xkn
-sXQ
-ilb
+ctH
+plf
+plf
+bYp
+fKT
 hTd
 jUW
 cjx
@@ -116742,69 +117897,69 @@ plf
 plf
 plf
 plf
-plf
-plf
-plf
 pka
-plf
-cTq
-fiZ
-njm
 kHU
-cTq
-fiZ
-njm
-plf
-cTq
-fiZ
-njm
-plf
+ghI
+uvL
 hSk
-plf
-plf
+hSk
+hSk
+hSk
+hSk
+hSk
+hSk
+hSk
+hSk
+hSk
+hSk
+hSk
+hSk
+hSk
 kHU
-gcf
 kHU
-vPk
-vPk
-oXk
-gqt
-vPk
-udN
-cSH
-vPk
-nHd
+kHU
+pka
+kHU
+pka
+pka
+kHU
+pka
+pka
+kHU
+kHU
+kHU
+kHU
 jXX
 qYx
-sow
+fBh
 gvm
 jXX
 aBV
-wDG
+gUA
 qhc
 jXX
 hQz
-siW
+wfI
 cpy
 jXX
 kHU
 jXX
 dGz
-agn
+mcN
 xUT
 jXX
 mQk
-mkX
+lPO
 bOd
 jXX
 kkr
-iFl
+sbT
 dCg
 jXX
 kHU
 jXX
 oge
-ddJ
+jEB
 bIc
 jXX
 plf
@@ -116812,38 +117967,38 @@ lLE
 jcC
 jiU
 svS
-nsa
+tvt
 flj
 hHS
 auG
-rwR
+txU
 eNx
 qVs
 ttr
 fXa
 vKa
-uZD
+tvt
 fzd
-oex
-qlj
-rii
-fzd
-oex
-qlj
-qlj
-rii
-rii
-rii
-rii
-rii
-qlj
-qlj
-oex
+tiI
+plf
+kHU
+chy
+vgR
+plf
+plf
+kHU
+kHU
+kHU
+kHU
+kHU
+plf
+plf
+vgR
+ajh
+kHU
+plf
+tiI
 xwj
-rii
-qlj
-oSO
-kRY
 jwI
 eAC
 jwI
@@ -116999,38 +118154,38 @@ plf
 plf
 plf
 plf
-plf
-plf
+pka
 plf
 kHU
+kHU
 plf
-cTq
-fiZ
-njm
-plf
-cTq
-fiZ
-njm
-plf
-cTq
-fiZ
-njm
+kHU
+oyu
+kHU
+kHU
 kHU
 hSk
 kHU
 kHU
 kHU
-gcf
-nHd
-vPk
-pGs
-vCv
-fiP
-mKP
-dtg
-cSH
-vPk
-iOt
+oyu
+kHU
+kHU
+hSk
+plf
+plf
+kHU
+plf
+plf
+kHU
+plf
+plf
+kHU
+plf
+plf
+plf
+kHU
+kHU
 jXX
 fqR
 qIC
@@ -117069,37 +118224,37 @@ lLE
 jcC
 jiU
 svS
-kZh
+hrg
 nUN
 rmd
 aUR
-rwR
+txU
 rzs
 uur
 vqO
 gph
 lqF
-uZD
+tvt
 fzd
-oex
-rii
-rii
-fzd
-oex
-qlj
-qlj
-rii
+tiI
+kHU
+kHU
+chy
+vgR
+plf
+plf
+kHU
 dfK
-gRp
+byu
 cNU
-rii
-rii
+kHU
+kHU
 wIr
-oex
-xwj
-rii
-rii
-oex
+vgR
+ajh
+kHU
+kHU
+tiI
 xwj
 jwI
 buY
@@ -117256,12 +118411,8 @@ plf
 plf
 plf
 plf
-plf
-plf
-plf
-lgc
-plf
-kHU
+pka
+pka
 plf
 kHU
 plf
@@ -117270,23 +118421,27 @@ fiZ
 njm
 plf
 kHU
-plf
+oyu
 kHU
+plf
+cTq
+fiZ
+njm
 plf
 hSk
 plf
 plf
 kHU
-gcf
-vPk
-vPk
-cZS
-rCs
-dPj
-dPj
-wUK
-cSH
-oxO
+plf
+pka
+kHU
+plf
+pka
+kHU
+plf
+plf
+kHU
+kHU
 dRh
 kHU
 gcf
@@ -117312,7 +118467,7 @@ kHU
 gvV
 plf
 gcf
-nHd
+plf
 gvV
 plf
 kHU
@@ -117326,37 +118481,37 @@ lLE
 jcC
 jiU
 msK
-nsa
-nsa
-nsa
-nsa
-nsa
-nsa
-qBN
-nsa
-qBN
-nsa
-uZD
+tvt
+tvt
+tvt
+tvt
+tvt
+tvt
+idM
+tvt
+idM
+tvt
+tvt
 fzd
-oex
-rii
-rii
-fzd
-gBi
-qlj
-qlj
-rii
+tiI
+kHU
+kHU
+dEz
+hfc
+plf
+plf
+kHU
 kIG
 dLx
 uwk
-rii
-qlj
-qlj
+kHU
+plf
+plf
 gBi
-xwj
-rii
-rii
-oex
+ctH
+kHU
+kHU
+tiI
 xwj
 jwI
 ara
@@ -117516,33 +118671,33 @@ plf
 plf
 plf
 plf
-lgc
-lgc
-kHU
-lgc
-kHU
+pka
 plf
-kHU
+cTq
+fiZ
+njm
 plf
-kHU
+cTq
+fiZ
+njm
 plf
-kHU
-lgc
-plf
+cTq
+fiZ
+njm
 plf
 hSk
-plf
-plf
 kHU
-gcf
-vPk
-tmQ
-hVJ
-uja
-nnA
-xjX
-gAh
-ckv
+kHU
+kHU
+kHU
+kHU
+kHU
+kHU
+kHU
+kHU
+kHU
+kHU
+kHU
 vPk
 qbA
 oxO
@@ -117579,10 +118734,10 @@ bwm
 gmU
 vPk
 kHU
-nsa
+tvt
 dwo
 jiU
-svS
+gYL
 lLE
 plf
 kHU
@@ -117593,27 +118748,27 @@ kHU
 plf
 kHU
 plf
-uZD
+tvt
 fzd
-oex
-rii
-rii
-fzd
-oex
+tiI
+kHU
+kHU
+chy
+vgR
 wIr
-rii
-rii
+kHU
+kHU
 xkn
-fKT
+tji
 dsj
-rii
-qlj
-qlj
-oex
-xwj
-rii
-rii
-oex
+kHU
+plf
+plf
+vgR
+ajh
+kHU
+kHU
+tiI
 xwj
 jwI
 hBT
@@ -117773,34 +118928,34 @@ plf
 plf
 plf
 plf
+pka
+kHU
+cTq
+fiZ
+njm
 plf
-plf
-plf
-lgc
-lgc
-lgc
-lgc
-lgc
-lgc
-lgc
-lgc
-lgc
-lgc
+cTq
+fiZ
+njm
+kHU
+cTq
+fiZ
+njm
 kHU
 hSk
 plf
 plf
 kHU
-wVj
-pLb
-uJe
-biK
-grm
-kkH
-lIG
-lTZ
-vEB
-mOt
+plf
+plf
+plf
+rkx
+rkx
+rkx
+rkx
+rkx
+rkx
+vPk
 aBv
 sVH
 aIO
@@ -117828,19 +118983,19 @@ pUh
 nIE
 kSO
 iDp
-gRR
-pte
+tCV
+vPk
 dPL
 aaj
 npo
 rcA
 vPk
-nsa
-nsa
-nsa
+wjb
+wjb
+wjb
 vrC
-nsa
-nsa
+wjb
+wjb
 ehA
 ehA
 ehA
@@ -117852,26 +119007,26 @@ bmZ
 klO
 ehA
 fzd
-oex
-qlj
-rii
-fzd
-oex
-qlj
-qlj
-rii
-rii
-rii
-rii
-rii
-qlj
-qlj
-oex
+tiI
+plf
+kHU
+chy
+vgR
+plf
+plf
+kHU
+kHU
+kHU
+kHU
+kHU
+plf
+plf
+vgR
+ajh
+kHU
+plf
+tiI
 xwj
-rii
-qlj
-sCh
-exw
 jwI
 aFy
 gPy
@@ -118030,34 +119185,34 @@ plf
 plf
 plf
 plf
+pka
 plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
+cTq
+fiZ
+njm
 kHU
+cTq
+fiZ
+njm
 plf
-hSk
-kHU
-kHU
-kHU
-kHU
-vPk
-qIT
-rJE
+cTq
+fiZ
+njm
+plf
+oyu
+uja
+uja
+uja
+kAl
+kAl
+kAl
+kAl
 gII
-uyQ
-uNw
-gOl
-vEB
-tGM
+rDL
+atL
+rDL
+gII
+vPk
 mXF
 mQf
 ftF
@@ -118095,7 +119250,7 @@ vPk
 pPg
 scK
 rat
-jiU
+owf
 aVC
 pwz
 ehA
@@ -118108,27 +119263,27 @@ gRG
 pZo
 tJP
 ehA
-dfK
 gRp
-cNU
-qlj
-fzd
+kip
+plf
+plf
+dEz
+hfc
+plf
+plf
+plf
+plf
+plf
+kHU
+plf
+plf
+plf
 gBi
-qlj
-qlj
-qlj
-qlj
-qlj
-rii
-qlj
-qlj
-qlj
-gBi
-xwj
-qlj
-dfK
-pZb
-vLF
+ctH
+plf
+plf
+vGC
+gRp
 jwI
 qMT
 cMM
@@ -118287,36 +119442,36 @@ plf
 plf
 plf
 plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-lgc
-plf
-hyD
-plf
-plf
 kHU
 plf
-vPk
+cTq
+fiZ
+njm
+plf
+cTq
+fiZ
+njm
+plf
+cTq
+fiZ
+njm
+plf
+hyD
+kou
+mqw
+jYh
+dtg
+jze
 udX
 dzq
-vPR
-drM
-uNw
-jze
+cfr
+gMT
+aIJ
+gMT
 lMA
-tGM
+vPk
 jLh
-uNw
+cXC
 sox
 xKk
 xFB
@@ -118353,7 +119508,7 @@ tuv
 xFG
 flb
 mrJ
-dLz
+rnA
 hkG
 ehA
 eTL
@@ -118365,27 +119520,27 @@ qAl
 wzP
 tlv
 ehA
-fzd
 btC
-xwj
-qlj
-xkn
+peZ
+kHU
+kHU
+hQo
 sYc
 wIr
-qlj
-qlj
-qlj
-qlj
+plf
+plf
+plf
+plf
 wIr
-qlj
-qlj
+plf
+plf
 wIr
 pry
-dsj
-qlj
-fzd
-rnA
-exw
+oGO
+kHU
+kHU
+abE
+vyR
 jwI
 hBT
 gPy
@@ -118544,37 +119699,37 @@ plf
 plf
 plf
 plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
 lgc
-kHU
-hSk
-plf
 plf
 kHU
 plf
-vPk
+kHU
+plf
+cTq
+fiZ
+njm
+plf
+kHU
+plf
+kHU
+kHU
+kHU
+uja
+uja
+uja
+aqy
+pGs
 aJG
 fTJ
 rQM
 uyQ
-uNw
+cSH
 vOB
-yjl
-mOt
-jLh
-lQn
-bTG
+ltv
+tmQ
+lNd
+gqt
+cZS
 dkZ
 dEp
 dEp
@@ -118610,7 +119765,7 @@ xFF
 xFG
 flb
 uDn
-rZU
+bhn
 ude
 ehA
 geB
@@ -118622,27 +119777,27 @@ gws
 tED
 gWQ
 wtG
-xkn
-fKT
-dsj
-rii
-rii
-xkn
-fKT
-fKT
-fKT
-fKT
-fKT
-fKT
-fKT
-fKT
-fKT
-dsj
-rii
-rii
-xkn
-fKT
-dsj
+sNl
+gma
+vNC
+vJD
+oex
+hQo
+lwK
+lwK
+lwK
+lwK
+ilk
+lwK
+lwK
+lwK
+lwK
+oGO
+oex
+hap
+vNC
+cyw
+ilb
 jwI
 sgS
 gPy
@@ -118801,48 +119956,48 @@ plf
 plf
 plf
 plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
 lgc
+lgc
+kHU
+lgc
+kHU
 plf
-hSk
+kHU
+plf
+kHU
+plf
+kHU
+lgc
 plf
 plf
 kHU
 plf
-oRS
+plf
+kAl
+fiP
+ebo
 nrh
-jQF
-pbm
+kAl
+odD
 hsW
-aIJ
-gMT
-pZC
-mbj
-gxk
+vPR
+uJe
+pbm
+vPk
+gYu
 jLz
 aAr
-cmG
-cmG
-cmG
-cmG
-cmG
-cmG
-cmG
-cmG
-cmG
-cmG
-hLs
+qSk
+qSk
+qSk
+qSk
+qSk
+qSk
+qSk
+qSk
+qSh
+aWD
+ufr
 csb
 uwG
 bfg
@@ -118866,8 +120021,8 @@ vPk
 qnQ
 hEd
 fDg
-jiU
-rZU
+owf
+bhn
 hkb
 ehA
 fUz
@@ -118879,27 +120034,27 @@ tUJ
 otd
 scX
 ehA
-uZD
+nsa
 jUd
-uZD
-oex
-oex
-oex
-oex
-wjb
-wjb
-wjb
-wjb
-wjb
-wjb
-wjb
+nsa
+mVR
+vNC
+vNC
+iIT
+etj
+etj
+etj
+mJd
+etj
+etj
+etj
 nFZ
-oex
-oex
-nFZ
-uZD
+vNC
+vNC
+bjg
+nsa
 bmQ
-uZD
+nsa
 jwI
 hBT
 wTL
@@ -119061,44 +120216,44 @@ plf
 plf
 plf
 plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
-plf
+lgc
+lgc
+lgc
+lgc
+lgc
+lgc
+lgc
+lgc
+lgc
+lgc
 kHU
-plf
-hSk
-plf
-plf
+lgc
 kHU
-plf
-oRS
+kHU
+kAl
+iOL
+grm
 eQM
-fTJ
+kAl
 fRu
 ohU
 kCA
 vwv
 sWI
-mOt
+vPk
 jFr
-wEc
+bFn
 emc
-wEc
-wEc
+bFn
+npG
 wEc
 eKz
 qCV
 wEc
 qaU
-qSk
-qSh
-aWD
+cmG
+lts
+cmG
 qWm
 eZV
 bOJ
@@ -119122,8 +120277,8 @@ vPk
 vPk
 ifq
 ifq
-nsa
-kJm
+wjb
+dIH
 qJk
 aQc
 ehA
@@ -119136,27 +120291,27 @@ uLf
 ihP
 ghY
 ehA
-nZC
-oex
-uZD
-uZD
-wjb
-wjb
-wjb
-wjb
+mBg
+qDT
+nsa
+nsa
+bKu
+bKu
+bKu
+bKu
 iPv
-bAA
-bAA
+vqL
+mTb
 bAA
 gnl
-wjb
-wjb
-wjb
-wjb
-uZD
-uZD
-oex
-nZC
+bKu
+bKu
+bKu
+bKu
+nsa
+nsa
+aIU
+qQz
 jwI
 ijY
 buY
@@ -119327,31 +120482,31 @@ plf
 plf
 plf
 plf
-lgc
 plf
-oyu
-jOT
-jOT
-jOT
-jOT
+plf
+pka
+plf
+plf
+kAl
+cha
 kAl
 kAl
 kAl
-bcW
-kWv
-tGM
-tGM
-tGM
-tGM
-tGM
-bwm
+jbr
+jbr
+jbr
+jbr
+jbr
+vPk
+cbA
+vPk
 aYm
-bwm
+vPk
 aqK
-bwm
-tGM
-tGM
-tGM
+vPk
+vPk
+vPk
+cbA
 yec
 aWD
 hZG
@@ -119377,7 +120532,7 @@ imT
 vPk
 pMJ
 oVc
-cOU
+sXQ
 uxc
 ifq
 peC
@@ -119393,26 +120548,26 @@ ked
 gFB
 bQs
 ehA
-nZC
-oex
-uZD
+oON
+cum
+nsa
 arF
 iLP
 iLP
 iLP
-wjb
+bKu
 hxo
 seP
 pYC
 xTZ
 whN
-wjb
+bKu
 iLP
 iLP
 iLP
 arF
-uZD
-oex
+nsa
+nqo
 nZC
 jwI
 ijY
@@ -119584,31 +120739,31 @@ plf
 plf
 plf
 plf
-lgc
+plf
+plf
+pka
 kHU
-qOG
-apR
-lla
-ibG
-tUY
-jwn
-jYh
-mhb
-vSO
-gdY
-vLk
-vPk
-cgu
-gza
-cCw
-dIE
+kHU
+kHU
+qnU
+tMY
+uOU
+mJs
+dYH
+wVj
+mbj
+pzQ
+rwn
+gxk
+lvT
+spB
 shx
-ohW
-ohW
-ohW
-ohW
+jEa
+nnA
+jEa
+jEa
 nUv
-tGM
+vPk
 nWR
 aWD
 dLs
@@ -119636,10 +120791,10 @@ hsm
 rwr
 sQF
 dWt
-nsa
+wjb
 ifq
 vsI
-azf
+qlj
 ehA
 sPV
 bgu
@@ -119650,27 +120805,27 @@ kHq
 dAf
 ehA
 ehA
-uZD
+nsa
 tLA
-uZD
-rhs
+nsa
+ccL
+get
+gvH
 vkK
-vkK
-vkK
-uZD
-hxo
-dyt
+nsa
+diQ
+vWf
 oos
-dyt
-whN
-uZD
-vkK
-vkK
-vkK
+vWf
+lVc
+nsa
+obx
+aXN
+aXN
 rhs
-uZD
+nsa
 mtH
-uZD
+nsa
 jwI
 jwI
 cMM
@@ -119841,31 +120996,31 @@ plf
 plf
 plf
 plf
-lgc
+plf
 plf
 kHU
-jOT
-jOT
-jOT
+plf
+plf
+kHU
 qnU
-tSt
-cXC
-tXv
-jIZ
-kou
+tMY
+jOT
+qkK
+hUj
+cxI
+cxI
 kFq
-mrj
-ohW
-syn
-pjj
 rVz
-uNw
-uNw
-uNw
-uNw
-uNw
+rbD
+cGK
+rbD
+pxK
+rVz
+iVQ
+mKP
+cxI
 fBl
-tGM
+vPk
 ckm
 aWD
 hZG
@@ -119890,7 +121045,7 @@ rZO
 iIJ
 vPk
 fPg
-sUm
+oAn
 oLl
 kDq
 ifq
@@ -119913,15 +121068,15 @@ jQj
 ovz
 ifQ
 uwt
-uwt
-kZh
-tlb
+nwK
+nsa
+amp
 jTp
 nBf
 vWf
 mKD
-kZh
-uwt
+nsa
+iUS
 uwt
 uwt
 hpC
@@ -120098,31 +121253,31 @@ plf
 plf
 plf
 plf
+plf
+plf
 kHU
 plf
-lgc
 plf
-plf
-kAl
-gbs
+kHU
+qnU
 tMY
 qaF
-kAl
-bjK
-aqy
-nFq
+cgu
+mOt
+xTO
+cxI
+dPj
+dyt
+lMM
+lMM
+lMM
+dyt
+cxI
+cxI
+rHh
+xTO
+tlM
 vPk
-wNt
-uNw
-aWD
-aWD
-aWD
-aWD
-aWD
-aWD
-uNw
-kLT
-tGM
 lkH
 aWD
 hZG
@@ -120147,13 +121302,13 @@ tzW
 xYR
 vPk
 vbZ
-lHG
+amw
 vdm
 djy
 qdl
 mSX
 tWC
-eXS
+sud
 ewi
 eto
 hXN
@@ -120163,28 +121318,28 @@ xEt
 tya
 xEy
 pUu
-qgD
-bau
-tiK
+bae
+iMK
+wMu
 elw
 sUm
 mts
 dQD
-cOU
+deM
 kLE
 tlb
-vWf
+svZ
 gpM
-vWf
-mKD
+dcO
+jSv
 xKm
-cOU
+nfY
 dQD
 mEc
-rZU
-bau
+pom
+vLF
 cmi
-elw
+erQ
 rtL
 jwI
 buY
@@ -120355,31 +121510,31 @@ plf
 plf
 plf
 plf
+plf
+plf
 lgc
+kHU
 plf
-lgc
-plf
-plf
-kAl
-kAl
-kAl
-kAl
-kAl
-bcW
+kHU
+dyt
+dyt
+wrI
+gms
+iOz
 oTP
+rVz
+pgW
+dyt
+cCw
+cCw
+cCw
+dyt
+cxI
+cxI
+sFM
+xTO
+tlM
 vPk
-vPk
-qTl
-uNw
-aWD
-phV
-kic
-mkS
-oPF
-aWD
-uNw
-kLT
-bwm
 cfD
 bTG
 hZG
@@ -120421,8 +121576,8 @@ oiI
 bVH
 pUu
 jgS
-bau
-cbc
+mje
+oBb
 elw
 sUm
 shG
@@ -120430,16 +121585,16 @@ dQD
 ksU
 nsa
 fGh
-hmC
+yfy
 kkY
 hmC
 wyP
 nsa
-gUA
+ksU
 wDR
 oGF
 rZU
-jyK
+bau
 oBb
 elw
 jNg
@@ -120612,29 +121767,29 @@ plf
 plf
 plf
 plf
+plf
+plf
+pka
 lgc
 plf
 kHU
-plf
-vPk
-vPk
-mqw
-gcE
+dyt
+tyI
 fWb
-qua
-cbk
+ktI
+lla
 hyA
-vNa
-vPk
-wNt
-uNw
-aWD
-wUS
-tGM
-gUl
-cfD
-aWD
-uNw
+vWq
+dPj
+vCv
+gdY
+gdY
+gdY
+dyt
+dyt
+dyt
+ahx
+cxI
 xKb
 szc
 oXV
@@ -120661,15 +121816,15 @@ vPk
 vPk
 vPk
 vPk
-vPk
-nsa
+wjb
+wjb
 ifq
-nsa
+wjb
 fJs
-cOU
-iGx
+sXQ
+rii
 plf
-iGx
+rii
 wdN
 vhV
 ehA
@@ -120678,26 +121833,26 @@ fti
 lzo
 ehA
 jgS
-bau
+eom
 uwB
 fRP
 sUm
 caP
 wDR
-xBg
+hXd
 nsa
-hyN
+kZh
 bKu
 xta
 bKu
-hyN
+kZh
 nsa
-hXd
+xBg
 dQD
 bxE
 rZU
-bau
-cmi
+jyK
+wNU
 rsB
 jwI
 jwI
@@ -120868,32 +122023,32 @@ plf
 plf
 plf
 plf
+plf
+plf
+plf
 kHU
 kHU
 kHU
 kHU
-vPk
-vPk
-pvz
-aWD
-aWD
-aWD
-aWD
-ifz
+dyt
+tyI
+jOT
 aQP
-nUT
-vPk
-gll
-uNw
-aWD
-tiN
-tGM
+aQP
+aQP
+wqg
+gIe
+wUS
+hAz
+qyx
+gUl
+vLk
 xNJ
-cfD
-aWD
-uNw
-kLT
-bwm
+pLy
+jnQ
+klu
+amM
+vPk
 cfD
 aWD
 mJM
@@ -120918,15 +122073,15 @@ tLi
 kFO
 eya
 vWT
-vPk
+wjb
 gjn
-cOU
+sXQ
 tur
 lcI
-cOU
-iGx
+sXQ
+rii
 kHU
-iGx
+rii
 wdN
 nhc
 ehA
@@ -120955,7 +122110,7 @@ izG
 hCG
 vej
 eWb
-wnj
+elw
 jwI
 ijY
 buY
@@ -121125,30 +122280,30 @@ plf
 plf
 plf
 plf
+plf
+plf
+plf
 lgc
 plf
 kHU
 plf
-vPk
-dwK
-aWD
-aWD
-jnQ
-rnl
-msR
-gms
-nqD
-apm
-bcW
+dyt
+jgq
+qWH
+xFL
+xTO
+cxI
+vPc
+dPj
+wUS
+hAz
+hAz
+wUK
+tbt
+hAz
+shj
 wNt
-uNw
-aWD
-ufr
-tGM
-tGM
-uwG
-aWD
-uNw
+gTw
 uBC
 lXB
 qby
@@ -121180,12 +122335,12 @@ ndf
 dux
 bsA
 xOo
-cOU
-iGx
+sXQ
+rii
 kHU
-iGx
+rii
 wdN
-rZU
+bhn
 evV
 hiE
 pUK
@@ -121382,35 +122537,35 @@ plf
 plf
 plf
 plf
+plf
+plf
+plf
 lgc
 plf
 lgc
 kHU
-oRS
-aWD
-aWD
-pLy
-vWF
-jQF
-uki
-msR
-aWD
+dyt
+hrc
+cFP
+dsq
+dsq
+dsq
 rot
-ryS
-wNt
-uNw
-aWD
-tiN
+nFq
+wUS
+hAz
+gll
+rnl
 cBU
-tGM
+xNJ
 nwH
-aWD
-uNw
-kLT
-bwm
+bSs
+uUs
+hLs
+vPk
 gAr
 ivG
-aWD
+ula
 bmj
 tGM
 stm
@@ -121434,13 +122589,13 @@ ihX
 gRR
 hDP
 gjn
-cOU
+sXQ
 bUP
 uRD
-cOU
-iGx
+sXQ
+rii
 plf
-iGx
+rii
 hdV
 qJk
 evV
@@ -121639,32 +122794,32 @@ plf
 plf
 plf
 plf
+plf
+plf
+plf
 kHU
 kHU
 lgc
 plf
-oRS
-aWD
-aWD
-kmP
-jQF
-jQF
-jQF
-mga
-aWD
-rot
-bcW
-wNt
-uNw
-aWD
-tiN
-gUl
-tGM
-cfD
-aWD
-uNw
-kLT
-tGM
+dyt
+qZe
+mrj
+gcE
+lla
+gcE
+ddt
+lVh
+dyt
+gdY
+gdY
+gdY
+vCv
+dyt
+dyt
+pjj
+cxI
+tSt
+cbA
 gOw
 kic
 mkS
@@ -121689,12 +122844,12 @@ fKV
 hAe
 xWl
 vlF
-vPk
+wjb
 aPN
 xxe
 sBQ
 uRD
-cOU
+sXQ
 xEE
 mre
 pss
@@ -121896,32 +123051,32 @@ plf
 plf
 plf
 plf
+plf
+plf
+plf
 lgc
 plf
 lgc
 kHU
-oRS
-aWD
-aWD
-rHh
-esv
-iYj
-qAK
-qyx
-aWD
-rot
-ryS
-wNt
-uNw
-aWD
-etT
-lMM
-hQX
-qkK
-aWD
-uNw
+dyt
+tQu
+vxg
+qTl
+kWv
+jwn
+kWv
+bxl
+dyt
+vnf
+vnf
+vnf
+dyt
+cxI
+cxI
+pZC
+cxI
 rVK
-tGM
+dyt
 tEF
 tEF
 jcs
@@ -121952,13 +123107,13 @@ dTp
 sHQ
 fdB
 nPH
-cOU
+sXQ
 aaV
-cOU
+sXQ
 wdN
 qHP
 evV
-rSA
+rNN
 sVD
 szf
 gLd
@@ -122153,35 +123308,35 @@ plf
 plf
 plf
 plf
+plf
+plf
+plf
 lgc
 plf
 kHU
 plf
-vPk
-jEa
-aWD
-aWD
-sKN
-npG
-qyx
-aWD
-aWD
-rot
-bcW
-wNt
-uNw
-aWD
-aWD
-aWD
-aWD
-aWD
-aWD
-uNw
-kLT
-jQF
+dyt
+pvz
+tXv
+jIZ
+lla
+lla
+apm
+vSO
+dyt
+lMM
+lMM
+lMM
+dyt
+cxI
+cxI
+hQX
+xTO
+heH
+syg
 tEF
 dsQ
-rdK
+bjK
 xDJ
 rdK
 kop
@@ -122207,7 +123362,7 @@ awp
 odu
 sPq
 qkU
-nPn
+pZb
 hKk
 mRh
 gfv
@@ -122242,7 +123397,7 @@ eXS
 aCh
 lkw
 jwI
-pPD
+nlx
 lTI
 jwI
 jwI
@@ -122410,30 +123565,30 @@ plf
 plf
 plf
 plf
+plf
+plf
+plf
 kHU
 kHU
 kHU
 kHU
-vPk
-vPk
-nQk
-aWD
-aWD
-aWD
-shj
-aWD
-lQn
-bHz
-vPk
-wNt
-uNw
-uNw
-uNw
-uNw
-uNw
-uNw
-uNw
-uNw
+dyt
+dyt
+wpR
+naa
+hKc
+cVB
+srP
+bzS
+anN
+xVu
+dee
+dee
+ibG
+sCh
+bou
+sKN
+cxI
 kLT
 rNm
 tEF
@@ -122464,11 +123619,11 @@ owM
 ekM
 lPP
 sHQ
-jTW
+kRY
 eAq
-qBN
+exw
 oUf
-nsa
+wjb
 nsa
 abg
 nsa
@@ -122489,7 +123644,7 @@ rym
 cXU
 qER
 inM
-tiI
+qgD
 nsa
 yid
 sUm
@@ -122668,26 +123823,26 @@ plf
 plf
 plf
 plf
+plf
+plf
+plf
 lgc
 plf
 kHU
 plf
-vPk
-vPk
-tbt
-khK
-odD
-ahx
-jFS
-mcx
-vPk
-vPk
-wNt
-uNw
-uNw
+dyt
+iYj
+mFB
+naO
+esv
+fFf
+dIE
+jzv
+uhp
+cak
 ozK
 ohW
-cxI
+ohW
 ohW
 ohW
 xQy
@@ -122925,31 +124080,31 @@ plf
 plf
 plf
 plf
+plf
+plf
+plf
 lgc
 kHU
 lgc
 plf
-kHU
-vPk
+oSO
 urd
-urd
-oRS
-vPk
-vPk
-vPk
-vPk
-diQ
-wNt
-uNw
-uNw
+dyt
+dyt
+bcW
+dyt
+dyt
+msR
+dyt
+vfU
 kiy
 nir
-tGM
-tGM
+hNK
+hNK
 oRS
 xcK
 oRS
-tGM
+hNK
 tEF
 rdK
 rFe
@@ -123000,7 +124155,7 @@ ijf
 umV
 jwI
 eLj
-cJM
+lgM
 cOU
 gKu
 gLD
@@ -123182,28 +124337,28 @@ plf
 plf
 plf
 plf
-lgc
+plf
+plf
 plf
 lgc
 plf
+lgc
 kHU
-nHd
-vfU
-vfU
-nHd
-dsq
-jFs
-ahU
+kHU
+jyl
 tYI
-bSs
+ahU
+kGh
+tYI
+ahU
 jyl
 tWL
-sTo
+noZ
 gjf
-wfx
-tGM
+noZ
+dyt
 wTX
-wNU
+jFX
 cIt
 jFX
 ieI
@@ -123441,31 +124596,31 @@ plf
 plf
 plf
 plf
+plf
+plf
+plf
 lgc
 kHU
 kHU
-kHU
-kHU
-kHU
-kHU
-nHd
-vPk
-oRS
-vPk
-vPk
-vPk
-vPk
-noZ
+uki
+uki
+uki
+kGh
+uki
+uki
+uki
+dyt
+aaS
 nGb
-noZ
-vPk
-uNw
+xiX
+dyt
+xTO
 xvk
 oaG
 qrx
 xbN
 tEF
-bxl
+meD
 eax
 mVU
 fqh
@@ -123701,28 +124856,28 @@ plf
 plf
 plf
 kHU
-nHd
-nHd
-nHd
-nHd
-nHd
 kHU
-plf
 kHU
-plf
 kHU
-vPk
+vWF
+jFS
+vWF
+wnj
+jFS
+vWF
+jFS
+dyt
 adu
-kiy
+nGb
 lzv
-vPk
-uns
+dyt
+jFX
 eeX
 pAq
-jFX
+eeX
 jFX
 tEF
-exB
+lkD
 rdK
 kAU
 pxm
@@ -123979,7 +125134,7 @@ tEF
 tEF
 tEF
 tEF
-ciW
+uMS
 wwi
 wwi
 wwi
@@ -124230,12 +125385,12 @@ cuJ
 mTp
 qYH
 raD
-sxB
-sxB
-liK
-sxB
-sxB
-sxB
+cuJ
+cuJ
+mzO
+cuJ
+cuJ
+cuJ
 rtw
 wwi
 plf

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -14,9 +14,9 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "aaj" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Unfiltered & Air to Mix"
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Unfiltered & Air to Mix";
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 9;
@@ -304,7 +304,6 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/port)
 "abX" = (
-/obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/machinery/atmospherics/components/unary/portables_connector,
 /turf/simulated/floor{
 	icon_state = "bot"
@@ -1820,6 +1819,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/grille,
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
 "anO" = (
@@ -4002,6 +4002,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/item/device/multitool,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "vault"
@@ -5728,15 +5729,10 @@
 	},
 /area/station/hallway/primary/port)
 "blH" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/shoes/magboots{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/clothing/shoes/magboots,
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = 28
 	},
+/obj/machinery/vending/eva/engineering,
 /turf/simulated/floor,
 /area/station/engineering/engine)
 "blI" = (
@@ -6379,7 +6375,14 @@
 /turf/simulated/floor,
 /area/station/civilian/chapel/mass_driver)
 "btC" = (
-/obj/machinery/power/emitter,
+/obj/structure/cable/yellow{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/emitter{
+	anchored = 1;
+	state = 2
+	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/singularity)
 "btE" = (
@@ -8572,6 +8575,7 @@
 	pixel_x = 28;
 	pixel_y = -5
 	},
+/obj/structure/cable,
 /turf/simulated/floor,
 /area/station/engineering/engine)
 "bTd" = (
@@ -8822,6 +8826,18 @@
 	icon_state = "darkblue"
 	},
 /area/station/hallway/primary/starboard)
+"bWe" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/turf/simulated/floor,
+/area/station/engineering/minisat_secure_area)
 "bWo" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -9059,7 +9075,7 @@
 	},
 /area/station/engineering/drone_fabrication)
 "bYD" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
+/obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 10
 	},
 /turf/simulated/floor,
@@ -9213,6 +9229,10 @@
 /area/station/rnd/robotics)
 "caP" = (
 /obj/structure/table/reinforced,
+/obj/item/weapon/wrench,
+/obj/item/weapon/wrench{
+	pixel_y = -6
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -10138,11 +10158,6 @@
 	},
 /area/station/cargo/office)
 "cmi" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8
 	},
@@ -11901,6 +11916,12 @@
 	icon_state = "purple"
 	},
 /area/station/rnd/xenobiology)
+"cJB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/engineering/break_room)
 "cJC" = (
 /turf/simulated/floor{
 	icon_state = "bot"
@@ -14175,6 +14196,13 @@
 	freq = 1400;
 	location = "Engineering"
 	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "atmos";
+	name = "Atmos Blast Door";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/station/engineering/monitoring)
 "dpi" = (
@@ -15020,9 +15048,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/structure/window/fulltile{
+/obj/structure/window/fulltile/reinforced/tinted{
 	grilled = 1;
-	icon_state = "gr_window"
+	icon_state = "gr_window_reinforced_tinted"
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/chiefs_office)
@@ -16482,7 +16510,7 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/meeting_room)
 "dVb" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
+/obj/machinery/atmospherics/components/binary/pump{
 	name = "Unfiltered to Mix"
 	},
 /turf/simulated/floor{
@@ -17434,7 +17462,11 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/power/smes,
+/obj/structure/cable/yellow{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "warndark"
@@ -18097,8 +18129,11 @@
 /turf/simulated/floor/plating,
 /area/station/civilian/toilet)
 "erQ" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "warning"
 	},
@@ -18169,14 +18204,20 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "ete" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor{
 	icon_state = "yellowfull"
@@ -19639,6 +19680,15 @@
 	icon_state = "bluecorner"
 	},
 /area/station/engineering/minisat_secure_area)
+"eLT" = (
+/obj/structure/cable/yellow,
+/obj/machinery/power/emitter{
+	anchored = 1;
+	state = 2;
+	dir = 1
+	},
+/turf/simulated/floor/plating/airless,
+/area/station/engineering/singularity)
 "eMm" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -22408,6 +22458,7 @@
 	network = list("SS13","Engineering");
 	dir = 5
 	},
+/obj/item/weapon/screwdriver,
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "yellow"
@@ -28064,8 +28115,8 @@
 "gRV" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor{
 	dir = 10;
@@ -28167,6 +28218,7 @@
 /area/station/cargo/office)
 "gTw" = (
 /obj/machinery/hologram/holopad,
+/obj/structure/grille,
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
 "gTB" = (
@@ -29035,10 +29087,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -30267,6 +30319,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/engineering/break_room)
 "htF" = (
@@ -30903,11 +30958,6 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "warning"
@@ -31115,6 +31165,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "hCG" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "yellow"
@@ -33093,6 +33148,9 @@
 /obj/machinery/meter,
 /obj/machinery/light/smart{
 	dir = 8
+	},
+/obj/structure/grille{
+	destroyed = 1
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/supermatter)
@@ -36007,7 +36065,7 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "iMK" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
+/obj/machinery/atmospherics/components/binary/pump{
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -36776,11 +36834,6 @@
 	},
 /area/station/ai_monitored/eva)
 "iWj" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -36789,6 +36842,16 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -39215,6 +39278,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/grille,
 /turf/simulated/floor{
 	icon_state = "yellowpatch"
 	},
@@ -39295,11 +39359,6 @@
 /turf/simulated/floor,
 /area/station/engineering/minisat_secure_area)
 "jBe" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
@@ -40340,11 +40399,11 @@
 	},
 /area/station/civilian/dormitories)
 "jNg" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -32
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor{
 	icon_state = "delivery"
 	},
@@ -42207,10 +42266,10 @@
 /area/station/engineering/drone_fabrication)
 "kjY" = (
 /obj/structure/rack,
+/obj/item/clothing/suit/storage/hazardvest,
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson,
 /obj/item/weapon/tank/emergency_oxygen/engi,
-/obj/item/clothing/suit/storage/hazardvest,
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
@@ -42626,9 +42685,6 @@
 	},
 /area/station/security/brig)
 "kpo" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
 /obj/machinery/camera{
 	c_tag = "MiniSat Transit Hallway";
 	network = list("SS13","Engineering");
@@ -43513,7 +43569,7 @@
 	},
 /area/station/maintenance/atmos)
 "kAY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 9
 	},
 /turf/simulated/floor,
@@ -44289,19 +44345,23 @@
 	},
 /area/station/medical/genetics)
 "kJm" = (
-/obj/structure/cable{
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "Sm";
+	layer = 2.8;
+	name = "Supermatter Shutters";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/engineering/minisat_secure_area)
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "kJq" = (
 /obj/machinery/computer/secure_data/detective_computer,
 /turf/simulated/floor/carpet/red,
@@ -45963,6 +46023,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -48571,6 +48639,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/barricade/wooden,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/supermatter)
 "lNc" = (
@@ -48725,9 +48794,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -48987,16 +49058,15 @@
 	},
 /area/station/medical/storage)
 "lRS" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
+/turf/simulated/floor{
+	icon_state = "neutralfull"
 	},
-/turf/simulated/floor/plating,
-/area/station/engineering/monitoring)
+/area/station/engineering/engine)
 "lRU" = (
 /obj/machinery/power/terminal{
 	dir = 4
@@ -49009,10 +49079,6 @@
 	},
 /area/station/maintenance/chapel)
 "lRY" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 1;
-	name = "Mix to Filter"
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -49023,6 +49089,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Mix to Filter"
 	},
 /turf/simulated/floor{
 	icon_state = "bot"
@@ -49432,14 +49502,14 @@
 	},
 /area/station/engineering/minisat_secure_area)
 "lYB" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "warning"
 	},
@@ -51000,6 +51070,10 @@
 /obj/item/stack/cable_coil,
 /obj/item/weapon/tank/emergency_oxygen/engi,
 /obj/item/stack/cable_coil,
+/obj/item/weapon/screwdriver{
+	pixel_x = -2;
+	pixel_y = 6
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -51060,7 +51134,6 @@
 	name = "Engineering External Access";
 	req_access = list(10,13)
 	},
-/obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -52438,11 +52511,6 @@
 	},
 /area/station/civilian/dormitories)
 "mOd" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -53918,6 +53986,9 @@
 /obj/machinery/light/smart,
 /obj/structure/sign/warning/enginesafety{
 	pixel_y = -32
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "yellowcorner"
@@ -55846,7 +55917,7 @@
 /area/shuttle/escape_pod4/station)
 "nEK" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/hidden/red{
+/obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -56106,6 +56177,10 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway)
+"nHQ" = (
+/obj/structure/girder,
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "nHW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -57313,6 +57388,22 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
+"nXA" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile/reinforced/phoron{
+	grilled = 1;
+	icon_state = "gr_window_reinforced_phoron"
+	},
+/obj/machinery/door/poddoor{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "Singularity";
+	layer = 2.8;
+	name = "Engine Shutters";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/engine)
 "nXD" = (
 /obj/machinery/alarm{
 	pixel_x = 29;
@@ -57337,6 +57428,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/hallway/primary/fore)
+"nXZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/engineering/break_room)
 "nYg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
@@ -58826,7 +58929,6 @@
 /turf/environment/space/shuttle,
 /area/shuttle/escape_pod3/station)
 "otY" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
 	dir = 9;
@@ -58905,13 +59007,13 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/disposalpipe/sortjunction{
 	dir = 8;
 	name = "Tech Storage";
 	sortType = "Tech Storage"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -59232,7 +59334,7 @@
 	},
 /area/station/security/vacantoffice)
 "oBb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/universal{
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -61152,7 +61254,7 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "pai" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
+/obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 9
 	},
 /turf/simulated/floor,
@@ -62282,9 +62384,9 @@
 /area/station/security/interrogation)
 "pom" = (
 /obj/structure/cable{
-	d1 = 2;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
+	icon_state = "4-8"
 	},
 /turf/simulated/floor{
 	icon_state = "yellow"
@@ -63002,6 +63104,7 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
+/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/supermatter)
 "pxL" = (
@@ -63625,14 +63728,12 @@
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
 "pEO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "caution"
+	dir = 4;
+	icon_state = "bluecorner"
 	},
-/area/station/hallway/primary/port)
+/area/station/engineering/minisat_secure_area)
 "pEQ" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -65486,6 +65587,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
+"qbB" = (
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "qbC" = (
 /obj/machinery/computer/rdconsole{
 	dir = 8
@@ -65499,7 +65604,7 @@
 	},
 /area/station/rnd/hor)
 "qbF" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/structure/closet/secure_closet/engineering_electrical,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "warndark"
@@ -70430,6 +70535,11 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
 	},
+/obj/structure/cable/yellow{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "warning"
 	},
@@ -70520,11 +70630,7 @@
 /turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
 "rtL" = (
-/obj/machinery/power/smes,
-/obj/structure/cable/yellow{
-	d2 = 8;
-	icon_state = "0-8"
-	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
@@ -71296,6 +71402,11 @@
 	c_tag = "Enginnering SMES";
 	network = list("SS13","Engineering");
 	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor{
 	dir = 6;
@@ -73732,6 +73843,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/obj/structure/grille,
 /turf/simulated/floor{
 	icon_state = "yellowpatch"
 	},
@@ -74488,7 +74600,7 @@
 	},
 /area/station/engineering/atmos/supermatter)
 "sqb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -74851,17 +74963,8 @@
 	},
 /area/station/engineering/singularity)
 "svo" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
+/obj/machinery/power/terminal,
+/obj/structure/cable,
 /turf/simulated/floor{
 	icon_state = "yellowfull"
 	},
@@ -78214,11 +78317,6 @@
 	},
 /area/station/engineering/engine)
 "toJ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -80647,14 +80745,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /obj/structure/disposalpipe/sortjunction/flipped{
 	dir = 1;
 	name = "Engineering Break Room";
 	sortType = "Engineering Break Room"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/engineering/break_room)
 "tWH" = (
@@ -81582,7 +81678,7 @@
 /area/shuttle/supply/station)
 "ujB" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/hidden/cyan{
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -82273,7 +82369,7 @@
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "usl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/cyan{
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 10
 	},
 /turf/simulated/floor,
@@ -82934,6 +83030,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
+/obj/structure/grille,
 /turf/simulated/floor{
 	icon_state = "yellowpatch"
 	},
@@ -83180,6 +83277,8 @@
 /area/station/rnd/hallway)
 "uFw" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "warningcorner"
@@ -86362,8 +86461,11 @@
 /area/station/medical/chemistry)
 "vyR" = (
 /obj/machinery/power/emitter{
+	anchored = 1;
+	state = 2;
 	dir = 1
 	},
+/obj/structure/cable/yellow,
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/singularity)
 "vyY" = (
@@ -87358,16 +87460,11 @@
 	},
 /area/station/hallway/primary/starboard)
 "vLF" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "warning"
-	},
-/area/station/engineering/engine)
+/turf/simulated/floor,
+/area/station/engineering/break_room)
 "vLG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet,
@@ -90807,18 +90904,13 @@
 	},
 /area/station/rnd/robotics)
 "wHv" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
+	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -91207,6 +91299,7 @@
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4
 	},
+/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/supermatter)
 "wNM" = (
@@ -91542,6 +91635,12 @@
 	icon_state = "bot"
 	},
 /area/station/rnd/hallway)
+"wTp" = (
+/obj/structure/grille{
+	destroyed = 1
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/supermatter)
 "wTt" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -92230,11 +92329,6 @@
 "xbN" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
-	},
-/obj/machinery/camera{
-	c_tag = "Project Closet";
-	network = list("SS13","Engineering");
-	dir = 1
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
@@ -93473,12 +93567,12 @@
 /area/station/engineering/atmos)
 "xrB" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/red{
-	dir = 4
-	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/universal{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/monitoring)
@@ -94324,7 +94418,7 @@
 	},
 /area/station/cargo/storage)
 "xBg" = (
-/obj/machinery/vending/eva/engineering,
+/obj/structure/dispenser/phoron,
 /turf/simulated/floor{
 	icon_state = "bot"
 	},
@@ -114139,14 +114233,14 @@ plf
 plf
 plf
 plf
-kHU
-kHU
-kHU
-kHU
-kHU
-kHU
-kHU
-kHU
+plf
+plf
+plf
+plf
+plf
+plf
+plf
+plf
 pka
 pka
 pka
@@ -114396,7 +114490,7 @@ plf
 plf
 plf
 plf
-kHU
+plf
 plf
 plf
 plf
@@ -117451,7 +117545,7 @@ jXX
 plf
 tvt
 pYQ
-kJm
+jiU
 kpo
 tvt
 jYE
@@ -117484,7 +117578,7 @@ ajh
 kHU
 kHU
 abE
-vyR
+eLT
 jwI
 hRb
 cjx
@@ -117964,8 +118058,8 @@ bIc
 jXX
 plf
 lLE
-jcC
-jiU
+pEO
+bWe
 svS
 tvt
 flj
@@ -121269,8 +121363,8 @@ cxI
 dPj
 dyt
 lMM
-lMM
-lMM
+kJm
+kJm
 dyt
 cxI
 cxI
@@ -121337,7 +121431,7 @@ nfY
 dQD
 mEc
 pom
-vLF
+bau
 cmi
 erQ
 rtL
@@ -121528,7 +121622,7 @@ dyt
 cCw
 cCw
 cCw
-dyt
+wTp
 cxI
 cxI
 sFM
@@ -121593,10 +121687,10 @@ nsa
 ksU
 wDR
 oGF
-rZU
+pom
 bau
 oBb
-elw
+erQ
 jNg
 jwI
 gPy
@@ -121821,7 +121915,7 @@ wjb
 ifq
 wjb
 fJs
-sXQ
+vLF
 rii
 plf
 rii
@@ -121842,15 +121936,15 @@ wDR
 hXd
 nsa
 kZh
-bKu
+nXA
 xta
-bKu
+nXA
 kZh
 nsa
 xBg
 dQD
 bxE
-rZU
+pom
 jyK
 wNU
 rsB
@@ -122078,11 +122172,11 @@ gjn
 sXQ
 tur
 lcI
-sXQ
+vLF
 rii
 kHU
 rii
-wdN
+nXZ
 nhc
 ehA
 ehA
@@ -122110,7 +122204,7 @@ izG
 hCG
 vej
 eWb
-elw
+erQ
 jwI
 ijY
 buY
@@ -122335,11 +122429,11 @@ ndf
 dux
 bsA
 xOo
-sXQ
+cJB
 rii
 kHU
 rii
-wdN
+hdV
 bhn
 evV
 hiE
@@ -122597,7 +122691,7 @@ rii
 plf
 rii
 hdV
-qJk
+bhn
 evV
 oKM
 wCx
@@ -122622,7 +122716,7 @@ lTQ
 mPx
 lTQ
 ete
-lTQ
+lRS
 svo
 ehX
 jwI
@@ -122814,7 +122908,7 @@ gdY
 gdY
 gdY
 vCv
-dyt
+nHQ
 dyt
 pjj
 cxI
@@ -123066,7 +123160,7 @@ kWv
 jwn
 kWv
 bxl
-dyt
+qbB
 vnf
 vnf
 vnf
@@ -123100,7 +123194,7 @@ sHQ
 anX
 xrB
 chj
-lRS
+xrB
 sHQ
 sHQ
 dTp
@@ -123324,7 +123418,7 @@ lla
 apm
 vSO
 dyt
-lMM
+kJm
 lMM
 lMM
 dyt
@@ -124902,7 +124996,7 @@ blv
 blv
 sqb
 uck
-pEO
+sqb
 hQQ
 hQQ
 qTx

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -7425,9 +7425,11 @@
 	},
 /area/station/engineering/engine)
 "bFn" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 5
+	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "yellow"
+	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
 "bFo" = (
@@ -9321,17 +9323,7 @@
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
 "cbS" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "yellow"
@@ -12653,6 +12645,11 @@
 "cSH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -17838,16 +17835,17 @@
 /turf/simulated/floor,
 /area/station/rnd/tox_launch)
 "emc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -19598,7 +19596,7 @@
 	dir = 4;
 	pixel_x = 22
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
+/obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "yellow"
@@ -26046,15 +26044,15 @@
 	},
 /area/station/hallway/secondary/entry)
 "gqt" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -28729,12 +28727,19 @@
 /turf/simulated/floor/plating,
 /area/station/security/hos)
 "gYu" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "yellow"
+	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
 "gYv" = (
@@ -39705,6 +39710,9 @@
 	},
 /area/station/bridge/ai_upload)
 "jFr" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 10
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "yellow"
@@ -40322,17 +40330,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "jLz" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 6
 	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -47192,10 +47191,17 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "lts" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -54762,8 +54768,9 @@
 /turf/simulated/floor,
 /area/station/rnd/robotics)
 "npG" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 6
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -65533,7 +65540,7 @@
 	},
 /area/station/engineering/atmos/supermatter)
 "qaU" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
+/obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "yellowcorner"
@@ -67582,7 +67589,7 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
+/obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "yellow"
@@ -90831,10 +90838,11 @@
 /turf/simulated/wall,
 /area/station/medical/chemistry)
 "wEc" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel,
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 10
+	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "yellow"
+	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
 "wEp" = (
@@ -120005,7 +120013,7 @@ ltv
 tmQ
 lNd
 gqt
-cZS
+gYu
 dkZ
 dEp
 dEp
@@ -120260,19 +120268,19 @@ vPR
 uJe
 pbm
 vPk
-gYu
-jLz
-qSk
-qSk
-qSk
-qSk
-qSk
-qSk
-qSk
-qSk
-qSk
-qSh
+jLh
 aWD
+lts
+cZS
+jLz
+cmG
+cmG
+cmG
+cmG
+cmG
+cmG
+cmG
+bFn
 ufr
 csb
 uwG
@@ -120520,16 +120528,16 @@ vPk
 jFr
 cbS
 emc
-bFn
+cbS
 npG
-wEc
+cbS
 eKz
 qCV
-wEc
+cbS
 qaU
-cmG
-lts
-cmG
+qSk
+qSh
+wEc
 qWm
 eZV
 bOJ

--- a/taucetistation.dme
+++ b/taucetistation.dme
@@ -491,6 +491,7 @@
 #include "code\game\area\awaymission_areas.dm"
 #include "code\game\area\centcom_areas.dm"
 #include "code\game\area\custom_areas.dm"
+#include "code\game\area\delta_areas.dm"
 #include "code\game\area\gamma_areas.dm"
 #include "code\game\area\main_areas.dm"
 #include "code\game\area\shuttle_areas.dm"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Заремаплена инженерка и атмос. Удалён каркас суперматерии с двигательного отсека и поставлена привычная для нас тесло-синга. Верхние отсеки атмоса были переделаны в дронную и строительную площадку под суперматерию (последняя не имеет энергопитания раундстартом).
![2023 06 22-15 54 13](https://github.com/TauCetiStation/TauCetiClassic/assets/96499407/84196baf-c5a3-456e-89bd-ea3bf0381854)
Нагрузку на атмос тестил, с сгоревшей токсинной работает как и должен. Сингулярность запускал, СМЕСы заряжает, не выпрыгивает за заборы (по крайней мере за 20-30 минут теста).
## Почему и что этот ПР улучшит
Закрытие пункта из TODO листа по ремапам на Дельте в закрепах мап-канала.
## Авторство

## Чеинжлог
