### PR TITLE
Массаж сердца

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -115,6 +115,7 @@ var/global/bridge_secret = null
 	var/health_threshold_softcrit = 0
 	var/health_threshold_crit = 0
 	var/health_threshold_dead = -100
+	var/health_threshold_cpr_allowed = -150
 
 	var/organ_health_multiplier = 1
 	var/organ_regeneration_multiplier = 1

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -2185,9 +2185,9 @@
 	var/obj/item/organ/internal/heart/Heart = organs_by_name[O_HEART]
 	var/obj/item/organ/internal/heart/Lungs = organs_by_name[O_LUNGS]
 
-	var/needed_massages = 12
+	var/needed_massages = 24
 	if(HAS_TRAIT(src, TRAIT_FAT))
-		needed_massages = 20
+		needed_massages = 42
 	if(Lungs && !Lungs.is_bruised())
 		adjustOxyLoss(-1.5)
 
@@ -2201,7 +2201,7 @@
 			massages_done_right = 0
 			return_to_body_dialog()
 
-			if(health > config.health_threshold_dead)
+			if(health > config.health_threshold_cpr_allowed)
 				Heart.heart_fibrillate()
 				to_chat(user, "<span class='notice'>You feel an irregular heartbeat coming form [src]'s body. It is in need of defibrillation you assume!</span>")
 			else
@@ -2242,7 +2242,7 @@
 	last_massage = world.time
 
 	var/obj/item/organ/external/BP = get_bodypart(Heart.parent_bodypart)
-	if (((BP.body_zone == BP_CHEST && op_stage.ribcage != 2) || BP.open < 2) && prob(5))
+	if (((BP.body_zone == BP_CHEST && op_stage.ribcage != 2) || BP.open < 2) && prob(1))
 		BP.fracture()
 		to_chat(user, "<span class='warning'>You hear cracking in [src]'s [BP]!.</span>")
 


### PR DESCRIPTION
## Описание изменений
Повысил порог массажа сердца до 150. Чтобы реанимировать человека гетто-способом надо сбросить урон на человеке до 150. Чтобы реанимировать человека дефибриллятором - всё также нужно сбросить урон до 100. Увеличил требуемое количество массажей сердца для реанимации человека.

## Почему и что этот ПР улучшит
Мотив этому таков, что при наличии дефибриллятора у тебя есть и Аппарат Искусственного Кровообращения, который поможет тебе сбросить урон на кукле до приемлемых значений. При гетто же реанимации, у тебя есть небольшой шанс сбросить 20-30 brute/burn урона на тушке, чтобы попытаться реанимировать. Запуск же сердца в фибрилляцию по завышенному критерию урона позволит имитировать АИК вручную.

## Авторство
AndreyGysev и все все все, кто помогал в дискорде.

## Чеинжлог
 :cl:
  - tweak: Введение сердца в фибрилляцию теперь возможно при уроне до 150 единиц. Требуемое для реанимации количество массажей сердца увеличено в 2 раза.