### PR TITLE
Less Nukies in lowpop

### DIFF
--- a/code/game/gamemodes/factions/syndicate.dm
+++ b/code/game/gamemodes/factions/syndicate.dm
@@ -53,24 +53,6 @@
 /datum/faction/nuclear/can_setup(num_players)
 	if (!..())
 		return FALSE
-	var/datum/game_mode/G = SSticker.mode
-	var/list/all_players = G.get_ready_players(check_ready = TRUE)
-	var/number_of_possible_security = 0
-	for(var/mob/M in all_players)
-		for(var/level in JP_LEVELS)
-			var/find_next_candidate = FALSE
-			for(var/job_title in global.security_positions)
-				if(M.client?.prefs?.job_preferences[job_title] == level)
-					//player with low prior most likely won't fit to that job
-					number_of_possible_security += level / 3
-					find_next_candidate = TRUE
-					break
-			if(find_next_candidate)
-				break
-
-	if(number_of_possible_security < ((min_roles + max_roles) / 2))
-		max_roles = clamp((max_roles), min_roles, number_of_possible_security * 1.5)
-
 	// Looking for map to nuclear spawn points
 	return length(landmarks_list["Syndicate-Commander"]) > 0 && length(landmarks_list["Syndicate-Spawn"]) > 0
 

--- a/code/game/gamemodes/factions/syndicate.dm
+++ b/code/game/gamemodes/factions/syndicate.dm
@@ -53,8 +53,23 @@
 /datum/faction/nuclear/can_setup(num_players)
 	if (!..())
 		return FALSE
+	var/datum/game_mode/G = SSticker.mode
+	var/list/all_players = G.get_ready_players(check_ready = TRUE)
+	var/number_of_possible_security = 0
+	for(var/mob/M in all_players)
+		for(var/level in JP_LEVELS)
+			var/find_next_candidate = FALSE
+			for(var/job_title in global.security_positions)
+				if(M.client?.prefs?.job_preferences[job_title] == level)
+					//player with low prior most likely won't fit to that job
+					number_of_possible_security += level / 3
+					find_next_candidate = TRUE
+					break
+			if(find_next_candidate)
+				break
 
-	max_roles = clamp((num_players/5), MIN_OPS, MAX_OPS)
+	if(number_of_possible_security < ((min_roles + max_roles) / 2))
+		max_roles = clamp((max_roles), min_roles, number_of_possible_security * 1.5)
 
 	// Looking for map to nuclear spawn points
 	return length(landmarks_list["Syndicate-Commander"]) > 0 && length(landmarks_list["Syndicate-Spawn"]) > 0

--- a/code/game/gamemodes/factions/syndicate.dm
+++ b/code/game/gamemodes/factions/syndicate.dm
@@ -53,6 +53,8 @@
 /datum/faction/nuclear/can_setup(num_players)
 	if (!..())
 		return FALSE
+
+	max_roles = clamp((num_players/5), MIN_OPS, MAX_OPS)
 	// Looking for map to nuclear spawn points
 	return length(landmarks_list["Syndicate-Commander"]) > 0 && length(landmarks_list["Syndicate-Spawn"]) > 0
 

--- a/code/game/gamemodes/modes_declares/nuclear.dm
+++ b/code/game/gamemodes/modes_declares/nuclear.dm
@@ -27,7 +27,7 @@
 				break
 	number_of_possible_security = pos_cadets / 2 + pos_officers
 	for(var/datum/faction/F in factions)
-		var/possible_max_roles = min(number_of_possible_security * 1.5, F.max_roles)
+		var/possible_max_roles = min(round(number_of_possible_security * 1.5), F.max_roles)
 		F.max_roles = clamp(possible_max_roles, F.min_roles, F.max_roles)
 	return ..()
 

--- a/code/game/gamemodes/modes_declares/nuclear.dm
+++ b/code/game/gamemodes/modes_declares/nuclear.dm
@@ -8,6 +8,29 @@
 	minimum_player_count = 15
 	minimum_players_bundles = 25
 
+/datum/game_mode/nuclear/PopulateFactions()
+	if(!factions.len)
+		return ..()
+	var/list/all_players = get_ready_players(check_ready = TRUE)
+	var/number_of_possible_security = 0
+	var/pos_cadets = 0
+	for(var/mob/M in all_players)
+		for(var/level in JP_LEVELS)
+			if(M.client?.prefs?.job_preferences["Security Cadet"] == level)
+				pos_cadets += level / 3
+				break
+	var/pos_officers = 0
+	for(var/mob/M in all_players)
+		for(var/level in JP_LEVELS)
+			if(M.client?.prefs?.job_preferences["Security Officer"] == level)
+				pos_officers += level / 3
+				break
+	number_of_possible_security = pos_cadets / 2 + pos_officers
+	for(var/datum/faction/F in factions)
+		var/possible_max_roles = min(number_of_possible_security * 1.5, F.max_roles)
+		F.max_roles = clamp(possible_max_roles, F.min_roles, F.max_roles)
+	return ..()
+
 /datum/game_mode/nuclear/announce()
 	to_chat(world, "<B>The current game mode is - Nuclear Emergency!</B>")
 	to_chat(world, "<B>Gorlex Maradeurs are approaching [station_name()]!</B>")


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Я не знаю узнать работает ли этот код или нет, но по идее это собирает всех людей которые готовы на момент начала раунда, в зависимости от выставленных префов рассчитывает примерное колличество абстрактных "офицеров". Устанавливает колличество нюкеров в размере колличество офицеров * 1.5.
То есть если в раунде: 
3+ офицера = 6 нюкеров
3 кадета = 3 нюкера
2 кадета 1 офицер = 3 нюкера
0 сб = 2 нюкера
## Почему и что этот ПР улучшит
closes #2184, нюка при отсутствии педального вмешательства будет менее говном.
## Авторство
помогали людук и волас
## Чеинжлог
:cl: Deahaka
- balance: Теперь отряд Ядерной Угрозы появляется в меньшем колличестве при низком онлайне.