### PR TITLE
Фикс метаболизма карбонов (кроме людей)

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -31,7 +31,7 @@
 
 	var/co2overloadtime = null
 
-	var/datum/modval/metabolism_factor = new (METABOLISM_FACTOR, multiple = 0.0)
+	var/datum/modval/metabolism_factor = new (METABOLISM_FACTOR)
 
 	var/obj/item/head
 	var/obj/item/shoes

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -46,6 +46,7 @@
 
 	if(species) // Just to be sure.
 		metabolism_factor.Set(species.metabolism_mod)
+		metabolism_factor.AddModifier("NeedHeart", multiple=-1)
 		butcher_results = species.butcher_drops.Copy()
 
 	dna.species = species.name


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
В modval убрал multiple=0 у всех карбонов, добавил модификатор c multiple=-1 (чтобы без сердца было 0) у людей.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
🆑 
- fix: Матрышки снова метаболизируют вещества (включая радий для антител)
