### PR TITLE
Откат уменьшения стана тактикал бол

### DIFF
--- a/code/game/objects/items/weapons/legcuffs.dm
+++ b/code/game/objects/items/weapons/legcuffs.dm
@@ -108,7 +108,7 @@
 	icon_state = "bola_r"
 	breakouttime = LEGCUFF_BREAKTIME_REINFORCED_BOLA
 	origin_tech = "engineering=4;combat=3"
-	weaken = 2
+	weaken = 6
 	throw_range = 5
 
 #undef LEGCUFF_BREAKTIME_DEFAULT


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Бола за деньги отличается от обычной 1 секундой стана. Мотивация покупать предмет убита.
## Почему и что этот ПР улучшит
завершение отката нерфа бол на хорошей ноте https://github.com/TauCetiStation/TauCetiClassic/pull/11013
## Авторство
Симбака напомнил
## Чеинжлог
:cl: Deahaka
- del: Время оглушения тактической болы предателей и ядерных оперативников возвращено до больших значений.