### PR TITLE
pda salary fix

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1920,6 +1920,8 @@
 /obj/item/device/pda/proc/check_rank(rank)
 	if((rank in command_positions) || (rank == "Quartermaster"))
 		boss_PDA = 1
+	else
+		boss_PDA = 0
 
 /obj/item/device/pda/proc/check_pda_server()
 	if(!global.message_servers)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
было: 
в ПДА карта главы? -> даём кнопку смены зарплат; в ПДА карта НЕ главы? -> ничего не делаем (если до этого дали кнопку смены зарплат, то никак её не забираем)

будет:
в ПДА карта НЕ главы? -> забираем кнопку смены зарплат (точнее забираем у ПДА статус boss_pda)

## Почему и что этот ПР улучшит
closes #11622
## Авторство

## Чеинжлог
