### PR TITLE
Генкасмерть говна

### DIFF
--- a/code/game/gamemodes/modes_gameplays/changeling/powers/fakedeath.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/fakedeath.dm
@@ -29,7 +29,7 @@
 		user.fake_death = FALSE
 		return FALSE
 	to_chat(user, "<span class='notice'>We begin our stasis, preparing energy to arise once more.</span>")
-	addtimer(CALLBACK(src, PROC_REF(give_revive_ability), user), rand(800, 2000))
+	addtimer(CALLBACK(src, PROC_REF(give_revive_ability), user), rand(1200, 2400))
 
 	feedback_add_details("changeling_powers","FD")
 	return TRUE

--- a/code/game/gamemodes/modes_gameplays/changeling/powers/fakedeath.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/fakedeath.dm
@@ -29,7 +29,7 @@
 		user.fake_death = FALSE
 		return FALSE
 	to_chat(user, "<span class='notice'>We begin our stasis, preparing energy to arise once more.</span>")
-	addtimer(CALLBACK(src, PROC_REF(give_revive_ability), user), rand(1200, 2400))
+	addtimer(CALLBACK(src, PROC_REF(give_revive_ability), user), rand(2, 3) MINUTES)
 
 	feedback_add_details("changeling_powers","FD")
 	return TRUE


### PR DESCRIPTION
## Описание изменений
Увеличил время реса генки с 800/2000 до 1200/2000.

## Почему и что этот ПР улучшит
По пошло нахуй блять генка ресался за минуту, вы ебанулись там в край, убивать уже пойманного генку два раза подряд пока несёте его в церковь. Нахуй так жить.

## Авторство
AndreyGysev и горящий стул.

## Чеинжлог
 :cl:
  - tweak: Увеличено время реса генки на 40 секунд гарантированно. Нахуй так жить.