### PR TITLE
New default light mode

### DIFF
--- a/code/modules/lighting/lamps/light_modes.dm
+++ b/code/modules/lighting/lamps/light_modes.dm
@@ -2,7 +2,7 @@ var/global/list/datum/light_mode/light_modes_by_type
 var/global/list/datum/light_mode/light_modes_by_name // for admins, may differ in content from light_modes_by_type
 
 #define DEFAULT_RANGE 8
-#define DEFAULT_POWER 2
+#define DEFAULT_POWER 2 // new more common default - 0.8
 
 /datum/light_mode
 	var/name
@@ -17,8 +17,8 @@ var/global/list/datum/light_mode/light_modes_by_name // for admins, may differ i
 /datum/light_mode/default
 	name = "Default"
 
-	color = "#ffffff" // todo: replace with softer light (6500К - #FFF9FD?)
-	power = DEFAULT_POWER
+	color = "#fff9fd"
+	power = 0.8
 	range = DEFAULT_RANGE
 
 /datum/light_mode/default/bulb

--- a/code/modules/lighting/lamps/light_modes.dm
+++ b/code/modules/lighting/lamps/light_modes.dm
@@ -18,8 +18,8 @@ var/global/list/datum/light_mode/light_modes_by_name // for admins, may differ i
 	name = "Default"
 
 	color = "#fff9fd"
-	power = 0.8
-	range = DEFAULT_RANGE
+	power = 1.2
+	range = 7
 
 /datum/light_mode/default/bulb
 	name = "Default Bulb"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Изменяет дефолтный мод освещения.

<details>
<summary>превью уже устарело, спрятал под спойлер</summary>


Было:

![Tau Ceti Station 2023-07-02 085823](https://github.com/TauCetiStation/TauCetiClassic/assets/4064061/70995154-8ac7-492c-97e6-9e19bbafd43f)

Стало:

![Tau Ceti Station 2023-07-02 085723](https://github.com/TauCetiStation/TauCetiClassic/assets/4064061/811529e3-300b-4b84-abe2-dc6d57ad4e10)

</details>


## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог

:cl: WalterJe
  - tweak: Дефолтный дневной свет на станции чуть менее белый, и менее сильный (больше теней).