### PR TITLE
Исправление опечатки в рецептах повара

### DIFF
--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -763,7 +763,7 @@
 	)
 	result = /obj/item/weapon/reagent_containers/food/snacks/soup/meatballsoup
 
-/datum/recipe/oven/ajurahma
+/datum/recipe/microwave/ajurahma
 	reagents = list("water" = 10, "sugar" = 10)
 	items = list(
 		/obj/item/weapon/reagent_containers/food/snacks/grown/korta_nut,


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
При копипастинге произошла опечатка и тип рецепта был неправильный, из-за чего микроволновка взрывалась и было всем грустно.
## Почему и что этот ПР улучшит
фикс багов
## Авторство

## Чеинжлог
