### PR TITLE
Дополнение хирургической сумки Синдиката

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -384,6 +384,13 @@
 	new /obj/item/clothing/suit/straight_jacket(src)
 	new /obj/item/clothing/mask/muzzle(src)
 	new /obj/item/stack/medical/advanced/bruise_pack(src)
+	new /obj/item/stack/medical/advanced/ointment(src)
+	new /obj/item/clothing/gloves/latex/nitrile(src)
+	new /obj/item/weapon/reagent_containers/spray/cleaner(src)
+	new /obj/item/weapon/reagent_containers/syringe/antiviral(src)
+	new /obj/item/device/healthanalyzer(src)
+	new /obj/item/clothing/accessory/stethoscope(src)
+	new /obj/item/device/mmi(src)
 
 /obj/item/weapon/storage/backpack/henchmen
 	name = "wings"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Дополняет хирургическую сумку Синдиката полезными и не очень вещями:
Набор от ожогов (нужен для некоторых операций)
Хирургические перчатки(не грязными же руками сердце собирать)
Космо Клинер (мыть перчатки и пациента)
Шприц с спейсалицином(все ошибаются)
Анализатор здоровья(знать где лечить)
Стереоскоп(для профессионалов)
ММИ(по описанию в аплинке, он также должен быть в сумке) (для жирного, безрукого, безногого, слепонемоглухого оперативника Синдиката)

Выглядит примерно так:
![2023-07-03_17-18-15](https://github.com/TauCetiStation/TauCetiClassic/assets/109436132/a732b272-1896-4c11-9c4b-72c99e876780)

## Почему и что этот ПР улучшит
Более полноценный набор для хирургии, для использования которого не нужно бежать в мед за добором недостающих инструментов и лекарств. 
## Авторство

## Чеинжлог
:cl:
 - bugfix: в хирургический набор добавлен ММИ.
 - tweak: добавлены полезные мелочи в хирургический набор Синдиката.