### PR TITLE
нерф скелетов v 1

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -162,6 +162,9 @@
 	var/armorval = 0
 	var/organnum = 0
 
+	if(species.name == SKELETON)
+		return 0
+
 	if(def_zone)
 		if(isbodypart(def_zone))
 			return getarmor_organ(def_zone, type)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
броня теперь совсем не защищает скелетов
## Почему и что этот ПР улучшит
при надевании буллетпруф доспеха скелет становится банально неуязвим. это активно абузили раньше, потом чето подзабыли, и вот снова скелеты рубят экипаж целиком, танкуя в упор обоймы из смг и картечь
## Авторство
я
## Чеинжлог
:cl:
- balance: Доспехи больше не защищают скелетов.
