### PR TITLE
нерф скелетов v 2

### DIFF
--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -1089,6 +1089,7 @@
 	dietflags = DIET_ALL
 	flesh_color = "#c0c0c0"
 
+	brute_mod = 2
 	oxy_mod = 0
 	tox_mod = 0
 	clone_mod = 0


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
скелет теперь ещё хрупче
## Почему и что этот ПР улучшит
при надевании буллетпруф доспеха скелет становится банально неуязвим. это активно абузили раньше, потом чето подзабыли, и вот снова скелеты рубят экипаж целиком, танкуя в упор обоймы из смг и картечь
в отличие от предыдущего пра, в этом броня будет влиять на защиту - например, не так легко будет сбить гроин скелету в буллетпруфе, но ноги всё ещё будут быстренько отлетать
## Авторство
я
## Чеинжлог
:cl:
- balance: Скелеты стали ещё хрупче.
