### PR TITLE
фикс быстрого снятия спес сьютов

### DIFF
--- a/code/datums/components/clickplace.dm
+++ b/code/datums/components/clickplace.dm
@@ -162,8 +162,9 @@
 
 	if(istype(I, /obj/item/clothing))
 		var/obj/item/clothing/C = I
-		if((!user.delay_clothing_unequip(C)) && (C.slot_equipped))
-			return
+		if(C.slot_equipped)
+			if((!user.delay_clothing_unequip(C)))
+				return
 
 	var/atom/old_loc = I.loc
 

--- a/code/datums/components/clickplace.dm
+++ b/code/datums/components/clickplace.dm
@@ -160,11 +160,8 @@
 	if(spare_slots <= 0)
 		return
 
-	if(istype(I, /obj/item/clothing))
-		var/obj/item/clothing/C = I
-		if(C.slot_equipped)
-			if((!user.delay_clothing_unequip(C)))
-				return
+	if((!user.delay_clothing_unequip(I)))
+		return
 
 	var/atom/old_loc = I.loc
 

--- a/code/datums/components/clickplace.dm
+++ b/code/datums/components/clickplace.dm
@@ -160,6 +160,11 @@
 	if(spare_slots <= 0)
 		return
 
+	if(istype(I, /obj/item/clothing))
+		var/obj/item/clothing/C = I
+		if((!user.delay_clothing_unequip(C)) && (C.slot_equipped))
+			return
+
 	var/atom/old_loc = I.loc
 
 	jump_out(I, user.loc)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
тайтл
## Почему и что этот ПР улучшит
меньше багов и абьюзов
## Авторство

## Чеинжлог
🆑 Simbaka
- fix: Пофикшена недоработка, позволяющая мгновенно снимать с персонажей различные космические скафандры.