### PR TITLE
смена режима гибдридного костюма больше не убирает замедление магбутсов

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -856,6 +856,8 @@
 			slowdown = initial(slowdown)
 			usr.visible_message("<span class='notice'>[usr]'s suit inflates and pressurizes.</span>")
 			armor = space_armor
+		if(magpulse)
+			slowdown += boots.slowdown_off
 		update_icon(usr)
 
 /obj/item/clothing/head/helmet/space/rig/syndi/heavy

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -860,6 +860,15 @@
 			slowdown += boots.slowdown_off
 		update_icon(usr)
 
+/obj/item/clothing/suit/space/rig/syndi/disable_magpulse(mob/user)
+	flags &= ~(NOSLIP | AIR_FLOW_PROTECT)
+	if(combat_mode)
+		slowdown = combat_slowdown
+	else
+		slowdown = initial(slowdown)
+	magpulse = FALSE
+	to_chat(user, "You disable \the [src] the mag-pulse traction system.")
+
 /obj/item/clothing/head/helmet/space/rig/syndi/heavy
 	name = "heavy hybrid helmet"
 	desc = "An advanced helmet designed for work in special operations. Created using older design of armored hardsuits."


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
см. название
## Почему и что этот ПР улучшит
fixes #10473 (там оказывается только с магбутсами проблема, с разрядкой нет никаких багов, ибо оно процессится постоянно)
## Авторство

## Чеинжлог
🆑 Simbaka
- fix: Переключение режимов гибридного (нюкерского) скафандра полностью убирало замедление, которое давали включенные магбутсы внутри оного. 