### PR TITLE
Фикс шкафа БЩ

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -427,7 +427,6 @@ ADD_TO_GLOBAL_LIST(/obj/structure/closet/secure_closet/security, sec_closets_lis
 
 /obj/structure/closet/blueshield
 	name = "Blueshield Officer's Wardrobe"
-	req_access = list(access_blueshield)
 	icon_state = "blueshield"
 	icon_closed = "blueshield"
 	icon_opened = "blueshieldopen"
@@ -445,6 +444,7 @@ ADD_TO_GLOBAL_LIST(/obj/structure/closet/secure_closet/security, sec_closets_lis
 
 /obj/structure/closet/secure_closet/blueshield
 	name = "Blueshield Officer's Equipment Locker"
+	req_access = list(access_blueshield)
 	icon_state = "blueshieldsecure1"
 	icon_closed = "blueshieldsecure"
 	icon_locked = "blueshieldsecure1"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Шкаф БЩ имел общий доступ что означало что его мог открыть кто угодно и забрать его крутую снарягу. Теперь же шкаф под защитой БЩ доступа как и должно быть
## Почему и что этот ПР улучшит
close fixed https://github.com/TauCetiStation/TauCetiClassic/issues/11695
## Авторство
Я
## Чеинжлог
Фикс доступа шкафа БЩ