### PR TITLE
Нёрф боргов. Часть вторая.

### DIFF
--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -75,8 +75,11 @@
 /datum/robot_component/armour
 	name = "armour plating"
 	external_type = /obj/item/robot_parts/robot_component/armour
-	max_damage = 25
+	max_damage = 5
 
+/datum/robot_component/armour/security
+	name = "security armor plating"
+	max_damage = 25
 
 // ACTUATOR
 // Enables movement.
@@ -161,6 +164,8 @@
 	components["camera"] = new/datum/robot_component/camera(src)
 	components["comms"] = new/datum/robot_component/binary_communication(src)
 	components["armour"] = new/datum/robot_component/armour(src)
+	if(can_be_security)
+		components["armour"] = new/datum/robot_component/armour/security(src)
 
 // Checks if component is functioning
 /mob/living/silicon/robot/proc/is_component_functioning(module_name)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Теперь у обслуживающих модулей боргов (медицинский, инженерный, научный и т.д) 5 брони, у сесюрити модуля остаётся 25.
## Почему и что этот ПР улучшит
Обслуживающие модули боргов теперь будут ролькохантить с опаской.
## Авторство
maleyvich
## Чеинжлог
:cl:
- tweak: Понижение брони у обслуживающих модулей боргов.

