### PR TITLE
Talismans rebalance

### DIFF
--- a/code/game/gamemodes/modes_gameplays/cult/talisman.dm
+++ b/code/game/gamemodes/modes_gameplays/cult/talisman.dm
@@ -6,6 +6,7 @@
 
 	var/disposable = FALSE
 	var/text_befor_riteinfo
+	var/filter_color = COLOR_BLUE_GRAY
 
 /obj/item/weapon/paper/talisman/atom_init(mapload, datum/religion/_religion, datum/religion_rites/_rite)
 	. = ..()
@@ -42,13 +43,17 @@
 
 	busy = TRUE
 	user.take_overall_damage(rand(1, 5), rand(1, 5))
+	user.add_filter("talisman", 2, outline_filter(1, filter_color))
 	if(rite?.perform_rite(user, src))
 		if(disposable)
 			qdel(src)
+	user.remove_filter("talisman")
 
 /obj/item/weapon/paper/talisman/chaplain
 	text_befor_riteinfo = "Божественным почерком написано"
+	filter_color = COLOR_AMBER
 
 /obj/item/weapon/paper/talisman/cult
 	icon_state = "scrap_bloodied"
 	text_befor_riteinfo = "Кровью наскребено"
+	filter_color = COLOR_CRIMSON_RED

--- a/code/game/gamemodes/modes_gameplays/cult/talisman.dm
+++ b/code/game/gamemodes/modes_gameplays/cult/talisman.dm
@@ -6,7 +6,6 @@
 
 	var/disposable = FALSE
 	var/text_befor_riteinfo
-	var/filter_color = COLOR_BLUE_GRAY
 
 /obj/item/weapon/paper/talisman/atom_init(mapload, datum/religion/_religion, datum/religion_rites/_rite)
 	. = ..()
@@ -43,17 +42,13 @@
 
 	busy = TRUE
 	user.take_overall_damage(rand(1, 5), rand(1, 5))
-	user.add_filter("talisman", 2, outline_filter(1, filter_color))
 	if(rite?.perform_rite(user, src))
 		if(disposable)
 			qdel(src)
-	user.remove_filter("talisman")
 
 /obj/item/weapon/paper/talisman/chaplain
 	text_befor_riteinfo = "Божественным почерком написано"
-	filter_color = COLOR_AMBER
 
 /obj/item/weapon/paper/talisman/cult
 	icon_state = "scrap_bloodied"
 	text_befor_riteinfo = "Кровью наскребено"
-	filter_color = COLOR_CRIMSON_RED

--- a/code/modules/religion/altar_types/altar_of_gods.dm
+++ b/code/modules/religion/altar_types/altar_of_gods.dm
@@ -279,6 +279,7 @@
 	T.rite.religion = religion
 	T.rite.favor_cost = 0
 	T.rite.piety_cost = 0
+	T.rite.divine_power = round(sqrt(R.divine_power))
 	religion.adjust_favor(-R.favor_cost*2)
 	religion.adjust_piety(-R.piety_cost*2)
 

--- a/code/modules/religion/rites/instant/instant.dm
+++ b/code/modules/religion/rites/instant/instant.dm
@@ -661,7 +661,7 @@
 		if(!(HULK in L.mutations))
 			L.Stuttering(stun_modifier)
 			L.Weaken(stun_modifier)
-			L.show_message("<span class='userdanger'>У вас будто бы вылетает из тела душа, а по возвращении в назад она потеряла контроль над телом..</span>", SHOWMSG_VISUAL)
+			L.show_message("<span class='userdanger'>У вас будто вылетает душа из тела, а по возвращению теряет контроль над телом!</span>", SHOWMSG_VISUAL)
 	return TRUE
 
 /datum/religion_rites/instant/communicate

--- a/code/modules/religion/rites/instant/instant.dm
+++ b/code/modules/religion/rites/instant/instant.dm
@@ -650,11 +650,11 @@
 	if(length(heretics) < 1)
 		to_chat(user, "<span class='warning'>Никого нет рядом.</span>")
 		return FALSE
-	var/stun_modifier = 12 / length(heretics) * round(sqrt(divine_power)) //Even 12 I think too much
+	var/stun_modifier = 12 / length(heretics) * round(sqrt(divine_power))
 	for(var/mob/living/L in heretics)
-		if(!(L.status_flags & CANSTUN)) //Hulks
+		if(!(L.status_flags & CANSTUN)) //Hulks, golems
 			L.Stun(stun_modifier / 2, TRUE)
-			flash_color(L, flash_time = stun_modifier / 2 SECONDS)
+			flash_color(L, flash_time = stun_modifier * 5)
 		else
 			L.Stun(stun_modifier * 0.8)
 			flash_color(L, flash_time = stun_modifier SECONDS)

--- a/code/modules/religion/rites/instant/instant.dm
+++ b/code/modules/religion/rites/instant/instant.dm
@@ -650,10 +650,14 @@
 	if(length(heretics) < 1)
 		to_chat(user, "<span class='warning'>Никого нет рядом.</span>")
 		return FALSE
-	var/stun_modifier = 12 / length(heretics) * divine_power
+	var/stun_modifier = 12 / length(heretics) * round(sqrt(divine_power)) //Even 12 I think too much
 	for(var/mob/living/L in heretics)
-		L.flash_eyes()
-		L.Stun(stun_modifier)
+		if(!(L.status_flags & CANSTUN)) //Hulks
+			L.Stun(stun_modifier / 2, TRUE)
+			flash_color(L, flash_time = stun_modifier / 2 SECONDS)
+		else
+			L.Stun(stun_modifier)
+			flash_color(L, flash_time = stun_modifier SECONDS)
 		if(!(HULK in L.mutations))
 			L.Stuttering(1)
 			L.Weaken(stun_modifier)

--- a/code/modules/religion/rites/instant/instant.dm
+++ b/code/modules/religion/rites/instant/instant.dm
@@ -656,10 +656,10 @@
 			L.Stun(stun_modifier / 2, TRUE)
 			flash_color(L, flash_time = stun_modifier / 2 SECONDS)
 		else
-			L.Stun(stun_modifier)
+			L.Stun(stun_modifier * 0.8)
 			flash_color(L, flash_time = stun_modifier SECONDS)
 		if(!(HULK in L.mutations))
-			L.Stuttering(1)
+			L.Stuttering(stun_modifier)
 			L.Weaken(stun_modifier)
 			L.show_message("<span class='userdanger'>У вас будто бы вылетает из тела душа, а по возвращении в назад она потеряла контроль над телом..</span>", SHOWMSG_VISUAL)
 	return TRUE

--- a/code/modules/religion/rites/instant/instant.dm
+++ b/code/modules/religion/rites/instant/instant.dm
@@ -130,7 +130,7 @@
 	var/turf/turf = get_turf(AOG)
 	playsound(AOG, 'sound/items/Welder2.ogg', VOL_EFFECTS_MASTER, 25)
 	turf.hotspot_expose(700, 125)
-	empulse(turf, 3, 5 * divine_power)
+	empulse(turf, 3 * sqrt(divine_power), 5 * divine_power)
 	return TRUE
 
 /datum/religion_rites/instant/cult/drain_torture
@@ -651,13 +651,13 @@
 		to_chat(user, "<span class='warning'>Никого нет рядом.</span>")
 		return FALSE
 	var/stun_modifier = 12 / length(heretics) * divine_power
-	for(var/mob/living/carbon/C in heretics)
-		C.flash_eyes()
-		if(!(HULK in C.mutations))
-			C.Stuttering(1)
-			C.Weaken(stun_modifier)
-			C.Stun(stun_modifier)
-			C.show_message("<span class='userdanger'>У вас будто бы вылетает из тела душа, а по возвращении в назад она потеряла контроль над телом..</span>", SHOWMSG_VISUAL)
+	for(var/mob/living/L in heretics)
+		L.flash_eyes()
+		L.Stun(stun_modifier)
+		if(!(HULK in L.mutations))
+			L.Stuttering(1)
+			L.Weaken(stun_modifier)
+			L.show_message("<span class='userdanger'>У вас будто бы вылетает из тела душа, а по возвращении в назад она потеряла контроль над телом..</span>", SHOWMSG_VISUAL)
 	return TRUE
 
 /datum/religion_rites/instant/communicate


### PR DESCRIPTION
## Описание изменений
Значительное изменение в работе талисманов со стороны жертвы. Много дебаффов, но есть и значительные плюсы.
<details><summary>Убрано</summary>
1) Теперь каст талисмана заметен со стороны

![image](https://github.com/TauCetiStation/TauCetiClassic/assets/50750952/44226995-00da-4311-bb30-857fd409580b)

</details>

2) Раньше талисманы всегда использовали первый уровень ритуала. Теперь используется уровень в корне, с округлением `round(sqrt(power)`. Т.е. ЭМИ ритуал 3 уровня на алтаре, в талисмане будет как корень 1.7, округляя до 2 уровня.

3) ЭМИ. У тяжёлого эми было добавлено усиление - `3 * корень силы ритуала`, лёгкое эми не трогал - `5 * силу ритуала`. 

4) Оглушение. Можно оглушить халков, големов и подобных животных, однако с уменьшенной длительностью. Также на него действует дополнительное пенальти в виде второго корня для силы. Т.е. для 24 секунд (вместо 12) оглушения одного человека нужен 7 уровень (и да, если культ вложил аж 7 аспектов в усиление, вы проморгали каст, у вас нет напарников, то это вполне справедливо будет полежать овощем)
## Почему и что этот ПР улучшит
1) Не самая приятная механика для сражения по ту сторону баррикад. 
2) Есть шанс того, что люди выдумают новые абузы. 
3) Ну и путь для новых баффов :smile: 
## Авторство

## Чеинжлог
:cl: 
- bugfix[link]: Сила талисмана культа зависит от силы ритуала
- balance: Радиус тяжёлого ЭМИ у ритуала увеличивается с силой аспектов. 