### PR TITLE
Changeling Transformation Sting. Rework

### DIFF
--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -47,7 +47,7 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	// From old dna.
 	var/b_type = "A+"  // Should probably change to an integer => string map but I'm lazy.
 	var/real_name          // Stores the real name of the person who originally got this dna datum. Used primarily for changelings,
-	var/original_essence_name //Stores THE REAL NAME for changeling transform sting
+	var/original_character_name //Stores THE REAL NAME for changeling transform sting
 
 	// New stuff
 	var/species = HUMAN

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -47,6 +47,7 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	// From old dna.
 	var/b_type = "A+"  // Should probably change to an integer => string map but I'm lazy.
 	var/real_name          // Stores the real name of the person who originally got this dna datum. Used primarily for changelings,
+	var/original_essence_name //Stores THE REAL NAME for changeling transform sting
 
 	// New stuff
 	var/species = HUMAN

--- a/code/game/gamemodes/modes_gameplays/changeling/powers/absorb.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/absorb.dm
@@ -145,7 +145,7 @@
 		for(var/datum/dna/D in absorbed_dna)
 			if(T.dna.uni_identity == D.uni_identity)
 				if(T.dna.struc_enzymes == D.struc_enzymes)
-					if(T.dna.original_essence_name == D.original_essence_name)
+					if(T.dna.original_character_name == D.original_character_name)
 						to_chat(U, "<span class='warning'>We already have that DNA in storage.</span>")
 						return FALSE
 	return TRUE

--- a/code/game/gamemodes/modes_gameplays/changeling/powers/absorb.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/absorb.dm
@@ -145,7 +145,7 @@
 		for(var/datum/dna/D in absorbed_dna)
 			if(T.dna.uni_identity == D.uni_identity)
 				if(T.dna.struc_enzymes == D.struc_enzymes)
-					if(T.dna.real_name == D.real_name)
+					if(T.dna.original_essence_name == D.original_essence_name)
 						to_chat(U, "<span class='warning'>We already have that DNA in storage.</span>")
 						return FALSE
 	return TRUE

--- a/code/game/gamemodes/modes_gameplays/changeling/powers/stings.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/stings.dm
@@ -144,7 +144,7 @@
 	var/datum/role/changeling/changeling = user.mind.GetRoleByType(/datum/role/changeling)
 	var/list/names = list()
 	for(var/datum/dna/DNA in changeling.absorbed_dna)
-		names += "[DNA.original_essence_name]"
+		names += "[DNA.original_character_name]"
 
 	var/S = input("Select the target DNA: ", "Target DNA", null) as null|anything in names
 	if(!S)	return
@@ -169,11 +169,11 @@
 		to_chat(user, "<span class='notice'>We stealthily sting [target.name].</span>")
 	target.visible_message("<span class='warning'>[target] transforms!</span>")
 	//save original
-	var/essence_name = target.dna.original_essence_name
+	var/essence_name = target.dna.original_character_name
 	target.dna = selected_dna.Clone()
 	target.real_name = selected_dna.real_name
 	//unchange this
-	target.dna.original_essence_name = essence_name
+	target.dna.original_character_name = essence_name
 	domutcheck(target, null)
 	target.UpdateAppearance()
 

--- a/code/game/gamemodes/modes_gameplays/changeling/powers/stings.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/stings.dm
@@ -140,12 +140,11 @@
 	genomecost = 2
 	var/datum/dna/selected_dna = null
 
-/obj/effect/proc_holder/changeling/sting/transformation/Click()
-	var/mob/user = usr
+/obj/effect/proc_holder/changeling/sting/transformation/set_sting(mob/user)
 	var/datum/role/changeling/changeling = user.mind.GetRoleByType(/datum/role/changeling)
 	var/list/names = list()
 	for(var/datum/dna/DNA in changeling.absorbed_dna)
-		names += "[DNA.real_name]"
+		names += "[DNA.original_essence_name]"
 
 	var/S = input("Select the target DNA: ", "Target DNA", null) as null|anything in names
 	if(!S)	return
@@ -169,8 +168,12 @@
 	if(ismonkey(target))
 		to_chat(user, "<span class='notice'>We stealthily sting [target.name].</span>")
 	target.visible_message("<span class='warning'>[target] transforms!</span>")
+	//save original
+	var/essence_name = target.dna.original_essence_name
 	target.dna = selected_dna.Clone()
 	target.real_name = selected_dna.real_name
+	//unchange this
+	target.dna.original_essence_name = essence_name
 	domutcheck(target, null)
 	target.UpdateAppearance()
 

--- a/code/game/gamemodes/modes_gameplays/changeling/powers/transform.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/transform.dm
@@ -18,10 +18,10 @@
 		return FALSE
 
 	user.visible_message("<span class='warning'>[user] transforms!</span>")
-	var/changeling_original_name = user.dna.original_essence_name
+	var/changeling_original_name = user.dna.original_character_name
 	user.dna = chosen_dna.Clone()
 	user.real_name = chosen_dna.real_name
-	user.dna.original_essence_name = changeling_original_name
+	user.dna.original_character_name = changeling_original_name
 	user.flavor_text = ""
 	user.UpdateAppearance()
 	domutcheck(user, null)
@@ -35,7 +35,7 @@
 /datum/role/changeling/proc/select_dna(prompt, title)
 	var/list/names = list()
 	for(var/datum/dna/DNA in absorbed_dna)
-		names += "[DNA.original_essence_name]"
+		names += "[DNA.original_character_name]"
 
 	var/chosen_name = input(prompt, title, null) as null|anything in names
 	if(!chosen_name)

--- a/code/game/gamemodes/modes_gameplays/changeling/powers/transform.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/transform.dm
@@ -18,8 +18,10 @@
 		return FALSE
 
 	user.visible_message("<span class='warning'>[user] transforms!</span>")
+	var/changeling_original_name = user.dna.original_essence_name
 	user.dna = chosen_dna.Clone()
 	user.real_name = chosen_dna.real_name
+	user.dna.original_essence_name = changeling_original_name
 	user.flavor_text = ""
 	user.UpdateAppearance()
 	domutcheck(user, null)
@@ -33,7 +35,7 @@
 /datum/role/changeling/proc/select_dna(prompt, title)
 	var/list/names = list()
 	for(var/datum/dna/DNA in absorbed_dna)
-		names += "[DNA.real_name]"
+		names += "[DNA.original_essence_name]"
 
 	var/chosen_name = input(prompt, title, null) as null|anything in names
 	if(!chosen_name)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -429,7 +429,7 @@
 	new_character.dna.ready_dna(new_character)
 	new_character.dna.b_type = client.prefs.b_type
 	new_character.dna.UpdateSE()
-	new_character.dna.original_essence_name = new_character.real_name
+	new_character.dna.original_character_name = new_character.real_name
 	new_character.nutrition = rand(NUTRITION_LEVEL_HUNGRY, NUTRITION_LEVEL_WELL_FED)
 	var/old_base_metabolism = new_character.get_metabolism_factor()
 	new_character.metabolism_factor.Set(old_base_metabolism * rand(9, 11) * 0.1)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -429,6 +429,7 @@
 	new_character.dna.ready_dna(new_character)
 	new_character.dna.b_type = client.prefs.b_type
 	new_character.dna.UpdateSE()
+	new_character.dna.original_essence_name = new_character.real_name
 	new_character.nutrition = rand(NUTRITION_LEVEL_HUNGRY, NUTRITION_LEVEL_WELL_FED)
 	var/old_base_metabolism = new_character.get_metabolism_factor()
 	new_character.metabolism_factor.Set(old_base_metabolism * rand(9, 11) * 0.1)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Теперь можно перевоплощать свою (живую) жертву в что угодно и это не будет влиять на возможность человека с подменёнными днк съесть.

Хотел сделать ещё возможность перевоплощать уже мёртвые тела, а не только живые, просмотрел историю этого кода в https://github.com/tgstation/tgstation/commit/70c6c46657f3751d382836d35d653347b6b8d927 и понял что это какой-то костыль. Для изменения потребуется больше времени и вникания в работу клонировальной машины (возможно таким образом можно что-то заабузить), поэтому не трогаю.

"уникальное имя" сохраняется когда появляется кукла > трансформ стинг создаёт копии днк, сохраняя уникальное имя > при поглощении проверяется уникальное имя, а не подменённое каким-либо способом > поглощение 10-го человека с одним и тем же именем не запрещается кодом. Узнать уникальное имя кроме как педальным способом никак нельзя.
![image](https://github.com/TauCetiStation/TauCetiClassic/assets/96499407/27bc860f-00ca-4120-8ec2-fbbde18fe0d0)

## Почему и что этот ПР улучшит
Ролеплей, геймплейные возможности генокрадам, должно повлиять на винрейт и популярность покупки этого скила 
![00000000000000000000000000000000sadsada00](https://github.com/TauCetiStation/TauCetiClassic/assets/96499407/ca50a62d-f234-4477-a0db-b8922beba84c)
## Авторство

## Чеинжлог
:cl: Deahaka
- experiment: Способность "Transformation Sting" генокрада теперь не запрещает поглощать жертвы.