### PR TITLE
Фикс хранилища пробирок

### DIFF
--- a/code/game/objects/items/weapons/storage/fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy.dm
@@ -390,9 +390,9 @@
 	icon = 'icons/obj/vialbox.dmi'
 	icon_state = "vialbox0"
 	item_state = "syringe_kit"
-	max_w_class = SIZE_SMALL
 	can_hold = list(/obj/item/weapon/reagent_containers/glass/beaker/vial)
 	storage_slots = 6
+	max_storage_space = 12
 	req_access = list(access_virology)
 
 /obj/item/weapon/storage/lockbox/vials/atom_init()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
В защищенное хранилище пробирок влезало только 5 колб. Теперь будет 6 как и положено.
## Почему и что этот ПР улучшит
fixes #11677
## Авторство

## Чеинжлог
