### PR TITLE
[Fix] При разборе пожарных створок теперь спавнится плата

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -212,6 +212,7 @@
 				if(blocked && density && hatch_open)
 					user.visible_message("<span class='danger'>[user] has removed the electronics from \the [src].</span>",
 										"You have removed the electronics from [src].")
+					new /obj/item/weapon/airalarm_electronics(loc)
 
 					deconstruct(TRUE)
 		return

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -212,7 +212,6 @@
 				if(blocked && density && hatch_open)
 					user.visible_message("<span class='danger'>[user] has removed the electronics from \the [src].</span>",
 										"You have removed the electronics from [src].")
-					new /obj/item/weapon/airalarm_electronics(loc)
 
 					deconstruct(TRUE)
 		return
@@ -256,6 +255,7 @@
 	if(flags & NODECONSTRUCT)
 		return ..()
 	take_out_wedged_item()
+	new /obj/item/weapon/airalarm_electronics(loc)
 	if(disassembled || prob(40))
 		var/obj/structure/firedoor_assembly/FA = new (loc)
 		if(disassembled)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Собственно, разбирая пожарные створки, теперь мы не будем терять плату аиралярма.
## Почему и что этот ПР улучшит
resolves #11563
## Авторство

## Чеинжлог
