### PR TITLE
test

### DIFF
--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -63,6 +63,7 @@
 	return QDEL_HINT_QUEUE
 
 /datum/proc/process()
+	SHOULD_NOT_SLEEP(TRUE)
 	set waitfor = FALSE
 	STOP_PROCESSING(SSobj, src)
 	return FALSE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Из любопытства, процессинг запускается из контроллера и *по идее* не должен иметь слипов - ведь это заморозит и контроллер.

Но у нас и на тг ``SHOULD_NOT_SLEEP`` не используется для ``process`` по какой-то причине.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
