### PR TITLE
Амогус-режим. Импосторы. "Самозванцы"

### DIFF
--- a/code/game/gamemodes/factions.dm
+++ b/code/game/gamemodes/factions.dm
@@ -105,6 +105,9 @@
 		return FALSE
 	return TRUE
 
+/datum/faction/proc/can_latespawn_mob(mob/P)
+	return TRUE
+
 // Basically, they are members of the new faction
 /datum/faction/proc/HandleNewMind(datum/mind/M, laterole) //Used on faction creation
 	SHOULD_CALL_PARENT(TRUE)

--- a/code/game/gamemodes/factions/changeling.dm
+++ b/code/game/gamemodes/factions/changeling.dm
@@ -15,11 +15,27 @@
 	var/list/hivemind_bank = list()
 
 /datum/faction/changeling/can_setup(num_players)
-	max_roles = 1 + round(num_players / 10)
+	limit_roles(num_players)
 	return TRUE
+
+/datum/faction/changeling/proc/limit_roles(num_players)
+	max_roles = 1 + round(num_players / 10)
+	return max_roles
 
 /datum/faction/changeling/GetFactionHeader()
 	var/icon/logo_left = get_logo_icon("change-logoa")
 	var/icon/logo_right = get_logo_icon("change-logob")
 	var/header = {"[bicon(logo_left, css = "style='position:relative; top:10px;'")] <FONT size = 2><B>[capitalize(name)]</B></FONT> [bicon(logo_right, css = "style='position:relative; top:10px;'")]"}
 	return header
+
+/datum/faction/changeling/imposter
+	name = "Changeling Imposters"
+	roletype = /datum/role/changeling/imposter
+	initroletype = /datum/role/changeling/imposter
+
+// Station has other antags
+/datum/faction/changeling/imposter/limit_roles(num_players)
+	max_roles = ..()
+	max_roles /= 2
+	log_debug("IMPOSTERS: Changeling faction limit roles: [max_roles]")
+	return max_roles

--- a/code/game/gamemodes/factions/traitors.dm
+++ b/code/game/gamemodes/factions/traitors.dm
@@ -16,10 +16,46 @@
 
 /datum/faction/traitor/can_setup(num_players)
 	. = ..()
+	limit_roles(num_players)
+	return TRUE
 
+/datum/faction/traitor/proc/limit_roles(num_players)
 	if(config.traitor_scaling)
 		max_roles = max(1, round(num_players/traitor_scaling_coeff))
 	else
 		max_roles = max(1, min(num_players, traitors_possible))
+	return max_roles
 
-	return TRUE
+/datum/faction/traitor/imposter
+	name = "Imposters"
+	roletype = /datum/role/traitor/imposter
+	initroletype = /datum/role/traitor/imposter
+	//latespawned human can be imposter
+	accept_latejoiners = TRUE
+
+// Station has other antags
+/datum/faction/traitor/imposter/limit_roles(num_players)
+	//one traitor is better than 4 in lowpop
+	if(num_players > max_roles * 3)
+		max_roles = 1
+		log_debug("IMPOSTERS: Only 1 imposter can be added to round in roundstart")
+		return max_roles
+	max_roles = ..()
+	max_roles /= 3
+	log_debug("IMPOSTERS: [src] faction has [max_roles] limit of roundstart roles")
+	return max_roles
+
+/datum/faction/traitor/imposter/can_latespawn_mob(mob/P)
+	//Not every joined human can start with traitor role
+	if(prob(80))
+		log_debug("IMPOSTERS: [P] latespawned without adding to [src] faction")
+		return FALSE
+	//calculate every time which members are succeed, stop spawn when at least 1 succeeded
+	for(var/datum/role/member_role in members)
+		if(member_role.IsSuccessful())
+			log_debug("IMPOSTERS: [P] wanna be a member of [src], but [src] faction members have completed objectives")
+			return FALSE
+	//probability 20% to increase amount of imposters by ~20%
+	if(members.len < (player_list.len / traitor_scaling_coeff) / 2)
+		return TRUE
+	log_debug("IMPOSTERS: Members ([members.len]) has enough people for current players amount ([player_list.len])")

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -171,6 +171,8 @@
 			continue
 		if(!F.can_join_faction(mob))
 			continue
+		if(!F.can_latespawn_mob(mob))
+			continue
 		possible_factions += F
 	if(possible_factions.len)
 		var/datum/faction/F = pick(possible_factions)

--- a/code/game/gamemodes/modes_declares/imposters.dm
+++ b/code/game/gamemodes/modes_declares/imposters.dm
@@ -1,0 +1,13 @@
+/datum/game_mode/imposter
+	name = "Imposter"
+	config_name = "imposter"
+	// Not one faction because faction-oriented code of roles
+	factions_allowed = list(/datum/faction/traitor/imposter, \
+	                        /datum/faction/changeling/imposter, \
+							/datum/faction/cult/heretics)
+	minimum_player_count = 10
+	minimum_players_bundles = 20
+
+/datum/game_mode/amogus/announce()
+	to_chat(world, "<B>The current game mode is - Imposter!</B>")
+	to_chat(world, "<B>There is a imposter on the station!</B>")

--- a/code/game/gamemodes/objectives/absorb.dm
+++ b/code/game/gamemodes/objectives/absorb.dm
@@ -25,3 +25,6 @@
 		if(C && C.absorbed_dna && (C.absorbedcount >= target_amount))
 			return OBJECTIVE_WIN
 	return OBJECTIVE_LOSS
+
+/datum/objective/absorb_changeling
+	explanation_text = "Absorb another Changeling."

--- a/code/game/gamemodes/objectives/target/assassinate.dm
+++ b/code/game/gamemodes/objectives/target/assassinate.dm
@@ -8,3 +8,18 @@
 			return OBJECTIVE_WIN
 		return OBJECTIVE_LOSS
 	return OBJECTIVE_WIN
+
+/datum/objective/target/assassinate/religious
+	var/datum/religion/religion = null
+
+/datum/objective/target/assassinate/religious/New(_religion)
+	. = ..()
+	religion = _religion
+
+/datum/objective/target/assassinate/religious/get_targets()
+	var/list/targets = list()
+	for(var/datum/mind/possible_target in SSticker.minds)
+		if(!religion.can_convert(possible_target.current))
+			targets += possible_target
+	log_debug("IMPOSTERS: Heretic objective has [targets.len] possible targets")
+	return targets

--- a/code/game/gamemodes/roles/changeling.dm
+++ b/code/game/gamemodes/roles/changeling.dm
@@ -229,7 +229,7 @@
 	. = ..()
 	var/datum/role/R = T.mind.GetRole(CHANGELING)
 	if(R)
-		for(var/datum/objective/absorb_changeling/objective in objectives)
+		for(var/datum/objective/absorb_changeling/objective in objectives.GetObjectives())
 			objective.completed = OBJECTIVE_WIN
 		log_debug("IMPOSTERS: [src] absorbs [T], who has Changeling Role")
 #undef OVEREATING_AMOUNT

--- a/code/game/gamemodes/roles/changeling.dm
+++ b/code/game/gamemodes/roles/changeling.dm
@@ -87,6 +87,10 @@
 /datum/role/changeling/forgeObjectives()
 	if(!..())
 		return FALSE
+	create_changeling_objectives()
+	return TRUE
+
+/datum/role/changeling/proc/create_changeling_objectives()
 	AppendObjective(/datum/objective/absorb)
 	AppendObjective(/datum/objective/target/assassinate)
 	AppendObjective(/datum/objective/steal)
@@ -94,7 +98,6 @@
 		AppendObjective(/datum/objective/survive)
 	else
 		AppendObjective(/datum/objective/escape)
-	return TRUE
 
 /datum/role/changeling/add_ui(datum/hud/hud)
 	if(!lingchemdisplay)
@@ -206,4 +209,27 @@
 			to_chat(M, "<font size='7' color='red'><b>A terrible roar is coming from somewhere around the station.</b></font>")
 			M.playsound_local(null, 'sound/antag/abomination_start.ogg', VOL_EFFECTS_VOICE_ANNOUNCEMENT, vary = FALSE, frequency = null, ignore_environment = TRUE)
 
+/datum/role/changeling/imposter
+	name = "Changeling imposter"
+	//Objectives imply the ability to destroy the security, and this is easiest to do when equipped and with access to the armory
+	restricted_jobs = list("AI", "Cyborg", "Security Officer", "Warden", "Head of Security", "Captain", "Blueshield Officer")
+	restricted_species_flags = list(IS_PLANT, IS_SYNTHETIC, NO_SCAN)
+
+/datum/role/changeling/imposter/create_changeling_objectives()
+	AppendObjective(/datum/objective/absorb)
+	AppendObjective(/datum/objective/target/assassinate)
+	AppendObjective(/datum/objective/absorb_changeling)
+	// Escape is more interesting
+	if(prob(1))
+		AppendObjective(/datum/objective/survive)
+	else
+		AppendObjective(/datum/objective/escape)
+
+/datum/role/changeling/imposter/absorb_dna(mob/living/carbon/T)
+	. = ..()
+	var/datum/role/R = T.mind.GetRole(CHANGELING)
+	if(R)
+		for(var/datum/objective/absorb_changeling/objective in objectives)
+			objective.completed = OBJECTIVE_WIN
+		log_debug("IMPOSTERS: [src] absorbs [T], who has Changeling Role")
 #undef OVEREATING_AMOUNT

--- a/code/game/gamemodes/roles/cultist.dm
+++ b/code/game/gamemodes/roles/cultist.dm
@@ -101,3 +101,16 @@
 
 	holy_rank = CULT_ROLE_MASTER
 	skillset_type = /datum/skillset/cultist/leader
+
+/datum/role/cultist/leader/heretic
+	name = "Heretic"
+
+//one objective about killing chaplain / other good boy
+/datum/role/cultist/leader/heretic/proc/create_heretic_objectives()
+	AppendObjective(/datum/objective/target/assassinate/religious)
+
+/datum/role/cultist/leader/heretic/forgeObjectives()
+	if(!..())
+		return FALSE
+	create_heretic_objectives()
+	return TRUE

--- a/code/game/gamemodes/roles/traitor.dm
+++ b/code/game/gamemodes/roles/traitor.dm
@@ -33,6 +33,10 @@
 /datum/role/traitor/forgeObjectives()
 	if(!..())
 		return FALSE
+	create_traitor_objectives()
+	return TRUE
+
+/datum/role/traitor/proc/create_traitor_objectives()
 	if(issilicon(antag.current))
 		AppendObjective(/datum/objective/target/assassinate, TRUE)
 		AppendObjective(/datum/objective/target/assassinate, TRUE)
@@ -53,7 +57,6 @@
 				AppendObjective(/datum/objective/survive)
 			else
 				AppendObjective(/datum/objective/hijack)
-	return TRUE
 
 /datum/role/traitor/process()
 	// For objectives such as "Make an example of...", which require mid-game checks for completion
@@ -136,3 +139,65 @@
 	. = ..()
 	var/mob/living/carbon/human/H = antag.current
 	H.equip_or_collect(new /obj/item/device/encryptionkey/syndicate(antag.current), SLOT_R_STORE)
+
+/datum/role/traitor/imposter
+	name = "Imposter"
+	//No restricts, everyone can be a traitor
+	restricted_jobs = list()
+	//Challenge
+	telecrystals = 0
+
+/datum/role/traitor/imposter/add_one_objective(datum/mind/traitor)
+	switch(rand(1, 100))
+		//most traitors is just stealers
+		if(1 to 90)
+			AppendObjective(/datum/objective/steal, TRUE)
+		if(91 to 93)
+			AppendObjective(/datum/objective/target/assassinate, TRUE)
+		if(94 to 96)
+			AppendObjective(/datum/objective/target/harm, TRUE)
+		else
+			AppendObjective(/datum/objective/target/dehead, TRUE)
+
+/datum/role/traitor/imposter/proc/add_rev_objectives()
+	var/list/heads = get_living_heads()
+	for(var/datum/mind/head_mind in heads)
+		var/datum/objective/target/rp_rev/rev_obj = AppendObjective(/datum/objective/target/rp_rev, TRUE)
+		if(rev_obj)
+			rev_obj.target = head_mind
+			rev_obj.explanation_text = "Capture, convert or exile from station [head_mind.name], the [head_mind.assigned_role]. Assassinate if you have no choice."
+
+/datum/role/traitor/imposter/create_traitor_objectives()
+	if(issilicon(antag.current))
+		//probability 10% for default silent assassin AI
+		if(prob(10))
+			log_debug("IMPOSTERS: silicon imposter ([antag.current]) has standart objectives")
+			return ..()
+		//probability 90% for peace-protecter AI
+		AppendObjective(/datum/objective/target/protect, TRUE)
+		AppendObjective(/datum/objective/target/protect, TRUE)
+		AppendObjective(/datum/objective/survive)
+		log_debug("IMPOSTERS: silicon imposter ([antag.current]) has protect objectives")
+		//and 10% prob to hijack shuttle when has protect objective
+		if(prob(10))
+			AppendObjective(/datum/objective/block)
+			log_debug("IMPOSTERS: silicon [antag.current] has hijack with protect objectives")
+		return
+	//1% prob to revolution objectives for non-silicon imposter
+	if(prob(1))
+		add_rev_objectives()
+		log_debug("IMPOSTERS: Non-silicon imposter ([antag.current]) has revolution objectives")
+		return
+	//default traitor objectives
+	for(var/i in 1 to 3)
+		add_one_objective()
+	//Setup last objective
+	switch(rand(1, 100))
+		//Escape is more interesting
+		if(1 to 90)
+			AppendObjective(/datum/objective/escape)
+		if(91 to 99)
+			AppendObjective(/datum/objective/survive)
+		else
+			AppendObjective(/datum/objective/hijack)
+	log_debug("IMPOSTERS: Non-silicon imposter ([antag.current]) has standart traitor objectives")

--- a/code/game/gamemodes/roles/traitor.dm
+++ b/code/game/gamemodes/roles/traitor.dm
@@ -10,6 +10,7 @@
 
 	greets = list(GREET_SYNDBEACON, GREET_LATEJOIN, GREET_AUTOTRAITOR, GREET_ROUNDSTART, GREET_DEFAULT)
 
+	var/give_uplink = TRUE
 	var/telecrystals = 20
 	skillset_type = /datum/skillset/max
 	moveset_type = /datum/combat_moveset/cqc
@@ -17,7 +18,8 @@
 
 /datum/role/traitor/New()
 	..()
-	AddComponent(/datum/component/gamemode/syndicate, telecrystals, "traitor")
+	if(give_uplink)
+		AddComponent(/datum/component/gamemode/syndicate, telecrystals, "traitor")
 
 /datum/role/traitor/proc/add_one_objective(datum/mind/traitor)
 	switch(rand(1,120))
@@ -145,6 +147,7 @@
 	//No restricts, everyone can be a traitor
 	restricted_jobs = list()
 	//Challenge
+	give_uplink = FALSE
 	telecrystals = 0
 
 /datum/role/traitor/imposter/add_one_objective(datum/mind/traitor)

--- a/taucetistation.dme
+++ b/taucetistation.dme
@@ -541,6 +541,7 @@
 #include "code\game\gamemodes\modes_declares\cult.dm"
 #include "code\game\gamemodes\modes_declares\extended.dm"
 #include "code\game\gamemodes\modes_declares\families.dm"
+#include "code\game\gamemodes\modes_declares\imposters.dm"
 #include "code\game\gamemodes\modes_declares\infestation.dm"
 #include "code\game\gamemodes\modes_declares\malfunction.dm"
 #include "code\game\gamemodes\modes_declares\nuclear.dm"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Я хочу больше амогус-ориентированных режимов, которые в отличии от других имеют хорошую вариативность от раунда к раунду.

Обсуждение на форуме подсказало, что просто выделение дополнительного выбора в воуте (https://forum.taucetistation.org/t/golosovanie-obsuzhdenie-dobavlenie-vouta-na-trejtorov/35918) имеет большую вероятность быть не пикнутой людьми, ведь это даст большую мету игрокам не-антагам на события в следующем раунде (банально будуть знать что сейчас триторы и прятать хайриск вещи).

Чтобы не продолжать мету, которая есть уже сейчас, надо внести амогус-ориентированный режим в пул других режимов (тимбазед останется с метой, так как Импосторы не командный режим), что я и сделал.

Да, я не учусь на своём опыте добавления режимов, но всё равно хочется это продвигать.

Особенности режима:
1. Никто, кроме одного из антагов не будет знать что этот режим сейчас выпал до тех пор, пока антаги не раскроются сами. В этом режиме импостором может быть и ГСБ и Капитан, и Варден и офицер и ИИ и даже киборг сам по себе. В этом режиме импостором может быть и прилетевший с велосити член экипажа. 
2. В этом режиме импостор будет иметь все задачи которые я посчитал интересными. Буквально всем возможность получить все виды задач конечно не делал, а разделил так, чтобы сохранять концепт режимов хотя бы на минимальном уровне. Были добавлены две новые задачи, которые подходят по стилю игры антагонистам их получивших. У трёх из четырёх вариаций импостеров будут нефиксированные задания, которые могут менять стиль и направление игры от раунда к раунду кардинально. У трёх из четырёх при этом могут выпасть задания на противостояние другим импостерам как из своей фракции прямым текстом, так и из чужих опосредованно.
3. Принцип действия режима схож с понятием "паноптикума", где достигается нужный эффект простой невозможностью быть уверенным в ситуации из-за гарантированного маленького шанса ошибиться. По-простому: как доверять офицеру на 100%, если существует маленький шанс, что он на самом деле один из предателей на станции? Вот и не надо доверять, если он творит дичь, а надо засадить его в общак.
4. Никаких мета-анонсов. Да, фейк-анонс возможно бы подыграл обстановке, но это же может и дать мету на то, что фейк-анонс = режим Импосторы.

#### Мейнтейнерам скорее всего интересно вот это:
<details>
<summary>
Как это всё реализовано?
</summary>
Добавлен гейммод "Импосторы" в сикрет бандл. Раундстартовые фракции гейммода: триторы-импосторы, генокрады-импосторы, культ еретика.

Триторы-импосторы: роль выдаётся всем профессиям, кроме велосити-слотов. Фракция будет расширяться зашедшеми игроками после раундстарта. Цели у органических форм жизни будут в 90% стелсовые (украсть что-то), в остальных случаях стандартные как и у обычных трейторов + шанс на цели революции. У роботов будут в 90% случаев цели на протект рандомных людей на станции, 10% на стандартные задачи трейторов-роботов.

Генокрады-импосторы: роль не выдаётся всем, но список заблокированных профессий ужат на 2 пункта. Имеют стандартные цели генокрадов, кроме новой добавленной цели на пожирание другого генокрада.

Культ еретика: одинокий лидер культа имеет 1 задание на проливание крови (убийство) человека который не может вступить в культ. Его фракция имеет в ~70% случаев цель на жертвование алтарю 5-ти человек, 25% на простые убийства и пара процентов на цели революции с процентом на необходимость сохранить состав СБ в живых.

Колличество скейлящихся антагов урезано на ~60% для каждой фракции, чтобы не набиралось по 7 генок и сверху 10 триторов. Надо ещё учитывать что не запрещается еретику вербовать в свой культ как других антагов, так и членов экипажа, а также рандом ивенты на соло-оперативников, блобов, ксеноморфов и абдукторов не выключены.
</details>

## Почему и что этот ПР улучшит
Суть задумки этого режима на сервере заключается в том, чтобы дать контент которого нет и не будет без этого никогда. Конкретно:
* Сломать мету на то, что есть профессии, которые не могут быть антагами. [читать пункт 1 в описании] Что хорошо не лишь на моих словах, а и подкрепляется скриншотом:
<details>
<summary>Скриншот</summary>

![24900e3a-70bb-451e-8b08-f79f22fa7e28](https://github.com/TauCetiStation/TauCetiClassic/assets/96499407/679b9b85-8f60-48bf-b0ed-5913c22e0cfc)
</details>

* Разнообразить раунды сильнее в плане действий антагонистов. Рандомность заданий не позволит сформировать какую-то простую мету на режим (как например с захватом зон культа, на который экипаж получает мету сразу как только видит культ/видит захват). [читать пункт 2 в описании]
* Разнообразить игровые ситуации в плане доверия друг к другу. [читать пункт 3 в описании]
## Авторство
Сам режим с офицерами-генокрадами под кодовым названием "AMOGUS" я увидел на ивенте от @KIBORG04 на сервере когда-то. Меня в нём замочил неприметный генокрад-тритор офицер - мой коллега. Я испытал как раз то, что этот режим даст другим игрокам, а именно смесь неожиданности, непонимания "как это так может быть?!!" и понимания что попал в ситуацию которую и не мог представить в обычном раунде. Этот режим имеет и мои собственные идеи и границы допустимого (например добавление в раунд культиста, что врядли бы мог представить Киборг). 
## Чеинжлог
:cl: Deahaka
- experiment: Добавлен новый режим "Самозванцы"