### PR TITLE
Главы-ксеносы, а также Синий Щит.

### DIFF
--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -59,7 +59,7 @@
 		AND BUMPING UP THE SAVEFILE_VERSION_MAX, AND SAVEFILE_VERSION_SPECIES_JOBS
 		~Luduk
 	*/
-	restricted_species = list(SKRELL, UNATHI, TAJARAN, DIONA, VOX, IPC)
+	restricted_species = list(TAJARAN, VOX, IPC)
 	skillsets = list("Head of Personnel" = /datum/skillset/hop)
 
 /datum/job/blueshield
@@ -85,5 +85,5 @@
 		AND BUMPING UP THE SAVEFILE_VERSION_MAX, AND SAVEFILE_VERSION_SPECIES_JOBS
 		~Luduk
 	*/
-	restricted_species = list(SKRELL, UNATHI, TAJARAN, DIONA, VOX, IPC)
+	restricted_species = list(TAJARAN, DIONA, VOX, IPC)
 	skillsets = list("Blueshield Officer" = /datum/skillset/blueshield)

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -27,7 +27,7 @@
 		AND BUMPING UP THE SAVEFILE_VERSION_MAX, AND SAVEFILE_VERSION_SPECIES_JOBS
 		~Luduk
 	*/
-	restricted_species = list(SKRELL, UNATHI, TAJARAN, DIONA, VOX, IPC)
+	restricted_species = list(TAJARAN, VOX, IPC)
 
 
 /datum/job/warden


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Порезаны ксенорестрикты Блющилда, ГСБ, ГП в сторону отката изменений 2020 года.
## Почему и что этот ПР улучшит
Ограничения вводились без каких либо объяснений что это улучшит, что отмечал SpaiR в ревью и так оно дошло до мержа. Ограничения на моё скромное мнение не пошли на пользу, а их частичный откат сделает игру разнообразнее и приятнее.
## Авторство

## Чеинжлог
:cl: Deahaka
- tweak: в ряды Глав Персонала, Глав Охраны и Синих Щитов теперь берут не только людей.