### PR TITLE
Починка багов крыс и ящерок годовой давности

### DIFF
--- a/code/datums/components/gnawing.dm
+++ b/code/datums/components/gnawing.dm
@@ -11,7 +11,7 @@
 		return
 	var/list/attack = animal.get_unarmed_attack()
 	for(var/obj/structure/cable/C in animal.loc)
-		C.take_damage(attack["damage"], attack["type"], MELEE)
+		C.take_damage(attack["damage"], attack["type"], MELEE, FALSE)
 
 /datum/component/gnawing/Destroy()
 	STOP_PROCESSING(SSgnaw, src)

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -35,6 +35,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	layer = 2.44 //Just below unary stuff, which is at 2.45 and above pipes, which are at 2.4
 	color = COLOR_RED
 	max_integrity = 5
+	resistance_flags = CAN_BE_HIT
 
 /obj/structure/cable/yellow
 	color = COLOR_YELLOW

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -174,6 +174,18 @@ By design, d1 is the smallest direction and d2 is the highest
 	else
 		return 0
 
+//Intent harm attackby. Destroying cable makes shock to user
+/obj/structure/cable/attacked_by(obj/item/attacking_item, mob/living/user, def_zone, power)
+	if(attacking_item.flags & CONDUCT)
+		shock(user, 100)
+	return ..()
+
+//Damage reduction to spend at least 2 hits cutting wires
+/obj/structure/cable/run_atom_armor(damage_amount, damage_type, damage_flag, attack_dir)
+	if(damage_type == BRUTE)
+		return damage_amount * 0.2
+	return ..()
+
 //explosion handling
 /obj/structure/cable/ex_act(severity)
 	switch(severity)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Возвращение механа из https://github.com/TauCetiStation/TauCetiClassic/pull/9211 до того как была переписана разрушаемость. Проводки не могли получать урон, потому и не хотели рваться. Теперь не будет неподходящего под жизнедеятельность крыс звука удара молотком по полу.
## Почему и что этот ПР улучшит
фикс багов
## Авторство

## Чеинжлог
:cl: Deahaka
- fix: Станционные грызуны больше не флудят звуками удара по полу.
- fix: Крысы и ящерицы вновь способны грызть проводку.