### PR TITLE
Уменьшает интервал между взятием некоторых гост-ролей.

### DIFF
--- a/code/datums/spawners_menu/spawners.dm
+++ b/code/datums/spawners_menu/spawners.dm
@@ -583,6 +583,7 @@ var/global/list/datum/spawners_cooldown = list()
 /datum/spawner/living/religion_familiar
 	name = "Фамильяр Религии"
 	desc = "Вы появляетесь в виде какого-то животного в подчинении определённой религии."
+	cooldown = 2 MINUTES
 
 	var/datum/religion/religion
 

--- a/code/datums/spawners_menu/spawners.dm
+++ b/code/datums/spawners_menu/spawners.dm
@@ -608,11 +608,13 @@ var/global/list/datum/spawners_cooldown = list()
 	name = "Оживлённый предмет"
 	id = "mimic"
 	desc = "Вы магическим образом ожили на станции"
+	cooldown = 1 MINUTES
 
 /datum/spawner/living/evil_shade
 	name = "Злой Дух"
 	id = "evil_shade"
 	desc = "Магическая сила призвала вас в мир, отомстите живым за причинённые обиды!"
+	cooldown = 2 MINUTES
 
 /datum/spawner/living/rat
 	name = "Крыса"


### PR DESCRIPTION
## Описание изменений
Часто умирающие и слабые гост-роли теперь имеют более низкую задержку между их взятием.
## Почему и что этот ПР улучшит
Наконец не будет висеть 3-5 пустых места гост-ролей.
## Авторство
-
## Чеинжлог
:cl: 
- tweak: Респавн таймер Злых духов, Фамильяров религии и оживших предметов стал короче.