### PR TITLE
Autosolar 2: Electric Boogaloo 

### DIFF
--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -263,9 +263,20 @@
 /obj/machinery/power/solar_control/atom_init()
 	. = ..()
 	connect_to_network()
+	if(track == 2 && SSticker.current_state != GAME_STATE_PLAYING)
+		RegisterSignal(SSticker, COMSIG_TICKER_ROUND_STARTING, .proc/on_sun_generated)
+
+/obj/machinery/power/solar_control/Destroy()
+		UnregisterSignal(SSticker, COMSIG_TICKER_ROUND_STARTING)
+		return ..()
+
+/obj/machinery/power/solar_control/proc/on_sun_generated(datum/source)
+	SIGNAL_HANDLER
 	if(!powernet)
 		return
+	setup_auto_tracking()
 	set_panels(cdir)
+	updateDialog()
 
 /obj/machinery/power/solar_control/disconnect_from_network()
 	..()
@@ -438,12 +449,7 @@
 			nexttime = world.time + 6000 / trackrate
 		track = text2num(href_list["track"])
 		if(powernet && (track == 2))
-			if(!SSsun.solars.Find(src,1,0))
-				SSsun.solars.Add(src)
-			for(var/obj/machinery/power/tracker/T in get_solars_powernet())
-				if(powernet.nodes[T])
-					cdir = T.sun_angle
-					break
+			setup_auto_tracking()
 
 	else if(href_list["trackdir"])
 		trackdir = text2num(href_list["trackdir"])
@@ -451,6 +457,14 @@
 	set_panels(cdir)
 	update_icon()
 	updateUsrDialog()
+
+/obj/machinery/power/solar_control/proc/setup_auto_tracking()
+	if(!SSsun.solars.Find(src,1,0))
+		SSsun.solars.Add(src)
+	for(var/obj/machinery/power/tracker/T in get_solars_powernet())
+		if(powernet.nodes[T])
+			cdir = T.sun_angle
+			break
 
 
 /obj/machinery/power/solar_control/proc/set_panels(cdir)

--- a/maps/gamma/gamma_revamp.dmm
+++ b/maps/gamma/gamma_revamp.dmm
@@ -6904,10 +6904,14 @@
 /obj/structure/window/thin/reinforced{
 	dir = 1
 	},
-/obj/machinery/power/smes,
 /obj/structure/cable/orange{
 	d2 = 8;
 	icon_state = "0-8"
+	},
+/obj/machinery/power/smes{
+	outputting = 1;
+	input_level = 90000;
+	input_attempt = 1
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -55555,7 +55559,8 @@
 /obj/machinery/power/solar_control{
 	dir = 8;
 	id = "aionesolar";
-	name = "First AI Solar Control"
+	name = "First AI Solar Control";
+	track = 2
 	},
 /obj/structure/cable/yellow,
 /turf/simulated/floor{
@@ -62280,7 +62285,8 @@
 /obj/machinery/power/solar_control{
 	dir = 4;
 	id = "aitwosolar";
-	name = "Second AI Solar Control"
+	name = "Second AI Solar Control";
+	track = 2
 	},
 /obj/structure/cable/yellow,
 /turf/simulated/floor{
@@ -95085,7 +95091,11 @@
 /obj/structure/window/thin/reinforced{
 	dir = 1
 	},
-/obj/machinery/power/smes,
+/obj/machinery/power/smes{
+	outputting = 1;
+	input_level = 90000;
+	input_attempt = 1
+	},
 /obj/structure/cable/orange{
 	d2 = 4;
 	icon_state = "0-4"


### PR DESCRIPTION
ПР с автосолярами от Гусева, но есть нюанс:

Этот ПР добавляет в билд сам механ автонастройки на карте. Что это значит? Маперы смогут настраивать соляры для дереликтов/станционных мест. На самой карте ничего не меняется, за исключением наработок для новой гаммы (но это всё равно моя песочница).

На новой гамме у спутника ИИ есть солнечные панели, теперь они настраиваются раундстартом.
![2023-07-25 16 40 00](https://github.com/TauCetiStation/TauCetiClassic/assets/29666964/15234173-c8a7-4f1c-bae6-07e2e01be99d)

## Описание изменений
Добавляет в игру механ автонастройки соляр посредством мапинга для будущего использования.

## Почему и что этот ПР улучшит
Даст маперам больше творческой свободы

## Авторство
@DarthSidiousPalpatine @AgRevol 
## Чеинжлог
Не требуется, игроки не заметят разницы пока-что.