### PR TITLE
Lifted lightmode debuffs: screen overlay in bar is gone

### DIFF
--- a/code/modules/smartlight/smartlight_presets.dm
+++ b/code/modules/smartlight/smartlight_presets.dm
@@ -48,7 +48,7 @@ var/global/list/smartlight_presets
 	available_modes = base.available_modes | available_modes
 	disabled_modes = base.disabled_modes | disabled_modes
 
-/* 
+/*
    Global Map presets
 */
 
@@ -78,14 +78,14 @@ var/global/list/smartlight_presets
 		/datum/light_mode/horror,
 	)
 
-/* 
+/*
    Local APC presets (will expand global one)
 */
 
 /datum/smartlight_preset/bar
 	name = "bar"
 
-	default_mode = /datum/light_mode/blue_night
+	default_mode = /datum/light_mode/default
 	no_nightshift_mode = TRUE
 
 	available_modes = list(


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Я просто предлагаю считать синий свет каждый раунд в баре бета-версией того, чем оно могло бы быть. Пока регулярно оно не вписывается в нормальную обстановку бара, пока игроки банально не ремапнут карту под новый свет, пока у нас нету инструментов для сбора фидбека и отслеживания целесообразности ставить синий свет раундстартом, я считаю наказывать игроков противным фильтром в таких обстоятельствах излишним. Вернутся к вопросу можно будет в будущем, когда будут исправлены уже все известные проблемы и система будет более красивой.
![01z](https://github.com/TauCetiStation/TauCetiClassic/assets/96499407/089c2d68-14b7-46de-a982-db86ebf022dc)

## Почему и что этот ПР улучшит
closes #11733
Если игроки захотят, они сами себе поставят что-то вот такое вычурное. Я не предлагаю забирать инструменты, а лишь не доводить не заинтересованных до слёз.
## Авторство

## Чеинжлог
:cl: Deahaka
- tweak: Свет в баре по умолчанию такой же как и на остальной части станции (всё еще можно изменить в АПЦ).