### PR TITLE
добавляет в лодаут охранный худ

### DIFF
--- a/code/modules/client/character_menu/loadout/loadout_glasses.dm
+++ b/code/modules/client/character_menu/loadout/loadout_glasses.dm
@@ -39,3 +39,8 @@
 /datum/gear/eyes/glasses/Jerusalem_Glasses
 	display_name = "Jerusalem Glasses"
 	path = /obj/item/clothing/glasses/jerusalem
+
+/datum/gear/eyes/glasses/sec_hud
+	display_name = "Security HUD"
+	path = /obj/item/clothing/glasses/hud/security
+	allowed_roles = list("Security Officer", "Warden", "Head of Security")


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
тайтл
## Почему и что этот ПР улучшит
больше моды, использование забытого контента, возможность отыгрыш персонажей из драгон болла
## Авторство
я
## Чеинжлог
🆑 
- rscadd: Офицеры, варден и ХоС могут взять в лодауте охранный ХУД.
