### PR TITLE
Explosions flame wave imitation

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -353,7 +353,8 @@
 /atom/proc/airlock_crush_act()
 	return
 
-/atom/proc/fire_act()
+// todo: exposed_temperature is only arg currently used, rest is some legacy (idk what they should do anyway)
+/atom/proc/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	return
 
 /atom/proc/singularity_act()

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -984,9 +984,9 @@ FIRE ALARM
 	else
 		icon_state = "fire0"
 
-/obj/machinery/firealarm/fire_act(datum/gas_mixture/air, temperature, volume)
+/obj/machinery/firealarm/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(detecting)
-		if(temperature > T0C+200)
+		if(exposed_temperature > T0C+200)
 			alarm()			// added check of detector status here
 	return
 

--- a/code/game/objects/items/latexballoon.dm
+++ b/code/game/objects/items/latexballoon.dm
@@ -39,8 +39,8 @@
 	. = ..()
 	burst()
 
-/obj/item/latexballon/fire_act(datum/gas_mixture/air, temperature, volume)
-	if(temperature > T0C+100)
+/obj/item/latexballon/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+	if(exposed_temperature > T0C+100)
 		burst()
 	return
 

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -105,12 +105,10 @@ var/global/list/wood_icons = list("wood","wood-broken")
 						break_tile_to_plating()
 					else
 						break_tile()
-					hotspot_expose(1000,CELL_VOLUME)
 					if(prob(33)) new /obj/item/stack/sheet/metal(src)
 		if(EXPLODE_LIGHT)
 			if(prob(50))
 				break_tile()
-				hotspot_expose(1000,CELL_VOLUME)
 
 /turf/simulated/floor/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(!burnt && prob(5))

--- a/code/modules/atmospheric/ZAS/Fire.dm
+++ b/code/modules/atmospheric/ZAS/Fire.dm
@@ -136,24 +136,30 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 
 	var/turf/T = get_turf(src)
 
+	if(isspaceturf(T))
+		return INITIALIZE_HINT_QDEL
+
 	var/datum/gas_mixture/air_contents = T.return_air()
 	if(!air_contents)
 		return INITIALIZE_HINT_QDEL
-
-	color = heat2color(temperature)
-	set_light(3, 3, color)
 
 	// todo: increase air temperature?
 	// todo: should FireBurn and fire_act be part of hotspot_expose?
 
 	var/fire_started = T.hotspot_expose(temperature) // can start real fire if possible
 
-	if(!fire_started) // if fire started - fire will burn them all, else do this once here
-		// part copypaste from obj/fire below
-		T.fire_act(exposed_temperature = temperature)
+	// part copypaste from obj/fire below
+	T.fire_act(exposed_temperature = temperature)
 
-		for(var/atom/A in T)
-			A.fire_act(exposed_temperature = temperature)
+	for(var/atom/A in T)
+		A.fire_act(exposed_temperature = temperature)
+
+	if(fire_started) // fire will handle visual
+		return INITIALIZE_HINT_QDEL
+
+	// else do temp fire flash
+	color = heat2color(temperature)
+	set_light(3, 3, color)
 
 	QDEL_IN(src, 2 SECONDS)
 

--- a/code/modules/atmospheric/ZAS/Fire.dm
+++ b/code/modules/atmospheric/ZAS/Fire.dm
@@ -16,8 +16,9 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 
 
 /turf/proc/hotspot_expose(exposed_temperature, exposed_volume, atom/firestarter)
+	return FALSE
 
-
+// todo: exposed_volume not used and idk what should do, should be removed
 /turf/simulated/hotspot_expose(exposed_temperature, exposed_volume, atom/firestarter)
 	if(fire_protection > world.time - 300)
 		return FALSE
@@ -115,6 +116,46 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 		zone.fuel_objs += fuel
 
 	return FALSE
+
+// todo: check effect/hotspot on tg, possible future refactoring needed
+// wrote it because create_fire() and /obj/fire will die right after spawn without fuel
+/obj/effect/firewave
+	anchored = TRUE
+	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+
+	blend_mode = BLEND_ADD
+
+	icon = 'icons/effects/fire.dmi'
+	icon_state = "1"
+	light_color = LIGHT_COLOR_FIRE
+	layer = OBJ_LAYER
+	flags = ABSTRACT
+
+/obj/effect/firewave/atom_init(mapload, temperature = 1000)
+	. = ..()
+
+	var/turf/T = get_turf(src)
+
+	var/datum/gas_mixture/air_contents = T.return_air()
+	if(!air_contents)
+		return INITIALIZE_HINT_QDEL
+
+	color = heat2color(temperature)
+	set_light(3, 3, color)
+
+	// todo: increase air temperature?
+	// todo: should FireBurn and fire_act be part of hotspot_expose?
+
+	var/fire_started = T.hotspot_expose(temperature) // can start real fire if possible
+
+	if(!fire_started) // if fire started - fire will burn them all, else do this once here
+		// part copypaste from obj/fire below
+		T.fire_act(exposed_temperature = temperature)
+
+		for(var/atom/A in T)
+			A.fire_act(exposed_temperature = temperature)
+
+	QDEL_IN(src, 2 SECONDS)
 
 /obj/fire
 	// Icon for fire on turfs.
@@ -264,6 +305,9 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 
 		total_fuel = gas_fuel + liquid_fuel
 		if(total_fuel <= 0.005)
+			#ifdef FIREDBG
+			log_debug("Burning canceled because no fuel!")
+			#endif
 			return FALSE
 
 		//*** Determine how fast the fire burns

--- a/code/modules/europa/fluids/fluid_update.dm
+++ b/code/modules/europa/fluids/fluid_update.dm
@@ -1,3 +1,5 @@
+// wtf is this, why we need additional init/del call everywhere for fluid_update
+
 /atom/movable/update_nearby_tiles()
 	. = ..()
 	fluid_update()

--- a/code/modules/events/cellular_biomass/biomass.dm
+++ b/code/modules/events/cellular_biomass/biomass.dm
@@ -130,6 +130,6 @@
 				return
 	qdel(src)
 
-/obj/effect/biomass/fire_act(null, temperature, volume) //hotspots kill biomass
-	if(temperature > T0C+100)
+/obj/effect/biomass/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume) //hotspots kill biomass
+	if(exposed_temperature > T0C+100)
 		qdel(src)

--- a/code/modules/events/cellular_biomass/spacevines.dm
+++ b/code/modules/events/cellular_biomass/spacevines.dm
@@ -183,6 +183,6 @@
 				return
 	qdel(src)
 
-/obj/structure/spacevine/fire_act(null, temperature, volume) //hotspots kill vines
-	if(temperature > T0C+100)
+/obj/structure/spacevine/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume) //hotspots kill vines
+	if(exposed_temperature > T0C+100)
 		qdel(src)

--- a/code/modules/holidays/new_year/snow.dm
+++ b/code/modules/holidays/new_year/snow.dm
@@ -79,7 +79,7 @@
 		return
 	qdel(src)
 
-/obj/item/snowball/fire_act()
+/obj/item/snowball/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	qdel(src)
 
 /obj/item/snowball/ex_act(severity)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -315,7 +315,7 @@
 	var/turf/location = get_turf(src)
 	location.hotspot_expose(fire_burn_temperature(), 50)
 
-/mob/living/fire_act()
+/mob/living/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	adjust_fire_stacks(0.5)
 	IgniteMob()
 

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -182,8 +182,8 @@
 	qdel(src)
 	return TRUE
 
-/obj/structure/reagent_dispensers/fire_act(datum/gas_mixture/air, temperature, volume)
-	if(temperature > T0C+500)
+/obj/structure/reagent_dispensers/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+	if(exposed_temperature > T0C+500)
 		if(explode())
 			return
 	return ..()

--- a/code/modules/scrap/scrap_light.dm
+++ b/code/modules/scrap/scrap_light.dm
@@ -164,7 +164,7 @@
 	Burn()
 	START_PROCESSING(SSobj, src)
 
-/obj/structure/bonfire/fire_act(exposed_temperature, exposed_volume)
+/obj/structure/bonfire/fire_act()
 	StartBurning()
 
 /obj/structure/bonfire/Crossed(atom/movable/AM)

--- a/code/modules/scrap/scrap_light.dm
+++ b/code/modules/scrap/scrap_light.dm
@@ -164,7 +164,7 @@
 	Burn()
 	START_PROCESSING(SSobj, src)
 
-/obj/structure/bonfire/fire_act()
+/obj/structure/bonfire/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	StartBurning()
 
 /obj/structure/bonfire/Crossed(atom/movable/AM)

--- a/code/modules/statistic/stat_dto.dm
+++ b/code/modules/statistic/stat_dto.dm
@@ -166,6 +166,8 @@
 	var/light_impact_range = 0
 	// int, [-infinity...]
 	var/flash_range = 0
+	// int, [-infinity...]
+	var/flame_range = 0
 	// string, [hh:mm]
 	var/occurred_time
 

--- a/code/modules/statistic/statistics_helpers.dm
+++ b/code/modules/statistic/statistics_helpers.dm
@@ -52,7 +52,7 @@
 
 	deaths += stat
 
-/datum/stat_collector/proc/add_explosion_stat(turf/epicenter, dev_range, hi_range, li_range, flash_range)
+/datum/stat_collector/proc/add_explosion_stat(turf/epicenter, dev_range, hi_range, li_range, flash_range, flame_range)
 	if(!SSticker || SSticker.current_state != GAME_STATE_PLAYING)
 		return
 
@@ -64,6 +64,7 @@
 	stat.heavy_impact_range = hi_range
 	stat.light_impact_range = li_range
 	stat.flash_range = flash_range
+	stat.flame_range = flame_range
 	stat.occurred_time = roundduration2text()
 
 	explosions += stat


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Более экспериментальная часть взрывов из #11256, так что отдельным PR-ом.

Добавляет эффект воспламенения после взрывов. Огонь не настоящий, потому что настоящий не умеет гореть сам по себе. И может спрайт огня в целом можно было бы заменить на что-то другое.

На ТГ это сделано через ``/obj/effect/hotspot``, оно тоже работает как-то отчасти вне атмоса, и в целом там атмос отличается от нашего. Так что написал для этого свой эффект у нас.

Попутно где-то сейчас начну собирать мысли по поводу рефакторинга огня.

## Почему и что этот ПР улучшит

Раз взрывы быстрые, мы можем их теперь делать более эффектными. Делает взрывы более эффектными.

## Авторство

## Чеинжлог
