### PR TITLE
Быстрая работа с спейс сюитами

### DIFF
--- a/code/__DEFINES/quirks.dm
+++ b/code/__DEFINES/quirks.dm
@@ -6,7 +6,7 @@
 #define QUIRK_ALCOHOL_TOLERANCE "Стойкость к Алкоголю"
 #define QUIRK_FREERUNNING "Фриран"
 #define QUIRK_LIGHT_STEP "Лёгкий Шаг"
-#define QUIRK_FAST_EQUIP "Улучшенная Координация"
+#define QUIRK_SLOW_EQUIP "Тормоз"
 #define QUIRK_FRIENDLY "Дружелюбный"
 
 // neutral quirks.

--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -155,7 +155,7 @@
 #define TRAIT_DALTONISM           "daltonism"
 #define TRAIT_COOLED              "external_cooling_device"
 #define TRAIT_NO_RUN              "no_run"
-#define TRAIT_FAST_EQUIP          "fast_equip"
+#define TRAIT_SLOW_EQUIP          "slow_equip"
 #define TRAIT_FRIENDLY            "friendly"
 #define TRAIT_NO_CLONE            "no_clone"
 #define TRAIT_VACCINATED          "vaccinated"

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -234,3 +234,11 @@
 		IS_PLANT = FALSE,
 		IS_SYNTHETIC = FALSE,
 	)
+
+/datum/quirk/slow_equip
+	name = QUIRK_SLOW_EQUIP
+	desc = "Вы не можете одеваться быстрее."
+	value = -2
+	mob_trait = TRAIT_SLOW_EQUIP
+	lose_text = "<span class='notice'Годы жизни на станции научили вас кое-чему.</span>"
+	gain_text = "<span class='danger'>Ваша координация стремительно деградировала.</span>"

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -238,7 +238,7 @@
 /datum/quirk/slow_equip
 	name = QUIRK_SLOW_EQUIP
 	desc = "Вы не можете одеваться быстрее."
-	value = -2
+	value = -1
 	mob_trait = TRAIT_SLOW_EQUIP
 	lose_text = "<span class='notice'Годы жизни на станции научили вас кое-чему.</span>"
 	gain_text = "<span class='danger'>Ваша координация стремительно деградировала.</span>"

--- a/code/datums/traits/positive.dm
+++ b/code/datums/traits/positive.dm
@@ -81,15 +81,6 @@
 	gain_text = "<span class='notice'>У вас лёгкая поступь.</span>"
 	lose_text = "<span class='danger'>Вы начинаете топотать, как грязный варвар.</span>"
 
-/datum/quirk/fast_equip
-	name = QUIRK_FAST_EQUIP
-	desc = "Вы можете одеваться быстрее."
-	value = 2
-	mob_trait = TRAIT_FAST_EQUIP
-	gain_text = "<span class='notice'Годы жизни на станции научили вас кое-чему.</span>"
-	lose_text = "<span class='danger'>Ваша координация стремительно деградировала.</span>"
-
-
 /datum/quirk/friendly
 	name = QUIRK_FRIENDLY
 	desc = "Ваши объятия прекрасны! В особенности, если вы в хорошем настроении."

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -452,7 +452,7 @@ BLIND     // can't see anything
 	pierce_protection = UPPER_TORSO|LOWER_TORSO|ARMS|LEGS
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/emergency_oxygen,/obj/item/device/suit_cooling_unit)
 	slowdown = 1.5
-	equip_time = 100 // Bone White - time to equip/unequip. see /obj/item/attack_hand (items.dm) and /obj/item/clothing/mob_can_equip (clothing.dm)
+	equip_time = 20 // Bone White - time to equip/unequip. see /obj/item/attack_hand (items.dm) and /obj/item/clothing/mob_can_equip (clothing.dm)
 	armor = list(melee = 0, bullet = 0, laser = 0,energy = 0, bomb = 0, bio = 100, rad = 50)
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | ARMS

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -537,7 +537,7 @@ var/global/list/slot_equipment_priority = list(
 
 	to_chat(usr, "<span class='notice'>You start unequipping the [C].</span>")
 	C.equipping = TRUE
-	var/equip_time = HAS_TRAIT(usr, TRAIT_FAST_EQUIP) ? C.equip_time / 2 : C.equip_time
+	var/equip_time = HAS_TRAIT(usr, TRAIT_SLOW_EQUIP) ? C.equip_time * 5 : C.equip_time
 	if(!do_after(usr, equip_time, target = C))
 		C.equipping = FALSE
 		to_chat(src, "<span class='red'>\The [C] is too fiddly to unequip whilst moving.</span>")
@@ -564,7 +564,7 @@ var/global/list/slot_equipment_priority = list(
 
 	to_chat(usr, "<span class='notice'>You start equipping the [C].</span>")
 	C.equipping = 1
-	var/equip_time = HAS_TRAIT(usr, TRAIT_FAST_EQUIP) ? C.equip_time / 2 : C.equip_time
+	var/equip_time = HAS_TRAIT(usr, TRAIT_SLOW_EQUIP) ? C.equip_time / 2 : C.equip_time
 	if(do_after(usr, equip_time, target = C))
 		equip_to_slot_if_possible(C, slot)
 		to_chat(usr, "<span class='notice'>You have finished equipping the [C].</span>")

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -564,7 +564,7 @@ var/global/list/slot_equipment_priority = list(
 
 	to_chat(usr, "<span class='notice'>You start equipping the [C].</span>")
 	C.equipping = 1
-	var/equip_time = HAS_TRAIT(usr, TRAIT_SLOW_EQUIP) ? C.equip_time / 2 : C.equip_time
+	var/equip_time = HAS_TRAIT(usr, TRAIT_SLOW_EQUIP) ? C.equip_time * 5 : C.equip_time
 	if(do_after(usr, equip_time, target = C))
 		equip_to_slot_if_possible(C, slot)
 		to_chat(usr, "<span class='notice'>You have finished equipping the [C].</span>")


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
В последнее время что-то остро стала чувствоваться боль от ригов https://github.com/TauCetiStation/TauCetiClassic/pull/11668
Поэтому было принято решение закопать грифозную механику подальше от игроков.
Теперь риги снимаются и одеваются намного быстрее. Квирк быстрое надевание, который не делал нихрена всё быстрее, заменён на крутой негативный квирк который реально влияет на ситуацию и компенсирует это двумя очками квирков.
## Почему и что этот ПР улучшит
Всё в соответствии с https://github.com/TauCetiStation/TauCetiClassic/issues/11670
Долгое надевание ригов увеличивает колличество жертв от разгерметизаций, делая разгерму выгодной. Долгое надевание ригов ничем не подкреплено, риги уже не защищают ни от чего, чтобы предположить что "это настолько имба, поэтому надо компенсировать временем".
## Авторство

## Чеинжлог
:cl: Deahaka
- tweak: Скорость снятия/надевания всех космических скафандров уменьшена.
- del: Позитивный квирк на ускорение экипирования вещей удалён.
- add: Добавлен негативный квирк увеличивающий время на экипирование вещей до старых значений.