### PR TITLE
Небольшое обновление способности абсорба генокрада

### DIFF
--- a/code/game/gamemodes/modes_gameplays/changeling/powers/absorb.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/absorb.dm
@@ -30,12 +30,11 @@
 	var/datum/role/changeling/changeling = user.mind.GetRoleByType(/datum/role/changeling)
 	var/obj/item/weapon/grab/G = user.get_active_hand()
 	var/mob/living/carbon/human/target = G.affecting
-	var/datum/mind/target_mind = target.mind
 	changeling.isabsorbing = 1
 	for(var/stage = 1, stage<=3, stage++)
 		switch(stage)
 			if(1)
-				if(target_mind)
+				if(target.mind)
 					to_chat(user, "<span class='notice'>This creature has mind. We will become one.</span>")
 				else
 					to_chat(user, "<span class='notice'>This creature is mindless. We'll just satisfy our hunger.</span>")
@@ -78,12 +77,12 @@
 	if(target.species && !(target.species.name in changeling.absorbed_species))
 		changeling.absorbed_species += target.species.name
 
-	if(target_mind)//if the victim has got a mind
+	if(target.mind)//if the victim has got a mind
 
-		target_mind.show_memory(user) //I can read your mind, kekeke. Output all their notes.
+		target.mind.show_memory(user) //I can read your mind, kekeke. Output all their notes.
 		changeling.geneticpoints += 2
-		user.mind.skills.transfer_skills(target_mind)
-		var/datum/role/changeling/C = target_mind.GetRoleByType(/datum/role/changeling)
+		user.mind.skills.transfer_skills(target.mind)
+		var/datum/role/changeling/C = target.mind.GetRoleByType(/datum/role/changeling)
 		if(C)//If the target was a changeling, suck out their extra juice and objective points!
 			changeling.chem_charges += min(C.chem_charges, changeling.chem_storage)
 			changeling.absorbedcount += C.absorbedcount

--- a/code/game/gamemodes/modes_gameplays/changeling/powers/absorb.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/absorb.dm
@@ -30,11 +30,16 @@
 	var/datum/role/changeling/changeling = user.mind.GetRoleByType(/datum/role/changeling)
 	var/obj/item/weapon/grab/G = user.get_active_hand()
 	var/mob/living/carbon/human/target = G.affecting
+	var/datum/mind/target_mind = target.mind
 	changeling.isabsorbing = 1
 	for(var/stage = 1, stage<=3, stage++)
 		switch(stage)
 			if(1)
-				to_chat(user, "<span class='notice'>This creature is compatible. We must hold still...</span>")
+				if(target_mind)
+					to_chat(user, "<span class='notice'>This creature has mind. We will become one.</span>")
+				else
+					to_chat(user, "<span class='notice'>This creature is mindless. We'll just satisfy our hunger.</span>")
+				to_chat(user, "<span class='notice'>We must hold still...</span>")
 			if(2)
 				to_chat(user, "<span class='notice'>We extend a proboscis.</span>")
 				user.visible_message("<span class='warning'>[user] extends a proboscis!</span>")
@@ -73,12 +78,12 @@
 	if(target.species && !(target.species.name in changeling.absorbed_species))
 		changeling.absorbed_species += target.species.name
 
-	if(target.mind)//if the victim has got a mind
+	if(target_mind)//if the victim has got a mind
 
-		target.mind.show_memory(user) //I can read your mind, kekeke. Output all their notes.
+		target_mind.show_memory(user) //I can read your mind, kekeke. Output all their notes.
 		changeling.geneticpoints += 2
-		user.mind.skills.transfer_skills(target.mind)
-		var/datum/role/changeling/C = target.mind.GetRoleByType(/datum/role/changeling)
+		user.mind.skills.transfer_skills(target_mind)
+		var/datum/role/changeling/C = target_mind.GetRoleByType(/datum/role/changeling)
 		if(C)//If the target was a changeling, suck out their extra juice and objective points!
 			changeling.chem_charges += min(C.chem_charges, changeling.chem_storage)
 			changeling.absorbedcount += C.absorbedcount


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Абсорб генокрада даёт 2 очка эволюции при поглощении существа с разумом и всего 0.5 при поглощении существа без разума, сейчас невозможно понять, поглощается ли кукла с разумом или нет, поэтому добавлено сообщение есть ли у существа разум.
## Почему и что этот ПР улучшит
Будет больше контроля при поглощении, можно будет не боятся сожрать бесполезную куклу, получив всего 0.5 очка эволюции. 
## Авторство

## Чеинжлог
:cl:
 - add: При поглощении существа генокрадом, ему выводится сообщение в лог, есть ли у поглощаемого существа разум.