### PR TITLE
Нерф манча офицеров. Рюкзаки замедляют при экипированной броне.

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -336,6 +336,9 @@
 ///from ai_actual_track(): (mob/living)
 #define COMSIG_LIVING_CAN_TRACK "mob_cantrack"
 	#define COMPONENT_CANT_TRACK (1<<0)
+///from /mob/living/carbon/human/movement_delay(): (tally, list/all_slots_list)
+#define COMSIG_SLOWDOWN_HUMAN "slowdown_human"
+
 
 /// from /datum/action/changeling/transform/sting_action(): (mob/living/carbon/human/user)
 #define COMSIG_CHANGELING_TRANSFORM "changeling_transform"

--- a/code/datums/elements/satchel_slowdown.dm
+++ b/code/datums/elements/satchel_slowdown.dm
@@ -7,13 +7,16 @@
 		return ELEMENT_INCOMPATIBLE
 	RegisterSignal(target, COMSIG_SLOWDOWN_HUMAN, PROC_REF(slowdown_user))
 
-//marine armor, detective suit exclude
+//marine armor exclude
 /datum/element/satchel_slowdown/proc/is_armorsuit_weared(list/slots_list)
 	. = FALSE
 	for(var/i in slots_list)
 		if(istype(i, /obj/item/clothing/suit/armor))
 			//no debuff nuclear operatives until space suits slow down with backpacks
 			if(istype(i, /obj/item/clothing/suit/armor/syndiassault))
+				continue
+			//detective suit exclude
+			if(istype(i, /obj/item/clothing/suit/armor/det_suit))
 				continue
 			. = TRUE
 			break

--- a/code/datums/elements/satchel_slowdown.dm
+++ b/code/datums/elements/satchel_slowdown.dm
@@ -1,0 +1,31 @@
+/datum/element/satchel_slowdown
+	element_flags = ELEMENT_DETACH
+
+/datum/element/satchel_slowdown/Attach(datum/target)
+	. = ..()
+	if(!isitem(target))
+		return ELEMENT_INCOMPATIBLE
+	RegisterSignal(target, COMSIG_SLOWDOWN_HUMAN, PROC_REF(slowdown_user))
+
+//marine armor, detective suit exclude
+/datum/element/satchel_slowdown/proc/is_armorsuit_weared(list/slots_list)
+	. = FALSE
+	for(var/i in slots_list)
+		if(istype(i, /obj/item/clothing/suit/armor))
+			//no debuff nuclear operatives until space suits slow down with backpacks
+			if(istype(i, /obj/item/clothing/suit/armor/syndiassault))
+				continue
+			. = TRUE
+			break
+		if(istype(i, /obj/item/clothing/suit/storage/flak))
+			. = TRUE
+			break
+
+/datum/element/satchel_slowdown/proc/slowdown_user(datum/source, list/reflist)
+	SIGNAL_HANDLER
+	if(is_armorsuit_weared(reflist[2]))
+		reflist[1]++
+
+/datum/element/satchel_slowdown/Detach(datum/source)
+	UnregisterSignal(source, COMSIG_SLOWDOWN_HUMAN)
+	return ..()

--- a/code/datums/elements/satchel_slowdown.dm
+++ b/code/datums/elements/satchel_slowdown.dm
@@ -7,17 +7,13 @@
 		return ELEMENT_INCOMPATIBLE
 	RegisterSignal(target, COMSIG_SLOWDOWN_HUMAN, PROC_REF(slowdown_user))
 
-//marine armor exclude
 /datum/element/satchel_slowdown/proc/is_armorsuit_weared(list/slots_list)
 	. = FALSE
 	for(var/i in slots_list)
-		if(istype(i, /obj/item/clothing/suit/armor))
-			//no debuff nuclear operatives until space suits slow down with backpacks
-			if(istype(i, /obj/item/clothing/suit/armor/syndiassault))
-				continue
-			//detective suit exclude
-			if(istype(i, /obj/item/clothing/suit/armor/det_suit))
-				continue
+		if(istype(i, /obj/item/clothing/suit/armor/riot))
+			. = TRUE
+			break
+		if(istype(i, /obj/item/clothing/suit/armor/hos))
 			. = TRUE
 			break
 		if(istype(i, /obj/item/clothing/suit/storage/flak))
@@ -27,7 +23,7 @@
 /datum/element/satchel_slowdown/proc/slowdown_user(datum/source, list/reflist)
 	SIGNAL_HANDLER
 	if(is_armorsuit_weared(reflist[2]))
-		reflist[1]++
+		reflist[1] += 0.5
 
 /datum/element/satchel_slowdown/Detach(datum/source)
 	UnregisterSignal(source, COMSIG_SLOWDOWN_HUMAN)

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -15,6 +15,10 @@
 	max_storage_space = DEFAULT_BACKPACK_STORAGE
 	var/opened = 0
 
+/obj/item/weapon/storage/backpack/New()
+	. = ..()
+	AddElement(/datum/element/satchel_slowdown)
+
 /obj/item/weapon/storage/backpack/ui_action_click()
 	if(!opened)
 		open(loc)

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -111,6 +111,13 @@
 	else
 		tally += species.speed_mod_no_shoes
 
+	var/list/all_human_cloth = get_all_slots()
+	// Need to wrap this in a list so we can pass a reference
+	var/list/reflist = list(tally, all_human_cloth)
+	for(var/obj/item/cloth in all_human_cloth)
+		SEND_SIGNAL(cloth, COMSIG_SLOWDOWN_HUMAN, reflist)
+	tally = reflist[1]
+
 	if(weight_tally > weight_negation)
 		tally += weight_tally - weight_negation
 

--- a/taucetistation.dme
+++ b/taucetistation.dme
@@ -346,6 +346,7 @@
 #include "code\datums\elements\_element.dm"
 #include "code\datums\elements\beauty.dm"
 #include "code\datums\elements\digitalcamo.dm"
+#include "code\datums\elements\satchel_slowdown.dm"
 #include "code\datums\emotes\emote.dm"
 #include "code\datums\emotes\misc.dm"
 #include "code\datums\emotes\state_checks.dm"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
детально расписано в https://forum.taucetistation.org/t/golosovanie-nerf-mancha-oficzerov-pr-na-podhode/40231

Рюкзак в сочетании с защитным снаряжением в слоте suit теперь замедляет человека. Эта механика не снимает правило о запрете манчкинизма и вас все равно могут забанить даже если вы согласны на штрафы чтобы понарушать правила.

**Как обойти**: перенос брони в рюкзаке не накладывает замедление, перенос брони или рюкзака отдельно от себя в режиме pull не накладывает замедления (если только вещь не имеет прописанное замедление при пуле). Удачи!

Не накладывал замедление от детективского пальто, в связи с тем, что детективу может для работы понадобится собирать много вещей не в целях нарушить правила. Не накладывал замедление от брони маринов, так как там красивый дуфельбаг в комплекте к костюму идёт. Специально отключил замедление для Nuclear Emergency отдельно, чтобы не дебафать ассаулт армор по сравнению с наборами ригов. Это планирую изменить отдельным ПРом, где попытаюсь включить замедление и для ригов, включая нюкерские c уже другой целью.
## Почему и что этот ПР улучшит
Нерф направлен на робустеров и должен побороть их желание манчить всё подряд на офицерах. Механика делает невыгодность и неудобность использования огромного хранилища для манча (рюкзака) в сочетании с желанной защитой, что даст необходимость использовать стратегии в которых робустеры будут уязвимее, чем прежде, что уменьшит процент игроков с таким паттерном поведения.
## Авторство

## Чеинжлог
:cl: Deahaka
- balance: Рюкзаки в сочетании с бронёй замедляют людей.