### PR TITLE
Last bumped

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -167,7 +167,6 @@
 	STOP_THROWING(src, A)
 
 	if(A && non_native_bump)
-		A.last_bumped = world.time
 		A.Bumped(src)
 
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -66,15 +66,12 @@ var/global/list/wedge_image_cache = list()
 	QDEL_NULL(wedged_item)
 	return ..()
 
-//process()
-	//return
-
 /obj/machinery/door/Bumped(atom/AM)
 	if(p_open || operating) return
+	if(world.time - last_bumped <= 7) return	//Can bump-open one airlock per animation. This is to prevent shock spam.
+	last_bumped = world.time
 	if(ismob(AM))
 		var/mob/M = AM
-		if(world.time - M.last_bumped <= 10) return	//Can bump-open one airlock per second. This is to prevent shock spam.
-		M.last_bumped = world.time
 		if(!M.restrained() && M.w_class >= SIZE_SMALL)
 			bumpopen(M)
 		return

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -68,7 +68,8 @@ var/global/list/wedge_image_cache = list()
 
 /obj/machinery/door/Bumped(atom/AM)
 	if(p_open || operating) return
-	if(world.time - last_bumped <= 7) return	//Can bump-open one airlock per animation. This is to prevent shock spam.
+	if(world.time - last_bumped <= 7)
+		return //Can bump-open one airlock per animation. This is to prevent shock spam.
 	last_bumped = world.time
 	if(ismob(AM))
 		var/mob/M = AM

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -77,12 +77,13 @@
 		return
 	if(!density)
 		return ..()
+	if(world.time - last_bumped <= 10)
+		return //Can bump-open one airlock per second. This is to prevent popup message spam.
+	last_bumped = world.time
 	if(istype(AM, /obj/mecha))
 		var/obj/mecha/mecha = AM
 		if (mecha.occupant)
 			var/mob/M = mecha.occupant
-			if(world.time - M.last_bumped <= 10) return //Can bump-open one airlock per second. This is to prevent popup message spam.
-			M.last_bumped = world.time
 			attack_hand(M)
 	return 0
 

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -147,9 +147,10 @@
 
 /obj/structure/inflatable/door/proc/TryToSwitchState(atom/user)
 	if(isSwitchingStates) return
+	if(world.time - last_bumped <= 22) return
+	last_bumped = world.time
 	if(ismob(user))
 		var/mob/M = user
-		if(world.time - user.last_bumped <= 60) return //NOTE do we really need that?
 		if(M.client)
 			if(iscarbon(M))
 				var/mob/living/carbon/C = M

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -147,7 +147,8 @@
 
 /obj/structure/inflatable/door/proc/TryToSwitchState(atom/user)
 	if(isSwitchingStates) return
-	if(world.time - last_bumped <= 22) return
+	if(world.time - last_bumped <= 22)
+		return
 	last_bumped = world.time
 	if(ismob(user))
 		var/mob/M = user


### PR DESCRIPTION
Часть 1
## Описание изменений
`last_bumped` - переменная, которая вызывается только если кто-то врезается в дверь (шлюз, надувная, либо стеклянное окошко). Каждый раз, когда мы открываем дверь, **моб** получает КД, до истечения которого он не может открыть следующую дверь, и не важно, эту же или другую.
И вот тут возникает проблема. Например, надувная дверь имеет задержку в 6 секунд. То-есть, после открытия шлюза, нам нужно прождать ещё 6 секунд, что бы открыть уже надувную дверцу. Что я предлагаю?
Перевести эту переменную с моба, на саму дверь. Что это нам даст?
1) Разным дверям можно поставить разную задержку открытия.
2) Не нужно будет стоять как истукан, если ошибся дверью, ожидая истечения таймера.
3) Те же одиссеи более не смогут спамить дверьми до состояния, когда те полностью красные.
4) Экономия на спичках с проверок моба до истечения таймера.

Какие минусы?
В корридорах, с 3 дверьми, при диагональной ходьбе, будут открываться 2 двери, а не одна.

Также немного уменьшил КД обычных дверей до 0.7 (с 1) секунд, по времени анимации, а также надувных дверей с 60 до 22.

P.s. Честно говоря, я не знаю зачем таймер бампа в **нажатии** у надувной двери
## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
:cl: 
- tweak: Двери будут открываться чуточку быстрее