### PR TITLE
Добавление карты гаммы в игру

### DIFF
--- a/code/game/objects/items/station_map.dm
+++ b/code/game/objects/items/station_map.dm
@@ -13,6 +13,6 @@
 	popup.set_content("<img src='nanomap.png' style='-ms-interpolation-mode:nearest-neighbor'>")
 	popup.open()
 
-/obj/item/station_map/prometheus
+/obj/item/station_map/prometheusmap
 	icon_state = "prometheus"
 	img = 'nano/images/nanomap_prometheus_1_small.png'

--- a/code/game/objects/structures/signs/signs_maps.dm
+++ b/code/game/objects/structures/signs/signs_maps.dm
@@ -4,17 +4,17 @@
 	name = "station map"
 	desc = "A framed picture of the station."
 
-/obj/structure/sign/map/boxmap-left
+/obj/structure/sign/map/boxmap_left
 	icon_state = "map-left"
 
-/obj/structure/sign/map/boxmap-right
+/obj/structure/sign/map/boxmap_right
 	icon_state = "map-right"
 
-/obj/structure/sign/map/gammamap-left
-	icon_state = "gammamap-left"
+/obj/structure/sign/map/gammamap_left
+	icon_state = "gammamap_left"
 
-/obj/structure/sign/map/gammamap-right
-	icon_state = "gammamap-right"
+/obj/structure/sign/map/gammamap_right
+	icon_state = "gammamap_right"
 
 /obj/structure/sign/map/prometheusmap
 	icon_state = "prometheus"

--- a/code/game/objects/structures/signs/signs_maps.dm
+++ b/code/game/objects/structures/signs/signs_maps.dm
@@ -4,17 +4,23 @@
 	name = "station map"
 	desc = "A framed picture of the station."
 
-/obj/structure/sign/map/left
+/obj/structure/sign/map/boxmap-left
 	icon_state = "map-left"
 
-/obj/structure/sign/map/right
+/obj/structure/sign/map/boxmap-right
 	icon_state = "map-right"
 
-/obj/structure/sign/map/prometheus
+/obj/structure/sign/map/gammamap-left
+	icon_state = "gammamap-left"
+
+/obj/structure/sign/map/gammamap-right
+	icon_state = "gammamap-right"
+
+/obj/structure/sign/map/prometheusmap
 	icon_state = "prometheus"
 	var/icon/img = 'nano/images/nanomap_prometheus_1_small.png'
 
-/obj/structure/sign/map/prometheus/examine(mob/user)
+/obj/structure/sign/map/prometheusmap/examine(mob/user)
 	..()
 	user << browse_rsc(img, "nanomap.png")
 	var/datum/browser/popup = new(user, "window=[name]", "[name]", 700, 700, ntheme = CSS_THEME_DARK)

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -27790,11 +27790,11 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "aYX" = (
-/obj/structure/sign/map/boxmap-left,
+/obj/structure/sign/map/boxmap_left,
 /turf/simulated/wall,
 /area/station/storage/primary)
 "aYY" = (
-/obj/structure/sign/map/boxmap-right,
+/obj/structure/sign/map/boxmap_right,
 /turf/simulated/wall,
 /area/station/storage/primary)
 "aYZ" = (

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -27790,11 +27790,11 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "aYX" = (
-/obj/structure/sign/map/left,
+/obj/structure/sign/map/boxmap-left,
 /turf/simulated/wall,
 /area/station/storage/primary)
 "aYY" = (
-/obj/structure/sign/map/right,
+/obj/structure/sign/map/boxmap-right,
 /turf/simulated/wall,
 /area/station/storage/primary)
 "aYZ" = (

--- a/maps/centcom/centcom.dmm
+++ b/maps/centcom/centcom.dmm
@@ -4018,7 +4018,7 @@
 	},
 /area/custom/syndicate_mothership)
 "akc" = (
-/obj/structure/sign/map/boxmap-right{
+/obj/structure/sign/map/boxmap_right{
 	pixel_y = 32
 	},
 /turf/unsimulated/floor{
@@ -4586,7 +4586,7 @@
 /turf/unsimulated/floor,
 /area/start)
 "alB" = (
-/obj/structure/sign/map/boxmap-left{
+/obj/structure/sign/map/boxmap_left{
 	pixel_y = 32
 	},
 /obj/machinery/light{

--- a/maps/centcom/centcom.dmm
+++ b/maps/centcom/centcom.dmm
@@ -4018,7 +4018,7 @@
 	},
 /area/custom/syndicate_mothership)
 "akc" = (
-/obj/structure/sign/map/right{
+/obj/structure/sign/map/boxmap-right{
 	pixel_y = 32
 	},
 /turf/unsimulated/floor{
@@ -4586,7 +4586,7 @@
 /turf/unsimulated/floor,
 /area/start)
 "alB" = (
-/obj/structure/sign/map/left{
+/obj/structure/sign/map/boxmap-left{
 	pixel_y = 32
 	},
 /obj/machinery/light{

--- a/maps/gamma/gamma.dmm
+++ b/maps/gamma/gamma.dmm
@@ -53741,7 +53741,7 @@
 /area/station/cargo/office)
 "qhF" = (
 /obj/structure/stool/bed/chair/metal/black,
-/obj/structure/sign/map/boxmap-left{
+/obj/structure/sign/map/boxmap_left{
 	pixel_y = 32
 	},
 /obj/machinery/light/smart{
@@ -58445,7 +58445,7 @@
 /area/station/security/iaa_office)
 "rKF" = (
 /obj/structure/stool/bed/chair/metal/black,
-/obj/structure/sign/map/boxmap-right{
+/obj/structure/sign/map/boxmap_right{
 	pixel_y = 32
 	},
 /obj/effect/landmark/start/assistant/test_subject,

--- a/maps/gamma/gamma.dmm
+++ b/maps/gamma/gamma.dmm
@@ -53741,7 +53741,7 @@
 /area/station/cargo/office)
 "qhF" = (
 /obj/structure/stool/bed/chair/metal/black,
-/obj/structure/sign/map/left{
+/obj/structure/sign/map/boxmap-left{
 	pixel_y = 32
 	},
 /obj/machinery/light/smart{
@@ -58445,7 +58445,7 @@
 /area/station/security/iaa_office)
 "rKF" = (
 /obj/structure/stool/bed/chair/metal/black,
-/obj/structure/sign/map/right{
+/obj/structure/sign/map/boxmap-right{
 	pixel_y = 32
 	},
 /obj/effect/landmark/start/assistant/test_subject,

--- a/maps/gamma/gamma_revamp.dmm
+++ b/maps/gamma/gamma_revamp.dmm
@@ -3203,7 +3203,7 @@
 /area/station/solar/starboard)
 "ajk" = (
 /obj/machinery/light,
-/obj/structure/sign/map/left{
+/obj/structure/sign/map/boxmap_left{
 	pixel_y = -32
 	},
 /turf/simulated/floor{
@@ -4992,7 +4992,7 @@
 /area/station/medical/sleeper)
 "aBM" = (
 /obj/machinery/door/firedoor,
-/obj/structure/sign/map/right{
+/obj/structure/sign/map/boxmap_right{
 	pixel_y = -32
 	},
 /turf/simulated/floor{

--- a/maps/prometheus/prometheus.dmm
+++ b/maps/prometheus/prometheus.dmm
@@ -1597,10 +1597,10 @@
 	pixel_y = 3
 	},
 /obj/item/clothing/glasses/welding,
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = -8
 	},
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = -8
 	},
 /turf/simulated/floor{
@@ -2180,7 +2180,7 @@
 	pixel_y = 28;
 	req_access = list(42)
 	},
-/obj/item/station_map/prometheus,
+/obj/item/station_map/prometheusmap,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "darkblue"
@@ -10196,7 +10196,7 @@
 /obj/structure/table,
 /obj/item/weapon/clipboard,
 /obj/item/weapon/pen,
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = -8
 	},
 /turf/simulated/floor{
@@ -13664,7 +13664,7 @@
 /obj/item/weapon/storage/bible{
 	pixel_y = 6
 	},
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = -8
 	},
 /turf/simulated/floor/wood,
@@ -18416,7 +18416,7 @@
 /obj/machinery/newscaster{
 	pixel_x = -28
 	},
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = -8
 	},
 /turf/simulated/floor{
@@ -24568,7 +24568,7 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = 4
 	},
 /obj/item/weapon/stamp/denied{
@@ -25082,7 +25082,7 @@
 	pixel_y = 3
 	},
 /obj/structure/table/woodentable,
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = 4
 	},
 /obj/item/weapon/stamp/denied{
@@ -26501,7 +26501,7 @@
 /obj/item/weapon/newspaper{
 	pixel_y = 5
 	},
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = 4
 	},
 /turf/simulated/floor{
@@ -27554,10 +27554,10 @@
 /obj/item/weapon/book/manual/wiki/supply_crates{
 	pixel_y = 2
 	},
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = 4
 	},
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = 4
 	},
 /turf/simulated/floor{
@@ -29832,7 +29832,7 @@
 	pixel_y = 4
 	},
 /obj/item/device/megaphone,
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = -8
 	},
 /turf/simulated/floor/carpet/blue2,
@@ -33142,11 +33142,11 @@
 	pixel_x = -5;
 	pixel_y = 4
 	},
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_x = 10;
 	pixel_y = 2
 	},
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_x = 6;
 	pixel_y = 2
 	},
@@ -34940,10 +34940,10 @@
 	pixel_x = 1;
 	pixel_y = 5
 	},
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = -8
 	},
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = -8
 	},
 /turf/simulated/floor{
@@ -35140,7 +35140,7 @@
 	id = "Detective";
 	pixel_x = -26
 	},
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = -2
 	},
 /obj/item/weapon/handcuffs{
@@ -38240,7 +38240,7 @@
 	pixel_y = -5
 	},
 /obj/structure/table,
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = -8
 	},
 /turf/simulated/floor{
@@ -40442,10 +40442,10 @@
 	pixel_x = -10;
 	pixel_y = 8
 	},
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = 4
 	},
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = 4
 	},
 /turf/simulated/floor{
@@ -49176,7 +49176,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = -8
 	},
 /turf/simulated/floor{
@@ -51774,7 +51774,7 @@
 "mkm" = (
 /obj/machinery/computer/skills,
 /obj/structure/table/glass,
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = 4
 	},
 /turf/simulated/floor{
@@ -53594,10 +53594,10 @@
 	icon_state = "0-4"
 	},
 /obj/item/device/tagger,
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = -8
 	},
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = -8
 	},
 /turf/simulated/floor{
@@ -55708,7 +55708,7 @@
 	pixel_x = 8;
 	pixel_y = 4
 	},
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_x = -6;
 	pixel_y = 2
 	},
@@ -60230,10 +60230,10 @@
 	pixel_y = 4
 	},
 /obj/structure/table/glass,
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = 4
 	},
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = 4
 	},
 /turf/simulated/floor,
@@ -62493,7 +62493,7 @@
 	pixel_x = -8;
 	pixel_y = 16
 	},
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = 2
 	},
 /turf/simulated/floor{
@@ -63918,7 +63918,7 @@
 	req_access = list(70)
 	},
 /obj/structure/window/thin/reinforced,
-/obj/item/station_map/prometheus,
+/obj/item/station_map/prometheusmap,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "whiteblue"
@@ -64022,7 +64022,7 @@
 	pixel_y = 2
 	},
 /obj/structure/table/woodentable,
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = -8
 	},
 /turf/simulated/floor{
@@ -66531,7 +66531,7 @@
 	pixel_x = -9;
 	pixel_y = 2
 	},
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_x = -4;
 	pixel_y = 4
 	},
@@ -68132,7 +68132,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = 4
 	},
 /turf/simulated/floor/carpet/red,
@@ -71915,7 +71915,7 @@
 /obj/item/weapon/pen{
 	pixel_y = 6
 	},
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = 6
 	},
 /turf/simulated/floor{
@@ -78807,7 +78807,7 @@
 	pixel_y = 2
 	},
 /obj/item/clothing/gloves/latex,
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = -8
 	},
 /turf/simulated/floor{
@@ -82028,7 +82028,7 @@
 	pixel_x = 28;
 	pixel_y = -5
 	},
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = -8
 	},
 /turf/simulated/floor{
@@ -87095,7 +87095,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/item/station_map/prometheus,
+/obj/item/station_map/prometheusmap,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "vault"
@@ -91277,7 +91277,7 @@
 /obj/structure/sign/poster/official/ian{
 	pixel_x = 32
 	},
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = -8
 	},
 /turf/simulated/floor/wood,
@@ -92370,7 +92370,7 @@
 	name = "Paramedic equipment";
 	req_access = list(70)
 	},
-/obj/item/station_map/prometheus,
+/obj/item/station_map/prometheusmap,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "whiteblue"
@@ -92901,9 +92901,9 @@
 /obj/item/weapon/storage/secure/briefcase{
 	pixel_y = 6
 	},
-/obj/item/station_map/prometheus,
-/obj/item/station_map/prometheus,
-/obj/item/station_map/prometheus,
+/obj/item/station_map/prometheusmap,
+/obj/item/station_map/prometheusmap,
+/obj/item/station_map/prometheusmap,
 /turf/simulated/floor{
 	icon_state = "darkred"
 	},
@@ -95028,7 +95028,7 @@
 	pixel_x = -28;
 	pixel_y = -5
 	},
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = -8
 	},
 /turf/simulated/floor{
@@ -95524,7 +95524,7 @@
 "xpb" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/fancy/donut_box,
-/obj/item/station_map/prometheus{
+/obj/item/station_map/prometheusmap{
 	pixel_y = -8
 	},
 /turf/simulated/floor{

--- a/maps/prometheus/prometheus.dmm
+++ b/maps/prometheus/prometheus.dmm
@@ -1371,7 +1371,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/structure/sign/map/prometheus{
+/obj/structure/sign/map/prometheusmap{
 	pixel_y = -32
 	},
 /turf/simulated/floor{
@@ -5798,7 +5798,7 @@
 /obj/machinery/light/smart{
 	dir = 1
 	},
-/obj/structure/sign/map/prometheus{
+/obj/structure/sign/map/prometheusmap{
 	pixel_y = 32
 	},
 /turf/simulated/floor{
@@ -10846,7 +10846,7 @@
 	c_tag = "Arrival Hallway North";
 	pixel_x = 20
 	},
-/obj/structure/sign/map/prometheus{
+/obj/structure/sign/map/prometheusmap{
 	pixel_y = 32
 	},
 /turf/simulated/floor{
@@ -19731,7 +19731,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/sign/map/prometheus{
+/obj/structure/sign/map/prometheusmap{
 	pixel_y = -32
 	},
 /turf/simulated/floor{
@@ -20807,7 +20807,7 @@
 	},
 /area/station/hallway/primary/port)
 "eFo" = (
-/obj/structure/sign/map/prometheus{
+/obj/structure/sign/map/prometheusmap{
 	pixel_y = -32
 	},
 /turf/simulated/floor{
@@ -29294,7 +29294,7 @@
 "gDL" = (
 /obj/machinery/computer/mine_sci_shuttle,
 /obj/machinery/light/smart,
-/obj/structure/sign/map/prometheus{
+/obj/structure/sign/map/prometheusmap{
 	pixel_y = -32
 	},
 /turf/simulated/floor{
@@ -35886,7 +35886,7 @@
 	c_tag = "Cargo Lobby West";
 	dir = 4
 	},
-/obj/structure/sign/map/prometheus{
+/obj/structure/sign/map/prometheusmap{
 	pixel_x = -32
 	},
 /turf/simulated/floor{
@@ -36289,7 +36289,7 @@
 	name = "Distribution and Waste Monitor";
 	sensors = list("mair_in_meter"="Mixed Air In","air_sensor"="Mixed Air Supply Tank","mair_out_meter"="Mixed Air Out","dloop_atm_meter"="Distribution Loop","wloop_atm_meter"="Waste Loop")
 	},
-/obj/structure/sign/map/prometheus{
+/obj/structure/sign/map/prometheusmap{
 	pixel_x = -32
 	},
 /turf/simulated/floor{
@@ -53143,7 +53143,7 @@
 /obj/machinery/light/smart{
 	dir = 1
 	},
-/obj/structure/sign/map/prometheus{
+/obj/structure/sign/map/prometheusmap{
 	pixel_y = 32
 	},
 /turf/simulated/floor{
@@ -56599,7 +56599,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/sign/map/prometheus{
+/obj/structure/sign/map/prometheusmap{
 	pixel_y = 32
 	},
 /turf/simulated/floor{
@@ -66331,7 +66331,7 @@
 /obj/structure/stool/bed/chair/metal/blue{
 	dir = 1
 	},
-/obj/structure/sign/map/prometheus{
+/obj/structure/sign/map/prometheusmap{
 	pixel_y = -32
 	},
 /turf/simulated/floor{
@@ -71267,7 +71267,7 @@
 "rkn" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/light/small,
-/obj/structure/sign/map/prometheus{
+/obj/structure/sign/map/prometheusmap{
 	pixel_y = -32
 	},
 /turf/simulated/floor{
@@ -81004,7 +81004,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/sign/map/prometheus{
+/obj/structure/sign/map/prometheusmap{
 	pixel_y = 32
 	},
 /turf/simulated/floor{
@@ -87025,7 +87025,7 @@
 "vjG" = (
 /obj/structure/stool/bed/chair/metal/red,
 /obj/effect/landmark/start/assistant/test_subject,
-/obj/structure/sign/map/prometheus{
+/obj/structure/sign/map/prometheusmap{
 	pixel_y = 32
 	},
 /turf/simulated/floor{
@@ -91489,7 +91489,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 1
 	},
-/obj/structure/sign/map/prometheus{
+/obj/structure/sign/map/prometheusmap{
 	pixel_y = 32
 	},
 /turf/simulated/floor{
@@ -97085,7 +97085,7 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/research_assistant,
-/obj/structure/sign/map/prometheus{
+/obj/structure/sign/map/prometheusmap{
 	pixel_y = 32
 	},
 /turf/simulated/floor{


### PR DESCRIPTION
Обобщение имён карт станций и добавление карты гаммы в игру

<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
В #11806 добавили спрайт карты гаммы, самой структуры в игру не добавили. 
Я добавил.
## Почему и что этот ПР улучшит
Возможность поставить карту гаммы на гамме.
## Авторство
TRISAGI0N
## Чеинжлог
Добавлены структуры карты гаммы.