### PR TITLE
fixes #11819

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -275,16 +275,12 @@ var/global/list/slot_equipment_priority = list(
 /mob/proc/drop_l_hand(atom/Target)
 	if(isitem(l_hand))
 		var/obj/item/W = l_hand
-		if(W.flags & NODROP)
-			return FALSE
 	return drop_from_inventory(l_hand, Target)
 
 //Drops the item in our right hand
 /mob/proc/drop_r_hand(atom/Target)
 	if(isitem(r_hand))
 		var/obj/item/W = r_hand
-		if(W.flags & NODROP)
-			return FALSE
 	return drop_from_inventory(r_hand, Target)
 
 //Drops the item in our active hand.

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -257,7 +257,7 @@ var/global/list/slot_equipment_priority = list(
 
 // Removes an item from inventory and places it in the target atom
 /mob/proc/drop_from_inventory(obj/item/W, atom/target=null, additional_pixel_x=0, additional_pixel_y=0, putdown_anim=TRUE)
-	if(!W)
+	if(!W || W.flags & NODROP || !W.canremove)
 		return FALSE
 
 	var/was_holding = (get_active_hand() == W) || (get_inactive_hand() == W)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -273,14 +273,10 @@ var/global/list/slot_equipment_priority = list(
 
 //Drops the item in our left hand
 /mob/proc/drop_l_hand(atom/Target)
-	if(isitem(l_hand))
-		var/obj/item/W = l_hand
 	return drop_from_inventory(l_hand, Target)
 
 //Drops the item in our right hand
 /mob/proc/drop_r_hand(atom/Target)
-	if(isitem(r_hand))
-		var/obj/item/W = r_hand
 	return drop_from_inventory(r_hand, Target)
 
 //Drops the item in our active hand.


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
фиксит #11819

## Почему и что этот ПР улучшит
drop_from_inventory теперь проверяет флаг NODROP, а еще canremove, так что к примеру капеллан больше не сможет снять ритуалом покров голема или шедоулинга. ну и меньше других проблем.

## Авторство
GrozaAndGrom

## Чеинжлог
не знаю, нужно ли