### PR TITLE
More explosions nerfs

### DIFF
--- a/code/datums/spells/in_hand.dm
+++ b/code/datums/spells/in_hand.dm
@@ -141,7 +141,7 @@
 		var/mob/living/M = target
 		M.fire_act()
 		M.adjust_fire_stacks(5)
-	explosion(get_turf(target), 0, 2)
+	explosion(get_turf(target), 0, 1, 2)
 	return ..()
 
 ///////////////////////////////////////////

--- a/code/datums/spells/in_hand.dm
+++ b/code/datums/spells/in_hand.dm
@@ -141,7 +141,7 @@
 		var/mob/living/M = target
 		M.fire_act()
 		M.adjust_fire_stacks(5)
-	explosion(get_turf(target), 0, 1, 2)
+	explosion(get_turf(target), 0, 0, 1, adminlog = FALSE)
 	return ..()
 
 ///////////////////////////////////////////

--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -282,7 +282,7 @@
 	proj_step_delay = 1
 
 /obj/effect/proc_holder/spell/turf/fireball/cast(turf/T)
-	explosion(T, -1, 1, 2, 3)
+	explosion(T, 0, 1, 2)
 
 
 /obj/effect/proc_holder/spell/targeted/inflict_handler/fireball

--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -282,7 +282,7 @@
 	proj_step_delay = 1
 
 /obj/effect/proc_holder/spell/turf/fireball/cast(turf/T)
-	explosion(T, 0, 1, 2)
+	explosion(T, 0, 0, 1, adminlog = FALSE)
 
 
 /obj/effect/proc_holder/spell/targeted/inflict_handler/fireball

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -75,7 +75,8 @@
 
 /obj/machinery/syndicate_beacon/proc/selfdestruct()
 	selfdestructing = 1
-	spawn() explosion(src.loc, 0, rand(1,3), rand(3,8))
+	var/power = rand(1, 3)
+	spawn() explosion(src.loc, 0, power, power*3)
 
 
 

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -486,7 +486,7 @@ var/global/mining_shuttle_location = 0 // 0 = station 13, 1 = mining station
 				if(!M)	return
 
 			if(target)
-				explosion(location, 2, 4, 5)
+				explosion(location, 0, 2, 4)
 				target.ex_act(EXPLODE_DEVASTATE)
 				if(src)
 					qdel(src)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -486,7 +486,7 @@ var/global/mining_shuttle_location = 0 // 0 = station 13, 1 = mining station
 				if(!M)	return
 
 			if(target)
-				explosion(location, 4)
+				explosion(location, 2, 4, 5)
 				target.ex_act(EXPLODE_DEVASTATE)
 				if(src)
 					qdel(src)

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -117,7 +117,7 @@
 	sharp = 0
 
 /obj/item/projectile/bullet/grenade/explosive/on_hit(atom/target, def_zone = BP_CHEST, blocked = 0)
-	explosion(target, 0, 2, 3)
+	explosion(target, 0, 1, 2)
 	return 1
 
 /obj/item/projectile/bullet/chem

--- a/code/modules/research/server.dm
+++ b/code/modules/research/server.dm
@@ -328,7 +328,7 @@
 		for(var/i in 1 to s.files.researched_tech.len)
 			s.files.forget_random_technology()
 	for(var/obj/machinery/computer/rdconsole/c in RDcomputer_list)
-		explosion(c.loc, 3, 2, 1)
+		explosion(c.loc, 0, 1, 3)
 	var/datum/faction/traitor/faction = find_faction_by_type(/datum/faction/traitor)
 	for(var/datum/role/traitor/T in faction.members)
 		for(var/datum/objective/research_sabotage/rs in T.objectives.objectives)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Если в [`bd3044b` (#11256)](https://github.com/TauCetiStation/TauCetiClassic/pull/11256/commits/bd3044b50f838647058058903e33e1010d99b5e0) я прошелся по первому из параметров взрывов, то теперь еще по второму.

Если принять во внимание https://github.com/TauCetiStation/TauCetiClassic/pull/11838, что плитка ломается в спесс с шансом 1 к 10. То, если у взрыва второй параметр (радиус высокого урона), к примеру, 2 - то посреди коридора это 9 задетых плиток и вероятно одна из них таки сломается.

Потому оптимальным для "небольших" точечных взрывов будет наверно взять параметры 0-1-x. Пол в эпицентре еще может сломаться, но с небольшим шансом 10%.

Вкупе с упомянутым ПР-ом должно закрыть/ close https://github.com/TauCetiStation/TauCetiClassic/issues/11833

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог

:cl: 
 - balance: Еще больше исправлений некоторых из случайно овербафнутых взрывов.
