### PR TITLE
nukies pinpointer update

### DIFF
--- a/code/game/gamemodes/modes_gameplays/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/modes_gameplays/nuclear/pinpointer.dm
@@ -130,31 +130,34 @@
 
 /obj/item/weapon/pinpointer/nukeop
 
-/obj/item/weapon/pinpointer/nukeop/attack_self(mob/user)
-	..()
-	if(mode == SEARCH_FOR_DISK)
-		to_chat(user, "<span class='notice'>Authentication Disk Locator active.</span>")
-	else
-		to_chat(user, "<span class='notice'>Shuttle Locator active.</span>")
+/obj/item/weapon/pinpointer/nukeop/verb/toggle_mode()
+	set category = "Object"
+	set name = "Toggle Pinpointer Mode"
+	set src in view(1)
 
-/obj/item/weapon/pinpointer/nukeop/process()
-	if(bomb_set)
-		mode = SEARCH_FOR_OBJECT
-		if(!istype(target, /obj/machinery/computer/syndicate_station))
+	reset_target()
+
+	switch(tgui_alert(usr, "Please select the mode you want to put the pinpointer in.", "Pinpointer Mode Select", list("Shuttle Location", "Disk Recovery", "Nuclear Warhead")))
+
+		if("Disk Recovery")
+			mode = SEARCH_FOR_DISK
+		if("Shuttle Location")
+			mode = SEARCH_FOR_OBJECT
 			target = locate(/obj/machinery/computer/syndicate_station)
-			if(!target)
-				icon_state = "pinonnull"
-				return
-			playsound(src, 'sound/machines/twobeep.ogg', VOL_EFFECTS_MASTER)	//Plays a beep
-			visible_message("Shuttle Locator active.")			//Lets the mob holding it know that the mode has changed
-			RegisterSignal(target, list(COMSIG_PARENT_QDELETING), PROC_REF(reset_target))
-	else
-		if(istype(target, /obj/machinery/computer/syndicate_station))
-			playsound(src, 'sound/machines/twobeep.ogg', VOL_EFFECTS_MASTER)
-			visible_message("<span class='notice'>Authentication Disk Locator active.</span>")
-			reset_target()
-		mode = SEARCH_FOR_DISK
-	return ..()
+			to_chat(usr, "You set the pinpointer to locate [target]")
+
+		if("Nuclear Warhead")
+			mode = SEARCH_FOR_OBJECT
+			for (var/obj/machinery/nuclearbomb/N in poi_list)
+				if(N.nuketype == "Syndi")
+					target = locate(N)
+					to_chat(usr, "You set the pinpointer to locate [target]")
+
+
+	if(mode && target)
+		RegisterSignal(target, list(COMSIG_PARENT_QDELETING), PROC_REF(reset_target))
+
+	return attack_self(usr)
 
 /proc/get_jobs_dna(list/required_positions)
 	var/list/players = list()

--- a/code/game/gamemodes/modes_gameplays/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/modes_gameplays/nuclear/pinpointer.dm
@@ -141,18 +141,20 @@
 
 		if("Disk")
 			mode = SEARCH_FOR_DISK
+			to_chat(usr, "<span class='notice'>Authentication Disk Locator active.</span>")
 		if("Shuttle Location")
 			mode = SEARCH_FOR_OBJECT
 			target = locate(/obj/machinery/computer/syndicate_station)
-			to_chat(usr, "You set the pinpointer to locate [target]")
+			to_chat(usr, "<span class='notice'>Shuttle Locator active.</span>")
 
 		if("Nuclear Warhead")
 			mode = SEARCH_FOR_OBJECT
 			for (var/obj/machinery/nuclearbomb/N in poi_list)
 				if(N.nuketype == "Syndi")
 					target = locate(N)
-					to_chat(usr, "You set the pinpointer to locate [target]")
+					to_chat(usr, "<span class='notice'>Nuclear Warhead Locator active.</span>")
 
+	playsound(src, 'sound/machines/twobeep.ogg', VOL_EFFECTS_MASTER)
 
 	if(mode && target)
 		RegisterSignal(target, list(COMSIG_PARENT_QDELETING), PROC_REF(reset_target))

--- a/code/game/gamemodes/modes_gameplays/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/modes_gameplays/nuclear/pinpointer.dm
@@ -139,7 +139,7 @@
 
 	switch(tgui_alert(usr, "Please select the mode you want to put the pinpointer in.", "Pinpointer Mode Select", list("Shuttle Location", "Disk", "Nuclear Warhead")))
 
-		if("Disk Recovery")
+		if("Disk")
 			mode = SEARCH_FOR_DISK
 		if("Shuttle Location")
 			mode = SEARCH_FOR_OBJECT

--- a/code/game/gamemodes/modes_gameplays/nuclear/pinpointer.dm
+++ b/code/game/gamemodes/modes_gameplays/nuclear/pinpointer.dm
@@ -137,7 +137,7 @@
 
 	reset_target()
 
-	switch(tgui_alert(usr, "Please select the mode you want to put the pinpointer in.", "Pinpointer Mode Select", list("Shuttle Location", "Disk Recovery", "Nuclear Warhead")))
+	switch(tgui_alert(usr, "Please select the mode you want to put the pinpointer in.", "Pinpointer Mode Select", list("Shuttle Location", "Disk", "Nuclear Warhead")))
 
 		if("Disk Recovery")
 			mode = SEARCH_FOR_DISK


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
нюкерский пинпоинтер теперь может в любой момент навестись не только на диск, а и на шаттл и бомбу нюкеров
![image](https://github.com/TauCetiStation/TauCetiClassic/assets/84613249/c0414c24-6c3f-4bbb-91b3-3399fece420f)

## Почему и что этот ПР улучшит
новичкам будет легче найти шаттл в космосе
а ещё раунд не будет стопариться, если вдруг очень умные космонавты решат спрятать/выкинуть бомбу в космос.
## Авторство

## Чеинжлог
🆑  Simbaka
- tweak: Целеуказатель ядерных оперативников теперь можно настроить на бомбу.