### PR TITLE
Карта гаммы на гамме

### DIFF
--- a/code/game/objects/structures/signs/signs_maps.dm
+++ b/code/game/objects/structures/signs/signs_maps.dm
@@ -10,6 +10,12 @@
 /obj/structure/sign/map/right
 	icon_state = "map-right"
 
+/obj/structure/sign/map/gamma_left
+	icon_state = "gammamap-left"
+
+/obj/structure/sign/map/gamma_right
+	icon_state = "gammamap-right"
+
 /obj/structure/sign/map/prometheus
 	icon_state = "prometheus"
 	var/icon/img = 'nano/images/nanomap_prometheus_1_small.png'

--- a/maps/gamma/gamma.dmm
+++ b/maps/gamma/gamma.dmm
@@ -3237,7 +3237,7 @@
 /area/station/solar/starboard)
 "ajk" = (
 /obj/machinery/light/smart,
-/obj/structure/sign/map/left{
+/obj/structure/sign/map/gamma_left{
 	pixel_y = -32
 	},
 /turf/simulated/floor{
@@ -5128,7 +5128,7 @@
 /area/station/medical/sleeper)
 "aBM" = (
 /obj/machinery/door/firedoor,
-/obj/structure/sign/map/right{
+/obj/structure/sign/map/gamma_right{
 	pixel_y = -32
 	},
 /turf/simulated/floor{
@@ -84077,7 +84077,7 @@
 /obj/machinery/light/smart{
 	dir = 1
 	},
-/obj/structure/sign/map/right{
+/obj/structure/sign/map/gamma_right{
 	pixel_y = 32
 	},
 /turf/simulated/floor/wood,
@@ -88621,7 +88621,7 @@
 	},
 /area/station/medical/genetics)
 "siR" = (
-/obj/structure/sign/map/left{
+/obj/structure/sign/map/gamma_left{
 	pixel_y = 32
 	},
 /turf/simulated/floor/wood,


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Заменил карты бокса на карты гаммы.
## Почему и что этот ПР улучшит
Наверное на станции должна быть карта этой станции, а не другой.
## Авторство
Я
## Чеинжлог
🆑 

- map: Карты бокса заменены на карты гаммы.