### PR TITLE
Увеличение количества выпадаемого из вендоматов лута.

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -566,7 +566,7 @@
 /obj/machinery/vending/proc/malfunction()
 	if(refill_canister)
 		//Dropping actual items
-		var/max_drop = rand(1, 3)
+		var/max_drop = rand(4, 6)
 		for(var/i = 1, i < max_drop, i++)
 			var/datum/data/vending_product/R = pick(src.product_records)
 			var/dump_path = R.product_path

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -566,7 +566,7 @@
 /obj/machinery/vending/proc/malfunction()
 	if(refill_canister)
 		//Dropping actual items
-		var/max_drop = rand(5, 7)
+		var/max_drop = rand(4, 6)
 		for(var/i = 1, i < max_drop, i++)
 			var/datum/data/vending_product/R = pick(src.product_records)
 			var/dump_path = R.product_path

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -566,7 +566,7 @@
 /obj/machinery/vending/proc/malfunction()
 	if(refill_canister)
 		//Dropping actual items
-		var/max_drop = rand(4, 6)
+		var/max_drop = rand(5, 7)
 		for(var/i = 1, i < max_drop, i++)
 			var/datum/data/vending_product/R = pick(src.product_records)
 			var/dump_path = R.product_path


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Одно время при поломке вендоматов из них выпадало всё их содержимое. И ингейм никто не был против этого, так как лута выпадало так дохуя, что его мог кто угодно брать в любых количествах и абсолютно бесплатно.

Это занерфили в хлам, так что из вендоматов щас падает 1-2 предмета и ящик, который никак не вскрыть.
И теперь никто вообще не ломает вендоматы, потому что это ничего вообще не даёт.

Немного повысил количество выпадаемых приколов, чтобы у голозадых и голодных тестсабжектов без зарплаты было больше мотивации ломать вендоматы. При этом количество всё ещё не настолько огромное, чтобы на это не было похуй всем окружающим.

Логика проста, поломка вендомата даёт столько еды, чтобы один ассистент мог спокойно жить до конца смены, не думая о ней, но при этом лишает весь остальной экипаж гораздо большего количества еды, что в сути должно вызвать негативную реакцию этого самого экипажа и попытки ингейм наказания вандала.

_на самом деле я просто хочу ломать за ассистента вендоматы копьём и получать за это хоть что-то_

## Почему и что этот ПР улучшит
Возможно появление ингейм ситуаций и конфликтов вокруг сломанных вендоматов.
## Авторство

## Чеинжлог
:cl: 
 - tweak: При поломке вендомата выпадает больше вещей.