### PR TITLE
Stunbaton Rewrite

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -343,6 +343,8 @@
 #define COMSIG_HUMAN_MONKEYIZE "human_monkeyize"
 /// from /mob/living/carbon/proc/finish_humanize(): (species)
 #define COMSIG_MONKEY_HUMANIZE "monkey_humanize"
+/// from /mob/verb/a_intent_change(): (intent as text)
+#define COMSIG_LIVING_INTENT_CHANGE "living_intent_change"
 
 // simple_animal/hostile signals
 /// from simple_animal/hostile/proc/UnarmedAttack(): (atom/target)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -102,9 +102,13 @@
 
 /obj/item/weapon/melee/baton/equipped(mob/living/user, slot)
 	. = ..()
-	set_status(user.a_intent, status)
-	if(istype(user))
-		RegisterSignal(user, COMSIG_LIVING_INTENT_CHANGE, PROC_REF(attempt_change_work))
+	if(!istype(user))
+		return
+	if(slot == SLOT_L_HAND || slot == SLOT_R_HAND)
+		set_status(user.a_intent, status)
+		RegisterSignal(user, COMSIG_LIVING_INTENT_CHANGE, PROC_REF(attempt_change_work), override = TRUE)
+	else
+		UnregisterSignal(user, COMSIG_LIVING_INTENT_CHANGE)
 
 /obj/item/weapon/melee/baton/dropped(mob/living/user)
 	if(istype(user))

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -54,13 +54,13 @@
 		to_chat(user, "<span class='warning'>\The [src] is out of charge.</span>")
 	add_fingerprint(user)
 
-/obj/item/weapon/melee/baton/proc/set_force_by_intent(mob/living/user)
+/obj/item/weapon/melee/baton/proc/get_force_by_intent(mob/living/user)
 	if(user.a_intent == INTENT_HARM)
 		return initial(force)
 	return 0
 
 /obj/item/weapon/melee/baton/attack(mob/living/M, mob/living/user, def_zone)
-	force = set_force_by_intent(user)
+	force = get_force_by_intent(user)
 	if(!status && user.a_intent != INTENT_HARM)
 		user.visible_message("<span class='warning'>[M] has been prodded with the [src] by [user]. Luckily it was off.</span>")
 		return

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -293,8 +293,7 @@
 		return FALSE
 
 	var/obj/item/organ/external/BP = get_bodypart(def_zone)
-	var/check_with_stump = istype(I, /obj/item/weapon/melee/baton)
-	if(check_with_stump ? (!BP || BP.is_stump) : !BP)
+	if(!BP || BP.is_stump)
 		to_chat(user, "What [parse_zone(def_zone)]?")
 		return FALSE
 	var/hit_area = BP.name

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -293,7 +293,8 @@
 		return FALSE
 
 	var/obj/item/organ/external/BP = get_bodypart(def_zone)
-	if (!BP)
+	var/check_with_stump = istype(I, /obj/item/weapon/melee/baton)
+	if(check_with_stump ? (!BP || BP.is_stump) : !BP)
 		to_chat(user, "What [parse_zone(def_zone)]?")
 		return FALSE
 	var/hit_area = BP.name
@@ -331,7 +332,12 @@
 		visible_message("<span class='userdanger'>[src] has been attacked in the [hit_area] with [I.name] by [user]!</span>", ignored_mobs = alt_alpperances_vieawers)
 
 	var/armor = run_armor_check(BP, MELEE, "Your armor has protected your [hit_area].", "Your armor has softened hit to your [hit_area].")
-	if(armor >= 100 || !I.force)
+	if(armor >= 100)
+		return FALSE
+	if(!I.force)
+		//return success for apply agony effect
+		if(istype(I, /obj/item/weapon/melee/baton))
+			return TRUE
 		return FALSE
 
 	//Apply weapon damage

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -334,10 +334,7 @@
 	if(armor >= 100)
 		return FALSE
 	if(!I.force)
-		//return success for apply agony effect
-		if(istype(I, /obj/item/weapon/melee/baton))
-			return TRUE
-		return FALSE
+		return TRUE
 
 	//Apply weapon damage
 	var/force_with_melee_skill = apply_skill_bonus(user, I.force, list(/datum/skill/melee = SKILL_LEVEL_NOVICE), 0.15) // +15% for each melee level

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -449,13 +449,16 @@ var/global/list/intents = list(INTENT_HELP, INTENT_PUSH, INTENT_GRAB, INTENT_HAR
 	set hidden = 1
 
 	if(isliving(src))
+		var/setting_intent = input
 		switch(input)
 			if(INTENT_HELP, INTENT_PUSH, INTENT_GRAB, INTENT_HARM)
-				set_a_intent(input)
+				setting_intent = input
 			if(INTENT_HOTKEY_RIGHT)
-				set_a_intent(intent_numeric((intent_numeric(a_intent)+1) % 4))
+				setting_intent = intent_numeric((intent_numeric(a_intent)+1) % 4)
 			if(INTENT_HOTKEY_LEFT)
-				set_a_intent(intent_numeric((intent_numeric(a_intent)+3) % 4))
+				setting_intent = intent_numeric((intent_numeric(a_intent)+3) % 4)
+		set_a_intent(setting_intent)
+		SEND_SIGNAL(src, COMSIG_LIVING_INTENT_CHANGE, setting_intent)
 
 /proc/broadcast_security_hud_message(message, broadcast_source)
 	var/datum/atom_hud/hud = huds[DATA_HUD_SECURITY]


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Переписал станбатон, убрав хардкод в attack()
Идея была в том, чтобы подтянуть из родителя сигналы и проверку на щиты.
Теперь станбатон не лучшее оружие в мили и с ним может конкурировать например катана или боец с щитом (за хорошую защиту получает внушительное замедление).
Учёт сопротивляемости брони и увеличение затрат по энергии для борга не делал (стабатон пробивает любую броню и у борга всё по старому используется), так как считаю что это должна быть отдельная тема для обсуждения.
## Почему и что этот ПР улучшит
Меньше хардкод-вещей которые не подчиняются писанным законам билда. Разнообразие инструментов для достижения целей. Фикс возможности станить чувачков батоном при ударе об отсутствующую конченость.
## Авторство

## Чеинжлог
:cl: Deahaka
- tweak: Дубинка СБ теперь может быть заблокирована щитом.