### PR TITLE
[MDB IGNORE] Delta Station Map Edit. Decals and Feedback changes

### DIFF
--- a/code/game/objects/effects/decals/turf_decal.dm
+++ b/code/game/objects/effects/decals/turf_decal.dm
@@ -26,7 +26,7 @@
 // It's just for quick access, feel free to varset decals with any color and alpha in map editor
 
 // strips and text decals
-/obj/effect/decal/turf_decal/alpha 
+/obj/effect/decal/turf_decal/alpha
 	name = "Transparent Turf Decals"
 	alpha = 100
 
@@ -50,10 +50,38 @@
 	name = "Transparent Gray Turf Decals"
 	color = "#666666"
 
+/obj/effect/decal/turf_decal/alpha/orange
+	name = "Transparent Orange Turf Decals"
+	color = "#efb341"
+
+/obj/effect/decal/turf_decal/alpha/white
+	name = "Transparent White Turf Decals"
+	color = "#bcbcbc"
+
+/obj/effect/decal/turf_decal/alpha/purple
+	name = "Transparent Purple Turf Decals"
+	color = "#d381c9"
+
+/obj/effect/decal/turf_decal/alpha/blue
+	name = "Transparent Blue Turf Decals"
+	color = "#52b4e9"
+
+/obj/effect/decal/turf_decal/alpha/dark_red
+	name = "Transparent Dark Red Turf Decals"
+	color = "#b11111"
+
+/obj/effect/decal/turf_decal/alpha/green
+	name = "Transparent Green Turf Decals"
+	color = "#9fed58"
+
 // sidings / borders
 /obj/effect/decal/turf_decal/wood
 	name = "Wood Turf Decals"
 	color = "#ffc500"
+
+/obj/effect/decal/turf_decal/wood/dark
+	name = "Dark Wood Turf Decals"
+	color = "#5d341f"
 
 /obj/effect/decal/turf_decal/metal
 	name = "Metal Turf Decals"

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -12816,6 +12816,9 @@
 /area/station/hallway/primary/fore)
 "cIT" = (
 /obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor,
 /area/station/rnd/hallway)
 "cJd" = (
@@ -13272,15 +13275,6 @@
 	},
 /turf/simulated/floor,
 /area/station/bridge/corp_lounge)
-"cOJ" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 10
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/rnd/hor)
 "cOS" = (
 /obj/machinery/teleport/hub,
 /turf/simulated/floor{
@@ -29215,15 +29209,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"gBc" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/rnd/hor)
 "gBg" = (
 /obj/structure/stool/bed,
 /obj/item/weapon/bedsheet/purple,
@@ -56509,7 +56494,7 @@
 "mKy" = (
 /obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "siding_line";
-	dir = 6
+	dir = 10
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -75738,6 +75723,15 @@
 "rmY" = (
 /turf/simulated/wall,
 /area/station/hallway/secondary/exit)
+"rnj" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/hor)
 "rnl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/engine,
@@ -84575,6 +84569,9 @@
 /obj/structure/drain{
 	drainage = 2
 	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "box_white"
+	},
 /turf/simulated/floor,
 /area/station/rnd/hallway/lobby)
 "tri" = (
@@ -84670,7 +84667,7 @@
 /obj/structure/drain{
 	drainage = 2
 	},
-/obj/effect/decal/turf_decal/alpha/cyan{
+/obj/effect/decal/turf_decal/alpha/blue{
 	icon_state = "box_white"
 	},
 /obj/effect/decal/turf_decal{
@@ -89431,6 +89428,15 @@
 "uBo" = (
 /turf/environment/space,
 /area/shuttle/syndicate/southeast)
+"uBq" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/hor)
 "uBu" = (
 /obj/structure/table/glass,
 /obj/item/device/radio/headset/headset_med,
@@ -91035,15 +91041,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
-"uWX" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/rnd/hor)
 "uWZ" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/box/syringes{
@@ -97796,6 +97793,15 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/engine)
+"wDW" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/hor)
 "wDY" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -135056,8 +135062,8 @@ mkl
 svQ
 vxf
 kiL
-uWX
-cOJ
+wDW
+mKy
 hzm
 vaP
 wwp
@@ -135570,8 +135576,8 @@ mkl
 svQ
 vxf
 kiL
-gBc
-mKy
+uBq
+rnj
 blq
 syE
 qbC

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -5507,6 +5507,19 @@
 	icon_state = "grimy"
 	},
 /area/station/security/hos)
+"beG" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/station/tcommsat/chamber)
 "beJ" = (
 /turf/simulated/wall,
 /area/station/medical/morgue)
@@ -8623,6 +8636,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 29
 	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "wooden"
 	},
@@ -10662,6 +10679,10 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "wooden"
@@ -12864,6 +12885,18 @@
 /obj/item/seeds/glowshroom,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"cKP" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line"
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "cKQ" = (
 /obj/machinery/door/window/eastleft{
 	name = "Shrubbery";
@@ -14147,6 +14180,19 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/misc_lab)
+"daU" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "dbf" = (
 /obj/decal/boxingrope{
 	dir = 9
@@ -14403,7 +14449,7 @@
 /area/station/engineering/atmos)
 "dfg" = (
 /turf/simulated/floor/carpet{
-	icon_state = "carpet6-2"
+	icon_state = "carpet10-8"
 	},
 /area/station/bridge)
 "dfo" = (
@@ -16579,16 +16625,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/qm)
-"dFC" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "gcircuit"
-	},
-/area/station/tcommsat/chamber)
 "dFV" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -20010,6 +20046,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "darkblue"
@@ -20952,6 +20992,10 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkblue"
@@ -21463,6 +21507,16 @@
 	icon_state = "caution"
 	},
 /area/station/medical/chemistry)
+"eOm" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/bluegrid{
+	icon_state = "gcircuit"
+	},
+/area/station/tcommsat/chamber)
 "eOt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -21550,6 +21604,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"ePt" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet6-2"
+	},
+/area/station/bridge)
 "ePG" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -31849,6 +31908,10 @@
 	},
 /area/station/hallway/secondary/entry)
 "hkF" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "darkblue"
@@ -37796,6 +37859,15 @@
 	},
 /turf/simulated/floor,
 /area/station/gateway)
+"iAw" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "iAz" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -44179,6 +44251,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkblue"
@@ -50377,6 +50453,13 @@
 /area/station/ai_monitored/storage_secure)
 "lqU" = (
 /obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line"
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 1
+	},
 /turf/simulated/floor{
 	icon_state = "wooden"
 	},
@@ -51249,6 +51332,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
 /turf/simulated/floor{
 	icon_state = "wooden"
 	},
@@ -51732,6 +51819,10 @@
 "lGH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "wooden"
@@ -54941,6 +55032,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "mue" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner"
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner";
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "wooden"
 	},
@@ -56048,11 +56146,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/checkpoint/engi)
-"mID" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet9-4"
-	},
-/area/station/bridge/captain_quarters)
 "mIP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -64736,6 +64829,9 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/disposal,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkblue"
@@ -64791,6 +64887,16 @@
 	},
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
+"oNP" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/station/bridge/corp_lounge)
 "oNS" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -67799,11 +67905,6 @@
 /obj/item/device/flashlight/lamp,
 /turf/simulated/floor/carpet/red,
 /area/station/civilian/dormitories/service_bedrooms)
-"pyh" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet10-8"
-	},
-/area/station/bridge)
 "pyk" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -69986,6 +70087,10 @@
 "pYl" = (
 /obj/structure/table,
 /obj/item/weapon/storage/briefcase/centcomm,
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkblue"
@@ -80358,6 +80463,11 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/atmos)
+"stN" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet9-4"
+	},
+/area/station/bridge/captain_quarters)
 "stP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -84138,6 +84248,25 @@
 	},
 /turf/simulated/floor,
 /area/station/gateway)
+"trE" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "trR" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -89980,6 +90109,10 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "darkblue"
@@ -91138,6 +91271,9 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -92042,19 +92178,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"vpL" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/bluegrid{
-	name = "Server Base";
-	nitrogen = 500;
-	oxygen = 0;
-	temperature = 80
-	},
-/area/station/tcommsat/chamber)
 "vpT" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -98262,6 +98385,10 @@
 /obj/structure/table,
 /obj/item/weapon/folder/blue,
 /obj/item/weapon/pen/blue,
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "darkblue"
@@ -141911,7 +142038,7 @@ pQD
 gIC
 gIC
 gIC
-vpL
+beG
 gIC
 gIC
 keH
@@ -142685,7 +142812,7 @@ xMO
 raJ
 cCX
 vyg
-dFC
+eOm
 lwt
 raJ
 eXe
@@ -142928,7 +143055,7 @@ gCE
 imK
 lEC
 wnY
-dfg
+ePt
 akc
 lZx
 gWd
@@ -142953,7 +143080,7 @@ jEs
 mKJ
 mMA
 vEH
-mue
+cKP
 rOO
 mzL
 nHg
@@ -143442,7 +143569,7 @@ gCE
 imK
 lEC
 mrs
-pyh
+dfg
 nSo
 lZx
 oay
@@ -143467,7 +143594,7 @@ wMM
 fgA
 mMA
 joF
-mue
+cKP
 eZe
 wAA
 nHg
@@ -143712,7 +143839,7 @@ knC
 aty
 wEV
 fAH
-dFC
+eOm
 aEE
 lwt
 wEV
@@ -143723,10 +143850,10 @@ pQD
 amY
 fgA
 mMA
-mue
-mue
+iAw
+daU
 lBF
-cje
+trE
 nHg
 nvi
 ogP
@@ -144239,7 +144366,7 @@ xVa
 mMA
 eIB
 pYl
-siC
+oNP
 jVM
 mMA
 elI
@@ -144481,9 +144608,9 @@ pQD
 gIC
 gIC
 gIC
-vpL
+beG
 gIC
-vpL
+beG
 gIC
 gIC
 aty
@@ -145763,7 +145890,7 @@ ibm
 adM
 sTY
 bIZ
-mID
+stN
 iaL
 cHR
 jKD

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -204,20 +204,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/bridge/meeting_room)
-"abm" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 9;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "abp" = (
 /obj/structure/easel,
 /obj/effect/decal/cleanable/dirt,
@@ -1600,16 +1586,6 @@
 /obj/structure/dumbbells_rack,
 /turf/simulated/floor,
 /area/station/security/prison)
-"akI" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-B";
-	location = "SSW-B"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "akJ" = (
 /obj/item/device/radio/beacon,
 /turf/simulated/floor,
@@ -3066,7 +3042,10 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "brown"
+	},
 /area/station/cargo/miningoffice)
 "aAP" = (
 /obj/structure/cable{
@@ -3139,6 +3118,16 @@
 	icon_state = "grimy"
 	},
 /area/station/maintenance/medbay)
+"aBi" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSE-FC";
+	location = "SEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "aBv" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4
@@ -3280,19 +3269,6 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/minisat_secure_area)
-"aDH" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "aDL" = (
 /obj/item/weapon/caution,
 /turf/simulated/floor/plating,
@@ -4717,7 +4693,7 @@
 /area/station/civilian/locker)
 "aUg" = (
 /turf/simulated/floor{
-	icon_state = "browncorner"
+	icon_state = "brown"
 	},
 /area/station/cargo/storage)
 "aUh" = (
@@ -7399,7 +7375,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "brown"
+	},
 /area/station/cargo/miningoffice)
 "bye" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
@@ -7730,16 +7708,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
-"bBc" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkred"
-	},
-/area/station/security/brig)
 "bBe" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/window/thin{
@@ -8231,13 +8199,6 @@
 "bFL" = (
 /obj/structure/stool/bed/chair/metal/white{
 	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
 	},
 /obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "siding_line";
@@ -12802,15 +12763,6 @@
 	},
 /turf/simulated/floor/carpet/red,
 /area/station/security/detectives_office)
-"cFx" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "cFz" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13835,15 +13787,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
-"cQQ" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "cQR" = (
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_y = -32
@@ -14491,12 +14434,24 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "brown"
+	},
 /area/station/cargo/miningoffice)
 "cZC" = (
 /obj/machinery/shieldwallgen,
 /turf/simulated/floor,
 /area/station/storage/emergency2)
+"cZM" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SWW-FC";
+	location = "SW-FC"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "cZQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -14655,6 +14610,9 @@
 	},
 /obj/item/weapon/storage/firstaid/small_firstaid_kit/civilian{
 	pixel_x = 3
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -15769,18 +15727,6 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/port)
-"doY" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "dpc" = (
 /obj/machinery/door/firedoor,
 /obj/structure/plasticflaps{
@@ -15816,6 +15762,16 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/station/cargo/storage)
+"dpo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "dpF" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -17943,6 +17899,15 @@
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/engineering/atmos)
+"dRj" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DN";
+	location = "SSE-FC"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "dRG" = (
 /obj/machinery/door/window/brigdoor{
 	id = "cargocell";
@@ -19044,7 +19009,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "brown"
+	},
 /area/station/cargo/storage)
 "edV" = (
 /obj/structure/stool/bed/chair{
@@ -19689,6 +19657,18 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
+"ekZ" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "elw" = (
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
@@ -20548,6 +20528,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/engineering/break_room)
+"ewl" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "ewm" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
@@ -21153,7 +21142,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "brown"
+	},
 /area/station/cargo/miningoffice)
 "eCF" = (
 /obj/structure/closet/toolcloset,
@@ -21460,6 +21451,15 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/bar)
+"eHG" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-B";
+	location = "S-MB"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry)
 "eHM" = (
 /obj/machinery/camera{
 	c_tag = "Research Circuits Lab";
@@ -21662,6 +21662,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
+"eJA" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "eJQ" = (
 /obj/machinery/camera{
 	c_tag = "Port Primary Hallway Mid"
@@ -23258,6 +23267,15 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
+"fce" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "fcg" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -24428,7 +24446,10 @@
 	dir = 8;
 	icon_state = "pipe-j2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "brown"
+	},
 /area/station/cargo/storage)
 "fqR" = (
 /obj/machinery/meter,
@@ -26411,17 +26432,18 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "fOp" = (
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Labor Camp Shuttle Airlock";
-	req_access = list(2)
+/obj/machinery/light/smart{
+	dir = 4
 	},
-/obj/effect/decal/turf_decal{
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NE-FC";
+	location = "NEE-FC"
+	},
+/turf/simulated/floor{
 	dir = 4;
-	icon_state = "warn"
+	icon_state = "neutralcorner"
 	},
-/turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/hallway/primary/central)
 "fOF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
@@ -26599,6 +26621,13 @@
 	icon_state = "whiteredcorner"
 	},
 /area/station/rnd/hallway)
+"fQh" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-FC";
+	location = "SSW-FC"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/starboard)
 "fQi" = (
 /obj/structure/stool/bed/chair{
 	dir = 1
@@ -27557,8 +27586,7 @@
 	location = "QM #4"
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "browncorner"
+	icon_state = "brown"
 	},
 /area/station/cargo/storage)
 "gcE" = (
@@ -27687,6 +27715,14 @@
 	icon_state = "white"
 	},
 /area/station/medical/virology)
+"geb" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "gej" = (
 /obj/item/clothing/mask/luchador,
 /obj/item/clothing/mask/luchador/rudos,
@@ -28026,16 +28062,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway/lobby)
-"giq" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NEE-FC";
-	location = "S-SV"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "gis" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/green,
@@ -28627,7 +28653,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "brown"
+	},
 /area/station/cargo/storage)
 "gnl" = (
 /obj/effect/decal/turf_decal{
@@ -29912,14 +29940,6 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge/captain_quarters)
-"gAh" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/civilian/gym)
 "gAj" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced/tinted{
@@ -30134,6 +30154,16 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
+"gCR" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NNW-B";
+	location = "NW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "gDg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -30681,19 +30711,6 @@
 	icon_state = "black"
 	},
 /area/station/hallway/secondary/exit)
-"gKc" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "gKj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -31271,7 +31288,9 @@
 /obj/effect/decal/turf_decal/alpha/black{
 	icon_state = "arrow"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/miningoffice)
 "gRG" = (
 /obj/machinery/computer/station_alert{
@@ -32903,6 +32922,19 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
+"hla" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "hlh" = (
 /obj/structure/table/woodentable,
 /obj/structure/cable{
@@ -34031,7 +34063,7 @@
 	req_access = list(2)
 	},
 /obj/effect/decal/turf_decal{
-	dir = 8;
+	dir = 4;
 	icon_state = "warn"
 	},
 /turf/simulated/floor/plating,
@@ -34180,6 +34212,16 @@
 	icon_state = "vaultfull"
 	},
 /area/station/maintenance/engineering)
+"hyc" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "hyh" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -35167,11 +35209,6 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/hallway)
-"hHC" = (
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "hHI" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/cleanable/dirt,
@@ -36704,15 +36741,6 @@
 "hZU" = (
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
-"iab" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "iag" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -36958,6 +36986,26 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"icE" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "icJ" = (
 /obj/structure/sign/departments/medbay,
 /turf/simulated/wall,
@@ -38205,7 +38253,9 @@
 	dir = 1;
 	icon_state = "arrow"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/miningoffice)
 "iqM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -40860,15 +40910,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/distribution)
-"iVF" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "iVK" = (
 /obj/structure/rack,
 /obj/item/weapon/mop,
@@ -42630,6 +42671,12 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/misc_lab)
+"jqE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "cafeteria"
+	},
+/area/station/security/prison)
 "jqH" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/computerframe{
@@ -42696,7 +42743,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	icon_state = "browncorner"
+	icon_state = "brown"
 	},
 /area/station/cargo/storage)
 "jrt" = (
@@ -43079,12 +43126,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
-"juH" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
-	},
-/turf/simulated/floor/carpet/red,
-/area/station/security/detectives_office)
 "juQ" = (
 /obj/structure/object_wall/cargo{
 	icon_state = "0,0"
@@ -43711,6 +43752,9 @@
 	pixel_y = 6
 	},
 /obj/item/weapon/storage/firstaid/o2,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "brown"
@@ -45539,13 +45583,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/science)
-"jVb" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=N-MB";
-	location = "NNW-B"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "jVh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/stool/bed/chair/wood/normal{
@@ -46622,11 +46659,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "kgH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SE-FC";
+	location = "SW-B"
 	},
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "khm" = (
 /obj/machinery/power/apc{
 	name = "apc down";
@@ -46833,15 +46874,6 @@
 	icon_state = "black"
 	},
 /area/station/civilian/gym)
-"kjh" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Security";
-	location = "S-C"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "kjv" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -47267,15 +47299,6 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/central)
-"kod" = (
-/obj/effect/decal/turf_decal/alpha/blue{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "koi" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -49154,7 +49177,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "brown"
+	},
 /area/station/cargo/storage)
 "kIS" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -49709,17 +49734,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
-"kOB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "kOM" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -49757,6 +49771,16 @@
 	icon_state = "neutralfull"
 	},
 /area/station/cargo/office)
+"kPh" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NEE-FC";
+	location = "S-SV"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "kPm" = (
 /obj/machinery/light/smart,
 /obj/machinery/status_display{
@@ -49821,6 +49845,16 @@
 	icon_state = "vaultfull"
 	},
 /area/station/bridge/hop_office)
+"kRd" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Central Access"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "kRe" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -50145,13 +50179,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/checkpoint/escape)
-"kTQ" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-MB";
-	location = "N-MB"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "kUa" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/food/condiment/saltshaker{
@@ -52635,26 +52662,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/cargo/storage)
-"lxA" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "lxE" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -52714,16 +52721,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/medbay)
-"lyl" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-FC";
-	location = "DS"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "bluecorner"
-	},
-/area/station/hallway/primary/central)
 "lyr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -53449,18 +53446,6 @@
 	icon_state = "wooden"
 	},
 /area/station/bridge/corp_lounge)
-"lGM" = (
-/obj/machinery/door_timer/cell_3{
-	pixel_x = 32;
-	pixel_y = 0;
-	dir = 4;
-	id = "Cell 3 perma"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "lGS" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -54246,7 +54231,7 @@
 	dir = 9
 	},
 /turf/simulated/floor{
-	dir = 1;
+	dir = 5;
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
@@ -55527,15 +55512,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/iaa_office)
-"mgH" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 5
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "mgK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55766,7 +55742,9 @@
 /obj/effect/decal/turf_decal/alpha/black{
 	icon_state = "arrow"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/miningoffice)
 "mjl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -59011,19 +58989,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel)
-"mUV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/flasher{
-	id = "Cell 1 perma";
-	pixel_y = -28
-	},
-/turf/simulated/floor,
-/area/station/security/prison)
 "mVg" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -59678,17 +59643,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/maintenance/engineering)
-"ncX" = (
-/obj/machinery/light/smart,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DS";
-	location = "DN-W"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "purplecorner"
-	},
-/area/station/hallway/primary/central)
 "nda" = (
 /obj/structure/table/reinforced,
 /obj/item/device/radio/intercom{
@@ -60728,6 +60682,16 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/atmos)
+"npU" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-B";
+	location = "SSW-B"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "npW" = (
 /obj/machinery/gateway,
 /obj/effect/decal/turf_decal/alpha/gray{
@@ -61134,7 +61098,10 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "brown"
+	},
 /area/station/cargo/storage)
 "nuV" = (
 /obj/effect/decal/turf_decal{
@@ -62589,26 +62556,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
-"nLu" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "nLP" = (
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
@@ -62781,25 +62728,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/reception)
-"nOT" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/main)
 "nOU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -62967,6 +62895,12 @@
 	icon_state = "wooden"
 	},
 /area/station/bridge/corp_lounge)
+"nQp" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "browncorner"
+	},
+/area/station/cargo/storage)
 "nQq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -63515,16 +63449,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
-"nWe" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "nWf" = (
 /obj/machinery/iv_drip,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -65372,6 +65296,13 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/distribution)
+"otp" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-MB";
+	location = "N-MB"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "otq" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -65655,26 +65586,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/wood,
 /area/station/maintenance/medbay)
-"oxM" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "oxO" = (
 /obj/structure/sign/warning/secure_area,
 /turf/simulated/wall/r_wall,
@@ -65889,6 +65800,13 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/blueshield)
+"oAX" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=CS-AR";
+	location = "SWW-FC"
+	},
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "oBa" = (
 /obj/structure/closet/lawcloset,
 /obj/item/device/cardpay{
@@ -66727,14 +66645,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
-"oLj" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "oLl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -66833,7 +66743,10 @@
 	pixel_x = -28;
 	pixel_y = -6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "brown"
+	},
 /area/station/cargo/storage)
 "oLS" = (
 /turf/simulated/floor{
@@ -67084,6 +66997,17 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"oOi" = (
+/obj/machinery/light/smart,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DS";
+	location = "DN-W"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "purplecorner"
+	},
+/area/station/hallway/primary/central)
 "oOj" = (
 /obj/structure/table,
 /obj/item/weapon/paper/carbon,
@@ -67096,7 +67020,10 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
+	},
 /area/station/cargo/storage)
 "oOv" = (
 /obj/machinery/camera{
@@ -67644,6 +67571,14 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/secondary/exit)
+"oVJ" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/civilian/gym)
 "oVL" = (
 /obj/machinery/door_control{
 	id = "evacbar_shutters";
@@ -68495,6 +68430,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"pfN" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "pfR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
@@ -68594,16 +68538,6 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/secondary/exit)
-"pho" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SWW-FC";
-	location = "SW-FC"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "pht" = (
 /obj/structure/table/woodentable/fancy/black,
 /obj/structure/window/thin/reinforced{
@@ -68639,6 +68573,20 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/engineering/atmos)
+"pii" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 9;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "pio" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -71841,13 +71789,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/tcommsat/chamber)
-"pQJ" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=CS-AR";
-	location = "SWW-FC"
-	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
 "pQK" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = -32
@@ -71977,6 +71918,16 @@
 	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
+"pSy" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-FC";
+	location = "DS"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
+/area/station/hallway/primary/central)
 "pSP" = (
 /obj/structure/table,
 /turf/simulated/floor{
@@ -72970,14 +72921,6 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/library)
-"qew" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/security/prison)
 "qeL" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -73742,15 +73685,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
-"qnx" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-B";
-	location = "S-MB"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/secondary/entry)
 "qnB" = (
 /obj/item/clothing/gloves/boxing/green,
 /obj/item/clothing/gloves/boxing/yellow,
@@ -74194,6 +74128,16 @@
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/starboard)
+"qsL" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SEE-FC";
+	location = "SE-FC"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "qsN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -75211,16 +75155,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/cmo)
-"qFB" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-C";
-	location = "CS-AR"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "qFO" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -75307,6 +75241,15 @@
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/station/security/vacantoffice)
+"qGY" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Security";
+	location = "S-C"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "qHh" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable{
@@ -76036,17 +75979,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/prison)
-"qQs" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "qQt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -78028,6 +77960,9 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -78928,6 +78863,18 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
+"ryM" = (
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Labor Camp Shuttle Airlock";
+	req_access = list(2)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
 "rzd" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -79622,7 +79569,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/storage)
 "rHa" = (
 /obj/structure/cable{
@@ -80278,6 +80227,27 @@
 	icon_state = "purplecorner"
 	},
 /area/station/rnd/hor)
+"rMH" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "rMI" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -81808,13 +81778,6 @@
 	icon_state = "gcircuit"
 	},
 /area/station/bridge/ai_upload)
-"sfB" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "sfJ" = (
 /obj/structure/object_wall/mining{
 	icon_state = "3-1"
@@ -81851,6 +81814,25 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/science)
+"sfQ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/main)
 "sfV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -82633,7 +82615,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/storage)
 "soh" = (
 /obj/effect/landmark/start/scientist,
@@ -83703,6 +83687,26 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/robotics)
+"sCe" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "sCh" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor,
@@ -83718,6 +83722,13 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/kitchen)
+"sCJ" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "sCO" = (
 /obj/structure/closet,
 /obj/item/stack/sheet/glass{
@@ -84075,16 +84086,6 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/toilet)
-"sGt" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NNW-B";
-	location = "NW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "sGy" = (
 /obj/structure/table/woodentable,
 /obj/item/stack/sheet/cloth{
@@ -84460,16 +84461,6 @@
 /obj/item/weapon/circuitboard/space_heater,
 /turf/simulated/floor,
 /area/station/maintenance/science)
-"sLt" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SEE-FC";
-	location = "SE-FC"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "sLC" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -85320,6 +85311,17 @@
 	icon_state = "red"
 	},
 /area/station/security/prison)
+"sVB" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "loadingarea"
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "arrow"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "sVD" = (
 /obj/structure/closet/toolcloset,
 /obj/machinery/light/small{
@@ -86559,12 +86561,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/medical/cryo)
-"tmj" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "cafeteria"
-	},
-/area/station/security/prison)
 "tmk" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -86811,13 +86807,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
-"tpk" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-FC";
-	location = "SSW-FC"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/starboard)
 "tpp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -89881,25 +89870,15 @@
 	},
 /area/station/rnd/hallway)
 "ucx" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "loadingarea"
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "arrow"
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 5;
+	icon_state = "brown"
 	},
-/area/station/security/brig)
-"ucC" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DN";
-	location = "SSE-FC"
-	},
-/turf/simulated/floor{
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
+/area/station/cargo/storage)
 "ucF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -90409,6 +90388,12 @@
 	icon_state = "white"
 	},
 /area/station/medical/hallway)
+"uiS" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
+	},
+/turf/simulated/floor/carpet/red,
+/area/station/security/detectives_office)
 "uiV" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -91269,6 +91254,18 @@
 	icon_state = "yellow"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
+"usd" = (
+/obj/machinery/door_timer/cell_3{
+	pixel_x = 32;
+	pixel_y = 0;
+	dir = 4;
+	id = "Cell 3 perma"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "usl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 10
@@ -91560,6 +91557,14 @@
 	},
 /turf/environment/space,
 /area/shuttle/mining/station)
+"uvJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/security/prison)
 "uvL" = (
 /obj/structure/cable,
 /turf/simulated/floor/plating/airless/catwalk,
@@ -92405,15 +92410,16 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "uHN" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Central Access"
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
 	},
-/area/station/security/lobby)
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "uHX" = (
 /turf/simulated/floor/wood,
 /area/station/maintenance/chapel)
@@ -93163,6 +93169,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/chapel)
+"uRM" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "uRO" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -93603,7 +93621,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
+	},
 /area/station/cargo/storage)
 "uXR" = (
 /obj/structure/cable{
@@ -94069,6 +94090,15 @@
 	icon_state = "darkbluefull"
 	},
 /area/station/engineering/minisat_secure_area)
+"vcx" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 5
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "vcL" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -94330,6 +94360,13 @@
 "vgR" = (
 /turf/simulated/floor/plating/airless,
 /area/space)
+"vgU" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=N-MB";
+	location = "NNW-B"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "vhk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/window/brigdoor,
@@ -94989,16 +95026,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
-"voF" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSE-FC";
-	location = "SEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "voI" = (
 /obj/machinery/disposal,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -95099,6 +95126,16 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
+"vpn" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/station/security/brig)
 "vpp" = (
 /obj/random/scrap/safe_even,
 /turf/simulated/floor/plating,
@@ -96176,6 +96213,16 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
+"vDx" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-C";
+	location = "CS-AR"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "vDC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -96211,7 +96258,9 @@
 /obj/effect/decal/turf_decal/alpha/black{
 	icon_state = "arrow"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/cargo/miningoffice)
 "vEq" = (
 /obj/structure/table,
@@ -97458,15 +97507,14 @@
 	},
 /area/station/bridge/teleporter)
 "vTX" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SE-FC";
-	location = "SW-B"
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "grimy"
 	},
-/area/station/hallway/primary/central)
+/area/station/security/hos)
 "vUe" = (
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
@@ -97642,13 +97690,6 @@
 	icon_state = "greenblue"
 	},
 /area/station/civilian/hydroponics)
-"vWA" = (
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/prison)
 "vWF" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
@@ -99503,6 +99544,9 @@
 	pixel_x = -1;
 	pixel_y = 10
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "brown"
 	},
@@ -100998,6 +101042,11 @@
 	icon_state = "darkblue"
 	},
 /area/station/security/checkpoint/escape_custom_desk)
+"wLh" = (
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "wLD" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -101351,27 +101400,6 @@
 	icon_state = "white"
 	},
 /area/station/rnd/hallway)
-"wQb" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "wQz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
@@ -101562,6 +101590,9 @@
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = -32
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	icon_state = "brown"
@@ -102483,18 +102514,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/hallway)
-"xel" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "xer" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -102704,6 +102723,19 @@
 /mob/living/simple_animal/mouse,
 /turf/simulated/floor/wood,
 /area/station/maintenance/medbay)
+"xgM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/flasher{
+	id = "Cell 1 perma";
+	pixel_y = -28
+	},
+/turf/simulated/floor,
+/area/station/security/prison)
 "xgN" = (
 /obj/machinery/seed_extractor,
 /obj/structure/window/thin{
@@ -103156,6 +103188,13 @@
 	},
 /turf/simulated/floor,
 /area/station/medical/hallway)
+"xnp" = (
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/prison)
 "xns" = (
 /obj/structure/grille{
 	destroyed = 1
@@ -103862,8 +103901,8 @@
 	pixel_x = -28
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "browncorner"
+	dir = 8;
+	icon_state = "brown"
 	},
 /area/station/cargo/storage)
 "xtY" = (
@@ -105066,6 +105105,26 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"xHe" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "xHu" = (
 /obj/structure/rack,
 /obj/item/weapon/circuitboard/solar_control,
@@ -105329,19 +105388,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
-"xKZ" = (
-/obj/machinery/light/smart{
-	dir = 4
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NE-FC";
-	location = "NEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "xLe" = (
 /obj/machinery/portable_atmospherics/powered/pump,
 /obj/machinery/light/smart{
@@ -105671,6 +105717,26 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
+"xOJ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "xPl" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -107172,6 +107238,17 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"ygd" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "ygh" = (
 /obj/random/vending/snack,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -135728,7 +135805,7 @@ doE
 doE
 doE
 lgU
-sLt
+qsL
 mhm
 doE
 mnD
@@ -136226,7 +136303,7 @@ wwi
 aYN
 wwi
 lfm
-voF
+aBi
 tZn
 oyb
 nAM
@@ -136244,7 +136321,7 @@ oyb
 bzt
 bzt
 rcq
-ucC
+dRj
 tYK
 wtC
 wtC
@@ -141623,7 +141700,7 @@ iSv
 xXt
 vAu
 ogP
-akI
+npU
 bAS
 nvi
 rnH
@@ -141639,7 +141716,7 @@ qbj
 qbj
 tmk
 ldb
-vTX
+kgH
 ogP
 iSi
 amv
@@ -141666,7 +141743,7 @@ vpT
 xei
 bFh
 vpT
-ncX
+oOi
 vIl
 olx
 frM
@@ -141834,7 +141911,7 @@ plf
 brw
 mko
 jsL
-qnx
+eHG
 ffX
 hbE
 sTt
@@ -142103,7 +142180,7 @@ gHT
 alc
 vDr
 fDL
-sGt
+gCR
 iwy
 xXt
 gNR
@@ -145947,7 +146024,7 @@ yaE
 yaE
 csG
 fYS
-kTQ
+otp
 alc
 gHT
 gHT
@@ -145956,7 +146033,7 @@ gHT
 gHT
 gHT
 alc
-jVb
+vgU
 fYS
 sEX
 srs
@@ -150096,7 +150173,7 @@ nuP
 cpR
 oRv
 ohw
-osg
+iPW
 ojt
 tpx
 gtB
@@ -150352,7 +150429,7 @@ iPW
 aUg
 tiC
 kxC
-kgH
+hVg
 snW
 smh
 gaF
@@ -150891,7 +150968,7 @@ mXl
 mXl
 mXl
 wLD
-giq
+kPh
 iwm
 mXl
 pRS
@@ -150909,7 +150986,7 @@ oNU
 mXl
 uxx
 xMc
-pho
+cZM
 nvi
 rnH
 cLM
@@ -150918,7 +150995,7 @@ nvi
 tOH
 mfI
 ogP
-lyl
+pSy
 sBG
 wjc
 wjc
@@ -151221,7 +151298,7 @@ xQo
 xQo
 xQo
 nKU
-tpk
+fQh
 xQo
 oPI
 mRu
@@ -151388,7 +151465,7 @@ cpR
 gtK
 cpR
 pxL
-xKZ
+fOp
 ffJ
 ape
 fZz
@@ -151407,7 +151484,7 @@ hRd
 ckx
 fZz
 lMB
-kjh
+qGY
 kzb
 vAu
 psV
@@ -151421,7 +151498,7 @@ vAu
 kRo
 vAu
 kCI
-qFB
+vDx
 ogP
 lwr
 mLS
@@ -151662,7 +151739,7 @@ erD
 erD
 cmN
 act
-uHN
+kRd
 xsY
 uuf
 jTW
@@ -152144,7 +152221,7 @@ fnT
 miA
 ojm
 lPc
-gaF
+nQp
 gaF
 rpV
 qSe
@@ -152401,11 +152478,11 @@ nkb
 adb
 hzP
 cpR
-oOk
+ucx
 oOk
 uXI
 oOk
-oOk
+hyc
 xqF
 aAF
 iqI
@@ -155512,8 +155589,8 @@ plf
 xyC
 cFp
 klH
-juH
-juH
+uiS
+uiS
 hGr
 aRu
 xyC
@@ -156016,11 +156093,11 @@ plf
 plf
 plf
 uRO
-fOp
+hwE
 uRO
 plf
 uRO
-fOp
+hwE
 uRO
 plf
 xyC
@@ -156037,8 +156114,8 @@ dnn
 aEr
 wPw
 jQy
-kod
-hHC
+pfN
+wLh
 jcX
 fJg
 nPU
@@ -156530,11 +156607,11 @@ plf
 cHH
 cHH
 jxX
-hwE
+ryM
 bjt
 stv
 jxX
-hwE
+ryM
 jxX
 adp
 kMq
@@ -156545,7 +156622,7 @@ xyC
 xyC
 xyC
 xyC
-sfB
+sCJ
 jtG
 wpm
 fJg
@@ -156791,7 +156868,7 @@ opt
 kms
 cHH
 eow
-abm
+pii
 goK
 hYT
 nsn
@@ -157044,7 +157121,7 @@ leA
 cHH
 adG
 iGB
-bBc
+vpn
 tTk
 qMX
 aZz
@@ -157305,7 +157382,7 @@ ikW
 qXE
 rjb
 utF
-ucx
+sVB
 uLd
 lat
 nsn
@@ -158104,7 +158181,7 @@ kIM
 vst
 mDV
 vKG
-pQJ
+oAX
 xoq
 tAM
 uQA
@@ -158823,14 +158900,14 @@ fAF
 fgx
 diq
 fAF
-lGM
+usd
 eTq
 fAF
 wNM
 oPD
 tif
 rHZ
-oxM
+sCe
 czU
 tqK
 hsq
@@ -159087,7 +159164,7 @@ qZx
 qZx
 fXG
 qZx
-lxA
+xOJ
 czU
 uvV
 kMw
@@ -159599,7 +159676,7 @@ fBm
 bvC
 hlv
 vqQ
-mUV
+xgM
 qZx
 tnw
 fLE
@@ -160617,7 +160694,7 @@ aXC
 bZu
 pLw
 unD
-qew
+uvJ
 oAx
 ulK
 eyO
@@ -161171,7 +161248,7 @@ sxG
 uOc
 hur
 hur
-aDH
+hla
 ekd
 lZw
 gqC
@@ -161425,7 +161502,7 @@ ixl
 mme
 uKd
 gRX
-xel
+uRM
 sRa
 nUj
 wUB
@@ -161454,13 +161531,13 @@ ncp
 ncp
 hbR
 mWz
-doY
+ekZ
 kLd
 syX
 tHk
 tHk
 dbf
-wQb
+rMH
 ram
 mWz
 lNQ
@@ -161717,7 +161794,7 @@ eFl
 aRb
 nDG
 jjN
-gKc
+bFL
 ram
 mWz
 ucd
@@ -161924,7 +162001,7 @@ afw
 nDf
 mZo
 qUR
-nOT
+sfQ
 mzV
 aSh
 mpR
@@ -162225,13 +162302,13 @@ ncp
 ncp
 hbR
 mWz
-qQs
+uHN
 sIY
 qls
 uOM
 uOM
 aeG
-bFL
+xHe
 ram
 mWz
 hPr
@@ -162421,7 +162498,7 @@ lhK
 wVg
 aFN
 jKZ
-tmj
+jqE
 rBo
 hlv
 qxh
@@ -162685,7 +162762,7 @@ xIO
 jps
 xIO
 qZx
-nLu
+icE
 tbS
 sZR
 kHU
@@ -162697,7 +162774,7 @@ fwH
 qoH
 vOW
 qoH
-oLj
+geb
 umQ
 gYp
 kHU
@@ -162935,7 +163012,7 @@ jvm
 hlv
 fVW
 fPH
-tmj
+jqE
 rnI
 hlv
 pHz
@@ -162950,11 +163027,11 @@ kHU
 plf
 cYc
 ueE
-nWe
+dpo
 wcJ
 iRz
 nez
-kOB
+ygd
 hlh
 gYp
 plf
@@ -163207,11 +163284,11 @@ kHU
 kHU
 cYc
 nfj
-iVF
+vTX
 eaE
 nRk
 rZh
-cFx
+eJA
 hmN
 gYp
 kHU
@@ -163255,7 +163332,7 @@ dJL
 nRG
 oXA
 oXA
-gAh
+oVJ
 dJL
 plf
 cdR
@@ -163464,11 +163541,11 @@ plf
 kHU
 huz
 sIx
-mgH
-cQQ
+vcx
+ewl
 kjv
-cQQ
-iab
+ewl
+fce
 tEU
 huz
 plf
@@ -165513,7 +165590,7 @@ plf
 kHU
 hlv
 lrm
-vWA
+xnp
 jno
 hlv
 cBu
@@ -166593,7 +166670,7 @@ kHU
 fMh
 plf
 dJL
-gAh
+oVJ
 oXA
 oXA
 nJn

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -4840,16 +4840,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
-"aWN" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkblue"
-	},
-/area/station/bridge/corp_lounge)
 "aWR" = (
 /obj/structure/stool/bed/chair/metal/green{
 	dir = 8
@@ -4993,6 +4983,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"aYE" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "purplefull"
+	},
+/area/station/hallway/primary/central)
 "aYN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/hydrant{
@@ -7643,19 +7642,6 @@
 	},
 /turf/environment/space/shuttle,
 /area/shuttle/escape_pod2/station)
-"bCh" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/bluegrid{
-	name = "Server Base";
-	nitrogen = 500;
-	oxygen = 0;
-	temperature = 80
-	},
-/area/station/tcommsat/chamber)
 "bCr" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 8
@@ -8850,6 +8836,11 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
+"bNZ" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet6-2"
+	},
+/area/station/bridge/captain_quarters)
 "bOd" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 4;
@@ -8936,6 +8927,25 @@
 /obj/machinery/vending/medical,
 /turf/simulated/floor,
 /area/station/medical/storage)
+"bPj" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "bPp" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -9113,14 +9123,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/lobby)
-"bRD" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "purplefull"
-	},
-/area/station/hallway/primary/central)
 "bRM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -12547,6 +12549,19 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
+"cFN" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "cFP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13376,7 +13391,7 @@
 /area/station/hallway/primary/fore)
 "cPN" = (
 /turf/simulated/floor/carpet{
-	icon_state = "carpet6-2"
+	icon_state = "carpet9-4"
 	},
 /area/station/bridge/captain_quarters)
 "cPY" = (
@@ -14445,7 +14460,7 @@
 /area/station/engineering/atmos)
 "dfg" = (
 /turf/simulated/floor/carpet{
-	icon_state = "carpet6-2"
+	icon_state = "carpet10-8"
 	},
 /area/station/bridge)
 "dfo" = (
@@ -22842,15 +22857,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/dormitories/courtroom)
-"fej" = (
-/obj/effect/decal/turf_decal{
-	dir = 6;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/rnd/robotics)
 "fek" = (
 /obj/structure/closet/wardrobe/grey,
 /turf/simulated/floor{
@@ -23678,6 +23684,14 @@
 /obj/item/toy/cards,
 /turf/simulated/floor/carpet/green,
 /area/station/hallway/primary/fore)
+"fqf" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/primary/central)
 "fqg" = (
 /obj/item/weapon/table_parts/wood/fancy,
 /turf/simulated/floor/plating,
@@ -28904,6 +28918,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line"
+	},
 /turf/simulated/floor/wood,
 /area/station/civilian/barbershop)
 "gyz" = (
@@ -31093,7 +31110,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -32217,6 +32234,16 @@
 	icon_state = "yellow"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
+"hoE" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "purplefull"
+	},
+/area/station/hallway/primary/central)
 "hoM" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots,
@@ -33190,6 +33217,16 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
+"hyB" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/station/bridge/corp_lounge)
 "hyD" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -33995,6 +34032,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line"
+	},
 /turf/simulated/floor/wood,
 /area/station/civilian/barbershop)
 "hGJ" = (
@@ -34608,6 +34648,9 @@
 	c_tag = "Barbershop";
 	dir = 1
 	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line"
+	},
 /turf/simulated/floor/wood,
 /area/station/civilian/barbershop)
 "hOM" = (
@@ -35168,6 +35211,15 @@
 /obj/random/foods/food_trash,
 /turf/simulated/floor,
 /area/station/maintenance/escape)
+"hVS" = (
+/obj/effect/decal/turf_decal{
+	dir = 6;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/robotics)
 "hVZ" = (
 /obj/structure/closet/wardrobe/chaplain_black,
 /obj/item/device/cardpay{
@@ -35505,18 +35557,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/brig)
-"hYX" = (
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner"
-	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "hYY" = (
 /obj/structure/closet/secure_closet/freezer/icecream,
 /turf/simulated/floor{
@@ -37742,6 +37782,11 @@
 	icon_state = "neutralfull"
 	},
 /area/station/gateway)
+"izk" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet6-2"
+	},
+/area/station/bridge)
 "izp" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -42517,6 +42562,10 @@
 /obj/machinery/newscaster{
 	pixel_y = 28
 	},
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "blackchecker"
 	},
@@ -43672,6 +43721,10 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 8
+	},
 /turf/simulated/floor{
 	icon_state = "blackchecker"
 	},
@@ -43884,6 +43937,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
+"jQL" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line"
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "jQT" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor{
@@ -45010,16 +45075,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/storage)
-"kfa" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "gcircuit"
-	},
-/area/station/tcommsat/chamber)
 "kfd" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -48723,25 +48778,6 @@
 	icon_state = "darkred"
 	},
 /area/station/security/warden)
-"kUQ" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "kVb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -50347,15 +50383,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
-"loV" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "purplefull"
-	},
-/area/station/hallway/primary/central)
 "lpw" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -55082,11 +55109,8 @@
 /area/station/maintenance/chapel)
 "mue" = (
 /obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line"
-	},
-/obj/effect/decal/turf_decal/wood{
 	icon_state = "siding_wood_line";
-	dir = 1
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "wooden"
@@ -58722,6 +58746,19 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/interrogation)
+"nnQ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/station/tcommsat/chamber)
 "nnZ" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 8
@@ -63207,6 +63244,9 @@
 	},
 /area/station/rnd/hallway)
 "oqZ" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line"
+	},
 /turf/simulated/floor/wood,
 /area/station/civilian/barbershop)
 "ord" = (
@@ -69778,11 +69818,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/reception)
-"pTa" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet9-4"
-	},
-/area/station/bridge/captain_quarters)
 "pTk" = (
 /obj/structure/table,
 /obj/item/weapon/storage/visuals/tray,
@@ -71391,15 +71426,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/storage/tech)
-"qmI" = (
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "qmP" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -71764,19 +71790,6 @@
 	icon_state = "dark"
 	},
 /area/station/aisat/teleport)
-"qrg" = (
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "qrj" = (
 /turf/simulated/wall,
 /area/station/bridge/meeting_room)
@@ -75744,6 +75757,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 6
+	},
 /turf/simulated/floor/wood,
 /area/station/civilian/barbershop)
 "rqZ" = (
@@ -75794,6 +75811,10 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "blackchecker"
@@ -83582,6 +83603,18 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/kitchen)
+"tho" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner"
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "thA" = (
 /obj/structure/object_wall/pod{
 	dir = 4;
@@ -85392,11 +85425,6 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/janitor)
-"tEy" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet10-8"
-	},
-/area/station/bridge)
 "tED" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -86058,6 +86086,9 @@
 "tMV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line"
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/barbershop)
@@ -88210,6 +88241,10 @@
 	},
 /obj/structure/sink{
 	pixel_y = 24
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 4
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/barbershop)
@@ -90923,6 +90958,10 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "blackchecker"
@@ -94564,7 +94603,7 @@
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "purplefull"
 	},
 /area/station/hallway/primary/central)
 "vUn" = (
@@ -94619,6 +94658,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
+"vVq" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/bluegrid{
+	icon_state = "gcircuit"
+	},
+/area/station/tcommsat/chamber)
 "vVA" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -101189,16 +101238,6 @@
 	icon_state = "red"
 	},
 /area/station/security/checkpoint/engi)
-"xyi" = (
-/obj/item/weapon/flora/random,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "purplefull"
-	},
-/area/station/hallway/primary/central)
 "xyp" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -136487,7 +136526,7 @@ bNg
 cLW
 rjR
 qgs
-fej
+hVS
 cVA
 wrb
 chV
@@ -138276,13 +138315,13 @@ pHa
 pHa
 pbn
 yhw
-loV
-loV
+aYE
+aYE
 qQu
-loV
-xyi
+aYE
+hoE
 bwA
-bRD
+vUh
 eKK
 oZa
 oZa
@@ -139559,7 +139598,7 @@ fFk
 hWY
 hWY
 giW
-vUh
+fqf
 mby
 oXw
 rdN
@@ -142127,7 +142166,7 @@ pQD
 gIC
 gIC
 gIC
-bCh
+nnQ
 gIC
 gIC
 keH
@@ -142901,7 +142940,7 @@ xMO
 raJ
 cCX
 vyg
-kfa
+vVq
 lwt
 raJ
 eXe
@@ -142912,7 +142951,7 @@ siM
 mKJ
 mMA
 bLg
-hYX
+tho
 lGH
 cje
 nHg
@@ -143144,7 +143183,7 @@ gCE
 imK
 lEC
 wnY
-dfg
+izk
 akc
 lZx
 gWd
@@ -143169,7 +143208,7 @@ jEs
 mKJ
 mMA
 vEH
-mue
+jQL
 rOO
 mzL
 nHg
@@ -143658,7 +143697,7 @@ gCE
 imK
 lEC
 mrs
-tEy
+dfg
 nSo
 lZx
 oay
@@ -143683,7 +143722,7 @@ wMM
 fgA
 mMA
 joF
-mue
+jQL
 eZe
 wAA
 nHg
@@ -143928,7 +143967,7 @@ knC
 aty
 wEV
 fAH
-kfa
+vVq
 aEE
 lwt
 wEV
@@ -143939,10 +143978,10 @@ pQD
 amY
 fgA
 mMA
-qmI
-qrg
+mue
+cFN
 lBF
-kUQ
+bPj
 nHg
 nvi
 ogP
@@ -144455,7 +144494,7 @@ xVa
 mMA
 eIB
 pYl
-aWN
+hyB
 jVM
 mMA
 elI
@@ -144697,9 +144736,9 @@ pQD
 gIC
 gIC
 gIC
-bCh
+nnQ
 gIC
-bCh
+nnQ
 gIC
 gIC
 aty
@@ -145979,7 +146018,7 @@ ibm
 adM
 sTY
 bIZ
-pTa
+cPN
 iaL
 cHR
 jKD
@@ -147011,7 +147050,7 @@ cjq
 nac
 hrj
 pEa
-cPN
+bNZ
 cqG
 iaL
 pst

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -4840,6 +4840,16 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
+"aWN" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/station/bridge/corp_lounge)
 "aWR" = (
 /obj/structure/stool/bed/chair/metal/green{
 	dir = 8
@@ -7633,6 +7643,19 @@
 	},
 /turf/environment/space/shuttle,
 /area/shuttle/escape_pod2/station)
+"bCh" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/station/tcommsat/chamber)
 "bCr" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 8
@@ -8723,7 +8746,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/rnd/robotics)
 "bNl" = (
@@ -9090,6 +9113,14 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/lobby)
+"bRD" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "purplefull"
+	},
+/area/station/hallway/primary/central)
 "bRM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -12944,7 +12975,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/rnd/robotics)
 "cLY" = (
@@ -13345,7 +13376,7 @@
 /area/station/hallway/primary/fore)
 "cPN" = (
 /turf/simulated/floor/carpet{
-	icon_state = "carpet9-4"
+	icon_state = "carpet6-2"
 	},
 /area/station/bridge/captain_quarters)
 "cPY" = (
@@ -14414,7 +14445,7 @@
 /area/station/engineering/atmos)
 "dfg" = (
 /turf/simulated/floor/carpet{
-	icon_state = "carpet10-8"
+	icon_state = "carpet6-2"
 	},
 /area/station/bridge)
 "dfo" = (
@@ -18258,7 +18289,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/rnd/robotics)
 "eaE" = (
@@ -20014,7 +20045,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/turf_decal/wood{
+/obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "siding_wood_line";
 	dir = 4
 	},
@@ -20960,7 +20991,7 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/obj/effect/decal/turf_decal/wood{
+/obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "siding_wood_line";
 	dir = 8
 	},
@@ -22811,6 +22842,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/dormitories/courtroom)
+"fej" = (
+/obj/effect/decal/turf_decal{
+	dir = 6;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/robotics)
 "fek" = (
 /obj/structure/closet/wardrobe/grey,
 /turf/simulated/floor{
@@ -25114,7 +25154,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/rnd/robotics)
 "fGV" = (
@@ -27376,16 +27416,6 @@
 	icon_state = "redyellowfull"
 	},
 /area/station/rnd/scibreak)
-"gjq" = (
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkblue"
-	},
-/area/station/bridge/corp_lounge)
 "gjC" = (
 /turf/simulated/floor/wood,
 /area/station/maintenance/science)
@@ -29870,7 +29900,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/rnd/robotics)
 "gLD" = (
@@ -31877,7 +31907,7 @@
 	},
 /area/station/hallway/secondary/entry)
 "hkF" = (
-/obj/effect/decal/turf_decal/wood{
+/obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "siding_wood_line";
 	dir = 4
 	},
@@ -35475,6 +35505,18 @@
 	icon_state = "dark"
 	},
 /area/station/security/brig)
+"hYX" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner"
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "hYY" = (
 /obj/structure/closet/secure_closet/freezer/icecream,
 /turf/simulated/floor{
@@ -35597,7 +35639,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/rnd/robotics)
 "iaC" = (
@@ -36000,16 +36042,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/break_room)
-"ift" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "gcircuit"
-	},
-/area/station/tcommsat/chamber)
 "ifx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -42414,7 +42446,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/rnd/robotics)
 "jBD" = (
@@ -44223,7 +44255,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/turf_decal/wood{
+/obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "siding_wood_line";
 	dir = 8
 	},
@@ -44978,6 +45010,16 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/storage)
+"kfa" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/bluegrid{
+	icon_state = "gcircuit"
+	},
+/area/station/tcommsat/chamber)
 "kfd" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -46659,15 +46701,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/dormitories/courtroom)
-"kyw" = (
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "kyz" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -48690,6 +48723,25 @@
 	icon_state = "darkred"
 	},
 /area/station/security/warden)
+"kUQ" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "kVb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -50295,6 +50347,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
+"loV" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "purplefull"
+	},
+/area/station/hallway/primary/central)
 "lpw" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -52370,25 +52431,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
-"lNo" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "lNr" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -55040,11 +55082,11 @@
 /area/station/maintenance/chapel)
 "mue" = (
 /obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner"
+	icon_state = "siding_wood_line"
 	},
 /obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner";
-	dir = 4
+	icon_state = "siding_wood_line";
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "wooden"
@@ -62057,6 +62099,9 @@
 /area/station/civilian/dormitories/courtroom)
 "oba" = (
 /obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -68086,18 +68131,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
-"pzL" = (
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line"
-	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "pzM" = (
 /obj/structure/bookcase{
 	name = "bookcase (Non-Fiction)"
@@ -69745,6 +69778,11 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/reception)
+"pTa" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet9-4"
+	},
+/area/station/bridge/captain_quarters)
 "pTk" = (
 /obj/structure/table,
 /obj/item/weapon/storage/visuals/tray,
@@ -70101,7 +70139,7 @@
 "pYl" = (
 /obj/structure/table,
 /obj/item/weapon/storage/briefcase/centcomm,
-/obj/effect/decal/turf_decal/wood{
+/obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "siding_wood_line";
 	dir = 8
 	},
@@ -70805,7 +70843,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/rnd/robotics)
 "qgt" = (
@@ -71353,6 +71391,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/storage/tech)
+"qmI" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "qmP" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -71603,11 +71650,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hor)
-"qoV" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet6-2"
-	},
-/area/station/bridge/captain_quarters)
 "qpp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -71722,6 +71764,19 @@
 	icon_state = "dark"
 	},
 /area/station/aisat/teleport)
+"qrg" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "qrj" = (
 /turf/simulated/wall,
 /area/station/bridge/meeting_room)
@@ -75239,7 +75294,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/rnd/robotics)
 "rkr" = (
@@ -78934,7 +78989,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/rnd/robotics)
 "sbr" = (
@@ -80413,19 +80468,6 @@
 	icon_state = "wooden"
 	},
 /area/station/bridge/corp_lounge)
-"ssN" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/bluegrid{
-	name = "Server Base";
-	nitrogen = 500;
-	oxygen = 0;
-	temperature = 80
-	},
-/area/station/tcommsat/chamber)
 "sta" = (
 /obj/structure/table/reinforced,
 /obj/item/device/flashlight/lamp,
@@ -85350,6 +85392,11 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/janitor)
+"tEy" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet10-8"
+	},
+/area/station/bridge)
 "tED" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -90123,7 +90170,7 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/obj/effect/decal/turf_decal/wood{
+/obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "siding_wood_line";
 	dir = 4
 	},
@@ -91867,7 +91914,7 @@
 /area/station/civilian/gym)
 "vlJ" = (
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/rnd/robotics)
 "vlN" = (
@@ -92098,7 +92145,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/rnd/robotics)
 "voO" = (
@@ -92559,11 +92606,6 @@
 	icon_state = "greenblue"
 	},
 /area/station/hallway/primary/fore)
-"vut" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet6-2"
-	},
-/area/station/bridge)
 "vux" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 1
@@ -93657,7 +93699,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/rnd/robotics)
 "vIN" = (
@@ -96296,16 +96338,6 @@
 	},
 /turf/simulated/floor/carpet/red,
 /area/station/security/detectives_office)
-"wqw" = (
-/obj/item/weapon/flora/random,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "purplefull"
-	},
-/area/station/hallway/primary/central)
 "wqS" = (
 /obj/structure/table,
 /obj/item/weapon/storage/belt/utility,
@@ -97688,7 +97720,7 @@
 	},
 /area/station/engineering/chiefs_office)
 "wHq" = (
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -98422,7 +98454,7 @@
 /obj/structure/table,
 /obj/item/weapon/folder/blue,
 /obj/item/weapon/pen/blue,
-/obj/effect/decal/turf_decal/wood{
+/obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "siding_wood_line";
 	dir = 4
 	},
@@ -99759,14 +99791,6 @@
 	icon_state = "caution"
 	},
 /area/station/medical/chemistry)
-"xiG" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "purplefull"
-	},
-/area/station/hallway/primary/central)
 "xiI" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
@@ -100343,6 +100367,9 @@
 "xpQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "whitehall"
@@ -100756,15 +100783,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
-"xty" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "purplefull"
-	},
-/area/station/hallway/primary/central)
 "xtC" = (
 /obj/structure/table/reinforced,
 /obj/item/toy/figure/borg,
@@ -101171,6 +101189,16 @@
 	icon_state = "red"
 	},
 /area/station/security/checkpoint/engi)
+"xyi" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "purplefull"
+	},
+/area/station/hallway/primary/central)
 "xyp" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -102481,19 +102509,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
-"xNS" = (
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "xNT" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -136472,7 +136487,7 @@ bNg
 cLW
 rjR
 qgs
-aqC
+fej
 cVA
 wrb
 chV
@@ -138261,13 +138276,13 @@ pHa
 pHa
 pbn
 yhw
-xty
-xty
+loV
+loV
 qQu
-xty
-wqw
+loV
+xyi
 bwA
-xiG
+bRD
 eKK
 oZa
 oZa
@@ -142112,7 +142127,7 @@ pQD
 gIC
 gIC
 gIC
-ssN
+bCh
 gIC
 gIC
 keH
@@ -142886,7 +142901,7 @@ xMO
 raJ
 cCX
 vyg
-ift
+kfa
 lwt
 raJ
 eXe
@@ -142897,7 +142912,7 @@ siM
 mKJ
 mMA
 bLg
-mue
+hYX
 lGH
 cje
 nHg
@@ -143129,7 +143144,7 @@ gCE
 imK
 lEC
 wnY
-vut
+dfg
 akc
 lZx
 gWd
@@ -143154,7 +143169,7 @@ jEs
 mKJ
 mMA
 vEH
-pzL
+mue
 rOO
 mzL
 nHg
@@ -143643,7 +143658,7 @@ gCE
 imK
 lEC
 mrs
-dfg
+tEy
 nSo
 lZx
 oay
@@ -143668,7 +143683,7 @@ wMM
 fgA
 mMA
 joF
-pzL
+mue
 eZe
 wAA
 nHg
@@ -143913,7 +143928,7 @@ knC
 aty
 wEV
 fAH
-ift
+kfa
 aEE
 lwt
 wEV
@@ -143924,10 +143939,10 @@ pQD
 amY
 fgA
 mMA
-kyw
-xNS
+qmI
+qrg
 lBF
-lNo
+kUQ
 nHg
 nvi
 ogP
@@ -144440,7 +144455,7 @@ xVa
 mMA
 eIB
 pYl
-gjq
+aWN
 jVM
 mMA
 elI
@@ -144682,9 +144697,9 @@ pQD
 gIC
 gIC
 gIC
-ssN
+bCh
 gIC
-ssN
+bCh
 gIC
 gIC
 aty
@@ -145964,7 +145979,7 @@ ibm
 adM
 sTY
 bIZ
-cPN
+pTa
 iaL
 cHR
 jKD
@@ -146996,7 +147011,7 @@ cjq
 nac
 hrj
 pEa
-qoV
+cPN
 cqG
 iaL
 pst

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -2614,6 +2614,15 @@
 	icon_state = "white"
 	},
 /area/station/civilian/dormitories)
+"avd" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "avo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on/atmos{
 	dir = 1;
@@ -3964,6 +3973,17 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
+"aLS" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "aMd" = (
 /obj/structure/object_wall/cargo{
 	icon_state = "5,0"
@@ -4486,6 +4506,18 @@
 	icon_state = "grimy"
 	},
 /area/station/storage/tools)
+"aSg" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "aSh" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 8
@@ -4645,18 +4677,6 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/locker)
-"aUc" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "aUg" = (
 /turf/simulated/floor{
 	icon_state = "browncorner"
@@ -8862,8 +8882,11 @@
 /area/station/civilian/kitchen)
 "bNb" = (
 /obj/structure/filingcabinet/security,
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
-	icon_state = "darkblue"
+	icon_state = "vaultfull"
 	},
 /area/station/security/blueshield)
 "bNg" = (
@@ -13626,12 +13649,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
-"cPK" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
-	},
-/turf/simulated/floor/carpet/red,
-/area/station/security/detectives_office)
 "cPN" = (
 /obj/structure/table/woodentable/fancy,
 /obj/effect/decal/turf_decal/metal{
@@ -30945,6 +30962,14 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/science)
+"gQk" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/civilian/gym)
 "gQo" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -35406,6 +35431,11 @@
 	icon_state = "neutral"
 	},
 /area/station/rnd/xenobiology)
+"hOp" = (
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "hOq" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
@@ -38486,6 +38516,19 @@
 /obj/item/weapon/reagent_containers/food/snacks/grown/harebell,
 /turf/simulated/floor,
 /area/station/civilian/chapel)
+"ixU" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "ixW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment{
@@ -41246,7 +41289,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor{
-	icon_state = "darkblue"
+	icon_state = "vaultfull"
 	},
 /area/station/security/blueshield)
 "jde" = (
@@ -44340,6 +44383,12 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/atmos)
+"jLl" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
+	},
+/turf/simulated/floor/carpet/red,
+/area/station/security/detectives_office)
 "jLq" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -44497,27 +44546,6 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/locker)
-"jNf" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "jNg" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -47423,19 +47451,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/bridge/meeting_room)
-"ksF" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "ksG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -47925,8 +47940,12 @@
 /area/station/maintenance/brig)
 "kzi" = (
 /obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 1
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/security/blueshield)
 "kzl" = (
@@ -52473,7 +52492,7 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/security/blueshield)
 "lAt" = (
@@ -53868,17 +53887,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
-"lPv" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "lPy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -54279,15 +54287,6 @@
 	icon_state = "yellow"
 	},
 /area/station/storage/emergency)
-"lUV" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Central Access"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "lUY" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -56393,6 +56392,16 @@
 	icon_state = "wooden"
 	},
 /area/station/bridge/corp_lounge)
+"mug" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Central Access"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "muh" = (
 /obj/structure/object_wall/cargo{
 	icon_state = "4,0"
@@ -57620,14 +57629,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/storage/tech)
-"mJA" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/civilian/gym)
 "mJM" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 10
@@ -65404,7 +65405,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor{
-	icon_state = "darkblue"
+	icon_state = "vaultfull"
 	},
 /area/station/security/blueshield)
 "oBa" = (
@@ -68589,6 +68590,27 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
+"pnb" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "pne" = (
 /turf/simulated/wall,
 /area/station/civilian/chapel/mass_driver)
@@ -72656,7 +72678,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor{
-	icon_state = "darkblue"
+	icon_state = "vaultfull"
 	},
 /area/station/security/blueshield)
 "qhC" = (
@@ -79228,8 +79250,12 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/weapon/lighter/zippo,
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 1
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/security/blueshield)
 "rIr" = (
@@ -83318,8 +83344,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/table/reinforced,
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 1
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/security/blueshield)
 "sEI" = (
@@ -90816,7 +90846,6 @@
 	name = "Central Access"
 	},
 /turf/simulated/floor{
-	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/station/security/lobby)
@@ -91579,7 +91608,7 @@
 	dir = 4
 	},
 /obj/machinery/disposal,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -93037,8 +93066,11 @@
 /area/station/cargo/recycler)
 "uYj" = (
 /obj/structure/closet/blueshield,
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
-	icon_state = "darkblue"
+	icon_state = "vaultfull"
 	},
 /area/station/security/blueshield)
 "uYo" = (
@@ -94847,7 +94879,7 @@
 	},
 /obj/effect/landmark/start/blueshield_officer,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/security/blueshield)
 "vuL" = (
@@ -100317,7 +100349,7 @@
 	pixel_y = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/security/blueshield)
 "wKZ" = (
@@ -104402,8 +104434,11 @@
 	},
 /obj/item/weapon/storage/firstaid/adv,
 /obj/item/weapon/storage/firstaid/small_firstaid_kit/civilian/strike,
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/security/blueshield)
 "xIq" = (
@@ -105531,8 +105566,12 @@
 "xVp" = (
 /obj/item/weapon/storage/box/cdeathalarm_kit,
 /obj/structure/table/reinforced,
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 1
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/security/blueshield)
 "xVu" = (
@@ -150936,9 +150975,9 @@ erD
 erD
 cmN
 act
-uuf
+mug
 xsY
-lUV
+uuf
 jTW
 jTW
 jTW
@@ -154786,8 +154825,8 @@ plf
 xyC
 cFp
 klH
-cPK
-cPK
+jLl
+jLl
 hGr
 aRu
 xyC
@@ -155311,8 +155350,8 @@ dnn
 aEr
 wPw
 jQy
-xPR
-xPR
+avd
+hOp
 jcX
 fJg
 nPU
@@ -160728,13 +160767,13 @@ ncp
 ncp
 hbR
 mWz
-aUc
+aSg
 kLd
 syX
 tHk
 tHk
 dbf
-jNf
+pnb
 ram
 mWz
 lNQ
@@ -160991,7 +161030,7 @@ eFl
 aRb
 nDG
 jjN
-ksF
+ixU
 ram
 mWz
 ucd
@@ -161499,7 +161538,7 @@ ncp
 ncp
 hbR
 mWz
-lPv
+aLS
 sIY
 qls
 uOM
@@ -162529,7 +162568,7 @@ dJL
 nRG
 oXA
 oXA
-mJA
+gQk
 dJL
 plf
 cdR
@@ -165867,7 +165906,7 @@ kHU
 fMh
 plf
 dJL
-mJA
+gQk
 oXA
 oXA
 nJn

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -927,19 +927,6 @@
 /obj/structure/stool/bed/chair/office/dark,
 /turf/simulated/floor,
 /area/station/maintenance/science)
-"aeA" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "aeD" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -2090,6 +2077,23 @@
 /obj/random/tools/tool,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
+"apc" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Entry Shuttle Airlock";
+	req_one_access = list(13)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "ape" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/directions/security{
@@ -3296,6 +3300,26 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/minisat_secure_area)
+"aDK" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "aDL" = (
 /obj/item/weapon/caution,
 /turf/simulated/floor/plating,
@@ -5004,6 +5028,16 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
+"aXu" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SEE-FC";
+	location = "SE-FC"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "aXC" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/cobweb,
@@ -5627,11 +5661,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port)
-"beh" = (
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "beo" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -5975,6 +6004,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/maintenance/science)
+"bhs" = (
+/obj/structure/closet/emcloset,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "bhv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor/carpet/blue2,
@@ -6010,15 +6048,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
-"bih" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "biv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -6383,8 +6412,7 @@
 	},
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
+	icon_state = "box_corners_white"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -6886,18 +6914,6 @@
 	},
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
-"brr" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "brv" = (
 /obj/machinery/optable,
 /obj/machinery/requests_console/forensic{
@@ -7864,6 +7880,18 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/lobby)
+"bBp" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "bBu" = (
 /obj/structure/table/woodentable,
 /obj/item/device/taperecorder,
@@ -8332,11 +8360,10 @@
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "box_corners_white";
-	dir = 1
+	dir = 4
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
+	icon_state = "box_corners_white"
 	},
 /obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "siding_line";
@@ -8740,6 +8767,13 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/starboard)
+"bJm" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-MB";
+	location = "N-MB"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "bJr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9194,6 +9228,15 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/science)
+"bOv" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 5
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "bOy" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/turretid/stun/AI_special{
@@ -9354,6 +9397,13 @@
 	icon_state = "vaultfull"
 	},
 /area/station/engineering/chiefs_office)
+"bQA" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=CS-AR";
+	location = "SWW-FC"
+	},
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "bQI" = (
 /obj/machinery/hydroponics/constructable,
 /turf/simulated/floor,
@@ -9435,6 +9485,17 @@
 	icon_state = "dark"
 	},
 /area/station/medical/virology)
+"bRn" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "bRy" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -10150,19 +10211,6 @@
 "bZk" = (
 /turf/simulated/wall/r_wall,
 /area/station/medical/genetics)
-"bZo" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "bZu" = (
 /turf/simulated/floor,
 /area/station/security/prison)
@@ -10288,16 +10336,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/mixing)
-"caB" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "caD" = (
 /obj/item/device/radio/beacon,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -10524,14 +10562,6 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/dormitories)
-"ccR" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/civilian/gym)
 "ccT" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -10589,19 +10619,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos/distribution)
-"cdw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "cdy" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -11270,12 +11287,6 @@
 	icon_state = "wooden"
 	},
 /area/station/bridge/corp_lounge)
-"ckp" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "cafeteria"
-	},
-/area/station/security/prison)
 "ckw" = (
 /obj/machinery/light/smart{
 	dir = 8
@@ -11381,6 +11392,16 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port)
+"clM" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-C";
+	location = "CS-AR"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "clN" = (
 /obj/structure/table,
 /obj/item/device/tagger/shop,
@@ -11701,6 +11722,15 @@
 	},
 /turf/simulated/floor/engine/airmix,
 /area/station/engineering/atmos)
+"cpB" = (
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "cpL" = (
 /obj/machinery/light/smart{
 	dir = 4
@@ -11861,17 +11891,6 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/primary/fore)
-"ctv" = (
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
 "ctH" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -12088,19 +12107,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/engi)
-"cvJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+"cvM" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
 	dir = 4
 	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 9
+/turf/simulated/floor{
+	icon_state = "neutralfull"
 	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
+/area/station/engineering/atmos)
 "cvO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -13316,6 +13334,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
+"cIf" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/civilian/gym)
 "cIm" = (
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Antechamber";
@@ -13686,6 +13712,12 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
+"cMP" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "cafeteria"
+	},
+/area/station/security/prison)
 "cMW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13974,6 +14006,13 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
+"cPJ" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "cPN" = (
 /obj/structure/table/woodentable/fancy,
 /obj/effect/decal/turf_decal/metal{
@@ -14356,21 +14395,6 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/chapel/mass_driver)
-"cTx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
 "cTK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/disposal,
@@ -14641,6 +14665,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/civilian/locker)
+"cWX" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_corner"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "arrows_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/hallway/secondary/entry)
 "cXg" = (
 /obj/structure/table/woodentable,
 /obj/item/device/flashlight/lamp{
@@ -14768,7 +14805,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
+	icon_state = "siding_line";
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -15607,13 +15644,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/bridge/corp_lounge)
-"diN" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-MB";
-	location = "N-MB"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "diQ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -17316,6 +17346,19 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
+"dED" = (
+/obj/machinery/light/smart{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NE-FC";
+	location = "NEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "dEP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18032,19 +18075,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/forensic_office)
-"dOg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "dOC" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -18067,6 +18097,17 @@
 	icon_state = "darkblue"
 	},
 /area/station/bridge)
+"dOQ" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "dOS" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -19009,17 +19050,6 @@
 	},
 /turf/simulated/floor,
 /area/station/storage/emergency2)
-"eae" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "eao" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -19294,18 +19324,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
-"ecQ" = (
-/obj/structure/stool/bed/chair/metal/black{
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "ecT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/woodentable,
@@ -19824,17 +19842,15 @@
 	},
 /area/station/hallway/primary/starboard)
 "ejv" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SE-FC";
+	location = "SW-B"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
-/area/station/engineering/engine)
+/area/station/hallway/primary/central)
 "ejG" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 1
@@ -19952,15 +19968,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/armoury)
-"ekf" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "ekl" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -20007,18 +20014,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor,
 /area/station/maintenance/medbay)
-"ekC" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/engineering/atmos/atmos_office)
 "ekD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -20301,23 +20296,12 @@
 /turf/simulated/floor,
 /area/station/rnd/chargebay)
 "enN" = (
-/obj/structure/table/reinforced,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/machinery/door_control{
 	id = "scince_lab_shutters";
 	name = "Science Lab Shutters";
 	pixel_x = 26
 	},
-/obj/item/weapon/stock_parts/console_screen,
-/obj/item/weapon/stock_parts/console_screen,
-/obj/item/weapon/stock_parts/micro_laser,
-/obj/item/weapon/stock_parts/micro_laser,
-/obj/item/weapon/stock_parts/manipulator,
-/obj/item/weapon/stock_parts/manipulator,
+/obj/machinery/autolathe,
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
@@ -21041,10 +21025,11 @@
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
-/obj/machinery/autolathe,
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
+/obj/structure/rack,
+/obj/item/clothing/glasses/welding,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -21643,16 +21628,6 @@
 /obj/structure/sign/plaques/kiddie,
 /turf/simulated/wall/r_wall,
 /area/station/aisat/antechamber_interior)
-"eEH" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "eEK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/woodentable,
@@ -21875,12 +21850,6 @@
 	c_tag = "Research Circuits Lab";
 	dir = 5;
 	network = list("SS13","Research")
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "arrow"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "loadingarea"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -22505,6 +22474,15 @@
 	icon_state = "caution"
 	},
 /area/station/medical/chemistry)
+"eOm" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-B";
+	location = "S-MB"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry)
 "eOt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -23010,22 +22988,6 @@
 	icon_state = "bluecorner"
 	},
 /area/station/security/lobby)
-"eUa" = (
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Entry Shuttle Airlock";
-	req_one_access = list(13)
-	},
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
 "eUf" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -23170,18 +23132,6 @@
 	icon_state = "yellowfull"
 	},
 /area/station/engineering/engine)
-"eWA" = (
-/obj/machinery/door_timer/cell_3{
-	pixel_x = 32;
-	pixel_y = 0;
-	dir = 4;
-	id = "Cell 3 perma"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "eWG" = (
 /turf/simulated/floor{
 	dir = 5;
@@ -24600,26 +24550,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/lobby)
-"fmg" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "fmh" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 1
@@ -25209,6 +25139,17 @@
 	icon_state = "darkblue"
 	},
 /area/station/engineering/minisat_secure_area)
+"ftt" = (
+/obj/machinery/light/smart,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DS";
+	location = "DN-W"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "purplecorner"
+	},
+/area/station/hallway/primary/central)
 "fty" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -25329,16 +25270,6 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/library)
-"fuL" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-C";
-	location = "CS-AR"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "fuM" = (
 /obj/machinery/vending/coffee,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -26896,6 +26827,11 @@
 	icon_state = "darkbrown"
 	},
 /area/station/medical/virology)
+"fNh" = (
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "fNA" = (
 /obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "box_corners_white";
@@ -26926,12 +26862,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "fOp" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-FC";
-	location = "SSW-FC"
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/starboard)
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "fOF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
@@ -27342,18 +27280,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/station/civilian/dormitories)
-"fTu" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "fTz" = (
 /turf/simulated/wall,
 /area/station/cargo/recycler)
@@ -27789,20 +27715,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"fYP" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_corner";
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "arrows_white";
-	dir = 8
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "black"
-	},
-/area/station/hallway/secondary/entry)
 "fYS" = (
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -28160,17 +28072,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
-"gdh" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "loadingarea"
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "arrow"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "gdx" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -28428,15 +28329,6 @@
 	icon_state = "damaged1"
 	},
 /area/station/maintenance/incinerator)
-"ggd" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-B";
-	location = "S-MB"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/secondary/entry)
 "ggr" = (
 /obj/structure/stool,
 /obj/machinery/light/smart,
@@ -28488,15 +28380,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
-"ghp" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DN";
-	location = "SSE-FC"
-	},
-/turf/simulated/floor{
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "ghu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -30453,6 +30336,15 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
+"gzK" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "gzO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -30808,6 +30700,17 @@
 /obj/item/weapon/table_parts,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"gEQ" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "loadingarea"
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "arrow"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "gER" = (
 /obj/structure/closet/secure_closet/hop,
 /obj/item/device/cardpay{
@@ -31298,13 +31201,6 @@
 	dir = 8;
 	icon_state = "blackcorner"
 	},
-/area/station/hallway/secondary/entry)
-"gKs" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=N-MB";
-	location = "NNW-B"
-	},
-/turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "gKt" = (
 /obj/structure/rack,
@@ -31962,16 +31858,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/armoury)
-"gSv" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NNW-B";
-	location = "NW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "gSy" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -32054,20 +31940,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/lobby)
-"gTo" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 9;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "gTw" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/grille,
@@ -32487,6 +32359,16 @@
 /obj/item/weapon/caution,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"gXt" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NEE-FC";
+	location = "S-SV"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "gXw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -32587,16 +32469,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/hos)
-"gYs" = (
-/obj/machinery/light/smart,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "gYu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -33381,13 +33253,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
-"hji" = (
-/obj/item/weapon/flora/random,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_right"
-	},
-/turf/simulated/floor,
-/area/station/storage/tech)
 "hjl" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -33431,16 +33296,6 @@
 	icon_state = "white"
 	},
 /area/station/rnd/hallway)
-"hjU" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
 "hjY" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -33557,17 +33412,6 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/break_room)
-"hkH" = (
-/obj/structure/stool/bed/chair/metal/black{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "hkQ" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/clipboard,
@@ -34228,13 +34072,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
-"hrw" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=CS-AR";
-	location = "SWW-FC"
-	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
 "hrO" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -34530,8 +34367,8 @@
 /area/station/maintenance/science)
 "hur" = (
 /obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
+	dir = 8;
+	icon_state = "warn"
 	},
 /obj/effect/decal/turf_decal{
 	dir = 4;
@@ -35383,6 +35220,18 @@
 	icon_state = "white"
 	},
 /area/station/medical/reception)
+"hBR" = (
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Labor Camp Shuttle Airlock";
+	req_access = list(2)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
 "hBT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -36035,6 +35884,19 @@
 /obj/item/target,
 /turf/simulated/floor/plating/airless,
 /area/station/rnd/test_area)
+"hIV" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/pump,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "arrival"
+	},
+/area/station/hallway/primary/port)
 "hJf" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
@@ -36611,15 +36473,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
-"hQm" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 5
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "hQo" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -36646,7 +36499,8 @@
 	},
 /obj/machinery/portable_atmospherics/powered/pump,
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
+	icon_state = "box_corners_white";
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -36962,6 +36816,15 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/chapel/office)
+"hVd" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "hVg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -38327,13 +38190,6 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/library)
-"ikk" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "ikm" = (
 /obj/machinery/computer/atmos_alert,
 /obj/machinery/light/small{
@@ -38621,6 +38477,24 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/mixing)
+"imA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "imK" = (
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -39476,17 +39350,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/brig/storage)
-"ixp" = (
-/obj/machinery/light/smart,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DS";
-	location = "DN-W"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "purplecorner"
-	},
-/area/station/hallway/primary/central)
 "ixC" = (
 /obj/item/target/syndicate,
 /turf/simulated/floor{
@@ -39675,6 +39538,17 @@
 	icon_state = "neutralfull"
 	},
 /area/station/gateway)
+"izh" = (
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "izp" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -39996,6 +39870,16 @@
 	icon_state = "vaultfull"
 	},
 /area/station/aisat/teleport)
+"iDl" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SWW-FC";
+	location = "SW-FC"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "iDo" = (
 /obj/structure/stool/bed/chair/office/light{
 	dir = 8
@@ -40070,7 +39954,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
+	icon_state = "siding_corner";
 	dir = 8
 	},
 /turf/simulated/floor,
@@ -40183,6 +40067,19 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/wood,
 /area/station/maintenance/medbay)
+"iFk" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "iFl" = (
 /turf/simulated/floor/engine/phoron,
 /area/station/engineering/atmos)
@@ -40578,21 +40475,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/rnd/test_area)
-"iIP" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/engineering/monitoring)
 "iIT" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -41586,19 +41468,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/chargebay)
-"iUC" = (
-/obj/machinery/light/smart{
-	dir = 4
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NE-FC";
-	location = "NEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "iUE" = (
 /obj/structure/table/woodentable,
 /obj/item/device/megaphone,
@@ -42695,6 +42564,19 @@
 	icon_state = "white"
 	},
 /area/station/rnd/robotics)
+"jgM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "jgS" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -42831,6 +42713,19 @@
 /obj/item/weapon/packageWrap,
 /turf/simulated/floor/plating,
 /area/station/storage/tools)
+"jiJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/flasher{
+	id = "Cell 3 perma";
+	pixel_y = -28
+	},
+/turf/simulated/floor,
+/area/station/security/prison)
 "jiS" = (
 /obj/machinery/light/smart{
 	dir = 8
@@ -44857,6 +44752,13 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/civilian/bar)
+"jFB" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-FC";
+	location = "SSW-FC"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/starboard)
 "jFP" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -46880,15 +46782,6 @@
 /obj/item/weapon/wrench,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"kak" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Central Access"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "kav" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
@@ -47008,19 +46901,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
-"kci" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "escape"
-	},
-/area/station/hallway/primary/port)
 "kcn" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/camera{
@@ -47282,6 +47162,21 @@
 	icon_state = "gcircuit"
 	},
 /area/station/rnd/xenobiology)
+"kff" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "kfj" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/computer/general_air_control/large_tank_control{
@@ -47499,23 +47394,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "kgH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
 	},
 /turf/simulated/floor{
-	icon_state = "neutralfull"
+	icon_state = "grimy"
 	},
-/area/station/hallway/primary/fore)
+/area/station/security/hos)
 "khm" = (
 /obj/machinery/power/apc{
 	name = "apc down";
@@ -47960,20 +47845,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/supermatter)
-"klw" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/powered/pump,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "arrival"
-	},
-/area/station/hallway/primary/port)
 "kly" = (
 /obj/structure/closet/crate,
 /obj/machinery/light/smart,
@@ -48857,6 +48728,18 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/library)
+"kww" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/engineering/atmos/atmos_office)
 "kwC" = (
 /obj/structure/morgue,
 /obj/effect/decal/turf_decal/alpha/gray{
@@ -48926,6 +48809,25 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/maintenance/cargo)
+"kxn" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/main)
 "kxp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
@@ -48956,19 +48858,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/civilian/toilet)
-"kxs" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "kxu" = (
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	dir = 4
@@ -49586,6 +49475,19 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
+"kEG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "kEH" = (
 /obj/machinery/life_assist/artificial_ventilation,
 /turf/simulated/floor/plating,
@@ -50605,6 +50507,19 @@
 	icon_state = "grimy"
 	},
 /area/station/security/hos)
+"kOc" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "kOe" = (
 /obj/structure/grille,
 /obj/structure/sign/warning/securearea{
@@ -51165,6 +51080,18 @@
 	icon_state = "redyellowfull"
 	},
 /area/station/maintenance/cargo)
+"kVe" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "kVf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -51223,6 +51150,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
+/area/station/security/prison)
+"kVQ" = (
+/obj/machinery/door_timer/cell_3{
+	pixel_x = 32;
+	pixel_y = 0;
+	dir = 4;
+	id = "Cell 3 perma"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "redcorner"
+	},
 /area/station/security/prison)
 "kVV" = (
 /obj/structure/cable{
@@ -52236,17 +52175,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/psych)
-"lix" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "liA" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -52428,6 +52356,17 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"lku" = (
+/obj/structure/stool/bed/chair/metal/black{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "lkv" = (
 /obj/structure/stool/bed/chair{
 	dir = 1
@@ -52652,6 +52591,19 @@
 	icon_state = "darkred"
 	},
 /area/station/security/execution)
+"lmy" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "lmF" = (
 /obj/machinery/computer/crew{
 	dir = 8
@@ -52824,6 +52776,27 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/monitoring)
+"lpA" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Antechamber";
+	req_one_access = list(66)
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/aisat/teleport)
 "lpN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -53271,6 +53244,13 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
+"lum" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=N-MB";
+	location = "NNW-B"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "luA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -54073,13 +54053,18 @@
 	},
 /area/station/cargo/miningoffice)
 "lEb" = (
-/obj/structure/table/reinforced,
-/obj/item/clothing/glasses/welding,
-/obj/machinery/door_control{
-	id = "scince_lab_shutters";
-	name = "Science Lab Shutters";
-	pixel_y = 26
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = 3
 	},
+/obj/item/weapon/stock_parts/console_screen,
+/obj/item/weapon/stock_parts/console_screen,
+/obj/item/weapon/stock_parts/micro_laser,
+/obj/item/weapon/stock_parts/micro_laser,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/item/weapon/stock_parts/manipulator,
+/obj/structure/table/reinforced,
 /turf/simulated/floor{
 	icon_state = "purplechecker"
 	},
@@ -54624,19 +54609,6 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/sleeper)
-"lKE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/flasher{
-	id = "Cell 3 perma";
-	pixel_y = -28
-	},
-/turf/simulated/floor,
-/area/station/security/prison)
 "lKG" = (
 /obj/machinery/hydroponics/constructable,
 /turf/simulated/floor/plating,
@@ -55028,6 +55000,21 @@
 /obj/item/stack/medical/bruise_pack,
 /turf/simulated/floor,
 /area/station/civilian/gym)
+"lNR" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/engineering/monitoring)
 "lNS" = (
 /obj/machinery/power/apc{
 	name = "apc down";
@@ -55348,6 +55335,16 @@
 	},
 /turf/simulated/floor,
 /area/station/medical/storage)
+"lRJ" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "lRS" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -55444,6 +55441,23 @@
 /obj/item/weapon/paper_bin,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/escape)
+"lTk" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "caution"
+	},
+/area/station/engineering/atmos/distribution)
 "lTn" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/weapon/reagent_containers/food/drinks/bottle/beer,
@@ -55637,25 +55651,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway)
-"lVN" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/main)
 "lVS" = (
 /obj/machinery/kitchen_machine/oven,
 /turf/simulated/floor{
@@ -55829,6 +55824,17 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
+"lXW" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos/atmos_office)
 "lXY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -56054,6 +56060,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/hallway/primary/central)
+"mbB" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_left"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/cold_room)
 "mbI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56230,15 +56245,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/armoury)
-"meu" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_left"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/civilian/cold_room)
 "mev" = (
 /obj/structure/displaycase_chassis,
 /obj/effect/decal/cleanable/dirt,
@@ -57328,16 +57334,6 @@
 	},
 /turf/simulated/floor,
 /area/station/gateway)
-"mqn" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSE-FC";
-	location = "SEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "mqw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -57421,14 +57417,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/break_room)
-"mri" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/security/prison)
 "mrj" = (
 /obj/machinery/atmospherics/components/trinary/tvalve/mirrored/digital/bypass{
 	dir = 8
@@ -59349,16 +59337,13 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/sleeper)
-"mOH" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-B";
-	location = "SSW-B"
+"mOx" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_right"
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
+/turf/simulated/floor,
+/area/station/storage/tech)
 "mOU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -59445,6 +59430,18 @@
 	},
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
+"mPY" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "mQa" = (
 /obj/structure/stool/bed/chair{
 	dir = 8
@@ -59877,6 +59874,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/qm)
+"mTD" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "mTN" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -60716,6 +60726,13 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/library)
+"ndp" = (
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/prison)
 "nds" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/machinery/light/small{
@@ -61957,22 +61974,6 @@
 	icon_state = "red"
 	},
 /area/station/security/brig/equipment)
-"nrP" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "nsa" = (
 /turf/simulated/wall/r_wall,
 /area/station/engineering/engine)
@@ -62110,16 +62111,6 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/hallway)
-"ntV" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SEE-FC";
-	location = "SE-FC"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "nub" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -62560,6 +62551,26 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway)
+"nyX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "nza" = (
 /obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor,
@@ -62795,14 +62806,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
-"nBM" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "nBQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -63323,6 +63326,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
+"nHt" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "nHx" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -63674,12 +63687,6 @@
 "nMg" = (
 /turf/simulated/wall,
 /area/station/medical/hallway)
-"nMh" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "browncorner"
-	},
-/area/station/cargo/storage)
 "nMn" = (
 /obj/random/vending/cola,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -64234,7 +64241,7 @@
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "box_corners_white";
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -65833,6 +65840,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
+"okz" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "browncorner"
+	},
+/area/station/cargo/storage)
 "okM" = (
 /turf/environment/space,
 /area/shuttle/syndicate/northeast)
@@ -65954,12 +65967,6 @@
 /obj/structure/window/thin,
 /turf/simulated/floor,
 /area/station/security/prison)
-"oms" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
-	},
-/turf/simulated/floor/carpet/red,
-/area/station/security/detectives_office)
 "omz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -66600,26 +66607,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
-"ovd" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "ovi" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -67590,19 +67577,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
-"oIo" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "oIK" = (
 /turf/simulated/wall/r_wall,
 /area/station/rnd/tox_launch)
@@ -68194,7 +68168,7 @@
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	dir = 4;
+	dir = 5;
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
@@ -68389,15 +68363,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/civilian/toilet)
-"oQP" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Security";
-	location = "S-C"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "oQQ" = (
 /obj/structure/sign/nanotrasen,
 /turf/simulated/wall/r_wall,
@@ -69959,17 +69924,6 @@
 	icon_state = "yellow"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
-"pko" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "yellow"
-	},
-/area/station/engineering/atmos)
 "pkt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -70087,6 +70041,18 @@
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/simulated/floor,
 /area/station/maintenance/cargo)
+"ple" = (
+/obj/structure/stool/bed/chair/metal/black{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "plf" = (
 /turf/environment/space,
 /area/space)
@@ -70625,6 +70591,16 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
+"prm" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-FC";
+	location = "DS"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
+/area/station/hallway/primary/central)
 "prx" = (
 /obj/machinery/door_control{
 	id = "east_science_hazard";
@@ -71398,16 +71374,6 @@
 	icon_state = "wooden"
 	},
 /area/station/bridge/corp_lounge)
-"pzl" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SWW-FC";
-	location = "SW-FC"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "pzr" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -72588,6 +72554,18 @@
 	icon_state = "neutralfull"
 	},
 /area/station/cargo/miningoffice)
+"pMZ" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "pNq" = (
 /obj/structure/sign/poster/official/ion_rifle{
 	pixel_x = 32
@@ -73021,6 +72999,22 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/xenobiology)
+"pQW" = (
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Entry Shuttle Airlock";
+	req_one_access = list(13)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "pRe" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/structure/disposalpipe/segment{
@@ -73122,26 +73116,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/maintenance/chapel)
-"pSR" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "pSS" = (
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the test chamber.";
@@ -73397,6 +73371,14 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/warden)
+"pWh" = (
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/break_room)
 "pWn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -74249,19 +74231,6 @@
 	icon_state = "gcircuit"
 	},
 /area/station/rnd/xenobiology)
-"qgf" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_corner"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "arrows_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "black"
-	},
-/area/station/hallway/secondary/entry)
 "qgs" = (
 /obj/effect/decal/turf_decal{
 	dir = 4;
@@ -74613,6 +74582,16 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"qjF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "qjH" = (
 /obj/machinery/light/smart{
 	dir = 1
@@ -75861,17 +75840,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/chargebay)
-"qzF" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos/atmos_office)
 "qzI" = (
 /obj/machinery/teleport/hub,
 /obj/machinery/alarm{
@@ -76442,6 +76410,16 @@
 	icon_state = "redyellowfull"
 	},
 /area/station/maintenance/cargo)
+"qGd" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "qGe" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
@@ -76472,16 +76450,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/cargo/recycler)
-"qGH" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "black"
-	},
-/area/station/hallway/secondary/entry)
 "qGO" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -77886,6 +77854,24 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
+"qXe" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/security/prison)
+"qXq" = (
+/obj/machinery/light/smart,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "qXu" = (
 /obj/machinery/portable_atmospherics/powered/pump,
 /obj/machinery/atmospherics/components/unary/portables_connector{
@@ -78013,15 +77999,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/ai_monitored/storage_secure)
-"qYG" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "qYH" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -78585,16 +78562,6 @@
 	icon_state = "red"
 	},
 /area/station/security/prison)
-"rgf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "rgg" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -79036,15 +79003,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
-"rlL" = (
-/obj/effect/decal/turf_decal{
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "rlM" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -79392,6 +79350,16 @@
 	},
 /turf/simulated/floor,
 /area/station/medical/cmo)
+"rqs" = (
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "rqx" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -80929,37 +80897,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/cargo/storage)
-"rGB" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SE-FC";
-	location = "SW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
-"rGW" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Antechamber";
-	req_one_access = list(66)
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/aisat/teleport)
 "rHa" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -81617,18 +81554,6 @@
 	icon_state = "purplecorner"
 	},
 /area/station/rnd/hor)
-"rMt" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "rMI" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -81954,6 +81879,19 @@
 	icon_state = "whitehall"
 	},
 /area/station/rnd/robotics)
+"rPW" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "rPX" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -82210,15 +82148,6 @@
 	},
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
-"rTs" = (
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
 "rTt" = (
 /obj/machinery/vending/tool,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -82311,6 +82240,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/maintenance/science)
+"rVa" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "rVd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -82655,26 +82593,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/scibreak)
-"rZd" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "rZe" = (
 /obj/structure/closet/secure_closet/iaa,
 /obj/machinery/camera{
@@ -83357,6 +83275,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories)
+"shz" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NNW-B";
+	location = "NW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "shE" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/weapon/shovel/spade,
@@ -84863,13 +84791,6 @@
 /obj/item/weapon/circuitboard/seed_extractor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
-"szm" = (
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/prison)
 "szq" = (
 /turf/simulated/floor{
 	icon_state = "darkbrown"
@@ -85813,18 +85734,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/bridge)
-"sKB" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "sKL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -86430,6 +86339,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/maintenance/incinerator)
+"sSA" = (
+/obj/structure/stool/bed/chair/metal/black{
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "sSE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -87639,16 +87560,6 @@
 	icon_state = "black"
 	},
 /area/station/hallway/primary/fore)
-"tie" = (
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "tif" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -87899,6 +87810,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"tlj" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "tlq" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -88404,6 +88324,20 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/primary/starboard)
+"tsL" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "escape"
+	},
+/area/station/hallway/primary/port)
 "tsT" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -89000,15 +88934,6 @@
 	icon_state = "dark"
 	},
 /area/station/medical/virology)
-"tzi" = (
-/obj/structure/closet/emcloset,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "tzm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light/small{
@@ -89322,6 +89247,15 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/atmos)
+"tCE" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "tCI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -89549,15 +89483,6 @@
 	icon_state = "neutral"
 	},
 /area/station/hallway/primary/central)
-"tES" = (
-/obj/item/weapon/flora/random,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "tEU" = (
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32;
@@ -90349,16 +90274,6 @@
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/engineering/atmos/distribution)
-"tPS" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-FC";
-	location = "DS"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "bluecorner"
-	},
-/area/station/hallway/primary/central)
 "tPT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -91201,13 +91116,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway/lobby)
-"uaw" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "uaL" = (
 /obj/structure/sign/poster/official/help_others{
 	pixel_x = 32
@@ -92919,7 +92827,6 @@
 	name = "Central Access"
 	},
 /turf/simulated/floor{
-	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/station/security/lobby)
@@ -93331,6 +93238,17 @@
 	icon_state = "darkblue"
 	},
 /area/station/bridge)
+"uzS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "uAq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -93880,13 +93798,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "uHN" = (
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-B";
+	location = "SSW-B"
 	},
 /turf/simulated/floor{
-	icon_state = "yellow"
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
-/area/station/engineering/break_room)
+/area/station/hallway/primary/central)
 "uHX" = (
 /turf/simulated/floor/wood,
 /area/station/maintenance/chapel)
@@ -93945,6 +93865,18 @@
 	icon_state = "caution"
 	},
 /area/station/storage/emergency)
+"uJO" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "uJP" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -94281,15 +94213,11 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "uNw" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
 	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkred"
-	},
-/area/station/security/brig)
+/turf/simulated/floor/carpet/red,
+/area/station/security/detectives_office)
 "uNx" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -94681,6 +94609,16 @@
 	icon_state = "purple"
 	},
 /area/station/medical/hallway)
+"uSL" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "uSN" = (
 /turf/simulated/floor{
 	icon_state = "redyellowfull"
@@ -95560,6 +95498,29 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/mixing)
+"vde" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 9;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
+"vdh" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Security";
+	location = "S-C"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "vdj" = (
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
@@ -95954,18 +95915,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"vih" = (
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Labor Camp Shuttle Airlock";
-	req_access = list(2)
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/brig)
 "vil" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -96077,6 +96026,16 @@
 	icon_state = "neutralfull"
 	},
 /area/station/cargo/storage)
+"vji" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/station/security/brig)
 "vjq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -96282,6 +96241,22 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
+"vlT" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "vme" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -96405,6 +96380,13 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"vnA" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "vnU" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1;
@@ -97702,16 +97684,6 @@
 /obj/structure/sign/warning/securearea,
 /turf/simulated/wall/r_wall,
 /area/station/rnd/hallway)
-"vDW" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NEE-FC";
-	location = "S-SV"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "vEp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -98413,6 +98385,16 @@
 	icon_state = "greencorner"
 	},
 /area/station/hallway/primary/fore)
+"vMb" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Central Access"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "vMc" = (
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32
@@ -98991,22 +98973,25 @@
 	},
 /area/station/bridge/teleporter)
 "vTX" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Entry Shuttle Airlock";
-	req_one_access = list(13)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /obj/effect/decal/turf_decal{
 	dir = 1;
-	icon_state = "warn"
+	icon_state = "warn_corner"
 	},
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
+/turf/simulated/floor{
+	icon_state = "redcorner"
 	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
+/area/station/security/prison)
 "vUe" = (
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
@@ -100275,18 +100260,6 @@
 	icon_state = "white"
 	},
 /area/station/medical/virology)
-"wjz" = (
-/obj/structure/stool/bed/chair/metal/black{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "wjA" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -101070,6 +101043,16 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/miningoffice)
+"wth" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSE-FC";
+	location = "SEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "wtl" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -103521,23 +103504,6 @@
 	icon_state = "white"
 	},
 /area/station/rnd/hallway)
-"wYv" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "caution"
-	},
-/area/station/engineering/atmos/distribution)
 "wYB" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor{
@@ -104092,18 +104058,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
-"xey" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "xeB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -104383,15 +104337,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig)
-"xhz" = (
-/obj/effect/decal/turf_decal/alpha/blue{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "xhL" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -104500,6 +104445,16 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/dormitories/service_bedrooms)
+"xji" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/hallway/secondary/entry)
 "xjp" = (
 /obj/structure/stool/bed/chair{
 	dir = 8
@@ -106354,6 +106309,15 @@
 /obj/structure/sign/nanotrasen,
 /turf/simulated/wall/r_wall,
 /area/station/bridge/teleporter)
+"xCK" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "xCL" = (
 /obj/structure/stool/bed/chair{
 	dir = 4
@@ -106416,6 +106380,27 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/mixing)
+"xDG" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "xDJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
@@ -106448,15 +106433,6 @@
 	},
 /turf/simulated/wall,
 /area/station/hallway/primary/starboard)
-"xEe" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "xEl" = (
 /obj/structure/table,
 /obj/item/device/camera/polar,
@@ -106984,6 +106960,20 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
+"xLb" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_corner";
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "arrows_white";
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/hallway/secondary/entry)
 "xLe" = (
 /obj/machinery/portable_atmospherics/powered/pump,
 /obj/machinery/light/smart{
@@ -108220,6 +108210,15 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/misc_lab)
+"xYt" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DN";
+	location = "SSE-FC"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "xYy" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 8
@@ -108381,16 +108380,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
-"yaF" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "yaN" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -118640,7 +118629,7 @@ eXX
 pGn
 fBB
 pGn
-rGW
+lpA
 pGn
 pGn
 oer
@@ -131995,7 +131984,7 @@ xFF
 xFG
 flb
 uDn
-uHN
+pWh
 ude
 ehA
 geB
@@ -132252,7 +132241,7 @@ qnQ
 hEd
 fDg
 owf
-uHN
+pWh
 hkb
 ehA
 fUz
@@ -132490,7 +132479,7 @@ bOJ
 oKV
 dup
 dup
-nRV
+mTD
 bOD
 cmG
 xqQ
@@ -132755,7 +132744,7 @@ oLJ
 kFc
 kFc
 cEO
-pko
+bRn
 azQ
 pfp
 imT
@@ -133001,7 +132990,7 @@ qSk
 qdn
 naA
 kdJ
-kxs
+nRV
 xqQ
 fmh
 mNB
@@ -133009,8 +132998,8 @@ bfy
 cmG
 dup
 htY
-caB
-caB
+qGd
+qGd
 nwM
 tCz
 gRR
@@ -133265,7 +133254,7 @@ nLs
 bTE
 tUm
 oPF
-bZo
+rPW
 rSb
 umn
 svw
@@ -134029,17 +134018,17 @@ bsZ
 fZH
 cTK
 whA
-ekC
 iDO
-iDO
-iDO
+kww
+kww
+kww
 xnu
 vCV
 lFG
 waB
 fMO
-fTu
-sKB
+kVe
+cvM
 kHT
 vPk
 vPk
@@ -134286,9 +134275,9 @@ pBb
 hrT
 qcT
 mrP
-qzF
-qzF
 daq
+daq
+lXW
 egG
 iEf
 hrT
@@ -134830,9 +134819,9 @@ hdV
 bhn
 evV
 oKM
-rMt
+bBp
 wCx
-ejv
+pMZ
 oDZ
 bau
 nkc
@@ -135089,7 +135078,7 @@ enq
 bgZ
 gCp
 tRh
-nrP
+vlT
 oyx
 mRP
 eZT
@@ -135843,7 +135832,7 @@ adw
 adw
 adw
 wjD
-iIP
+lNR
 cgv
 owM
 ekM
@@ -136346,7 +136335,7 @@ jlK
 tEF
 tne
 cEZ
-wYv
+lTk
 iGS
 ciX
 jau
@@ -137128,13 +137117,13 @@ tEF
 sHQ
 dpc
 sHQ
+tsL
 blv
-kci
 sqb
 uck
 sqb
-klw
 hQQ
+hIV
 qTx
 bUU
 iky
@@ -137400,7 +137389,7 @@ doE
 doE
 doE
 lgU
-ntV
+aXu
 mhm
 doE
 mnD
@@ -137898,7 +137887,7 @@ wwi
 aYN
 wwi
 lfm
-mqn
+wth
 tZn
 oyb
 nAM
@@ -137916,7 +137905,7 @@ oyb
 bzt
 bzt
 rcq
-ghp
+xYt
 tYK
 wtC
 wtC
@@ -139446,7 +139435,7 @@ xNR
 oYv
 cGN
 vzT
-hji
+mOx
 oVN
 cdA
 jTf
@@ -139946,7 +139935,7 @@ aSY
 uum
 lVS
 srt
-meu
+mbB
 uos
 gTB
 kst
@@ -140663,14 +140652,14 @@ yaE
 ffS
 aev
 yaE
-vTX
+apc
 yaE
 aqg
 aqg
 aqg
 mlH
 yaE
-vTX
+apc
 yaE
 eeB
 ffS
@@ -140717,7 +140706,7 @@ kBq
 biv
 pED
 bNa
-hjU
+uSL
 kIU
 lBN
 yeY
@@ -140974,7 +140963,7 @@ dtM
 fty
 abG
 vLv
-hjU
+uSL
 kIU
 jVV
 ekm
@@ -141691,7 +141680,7 @@ yaE
 ffS
 eeB
 yaE
-vTX
+apc
 yaE
 mlH
 nhe
@@ -142742,11 +142731,11 @@ dbB
 idn
 fRR
 ofi
-tES
+xCK
 miI
 ffS
 jjY
-tzi
+bhs
 wwi
 pkS
 wwi
@@ -143295,7 +143284,7 @@ iSv
 xXt
 vAu
 ogP
-mOH
+uHN
 bAS
 nvi
 rnH
@@ -143311,7 +143300,7 @@ qbj
 qbj
 tmk
 ldb
-rGB
+ejv
 ogP
 iSi
 amv
@@ -143338,7 +143327,7 @@ vpT
 xei
 bFh
 vpT
-ixp
+ftt
 vIl
 olx
 frM
@@ -143506,7 +143495,7 @@ plf
 brw
 mko
 jsL
-ggd
+eOm
 ffX
 hbE
 sTt
@@ -143775,7 +143764,7 @@ gHT
 alc
 vDr
 fDL
-gSv
+shz
 iwy
 xXt
 gNR
@@ -144281,10 +144270,10 @@ fYS
 slo
 ffS
 pLB
-tES
+xCK
 dDs
 acf
-ecQ
+sSA
 aSq
 ffS
 gvF
@@ -144556,17 +144545,17 @@ hXb
 hXb
 hXb
 che
-rTs
-kgH
-rTs
-rTs
-rTs
-rTs
-rTs
-rTs
-rTs
-cTx
-rTs
+fOp
+imA
+fOp
+fOp
+fOp
+fOp
+fOp
+fOp
+fOp
+kff
+fOp
 vos
 did
 did
@@ -144775,7 +144764,7 @@ kHU
 kHU
 kHU
 yaE
-eUa
+pQW
 yaE
 kHU
 plf
@@ -145060,7 +145049,7 @@ kHU
 yaE
 hkD
 fYS
-rlL
+cpB
 wts
 mge
 qed
@@ -145574,7 +145563,7 @@ plf
 yaE
 vDr
 fYS
-tie
+rqs
 tEo
 nIB
 iEL
@@ -145831,7 +145820,7 @@ kHU
 yaE
 csG
 fYS
-gYs
+qXq
 wts
 npC
 txi
@@ -145854,13 +145843,13 @@ cCx
 mES
 tJq
 ikZ
-cvJ
+kEG
 oki
-ikk
-ikk
-dOg
+vnA
+vnA
+iFk
 tWH
-dOg
+iFk
 qcF
 bRX
 qSi
@@ -146111,7 +146100,7 @@ tJq
 ucP
 tJq
 fSC
-cdw
+jgM
 ktM
 uuo
 djH
@@ -146594,10 +146583,10 @@ fYS
 jNI
 ffS
 ylK
-wjz
+ple
 cmX
 fRR
-hkH
+lku
 ryG
 ffS
 uAC
@@ -146831,14 +146820,14 @@ xjr
 xjr
 kHU
 dhU
-eUa
+pQW
 yaE
 kHU
 plf
 plf
 kHU
 yaE
-eUa
+pQW
 yaE
 plf
 plf
@@ -147619,7 +147608,7 @@ yaE
 yaE
 csG
 fYS
-diN
+bJm
 alc
 gHT
 gHT
@@ -147628,7 +147617,7 @@ gHT
 gHT
 gHT
 alc
-gKs
+lum
 fYS
 sEX
 srs
@@ -147878,12 +147867,12 @@ lrr
 fYS
 wtr
 sDu
-qgf
-qGH
-qGH
-qGH
-qGH
-fYP
+cWX
+xji
+xji
+xji
+xji
+xLb
 xao
 csG
 fYS
@@ -148887,14 +148876,14 @@ xjr
 xjr
 kHU
 dhU
-eUa
+pQW
 yaE
 kHU
 plf
 plf
 kHU
 yaE
-eUa
+pQW
 yaE
 plf
 plf
@@ -149144,14 +149133,14 @@ xjr
 xjr
 plf
 yaE
-ctv
+izh
 yaE
 yaE
 yaE
 yaE
 yaE
 yaE
-ctv
+izh
 yaE
 plf
 plf
@@ -152563,7 +152552,7 @@ mXl
 mXl
 mXl
 wLD
-vDW
+gXt
 iwm
 mXl
 pRS
@@ -152581,7 +152570,7 @@ oNU
 mXl
 uxx
 xMc
-pzl
+iDl
 nvi
 rnH
 cLM
@@ -152590,7 +152579,7 @@ nvi
 tOH
 mfI
 ogP
-tPS
+prm
 sBG
 wjc
 wjc
@@ -152893,7 +152882,7 @@ xQo
 xQo
 xQo
 nKU
-fOp
+jFB
 xQo
 oPI
 mRu
@@ -153060,7 +153049,7 @@ cpR
 gtK
 cpR
 pxL
-iUC
+dED
 ffJ
 ape
 fZz
@@ -153079,7 +153068,7 @@ hRd
 ckx
 fZz
 lMB
-oQP
+vdh
 kzb
 vAu
 psV
@@ -153093,7 +153082,7 @@ vAu
 kRo
 vAu
 kCI
-fuL
+clM
 ogP
 lwr
 mLS
@@ -153334,9 +153323,9 @@ erD
 erD
 cmN
 act
-uuf
+vMb
 xsY
-kak
+uuf
 jTW
 jTW
 jTW
@@ -153816,7 +153805,7 @@ fnT
 miA
 ojm
 lPc
-nMh
+okz
 gaF
 rpV
 qSe
@@ -154073,11 +154062,11 @@ nkb
 adb
 hzP
 cpR
-eEH
 oOk
+nHt
 uXI
-oOk
-yaF
+nHt
+lRJ
 xqF
 aAF
 iqI
@@ -157184,8 +157173,8 @@ plf
 xyC
 cFp
 klH
-oms
-oms
+uNw
+uNw
 hGr
 aRu
 xyC
@@ -157688,11 +157677,11 @@ plf
 plf
 plf
 uRO
-vih
+hBR
 uRO
 plf
 uRO
-vih
+hBR
 uRO
 plf
 xyC
@@ -157709,8 +157698,8 @@ dnn
 aEr
 wPw
 jQy
-xhz
-beh
+hVd
+fNh
 jcX
 fJg
 nPU
@@ -158217,7 +158206,7 @@ xyC
 xyC
 xyC
 xyC
-uaw
+cPJ
 jtG
 wpm
 fJg
@@ -158463,7 +158452,7 @@ opt
 kms
 cHH
 eow
-gTo
+vde
 goK
 hYT
 nsn
@@ -158716,7 +158705,7 @@ leA
 cHH
 adG
 iGB
-uNw
+vji
 tTk
 qMX
 aZz
@@ -158977,7 +158966,7 @@ ikW
 qXE
 rjb
 utF
-gdh
+gEQ
 uLd
 lat
 nsn
@@ -159776,7 +159765,7 @@ kIM
 vst
 mDV
 vKG
-hrw
+bQA
 xoq
 tAM
 uQA
@@ -160495,14 +160484,14 @@ fAF
 fgx
 diq
 fAF
-eWA
+kVQ
 eTq
 fAF
 wNM
 oPD
 tif
 rHZ
-ovd
+aDK
 czU
 tqK
 hsq
@@ -160759,7 +160748,7 @@ qZx
 qZx
 fXG
 qZx
-pSR
+vTX
 czU
 uvV
 kMw
@@ -161265,7 +161254,7 @@ blh
 cra
 hlv
 dVr
-lKE
+jiJ
 hlv
 fBm
 bvC
@@ -162289,7 +162278,7 @@ aXC
 bZu
 pLw
 unD
-mri
+qXe
 oAx
 ulK
 eyO
@@ -162841,9 +162830,9 @@ ilq
 uKd
 sxG
 uOc
-oIo
-oIo
 hur
+hur
+kOc
 ekd
 lZw
 gqC
@@ -163097,7 +163086,7 @@ ixl
 mme
 uKd
 gRX
-brr
+uJO
 sRa
 nUj
 wUB
@@ -163126,13 +163115,13 @@ ncp
 ncp
 hbR
 mWz
-xey
+mPY
 kLd
 syX
 tHk
 tHk
 dbf
-bFL
+xDG
 ram
 mWz
 lNQ
@@ -163389,7 +163378,7 @@ eFl
 aRb
 nDG
 jjN
-aeA
+lmy
 ram
 mWz
 ucd
@@ -163596,7 +163585,7 @@ afw
 nDf
 mZo
 qUR
-lVN
+kxn
 mzV
 aSh
 mpR
@@ -163897,13 +163886,13 @@ ncp
 ncp
 hbR
 mWz
-lix
+dOQ
 sIY
 qls
 uOM
 uOM
 aeG
-fmg
+bFL
 ram
 mWz
 hPr
@@ -164093,7 +164082,7 @@ lhK
 wVg
 aFN
 jKZ
-ckp
+cMP
 rBo
 hlv
 qxh
@@ -164357,7 +164346,7 @@ xIO
 jps
 xIO
 qZx
-rZd
+nyX
 tbS
 sZR
 kHU
@@ -164369,7 +164358,7 @@ fwH
 qoH
 vOW
 qoH
-nBM
+kgH
 umQ
 gYp
 kHU
@@ -164607,7 +164596,7 @@ jvm
 hlv
 fVW
 fPH
-ckp
+cMP
 rnI
 hlv
 pHz
@@ -164622,11 +164611,11 @@ kHU
 plf
 cYc
 ueE
-rgf
+qjF
 wcJ
 iRz
 nez
-eae
+uzS
 hlh
 gYp
 plf
@@ -164879,11 +164868,11 @@ kHU
 kHU
 cYc
 nfj
-ekf
+rVa
 eaE
 nRk
 rZh
-qYG
+tlj
 hmN
 gYp
 kHU
@@ -164927,7 +164916,7 @@ dJL
 nRG
 oXA
 oXA
-ccR
+cIf
 dJL
 plf
 cdR
@@ -165136,11 +165125,11 @@ plf
 kHU
 huz
 sIx
-hQm
-xEe
+bOv
+gzK
 kjv
-xEe
-bih
+gzK
+tCE
 tEU
 huz
 plf
@@ -167185,7 +167174,7 @@ plf
 kHU
 hlv
 lrm
-szm
+ndp
 jno
 hlv
 cBu
@@ -168265,7 +168254,7 @@ kHU
 fMh
 plf
 dJL
-ccR
+cIf
 oXA
 oXA
 nJn

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -88,6 +88,11 @@
 	icon_state = "neutral"
 	},
 /area/station/hallway/secondary/entry)
+"aaG" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet6-2"
+	},
+/area/station/bridge)
 "aaP" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor{
@@ -2074,15 +2079,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway)
-"apz" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "purplefull"
-	},
-/area/station/hallway/primary/central)
 "apA" = (
 /obj/effect/landmark{
 	name = "blobstart"
@@ -3733,6 +3729,19 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
+"aJb" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/station/tcommsat/chamber)
 "aJe" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -4028,8 +4037,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/effect/decal/turf_decal/alpha{
+	icon_state = "siding_line";
+	dir = 5
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/medical/genetics)
 "aMR" = (
@@ -7516,6 +7529,13 @@
 /area/station/cargo/storage)
 "bAN" = (
 /obj/machinery/computer/scan_consolenew,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_right"
+	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "darkblue"
@@ -7943,18 +7963,6 @@
 	icon_state = "purplecorner"
 	},
 /area/station/hallway/primary/central)
-"bFk" = (
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line"
-	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "bFm" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/ai_status_display{
@@ -11936,6 +11944,10 @@
 	},
 /area/station/engineering/minisat_secure_area)
 "czd" = (
+/obj/effect/decal/turf_decal{
+	dir = 6;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "caution"
@@ -12670,16 +12682,6 @@
 	},
 /turf/simulated/floor,
 /area/station/gateway)
-"cHi" = (
-/obj/item/weapon/flora/random,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "purplefull"
-	},
-/area/station/hallway/primary/central)
 "cHl" = (
 /obj/machinery/door/airlock/glass{
 	autoclose = 0;
@@ -13376,7 +13378,7 @@
 /area/station/hallway/primary/fore)
 "cPN" = (
 /turf/simulated/floor/carpet{
-	icon_state = "carpet6-2"
+	icon_state = "carpet9-4"
 	},
 /area/station/bridge/captain_quarters)
 "cPY" = (
@@ -13924,6 +13926,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "darkblue"
@@ -14442,7 +14447,7 @@
 /area/station/engineering/atmos)
 "dfg" = (
 /turf/simulated/floor/carpet{
-	icon_state = "carpet6-2"
+	icon_state = "carpet10-8"
 	},
 /area/station/bridge)
 "dfo" = (
@@ -15522,6 +15527,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkblue"
@@ -16227,6 +16236,10 @@
 	dir = 1;
 	name = "Chemistry APC";
 	pixel_y = 28
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "siding_line";
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 9;
@@ -16997,7 +17010,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/medical/genetics)
 "dKa" = (
@@ -18949,11 +18962,6 @@
 	icon_state = "dark"
 	},
 /area/station/aisat/ai_chamber)
-"eiZ" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet9-4"
-	},
-/area/station/bridge/captain_quarters)
 "ejc" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -19523,6 +19531,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
+"epm" = (
+/obj/effect/decal/turf_decal{
+	dir = 6;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/robotics)
 "epp" = (
 /obj/machinery/light/smart{
 	dir = 4
@@ -21508,6 +21525,9 @@
 /area/station/medical/surgeryobs)
 "eOj" = (
 /obj/machinery/chem_dispenser,
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "caution"
@@ -24822,6 +24842,13 @@
 	dir = 1;
 	pixel_y = 6
 	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "darkblue"
@@ -25655,8 +25682,12 @@
 	},
 /area/station/medical/storage)
 "fMG" = (
+/obj/effect/decal/turf_decal/alpha{
+	icon_state = "siding_line";
+	dir = 8
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/medical/genetics)
 "fMO" = (
@@ -28184,19 +28215,6 @@
 "gqV" = (
 /turf/simulated/wall/r_wall,
 /area/station/rnd/scibreak)
-"gqX" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/bluegrid{
-	name = "Server Base";
-	nitrogen = 500;
-	oxygen = 0;
-	temperature = 80
-	},
-/area/station/tcommsat/chamber)
 "grm" = (
 /obj/machinery/power/solar_control{
 	dir = 8;
@@ -28807,6 +28825,16 @@
 	icon_state = "yellowpatch"
 	},
 /area/station/engineering/atmos/supermatter)
+"gxp" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "purplefull"
+	},
+/area/station/hallway/primary/central)
 "gxv" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -29872,6 +29900,9 @@
 /area/station/hallway/secondary/entry)
 "gLa" = (
 /obj/machinery/dna_scannernew,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_right"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkblue"
@@ -30873,15 +30904,6 @@
 	},
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
-"gWy" = (
-/obj/effect/decal/turf_decal{
-	dir = 6;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/rnd/robotics)
 "gWA" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -31725,6 +31747,9 @@
 	},
 /obj/machinery/computer/scan_consolenew{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_left"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -32988,6 +33013,9 @@
 /obj/machinery/computer/scan_consolenew{
 	dir = 8
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_right"
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "darkblue"
@@ -33372,8 +33400,12 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/effect/decal/turf_decal/alpha{
+	icon_state = "siding_line";
+	dir = 9
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/medical/genetics)
 "hzG" = (
@@ -37907,6 +37939,9 @@
 /area/station/rnd/hallway/lobby)
 "iAI" = (
 /obj/machinery/dna_scannernew,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_left"
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "darkblue"
@@ -39158,18 +39193,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
-"iPA" = (
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner"
-	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "iPB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -39357,8 +39380,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha{
+	icon_state = "siding_line";
+	dir = 4
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/medical/genetics)
 "iRo" = (
@@ -40268,19 +40295,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
-"jcB" = (
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "jcC" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -43848,6 +43862,9 @@
 "jQh" = (
 /obj/structure/closet/secure_closet/medical1,
 /obj/item/weapon/storage/pill_bottle/dylovene,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkbluecorners"
@@ -44050,8 +44067,12 @@
 /obj/structure/stool/bed/chair/office/light{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha{
+	icon_state = "siding_line";
+	dir = 4
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/medical/genetics)
 "jTm" = (
@@ -44484,6 +44505,10 @@
 	},
 /area/station/security/lobby)
 "jXH" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "caution"
@@ -46261,6 +46286,15 @@
 	icon_state = "neutral"
 	},
 /area/station/hallway/primary/fore)
+"krH" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "krJ" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -46952,6 +46986,18 @@
 	icon_state = "showroomfloor"
 	},
 /area/station/civilian/cold_room)
+"kAR" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line"
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "kAU" = (
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
@@ -48005,8 +48051,12 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/effect/decal/turf_decal/alpha{
+	icon_state = "siding_line";
+	dir = 4
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/medical/genetics)
 "kLE" = (
@@ -51936,6 +51986,10 @@
 /area/station/engineering/engine)
 "lId" = (
 /obj/machinery/chem_master,
+/obj/effect/decal/turf_decal{
+	dir = 10;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "caution"
@@ -55097,8 +55151,11 @@
 /area/station/maintenance/chapel)
 "mue" = (
 /obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line";
-	dir = 8
+	icon_state = "siding_wood_corner"
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner";
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "wooden"
@@ -55557,6 +55614,10 @@
 "mAf" = (
 /obj/structure/stool/bed/chair/office/light{
 	dir = 1
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -56513,6 +56574,9 @@
 /area/station/ai_monitored/eva)
 "mNx" = (
 /obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "bluefull"
 	},
@@ -60813,6 +60877,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "siding_line";
+	dir = 10
+	},
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "neutral"
@@ -62362,6 +62430,9 @@
 /turf/simulated/floor/wood,
 /area/station/maintenance/medbay)
 "oen" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "siding_line"
+	},
 /turf/simulated/floor{
 	icon_state = "neutral"
 	},
@@ -66347,6 +66418,19 @@
 /obj/effect/decal/cleanable/vomit,
 /turf/simulated/floor,
 /area/station/maintenance/medbay)
+"pfz" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "pfA" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Delivery Office";
@@ -72301,8 +72385,12 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/effect/decal/turf_decal/alpha{
+	icon_state = "siding_line";
+	dir = 1
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/medical/genetics)
 "qyc" = (
@@ -73079,6 +73167,14 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/effect/decal/turf_decal{
+	dir = 5;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "caution"
@@ -73359,6 +73455,25 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"qLs" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "qLu" = (
 /obj/structure/window/thin/reinforced{
 	dir = 4
@@ -74697,6 +74812,14 @@
 "rbY" = (
 /turf/simulated/floor,
 /area/station/security/main)
+"rcg" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "purplefull"
+	},
+/area/station/hallway/primary/central)
 "rcq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -78258,6 +78381,16 @@
 	icon_state = "dark"
 	},
 /area/station/cargo/recycleroffice)
+"rRm" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/station/bridge/corp_lounge)
 "rRo" = (
 /obj/machinery/recharger,
 /obj/structure/table/woodentable,
@@ -80059,11 +80192,6 @@
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
-	},
-/area/station/bridge)
-"smZ" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet10-8"
 	},
 /area/station/bridge)
 "snp" = (
@@ -82258,16 +82386,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/brig)
-"sPP" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkblue"
-	},
-/area/station/bridge/corp_lounge)
 "sPU" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/rglass{
@@ -83105,8 +83223,12 @@
 /area/station/civilian/locker)
 "taF" = (
 /obj/effect/landmark/start/geneticist,
+/obj/effect/decal/turf_decal/alpha{
+	icon_state = "siding_line";
+	dir = 8
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/medical/genetics)
 "taG" = (
@@ -84928,14 +85050,6 @@
 	icon_state = "dark"
 	},
 /area/station/medical/virology)
-"tzk" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/primary/central)
 "tzm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light/small{
@@ -86935,6 +87049,9 @@
 /area/station/civilian/dormitories)
 "tZe" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "siding_line"
+	},
 /turf/simulated/floor{
 	icon_state = "neutral"
 	},
@@ -87146,6 +87263,9 @@
 /obj/item/weapon/storage/pill_bottle/inaprovaline,
 /obj/item/device/cardpay{
 	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "siding_line"
 	},
 /turf/simulated/floor{
 	dir = 6;
@@ -88532,6 +88652,16 @@
 	icon_state = "neutralfull"
 	},
 /area/station/cargo/qm)
+"usC" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/bluegrid{
+	icon_state = "gcircuit"
+	},
+/area/station/tcommsat/chamber)
 "usJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -89813,6 +89943,11 @@
 	icon_state = "neutral"
 	},
 /area/station/engineering/chiefs_office)
+"uLl" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet6-2"
+	},
+/area/station/bridge/captain_quarters)
 "uLo" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -91261,6 +91396,9 @@
 	},
 /area/station/rnd/mixing)
 "vdj" = (
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	icon_state = "caution"
 	},
@@ -93303,6 +93441,9 @@
 /area/station/rnd/lab)
 "vDf" = (
 /obj/machinery/dna_scannernew,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_left"
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "darkblue"
@@ -93834,8 +93975,11 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/effect/decal/turf_decal/alpha{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/medical/genetics)
 "vKa" = (
@@ -94592,7 +94736,7 @@
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	icon_state = "purplefull"
+	icon_state = "vaultfull"
 	},
 /area/station/hallway/primary/central)
 "vUn" = (
@@ -95222,6 +95366,10 @@
 "wbC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 9;
+	icon_state = "warn"
 	},
 /turf/simulated/floor{
 	dir = 9;
@@ -100491,16 +100639,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/miningoffice)
-"xqL" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "gcircuit"
-	},
-/area/station/tcommsat/chamber)
 "xqN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -100772,6 +100910,10 @@
 /area/station/security/prison)
 "xsW" = (
 /obj/machinery/chem_dispenser,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "caution"
@@ -101873,8 +102015,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/effect/decal/turf_decal/alpha{
+	icon_state = "siding_line";
+	dir = 8
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/medical/genetics)
 "xFi" = (
@@ -102179,6 +102325,20 @@
 /obj/structure/stool/bed/chair,
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
+"xJQ" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "caution"
+	},
+/area/station/medical/chemistry)
 "xJS" = (
 /turf/simulated/floor{
 	dir = 10;
@@ -103158,25 +103318,6 @@
 	icon_state = "carpet14-10"
 	},
 /area/station/bridge)
-"xVl" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "xVm" = (
 /obj/machinery/alarm{
 	pixel_y = -32
@@ -103284,6 +103425,15 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/library)
+"xWe" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "purplefull"
+	},
+/area/station/hallway/primary/central)
 "xWl" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -136539,7 +136689,7 @@ bNg
 cLW
 rjR
 qgs
-gWy
+epm
 cVA
 wrb
 chV
@@ -138328,13 +138478,13 @@ pHa
 pHa
 pbn
 yhw
-apz
-apz
+xWe
+xWe
 qQu
-apz
-cHi
+xWe
+gxp
 bwA
-vUh
+rcg
 eKK
 oZa
 oZa
@@ -139611,7 +139761,7 @@ fFk
 hWY
 hWY
 giW
-tzk
+vUh
 mby
 oXw
 rdN
@@ -142179,7 +142329,7 @@ pQD
 gIC
 gIC
 gIC
-gqX
+aJb
 gIC
 gIC
 keH
@@ -142953,7 +143103,7 @@ xMO
 raJ
 cCX
 vyg
-xqL
+usC
 lwt
 raJ
 eXe
@@ -142964,7 +143114,7 @@ siM
 mKJ
 mMA
 bLg
-iPA
+mue
 lGH
 cje
 nHg
@@ -143196,7 +143346,7 @@ gCE
 imK
 lEC
 wnY
-dfg
+aaG
 akc
 lZx
 gWd
@@ -143221,7 +143371,7 @@ jEs
 mKJ
 mMA
 vEH
-bFk
+kAR
 rOO
 mzL
 nHg
@@ -143710,7 +143860,7 @@ gCE
 imK
 lEC
 mrs
-smZ
+dfg
 nSo
 lZx
 oay
@@ -143735,7 +143885,7 @@ wMM
 fgA
 mMA
 joF
-bFk
+kAR
 eZe
 wAA
 nHg
@@ -143980,7 +144130,7 @@ knC
 aty
 wEV
 fAH
-xqL
+usC
 aEE
 lwt
 wEV
@@ -143991,10 +144141,10 @@ pQD
 amY
 fgA
 mMA
-mue
-jcB
+krH
+pfz
 lBF
-xVl
+qLs
 nHg
 nvi
 ogP
@@ -144263,7 +144413,7 @@ sew
 rHU
 rHU
 sew
-qIs
+xJQ
 cyz
 eOj
 sew
@@ -144507,7 +144657,7 @@ xVa
 mMA
 eIB
 pYl
-sPP
+rRm
 jVM
 mMA
 elI
@@ -144749,9 +144899,9 @@ pQD
 gIC
 gIC
 gIC
-gqX
+aJb
 gIC
-gqX
+aJb
 gIC
 gIC
 aty
@@ -146031,7 +146181,7 @@ ibm
 adM
 sTY
 bIZ
-eiZ
+cPN
 iaL
 cHR
 jKD
@@ -147063,7 +147213,7 @@ cjq
 nac
 hrj
 pEa
-cPN
+uLl
 cqG
 iaL
 pst

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -1646,7 +1646,10 @@
 	dir = 1;
 	icon_state = "warn_corner"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/primary/central)
 "alB" = (
 /turf/simulated/floor{
@@ -5353,7 +5356,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/primary/central)
 "bcE" = (
 /obj/structure/cable{
@@ -13262,7 +13267,10 @@
 	dir = 4;
 	icon_state = "warn_corner"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/primary/central)
 "cME" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -19193,7 +19201,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/primary/central)
 "eiz" = (
 /obj/random/scrap/safe_even,
@@ -35461,7 +35471,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/primary/central)
 "hQk" = (
 /obj/structure/cable{
@@ -54935,7 +54947,10 @@
 	dir = 1;
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/primary/central)
 "mgQ" = (
 /obj/structure/disposalpipe/segment,
@@ -65178,6 +65193,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "oBr" = (
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "yellowcorner"
@@ -89781,7 +89797,12 @@
 	id = "vac_offic";
 	name = "Vacant Office"
 	},
-/turf/simulated/floor,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/hallway/primary/central)
 "ulW" = (
 /obj/structure/cable{

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -4645,6 +4645,18 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/locker)
+"aUc" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "aUg" = (
 /turf/simulated/floor{
 	icon_state = "browncorner"
@@ -4951,6 +4963,9 @@
 	},
 /obj/structure/window/thin{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -6748,6 +6763,9 @@
 /obj/machinery/requests_console/forensic{
 	pixel_y = 30
 	},
+/obj/effect/decal/turf_decal/alpha/red{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -8134,6 +8152,13 @@
 "bFL" = (
 /obj/structure/stool/bed/chair/metal/white{
 	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
 	},
 /obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "siding_line";
@@ -13601,6 +13626,12 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
+"cPK" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
+	},
+/turf/simulated/floor/carpet/red,
+/area/station/security/detectives_office)
 "cPN" = (
 /obj/structure/table/woodentable/fancy,
 /obj/effect/decal/turf_decal/metal{
@@ -25182,7 +25213,11 @@
 	pixel_y = -32
 	},
 /obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot_right"
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "box_corners_white";
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -25311,6 +25346,9 @@
 /area/station/medical/genetics)
 "fCi" = (
 /obj/structure/filingcabinet/security,
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -27766,26 +27804,6 @@
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/auxport)
-"ghK" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "ghN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/effect/decal/turf_decal{
@@ -30970,14 +30988,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
-"gRf" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/civilian/gym)
 "gRg" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -31204,17 +31214,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/lobby)
-"gTv" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "gTw" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/grille,
@@ -42667,7 +42666,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/security/lobby)
 "jtS" = (
 /obj/structure/closet{
@@ -44496,6 +44497,27 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/locker)
+"jNf" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "jNg" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -46773,6 +46795,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
+	},
 /turf/simulated/floor/carpet/red,
 /area/station/security/detectives_office)
 "klO" = (
@@ -47398,6 +47423,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/bridge/meeting_room)
+"ksF" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "ksG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -53830,6 +53868,17 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"lPv" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "lPy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -54230,6 +54279,15 @@
 	icon_state = "yellow"
 	},
 /area/station/storage/emergency)
+"lUV" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Central Access"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "lUY" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -57151,6 +57209,9 @@
 "mDl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -57559,6 +57620,14 @@
 	icon_state = "neutralfull"
 	},
 /area/station/storage/tech)
+"mJA" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/civilian/gym)
 "mJM" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 10
@@ -73389,6 +73458,9 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -76642,6 +76714,9 @@
 /obj/structure/window/thin{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -79675,6 +79750,12 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -82213,6 +82294,12 @@
 /area/station/civilian/kitchen)
 "srx" = (
 /obj/machinery/photocopier,
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -84266,6 +84353,9 @@
 	},
 /obj/structure/window/thin{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -86915,6 +87005,9 @@
 "tzR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
+	},
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	icon_state = "grimy"
@@ -90364,18 +90457,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
-"upw" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "upB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -90734,7 +90815,10 @@
 /obj/machinery/door/airlock/glass{
 	name = "Central Access"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
 /area/station/security/lobby)
 "uui" = (
 /obj/machinery/atmospherics/components/unary/portables_connector,
@@ -102554,27 +102638,6 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
-"xoG" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "xoM" = (
 /mob/living/simple_animal/chicken{
 	name = "Commander Clucky"
@@ -102608,6 +102671,9 @@
 /area/station/cargo/storage)
 "xoX" = (
 /obj/machinery/vending/noiromat,
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -102963,9 +103029,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "xss" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -150875,7 +150938,7 @@ cmN
 act
 uuf
 xsY
-uuf
+lUV
 jTW
 jTW
 jTW
@@ -154723,8 +154786,8 @@ plf
 xyC
 cFp
 klH
-wbf
-wbf
+cPK
+cPK
 hGr
 aRu
 xyC
@@ -160665,13 +160728,13 @@ ncp
 ncp
 hbR
 mWz
-upw
+aUc
 kLd
 syX
 tHk
 tHk
 dbf
-xoG
+jNf
 ram
 mWz
 lNQ
@@ -160928,7 +160991,7 @@ eFl
 aRb
 nDG
 jjN
-bFL
+ksF
 ram
 mWz
 ucd
@@ -161436,13 +161499,13 @@ ncp
 ncp
 hbR
 mWz
-gTv
+lPv
 sIY
 qls
 uOM
 uOM
 aeG
-ghK
+bFL
 ram
 mWz
 hPr
@@ -162466,7 +162529,7 @@ dJL
 nRG
 oXA
 oXA
-gRf
+mJA
 dJL
 plf
 cdR
@@ -165804,7 +165867,7 @@ kHU
 fMh
 plf
 dJL
-gRf
+mJA
 oXA
 oXA
 nJn

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -2330,10 +2330,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -4176,10 +4172,6 @@
 	pixel_x = 28;
 	pixel_y = -5
 	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -5831,9 +5823,6 @@
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "box_white"
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -9067,6 +9056,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
 	},
 /turf/simulated/floor,
 /area/station/rnd/tox_launch)
@@ -19345,6 +19341,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
 /turf/simulated/floor,
 /area/station/rnd/tox_launch)
 "emc" = (
@@ -24492,6 +24495,9 @@
 	dir = 1
 	},
 /obj/machinery/vending/phoronresearch,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -26886,9 +26892,8 @@
 /area/station/rnd/xenobiology)
 "gbQ" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -34611,6 +34616,13 @@
 /turf/simulated/wall,
 /area/station/security/detectives_office)
 "hLq" = (
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
 /turf/simulated/floor,
 /area/station/rnd/tox_launch)
 "hLs" = (
@@ -43935,9 +43947,6 @@
 	name = "Toxins Launch APC";
 	pixel_x = 28
 	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -47476,9 +47485,6 @@
 	},
 /area/station/medical/chemistry)
 "kDj" = (
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -48362,6 +48368,9 @@
 /area/station/engineering/atmos/supermatter)
 "kLU" = (
 /obj/structure/closet/bombcloset,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -58224,9 +58233,6 @@
 	name = "Test Chamber Telescreen";
 	network = list("Toxins  Test  Area");
 	pixel_x = -30
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -69865,6 +69871,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -70322,9 +70331,9 @@
 	network = list("Toxins  Test  Area");
 	pixel_x = -30
 	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
+/obj/effect/decal/turf_decal/alpha{
+	icon_state = "warn_end";
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/station/rnd/tox_launch)
@@ -70492,15 +70501,6 @@
 	icon_state = "yellowfull"
 	},
 /area/station/medical/chemistry)
-"pVb" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/rnd/tox_launch)
 "pVj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -87048,10 +87048,6 @@
 	layer = 4;
 	pixel_y = -26
 	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -92011,10 +92007,6 @@
 "vbS" = (
 /obj/structure/stool/bed/chair/office/light{
 	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -100458,9 +100450,6 @@
 /area/station/rnd/hallway/lobby)
 "xfJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -101953,6 +101942,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
 	},
 /turf/simulated/floor,
 /area/station/rnd/tox_launch)
@@ -134089,7 +134085,7 @@ eWN
 kLU
 kDj
 hLq
-pVb
+kDj
 mjh
 wgE
 tMa

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -8132,6 +8132,10 @@
 /obj/structure/stool/bed/chair/metal/white{
 	dir = 1
 	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "black"
@@ -14739,6 +14743,9 @@
 /area/station/civilian/chapel/office)
 "dfA" = (
 /obj/random/vending/cola,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -22737,6 +22744,9 @@
 /area/station/civilian/locker)
 "eYy" = (
 /obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -24818,6 +24828,27 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/tox_launch)
+"fwr" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "fwH" = (
 /mob/living/simple_animal/corgi/borgi,
 /turf/simulated/floor{
@@ -27951,6 +27982,10 @@
 /turf/simulated/floor/wood,
 /area/station/maintenance/science)
 "gjF" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_corner";
+	dir = 8
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "blackcorner"
@@ -33616,6 +33651,9 @@
 /area/station/civilian/chapel)
 "hva" = (
 /obj/machinery/vending/cigarette,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -45062,6 +45100,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"jUi" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "jUj" = (
 /obj/structure/stool/bed/chair/comfy/brown,
 /obj/machinery/light/smart{
@@ -46002,6 +46051,9 @@
 /area/station/medical/psych)
 "keN" = (
 /obj/random/vending/snack,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "wooden-2"
 	},
@@ -46444,6 +46496,10 @@
 	},
 /area/station/hallway/primary/central)
 "kiT" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 8
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "black"
@@ -48967,6 +49023,9 @@
 	density = 0;
 	dir = 8
 	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line"
+	},
 /turf/simulated/floor{
 	icon_state = "black"
 	},
@@ -49704,6 +49763,18 @@
 	icon_state = "dark"
 	},
 /area/station/security/checkpoint/escape)
+"kTS" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "kUa" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/food/condiment/saltshaker{
@@ -53533,6 +53604,10 @@
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
 "lNr" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_corner";
+	dir = 1
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "blackcorner"
@@ -56487,6 +56562,9 @@
 	dir = 8
 	},
 /obj/machinery/vending/coffee,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -61842,6 +61920,9 @@
 /area/station/civilian/chapel/mass_driver)
 "nJn" = (
 /obj/machinery/light/smart,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -62559,6 +62640,9 @@
 "nRG" = (
 /obj/machinery/light/smart{
 	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -63890,6 +63974,9 @@
 /area/station/hallway/primary/central)
 "ogZ" = (
 /obj/decal/boxingrope,
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line"
+	},
 /turf/simulated/floor{
 	icon_state = "black"
 	},
@@ -67664,6 +67751,10 @@
 /area/station/engineering/engine)
 "pey" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "black"
@@ -72468,6 +72559,9 @@
 /area/station/maintenance/medbay)
 "qhu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_corner"
+	},
 /turf/simulated/floor{
 	icon_state = "blackcorner"
 	},
@@ -83489,6 +83583,9 @@
 	density = 0;
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line"
+	},
 /turf/simulated/floor{
 	icon_state = "black"
 	},
@@ -87985,6 +88082,9 @@
 /area/station/rnd/xenobiology)
 "tNG" = (
 /obj/random/vending/cola,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "wooden-2"
 	},
@@ -94154,6 +94254,9 @@
 /area/station/maintenance/engineering)
 "voI" = (
 /obj/machinery/disposal,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whitehall"
@@ -96942,6 +97045,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"vYa" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/civilian/gym)
 "vYb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -97926,6 +98037,26 @@
 	},
 /turf/simulated/floor,
 /area/station/security/checkpoint/medbay)
+"wjT" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "wjU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -103092,6 +103223,10 @@
 /area/station/rnd/scibreak)
 "xvu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_corner";
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "blackcorner"
@@ -104862,6 +104997,10 @@
 "xQv" = (
 /obj/effect/landmark/start/assistant/test_subject,
 /obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
 	dir = 1
 	},
 /turf/simulated/floor{
@@ -160509,13 +160648,13 @@ ncp
 ncp
 hbR
 mWz
-mmq
+kTS
 kLd
 syX
 tHk
 tHk
 dbf
-bFL
+fwr
 ram
 mWz
 lNQ
@@ -161280,13 +161419,13 @@ ncp
 ncp
 hbR
 mWz
-mmq
+jUi
 sIY
 qls
 uOM
 uOM
 aeG
-bFL
+wjT
 ram
 mWz
 hPr
@@ -162310,7 +162449,7 @@ dJL
 nRG
 oXA
 oXA
-oXA
+vYa
 dJL
 plf
 cdR
@@ -165648,7 +165787,7 @@ kHU
 fMh
 plf
 dJL
-oXA
+vYa
 oXA
 oXA
 nJn

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -10273,6 +10273,16 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/hallway/primary/starboard)
+"cek" = (
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "ceI" = (
 /obj/machinery/camera{
 	c_tag = "Port Primary Hallway South";
@@ -27457,6 +27467,17 @@
 	icon_state = "redyellowfull"
 	},
 /area/station/rnd/scibreak)
+"gjt" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "gjC" = (
 /turf/simulated/floor/wood,
 /area/station/maintenance/science)
@@ -29415,6 +29436,13 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/mixing)
+"gEW" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "gEX" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -39387,6 +39415,15 @@
 	icon_state = "dark"
 	},
 /area/station/security/brig/storage)
+"iQD" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 10
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/hor)
 "iQE" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
@@ -41915,6 +41952,13 @@
 	},
 /turf/environment/space,
 /area/shuttle/supply/station)
+"juT" = (
+/obj/effect/decal/turf_decal{
+	dir = 5;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "juV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -49661,6 +49705,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
 	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
 /turf/simulated/floor/engine,
 /area/station/rnd/telesci)
 "ldE" = (
@@ -56494,7 +56542,7 @@
 "mKy" = (
 /obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "siding_line";
-	dir = 10
+	dir = 6
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -73443,6 +73491,15 @@
 	icon_state = "dark"
 	},
 /area/station/security/iaa_office)
+"qJt" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/hor)
 "qJx" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -75723,15 +75780,6 @@
 "rmY" = (
 /turf/simulated/wall,
 /area/station/hallway/secondary/exit)
-"rnj" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/rnd/hor)
 "rnl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor/engine,
@@ -78424,6 +78472,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
+"rQg" = (
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "rQp" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -79197,6 +79252,10 @@
 "saw" = (
 /obj/machinery/light/smart{
 	dir = 1
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
 	},
 /turf/simulated/floor/engine,
 /area/station/rnd/telesci)
@@ -82117,6 +82176,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/bridge)
+"sKx" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/hor)
 "sKL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -86409,6 +86477,12 @@
 /obj/item/weapon/storage/box,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
+"tOj" = (
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "tOH" = (
 /obj/structure/sign/directions/evac{
 	pixel_x = -32;
@@ -88272,6 +88346,17 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway/lobby)
+"umg" = (
+/obj/effect/decal/turf_decal{
+	dir = 10;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "umi" = (
 /obj/machinery/door/airlock{
 	name = "Locker Room"
@@ -89428,15 +89513,6 @@
 "uBo" = (
 /turf/environment/space,
 /area/shuttle/syndicate/southeast)
-"uBq" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/rnd/hor)
 "uBu" = (
 /obj/structure/table/glass,
 /obj/item/device/radio/headset/headset_med,
@@ -91418,6 +91494,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
+"vaZ" = (
+/obj/effect/decal/turf_decal{
+	dir = 9;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "vbc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -97793,15 +97879,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/engine)
-"wDW" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/rnd/hor)
 "wDY" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -103615,6 +103692,13 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
+"xWB" = (
+/obj/effect/decal/turf_decal{
+	dir = 6;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "xWF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -134541,9 +134625,9 @@ ylt
 omz
 vil
 lhp
-bks
+vaZ
 ldt
-bks
+umg
 ekl
 svQ
 nxb
@@ -134800,7 +134884,7 @@ evL
 bOA
 saw
 tVQ
-bks
+tOj
 jwK
 svQ
 vxf
@@ -135055,15 +135139,15 @@ wtC
 ijY
 evL
 lhp
+gjt
 bks
-bks
-bks
+cek
 mkl
 svQ
 vxf
 kiL
-wDW
-mKy
+qJt
+iQD
 hzm
 vaP
 wwp
@@ -135312,9 +135396,9 @@ wtC
 hBT
 npX
 fbt
+gEW
 bks
-bks
-bks
+tOj
 fte
 uly
 vxf
@@ -135569,15 +135653,15 @@ dyG
 bwi
 evL
 lhp
+gEW
 bks
-bks
-bks
+tOj
 mkl
 svQ
 vxf
 kiL
-uBq
-rnj
+sKx
+mKy
 blq
 syE
 qbC
@@ -135828,7 +135912,7 @@ lud
 bOA
 saw
 bks
-bks
+tOj
 bYy
 svQ
 vxf
@@ -136083,9 +136167,9 @@ oZa
 daK
 pPD
 lhp
-bks
-bks
-bks
+juT
+rQg
+xWB
 vmY
 svQ
 jHw

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -2721,12 +2721,6 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/reception)
-"awi" = (
-/obj/random/scrap/safe_even,
-/turf/simulated/floor/plating{
-	icon_state = "foam_plating"
-	},
-/area/station/maintenance/science)
 "awp" = (
 /obj/machinery/computer/security/engineering{
 	dir = 4
@@ -23605,9 +23599,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/plating{
-	icon_state = "foam_plating"
-	},
+/turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "fby" = (
 /obj/effect/decal/cleanable/dirt,
@@ -31594,9 +31586,7 @@
 /area/station/engineering/atmos)
 "gPj" = (
 /obj/effect/decal/cleanable/blood/gibs/xeno,
-/turf/simulated/floor/plating{
-	icon_state = "foam_plating"
-	},
+/turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "gPx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -57154,9 +57144,7 @@
 /area/station/rnd/xenobiology)
 "mpi" = (
 /obj/random/foods/food_trash,
-/turf/simulated/floor/plating{
-	icon_state = "foam_plating"
-	},
+/turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "mpA" = (
 /obj/structure/rack,
@@ -61893,9 +61881,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating{
-	icon_state = "foam_plating"
-	},
+/turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "nrO" = (
 /obj/structure/cable{
@@ -104679,9 +104665,7 @@
 "xnc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/plating{
-	icon_state = "foam_plating"
-	},
+/turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "xnj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -106632,11 +106616,6 @@
 	icon_state = "dark"
 	},
 /area/station/bridge/cmf_room)
-"xFN" = (
-/turf/simulated/floor/plating{
-	icon_state = "foam_plating"
-	},
-/area/station/maintenance/science)
 "xFQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -127425,7 +127404,7 @@ kHU
 kHU
 kHU
 cjx
-xFN
+ilA
 fbu
 cjx
 gMM
@@ -128720,7 +128699,7 @@ spu
 tZY
 gVW
 cjx
-awi
+lEt
 lUT
 xnc
 ilA
@@ -128967,7 +128946,7 @@ tCf
 mIP
 scw
 flv
-awi
+lEt
 cjx
 unh
 bbc
@@ -129238,7 +129217,7 @@ yhZ
 cfJ
 cjx
 xRM
-xFN
+ilA
 lEt
 cjx
 plf

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -609,6 +609,10 @@
 /obj/item/clothing/mask/muzzle,
 /obj/item/clothing/ears/earmuffs,
 /obj/item/clothing/ears/earmuffs,
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "whiteblue"
@@ -2324,7 +2328,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/medical/medbreak)
 "aso" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -2742,6 +2748,9 @@
 /area/station/civilian/locker)
 "axc" = (
 /obj/machinery/computer/diseasesplicer,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "darkbrown"
@@ -3566,6 +3575,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 1
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -4735,6 +4748,9 @@
 /area/station/storage/primary)
 "aVy" = (
 /obj/machinery/computer/centrifuge,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -5807,7 +5823,9 @@
 /area/station/maintenance/science)
 "bhv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/carpet/blue2{
+	icon_state = "blue2carpet15-15"
+	},
 /area/station/medical/psych)
 "bhy" = (
 /obj/item/weapon/flora/random,
@@ -5861,7 +5879,9 @@
 "biC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/carpet/blue2{
+	icon_state = "blue2carpet13-5"
+	},
 /area/station/medical/psych)
 "biE" = (
 /obj/structure/cable{
@@ -6146,7 +6166,8 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
 "blq" = (
@@ -6549,6 +6570,10 @@
 /turf/simulated/floor,
 /area/station/rnd/robotics)
 "bpA" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "wooden"
 	},
@@ -7302,6 +7327,9 @@
 /area/station/hallway/primary/starboard)
 "byB" = (
 /obj/machinery/chem_master,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -8600,6 +8628,10 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -8696,7 +8728,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/medical/medbreak)
 "bLC" = (
 /obj/machinery/camera{
@@ -8948,6 +8982,9 @@
 /area/station/maintenance/atmos)
 "bOW" = (
 /obj/machinery/vending/medical,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor,
 /area/station/medical/storage)
 "bPp" = (
@@ -11025,6 +11062,9 @@
 	pixel_y = -32
 	},
 /obj/machinery/disease2/diseaseanalyser,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -11131,11 +11171,17 @@
 /turf/simulated/floor/wood,
 /area/station/maintenance/science)
 "cnr" = (
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "whitegreencorner"
+/obj/structure/morgue{
+	dir = 8
 	},
-/area/station/medical/hallway)
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/medical/morgue)
 "cnS" = (
 /obj/machinery/conveyor{
 	dir = 10;
@@ -11873,7 +11919,7 @@
 	},
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "whitered"
+	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
 "cym" = (
@@ -12800,11 +12846,32 @@
 /area/station/security/brig)
 "cHN" = (
 /obj/machinery/disease2/incubator,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "darkbrown"
 	},
 /area/station/medical/virology)
+"cHP" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(12)
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/medbay)
 "cHR" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -12974,6 +13041,11 @@
 /obj/item/seeds/glowshroom,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"cKN" = (
+/turf/simulated/floor/carpet/blue2{
+	icon_state = "blue2carpet11-12"
+	},
+/area/station/medical/psych)
 "cKQ" = (
 /obj/machinery/door/window/eastleft{
 	name = "Shrubbery";
@@ -14366,24 +14438,15 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/miningoffice)
-"ddd" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"ddj" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "box_corners_white";
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/maintenance{
-	req_access = list(12)
+/turf/simulated/floor{
+	icon_state = "dark"
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/maintenance/medbay)
+/area/station/medical/morgue)
 "ddl" = (
 /obj/machinery/monkey_recycler,
 /obj/effect/decal/turf_decal/alpha/red{
@@ -15294,8 +15357,8 @@
 "dmc" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "whitegreencorner"
+	dir = 8;
+	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
 "dmr" = (
@@ -16361,6 +16424,9 @@
 /area/station/maintenance/auxsolarport)
 "dzK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line"
+	},
 /turf/simulated/floor{
 	icon_state = "whiteblue"
 	},
@@ -18039,6 +18105,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "barber"
@@ -18668,6 +18737,10 @@
 /obj/machinery/alarm{
 	pixel_y = -32
 	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -18750,6 +18823,9 @@
 /area/station/hallway/primary/central)
 "eeT" = (
 /obj/machinery/computer/operating,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -19128,6 +19204,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
+/obj/effect/decal/turf_decal/alpha/red{
+	icon_state = "bot"
+	},
 /turf/simulated/floor,
 /area/station/medical/storage)
 "ejJ" = (
@@ -19308,6 +19387,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -21431,6 +21513,16 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/singularity)
+"eMg" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 5
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "barber"
+	},
+/area/station/medical/storage)
 "eMm" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -21690,6 +21782,13 @@
 /obj/structure/window/thin{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/medical/surgeryobs)
 "eOL" = (
@@ -21931,6 +22030,11 @@
 	icon_state = "purple"
 	},
 /area/station/rnd/xenobiology)
+"eRo" = (
+/turf/simulated/floor/carpet/blue2{
+	icon_state = "blue2carpet7-3"
+	},
+/area/station/medical/psych)
 "eRS" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -23111,7 +23215,8 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "whitegreen"
 	},
 /area/station/medical/hallway)
 "ffJ" = (
@@ -25186,6 +25291,10 @@
 	dir = 1;
 	network = list("SS13","Medical")
 	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 6
+	},
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "whiteblue"
@@ -25808,6 +25917,10 @@
 	},
 /area/station/security/checkpoint)
 "fMw" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_corner";
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "barber"
@@ -25843,6 +25956,15 @@
 	icon_state = "darkbrown"
 	},
 /area/station/medical/virology)
+"fNA" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/medical/morgue)
 "fNC" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/folder/blue,
@@ -28062,6 +28184,10 @@
 /area/station/civilian/chapel/office)
 "gnx" = (
 /obj/structure/morgue,
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -29062,6 +29188,15 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
+"gyl" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/medical/morgue)
 "gyn" = (
 /obj/structure/table,
 /obj/machinery/chem_dispenser/beer{
@@ -30152,7 +30287,9 @@
 /area/station/maintenance/medbay)
 "gLL" = (
 /obj/structure/stool/bed/chair/comfy/brown,
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/carpet/blue2{
+	icon_state = "blue2carpet10-8"
+	},
 /area/station/medical/psych)
 "gLY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/on{
@@ -31900,6 +32037,9 @@
 "hhw" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/structure/stool/bed/chair/office/light,
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line"
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -32261,6 +32401,14 @@
 /area/station/ai_monitored/eva)
 "hlU" = (
 /obj/machinery/bodyscanner,
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/station/medical/surgeryobs)
 "hmn" = (
@@ -33050,6 +33198,9 @@
 	},
 /obj/structure/window/thin{
 	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "box_white"
 	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -33879,6 +34030,9 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -39819,6 +39973,16 @@
 	icon_state = "vaultfull"
 	},
 /area/station/engineering/atmos)
+"iTx" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_corner";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "barber"
+	},
+/area/station/medical/storage)
 "iTz" = (
 /obj/structure/window/thin/reinforced{
 	dir = 8
@@ -39989,6 +40153,9 @@
 /obj/item/weapon/mop,
 /obj/item/weapon/reagent_containers/spray/cleaner{
 	pixel_x = 3
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	dir = 6;
@@ -41462,6 +41629,10 @@
 	},
 /area/station/engineering/engine)
 "jmY" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 6
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -41483,6 +41654,9 @@
 /area/station/engineering/atmos/distribution)
 "jnB" = (
 /obj/machinery/computer/operating,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "darkblue"
@@ -41864,6 +42038,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
+	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -42478,6 +42656,16 @@
 	icon_state = "darkblue"
 	},
 /area/station/bridge)
+"jxE" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "barber"
+	},
+/area/station/medical/storage)
 "jxP" = (
 /obj/machinery/vending/barbervend,
 /turf/simulated/floor/wood,
@@ -43405,6 +43593,10 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 8
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -43811,6 +44003,9 @@
 /obj/item/weapon/pen/blue{
 	pixel_x = -3;
 	pixel_y = 2
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -44698,6 +44893,16 @@
 /obj/structure/stool/bed,
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories/service_bedrooms)
+"jWE" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "barber"
+	},
+/area/station/medical/storage)
 "jWH" = (
 /obj/effect/landmark/start/shaft_miner,
 /turf/simulated/floor{
@@ -45378,7 +45583,9 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/carpet/blue2{
+	icon_state = "blue2carpet6-2"
+	},
 /area/station/medical/psych)
 "keN" = (
 /obj/random/vending/snack,
@@ -46127,6 +46334,9 @@
 	},
 /area/station/security/brig)
 "kmx" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "whiteblue"
@@ -46531,6 +46741,10 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -46921,6 +47135,16 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/library)
+"kwC" = (
+/obj/structure/morgue,
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/medical/morgue)
 "kwI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -47762,6 +47986,10 @@
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -50192,6 +50420,10 @@
 	name = "Psyciatric Office APC";
 	pixel_x = -28
 	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 10
+	},
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "whiteblue"
@@ -52533,6 +52765,9 @@
 /area/station/medical/cmo)
 "lKD" = (
 /obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "whitebluecorner"
 	},
@@ -53911,6 +54146,10 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "barber"
@@ -54174,6 +54413,13 @@
 	c_tag = "Medbay Cryogenics";
 	dir = 4;
 	network = list("SS13","Medical")
+	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_corner";
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line"
 	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -54701,6 +54947,9 @@
 "mlF" = (
 /obj/machinery/computer/operating{
 	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -55531,6 +55780,9 @@
 /obj/machinery/optable,
 /obj/machinery/status_display{
 	pixel_y = 32
+	},
+/obj/effect/decal/turf_decal/alpha/red{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -60822,6 +61074,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -61922,6 +62177,9 @@
 	c_tag = "Medbay Morgue";
 	dir = 10;
 	network = list("SS13","Medical")
+	},
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "box_corners_white"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -64877,6 +65135,16 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/engine)
+"oGJ" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "barber"
+	},
+/area/station/medical/storage)
 "oGK" = (
 /obj/structure/reagent_dispensers/aqueous_foam_tank,
 /turf/simulated/floor{
@@ -66430,6 +66698,13 @@
 /area/station/rnd/robotics)
 "oZh" = (
 /obj/machinery/door/firedoor,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/green{
+	icon_state = "siding_line"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -66444,6 +66719,9 @@
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -22
+	},
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "box_corners_white"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -66731,6 +67009,14 @@
 	icon_state = "darkblue"
 	},
 /area/station/security/checkpoint/escape_custom_desk)
+"pdC" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/station/medical/surgeryobs)
 "pdZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -69206,6 +69492,15 @@
 	icon_state = "caution"
 	},
 /area/station/engineering/atmos/distribution)
+"pES" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/station/medical/surgeryobs)
 "pFa" = (
 /turf/simulated/floor{
 	dir = 9;
@@ -69903,12 +70198,18 @@
 	},
 /area/station/medical/virology)
 "pOh" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line"
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
 /area/station/medical/cryo)
 "pOj" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line"
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -73011,6 +73312,10 @@
 /obj/machinery/light/smart{
 	dir = 1
 	},
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -74111,6 +74416,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
 	},
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -74740,6 +75049,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -75230,6 +75543,9 @@
 /area/station/civilian/janitor)
 "raB" = (
 /obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -75694,6 +76010,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -78308,6 +78627,10 @@
 /obj/structure/disposalpipe/junction{
 	icon_state = "pipe-j2"
 	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 8
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -78340,6 +78663,9 @@
 /area/station/engineering/atmos)
 "rJY" = (
 /obj/machinery/optable,
+/obj/effect/decal/turf_decal/alpha/red{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -79607,6 +79933,10 @@
 "rZJ" = (
 /obj/machinery/light_switch{
 	pixel_y = -28
+	},
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "box_corners_white";
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -81752,6 +82082,10 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 6
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "barber"
@@ -82926,6 +83260,10 @@
 "sOe" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/box/cups,
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 5
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "whiteblue"
@@ -83344,6 +83682,9 @@
 /area/station/cargo/miningoffice)
 "sTP" = (
 /obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /obj/effect/decal/turf_decal{
 	dir = 4;
 	icon_state = "warn"
@@ -83417,6 +83758,12 @@
 	drainage = 2
 	},
 /obj/structure/window/thin,
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "box_white"
+	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line"
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -83647,6 +83994,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 10
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -84263,6 +84614,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 9
+	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "whiteblue"
@@ -84271,6 +84626,9 @@
 "tfX" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -84716,6 +85074,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 8
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -85502,6 +85864,9 @@
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "box_white"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -86054,7 +86419,9 @@
 	},
 /area/station/bridge/meeting_room)
 "tCY" = (
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/carpet/blue2{
+	icon_state = "blue2carpet9-4"
+	},
 /area/station/medical/psych)
 "tDb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -87111,6 +87478,10 @@
 /obj/item/toy/figure/md{
 	pixel_y = 14
 	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "wooden"
 	},
@@ -87571,7 +87942,9 @@
 	dir = 1
 	},
 /obj/item/toy/plushie/tuxedo_cat,
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/carpet/blue2{
+	icon_state = "blue2carpet14-10"
+	},
 /area/station/medical/psych)
 "tXo" = (
 /obj/structure/object_wall/pod{
@@ -88401,6 +88774,14 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port)
+"uhS" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/medical/morgue)
 "uhT" = (
 /obj/structure/table,
 /obj/item/clothing/mask/gas/coloured,
@@ -90254,6 +90635,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line"
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -90284,6 +90668,9 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -95387,6 +95774,9 @@
 /area/station/aisat)
 "vTJ" = (
 /obj/machinery/disposal,
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -95532,6 +95922,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "barber"
@@ -95667,7 +96061,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/medical/medbreak)
 "vWT" = (
 /obj/structure/closet/radiation,
@@ -98282,6 +98678,9 @@
 /obj/structure/window/thin/reinforced{
 	dir = 8
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkblue"
@@ -99792,6 +100191,16 @@
 	icon_state = "vaultfull"
 	},
 /area/station/maintenance/science)
+"wWO" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 9
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "barber"
+	},
+/area/station/medical/storage)
 "wXp" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -100694,6 +101103,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 8
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -101116,7 +101529,9 @@
 	pixel_y = -5
 	},
 /obj/effect/landmark/start/psychiatrist,
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/carpet/blue2{
+	icon_state = "blue2carpet5-1"
+	},
 /area/station/medical/psych)
 "xnP" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
@@ -103726,6 +104141,10 @@
 /obj/structure/disposalpipe/trunk,
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
+	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/station/medical/sleeper)
@@ -135939,7 +136358,7 @@ pKT
 sdW
 uOI
 nPL
-ddd
+cHP
 nEL
 pMF
 qpQ
@@ -143387,15 +143806,15 @@ nWN
 qFs
 vzs
 bCv
-sDa
+hYm
 sDa
 dmc
 ffG
 blp
-cnr
 sDa
+hYm
 ntM
-sDa
+hYm
 ujr
 gJC
 gJC
@@ -144426,7 +144845,7 @@ gnx
 qMt
 lKf
 gnx
-gnx
+kwC
 beJ
 pku
 dTj
@@ -144680,9 +145099,9 @@ hhw
 weB
 beJ
 bKz
-xly
+uhS
 lKf
-xly
+gyl
 oZs
 beJ
 lOY
@@ -145190,13 +145609,13 @@ fVI
 jug
 cdS
 lnd
-jmY
+pdC
 hlU
 beJ
 qyW
-xly
+ddj
 odg
-xly
+fNA
 rZJ
 beJ
 ebE
@@ -145436,9 +145855,9 @@ nkW
 sPy
 sBD
 ktg
-fMw
-fMw
-fMw
+wWO
+oGJ
+oGJ
 sXO
 leI
 sBD
@@ -145446,14 +145865,14 @@ qQK
 xZn
 kpr
 adj
-jmY
+pES
 jmY
 eOJ
 beJ
-jtc
+cnr
 jtc
 odg
-jtc
+cnr
 nTu
 beJ
 rmY
@@ -145693,7 +146112,7 @@ qQA
 god
 sbr
 xai
-fMw
+jxE
 dPF
 xxd
 rgY
@@ -145949,8 +146368,8 @@ wlv
 mMZ
 gMr
 lwH
-fMw
-fMw
+oGJ
+iTx
 iqO
 jPQ
 elA
@@ -146206,7 +146625,7 @@ wlv
 mMZ
 gMr
 lwH
-fMw
+jWE
 fMw
 oUW
 mqF
@@ -146464,7 +146883,7 @@ dTh
 mOv
 sbr
 xai
-fMw
+eMg
 mbK
 vVA
 szQ
@@ -147753,7 +148172,7 @@ sTP
 mzd
 kdH
 keK
-tCY
+eRo
 xnG
 tfW
 lij
@@ -148267,7 +148686,7 @@ omM
 gUd
 kdH
 gLL
-tCY
+cKN
 tCY
 sOe
 fFv

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -1570,17 +1570,6 @@
 	},
 /turf/simulated/floor,
 /area/station/medical/cryo)
-"akr" = (
-/obj/structure/stool/bed/chair/metal/black{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "akv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -2140,18 +2129,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
-"apO" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
+"apD" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "caution"
+	},
+/area/station/engineering/atmos/distribution)
 "apV" = (
 /turf/simulated/floor/carpet,
 /area/station/bridge/meeting_room)
@@ -2655,13 +2649,6 @@
 "auA" = (
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
-"auB" = (
-/obj/item/weapon/flora/random,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_left"
-	},
-/turf/simulated/floor,
-/area/station/storage/tech)
 "auG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -2838,15 +2825,6 @@
 	icon_state = "darkbrown"
 	},
 /area/station/medical/virology)
-"axf" = (
-/obj/effect/decal/turf_decal{
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "axg" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -4201,6 +4179,18 @@
 /obj/machinery/status_display,
 /turf/simulated/wall,
 /area/station/security/checkpoint/escape)
+"aNp" = (
+/obj/machinery/door_timer/cell_3{
+	pixel_x = 32;
+	pixel_y = 0;
+	dir = 4;
+	id = "Cell 3 perma"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "aNv" = (
 /obj/structure/stool,
 /turf/simulated/floor{
@@ -4604,6 +4594,16 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/station/security/main)
+"aSi" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSE-FC";
+	location = "SEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "aSl" = (
 /obj/machinery/computer/gravity_control_computer,
 /obj/effect/decal/turf_decal/alpha/gray{
@@ -5002,29 +5002,39 @@
 /obj/structure/mopbucket,
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
+"aWz" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
+"aWC" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Entry Shuttle Airlock";
+	req_one_access = list(13)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "aWD" = (
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
-"aWN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
 "aWR" = (
 /obj/structure/stool/bed/chair/metal/green{
 	dir = 8
@@ -5486,6 +5496,19 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/sleeper)
+"bcl" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "escape"
+	},
+/area/station/hallway/primary/port)
 "bcv" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -5573,13 +5596,6 @@
 	icon_state = "2-3"
 	},
 /area/shuttle/mining/station)
-"bcT" = (
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/prison)
 "bcW" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced/phoron{
@@ -6348,6 +6364,15 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/maintenance/science)
+"blc" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_left"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/cold_room)
 "blh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/machinery/light/small{
@@ -6423,7 +6448,8 @@
 	},
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
+	icon_state = "box_corners_white";
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -6581,14 +6607,6 @@
 /obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
-"bmL" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/civilian/gym)
 "bmM" = (
 /turf/simulated/floor{
 	icon_state = "grimy"
@@ -7123,18 +7141,6 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
-"btz" = (
-/obj/structure/stool/bed/chair/metal/black{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "btA" = (
 /obj/structure/table/woodentable/fancy,
 /turf/simulated/floor,
@@ -7547,6 +7553,15 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/miningoffice)
+"byc" = (
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "bye" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 1
@@ -8819,15 +8834,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/hor)
-"bJx" = (
-/obj/item/weapon/flora/random,
-/obj/machinery/light/smart{
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "white"
-	},
-/area/station/rnd/hallway/lobby)
 "bJz" = (
 /obj/effect/landmark{
 	name = "blobstart"
@@ -10579,14 +10585,6 @@
 	icon_state = "grimy"
 	},
 /area/station/tcommsat/computer)
-"cdd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/security/prison)
 "cde" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -11916,6 +11914,25 @@
 	},
 /turf/simulated/shuttle/floor/wagon,
 /area/shuttle/supply/station)
+"cue" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/main)
 "cug" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -11928,16 +11945,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
-"cul" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-B";
-	location = "SSW-B"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "cum" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/machinery/embedded_controller/radio/airlock_controller{
@@ -12285,6 +12292,14 @@
 "cxI" = (
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/supermatter)
+"cxQ" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/civilian/gym)
 "cxU" = (
 /obj/machinery/shower/free{
 	dir = 4
@@ -12423,6 +12438,17 @@
 	icon_state = "caution"
 	},
 /area/station/medical/chemistry)
+"cyD" = (
+/obj/machinery/light/smart,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DS";
+	location = "DN-W"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "purplecorner"
+	},
+/area/station/hallway/primary/central)
 "cyQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -12685,6 +12711,18 @@
 /obj/structure/sign/nanotrasen,
 /turf/simulated/wall/r_wall,
 /area/station/bridge/ai_upload)
+"cBK" = (
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Labor Camp Shuttle Airlock";
+	req_access = list(2)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
 "cBU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/structure/window/fulltile/reinforced/phoron{
@@ -14718,19 +14756,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/miningoffice)
-"cZj" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "cZC" = (
 /obj/machinery/shieldwallgen,
 /turf/simulated/floor,
@@ -17176,7 +17201,7 @@
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "box_corners_white";
-	dir = 8
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -19154,6 +19179,12 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/misc_lab)
+"ebs" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "browncorner"
+	},
+/area/station/cargo/storage)
 "ebv" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -19780,21 +19811,15 @@
 	},
 /area/station/hallway/primary/starboard)
 "ejv" = (
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Entry Shuttle Airlock";
-	req_one_access = list(13)
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-FC";
+	location = "DS"
 	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "bluecorner"
 	},
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/primary/central)
 "ejG" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 1
@@ -20420,6 +20445,15 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/library)
+"eqV" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 29
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "blackcorner"
+	},
+/area/station/hallway/primary/starboard)
 "ern" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -20527,16 +20561,16 @@
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/engineering)
 "esZ" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "loadingarea"
+/obj/structure/stool/bed/chair/metal/black{
+	dir = 4
 	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "arrow"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
-/area/station/security/brig)
+/area/station/hallway/secondary/entry)
 "etb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -21378,16 +21412,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
-"eBc" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-C";
-	location = "CS-AR"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "eBe" = (
 /obj/machinery/camera{
 	c_tag = "Mining Shuttle Preparation";
@@ -22422,6 +22446,16 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/surgeryobs)
+"eOf" = (
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "eOj" = (
 /obj/machinery/chem_dispenser,
 /obj/effect/decal/turf_decal{
@@ -22553,9 +22587,6 @@
 /obj/item/weapon/wrench,
 /obj/machinery/alarm{
 	pixel_y = -32
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 28
 	},
 /turf/simulated/floor{
 	icon_state = "redfull"
@@ -23320,15 +23351,6 @@
 	icon_state = "purplecorner"
 	},
 /area/station/rnd/hor)
-"eZG" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "eZH" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -24641,6 +24663,20 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
+"foe" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/pump,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "arrival"
+	},
+/area/station/hallway/primary/port)
 "foh" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor,
@@ -25146,6 +25182,16 @@
 	icon_state = "blue"
 	},
 /area/station/engineering/atmos)
+"ftN" = (
+/obj/machinery/light/smart,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "ftS" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/structure/cable{
@@ -26581,18 +26627,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison)
-"fKC" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "fKP" = (
 /obj/effect/decal/turf_decal{
 	dir = 1;
@@ -26786,6 +26820,17 @@
 	icon_state = "darkbrown"
 	},
 /area/station/medical/virology)
+"fNf" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "loadingarea"
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "arrow"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "fNA" = (
 /obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "box_corners_white";
@@ -26816,12 +26861,19 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "fOp" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-MB";
-	location = "N-MB"
+/obj/machinery/atm{
+	pixel_y = -28
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
 /area/station/hallway/secondary/entry)
+"fOt" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "cafeteria"
+	},
+/area/station/security/prison)
 "fOF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
@@ -27169,6 +27221,14 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/theatre)
+"fSI" = (
+/obj/machinery/atm{
+	pixel_y = -28
+	},
+/turf/simulated/floor{
+	icon_state = "redyellowfull"
+	},
+/area/station/hallway/primary/fore)
 "fSK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor,
@@ -27232,13 +27292,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/station/civilian/dormitories)
-"fTx" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "fTz" = (
 /turf/simulated/wall,
 /area/station/cargo/recycler)
@@ -27264,18 +27317,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/mixing)
-"fUo" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/engineering/atmos/atmos_office)
 "fUu" = (
 /obj/effect/landmark/start/chief_engineer,
 /obj/structure/stool/bed/chair/office/light{
@@ -27499,16 +27540,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
-"fWL" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "fWT" = (
 /obj/machinery/smartfridge/chemistry,
 /turf/simulated/wall/r_wall,
@@ -27867,16 +27898,6 @@
 	},
 /turf/simulated/floor,
 /area/station/storage/primary)
-"gba" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NNW-B";
-	location = "NW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "gbj" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/pen,
@@ -28411,13 +28432,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/minisat_secure_area)
-"ghB" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-FC";
-	location = "SSW-FC"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/starboard)
 "ghI" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable{
@@ -28838,15 +28852,6 @@
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
-"glf" = (
-/obj/item/weapon/flora/random,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "gli" = (
 /obj/structure/rack,
 /obj/item/weapon/tank/oxygen,
@@ -29347,16 +29352,6 @@
 	icon_state = "redyellowfull"
 	},
 /area/station/hallway/primary/fore)
-"gpJ" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SEE-FC";
-	location = "SE-FC"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "gpM" = (
 /obj/structure/particle_accelerator/end_cap{
 	dir = 8
@@ -29467,15 +29462,18 @@
 	icon_state = "neutralfull"
 	},
 /area/station/storage/primary)
-"grs" = (
-/obj/structure/kitchenspike,
+"grp" = (
+/obj/structure/stool/bed/chair/metal/black{
+	dir = 4
+	},
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_right"
+	icon_state = "box_corners_white";
+	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
-/area/station/civilian/cold_room)
+/area/station/hallway/secondary/entry)
 "grP" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -29686,23 +29684,6 @@
 	icon_state = "floor"
 	},
 /area/shuttle/escape_pod3/station)
-"guc" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Entry Shuttle Airlock";
-	req_one_access = list(13)
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
 "gui" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -30672,19 +30653,6 @@
 	icon_state = "red"
 	},
 /area/station/security/brig)
-"gDv" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/powered/pump,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "arrival"
-	},
-/area/station/hallway/primary/port)
 "gDL" = (
 /obj/effect/landmark/start/bartender,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -31391,17 +31359,6 @@
 	icon_state = "wooden"
 	},
 /area/station/hallway/secondary/exit)
-"gMq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "gMr" = (
 /turf/simulated/floor{
 	icon_state = "whiteblue"
@@ -31746,13 +31703,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
-"gQW" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "gRg" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -31824,15 +31774,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/cargo/miningoffice)
-"gRB" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 5
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "gRG" = (
 /obj/machinery/computer/station_alert{
 	dir = 4
@@ -32622,15 +32563,6 @@
 	icon_state = "yellow"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
-"gZr" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Security";
-	location = "S-C"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "gZz" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -32728,6 +32660,19 @@
 	icon_state = "whitehall"
 	},
 /area/station/rnd/hallway)
+"haL" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "hba" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33294,15 +33239,6 @@
 /obj/structure/sign/warning/nosmoking,
 /turf/simulated/wall,
 /area/station/engineering/break_room)
-"hiT" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "hjc" = (
 /turf/simulated/floor{
 	dir = 9;
@@ -34529,19 +34465,6 @@
 	icon_state = "white"
 	},
 /area/station/civilian/gym)
-"hve" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "hvk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -34658,7 +34581,7 @@
 	req_access = list(2)
 	},
 /obj/effect/decal/turf_decal{
-	dir = 4;
+	dir = 8;
 	icon_state = "warn"
 	},
 /turf/simulated/floor/plating,
@@ -34694,6 +34617,16 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/chapel)
+"hxc" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "hxf" = (
 /turf/simulated/floor/bluegrid{
 	icon_state = "rcircuit"
@@ -36069,6 +36002,16 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
+"hKr" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NNW-B";
+	location = "NW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "hKs" = (
 /obj/structure/object_wall/pod{
 	icon_state = "2,2"
@@ -36557,8 +36500,7 @@
 	},
 /obj/machinery/portable_atmospherics/powered/pump,
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
+	icon_state = "box_corners_white"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -37384,16 +37326,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
-"ian" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkred"
-	},
-/area/station/security/brig)
 "iau" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -39350,26 +39282,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
-"iwN" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "ixa" = (
 /obj/machinery/status_display{
 	pixel_y = 32
@@ -39640,6 +39552,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"izL" = (
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/break_room)
 "izS" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/status_display{
@@ -39942,7 +39862,7 @@
 "iDw" = (
 /obj/item/weapon/flora/random,
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_right"
+	icon_state = "bot_left"
 	},
 /turf/simulated/floor,
 /area/station/storage/tech)
@@ -40051,6 +39971,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/engineering/atmos/atmos_office)
+"iEs" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "iEA" = (
 /obj/structure/rack,
 /obj/item/weapon/reagent_containers/watertank_backpack,
@@ -40665,6 +40594,19 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/robotics)
+"iLH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "iLJ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -41515,18 +41457,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
-"iUJ" = (
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Labor Camp Shuttle Airlock";
-	req_access = list(2)
-	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/brig)
 "iUS" = (
 /obj/machinery/door_control{
 	id = "Singularity";
@@ -41860,18 +41790,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"iYG" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "iYX" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -44687,19 +44605,17 @@
 	},
 /area/station/hallway/primary/starboard)
 "jEs" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
+/obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
 	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "escape"
+	icon_state = "neutralfull"
 	},
-/area/station/hallway/primary/port)
+/area/station/engineering/atmos)
 "jEB" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
@@ -44817,6 +44733,16 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
+"jFY" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "jFZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/light/small{
@@ -45004,6 +44930,15 @@
 	icon_state = "darkbrown"
 	},
 /area/station/bridge)
+"jIr" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "jIt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -45195,6 +45130,15 @@
 	},
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
+"jJx" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "jJB" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -45234,16 +45178,6 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge/captain_quarters)
-"jKe" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "black"
-	},
-/area/station/hallway/secondary/entry)
 "jKp" = (
 /obj/effect/decal/turf_decal{
 	dir = 5;
@@ -45599,16 +45533,6 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/engine)
-"jNh" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SWW-FC";
-	location = "SW-FC"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "jNo" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -45683,19 +45607,6 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
-"jNN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "jNO" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -47404,19 +47315,6 @@
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
-"kgh" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "kgj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -47450,13 +47348,29 @@
 /obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"kgH" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
+"kgF" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 4
 	},
-/area/station/security/lobby)
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos/atmos_office)
+"kgH" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/engineering/atmos/atmos_office)
 "khm" = (
 /obj/machinery/power/apc{
 	name = "apc down";
@@ -48739,6 +48653,20 @@
 	icon_state = "darkred"
 	},
 /area/station/security/checkpoint/escape)
+"kvc" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_corner";
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "arrows_white";
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/hallway/secondary/entry)
 "kvh" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -48746,17 +48674,6 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/lobby)
-"kvi" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos/atmos_office)
 "kvu" = (
 /turf/simulated/wall,
 /area/station/civilian/bar)
@@ -48933,6 +48850,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"kyb" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/engineering/monitoring)
 "kyd" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable{
@@ -49263,16 +49195,6 @@
 	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
-	},
-/area/station/hallway/secondary/entry)
-"kBE" = (
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
 "kBF" = (
@@ -50031,6 +49953,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/maintenance/incinerator)
+"kIT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "kIU" = (
 /turf/simulated/wall,
 /area/station/civilian/cold_room)
@@ -50446,6 +50381,21 @@
 "kMA" = (
 /turf/simulated/floor/carpet,
 /area/station/bridge/captain_quarters)
+"kMI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "kMJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/turf_decal{
@@ -50561,26 +50511,6 @@
 	icon_state = "white"
 	},
 /area/station/civilian/dormitories)
-"kOo" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "kOx" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(25)
@@ -50906,6 +50836,13 @@
 	icon_state = "vaultfull"
 	},
 /area/station/storage/tech)
+"kSL" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=CS-AR";
+	location = "SWW-FC"
+	},
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "kSN" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -51833,11 +51770,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/gateway)
-"lcG" = (
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "lcI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -52278,11 +52210,21 @@
 	},
 /area/station/cargo/storage)
 "ljq" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 28
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/wood,
-/area/station/bridge/captain_quarters)
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "ljv" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -52341,14 +52283,10 @@
 	},
 /area/station/cargo/office)
 "lki" = (
-/obj/structure/closet/emcloset,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/security/blueshield)
 "lkl" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -52853,16 +52791,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
-"lqu" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSE-FC";
-	location = "SEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "lqF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -55301,6 +55229,15 @@
 	},
 /turf/simulated/floor,
 /area/station/medical/storage)
+"lRR" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "lRS" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -55635,6 +55572,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
+"lWG" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "lWH" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -56114,16 +56060,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
-"mdd" = (
-/obj/machinery/light/smart,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "mdk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/stool/bed/chair/office/dark,
@@ -56957,19 +56893,6 @@
 	},
 /turf/simulated/floor,
 /area/station/gateway)
-"mmK" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_corner"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "arrows_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "black"
-	},
-/area/station/hallway/secondary/entry)
 "mmN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -57060,9 +56983,6 @@
 /area/station/security/checkpoint/escape)
 "mnD" = (
 /obj/item/weapon/flora/random,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
-	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "yellowcorner"
@@ -57668,15 +57588,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"mub" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-B";
-	location = "S-MB"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/secondary/entry)
 "mue" = (
 /obj/effect/decal/turf_decal/wood/dark{
 	icon_state = "siding_wood_corner";
@@ -59012,6 +58923,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"mKE" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=N-MB";
+	location = "NNW-B"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "mKJ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -59905,19 +59823,26 @@
 /obj/structure/filingcabinet/medical,
 /turf/simulated/floor/wood,
 /area/station/bridge/hop_office)
-"mUy" = (
-/obj/structure/disposalpipe/segment{
+"mUz" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NW-B";
-	location = "NE-FC"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn_corner"
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "redcorner"
 	},
-/area/station/hallway/primary/central)
+/area/station/security/prison)
 "mUL" = (
 /obj/machinery/atm{
 	pixel_y = -28
@@ -60001,17 +59926,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
-"mVn" = (
-/obj/machinery/light/smart,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DS";
-	location = "DN-W"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "purplecorner"
-	},
-/area/station/hallway/primary/central)
 "mVt" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -60105,6 +60019,17 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/chapel/mass_driver)
+"mWj" = (
+/obj/machinery/light/smart{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -28
+	},
+/turf/simulated/floor{
+	icon_state = "wooden-2"
+	},
+/area/station/civilian/gym)
 "mWq" = (
 /obj/structure/stool/bed/chair{
 	dir = 1
@@ -60255,13 +60180,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
-"mYf" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=N-MB";
-	location = "NNW-B"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "mYj" = (
 /turf/simulated/wall/r_wall,
 /area/station/rnd/mixing)
@@ -60606,6 +60524,13 @@
 	icon_state = "whitehall"
 	},
 /area/station/rnd/hallway)
+"ncd" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-MB";
+	location = "N-MB"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "ncg" = (
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
@@ -60862,6 +60787,15 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"ngf" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 5
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "ngn" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -61040,15 +60974,6 @@
 	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
-"nip" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 29
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "blackcorner"
-	},
-/area/station/hallway/primary/starboard)
 "niq" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -61555,16 +61480,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/station/maintenance/chapel)
-"noE" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
 "noM" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -61838,6 +61753,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/tcommsat/chamber)
+"nqP" = (
+/obj/item/weapon/flora/random,
+/obj/machinery/light/smart{
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/station/rnd/hallway/lobby)
 "nqQ" = (
 /obj/structure/stool/bed,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -62076,12 +62000,6 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/hallway)
-"ntN" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
-	},
-/turf/simulated/floor/carpet/red,
-/area/station/security/detectives_office)
 "nub" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -62265,15 +62183,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
-"nwD" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DN";
-	location = "SSE-FC"
-	},
-/turf/simulated/floor{
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "nwF" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable{
@@ -62751,6 +62660,18 @@
 	icon_state = "greencorner"
 	},
 /area/station/civilian/hydroponics)
+"nBx" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "nBB" = (
 /obj/machinery/power/apc/largecell{
 	dir = 1;
@@ -62784,17 +62705,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/reception)
-"nBW" = (
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
 "nCa" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -62906,6 +62816,9 @@
 	},
 /area/station/security/main)
 "nDw" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 29
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "whitepurplecorner"
@@ -63421,6 +63334,19 @@
 	icon_state = "greenblue"
 	},
 /area/station/civilian/hydroponics)
+"nJd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NW-B";
+	location = "NE-FC"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "nJf" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -63500,18 +63426,6 @@
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall,
 /area/station/engineering/engine)
-"nJx" = (
-/obj/structure/stool/bed/chair/metal/black{
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "nJB" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -64678,19 +64592,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/rnd/scibreak)
-"nXk" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "nXl" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
@@ -65152,6 +65053,19 @@
 	icon_state = "wooden-2"
 	},
 /area/station/civilian/gym)
+"obM" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_corner"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "arrows_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/hallway/secondary/entry)
 "oci" = (
 /obj/structure/stool/bed/chair/comfy/brown{
 	dir = 4
@@ -65331,9 +65245,27 @@
 "oer" = (
 /turf/simulated/wall/r_wall,
 /area/station/bridge/ai_upload)
+"oes" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
+	},
+/turf/simulated/floor/carpet/red,
+/area/station/security/detectives_office)
 "oex" = (
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/singularity)
+"oeE" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "oeN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -65829,6 +65761,22 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
+"okD" = (
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Entry Shuttle Airlock";
+	req_one_access = list(13)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "okM" = (
 /turf/environment/space,
 /area/shuttle/syndicate/northeast)
@@ -65924,19 +65872,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
-"omc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 9
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "omd" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -67108,18 +67043,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/brig)
-"oCX" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "oCZ" = (
 /turf/simulated/wall,
 /area/station/bridge/teleporter)
@@ -67367,6 +67290,16 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/chargebay)
+"oFY" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "oGb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -67382,19 +67315,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"oGg" = (
-/obj/machinery/light/smart{
-	dir = 4
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NE-FC";
-	location = "NEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "oGh" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
@@ -67596,16 +67516,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
-"oIs" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "oIK" = (
 /turf/simulated/wall/r_wall,
 /area/station/rnd/tox_launch)
@@ -68222,6 +68132,15 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/qm)
+"oOx" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DN";
+	location = "SSE-FC"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "oOy" = (
 /obj/structure/sign/nanotrasen{
 	pixel_y = -32
@@ -68856,19 +68775,6 @@
 /obj/item/weapon/flora/random,
 /turf/simulated/floor,
 /area/station/gateway)
-"oWR" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "oXd" = (
 /obj/structure/closet/secure_closet/injection,
 /turf/simulated/floor{
@@ -68904,26 +68810,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/storage/primary)
-"oXz" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "oXA" = (
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -69965,6 +69851,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/recycler)
+"pjY" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Security";
+	location = "S-C"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "pka" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -70126,16 +70021,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/minisat_secure_area)
-"plo" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "plp" = (
 /obj/structure/stool/bed/chair,
 /turf/simulated/floor{
@@ -71605,17 +71490,17 @@
 	},
 /area/station/engineering/atmos)
 "pBf" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
 	},
 /obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
+	icon_state = "warn"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/engineering/engine)
+/area/station/security/armoury)
 "pBn" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -71798,14 +71683,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/cargo/recycler)
-"pDr" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "pDB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -72831,6 +72708,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"pPI" = (
+/obj/structure/stool/bed/chair/metal/black{
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "pPK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -73187,15 +73076,6 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/break_room)
-"pSV" = (
-/obj/machinery/vending/coffee,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/primary/central)
 "pSX" = (
 /obj/structure/stool/bed/roller,
 /turf/simulated/floor{
@@ -73716,6 +73596,26 @@
 /obj/item/weapon/storage/wallet,
 /turf/simulated/floor/carpet/black,
 /area/station/maintenance/engineering)
+"pZy" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "pZC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -74718,6 +74618,16 @@
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall,
 /area/station/engineering/monitoring)
+"qkZ" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/station/security/brig)
 "qlc" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -74861,6 +74771,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/storage/tech)
+"qmD" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_right"
+	},
+/turf/simulated/floor,
+/area/station/storage/tech)
 "qmP" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -74942,15 +74859,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
-"qnv" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "qnB" = (
 /obj/item/clothing/gloves/boxing/green,
 /obj/item/clothing/gloves/boxing/yellow,
@@ -74968,6 +74876,18 @@
 	icon_state = "dark"
 	},
 /area/station/maintenance/engineering)
+"qnH" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "qnN" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -75959,6 +75879,13 @@
 "qAy" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/incinerator)
+"qAz" = (
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/prison)
 "qAA" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -76511,6 +76438,12 @@
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/station/security/vacantoffice)
+"qHb" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "qHh" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable{
@@ -76669,6 +76602,13 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/robotics)
+"qIM" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "qIO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -76997,6 +76937,20 @@
 	icon_state = "dark"
 	},
 /area/station/medical/morgue)
+"qMu" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 9;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "qMw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -77468,6 +77422,14 @@
 	},
 /turf/simulated/floor,
 /area/station/storage/emergency)
+"qSr" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "qSt" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -77717,6 +77679,14 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/main)
+"qVa" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/security/prison)
 "qVm" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -78494,6 +78464,18 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
+"reZ" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "rfw" = (
 /obj/machinery/camera{
 	c_tag = "Port Primary Hallway East"
@@ -79098,27 +79080,6 @@
 	icon_state = "neutral"
 	},
 /area/station/rnd/xenobiology)
-"rmR" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Antechamber";
-	req_one_access = list(66)
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/aisat/teleport)
 "rmU" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -80029,16 +79990,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
-"rxv" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NEE-FC";
-	location = "S-SV"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "rxw" = (
 /obj/structure/table,
 /obj/item/device/paicard,
@@ -80682,15 +80633,6 @@
 	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
-"rDD" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "rDL" = (
 /obj/machinery/drone_fabricator,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -81694,6 +81636,19 @@
 	},
 /turf/simulated/floor/carpet/red,
 /area/station/security/detectives_office)
+"rNB" = (
+/obj/machinery/light/smart{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NE-FC";
+	location = "NEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "rNG" = (
 /turf/environment/space,
 /area/shuttle/syndicate/northwest)
@@ -82196,21 +82151,6 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
-"rTC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
 "rTL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -82272,6 +82212,16 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
+"rUV" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "rUY" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -83056,6 +83006,15 @@
 /mob/living/simple_animal/mouse,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"seG" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Central Access"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "seH" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
@@ -84401,6 +84360,24 @@
 /obj/item/weapon/flora/random,
 /turf/simulated/floor,
 /area/station/civilian/chapel/mass_driver)
+"stH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "stM" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red,
 /obj/structure/disposalpipe/segment,
@@ -84665,18 +84642,6 @@
 /obj/structure/closet/crate/secure/woodseccrate,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"sxe" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "sxB" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -84827,6 +84792,15 @@
 /obj/item/weapon/circuitboard/seed_extractor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"szp" = (
+/obj/structure/closet/emcloset,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "szq" = (
 /turf/simulated/floor{
 	icon_state = "darkbrown"
@@ -84856,17 +84830,6 @@
 	icon_state = "gcircuit"
 	},
 /area/station/maintenance/science)
-"szH" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "yellow"
-	},
-/area/station/engineering/atmos)
 "szQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -85524,6 +85487,16 @@
 /obj/machinery/status_display,
 /turf/simulated/wall,
 /area/station/storage/tech)
+"sHL" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-C";
+	location = "CS-AR"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "sHQ" = (
 /turf/simulated/wall/r_wall,
 /area/station/engineering/monitoring)
@@ -86117,14 +86090,6 @@
 	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
-"sOy" = (
-/obj/machinery/atm{
-	pixel_y = -28
-	},
-/turf/simulated/floor{
-	icon_state = "redyellowfull"
-	},
-/area/station/hallway/primary/fore)
 "sOD" = (
 /obj/effect/decal/turf_decal{
 	dir = 8;
@@ -86702,12 +86667,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/engineering/atmos)
-"sVN" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "browncorner"
-	},
-/area/station/cargo/storage)
 "sWq" = (
 /obj/item/weapon/flora/random,
 /obj/structure/window/thin{
@@ -87717,6 +87676,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"tjl" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "tjn" = (
 /obj/structure/stool/bed/chair/metal{
 	dir = 4
@@ -88337,23 +88307,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
-"tro" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "caution"
-	},
-/area/station/engineering/atmos/distribution)
 "try" = (
 /obj/structure/closet/secure_closet/medical1,
 /obj/structure/cable{
@@ -89009,14 +88962,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/rnd/xenobiology)
-"tzx" = (
-/obj/machinery/atm{
-	pixel_y = -28
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "tzH" = (
 /obj/machinery/power/solar_control{
 	id = "aftstarboard";
@@ -89289,6 +89234,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/maintenance/cargo)
+"tCv" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "tCz" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/cyan,
 /obj/effect/decal/turf_decal/alpha/orange{
@@ -89835,6 +89793,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/range)
+"tJn" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SE-FC";
+	location = "SW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "tJq" = (
 /turf/simulated/wall,
 /area/station/hallway/primary/fore)
@@ -89894,6 +89862,26 @@
 	icon_state = "dark"
 	},
 /area/station/medical/virology)
+"tKf" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "tKg" = (
 /obj/machinery/camera{
 	c_tag = "Upper Atmospherics North";
@@ -90208,17 +90196,6 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/library)
-"tNo" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "tNE" = (
 /obj/structure/sink{
 	dir = 4;
@@ -91088,13 +91065,6 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/port)
-"tZu" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=CS-AR";
-	location = "SWW-FC"
-	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
 "tZz" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -91152,6 +91122,17 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"uaf" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "ual" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -91321,11 +91302,18 @@
 	},
 /area/station/rnd/hallway)
 "ucx" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "cafeteria"
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
 	},
-/area/station/security/prison)
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "ucF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -91338,16 +91326,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/engineering/chiefs_office)
-"ucG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "ucP" = (
 /obj/machinery/door/airlock{
 	name = "Bar";
@@ -92911,6 +92889,13 @@
 	icon_state = "caution"
 	},
 /area/station/storage/emergency)
+"uul" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "uum" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -93692,15 +93677,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/medical/medbreak)
-"uFa" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Central Access"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "uFj" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor,
@@ -93866,24 +93842,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "uHN" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/vending/coffee,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
-/area/station/security/main)
+/area/station/hallway/primary/central)
 "uHX" = (
 /turf/simulated/floor/wood,
 /area/station/maintenance/chapel)
@@ -93962,6 +93928,15 @@
 	icon_state = "whitepurplefull"
 	},
 /area/station/rnd/xenobiology)
+"uJV" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-B";
+	location = "S-MB"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry)
 "uJW" = (
 /obj/structure/object_wall/pod{
 	icon_state = "1,2"
@@ -94125,6 +94100,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/bridge/corp_lounge)
+"uLx" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/hallway/secondary/entry)
 "uLI" = (
 /obj/structure/sign/warning,
 /turf/simulated/wall/r_wall,
@@ -94193,15 +94178,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
-"uMf" = (
-/obj/effect/decal/turf_decal/alpha/blue{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "uMg" = (
 /obj/machinery/power/solar{
 	id = "auxsolareast";
@@ -94288,12 +94264,12 @@
 /area/station/security/prison)
 "uNw" = (
 /obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-FC";
-	location = "DS"
+	codes_txt = "patrol;next_patrol=NEE-FC";
+	location = "S-SV"
 	},
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "bluecorner"
+	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
 "uNx" = (
@@ -94338,6 +94314,19 @@
 /obj/machinery/cell_charger,
 /turf/simulated/floor,
 /area/station/gateway)
+"uOh" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "uOm" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -94609,20 +94598,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
-"uRs" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_corner";
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "arrows_white";
-	dir = 8
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "black"
-	},
-/area/station/hallway/secondary/entry)
 "uRx" = (
 /obj/structure/stool/bed/chair/metal{
 	dir = 1
@@ -94855,22 +94830,6 @@
 	icon_state = "darkred"
 	},
 /area/station/hallway/primary/fore)
-"uUF" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "uUJ" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -98428,6 +98387,13 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/simulated/floor,
 /area/station/maintenance/science)
+"vLS" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-FC";
+	location = "SSW-FC"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/starboard)
 "vLX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -99015,17 +98981,15 @@
 	},
 /area/station/bridge/teleporter)
 "vTX" = (
-/obj/machinery/door_timer/cell_3{
-	pixel_x = 32;
-	pixel_y = 0;
-	dir = 4;
-	id = "Cell 3 perma"
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-B";
+	location = "SSW-B"
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "redcorner"
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
-/area/station/security/prison)
+/area/station/hallway/primary/central)
 "vUe" = (
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
@@ -99956,14 +99920,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/science)
-"weD" = (
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "yellow"
-	},
-/area/station/engineering/break_room)
 "weQ" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor{
@@ -100210,6 +100166,27 @@
 	},
 /turf/simulated/floor,
 /area/station/security/checkpoint/medbay)
+"wiC" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Antechamber";
+	req_one_access = list(66)
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/aisat/teleport)
 "wiG" = (
 /obj/structure/closet/secure_closet/barber,
 /obj/item/device/cardpay{
@@ -100559,14 +100536,14 @@
 /area/station/cargo/storage)
 "wmh" = (
 /obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SE-FC";
-	location = "SW-B"
+	codes_txt = "patrol;next_patrol=SEE-FC";
+	location = "SE-FC"
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "yellowcorner"
 	},
-/area/station/hallway/primary/central)
+/area/station/hallway/primary/port)
 "wmj" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -100794,21 +100771,19 @@
 	icon_state = "white"
 	},
 /area/station/medical/hallway)
-"woY" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+"woW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
 	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 8
+/obj/machinery/flasher{
+	id = "Cell 3 perma";
+	pixel_y = -28
 	},
 /turf/simulated/floor,
-/area/station/engineering/monitoring)
+/area/station/security/prison)
 "wpa" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -100828,6 +100803,7 @@
 "wpm" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
+	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/station/security/lobby)
@@ -101284,19 +101260,6 @@
 "wwi" = (
 /turf/simulated/wall,
 /area/station/maintenance/atmos)
-"wwn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/flasher{
-	id = "Cell 3 perma";
-	pixel_y = -28
-	},
-/turf/simulated/floor,
-/area/station/security/prison)
 "wwp" = (
 /obj/structure/table/reinforced,
 /obj/item/device/aicard,
@@ -101365,20 +101328,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/maintenance/science)
-"wxp" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 9;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "wxA" = (
 /obj/machinery/door/airlock/glass{
 	name = "Holodeck Door"
@@ -102318,7 +102267,7 @@
 "wHb" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_left"
+	icon_state = "bot_right"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -103512,14 +103461,6 @@
 	icon_state = "barber"
 	},
 /area/station/medical/storage)
-"wXl" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/turf/simulated/floor{
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "wXp" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -104292,6 +104233,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"xfQ" = (
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "xfW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -105532,6 +105484,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
+"xuq" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SWW-FC";
+	location = "SW-FC"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "xut" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -106478,6 +106440,16 @@
 	},
 /turf/simulated/wall,
 /area/station/hallway/primary/starboard)
+"xEa" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "xEl" = (
 /obj/structure/table,
 /obj/item/device/camera/polar,
@@ -107223,6 +107195,15 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
+"xMW" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "xNJ" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /turf/simulated/floor/engine,
@@ -108265,6 +108246,19 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
+"xYF" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "xYP" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/cleanable/dirt,
@@ -108789,6 +108783,14 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
+"yeU" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/simulated/floor{
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "yeY" = (
 /obj/effect/decal/turf_decal{
 	dir = 8;
@@ -118651,7 +118653,7 @@ eXX
 pGn
 fBB
 pGn
-rmR
+wiC
 pGn
 pGn
 oer
@@ -132006,7 +132008,7 @@ xFF
 xFG
 flb
 uDn
-weD
+izL
 ude
 ehA
 geB
@@ -132263,7 +132265,7 @@ qnQ
 hEd
 fDg
 owf
-weD
+izL
 hkb
 ehA
 fUz
@@ -132766,7 +132768,7 @@ oLJ
 kFc
 kFc
 cEO
-szH
+tjl
 azQ
 pfp
 imT
@@ -133012,7 +133014,7 @@ qSk
 qdn
 naA
 kdJ
-oWR
+xYF
 xqQ
 fmh
 mNB
@@ -133020,8 +133022,8 @@ bfy
 cmG
 dup
 htY
-oIs
-oIs
+jFY
+jFY
 nwM
 tCz
 gRR
@@ -133276,7 +133278,7 @@ nLs
 bTE
 tUm
 oPF
-kgh
+uOh
 rSb
 umn
 svw
@@ -134040,7 +134042,7 @@ bsZ
 fZH
 cTK
 whA
-fUo
+kgH
 iDO
 iDO
 iDO
@@ -134049,8 +134051,8 @@ vCV
 lFG
 waB
 fMO
-sxe
-fKC
+jEs
+reZ
 kHT
 vPk
 vPk
@@ -134299,7 +134301,7 @@ qcT
 mrP
 daq
 daq
-kvi
+kgF
 egG
 iEf
 hrT
@@ -134841,9 +134843,9 @@ hdV
 bhn
 evV
 oKM
-iYG
+nBx
 wCx
-pBf
+oeE
 oDZ
 bau
 nkc
@@ -135100,7 +135102,7 @@ enq
 bgZ
 gCp
 tRh
-uUF
+ljq
 oyx
 mRP
 eZT
@@ -135854,7 +135856,7 @@ adw
 adw
 adw
 wjD
-woY
+kyb
 cgv
 owM
 ekM
@@ -136357,7 +136359,7 @@ jlK
 tEF
 tne
 cEZ
-tro
+apD
 iGS
 ciX
 jau
@@ -136892,7 +136894,7 @@ qTx
 qTx
 lGc
 rjD
-wXl
+yeU
 uSc
 uib
 uSc
@@ -137139,13 +137141,13 @@ tEF
 sHQ
 dpc
 sHQ
-jEs
 blv
+bcl
 sqb
 uck
 sqb
+foe
 hQQ
-gDv
 qTx
 bUU
 iky
@@ -137411,7 +137413,7 @@ doE
 doE
 doE
 lgU
-gpJ
+wmh
 mhm
 doE
 mnD
@@ -137909,7 +137911,7 @@ wwi
 aYN
 wwi
 lfm
-lqu
+aSi
 tZn
 oyb
 nAM
@@ -137927,7 +137929,7 @@ oyb
 bzt
 bzt
 rcq
-nwD
+oOx
 tYK
 wtC
 wtC
@@ -138943,7 +138945,7 @@ xNR
 rMP
 nAi
 vfr
-auB
+iDw
 rDd
 jcO
 iNE
@@ -139457,7 +139459,7 @@ xNR
 oYv
 cGN
 vzT
-iDw
+qmD
 oVN
 cdA
 jTf
@@ -139700,7 +139702,7 @@ tRk
 vdt
 rwG
 srt
-grs
+wHb
 dOS
 rfL
 qsE
@@ -139957,7 +139959,7 @@ aSY
 uum
 lVS
 srt
-wHb
+blc
 uos
 gTB
 kst
@@ -140160,14 +140162,14 @@ kHU
 kHU
 kHU
 yaE
-ejv
+okD
 yaE
 kHU
 plf
 plf
 kHU
 yaE
-ejv
+okD
 yaE
 kHU
 kHU
@@ -140674,14 +140676,14 @@ yaE
 ffS
 aev
 yaE
-guc
+aWC
 yaE
 aqg
 aqg
 aqg
 mlH
 yaE
-guc
+aWC
 yaE
 eeB
 ffS
@@ -140728,7 +140730,7 @@ kBq
 biv
 pED
 bNa
-noE
+xEa
 kIU
 lBN
 yeY
@@ -140985,7 +140987,7 @@ dtM
 fty
 abG
 vLv
-noE
+xEa
 kIU
 jVV
 ekm
@@ -141702,7 +141704,7 @@ yaE
 ffS
 eeB
 yaE
-guc
+aWC
 yaE
 mlH
 nhe
@@ -142061,7 +142063,7 @@ oZa
 xyx
 dJC
 gjY
-bJx
+nqP
 kdp
 xfI
 eIi
@@ -142216,7 +142218,7 @@ kHU
 kHU
 kHU
 yaE
-ejv
+okD
 yaE
 kHU
 plf
@@ -142753,11 +142755,11 @@ dbB
 idn
 fRR
 ofi
-glf
+jJx
 miI
 ffS
 jjY
-lki
+szp
 wwi
 pkS
 wwi
@@ -143047,7 +143049,7 @@ gNR
 fZQ
 nIu
 qMb
-pSV
+uHN
 jxa
 egV
 aaz
@@ -143306,7 +143308,7 @@ iSv
 xXt
 vAu
 ogP
-cul
+vTX
 bAS
 nvi
 rnH
@@ -143322,7 +143324,7 @@ qbj
 qbj
 tmk
 ldb
-wmh
+tJn
 ogP
 iSi
 amv
@@ -143349,7 +143351,7 @@ vpT
 xei
 bFh
 vpT
-mVn
+cyD
 vIl
 olx
 frM
@@ -143517,7 +143519,7 @@ plf
 brw
 mko
 jsL
-mub
+uJV
 ffX
 hbE
 sTt
@@ -143786,7 +143788,7 @@ gHT
 alc
 vDr
 fDL
-gba
+hKr
 iwy
 xXt
 gNR
@@ -143818,7 +143820,7 @@ hAK
 kne
 twi
 xXt
-mUy
+nJd
 ogP
 nvi
 kRo
@@ -144292,10 +144294,10 @@ fYS
 slo
 ffS
 pLB
-glf
-nJx
-acf
+jJx
 dDs
+acf
+pPI
 aSq
 ffS
 gvF
@@ -144568,7 +144570,7 @@ hXb
 hXb
 che
 siM
-aWN
+stH
 siM
 siM
 siM
@@ -144576,7 +144578,7 @@ siM
 siM
 siM
 siM
-rTC
+kMI
 siM
 vos
 did
@@ -144834,7 +144836,7 @@ fjB
 qSx
 dtr
 czE
-sOy
+fSI
 tJq
 gIl
 rdY
@@ -145071,7 +145073,7 @@ kHU
 yaE
 hkD
 fYS
-axf
+byc
 wts
 mge
 qed
@@ -145351,13 +145353,13 @@ mpN
 uQg
 tJq
 oFm
-gQW
+qIM
 xsb
-gQW
-gQW
-gQW
+qIM
+qIM
+qIM
 mtf
-gQW
+qIM
 jpq
 bsc
 mfI
@@ -145585,7 +145587,7 @@ plf
 yaE
 vDr
 fYS
-kBE
+eOf
 tEo
 nIB
 iEL
@@ -145842,7 +145844,7 @@ kHU
 yaE
 csG
 fYS
-mdd
+ftN
 wts
 npC
 txi
@@ -145865,13 +145867,13 @@ cCx
 mES
 tJq
 ikZ
-omc
+kIT
 oki
-fTx
-fTx
-hve
+uul
+uul
+iLH
 tWH
-hve
+iLH
 qcF
 bRX
 qSi
@@ -146099,7 +146101,7 @@ kHU
 yaE
 csG
 fYS
-tzx
+fOp
 wts
 bCJ
 euO
@@ -146122,7 +146124,7 @@ tJq
 ucP
 tJq
 fSC
-jNN
+haL
 ktM
 uuo
 djH
@@ -146605,10 +146607,10 @@ fYS
 jNI
 ffS
 ylK
-btz
+grp
 cmX
 fRR
-akr
+esZ
 ryG
 ffS
 uAC
@@ -147630,7 +147632,7 @@ yaE
 yaE
 csG
 fYS
-fOp
+ncd
 alc
 gHT
 gHT
@@ -147639,7 +147641,7 @@ gHT
 gHT
 gHT
 alc
-mYf
+mKE
 fYS
 sEX
 srs
@@ -147889,12 +147891,12 @@ lrr
 fYS
 wtr
 sDu
-mmK
-jKe
-jKe
-jKe
-jKe
-uRs
+obM
+uLx
+uLx
+uLx
+uLx
+kvc
 xao
 csG
 fYS
@@ -149155,14 +149157,14 @@ xjr
 xjr
 plf
 yaE
-nBW
+xfQ
 yaE
 yaE
 yaE
 yaE
 yaE
 yaE
-nBW
+xfQ
 yaE
 plf
 plf
@@ -151098,7 +151100,7 @@ sbN
 uKh
 sHC
 npd
-nip
+eqV
 xQo
 mUL
 rmY
@@ -152058,7 +152060,7 @@ iaL
 smi
 hZU
 pqH
-ljq
+hZU
 rRo
 iaL
 qbl
@@ -152574,7 +152576,7 @@ mXl
 mXl
 mXl
 wLD
-rxv
+uNw
 iwm
 mXl
 pRS
@@ -152592,7 +152594,7 @@ oNU
 mXl
 uxx
 xMc
-jNh
+xuq
 nvi
 rnH
 cLM
@@ -152601,7 +152603,7 @@ nvi
 tOH
 mfI
 ogP
-uNw
+ejv
 sBG
 wjc
 wjc
@@ -152904,7 +152906,7 @@ xQo
 xQo
 xQo
 nKU
-ghB
+vLS
 xQo
 oPI
 mRu
@@ -153071,7 +153073,7 @@ cpR
 gtK
 cpR
 pxL
-oGg
+rNB
 ffJ
 ape
 fZz
@@ -153090,7 +153092,7 @@ hRd
 ckx
 fZz
 lMB
-gZr
+pjY
 kzb
 vAu
 psV
@@ -153104,7 +153106,7 @@ vAu
 kRo
 vAu
 kCI
-eBc
+sHL
 ogP
 lwr
 mLS
@@ -153347,7 +153349,7 @@ cmN
 act
 uuf
 xsY
-uFa
+seG
 jTW
 jTW
 jTW
@@ -153827,7 +153829,7 @@ fnT
 miA
 ojm
 lPc
-sVN
+ebs
 gaF
 rpV
 qSe
@@ -154084,11 +154086,11 @@ nkb
 adb
 hzP
 cpR
-plo
+hxc
 oOk
 uXI
 oOk
-fWL
+oFY
 xqF
 aAF
 iqI
@@ -157195,8 +157197,8 @@ plf
 xyC
 cFp
 klH
-ntN
-ntN
+oes
+oes
 hGr
 aRu
 xyC
@@ -157699,11 +157701,11 @@ plf
 plf
 plf
 uRO
-hwE
+cBK
 uRO
 plf
 uRO
-hwE
+cBK
 uRO
 plf
 xyC
@@ -157720,8 +157722,8 @@ dnn
 aEr
 wPw
 jQy
-uMf
-lcG
+xMW
+lki
 jcX
 fJg
 nPU
@@ -158213,11 +158215,11 @@ plf
 cHH
 cHH
 jxX
-iUJ
+hwE
 bjt
 stv
 jxX
-iUJ
+hwE
 jxX
 adp
 kMq
@@ -158228,9 +158230,9 @@ xyC
 xyC
 xyC
 xyC
-kgH
-jtG
 wpm
+jtG
+qHb
 fJg
 fJg
 fJg
@@ -158474,7 +158476,7 @@ opt
 kms
 cHH
 eow
-wxp
+qMu
 goK
 hYT
 nsn
@@ -158727,7 +158729,7 @@ leA
 cHH
 adG
 iGB
-ian
+qkZ
 tTk
 qMX
 aZz
@@ -158988,7 +158990,7 @@ ikW
 qXE
 rjb
 utF
-esZ
+fNf
 uLd
 lat
 nsn
@@ -159787,7 +159789,7 @@ kIM
 vst
 mDV
 vKG
-tZu
+kSL
 xoq
 tAM
 uQA
@@ -160506,14 +160508,14 @@ fAF
 fgx
 diq
 fAF
-vTX
+aNp
 eTq
 fAF
 wNM
 oPD
 tif
 rHZ
-iwN
+pZy
 czU
 tqK
 hsq
@@ -160770,7 +160772,7 @@ qZx
 qZx
 fXG
 qZx
-oXz
+tKf
 czU
 uvV
 kMw
@@ -161276,7 +161278,7 @@ blh
 cra
 hlv
 dVr
-wwn
+woW
 hlv
 fBm
 bvC
@@ -162300,7 +162302,7 @@ aXC
 bZu
 pLw
 unD
-cdd
+qVa
 oAx
 ulK
 eyO
@@ -162620,7 +162622,7 @@ obL
 swQ
 mdF
 cwA
-peS
+mWj
 sOK
 pJx
 gej
@@ -162854,7 +162856,7 @@ sxG
 uOc
 hur
 hur
-nXk
+ucx
 ekd
 lZw
 gqC
@@ -163108,7 +163110,7 @@ ixl
 mme
 uKd
 gRX
-oCX
+pBf
 sRa
 nUj
 wUB
@@ -163137,7 +163139,7 @@ ncp
 ncp
 hbR
 mWz
-apO
+qnH
 kLd
 syX
 tHk
@@ -163400,7 +163402,7 @@ eFl
 aRb
 nDG
 jjN
-cZj
+tCv
 ram
 mWz
 ucd
@@ -163607,7 +163609,7 @@ afw
 nDf
 mZo
 qUR
-uHN
+cue
 mzV
 aSh
 mpR
@@ -163908,7 +163910,7 @@ ncp
 ncp
 hbR
 mWz
-tNo
+aWz
 sIY
 qls
 uOM
@@ -164104,7 +164106,7 @@ lhK
 wVg
 aFN
 jKZ
-ucx
+fOt
 rBo
 hlv
 qxh
@@ -164368,7 +164370,7 @@ xIO
 jps
 xIO
 qZx
-kOo
+mUz
 tbS
 sZR
 kHU
@@ -164380,7 +164382,7 @@ fwH
 qoH
 vOW
 qoH
-pDr
+qSr
 umQ
 gYp
 kHU
@@ -164618,7 +164620,7 @@ jvm
 hlv
 fVW
 fPH
-ucx
+fOt
 rnI
 hlv
 pHz
@@ -164633,11 +164635,11 @@ kHU
 plf
 cYc
 ueE
-ucG
+rUV
 wcJ
 iRz
 nez
-gMq
+uaf
 hlh
 gYp
 plf
@@ -164890,11 +164892,11 @@ kHU
 kHU
 cYc
 nfj
-qnv
+lRR
 eaE
 nRk
 rZh
-eZG
+iEs
 hmN
 gYp
 kHU
@@ -164938,7 +164940,7 @@ dJL
 nRG
 oXA
 oXA
-bmL
+cxQ
 dJL
 plf
 cdR
@@ -165147,11 +165149,11 @@ plf
 kHU
 huz
 sIx
-gRB
-rDD
+ngf
+jIr
 kjv
-rDD
-hiT
+jIr
+lWG
 tEU
 huz
 plf
@@ -167196,7 +167198,7 @@ plf
 kHU
 hlv
 lrm
-bcT
+qAz
 jno
 hlv
 cBu
@@ -168276,7 +168278,7 @@ kHU
 fMh
 plf
 dJL
-bmL
+cxQ
 oXA
 oXA
 nJn

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -8465,10 +8465,11 @@
 	pixel_x = -4;
 	pixel_y = 10
 	},
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "purple"
+/obj/effect/decal/turf_decal/alpha/purple{
+	icon_state = "siding_line";
+	dir = 6
 	},
+/turf/simulated/floor,
 /area/station/rnd/hor)
 "bJz" = (
 /obj/effect/landmark{
@@ -13271,6 +13272,15 @@
 	},
 /turf/simulated/floor,
 /area/station/bridge/corp_lounge)
+"cOJ" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 10
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/hor)
 "cOS" = (
 /obj/machinery/teleport/hub,
 /turf/simulated/floor{
@@ -14241,9 +14251,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	dir = 9;
-	icon_state = "neutral"
+	dir = 8;
+	icon_state = "purplecorner"
 	},
 /area/station/rnd/hor)
 "dcr" = (
@@ -22386,7 +22397,7 @@
 /obj/item/weapon/book/manual/wiki/possible_threats,
 /obj/item/device/megaphone,
 /turf/simulated/floor{
-	icon_state = "neutral"
+	icon_state = "purplecorner"
 	},
 /area/station/rnd/hor)
 "eZH" = (
@@ -25200,9 +25211,10 @@
 	dir = 1
 	},
 /obj/item/weapon/bedsheet/rd,
-/turf/simulated/floor{
-	icon_state = "purple"
+/obj/effect/decal/turf_decal/alpha/purple{
+	icon_state = "siding_line"
 	},
+/turf/simulated/floor,
 /area/station/rnd/hor)
 "fHs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -29203,6 +29215,15 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"gBc" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/hor)
 "gBg" = (
 /obj/structure/stool/bed,
 /obj/item/weapon/bedsheet/purple,
@@ -29687,6 +29708,10 @@
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
+	},
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = 22
 	},
 /turf/simulated/floor,
 /area/station/rnd/hor)
@@ -35768,7 +35793,7 @@
 	dir = 6
 	},
 /obj/structure/disposalpipe/segment{
-	dir = 1;
+	dir = 4;
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
@@ -36367,10 +36392,11 @@
 /obj/structure/mirror{
 	pixel_y = 32
 	},
-/turf/simulated/floor{
-	dir = 10;
-	icon_state = "purple"
+/obj/effect/decal/turf_decal/alpha/purple{
+	icon_state = "siding_line";
+	dir = 10
 	},
+/turf/simulated/floor,
 /area/station/rnd/hor)
 "ihP" = (
 /obj/structure/cable{
@@ -39782,8 +39808,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor{
-	dir = 6;
-	icon_state = "neutral"
+	icon_state = "purplecorner"
 	},
 /area/station/rnd/hor)
 "iWg" = (
@@ -39922,10 +39947,7 @@
 /turf/simulated/wall/r_wall,
 /area/station/security/range)
 "iXs" = (
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutral"
-	},
+/turf/simulated/floor,
 /area/station/rnd/hor)
 "iXC" = (
 /obj/structure/cable{
@@ -46307,6 +46329,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "whitepurplecorner"
@@ -49377,14 +49400,11 @@
 	},
 /area/station/security/brig)
 "kZU" = (
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = 22
-	},
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk,
 /obj/machinery/light/smart{
 	dir = 8
+	},
+/obj/structure/rd_armor_stand{
+	pixel_y = 17
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
@@ -55324,8 +55344,7 @@
 	pixel_x = 32
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "neutral"
+	icon_state = "purplecorner"
 	},
 /area/station/rnd/hor)
 "mvD" = (
@@ -56488,6 +56507,10 @@
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/singularity)
 "mKy" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 6
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -76837,6 +76860,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "whitepurple"
@@ -78071,7 +78095,8 @@
 	network = list("SS13","Research")
 	},
 /turf/simulated/floor{
-	icon_state = "neutral"
+	dir = 8;
+	icon_state = "purplecorner"
 	},
 /area/station/rnd/hor)
 "rMI" = (
@@ -91010,6 +91035,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
+"uWX" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/hor)
 "uWZ" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/box/syringes{
@@ -92550,10 +92584,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutral"
-	},
+/turf/simulated/floor,
 /area/station/rnd/hor)
 "vqz" = (
 /obj/machinery/door/firedoor,
@@ -94816,13 +94847,19 @@
 	},
 /area/station/civilian/dormitories/service_bedrooms)
 "vTR" = (
-/obj/item/weapon/flora/random,
 /obj/machinery/requests_console/rd{
 	pixel_x = -32
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
 /turf/simulated/floor{
-	dir = 10;
-	icon_state = "neutral"
+	dir = 8;
+	icon_state = "purplecorner"
 	},
 /area/station/rnd/hor)
 "vTS" = (
@@ -96419,6 +96456,9 @@
 /area/station/maintenance/engineering)
 "wmV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -135016,8 +135056,8 @@ mkl
 svQ
 vxf
 kiL
-mKy
-mKy
+uWX
+cOJ
 hzm
 vaP
 wwp
@@ -135530,7 +135570,7 @@ mkl
 svQ
 vxf
 kiL
-mKy
+gBc
 mKy
 blq
 syE

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -1249,7 +1249,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/antechamber_interior)
 "ahI" = (
@@ -1678,6 +1678,12 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
+"alL" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
+	},
+/turf/simulated/floor/carpet/red,
+/area/station/security/detectives_office)
 "alS" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/firealarm{
@@ -2459,6 +2465,19 @@
 	icon_state = "4,3"
 	},
 /area/shuttle/supply/station)
+"asZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "ath" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3091,7 +3110,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/ai_monitored/storage_secure)
 "aAT" = (
@@ -3492,17 +3511,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/hallway/primary/starboard)
-"aFn" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "aFr" = (
 /obj/machinery/photocopier,
 /obj/effect/decal/cleanable/dirt,
@@ -3936,6 +3944,15 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"aKm" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_right"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/cold_room)
 "aKr" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3999,13 +4016,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/dormitories/courtroom)
-"aKY" = (
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/prison)
 "aLa" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
@@ -4306,27 +4316,6 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
-"aOX" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "aPm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -5535,7 +5524,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
 "bcR" = (
@@ -6019,15 +6008,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/tox_launch)
-"bhB" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "bhS" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -6098,16 +6078,6 @@
 	icon_state = "dark"
 	},
 /area/station/bridge/nuke_storage)
-"biU" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "biZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -6227,12 +6197,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/starboard)
-"bjV" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
-	},
-/turf/simulated/floor/carpet/red,
-/area/station/security/detectives_office)
 "bjW" = (
 /obj/machinery/meter{
 	name = "Mixed Air Tank In"
@@ -6414,8 +6378,7 @@
 	},
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
+	icon_state = "box_corners_white"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -7689,6 +7652,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
+"bzG" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DN";
+	location = "SSE-FC"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "bzN" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -7881,6 +7853,15 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/lobby)
+"bBs" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "bBu" = (
 /obj/structure/table/woodentable,
 /obj/item/device/taperecorder,
@@ -7888,16 +7869,6 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/library)
-"bBB" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-B";
-	location = "SSW-B"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "bBP" = (
 /obj/machinery/power/port_gen/pacman{
 	anchored = 1
@@ -8558,6 +8529,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/library)
+"bGI" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "bGL" = (
 /obj/machinery/light/smart{
 	dir = 4
@@ -8717,7 +8697,7 @@
 	pixel_y = -25
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/antechamber_interior)
 "bJc" = (
@@ -9222,7 +9202,7 @@
 	pixel_x = -26
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/teleport)
 "bOz" = (
@@ -11688,24 +11668,6 @@
 "cpR" = (
 /turf/simulated/wall,
 /area/station/cargo/storage)
-"cql" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
 "cqB" = (
 /obj/item/weapon/flora/random,
 /obj/item/device/radio/intercom{
@@ -11737,6 +11699,18 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/library)
+"cqV" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "cqW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -12180,7 +12154,7 @@
 /area/space)
 "cwC" = (
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/teleport)
 "cwM" = (
@@ -12781,7 +12755,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
 "cDr" = (
@@ -12989,7 +12963,7 @@
 /obj/item/weapon/flora/random,
 /obj/machinery/light/smart,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/antechamber_interior)
 "cFp" = (
@@ -13279,6 +13253,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
+"cHV" = (
+/obj/machinery/door_timer/cell_3{
+	pixel_x = 32;
+	pixel_y = 0;
+	dir = 4;
+	id = "Cell 3 perma"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "cIm" = (
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Antechamber";
@@ -13289,7 +13275,7 @@
 	pixel_y = 24
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/antechamber_interior)
 "cIt" = (
@@ -13432,6 +13418,20 @@
 	},
 /turf/environment/space,
 /area/shuttle/mining/station)
+"cKz" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 9;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "cKC" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/cleanable/dirt,
@@ -13547,6 +13547,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig/storage)
+"cMf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "cMg" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -14557,15 +14570,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/robotics)
-"cWF" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "cWM" = (
 /obj/effect/decal/turf_decal{
 	dir = 5;
@@ -14722,7 +14726,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
+	icon_state = "siding_line";
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -15995,18 +15999,6 @@
 /obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"doa" = (
-/obj/machinery/door_timer/cell_3{
-	pixel_x = 32;
-	pixel_y = 0;
-	dir = 4;
-	id = "Cell 3 perma"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "doE" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -16183,6 +16175,16 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/psych)
+"dqP" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-FC";
+	location = "DS"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
+/area/station/hallway/primary/central)
 "dqQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -16399,16 +16401,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
-"dtn" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
 "dtr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -16452,7 +16444,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
 "dtM" = (
@@ -16977,13 +16969,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/psych)
-"dzS" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "dAb" = (
 /obj/structure/sign/nanotrasen,
 /turf/simulated/wall/r_wall,
@@ -17515,16 +17500,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"dHD" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "dHJ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -17609,26 +17584,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/dormitories/courtroom)
-"dIz" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "dID" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor{
@@ -17977,6 +17932,15 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
+"dMN" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-B";
+	location = "S-MB"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry)
 "dNl" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
@@ -18283,7 +18247,7 @@
 	pixel_x = 22
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/antechamber_interior)
 "dSt" = (
@@ -18907,13 +18871,6 @@
 /obj/effect/decal/cleanable/vomit,
 /turf/simulated/floor/wood,
 /area/station/maintenance/medbay)
-"dYF" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-MB";
-	location = "N-MB"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "dYH" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -18952,17 +18909,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
-"dZh" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "dZk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -19287,15 +19233,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
-"ecN" = (
-/obj/effect/decal/turf_decal/alpha/blue{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "ecT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/woodentable,
@@ -19655,7 +19592,7 @@
 "ehd" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/teleport)
 "ehA" = (
@@ -19814,11 +19751,18 @@
 	},
 /area/station/hallway/primary/starboard)
 "ejv" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "cafeteria"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/area/station/security/prison)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "ejG" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 1
@@ -20818,7 +20762,7 @@
 	req_access = list(16)
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
 "evz" = (
@@ -20880,7 +20824,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
 "ewd" = (
@@ -20948,15 +20892,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/bridge/corp_lounge)
-"ewB" = (
-/obj/effect/decal/turf_decal{
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "ewE" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -21166,7 +21101,7 @@
 	network = list("MiniSat")
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/teleport)
 "eyw" = (
@@ -21547,18 +21482,6 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/engine)
-"eCW" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "eDr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -22125,7 +22048,7 @@
 "eKH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
 "eKK" = (
@@ -22984,16 +22907,6 @@
 	icon_state = "bluecorner"
 	},
 /area/station/security/lobby)
-"eUc" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-FC";
-	location = "DS"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "bluecorner"
-	},
-/area/station/hallway/primary/central)
 "eUf" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -23461,16 +23374,6 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/xenobiology)
-"fay" = (
-/obj/machinery/light/smart,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "faz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -23767,6 +23670,14 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/sleeper)
+"fdb" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/civilian/gym)
 "fdi" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/tinted,
@@ -23882,6 +23793,21 @@
 	icon_state = "bluefull"
 	},
 /area/station/civilian/locker)
+"feq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "fes" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
@@ -24202,6 +24128,14 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
+"fia" = (
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/break_room)
 "fif" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -24452,6 +24386,26 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge)
+"fkA" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "fkM" = (
 /obj/structure/window/fulltile/tinted{
 	grilled = 1;
@@ -24728,6 +24682,16 @@
 	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
+"fpE" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SWW-FC";
+	location = "SW-FC"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "fpT" = (
 /obj/structure/table/woodentable/poker,
 /obj/item/toy/cards,
@@ -26591,21 +26555,9 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/teleport)
-"fJZ" = (
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Labor Camp Shuttle Airlock";
-	req_access = list(2)
-	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/brig)
 "fKh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/decal/turf_decal{
@@ -26741,6 +26693,13 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
+"fLG" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-MB";
+	location = "N-MB"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "fLI" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -26871,11 +26830,14 @@
 /area/station/maintenance/brig)
 "fOp" = (
 /obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-FC";
-	location = "SSW-FC"
+	codes_txt = "patrol;next_patrol=S-C";
+	location = "CS-AR"
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/starboard)
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "fOF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
@@ -27074,16 +27036,6 @@
 	icon_state = "red"
 	},
 /area/station/security/brig)
-"fQl" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "fQK" = (
 /obj/effect/decal/turf_decal/alpha/dark_red{
 	icon_state = "warn";
@@ -27321,6 +27273,16 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/mixing)
+"fTZ" = (
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "fUu" = (
 /obj/effect/landmark/start/chief_engineer,
 /obj/structure/stool/bed/chair/office/light{
@@ -27656,7 +27618,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
 "fXZ" = (
@@ -27708,6 +27670,13 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
+"fYw" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "fYD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -27833,7 +27802,7 @@
 "fZY" = (
 /obj/machinery/computer/aiupload,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
 "gai" = (
@@ -28106,7 +28075,7 @@
 	req_one_access = list(66)
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/ai_monitored/storage_secure)
 "gdS" = (
@@ -30570,7 +30539,7 @@
 "gBV" = (
 /obj/machinery/computer/borgupload,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
 "gBW" = (
@@ -30595,7 +30564,6 @@
 	icon_state = "delivery"
 	},
 /obj/effect/decal/turf_decal{
-	dir = 4;
 	icon_state = "warn_corner"
 	},
 /turf/simulated/floor{
@@ -30904,6 +30872,18 @@
 	icon_state = "vaultfull"
 	},
 /area/station/engineering/atmos)
+"gGC" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "gGH" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/folder/blue,
@@ -31599,8 +31579,7 @@
 	dir = 4
 	},
 /obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 8
+	icon_state = "siding_line"
 	},
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
@@ -31738,6 +31717,13 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/singularity)
+"gRv" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=N-MB";
+	location = "NNW-B"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "gRy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -32795,15 +32781,6 @@
 /obj/random/foods/food_trash,
 /turf/simulated/floor,
 /area/station/maintenance/medbay)
-"hcI" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Central Access"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "hcM" = (
 /obj/effect/landmark/start/assistant/test_subject,
 /obj/structure/stool/bed/chair/metal/blue{
@@ -32876,13 +32853,6 @@
 /obj/machinery/status_display,
 /turf/simulated/wall,
 /area/station/engineering/engine)
-"hdM" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "hdN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -33344,6 +33314,16 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/qm)
+"hkq" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "hkt" = (
 /obj/structure/rack,
 /obj/item/weapon/crowbar,
@@ -33369,7 +33349,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/antechamber_interior)
 "hkx" = (
@@ -33526,6 +33506,27 @@
 	},
 /turf/simulated/floor,
 /area/station/medical/surgeryobs)
+"hlV" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-B";
+	location = "SSW-B"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
+"hlZ" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "hmn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -33717,16 +33718,6 @@
 	icon_state = "yellow"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
-"hoG" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSE-FC";
-	location = "SEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "hoM" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots,
@@ -33765,19 +33756,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/civilian/locker)
-"hoX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "hpb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/decal/turf_decal/alpha/dark_red{
@@ -34393,8 +34371,8 @@
 /area/station/maintenance/science)
 "hur" = (
 /obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
+	dir = 8;
+	icon_state = "warn"
 	},
 /obj/effect/decal/turf_decal{
 	dir = 4;
@@ -35484,7 +35462,7 @@
 	pixel_y = 32
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/antechamber_interior)
 "hEX" = (
@@ -35778,6 +35756,14 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/locker)
+"hHQ" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "hHS" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -35870,14 +35856,6 @@
 	icon_state = "red"
 	},
 /area/station/engineering/atmos)
-"hIP" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/civilian/gym)
 "hIQ" = (
 /obj/structure/sign/nanotrasen{
 	pixel_x = -32;
@@ -36097,14 +36075,6 @@
 	icon_state = "neutral"
 	},
 /area/station/medical/storage)
-"hLU" = (
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "yellow"
-	},
-/area/station/engineering/break_room)
 "hMb" = (
 /obj/structure/closet/wardrobe/red,
 /obj/structure/cable{
@@ -36128,6 +36098,23 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/gym)
+"hMn" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "hMx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -36218,6 +36205,18 @@
 	icon_state = "redbluefull"
 	},
 /area/station/civilian/theatre)
+"hNq" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "hNE" = (
 /obj/machinery/sleeper{
 	dir = 4
@@ -36508,7 +36507,8 @@
 	},
 /obj/machinery/portable_atmospherics/powered/pump,
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
+	icon_state = "box_corners_white";
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -36707,18 +36707,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
-"hTG" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "hUj" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -37180,16 +37168,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
-"hYh" = (
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "hYi" = (
 /obj/machinery/space_heater,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -38936,18 +38914,6 @@
 	},
 /turf/simulated/floor,
 /area/station/gateway)
-"isz" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "isB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
@@ -39076,6 +39042,19 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
+"itO" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "itP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -39114,7 +39093,7 @@
 	dir = 9
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
 "iuu" = (
@@ -39867,7 +39846,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/teleport)
 "iDo" = (
@@ -40103,7 +40082,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
 "iFV" = (
@@ -40495,7 +40474,7 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
 "iJz" = (
@@ -40615,6 +40594,24 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/robotics)
+"iLy" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "iLJ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -40624,7 +40621,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/antechamber_interior)
 "iLM" = (
@@ -41250,6 +41247,15 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/fore)
+"iRQ" = (
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "iRS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -41324,26 +41330,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/fore)
-"iSy" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "iSP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -41485,16 +41471,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
-"iUP" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SWW-FC";
-	location = "SW-FC"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "iUS" = (
 /obj/machinery/door_control{
 	id = "Singularity";
@@ -41668,7 +41644,7 @@
 	},
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/teleport)
 "iWC" = (
@@ -41849,6 +41825,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/barbershop)
+"iZd" = (
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Labor Camp Shuttle Airlock";
+	req_access = list(2)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
 "iZg" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -41912,6 +41900,17 @@
 	icon_state = "dark"
 	},
 /area/station/cargo/recycleroffice)
+"iZU" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos/atmos_office)
 "jat" = (
 /obj/machinery/porta_turret/station_default{
 	dir = 4
@@ -41922,7 +41921,7 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
 "jau" = (
@@ -42447,7 +42446,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/teleport)
 "jfI" = (
@@ -43445,6 +43444,16 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/execution)
+"jrE" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NNW-B";
+	location = "NW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "jrT" = (
 /turf/simulated/floor{
 	icon_state = "blue"
@@ -43516,19 +43525,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
-"jsg" = (
-/obj/machinery/light/smart{
-	dir = 4
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NE-FC";
-	location = "NEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "jsn" = (
 /obj/structure/sign/poster/official/do_not_question{
 	pixel_y = -32
@@ -44116,7 +44112,7 @@
 	network = list("SS13","RD","AIUpload")
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
 "jxu" = (
@@ -44158,6 +44154,26 @@
 /obj/machinery/vending/barbervend,
 /turf/simulated/floor/wood,
 /area/station/civilian/barbershop)
+"jxV" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "jxX" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -44186,7 +44202,7 @@
 "jye" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/teleport)
 "jyh" = (
@@ -44701,7 +44717,7 @@
 /area/station/civilian/gym)
 "jFo" = (
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
 "jFr" = (
@@ -45212,7 +45228,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/ai_monitored/storage_secure)
 "jKu" = (
@@ -46403,7 +46419,7 @@
 "jWu" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/antechamber_interior)
 "jWv" = (
@@ -46618,6 +46634,18 @@
 	icon_state = "neutralfull"
 	},
 /area/station/civilian/locker)
+"jYr" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "jYs" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable{
@@ -46870,8 +46898,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
 "kbS" = (
@@ -47358,14 +47389,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "kgH" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
+	icon_state = "siding_corner";
+	dir = 8
 	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
+/turf/simulated/floor,
+/area/station/engineering/atmos/atmos_office)
 "khm" = (
 /obj/machinery/power/apc{
 	name = "apc down";
@@ -48675,8 +48709,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/ai_monitored/storage_secure)
 "kwo" = (
@@ -53189,7 +53226,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
 "lvF" = (
@@ -53349,7 +53386,7 @@
 	},
 /obj/machinery/atmospherics/components/binary/pump/on,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/ai_monitored/storage_secure)
 "lxd" = (
@@ -53456,17 +53493,6 @@
 	icon_state = "red"
 	},
 /area/station/security/brig)
-"lyJ" = (
-/obj/machinery/light/smart,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DS";
-	location = "DN-W"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "purplecorner"
-	},
-/area/station/hallway/primary/central)
 "lyZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -53840,14 +53866,6 @@
 	icon_state = "dark"
 	},
 /area/station/aisat/ai_chamber)
-"lDA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/security/prison)
 "lDB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54728,6 +54746,16 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor,
 /area/station/maintenance/incinerator)
+"lNf" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SEE-FC";
+	location = "SE-FC"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "lNi" = (
 /obj/machinery/light/smart{
 	dir = 1
@@ -55047,6 +55075,13 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/hallway/primary/fore)
+"lPW" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=CS-AR";
+	location = "SWW-FC"
+	},
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "lQn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -55283,6 +55318,13 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/secondary/exit)
+"lTq" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "lTt" = (
 /turf/simulated/floor{
 	dir = 5;
@@ -55333,6 +55375,26 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/bridge/corp_lounge)
+"lUe" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "lUh" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -55427,19 +55489,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/supermatter)
-"lVm" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "lVq" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -56039,19 +56088,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/armoury)
-"meb" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "escape"
-	},
-/area/station/hallway/primary/port)
 "mev" = (
 /obj/structure/displaycase_chassis,
 /obj/effect/decal/cleanable/dirt,
@@ -56608,6 +56644,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/rnd/telesci)
+"mkn" = (
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "mko" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -58108,7 +58153,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/ai_monitored/storage_secure)
 "mBg" = (
@@ -59749,7 +59794,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/antechamber_interior)
 "mUn" = (
@@ -60846,7 +60891,7 @@
 	pixel_y = 22
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/antechamber_interior)
 "nim" = (
@@ -61285,7 +61330,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
 "nnK" = (
@@ -61898,13 +61943,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
-"nur" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=CS-AR";
-	location = "SWW-FC"
-	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
 "nuA" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/alarm{
@@ -63734,16 +63772,6 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/storage/emergency)
-"nQm" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NEE-FC";
-	location = "S-SV"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "nQo" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -63994,7 +64022,7 @@
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "box_corners_white";
-	dir = 4
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -65098,15 +65126,6 @@
 "oex" = (
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/singularity)
-"oeF" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "oeN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -65810,6 +65829,12 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
+"onT" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "browncorner"
+	},
+/area/station/cargo/storage)
 "ooi" = (
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = 28
@@ -65860,7 +65885,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/turf_decal{
-	dir = 9;
+	dir = 10;
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
@@ -66131,19 +66156,6 @@
 	icon_state = "neutral"
 	},
 /area/station/engineering/chiefs_office)
-"ote" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "oti" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -66332,6 +66344,16 @@
 	icon_state = "bluecorner"
 	},
 /area/station/maintenance/chapel)
+"ouM" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "ouN" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -66456,22 +66478,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
-"owP" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "oxs" = (
 /obj/structure/closet/athletic_mixed,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -67180,6 +67186,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/prison)
+"oGm" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Security";
+	location = "S-C"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "oGp" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -67656,6 +67671,17 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/storage)
+"oLH" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "oLJ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -67950,7 +67976,7 @@
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	dir = 6;
+	dir = 4;
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
@@ -68428,6 +68454,13 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
+"oUT" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_left"
+	},
+/turf/simulated/floor,
+/area/station/storage/tech)
 "oUW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
@@ -68609,12 +68642,6 @@
 /obj/item/weapon/flora/random,
 /turf/simulated/floor,
 /area/station/gateway)
-"oXc" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "browncorner"
-	},
-/area/station/cargo/storage)
 "oXd" = (
 /obj/structure/closet/secure_closet/injection,
 /turf/simulated/floor{
@@ -69048,7 +69075,7 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/teleport)
 "pcE" = (
@@ -69655,7 +69682,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
 "pjO" = (
@@ -70183,6 +70210,19 @@
 	icon_state = "red"
 	},
 /area/station/security/checkpoint/engi)
+"poO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/flasher{
+	id = "Cell 1 perma";
+	pixel_y = -28
+	},
+/turf/simulated/floor,
+/area/station/security/prison)
 "poS" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/turf_decal{
@@ -70292,7 +70332,7 @@
 /area/station/maintenance/engineering)
 "ppR" = (
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/antechamber_interior)
 "pqf" = (
@@ -71255,7 +71295,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/teleport)
 "pAK" = (
@@ -71908,16 +71948,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
-"pHD" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SE-FC";
-	location = "SW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "pHK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -72816,6 +72846,15 @@
 	icon_state = "purplecorner"
 	},
 /area/station/rnd/telesci)
+"pRG" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 5
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "pRL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -73773,6 +73812,15 @@
 "qdH" = (
 /turf/simulated/wall,
 /area/station/security/checkpoint/escape_custom_desk)
+"qdK" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "qdU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -74769,6 +74817,19 @@
 	icon_state = "grimy"
 	},
 /area/station/security/vacantoffice)
+"qoy" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "qoD" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/window/thin{
@@ -74914,11 +74975,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/teleport)
 "qrj" = (
@@ -74943,15 +75004,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
-"qrB" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Security";
-	location = "S-C"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "qrH" = (
 /obj/structure/object_wall/pod{
 	dir = 4;
@@ -75517,7 +75569,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
 "qyx" = (
@@ -75577,7 +75629,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/teleport)
 "qzK" = (
@@ -75770,19 +75822,6 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
-"qCc" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "qCm" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -76755,6 +76794,18 @@
 	icon_state = "darkredfull"
 	},
 /area/station/security/brig)
+"qNw" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "qNE" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/box/masks{
@@ -77700,7 +77751,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/ai_monitored/storage_secure)
 "qYH" = (
@@ -77757,6 +77808,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/supermatter)
+"qZr" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "qZv" = (
 /obj/structure/table,
 /obj/item/weapon/storage/toolbox/mechanical,
@@ -77784,7 +77845,7 @@
 	pixel_y = 22
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
 "qZV" = (
@@ -77900,7 +77961,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/ai_monitored/storage_secure)
 "raY" = (
@@ -77991,6 +78052,15 @@
 "rbY" = (
 /turf/simulated/floor,
 /area/station/security/main)
+"rcc" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "rcq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -78087,13 +78157,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/server)
-"rdF" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "rdK" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
@@ -78229,6 +78292,16 @@
 /obj/structure/sign/warning,
 /turf/simulated/wall/r_wall,
 /area/station/rnd/storage)
+"rfF" = (
+/obj/machinery/light/smart,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "rfL" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -78602,20 +78675,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/rnd/robotics)
-"rjT" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/powered/pump,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "arrival"
-	},
-/area/station/hallway/primary/port)
 "rkr" = (
 /obj/structure/rack,
 /obj/random/cloth/gloves_safe,
@@ -78785,7 +78844,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/computer/smartlight,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
 "rmo" = (
@@ -78855,6 +78914,20 @@
 	icon_state = "solarpanel"
 	},
 /area/station/solar/auxstarboard)
+"rnx" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "escape"
+	},
+/area/station/hallway/primary/port)
 "rnA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -79900,16 +79973,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
-"ryN" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkred"
-	},
-/area/station/security/brig)
 "rzd" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -80259,14 +80322,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/incinerator)
-"rBK" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "rBN" = (
 /obj/structure/window/thin/reinforced{
 	dir = 8
@@ -81334,6 +81389,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/medbay)
+"rMX" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SE-FC";
+	location = "SW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "rNc" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -81717,23 +81782,6 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
-"rRt" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "caution"
-	},
-/area/station/engineering/atmos/distribution)
 "rRv" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -81750,16 +81798,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/brig/storage)
-"rRC" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SEE-FC";
-	location = "SE-FC"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "rRF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -81779,15 +81817,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/civilian/locker)
-"rRM" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "rRQ" = (
 /obj/structure/filingcabinet,
 /obj/machinery/light/small{
@@ -82070,6 +82099,13 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/locker)
+"rVJ" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-FC";
+	location = "SSW-FC"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/starboard)
 "rVK" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -83656,6 +83692,16 @@
 /obj/structure/door_assembly/door_assembly_fre,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"snN" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NEE-FC";
+	location = "S-SV"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "snQ" = (
 /turf/simulated/floor{
 	dir = 6;
@@ -83945,6 +83991,16 @@
 	icon_state = "grimy"
 	},
 /area/station/security/detectives_office)
+"srz" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "srI" = (
 /obj/structure/window/thin/reinforced{
 	dir = 8
@@ -84610,6 +84666,13 @@
 	icon_state = "grimy"
 	},
 /area/station/storage/tools)
+"sAu" = (
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/prison)
 "sAP" = (
 /obj/structure/table/glass,
 /obj/item/device/radio/intercom{
@@ -84918,13 +84981,6 @@
 	icon_state = "darkred"
 	},
 /area/station/security/checkpoint/medbay)
-"sEj" = (
-/obj/item/weapon/flora/random,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_left"
-	},
-/turf/simulated/floor,
-/area/station/storage/tech)
 "sEp" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
@@ -85376,7 +85432,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
 "sJm" = (
@@ -86389,6 +86445,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/engineering/atmos)
+"sVK" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "sWq" = (
 /obj/item/weapon/flora/random,
 /obj/structure/window/thin{
@@ -86549,6 +86614,16 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
+"sYl" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/station/security/brig)
 "sYm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
@@ -87150,20 +87225,6 @@
 	icon_state = "dark"
 	},
 /area/station/medical/cryo)
-"tfZ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor,
-/area/station/engineering/monitoring)
 "tgi" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -87243,6 +87304,17 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
+"tgN" = (
+/obj/machinery/light/smart,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DS";
+	location = "DN-W"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "purplecorner"
+	},
+/area/station/hallway/primary/central)
 "tgP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -87593,7 +87665,7 @@
 "tlH" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
 "tlK" = (
@@ -88167,7 +88239,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/ai_monitored/storage_secure)
 "ttW" = (
@@ -88419,6 +88491,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"tws" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "cafeteria"
+	},
+/area/station/security/prison)
 "twB" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/components/unary/portables_connector{
@@ -89281,6 +89359,27 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/bridge/hop_office)
+"tGm" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "tGH" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/light/smart{
@@ -89570,20 +89669,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/engineering/atmos)
-"tKo" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 10;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "tKs" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
@@ -90018,26 +90103,6 @@
 	},
 /turf/simulated/floor,
 /area/station/medical/hallway)
-"tQo" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "tQu" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -90488,13 +90553,6 @@
 /obj/machinery/telepad,
 /turf/simulated/floor/engine,
 /area/station/rnd/telesci)
-"tWd" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=N-MB";
-	location = "NNW-B"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "tWr" = (
 /obj/structure/table/reinforced,
 /obj/item/device/mmi,
@@ -91010,25 +91068,15 @@
 	},
 /area/station/rnd/hallway)
 "ucx" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Central Access"
 	},
 /turf/simulated/floor{
-	icon_state = "redcorner"
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
-/area/station/security/prison)
+/area/station/security/lobby)
 "ucF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -91580,7 +91628,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
 "ujr" = (
@@ -92587,7 +92635,6 @@
 	name = "Central Access"
 	},
 /turf/simulated/floor{
-	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/station/security/lobby)
@@ -92731,7 +92778,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
 "uvV" = (
@@ -93015,18 +93062,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
-"uAG" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "uAM" = (
 /obj/structure/sign/directions/engineering{
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
@@ -93319,6 +93354,23 @@
 	},
 /turf/simulated/wall,
 /area/station/hallway/secondary/entry)
+"uEv" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "caution"
+	},
+/area/station/engineering/atmos/distribution)
 "uEC" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced/phoron{
@@ -93507,15 +93559,6 @@
 	icon_state = "purple"
 	},
 /area/station/rnd/xenobiology)
-"uGh" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DN";
-	location = "SSE-FC"
-	},
-/turf/simulated/floor{
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "uGq" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -93569,17 +93612,18 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "uHN" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
 	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 8
+/obj/machinery/portable_atmospherics/powered/pump,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
 	},
-/turf/simulated/floor,
-/area/station/engineering/atmos/atmos_office)
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "arrival"
+	},
+/area/station/hallway/primary/port)
 "uHX" = (
 /turf/simulated/floor/wood,
 /area/station/maintenance/chapel)
@@ -93974,14 +94018,13 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "uNw" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_left"
-	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "neutralfull"
 	},
-/area/station/civilian/cold_room)
+/area/station/security/prison)
 "uNx" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -94448,7 +94491,7 @@
 	dir = 5
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
 "uTH" = (
@@ -94502,6 +94545,16 @@
 /obj/item/device/mmi/radio_enabled,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"uUp" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSE-FC";
+	location = "SEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "uUs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor,
@@ -94663,7 +94716,7 @@
 	pixel_y = -22
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/teleport)
 "uVY" = (
@@ -95488,6 +95541,18 @@
 	icon_state = "dark"
 	},
 /area/station/bridge)
+"vgK" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "vgN" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -96050,6 +96115,13 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/telesci)
+"vnc" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "vnf" = (
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -96393,21 +96465,6 @@
 	icon_state = "3-2"
 	},
 /area/shuttle/mining/station)
-"vrr" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
 "vrt" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil/random,
@@ -96657,7 +96714,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/ai_monitored/storage_secure)
 "vtZ" = (
@@ -96979,19 +97036,6 @@
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/singularity)
-"vyT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/flasher{
-	id = "Cell 1 perma";
-	pixel_y = -28
-	},
-/turf/simulated/floor,
-/area/station/security/prison)
 "vyY" = (
 /turf/simulated/shuttle/floor/cargo{
 	icon_state = "2,1"
@@ -97578,7 +97622,7 @@
 	icon_state = "1-4"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
 "vFo" = (
@@ -97990,7 +98034,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/teleport)
 "vKG" = (
@@ -98102,17 +98146,6 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/simulated/floor,
 /area/station/maintenance/science)
-"vLT" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos/atmos_office)
 "vLX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -98312,7 +98345,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/antechamber_interior)
 "vOW" = (
@@ -98533,6 +98566,21 @@
 	icon_state = "neutral"
 	},
 /area/station/hallway/primary/central)
+"vSu" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/engineering/monitoring)
 "vSv" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal{
@@ -98700,16 +98748,15 @@
 	},
 /area/station/bridge/teleporter)
 "vTX" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "loadingarea"
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "arrow"
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "neutralfull"
 	},
-/area/station/security/brig)
+/area/station/engineering/atmos)
 "vUe" = (
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
@@ -99647,19 +99694,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
-"weV" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 9
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "wfp" = (
 /obj/machinery/light/smart,
 /obj/structure/table/glass,
@@ -99998,7 +100032,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -100909,6 +100943,26 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/surgeryobs)
+"wvg" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "wvl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -101475,11 +101529,6 @@
 	icon_state = "darkredcorners"
 	},
 /area/station/security/checkpoint/escape)
-"wBE" = (
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "wBF" = (
 /obj/machinery/mech_bay_recharge_port{
 	dir = 1
@@ -101735,6 +101784,25 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
+"wEd" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/main)
 "wEp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/item/device/radio/intercom{
@@ -101924,6 +101992,11 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
+"wGo" = (
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "wGs" = (
 /obj/structure/closet/wardrobe/white,
 /turf/simulated/floor,
@@ -101967,7 +102040,7 @@
 "wHb" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_right"
+	icon_state = "bot_left"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -102159,7 +102232,7 @@
 	},
 /obj/structure/cable,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/teleport)
 "wJu" = (
@@ -103128,6 +103201,19 @@
 	icon_state = "blackchecker"
 	},
 /area/station/maintenance/chapel)
+"wWB" = (
+/obj/machinery/light/smart{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NE-FC";
+	location = "NEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "wWD" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -103442,15 +103528,6 @@
 	},
 /turf/simulated/floor,
 /area/station/medical/storage)
-"xak" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-B";
-	location = "S-MB"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/secondary/entry)
 "xao" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -103520,7 +103597,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/ai_monitored/storage_secure)
 "xaY" = (
@@ -103750,16 +103827,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/rnd/xenobiology)
-"xee" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "xef" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/multi_tile/glass,
@@ -103921,16 +103988,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/tox_launch)
-"xfK" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-C";
-	location = "CS-AR"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "xfO" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Treatment Center";
@@ -104147,6 +104204,17 @@
 	icon_state = "caution"
 	},
 /area/station/medical/chemistry)
+"xiB" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "loadingarea"
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "arrow"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "xiI" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
@@ -105170,7 +105238,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/teleport)
 "xtN" = (
@@ -105237,7 +105305,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/teleport)
 "xuE" = (
@@ -105319,6 +105387,27 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
+"xvn" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Antechamber";
+	req_one_access = list(66)
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/aisat/teleport)
 "xvs" = (
 /obj/structure/toilet{
 	dir = 8
@@ -105594,17 +105683,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway)
-"xys" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "yellow"
-	},
-/area/station/engineering/atmos)
 "xyt" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -105770,15 +105848,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
-"xzW" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 5
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "xAc" = (
 /obj/structure/closet,
 /obj/structure/cable{
@@ -106061,18 +106130,6 @@
 /obj/structure/table,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"xCl" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "xCq" = (
 /obj/structure/sink{
 	dir = 4;
@@ -106508,6 +106565,19 @@
 	icon_state = "white"
 	},
 /area/station/rnd/hallway)
+"xIL" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "xIO" = (
 /obj/structure/stool/bed/chair{
 	dir = 8
@@ -106745,7 +106815,7 @@
 "xLs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
 "xLy" = (
@@ -107036,18 +107106,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
-"xPk" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "xPl" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -107117,25 +107175,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/blueshield)
-"xPS" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/main)
 "xPV" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -107619,6 +107658,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/carpet,
 /area/station/bridge)
+"xVk" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "xVm" = (
 /obj/machinery/alarm{
 	pixel_y = -32
@@ -108190,7 +108240,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/aisat/teleport)
 "ybu" = (
@@ -108487,7 +108537,7 @@
 	pixel_y = -24
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
 "yep" = (
@@ -108541,16 +108591,6 @@
 "yfc" = (
 /turf/simulated/floor/plating/airless,
 /area/station/rnd/test_area)
-"yfe" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NNW-B";
-	location = "NW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "yfv" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -108797,19 +108837,6 @@
 	icon_state = "dark"
 	},
 /area/station/bridge)
-"yjm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "yjy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -118400,7 +118427,7 @@ eXX
 pGn
 fBB
 pGn
-rAm
+xvn
 pGn
 pGn
 oer
@@ -131755,7 +131782,7 @@ xFF
 xFG
 flb
 uDn
-hLU
+fia
 ude
 ehA
 geB
@@ -132012,7 +132039,7 @@ qnQ
 hEd
 fDg
 owf
-hLU
+fia
 hkb
 ehA
 fUz
@@ -132250,7 +132277,7 @@ bOJ
 oKV
 dup
 dup
-lVm
+nRV
 bOD
 cmG
 xqQ
@@ -132515,7 +132542,7 @@ oLJ
 kFc
 kFc
 cEO
-xys
+xVk
 azQ
 pfp
 imT
@@ -132761,7 +132788,7 @@ qSk
 qdn
 naA
 kdJ
-nRV
+qoy
 xqQ
 fmh
 mNB
@@ -132769,8 +132796,8 @@ bfy
 cmG
 dup
 htY
-dHD
-dHD
+vTX
+vTX
 nwM
 tCz
 gRR
@@ -133025,7 +133052,7 @@ nLs
 bTE
 tUm
 oPF
-qCc
+itO
 rSb
 umn
 svw
@@ -133789,7 +133816,7 @@ bsZ
 fZH
 cTK
 whA
-uHN
+kgH
 iDO
 iDO
 iDO
@@ -133798,8 +133825,8 @@ vCV
 lFG
 waB
 fMO
-xCl
-xPk
+vgK
+cqV
 kHT
 vPk
 vPk
@@ -134046,9 +134073,9 @@ pBb
 hrT
 qcT
 mrP
-vLT
-vLT
 daq
+daq
+iZU
 egG
 iEf
 hrT
@@ -134590,9 +134617,9 @@ hdV
 bhn
 evV
 oKM
-uAG
+jYr
 wCx
-isz
+qNw
 oDZ
 bau
 nkc
@@ -134847,9 +134874,9 @@ moL
 ojN
 enq
 bgZ
-gCp
+hMn
 tRh
-owP
+gCp
 oyx
 mRP
 eZT
@@ -135346,7 +135373,7 @@ gpz
 nds
 gpz
 wjD
-tfZ
+gPB
 bbv
 awp
 odu
@@ -135603,7 +135630,7 @@ adw
 adw
 adw
 wjD
-gPB
+vSu
 cgv
 owM
 ekM
@@ -136106,7 +136133,7 @@ jlK
 tEF
 tne
 cEZ
-rRt
+uEv
 iGS
 ciX
 jau
@@ -136888,13 +136915,13 @@ tEF
 sHQ
 dpc
 sHQ
+rnx
 blv
-meb
 sqb
 uck
 sqb
-rjT
 hQQ
+uHN
 qTx
 bUU
 iky
@@ -137160,7 +137187,7 @@ doE
 doE
 doE
 lgU
-rRC
+lNf
 mhm
 doE
 mnD
@@ -137658,7 +137685,7 @@ wwi
 aYN
 wwi
 lfm
-hoG
+uUp
 tZn
 oyb
 nAM
@@ -137676,7 +137703,7 @@ oyb
 bzt
 bzt
 rcq
-uGh
+bzG
 tYK
 wtC
 wtC
@@ -138692,7 +138719,7 @@ xNR
 rMP
 nAi
 vfr
-sEj
+oUT
 rDd
 jcO
 iNE
@@ -139449,7 +139476,7 @@ tRk
 vdt
 rwG
 srt
-wHb
+aKm
 dOS
 rfL
 qsE
@@ -139706,7 +139733,7 @@ aSY
 uum
 lVS
 srt
-uNw
+wHb
 uos
 gTB
 kst
@@ -140477,7 +140504,7 @@ kBq
 biv
 pED
 bNa
-dtn
+ouM
 kIU
 lBN
 yeY
@@ -140734,7 +140761,7 @@ dtM
 fty
 abG
 vLv
-dtn
+ouM
 kIU
 jVV
 ekm
@@ -143055,7 +143082,7 @@ iSv
 xXt
 vAu
 ogP
-bBB
+hlV
 bAS
 nvi
 rnH
@@ -143071,7 +143098,7 @@ qbj
 qbj
 tmk
 ldb
-pHD
+rMX
 ogP
 iSi
 amv
@@ -143098,7 +143125,7 @@ vpT
 xei
 bFh
 vpT
-lyJ
+tgN
 vIl
 olx
 frM
@@ -143266,7 +143293,7 @@ plf
 brw
 mko
 jsL
-xak
+dMN
 ffX
 hbE
 sTt
@@ -143535,7 +143562,7 @@ gHT
 alc
 vDr
 fDL
-yfe
+jrE
 iwy
 xXt
 gNR
@@ -144316,17 +144343,17 @@ hXb
 hXb
 hXb
 che
-kgH
-cql
-kgH
-kgH
-kgH
-kgH
-kgH
-kgH
-kgH
-vrr
-kgH
+iRQ
+iLy
+iRQ
+iRQ
+iRQ
+iRQ
+iRQ
+iRQ
+iRQ
+feq
+iRQ
 vos
 did
 did
@@ -144820,7 +144847,7 @@ kHU
 yaE
 hkD
 fYS
-ewB
+mkn
 wts
 mge
 qed
@@ -145100,13 +145127,13 @@ mpN
 uQg
 tJq
 oFm
-dzS
+lTq
 xsb
-dzS
-dzS
-dzS
+lTq
+lTq
+lTq
 mtf
-dzS
+lTq
 jpq
 bsc
 mfI
@@ -145334,7 +145361,7 @@ plf
 yaE
 vDr
 fYS
-hYh
+fTZ
 tEo
 nIB
 iEL
@@ -145591,7 +145618,7 @@ kHU
 yaE
 csG
 fYS
-fay
+rfF
 wts
 npC
 txi
@@ -145614,13 +145641,13 @@ cCx
 mES
 tJq
 ikZ
-weV
+asZ
 oki
-hdM
-hdM
-hoX
+fYw
+fYw
+ejv
 tWH
-hoX
+ejv
 qcF
 bRX
 qSi
@@ -145871,7 +145898,7 @@ tJq
 ucP
 tJq
 fSC
-yjm
+cMf
 ktM
 uuo
 djH
@@ -147379,7 +147406,7 @@ yaE
 yaE
 csG
 fYS
-dYF
+fLG
 alc
 gHT
 gHT
@@ -147388,7 +147415,7 @@ gHT
 gHT
 gHT
 alc
-tWd
+gRv
 fYS
 sEX
 srs
@@ -152323,7 +152350,7 @@ mXl
 mXl
 mXl
 wLD
-nQm
+snN
 iwm
 mXl
 pRS
@@ -152341,7 +152368,7 @@ oNU
 mXl
 uxx
 xMc
-iUP
+fpE
 nvi
 rnH
 cLM
@@ -152350,7 +152377,7 @@ nvi
 tOH
 mfI
 ogP
-eUc
+dqP
 sBG
 wjc
 wjc
@@ -152653,7 +152680,7 @@ xQo
 xQo
 xQo
 nKU
-fOp
+rVJ
 xQo
 oPI
 mRu
@@ -152820,7 +152847,7 @@ cpR
 gtK
 cpR
 pxL
-jsg
+wWB
 ffJ
 ape
 fZz
@@ -152839,7 +152866,7 @@ hRd
 ckx
 fZz
 lMB
-qrB
+oGm
 kzb
 vAu
 psV
@@ -152853,7 +152880,7 @@ vAu
 kRo
 vAu
 kCI
-xfK
+fOp
 ogP
 lwr
 mLS
@@ -153094,9 +153121,9 @@ erD
 erD
 cmN
 act
-uuf
+ucx
 xsY
-hcI
+uuf
 jTW
 jTW
 jTW
@@ -153576,7 +153603,7 @@ fnT
 miA
 ojm
 lPc
-oXc
+onT
 gaF
 rpV
 qSe
@@ -153833,11 +153860,11 @@ nkb
 adb
 hzP
 cpR
-fQl
-biU
-uXI
-biU
+qZr
 oOk
+uXI
+oOk
+srz
 xqF
 aAF
 iqI
@@ -156944,8 +156971,8 @@ plf
 xyC
 cFp
 klH
-bjV
-bjV
+alL
+alL
 hGr
 aRu
 xyC
@@ -157469,8 +157496,8 @@ dnn
 aEr
 wPw
 jQy
-ecN
-wBE
+sVK
+wGo
 jcX
 fJg
 nPU
@@ -157962,11 +157989,11 @@ plf
 cHH
 cHH
 jxX
-fJZ
+iZd
 bjt
 stv
 jxX
-fJZ
+iZd
 jxX
 adp
 kMq
@@ -157977,7 +158004,7 @@ xyC
 xyC
 xyC
 xyC
-rdF
+vnc
 jtG
 wpm
 fJg
@@ -158219,11 +158246,11 @@ wVt
 cHH
 cjS
 bNB
-tKo
+opt
 kms
 cHH
 eow
-opt
+cKz
 goK
 hYT
 nsn
@@ -158476,7 +158503,7 @@ leA
 cHH
 adG
 iGB
-ryN
+sYl
 tTk
 qMX
 aZz
@@ -158737,7 +158764,7 @@ ikW
 qXE
 rjb
 utF
-vTX
+xiB
 uLd
 lat
 nsn
@@ -159536,7 +159563,7 @@ kIM
 vst
 mDV
 vKG
-nur
+lPW
 xoq
 tAM
 uQA
@@ -160255,14 +160282,14 @@ fAF
 fgx
 diq
 fAF
-doa
+cHV
 eTq
 fAF
 wNM
 oPD
 tif
 rHZ
-tQo
+lUe
 czU
 tqK
 hsq
@@ -160519,7 +160546,7 @@ qZx
 qZx
 fXG
 qZx
-ucx
+wvg
 czU
 uvV
 kMw
@@ -161031,7 +161058,7 @@ fBm
 bvC
 hlv
 vqQ
-vyT
+poO
 qZx
 tnw
 fLE
@@ -162049,7 +162076,7 @@ aXC
 bZu
 pLw
 unD
-lDA
+uNw
 oAx
 ulK
 eyO
@@ -162601,9 +162628,9 @@ ilq
 uKd
 sxG
 uOc
-ote
-ote
 hur
+hur
+xIL
 ekd
 lZw
 gqC
@@ -162857,7 +162884,7 @@ ixl
 mme
 uKd
 gRX
-eCW
+gGC
 sRa
 nUj
 wUB
@@ -162886,13 +162913,13 @@ ncp
 ncp
 hbR
 mWz
-hTG
+hNq
 kLd
 syX
 tHk
 tHk
 dbf
-aOX
+tGm
 ram
 mWz
 lNQ
@@ -163356,7 +163383,7 @@ afw
 nDf
 mZo
 qUR
-xPS
+wEd
 mzV
 aSh
 mpR
@@ -163657,13 +163684,13 @@ ncp
 ncp
 hbR
 mWz
-dZh
+hlZ
 sIY
 qls
 uOM
 uOM
 aeG
-dIz
+jxV
 ram
 mWz
 hPr
@@ -163853,7 +163880,7 @@ lhK
 wVg
 aFN
 jKZ
-ejv
+tws
 rBo
 hlv
 qxh
@@ -164117,7 +164144,7 @@ xIO
 jps
 xIO
 qZx
-iSy
+fkA
 tbS
 sZR
 kHU
@@ -164129,7 +164156,7 @@ fwH
 qoH
 vOW
 qoH
-rBK
+hHQ
 umQ
 gYp
 kHU
@@ -164367,7 +164394,7 @@ jvm
 hlv
 fVW
 fPH
-ejv
+tws
 rnI
 hlv
 pHz
@@ -164382,11 +164409,11 @@ kHU
 plf
 cYc
 ueE
-xee
+hkq
 wcJ
 iRz
 nez
-aFn
+oLH
 hlh
 gYp
 plf
@@ -164639,11 +164666,11 @@ kHU
 kHU
 cYc
 nfj
-bhB
+rcc
 eaE
 nRk
 rZh
-rRM
+bGI
 hmN
 gYp
 kHU
@@ -164687,7 +164714,7 @@ dJL
 nRG
 oXA
 oXA
-hIP
+fdb
 dJL
 plf
 cdR
@@ -164896,11 +164923,11 @@ plf
 kHU
 huz
 sIx
-xzW
-cWF
+pRG
+qdK
 kjv
-cWF
-oeF
+qdK
+bBs
 tEU
 huz
 plf
@@ -166945,7 +166972,7 @@ plf
 kHU
 hlv
 lrm
-aKY
+sAu
 jno
 hlv
 cBu
@@ -168025,7 +168052,7 @@ kHU
 fMh
 plf
 dJL
-hIP
+fdb
 oXA
 oXA
 nJn

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -40815,6 +40815,15 @@
 /obj/structure/window/thin,
 /turf/simulated/floor/grass,
 /area/station/hallway/primary/fore)
+"jbe" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 5
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/hallway/secondary/exit)
 "jbl" = (
 /obj/structure/closet/secure_closet/scientist,
 /obj/item/device/cardpay{
@@ -55758,6 +55767,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/storage/tech)
+"msg" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/hallway/secondary/exit)
 "msk" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -66648,8 +66666,7 @@
 	pixel_y = -26
 	},
 /obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 6
+	icon_state = "siding_wood_line"
 	},
 /turf/simulated/floor{
 	icon_state = "wooden"
@@ -78021,10 +78038,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 4
-	},
 /turf/simulated/floor{
 	icon_state = "wooden"
 	},
@@ -86573,6 +86586,15 @@
 	icon_state = "white"
 	},
 /area/station/rnd/hallway)
+"tAZ" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/hallway/secondary/exit)
 "tBc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -87124,7 +87146,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/decal/turf_decal/wood/dark{
 	icon_state = "siding_wood_line";
-	dir = 5
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "wooden"
@@ -148294,9 +148316,9 @@ xQo
 ukM
 rmY
 kbr
-nGt
-nGt
-nGt
+jbe
+tAZ
+msg
 ryF
 nGt
 djc

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -2751,7 +2751,10 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/obj/machinery/hologram/holopad,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/civilian/locker)
 "axc" = (
 /obj/machinery/computer/diseasesplicer,
@@ -4632,8 +4635,8 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_white"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -5431,8 +5434,8 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_white"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -10153,8 +10156,12 @@
 /area/station/maintenance/escape)
 "cce" = (
 /obj/structure/closet/wardrobe/white,
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 8
+	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "bluefull"
 	},
 /area/station/civilian/locker)
 "ccf" = (
@@ -12465,11 +12472,11 @@
 	pixel_x = 32
 	},
 /obj/item/weapon/storage/wallet,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/civilian/locker)
 "cDM" = (
@@ -13423,7 +13430,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/civilian/locker)
 "cOe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -14712,7 +14721,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	icon_state = "cafeteria"
+	icon_state = "neutralfull"
 	},
 /area/station/civilian/locker)
 "dfw" = (
@@ -16943,8 +16952,12 @@
 /obj/machinery/light/smart{
 	dir = 8
 	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 4
+	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "bluefull"
 	},
 /area/station/civilian/locker)
 "dGp" = (
@@ -17375,6 +17388,9 @@
 "dKX" = (
 /obj/structure/stool/bed,
 /obj/item/weapon/bedsheet/yellow,
+/obj/machinery/status_display{
+	pixel_x = 32
+	},
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories)
 "dLb" = (
@@ -18155,8 +18171,12 @@
 /area/station/bridge/meeting_room)
 "dVF" = (
 /obj/machinery/vending/cigarette,
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 8
+	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "bluefull"
 	},
 /area/station/civilian/locker)
 "dVH" = (
@@ -18877,8 +18897,12 @@
 "eel" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 4
+	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "bluefull"
 	},
 /area/station/civilian/locker)
 "een" = (
@@ -22641,11 +22665,11 @@
 /area/station/aisat/ai_chamber)
 "eXY" = (
 /obj/structure/closet/secure_closet/personal,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/civilian/locker)
 "eYc" = (
@@ -23242,8 +23266,12 @@
 /area/station/civilian/dormitories/courtroom)
 "fek" = (
 /obj/structure/closet/wardrobe/grey,
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 8
+	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "bluefull"
 	},
 /area/station/civilian/locker)
 "fes" = (
@@ -28501,6 +28529,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"goz" = (
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -32
+	},
+/turf/simulated/floor/carpet/purple,
+/area/station/civilian/dormitories)
 "goK" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -29730,6 +29765,9 @@
 "gBg" = (
 /obj/structure/stool/bed,
 /obj/item/weapon/bedsheet/purple,
+/obj/machinery/status_display{
+	pixel_x = 32
+	},
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories)
 "gBi" = (
@@ -29881,6 +29919,13 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/primary/fore)
+"gDY" = (
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -32
+	},
+/turf/simulated/floor/carpet/blue2,
+/area/station/civilian/dormitories)
 "gEa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -31597,7 +31642,7 @@
 	pixel_x = -12
 	},
 /turf/simulated/floor{
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/civilian/locker)
 "gYo" = (
@@ -32220,7 +32265,7 @@
 	dir = 5
 	},
 /turf/simulated/floor{
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/civilian/locker)
 "hgm" = (
@@ -34607,8 +34652,11 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/status_display{
+	pixel_y = 32
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/civilian/locker)
 "hFB" = (
@@ -34999,6 +35047,20 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
+"hKe" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 28;
+	pixel_y = -5
+	},
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/station/civilian/dormitories)
 "hKj" = (
 /obj/machinery/status_display{
 	pixel_x = -32
@@ -35934,8 +35996,12 @@
 /area/station/cargo/storage)
 "hWA" = (
 /obj/structure/closet/wardrobe/mixed,
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 8
+	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "bluefull"
 	},
 /area/station/civilian/locker)
 "hWG" = (
@@ -37428,7 +37494,7 @@
 /area/station/medical/hallway)
 "imd" = (
 /turf/simulated/floor{
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/civilian/locker)
 "imk" = (
@@ -37678,7 +37744,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/civilian/locker)
 "ipd" = (
@@ -38184,11 +38250,11 @@
 "ivp" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/item/weapon/storage/wallet,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/civilian/locker)
 "ivs" = (
@@ -38418,11 +38484,11 @@
 /obj/structure/sign/nanotrasen{
 	pixel_x = -32
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/civilian/locker)
 "iyu" = (
@@ -39818,7 +39884,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -40558,6 +40624,9 @@
 "iWu" = (
 /obj/structure/stool/bed,
 /obj/item/weapon/bedsheet/red,
+/obj/machinery/status_display{
+	pixel_x = 32
+	},
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories)
 "iWv" = (
@@ -41866,7 +41935,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/multi_tile/glass,
 /turf/simulated/floor{
-	icon_state = "cafeteria"
+	icon_state = "neutralfull"
 	},
 /area/station/civilian/locker)
 "jlJ" = (
@@ -44074,7 +44143,7 @@
 	dir = 10
 	},
 /turf/simulated/floor{
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/civilian/locker)
 "jKD" = (
@@ -45311,7 +45380,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	icon_state = "cafeteria"
+	icon_state = "vaultfull"
 	},
 /area/station/civilian/locker)
 "jXj" = (
@@ -45706,11 +45775,11 @@
 	c_tag = "Dormitories Locker Room East";
 	dir = 9
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/civilian/locker)
 "kco" = (
@@ -46949,8 +47018,8 @@
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 8
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "outline_bold"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -49182,10 +49251,18 @@
 /turf/environment/space,
 /area/space)
 "kOi" = (
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
 	},
-/area/station/civilian/locker)
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 22
+	},
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/station/civilian/dormitories)
 "kOx" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(25)
@@ -64177,8 +64254,11 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/ai_status_display{
+	pixel_y = 32
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/civilian/locker)
 "omb" = (
@@ -64923,7 +65003,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/civilian/locker)
 "oxx" = (
 /obj/machinery/light/smart{
@@ -66536,7 +66618,7 @@
 	dir = 10
 	},
 /turf/simulated/floor{
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/civilian/locker)
 "oQG" = (
@@ -70389,10 +70471,6 @@
 "pJx" = (
 /obj/structure/rack,
 /obj/item/weapon/storage/toolbox/mechanical,
-/obj/machinery/alarm{
-	pixel_x = -28;
-	pixel_y = -6
-	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
@@ -75844,8 +75922,8 @@
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 8
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "outline_bold"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -76518,8 +76596,12 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 8
+	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "bluefull"
 	},
 /area/station/civilian/locker)
 "rgE" = (
@@ -82394,8 +82476,12 @@
 /area/station/engineering/engine)
 "swq" = (
 /obj/machinery/vending/clothing,
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 8
+	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "bluefull"
 	},
 /area/station/civilian/locker)
 "sws" = (
@@ -83883,6 +83969,10 @@
 "sOK" = (
 /obj/item/cardboard_cutout{
 	icon_state = "cutout_clown"
+	},
+/obj/machinery/alarm{
+	pixel_x = -28;
+	pixel_y = -6
 	},
 /turf/simulated/floor{
 	dir = 9;
@@ -89616,6 +89706,13 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/tox_launch)
+"uke" = (
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = 22
+	},
+/turf/simulated/floor/carpet/green,
+/area/station/civilian/dormitories)
 "uki" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 8
@@ -92140,7 +92237,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/civilian/locker)
 "uQI" = (
 /turf/simulated/shuttle/floor/cargo{
@@ -96851,7 +96950,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
-	icon_state = "cafeteria"
+	icon_state = "blackchecker"
 	},
 /area/station/civilian/locker)
 "vYd" = (
@@ -97905,11 +98004,11 @@
 	c_tag = "Locker Room East";
 	dir = 5
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/civilian/locker)
 "wlk" = (
@@ -101035,14 +101134,13 @@
 	},
 /area/shuttle/supply/station)
 "wZg" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
+/obj/structure/sign/warning/pods{
+	pixel_y = -32
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "neutral"
 	},
-/area/station/maintenance/brig)
+/area/station/civilian/dormitories)
 "wZn" = (
 /obj/structure/table,
 /obj/item/clothing/accessory/stethoscope,
@@ -101465,6 +101563,13 @@
 	icon_state = "vaultfull"
 	},
 /area/station/rnd/xenobiology)
+"xef" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/multi_tile/glass,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/civilian/locker)
 "xei" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -104314,8 +104419,8 @@
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 8
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "outline_bold"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -104819,8 +104924,12 @@
 /area/station/cargo/qm)
 "xRq" = (
 /obj/machinery/washing_machine,
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 4
+	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "bluefull"
 	},
 /area/station/civilian/locker)
 "xRs" = (
@@ -155248,7 +155357,7 @@ wzd
 iBx
 vst
 olT
-kOi
+hVa
 smC
 tAM
 fCz
@@ -155760,7 +155869,7 @@ adp
 bLN
 wzd
 pHC
-wZg
+vst
 sXW
 sXW
 ize
@@ -155772,7 +155881,7 @@ hMR
 hVa
 hVa
 blj
-jlH
+xef
 ipa
 imd
 imd
@@ -156276,7 +156385,7 @@ wzd
 vAP
 vst
 hFn
-kOi
+hVa
 smC
 tEg
 mjC
@@ -157315,9 +157424,9 @@ xUx
 ieL
 avb
 kBl
-ieL
+hKe
 ihW
-ieL
+kOi
 mAe
 avb
 ieL
@@ -158854,7 +158963,7 @@ kSw
 xUx
 xpn
 uGN
-qBh
+goz
 xUx
 jFR
 dYl
@@ -158862,7 +158971,7 @@ kpx
 xUx
 kYa
 lzO
-crz
+gDY
 xUx
 gex
 hdR
@@ -159113,7 +159222,7 @@ xzC
 qBh
 qBh
 xUx
-jFR
+uke
 kHM
 hkQ
 xUx
@@ -159379,7 +159488,7 @@ dKX
 rDT
 xUx
 gex
-hdR
+wZg
 xUx
 bwO
 aoy

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -14366,6 +14366,24 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/miningoffice)
+"ddd" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(12)
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/medbay)
 "ddl" = (
 /obj/machinery/monkey_recycler,
 /obj/effect/decal/turf_decal/alpha/red{
@@ -26443,6 +26461,10 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -26475,6 +26497,10 @@
 	req_access = list(12)
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/decal/turf_decal{
+	dir = 3;
+	icon_state = "warn"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "fWA" = (
@@ -38730,6 +38756,10 @@
 	req_access = list(12)
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "iGO" = (
@@ -41984,6 +42014,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
 /turf/simulated/floor,
 /area/station/rnd/tox_launch)
 "jtG" = (
@@ -44025,6 +44063,14 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
 	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
@@ -49448,6 +49494,10 @@
 	id = "Biohazard";
 	name = "Biohazard Shutter";
 	opacity = 0
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
 	},
 /turf/simulated/floor,
 /area/station/rnd/hallway)
@@ -69606,6 +69656,10 @@
 	req_access = list(12)
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/decal/turf_decal{
+	dir = 3;
+	icon_state = "warn"
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "pLk" = (
@@ -135885,7 +135939,7 @@ pKT
 sdW
 uOI
 nPL
-pKT
+ddd
 nEL
 pMF
 qpQ

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -226,7 +226,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/medical/cryo)
 "abD" = (
 /obj/structure/table/reinforced,
@@ -1420,7 +1422,7 @@
 	dir = 9
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "wooden"
 	},
 /area/station/hallway/secondary/exit)
 "ajq" = (
@@ -1598,8 +1600,12 @@
 /area/station/rnd/hallway)
 "akP" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 1
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "wooden"
 	},
 /area/station/hallway/secondary/exit)
 "akS" = (
@@ -3566,6 +3572,14 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/atmos)
+"aGI" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line"
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/hallway/secondary/exit)
 "aGL" = (
 /turf/simulated/wall,
 /area/station/cargo/recycleroffice)
@@ -3989,7 +4003,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "wooden"
 	},
 /area/station/hallway/secondary/exit)
 "aMx" = (
@@ -4432,6 +4446,9 @@
 /area/station/security/detectives_office)
 "aRv" = (
 /obj/machinery/computer/station_alert,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkredcorners"
@@ -5021,6 +5038,9 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_right"
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "darkblue"
@@ -5354,7 +5374,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/medical/cryo)
 "bcG" = (
 /obj/machinery/door/firedoor,
@@ -8473,6 +8495,18 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
+"bJf" = (
+/obj/structure/stool/bed/chair/metal{
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/hallway/secondary/exit)
 "bJk" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -10715,6 +10749,9 @@
 	pixel_y = -22
 	},
 /obj/structure/closet/emcloset,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -13766,6 +13803,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/lobby)
+"cSz" = (
+/obj/structure/stool/bed/chair/metal{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/hallway/secondary/exit)
 "cSB" = (
 /obj/structure/object_wall/mining{
 	icon_state = "1-8"
@@ -15911,6 +15960,18 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge/captain_quarters)
+"dty" = (
+/obj/structure/stool/bed/chair/metal/red{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "darkred"
+	},
+/area/station/security/checkpoint/escape)
 "dtG" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/aiModule/purge{
@@ -16617,6 +16678,9 @@
 "dDB" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "darkblue"
@@ -17832,6 +17896,9 @@
 	},
 /area/station/rnd/hallway)
 "dTH" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "blue"
@@ -20277,6 +20344,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
+"ewG" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "blue"
+	},
+/area/station/hallway/primary/starboard)
 "ewM" = (
 /obj/structure/stool/bed/chair/comfy/black{
 	dir = 4
@@ -20526,6 +20602,9 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/light/smart{
 	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -21068,6 +21147,9 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -22219,6 +22301,9 @@
 	},
 /area/station/engineering/chiefs_office)
 "eTM" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "blue"
@@ -23640,6 +23725,9 @@
 	dir = 4;
 	pixel_x = 22
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_right"
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "darkblue"
@@ -23909,6 +23997,9 @@
 /area/station/maintenance/medbay)
 "foK" = (
 /obj/machinery/computer/security,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkredcorners"
@@ -24222,6 +24313,9 @@
 /area/station/medical/sleeper)
 "fsz" = (
 /obj/structure/table,
+/obj/item/weapon/flora/deskleaf{
+	pixel_y = 7
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -24230,6 +24324,9 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -24784,6 +24881,9 @@
 /area/station/rnd/storage)
 "fyI" = (
 /obj/structure/closet/secure_closet/freezer/milkshake,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -25046,6 +25146,9 @@
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = 22
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -26373,6 +26476,14 @@
 /obj/item/weapon/flora/random,
 /turf/simulated/floor,
 /area/station/civilian/toilet)
+"fTm" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/hallway/secondary/exit)
 "fTo" = (
 /obj/machinery/door/poddoor{
 	id = "chapelgun";
@@ -26753,6 +26864,17 @@
 	icon_state = "dark"
 	},
 /area/station/bridge/ai_upload)
+"fXZ" = (
+/obj/structure/stool/bed/chair/metal{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/hallway/secondary/exit)
 "fYc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/wall/r_wall,
@@ -27491,8 +27613,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "wooden"
 	},
 /area/station/hallway/secondary/exit)
 "ghz" = (
@@ -29477,6 +29603,10 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -30336,6 +30466,15 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/misc_lab)
+"gMg" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 10
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/hallway/secondary/exit)
 "gMr" = (
 /turf/simulated/floor{
 	icon_state = "whiteblue"
@@ -31733,6 +31872,10 @@
 	pixel_x = 28;
 	pixel_y = -5
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -32075,6 +32218,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"hhW" = (
+/obj/structure/stool/bed/chair/metal{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/hallway/secondary/exit)
 "hid" = (
 /obj/machinery/light/smart{
 	dir = 8
@@ -34159,6 +34314,9 @@
 	c_tag = "Starboard Escape Entrance";
 	dir = 5
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -35186,6 +35344,9 @@
 	c_tag = "Escape Customs Desk";
 	dir = 9
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_right"
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "darkblue"
@@ -35967,6 +36128,9 @@
 /area/station/security/brig)
 "hYY" = (
 /obj/structure/closet/secure_closet/freezer/icecream,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -41507,6 +41671,9 @@
 /area/station/security/brig)
 "jlk" = (
 /obj/machinery/vending/cigarette,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -42124,6 +42291,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -42729,6 +42899,9 @@
 /area/station/engineering/atmos/supermatter)
 "jyz" = (
 /obj/random/vending/snack,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -43867,6 +44040,9 @@
 /area/station/security/prison)
 "jLa" = (
 /obj/structure/closet/emcloset,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -47103,6 +47279,9 @@
 /area/station/ai_monitored/eva)
 "kvb" = (
 /obj/structure/stool/bed/chair/metal/red,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "box_corners_white"
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "darkred"
@@ -50418,6 +50597,9 @@
 /obj/structure/sign/poster/official/do_not_question{
 	pixel_x = -32
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "darkblue"
@@ -53020,6 +53202,18 @@
 /obj/structure/barricade/wooden,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/supermatter)
+"lMT" = (
+/obj/structure/stool/bed/chair/metal{
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/hallway/secondary/exit)
 "lNc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -54095,8 +54289,12 @@
 /area/station/engineering/engine)
 "maZ" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 9
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "wooden"
 	},
 /area/station/hallway/secondary/exit)
 "mbc" = (
@@ -55272,6 +55470,10 @@
 "moM" = (
 /obj/structure/stool/bed/chair/metal/red{
 	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "box_corners_white";
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "darkred"
@@ -58866,6 +59068,9 @@
 /obj/machinery/computer/secure_data{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "darkredcorners"
@@ -59189,6 +59394,18 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/civilian/holodeck/alphadeck)
+"nkw" = (
+/obj/structure/stool/bed/chair/metal/red{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/checkpoint/escape)
 "nkI" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/glass/beaker/large,
@@ -61422,6 +61639,9 @@
 /area/station/civilian/gym)
 "nKi" = (
 /obj/structure/closet/secure_closet/brig,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -61520,6 +61740,9 @@
 /area/station/medical/hallway)
 "nMn" = (
 /obj/random/vending/cola,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -63625,6 +63848,9 @@
 /area/station/engineering/break_room)
 "ojS" = (
 /obj/machinery/computer/arcade,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -66407,6 +66633,10 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -66417,8 +66647,12 @@
 	name = "Shutters";
 	pixel_y = -26
 	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 6
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "wooden"
 	},
 /area/station/hallway/secondary/exit)
 "oVN" = (
@@ -67342,6 +67576,9 @@
 	},
 /obj/machinery/light/smart{
 	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -74104,6 +74341,9 @@
 /area/station/maintenance/science)
 "qIx" = (
 /obj/machinery/vending/coffee,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "blackcorner"
@@ -77400,6 +77640,9 @@
 /area/station/civilian/locker)
 "rxC" = (
 /obj/structure/closet/emcloset,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
 /obj/effect/decal/turf_decal{
 	dir = 8;
 	icon_state = "warn_corner"
@@ -77778,8 +78021,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 4
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "wooden"
 	},
 /area/station/hallway/secondary/exit)
 "rAE" = (
@@ -80034,6 +80281,18 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/rnd/telesci)
+"saA" = (
+/obj/structure/stool/bed/chair/metal/red{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/checkpoint/escape)
 "saE" = (
 /obj/machinery/r_n_d/server/robotics,
 /turf/simulated/floor/bluegrid{
@@ -82162,6 +82421,9 @@
 /obj/machinery/light/smart{
 	dir = 1
 	},
+/obj/item/weapon/flora/deskleaf{
+	pixel_y = 7
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -83010,6 +83272,9 @@
 /area/station/engineering/atmos/supermatter)
 "sKR" = (
 /obj/structure/closet/emcloset,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
 /obj/effect/decal/turf_decal{
 	dir = 1;
 	icon_state = "warn_corner"
@@ -84698,6 +84963,18 @@
 	icon_state = "blackcorner"
 	},
 /area/station/hallway/primary/starboard)
+"tgB" = (
+/obj/structure/stool/bed/chair/metal/red{
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/checkpoint/escape)
 "tgI" = (
 /obj/structure/disposalpipe/junction{
 	dir = 2;
@@ -84862,6 +85139,10 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Escape Shuttle Hallway East";
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
 	dir = 1
 	},
 /turf/simulated/floor{
@@ -86841,8 +87122,12 @@
 /area/station/civilian/chapel)
 "tHE" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 5
+	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "wooden"
 	},
 /area/station/hallway/secondary/exit)
 "tHI" = (
@@ -88522,6 +88807,9 @@
 /obj/structure/filingcabinet,
 /obj/machinery/status_display{
 	pixel_y = 32
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -91590,6 +91878,10 @@
 	dir = 1
 	},
 /obj/machinery/light/smart,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -91892,6 +92184,10 @@
 	frequency = 1475;
 	name = "Station Intercom (Security)";
 	pixel_y = 22
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "box_corners_white";
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -93238,6 +93534,15 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
+"vmo" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/hallway/secondary/exit)
 "vmq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -94698,6 +95003,9 @@
 /obj/item/clothing/mask/gas/sechailer{
 	pixel_y = -2
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkredcorners"
@@ -95786,6 +96094,18 @@
 	req_access = list(1)
 	},
 /turf/simulated/floor/plating,
+/area/station/security/checkpoint/escape)
+"vTD" = (
+/obj/structure/stool/bed/chair/metal/red{
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/security/checkpoint/escape)
 "vTG" = (
 /obj/machinery/camera{
@@ -98571,6 +98891,9 @@
 /obj/structure/rack,
 /obj/item/weapon/screwdriver,
 /obj/item/weapon/wirecutters,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "darkredcorners"
@@ -99174,6 +99497,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -99354,6 +99680,9 @@
 "wKZ" = (
 /obj/structure/closet,
 /obj/item/weapon/storage/box/ids,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "darkblue"
@@ -100581,6 +100910,9 @@
 /area/station/ai_monitored/storage_secure)
 "xaY" = (
 /obj/structure/closet/emcloset,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -104173,7 +104505,9 @@
 	icon_state = "siding_line";
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/medical/sleeper)
 "xRy" = (
 /obj/structure/cable{
@@ -146420,7 +146754,7 @@ fyI
 upB
 maZ
 ghu
-nGt
+gMg
 dKO
 kWl
 djc
@@ -146677,7 +147011,7 @@ hYY
 nGt
 akP
 ajn
-nGt
+aGI
 dKO
 kWl
 djc
@@ -146688,7 +147022,7 @@ qec
 qec
 mRu
 ier
-rXN
+cSz
 rmY
 kvb
 vfW
@@ -146932,15 +147266,15 @@ iVK
 beJ
 iiQ
 nGt
-nGt
+vmo
 aMr
-nGt
+aGI
 mSl
 kWl
 djc
 bAQ
 ier
-aPX
+lMT
 aPX
 oVA
 djc
@@ -147189,9 +147523,9 @@ beJ
 beJ
 rmY
 xXS
-nGt
+vmo
 aMr
-nGt
+aGI
 mSl
 kWl
 djc
@@ -147446,17 +147780,17 @@ tmK
 unB
 rmY
 gyn
-nGt
+vmo
 aMr
-nGt
+aGI
 mSl
 kWl
 djc
 bAQ
 ier
+hhW
 tjn
-tjn
-tjn
+fXZ
 djc
 bcv
 sic
@@ -147717,7 +148051,7 @@ jaz
 mRu
 tdg
 ier
-nGt
+fTm
 lTd
 pWA
 ntv
@@ -147979,7 +148313,7 @@ qms
 cTN
 eum
 uzI
-moM
+dty
 ujC
 plf
 kHU
@@ -148482,9 +148816,9 @@ xmW
 djc
 bAQ
 ier
+lMT
 aPX
-aPX
-aPX
+bJf
 djc
 olv
 gKa
@@ -148996,7 +149330,7 @@ rmY
 djc
 bAQ
 ier
-tjn
+hhW
 tjn
 phn
 djc
@@ -149007,7 +149341,7 @@ nKi
 nKi
 xfW
 fJU
-jUt
+nkw
 tlK
 plf
 kHU
@@ -149515,13 +149849,13 @@ mZB
 mRu
 mRu
 ier
-rXN
+cSz
 rmY
 bLC
 dpF
 gVK
 wTN
-jUt
+saA
 tlK
 plf
 pka
@@ -149775,9 +150109,9 @@ gKa
 xaY
 rmY
 kTP
+vTD
 dVh
-dVh
-dVh
+tgB
 aNm
 tlK
 kHU
@@ -150005,7 +150339,7 @@ gAR
 xDQ
 dTH
 eTM
-eTM
+ewG
 vMc
 jlE
 efB
@@ -150022,10 +150356,10 @@ xfr
 cea
 rmY
 sAP
+lMT
 aPX
 aPX
-aPX
-aPX
+bJf
 jyz
 nMn
 kKw

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -20991,6 +20991,27 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/engine)
+"eDb" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "eDr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -24828,27 +24849,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/tox_launch)
-"fwr" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "fwH" = (
 /mob/living/simple_animal/corgi/borgi,
 /turf/simulated/floor{
@@ -30843,6 +30843,14 @@
 	icon_state = "foam_plating"
 	},
 /area/station/maintenance/science)
+"gPl" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/civilian/gym)
 "gPx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -45100,17 +45108,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
-"jUi" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "jUj" = (
 /obj/structure/stool/bed/chair/comfy/brown,
 /obj/machinery/light/smart{
@@ -47418,6 +47415,26 @@
 	icon_state = "darkblue"
 	},
 /area/station/engineering/minisat_secure_area)
+"ksT" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "ksU" = (
 /obj/structure/closet/radiation,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -49763,18 +49780,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/checkpoint/escape)
-"kTS" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "kUa" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/food/condiment/saltshaker{
@@ -51205,6 +51210,18 @@
 	icon_state = "caution"
 	},
 /area/station/storage/emergency)
+"lkT" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "lkU" = (
 /turf/simulated/wall,
 /area/station/maintenance/starboardsolar)
@@ -64660,6 +64677,11 @@
 /obj/effect/decal/turf_decal{
 	dir = 10;
 	icon_state = "warn"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "apc left";
+	pixel_x = -28
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboardsolar)
@@ -84056,6 +84078,17 @@
 	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
+"sOy" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "sOD" = (
 /obj/effect/decal/turf_decal{
 	dir = 8;
@@ -97045,14 +97078,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"vYa" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/civilian/gym)
 "vYb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -98037,26 +98062,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/checkpoint/medbay)
-"wjT" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "wjU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -160648,13 +160653,13 @@ ncp
 ncp
 hbR
 mWz
-kTS
+lkT
 kLd
 syX
 tHk
 tHk
 dbf
-fwr
+eDb
 ram
 mWz
 lNQ
@@ -161419,13 +161424,13 @@ ncp
 ncp
 hbR
 mWz
-jUi
+sOy
 sIY
 qls
 uOM
 uOM
 aeG
-wjT
+ksT
 ram
 mWz
 hPr
@@ -162449,7 +162454,7 @@ dJL
 nRG
 oXA
 oXA
-vYa
+gPl
 dJL
 plf
 cdR
@@ -165787,7 +165792,7 @@ kHU
 fMh
 plf
 dJL
-vYa
+gPl
 oXA
 oXA
 nJn

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -848,10 +848,6 @@
 /obj/item/clothing/head/helmet/laserproof,
 /obj/item/clothing/head/helmet/laserproof,
 /obj/item/clothing/head/helmet/laserproof,
-/obj/effect/decal/turf_decal{
-	dir = 5;
-	icon_state = "warn"
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -1916,7 +1912,7 @@
 /obj/machinery/light/smart,
 /obj/machinery/recharger,
 /turf/simulated/floor{
-	icon_state = "redfull"
+	icon_state = "darkredfull"
 	},
 /area/station/security/brig/equipment)
 "anP" = (
@@ -2013,7 +2009,19 @@
 	pixel_x = 32
 	},
 /obj/structure/rack,
-/obj/item/weapon/storage/toolbox/mechanical,
+/obj/item/weapon/kitchenknife/combat,
+/obj/item/weapon/kitchenknife/combat,
+/obj/item/weapon/kitchenknife/combat,
+/obj/item/weapon/kitchenknife/combat,
+/obj/item/weapon/kitchenknife/combat,
+/obj/item/weapon/kitchenknife/combat,
+/obj/item/weapon/kitchenknife/combat,
+/obj/item/weapon/kitchenknife/combat,
+/obj/item/weapon/kitchenknife/combat,
+/obj/item/weapon/kitchenknife/combat,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -2614,15 +2622,6 @@
 	icon_state = "white"
 	},
 /area/station/civilian/dormitories)
-"avd" = (
-/obj/effect/decal/turf_decal/alpha/blue{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "avo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on/atmos{
 	dir = 1;
@@ -3364,6 +3363,14 @@
 	name = "Security Delivery";
 	req_access = list(63)
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "arrow";
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	dir = 1;
+	icon_state = "loadingarea"
+	},
 /turf/simulated/floor{
 	icon_state = "red"
 	},
@@ -3973,17 +3980,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
-"aLS" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "aMd" = (
 /obj/structure/object_wall/cargo{
 	icon_state = "5,0"
@@ -4070,6 +4066,9 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -4506,18 +4505,6 @@
 	icon_state = "grimy"
 	},
 /area/station/storage/tools)
-"aSg" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "aSh" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 8
@@ -12348,6 +12335,15 @@
 	icon_state = "darkbluecorners"
 	},
 /area/station/medical/genetics)
+"cBc" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "cBp" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -15316,6 +15312,10 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkredcorners"
@@ -16416,6 +16416,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/decal/turf_decal{
 	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
@@ -19010,6 +19013,14 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"eeP" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/civilian/gym)
 "eeT" = (
 /obj/machinery/computer/operating,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -19449,10 +19460,6 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -19465,7 +19472,7 @@
 	dir = 4
 	},
 /obj/effect/decal/turf_decal{
-	dir = 8;
+	dir = 4;
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
@@ -21574,10 +21581,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/window/thin{
 	dir = 8
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -23753,6 +23756,13 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/station/security/range)
+"fjs" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "fjy" = (
 /obj/structure/sign/directions/supply{
 	dir = 4
@@ -24004,6 +24014,9 @@
 /area/station/maintenance/engineering)
 "flQ" = (
 /obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -26267,14 +26280,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "fOp" = (
-/obj/effect/decal/turf_decal{
-	dir = 3;
-	icon_state = "warn"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Central Access"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
-/area/station/security/armoury)
+/area/station/security/lobby)
 "fOF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
@@ -26724,6 +26738,10 @@
 "fUB" = (
 /obj/effect/decal/turf_decal{
 	dir = 4;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
@@ -28539,6 +28557,19 @@
 	icon_state = "black"
 	},
 /area/station/hallway/secondary/exit)
+"gnI" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "gnJ" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -30962,14 +30993,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/science)
-"gQk" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/civilian/gym)
 "gQo" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -31966,6 +31989,11 @@
 	temperature = 80
 	},
 /area/station/tcommsat/chamber)
+"hbd" = (
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "hbe" = (
 /obj/machinery/r_n_d/circuit_imprinter,
 /obj/item/weapon/reagent_containers/glass/beaker/sulphuric,
@@ -33139,6 +33167,10 @@
 	dir = 4;
 	icon_state = "warn"
 	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -33620,6 +33652,10 @@
 "hur" = (
 /obj/effect/decal/turf_decal{
 	dir = 8;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
@@ -35431,11 +35467,6 @@
 	icon_state = "neutral"
 	},
 /area/station/rnd/xenobiology)
-"hOp" = (
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "hOq" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/plating,
@@ -36108,8 +36139,8 @@
 	name = "Security Blast Door";
 	opacity = 0
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -37230,6 +37261,9 @@
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -38516,19 +38550,6 @@
 /obj/item/weapon/reagent_containers/food/snacks/grown/harebell,
 /turf/simulated/floor,
 /area/station/civilian/chapel)
-"ixU" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "ixW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment{
@@ -39438,6 +39459,17 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/distribution)
+"iGX" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "iGZ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -42563,8 +42595,11 @@
 	pixel_y = -32
 	},
 /obj/structure/closet/secure_closet/security,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
-	icon_state = "redfull"
+	icon_state = "darkredfull"
 	},
 /area/station/security/brig/equipment)
 "jsw" = (
@@ -43391,8 +43426,8 @@
 	name = "Security Blast Door";
 	opacity = 0
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -44383,12 +44418,6 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/atmos)
-"jLl" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
-	},
-/turf/simulated/floor/carpet/red,
-/area/station/security/detectives_office)
 "jLq" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -46040,11 +46069,11 @@
 /obj/machinery/light/smart{
 	dir = 8
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot_left"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/security/armoury)
 "ked" = (
@@ -46469,6 +46498,27 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/robotics)
+"kik" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "kin" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -46940,6 +46990,9 @@
 /obj/item/ammo_box/magazine/glock/rubber,
 /obj/machinery/light/smart{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -50563,11 +50616,11 @@
 /area/station/hallway/secondary/entry)
 "lbo" = (
 /obj/machinery/flasher/portable,
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot_left"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/security/armoury)
 "lbq" = (
@@ -51902,10 +51955,6 @@
 /obj/item/weapon/gun/energy/ionrifle{
 	pixel_y = 3
 	},
-/obj/effect/decal/turf_decal{
-	dir = 6;
-	icon_state = "warn"
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -52725,6 +52774,8 @@
 /turf/simulated/floor,
 /area/station/maintenance/medbay)
 "lDs" = (
+/obj/structure/rack,
+/obj/item/weapon/storage/toolbox/mechanical,
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -54594,8 +54645,8 @@
 	name = "Officer Beepsky"
 	},
 /obj/effect/decal/turf_decal{
-	dir = 10;
-	icon_state = "warn"
+	dir = 4;
+	icon_state = "warn_corner"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -56392,16 +56443,6 @@
 	icon_state = "wooden"
 	},
 /area/station/bridge/corp_lounge)
-"mug" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Central Access"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "muh" = (
 /obj/structure/object_wall/cargo{
 	icon_state = "4,0"
@@ -56609,8 +56650,12 @@
 /area/station/security/brig/equipment)
 "mxb" = (
 /obj/effect/decal/turf_decal{
-	dir = 6;
+	dir = 4;
 	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -57892,7 +57937,7 @@
 	dir = 1
 	},
 /obj/effect/decal/turf_decal{
-	dir = 3;
+	dir = 1;
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
@@ -62262,6 +62307,18 @@
 	icon_state = "neutral"
 	},
 /area/station/medical/chemistry)
+"nMY" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "nNa" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
@@ -62804,6 +62861,19 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/bridge)
+"nSs" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "nSC" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots,
@@ -62955,10 +63025,6 @@
 /obj/item/weapon/gun/energy/laser,
 /obj/item/weapon/gun/energy/laser,
 /obj/item/weapon/gun/energy/laser,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -65570,8 +65636,8 @@
 	name = "Security Blast Door";
 	opacity = 0
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -66987,8 +67053,11 @@
 /area/station/civilian/dormitories/service_bedrooms)
 "oTu" = (
 /obj/structure/closet/secure_closet/security,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
-	icon_state = "redfull"
+	icon_state = "darkredfull"
 	},
 /area/station/security/brig/equipment)
 "oTC" = (
@@ -68590,27 +68659,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
-"pnb" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "pne" = (
 /turf/simulated/wall,
 /area/station/civilian/chapel/mass_driver)
@@ -71729,6 +71777,9 @@
 /area/station/security/checkpoint/escape_custom_desk)
 "pWg" = (
 /obj/structure/closet/secure_closet/warden,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -78756,6 +78807,18 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"rCk" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "rCn" = (
 /turf/environment/space,
 /area/shuttle/vox/southeast_solars)
@@ -84362,10 +84425,6 @@
 /obj/structure/window/thin{
 	dir = 1
 	},
-/obj/effect/decal/turf_decal{
-	dir = 9;
-	icon_state = "warn"
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -87167,6 +87226,10 @@
 	name = "Station Intercom (Security)";
 	pixel_y = -32
 	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	icon_state = "darkred"
 	},
@@ -88267,6 +88330,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -92245,6 +92311,9 @@
 /obj/effect/decal/turf_decal{
 	dir = 9;
 	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -98614,7 +98683,9 @@
 /area/station/cargo/office)
 "wpm" = (
 /obj/machinery/door/firedoor,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
 /area/station/security/lobby)
 "wpM" = (
 /obj/structure/table/woodentable,
@@ -101007,10 +101078,6 @@
 	},
 /obj/item/ammo_box/magazine/plasma,
 /obj/item/ammo_box/magazine/plasma,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -101917,6 +101984,12 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor,
 /area/station/maintenance/science)
+"xeU" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
+	},
+/turf/simulated/floor/carpet/red,
+/area/station/security/detectives_office)
 "xfr" = (
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -102204,10 +102277,6 @@
 /obj/structure/window/thin,
 /obj/item/weapon/gun/projectile/shotgun/combat/nonlethal{
 	pixel_y = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 10;
-	icon_state = "warn"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -104066,6 +104135,10 @@
 /obj/effect/decal/turf_decal{
 	dir = 5;
 	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -150975,7 +151048,7 @@ erD
 erD
 cmN
 act
-mug
+fOp
 xsY
 uuf
 jTW
@@ -154825,8 +154898,8 @@ plf
 xyC
 cFp
 klH
-jLl
-jLl
+xeU
+xeU
 hGr
 aRu
 xyC
@@ -155350,8 +155423,8 @@ dnn
 aEr
 wPw
 jQy
-avd
-hOp
+cBc
+hbd
 jcX
 fJg
 nPU
@@ -155858,7 +155931,7 @@ xyC
 xyC
 xyC
 xyC
-wpm
+fjs
 jtG
 wpm
 fJg
@@ -160484,7 +160557,7 @@ sxG
 uOc
 hur
 hur
-hur
+nSs
 ekd
 lZw
 gqC
@@ -160738,7 +160811,7 @@ ixl
 mme
 uKd
 gRX
-cBY
+nMY
 sRa
 nUj
 wUB
@@ -160767,13 +160840,13 @@ ncp
 ncp
 hbR
 mWz
-aSg
+rCk
 kLd
 syX
 tHk
 tHk
 dbf
-pnb
+kik
 ram
 mWz
 lNQ
@@ -161000,7 +161073,7 @@ aeg
 ejY
 eKu
 lsy
-fOp
+cBY
 jWf
 hPH
 rUh
@@ -161030,7 +161103,7 @@ eFl
 aRb
 nDG
 jjN
-ixU
+gnI
 ram
 mWz
 ucd
@@ -161538,7 +161611,7 @@ ncp
 ncp
 hbR
 mWz
-aLS
+iGX
 sIY
 qls
 uOM
@@ -162568,7 +162641,7 @@ dJL
 nRG
 oXA
 oXA
-gQk
+eeP
 dJL
 plf
 cdR
@@ -165906,7 +165979,7 @@ kHU
 fMh
 plf
 dJL
-gQk
+eeP
 oXA
 oXA
 nJn

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -927,6 +927,19 @@
 /obj/structure/stool/bed/chair/office/dark,
 /turf/simulated/floor,
 /area/station/maintenance/science)
+"aeA" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "aeD" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -1678,12 +1691,6 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
-"alL" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
-	},
-/turf/simulated/floor/carpet/red,
-/area/station/security/detectives_office)
 "alS" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/firealarm{
@@ -2465,19 +2472,6 @@
 	icon_state = "4,3"
 	},
 /area/shuttle/supply/station)
-"asZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 9
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "ath" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -3944,15 +3938,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
-"aKm" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_right"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/civilian/cold_room)
 "aKr" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -4623,7 +4608,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/hallway/secondary/entry)
 "aSs" = (
 /obj/machinery/door/firedoor,
@@ -5192,6 +5179,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -5636,6 +5627,11 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port)
+"beh" = (
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "beo" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -6014,6 +6010,15 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
+"bih" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "biv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -6378,7 +6383,8 @@
 	},
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
+	icon_state = "box_corners_white";
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -6880,6 +6886,18 @@
 	},
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
+"brr" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "brv" = (
 /obj/machinery/optable,
 /obj/machinery/requests_console/forensic{
@@ -7296,7 +7314,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/hallway/secondary/entry)
 "bwi" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7652,15 +7672,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
-"bzG" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DN";
-	location = "SSE-FC"
-	},
-/turf/simulated/floor{
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "bzN" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -7853,15 +7864,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/lobby)
-"bBs" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "bBu" = (
 /obj/structure/table/woodentable,
 /obj/item/device/taperecorder,
@@ -8328,6 +8330,14 @@
 /obj/structure/stool/bed/chair/metal/white{
 	dir = 1
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
 /obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "siding_line";
 	dir = 1
@@ -8529,15 +8539,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/library)
-"bGI" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "bGL" = (
 /obj/machinery/light/smart{
 	dir = 4
@@ -10149,6 +10150,19 @@
 "bZk" = (
 /turf/simulated/wall/r_wall,
 /area/station/medical/genetics)
+"bZo" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "bZu" = (
 /turf/simulated/floor,
 /area/station/security/prison)
@@ -10274,6 +10288,16 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/mixing)
+"caB" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "caD" = (
 /obj/item/device/radio/beacon,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -10500,6 +10524,14 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/dormitories)
+"ccR" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/civilian/gym)
 "ccT" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -10557,6 +10589,19 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos/distribution)
+"cdw" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "cdy" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -11225,6 +11270,12 @@
 	icon_state = "wooden"
 	},
 /area/station/bridge/corp_lounge)
+"ckp" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "cafeteria"
+	},
+/area/station/security/prison)
 "ckw" = (
 /obj/machinery/light/smart{
 	dir = 8
@@ -11699,18 +11750,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/library)
-"cqV" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "cqW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -11822,6 +11861,17 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/primary/fore)
+"ctv" = (
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "ctH" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -12038,6 +12088,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/engi)
+"cvJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "cvO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -13253,18 +13316,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
-"cHV" = (
-/obj/machinery/door_timer/cell_3{
-	pixel_x = 32;
-	pixel_y = 0;
-	dir = 4;
-	id = "Cell 3 perma"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "cIm" = (
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Antechamber";
@@ -13418,20 +13469,6 @@
 	},
 /turf/environment/space,
 /area/shuttle/mining/station)
-"cKz" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 9;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "cKC" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/cleanable/dirt,
@@ -13547,19 +13584,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig/storage)
-"cMf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "cMg" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -13773,6 +13797,9 @@
 /area/space)
 "cNX" = (
 /obj/structure/closet/emcloset,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -14329,6 +14356,21 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/chapel/mass_driver)
+"cTx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "cTK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/disposal,
@@ -14726,7 +14768,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
+	icon_state = "siding_corner";
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -14830,6 +14872,9 @@
 	dir = 1
 	},
 /obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -15562,6 +15607,13 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/bridge/corp_lounge)
+"diN" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-MB";
+	location = "N-MB"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "diQ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -16175,16 +16227,6 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/psych)
-"dqP" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-FC";
-	location = "DS"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "bluecorner"
-	},
-/area/station/hallway/primary/central)
 "dqQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -17141,6 +17183,10 @@
 /obj/structure/stool/bed/chair/metal/black{
 	dir = 8
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -17932,15 +17978,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
-"dMN" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-B";
-	location = "S-MB"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/secondary/entry)
 "dNl" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
@@ -17995,6 +18032,19 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/forensic_office)
+"dOg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "dOC" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -18959,6 +19009,17 @@
 	},
 /turf/simulated/floor,
 /area/station/storage/emergency2)
+"eae" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "eao" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -19233,6 +19294,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"ecQ" = (
+/obj/structure/stool/bed/chair/metal/black{
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "ecT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/woodentable,
@@ -19751,18 +19824,17 @@
 	},
 /area/station/hallway/primary/starboard)
 "ejv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
 	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 8
+/turf/simulated/floor{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
+/area/station/engineering/engine)
 "ejG" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 1
@@ -19880,6 +19952,15 @@
 	icon_state = "dark"
 	},
 /area/station/security/armoury)
+"ekf" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "ekl" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -19926,6 +20007,18 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor,
 /area/station/maintenance/medbay)
+"ekC" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/engineering/atmos/atmos_office)
 "ekD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -21550,6 +21643,16 @@
 /obj/structure/sign/plaques/kiddie,
 /turf/simulated/wall/r_wall,
 /area/station/aisat/antechamber_interior)
+"eEH" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "eEK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/woodentable,
@@ -22907,6 +23010,22 @@
 	icon_state = "bluecorner"
 	},
 /area/station/security/lobby)
+"eUa" = (
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Entry Shuttle Airlock";
+	req_one_access = list(13)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "eUf" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -23051,6 +23170,18 @@
 	icon_state = "yellowfull"
 	},
 /area/station/engineering/engine)
+"eWA" = (
+/obj/machinery/door_timer/cell_3{
+	pixel_x = 32;
+	pixel_y = 0;
+	dir = 4;
+	id = "Cell 3 perma"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "eWG" = (
 /turf/simulated/floor{
 	dir = 5;
@@ -23570,6 +23701,10 @@
 	dir = 4;
 	icon_state = "warn"
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "fcg" = (
@@ -23670,14 +23805,6 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/sleeper)
-"fdb" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/civilian/gym)
 "fdi" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/tinted,
@@ -23793,21 +23920,6 @@
 	icon_state = "bluefull"
 	},
 /area/station/civilian/locker)
-"feq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
 "fes" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
@@ -24128,14 +24240,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
-"fia" = (
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "yellow"
-	},
-/area/station/engineering/break_room)
 "fif" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -24386,26 +24490,6 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge)
-"fkA" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "fkM" = (
 /obj/structure/window/fulltile/tinted{
 	grilled = 1;
@@ -24516,6 +24600,26 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/lobby)
+"fmg" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "fmh" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 1
@@ -24682,16 +24786,6 @@
 	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
-"fpE" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SWW-FC";
-	location = "SW-FC"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "fpT" = (
 /obj/structure/table/woodentable/poker,
 /obj/item/toy/cards,
@@ -25235,6 +25329,16 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/library)
+"fuL" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-C";
+	location = "CS-AR"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "fuM" = (
 /obj/machinery/vending/coffee,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -26693,13 +26797,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
-"fLG" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-MB";
-	location = "N-MB"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "fLI" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -26830,14 +26927,11 @@
 /area/station/maintenance/brig)
 "fOp" = (
 /obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-C";
-	location = "CS-AR"
+	codes_txt = "patrol;next_patrol=SW-FC";
+	location = "SSW-FC"
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
+/turf/simulated/floor,
+/area/station/hallway/primary/starboard)
 "fOF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
@@ -27248,6 +27342,18 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/station/civilian/dormitories)
+"fTu" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "fTz" = (
 /turf/simulated/wall,
 /area/station/cargo/recycler)
@@ -27273,16 +27379,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/mixing)
-"fTZ" = (
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "fUu" = (
 /obj/effect/landmark/start/chief_engineer,
 /obj/structure/stool/bed/chair/office/light{
@@ -27670,13 +27766,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
-"fYw" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "fYD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -27700,6 +27789,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"fYP" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_corner";
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "arrows_white";
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/hallway/secondary/entry)
 "fYS" = (
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -28057,6 +28160,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
+"gdh" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "loadingarea"
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "arrow"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "gdx" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -28314,6 +28428,15 @@
 	icon_state = "damaged1"
 	},
 /area/station/maintenance/incinerator)
+"ggd" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-B";
+	location = "S-MB"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry)
 "ggr" = (
 /obj/structure/stool,
 /obj/machinery/light/smart,
@@ -28365,6 +28488,15 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"ghp" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DN";
+	location = "SSE-FC"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "ghu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -30564,6 +30696,7 @@
 	icon_state = "delivery"
 	},
 /obj/effect/decal/turf_decal{
+	dir = 4;
 	icon_state = "warn_corner"
 	},
 /turf/simulated/floor{
@@ -30872,18 +31005,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/engineering/atmos)
-"gGC" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "gGH" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/folder/blue,
@@ -31177,6 +31298,13 @@
 	dir = 8;
 	icon_state = "blackcorner"
 	},
+/area/station/hallway/secondary/entry)
+"gKs" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=N-MB";
+	location = "NNW-B"
+	},
+/turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "gKt" = (
 /obj/structure/rack,
@@ -31673,7 +31801,7 @@
 	dir = 4
 	},
 /obj/machinery/flasher{
-	id = "Cell 3 perma";
+	id = "Cell 1 perma";
 	pixel_y = -28
 	},
 /turf/simulated/floor,
@@ -31717,13 +31845,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/singularity)
-"gRv" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=N-MB";
-	location = "NNW-B"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "gRy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -31841,6 +31962,16 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/armoury)
+"gSv" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NNW-B";
+	location = "NW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "gSy" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -31923,6 +32054,20 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/lobby)
+"gTo" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 9;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "gTw" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/grille,
@@ -32442,6 +32587,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/hos)
+"gYs" = (
+/obj/machinery/light/smart,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "gYu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -33226,6 +33381,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
+"hji" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_right"
+	},
+/turf/simulated/floor,
+/area/station/storage/tech)
 "hjl" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -33269,6 +33431,16 @@
 	icon_state = "white"
 	},
 /area/station/rnd/hallway)
+"hjU" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "hjY" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -33314,16 +33486,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/qm)
-"hkq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "hkt" = (
 /obj/structure/rack,
 /obj/item/weapon/crowbar,
@@ -33395,6 +33557,17 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/break_room)
+"hkH" = (
+/obj/structure/stool/bed/chair/metal/black{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "hkQ" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/clipboard,
@@ -33506,27 +33679,6 @@
 	},
 /turf/simulated/floor,
 /area/station/medical/surgeryobs)
-"hlV" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-B";
-	location = "SSW-B"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
-"hlZ" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "hmn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -34076,6 +34228,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"hrw" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=CS-AR";
+	location = "SWW-FC"
+	},
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "hrO" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -34371,8 +34530,8 @@
 /area/station/maintenance/science)
 "hur" = (
 /obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
+	dir = 1;
+	icon_state = "warn_corner"
 	},
 /obj/effect/decal/turf_decal{
 	dir = 4;
@@ -34581,7 +34740,7 @@
 	req_access = list(2)
 	},
 /obj/effect/decal/turf_decal{
-	dir = 4;
+	dir = 8;
 	icon_state = "warn"
 	},
 /turf/simulated/floor/plating,
@@ -35587,6 +35746,14 @@
 	name = "Entry Shuttle Airlock";
 	req_one_access = list(13)
 	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "hGr" = (
@@ -35756,14 +35923,6 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/locker)
-"hHQ" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "hHS" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -36098,23 +36257,6 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/gym)
-"hMn" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "hMx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -36205,18 +36347,6 @@
 	icon_state = "redbluefull"
 	},
 /area/station/civilian/theatre)
-"hNq" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "hNE" = (
 /obj/machinery/sleeper{
 	dir = 4
@@ -36481,6 +36611,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"hQm" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 5
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "hQo" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -36507,8 +36646,7 @@
 	},
 /obj/machinery/portable_atmospherics/powered/pump,
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
+	icon_state = "box_corners_white"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -37596,6 +37734,10 @@
 	pixel_x = -28;
 	pixel_y = -5
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -38185,6 +38327,13 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/library)
+"ikk" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "ikm" = (
 /obj/machinery/computer/atmos_alert,
 /obj/machinery/light/small{
@@ -39042,19 +39191,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
-"itO" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "itP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -39340,6 +39476,17 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/brig/storage)
+"ixp" = (
+/obj/machinery/light/smart,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DS";
+	location = "DN-W"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "purplecorner"
+	},
+/area/station/hallway/primary/central)
 "ixC" = (
 /obj/item/target/syndicate,
 /turf/simulated/floor{
@@ -39871,7 +40018,7 @@
 "iDw" = (
 /obj/item/weapon/flora/random,
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_right"
+	icon_state = "bot_left"
 	},
 /turf/simulated/floor,
 /area/station/storage/tech)
@@ -40431,6 +40578,21 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/rnd/test_area)
+"iIP" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/engineering/monitoring)
 "iIT" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -40594,24 +40756,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/robotics)
-"iLy" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
 "iLJ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -41247,15 +41391,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/fore)
-"iRQ" = (
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
 "iRS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -41451,6 +41586,19 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/chargebay)
+"iUC" = (
+/obj/machinery/light/smart{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NE-FC";
+	location = "NEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "iUE" = (
 /obj/structure/table/woodentable,
 /obj/item/device/megaphone,
@@ -41825,18 +41973,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/barbershop)
-"iZd" = (
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Labor Camp Shuttle Airlock";
-	req_access = list(2)
-	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/brig)
 "iZg" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -41900,17 +42036,6 @@
 	icon_state = "dark"
 	},
 /area/station/cargo/recycleroffice)
-"iZU" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos/atmos_office)
 "jat" = (
 /obj/machinery/porta_turret/station_default{
 	dir = 4
@@ -42845,7 +42970,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/hallway/secondary/entry)
 "jkq" = (
 /obj/effect/decal/cleanable/dirt,
@@ -43034,7 +43161,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -43444,16 +43572,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/execution)
-"jrE" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NNW-B";
-	location = "NW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "jrT" = (
 /turf/simulated/floor{
 	icon_state = "blue"
@@ -44154,26 +44272,6 @@
 /obj/machinery/vending/barbervend,
 /turf/simulated/floor/wood,
 /area/station/civilian/barbershop)
-"jxV" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "jxX" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -46634,18 +46732,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/civilian/locker)
-"jYr" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "jYs" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable{
@@ -46794,6 +46880,15 @@
 /obj/item/weapon/wrench,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"kak" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Central Access"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "kav" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
@@ -46913,6 +47008,19 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"kci" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "escape"
+	},
+/area/station/hallway/primary/port)
 "kcn" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/camera{
@@ -47025,7 +47133,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/hallway/secondary/entry)
 "kdH" = (
 /turf/simulated/wall,
@@ -47389,17 +47499,23 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "kgH" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 8
+	icon_state = "siding_line";
+	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/engineering/atmos/atmos_office)
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "khm" = (
 /obj/machinery/power/apc{
 	name = "apc down";
@@ -47844,6 +47960,20 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/supermatter)
+"klw" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/pump,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "arrival"
+	},
+/area/station/hallway/primary/port)
 "kly" = (
 /obj/structure/closet/crate,
 /obj/machinery/light/smart,
@@ -48826,6 +48956,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/civilian/toilet)
+"kxs" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "kxu" = (
 /obj/machinery/atmospherics/components/binary/valve/digital{
 	dir = 4
@@ -52093,6 +52236,17 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/psych)
+"lix" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "liA" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -54470,6 +54624,19 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/sleeper)
+"lKE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/flasher{
+	id = "Cell 3 perma";
+	pixel_y = -28
+	},
+/turf/simulated/floor,
+/area/station/security/prison)
 "lKG" = (
 /obj/machinery/hydroponics/constructable,
 /turf/simulated/floor/plating,
@@ -54746,16 +54913,6 @@
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor,
 /area/station/maintenance/incinerator)
-"lNf" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SEE-FC";
-	location = "SE-FC"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "lNi" = (
 /obj/machinery/light/smart{
 	dir = 1
@@ -55075,13 +55232,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/hallway/primary/fore)
-"lPW" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=CS-AR";
-	location = "SWW-FC"
-	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
 "lQn" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -55318,13 +55468,6 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/secondary/exit)
-"lTq" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "lTt" = (
 /turf/simulated/floor{
 	dir = 5;
@@ -55375,26 +55518,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/bridge/corp_lounge)
-"lUe" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "lUh" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -55514,6 +55637,25 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway)
+"lVN" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/main)
 "lVS" = (
 /obj/machinery/kitchen_machine/oven,
 /turf/simulated/floor{
@@ -56088,6 +56230,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/armoury)
+"meu" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_left"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/cold_room)
 "mev" = (
 /obj/structure/displaycase_chassis,
 /obj/effect/decal/cleanable/dirt,
@@ -56478,7 +56629,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/hallway/secondary/entry)
 "miK" = (
 /obj/structure/cable{
@@ -56644,15 +56797,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/rnd/telesci)
-"mkn" = (
-/obj/effect/decal/turf_decal{
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "mko" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -57184,6 +57328,16 @@
 	},
 /turf/simulated/floor,
 /area/station/gateway)
+"mqn" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSE-FC";
+	location = "SEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "mqw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -57267,6 +57421,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/break_room)
+"mri" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/security/prison)
 "mrj" = (
 /obj/machinery/atmospherics/components/trinary/tvalve/mirrored/digital/bypass{
 	dir = 8
@@ -59187,6 +59349,16 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/sleeper)
+"mOH" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-B";
+	location = "SSW-B"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "mOU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -61785,6 +61957,22 @@
 	icon_state = "red"
 	},
 /area/station/security/brig/equipment)
+"nrP" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "nsa" = (
 /turf/simulated/wall/r_wall,
 /area/station/engineering/engine)
@@ -61922,6 +62110,16 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/hallway)
+"ntV" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SEE-FC";
+	location = "SE-FC"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "nub" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -62597,6 +62795,14 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
+"nBM" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "nBQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -63468,6 +63674,12 @@
 "nMg" = (
 /turf/simulated/wall,
 /area/station/medical/hallway)
+"nMh" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "browncorner"
+	},
+/area/station/cargo/storage)
 "nMn" = (
 /obj/random/vending/cola,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -65151,6 +65363,9 @@
 /obj/structure/stool/bed/chair/metal/black{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -65739,6 +65954,12 @@
 /obj/structure/window/thin,
 /turf/simulated/floor,
 /area/station/security/prison)
+"oms" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
+	},
+/turf/simulated/floor/carpet/red,
+/area/station/security/detectives_office)
 "omz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -65828,12 +66049,6 @@
 	icon_state = "delivery"
 	},
 /turf/simulated/floor,
-/area/station/cargo/storage)
-"onT" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "browncorner"
-	},
 /area/station/cargo/storage)
 "ooi" = (
 /obj/structure/sign/warning/nosmoking{
@@ -66344,16 +66559,6 @@
 	icon_state = "bluecorner"
 	},
 /area/station/maintenance/chapel)
-"ouM" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
 "ouN" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -66395,6 +66600,26 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
+"ovd" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "ovi" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -67186,15 +67411,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/prison)
-"oGm" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Security";
-	location = "S-C"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "oGp" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -67374,6 +67590,19 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
+"oIo" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "oIK" = (
 /turf/simulated/wall/r_wall,
 /area/station/rnd/tox_launch)
@@ -67671,17 +67900,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/storage)
-"oLH" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "oLJ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -68171,6 +68389,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/civilian/toilet)
+"oQP" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Security";
+	location = "S-C"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "oQQ" = (
 /obj/structure/sign/nanotrasen,
 /turf/simulated/wall/r_wall,
@@ -68454,13 +68681,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
-"oUT" = (
-/obj/item/weapon/flora/random,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_left"
-	},
-/turf/simulated/floor,
-/area/station/storage/tech)
 "oUW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
@@ -68943,7 +69163,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/hallway/secondary/entry)
 "paE" = (
 /obj/structure/cable{
@@ -69737,6 +69959,17 @@
 	icon_state = "yellow"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
+"pko" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "pkt" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -70210,19 +70443,6 @@
 	icon_state = "red"
 	},
 /area/station/security/checkpoint/engi)
-"poO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/flasher{
-	id = "Cell 1 perma";
-	pixel_y = -28
-	},
-/turf/simulated/floor,
-/area/station/security/prison)
 "poS" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/turf_decal{
@@ -71178,6 +71398,16 @@
 	icon_state = "wooden"
 	},
 /area/station/bridge/corp_lounge)
+"pzl" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SWW-FC";
+	location = "SW-FC"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "pzr" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -72234,7 +72464,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/hallway/secondary/entry)
 "pLE" = (
 /obj/effect/decal/cleanable/blood/xeno,
@@ -72846,15 +73078,6 @@
 	icon_state = "purplecorner"
 	},
 /area/station/rnd/telesci)
-"pRG" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 5
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "pRL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -72899,6 +73122,26 @@
 	icon_state = "vaultfull"
 	},
 /area/station/maintenance/chapel)
+"pSR" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "pSS" = (
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the test chamber.";
@@ -73812,15 +74055,6 @@
 "qdH" = (
 /turf/simulated/wall,
 /area/station/security/checkpoint/escape_custom_desk)
-"qdK" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "qdU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -74015,6 +74249,19 @@
 	icon_state = "gcircuit"
 	},
 /area/station/rnd/xenobiology)
+"qgf" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_corner"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "arrows_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/hallway/secondary/entry)
 "qgs" = (
 /obj/effect/decal/turf_decal{
 	dir = 4;
@@ -74030,6 +74277,14 @@
 	locked = 1;
 	name = "Entry Shuttle Airlock";
 	req_one_access = list(13)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
@@ -74817,19 +75072,6 @@
 	icon_state = "grimy"
 	},
 /area/station/security/vacantoffice)
-"qoy" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "qoD" = (
 /obj/structure/flora/ausbushes/leafybush,
 /obj/structure/window/thin{
@@ -75619,6 +75861,17 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/chargebay)
+"qzF" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos/atmos_office)
 "qzI" = (
 /obj/machinery/teleport/hub,
 /obj/machinery/alarm{
@@ -76219,6 +76472,16 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/cargo/recycler)
+"qGH" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/hallway/secondary/entry)
 "qGO" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -76794,18 +77057,6 @@
 	icon_state = "darkredfull"
 	},
 /area/station/security/brig)
-"qNw" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "qNE" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/box/masks{
@@ -77690,6 +77941,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "qYg" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "qYj" = (
@@ -77754,6 +78013,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/ai_monitored/storage_secure)
+"qYG" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "qYH" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -77808,16 +78076,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/supermatter)
-"qZr" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "qZv" = (
 /obj/structure/table,
 /obj/item/weapon/storage/toolbox/mechanical,
@@ -78052,15 +78310,6 @@
 "rbY" = (
 /turf/simulated/floor,
 /area/station/security/main)
-"rcc" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "rcq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -78292,16 +78541,6 @@
 /obj/structure/sign/warning,
 /turf/simulated/wall/r_wall,
 /area/station/rnd/storage)
-"rfF" = (
-/obj/machinery/light/smart,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "rfL" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -78346,6 +78585,16 @@
 	icon_state = "red"
 	},
 /area/station/security/prison)
+"rgf" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "rgg" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -78787,6 +79036,15 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"rlL" = (
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "rlM" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -78914,20 +79172,6 @@
 	icon_state = "solarpanel"
 	},
 /area/station/solar/auxstarboard)
-"rnx" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "escape"
-	},
-/area/station/hallway/primary/port)
 "rnA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -79971,7 +80215,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/hallway/secondary/entry)
 "rzd" = (
 /obj/structure/cable{
@@ -80683,6 +80929,37 @@
 	icon_state = "neutralfull"
 	},
 /area/station/cargo/storage)
+"rGB" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SE-FC";
+	location = "SW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
+"rGW" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Antechamber";
+	req_one_access = list(66)
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/aisat/teleport)
 "rHa" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -81340,6 +81617,18 @@
 	icon_state = "purplecorner"
 	},
 /area/station/rnd/hor)
+"rMt" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "rMI" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -81389,16 +81678,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/medbay)
-"rMX" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SE-FC";
-	location = "SW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "rNc" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -81931,6 +82210,15 @@
 	},
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
+"rTs" = (
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "rTt" = (
 /obj/machinery/vending/tool,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -82099,13 +82387,6 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/locker)
-"rVJ" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-FC";
-	location = "SSW-FC"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/starboard)
 "rVK" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -82374,6 +82655,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/scibreak)
+"rZd" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "rZe" = (
 /obj/structure/closet/secure_closet/iaa,
 /obj/machinery/camera{
@@ -83692,16 +83993,6 @@
 /obj/structure/door_assembly/door_assembly_fre,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"snN" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NEE-FC";
-	location = "S-SV"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "snQ" = (
 /turf/simulated/floor{
 	dir = 6;
@@ -83991,16 +84282,6 @@
 	icon_state = "grimy"
 	},
 /area/station/security/detectives_office)
-"srz" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "srI" = (
 /obj/structure/window/thin/reinforced{
 	dir = 8
@@ -84582,6 +84863,13 @@
 /obj/item/weapon/circuitboard/seed_extractor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"szm" = (
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/prison)
 "szq" = (
 /turf/simulated/floor{
 	icon_state = "darkbrown"
@@ -84666,13 +84954,6 @@
 	icon_state = "grimy"
 	},
 /area/station/storage/tools)
-"sAu" = (
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/prison)
 "sAP" = (
 /obj/structure/table/glass,
 /obj/item/device/radio/intercom{
@@ -85532,6 +85813,18 @@
 	icon_state = "vaultfull"
 	},
 /area/station/bridge)
+"sKB" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "sKL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -86445,15 +86738,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/engineering/atmos)
-"sVK" = (
-/obj/effect/decal/turf_decal/alpha/blue{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "sWq" = (
 /obj/item/weapon/flora/random,
 /obj/structure/window/thin{
@@ -86614,16 +86898,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
-"sYl" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkred"
-	},
-/area/station/security/brig)
 "sYm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
@@ -87304,17 +87578,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
-"tgN" = (
-/obj/machinery/light/smart,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DS";
-	location = "DN-W"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "purplecorner"
-	},
-/area/station/hallway/primary/central)
 "tgP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -87376,6 +87639,16 @@
 	icon_state = "black"
 	},
 /area/station/hallway/primary/fore)
+"tie" = (
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "tif" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -88079,6 +88352,10 @@
 	dir = 4;
 	icon_state = "warn"
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "trd" = (
@@ -88491,12 +88768,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"tws" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "cafeteria"
-	},
-/area/station/security/prison)
 "twB" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/components/unary/portables_connector{
@@ -88729,6 +89000,15 @@
 	icon_state = "dark"
 	},
 /area/station/medical/virology)
+"tzi" = (
+/obj/structure/closet/emcloset,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "tzm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light/small{
@@ -89269,6 +89549,15 @@
 	icon_state = "neutral"
 	},
 /area/station/hallway/primary/central)
+"tES" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "tEU" = (
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32;
@@ -89359,27 +89648,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/bridge/hop_office)
-"tGm" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "tGH" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/light/smart{
@@ -90081,6 +90349,16 @@
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/engineering/atmos/distribution)
+"tPS" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-FC";
+	location = "DS"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
+/area/station/hallway/primary/central)
 "tPT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -90923,6 +91201,13 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway/lobby)
+"uaw" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "uaL" = (
 /obj/structure/sign/poster/official/help_others{
 	pixel_x = 32
@@ -91068,15 +91353,12 @@
 	},
 /area/station/rnd/hallway)
 "ucx" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Central Access"
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 4
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "ucF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -91369,7 +91651,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/hallway/secondary/entry)
 "ugF" = (
 /obj/machinery/door/firedoor,
@@ -92635,6 +92919,7 @@
 	name = "Central Access"
 	},
 /turf/simulated/floor{
+	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/station/security/lobby)
@@ -93354,23 +93639,6 @@
 	},
 /turf/simulated/wall,
 /area/station/hallway/secondary/entry)
-"uEv" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "caution"
-	},
-/area/station/engineering/atmos/distribution)
 "uEC" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced/phoron{
@@ -93612,18 +93880,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "uHN" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/powered/pump,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "arrival"
+	icon_state = "yellow"
 	},
-/area/station/hallway/primary/port)
+/area/station/engineering/break_room)
 "uHX" = (
 /turf/simulated/floor/wood,
 /area/station/maintenance/chapel)
@@ -94018,13 +94281,15 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "uNw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "neutralfull"
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
 	},
-/area/station/security/prison)
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/station/security/brig)
 "uNx" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -94545,16 +94810,6 @@
 /obj/item/device/mmi/radio_enabled,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
-"uUp" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSE-FC";
-	location = "SEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "uUs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor,
@@ -95541,18 +95796,6 @@
 	icon_state = "dark"
 	},
 /area/station/bridge)
-"vgK" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "vgN" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -95711,6 +95954,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"vih" = (
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Labor Camp Shuttle Airlock";
+	req_access = list(2)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
 "vil" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -96115,13 +96370,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/telesci)
-"vnc" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "vnf" = (
 /obj/structure/cable/yellow{
 	d2 = 4;
@@ -97454,6 +97702,16 @@
 /obj/structure/sign/warning/securearea,
 /turf/simulated/wall/r_wall,
 /area/station/rnd/hallway)
+"vDW" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NEE-FC";
+	location = "S-SV"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "vEp" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -98566,21 +98824,6 @@
 	icon_state = "neutral"
 	},
 /area/station/hallway/primary/central)
-"vSu" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/engineering/monitoring)
 "vSv" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal{
@@ -98748,15 +98991,22 @@
 	},
 /area/station/bridge/teleporter)
 "vTX" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Entry Shuttle Airlock";
+	req_one_access = list(13)
 	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
 	},
-/area/station/engineering/atmos)
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "vUe" = (
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
@@ -100025,6 +100275,18 @@
 	icon_state = "white"
 	},
 /area/station/medical/virology)
+"wjz" = (
+/obj/structure/stool/bed/chair/metal/black{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "wjA" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -100943,26 +101205,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/surgeryobs)
-"wvg" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "wvl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -101784,25 +102026,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
-"wEd" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/main)
 "wEp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/item/device/radio/intercom{
@@ -101992,11 +102215,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
-"wGo" = (
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "wGs" = (
 /obj/structure/closet/wardrobe/white,
 /turf/simulated/floor,
@@ -102040,7 +102258,7 @@
 "wHb" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_left"
+	icon_state = "bot_right"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -103201,19 +103419,6 @@
 	icon_state = "blackchecker"
 	},
 /area/station/maintenance/chapel)
-"wWB" = (
-/obj/machinery/light/smart{
-	dir = 4
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NE-FC";
-	location = "NEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "wWD" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -103316,6 +103521,23 @@
 	icon_state = "white"
 	},
 /area/station/rnd/hallway)
+"wYv" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "caution"
+	},
+/area/station/engineering/atmos/distribution)
 "wYB" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor{
@@ -103870,6 +104092,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
+"xey" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "xeB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -104149,6 +104383,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig)
+"xhz" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "xhL" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -104204,17 +104447,6 @@
 	icon_state = "caution"
 	},
 /area/station/medical/chemistry)
-"xiB" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "loadingarea"
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "arrow"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "xiI" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
@@ -105387,27 +105619,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
-"xvn" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Antechamber";
-	req_one_access = list(66)
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/aisat/teleport)
 "xvs" = (
 /obj/structure/toilet{
 	dir = 8
@@ -106237,6 +106448,15 @@
 	},
 /turf/simulated/wall,
 /area/station/hallway/primary/starboard)
+"xEe" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "xEl" = (
 /obj/structure/table,
 /obj/item/device/camera/polar,
@@ -106565,19 +106785,6 @@
 	icon_state = "white"
 	},
 /area/station/rnd/hallway)
-"xIL" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "xIO" = (
 /obj/structure/stool/bed/chair{
 	dir = 8
@@ -107102,6 +107309,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -107388,6 +107596,10 @@
 /area/station/maintenance/science)
 "xRU" = (
 /obj/structure/closet/emcloset,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -107658,17 +107870,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/carpet,
 /area/station/bridge)
-"xVk" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "yellow"
-	},
-/area/station/engineering/atmos)
 "xVm" = (
 /obj/machinery/alarm{
 	pixel_y = -32
@@ -108180,6 +108381,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
+"yaF" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "yaN" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -109028,7 +109239,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/hallway/secondary/entry)
 "ylW" = (
 /obj/machinery/hydroponics/soil,
@@ -118427,7 +118640,7 @@ eXX
 pGn
 fBB
 pGn
-xvn
+rGW
 pGn
 pGn
 oer
@@ -131782,7 +131995,7 @@ xFF
 xFG
 flb
 uDn
-fia
+uHN
 ude
 ehA
 geB
@@ -132039,7 +132252,7 @@ qnQ
 hEd
 fDg
 owf
-fia
+uHN
 hkb
 ehA
 fUz
@@ -132542,7 +132755,7 @@ oLJ
 kFc
 kFc
 cEO
-xVk
+pko
 azQ
 pfp
 imT
@@ -132788,7 +133001,7 @@ qSk
 qdn
 naA
 kdJ
-qoy
+kxs
 xqQ
 fmh
 mNB
@@ -132796,8 +133009,8 @@ bfy
 cmG
 dup
 htY
-vTX
-vTX
+caB
+caB
 nwM
 tCz
 gRR
@@ -133052,7 +133265,7 @@ nLs
 bTE
 tUm
 oPF
-itO
+bZo
 rSb
 umn
 svw
@@ -133816,7 +134029,7 @@ bsZ
 fZH
 cTK
 whA
-kgH
+ekC
 iDO
 iDO
 iDO
@@ -133825,8 +134038,8 @@ vCV
 lFG
 waB
 fMO
-vgK
-cqV
+fTu
+sKB
 kHT
 vPk
 vPk
@@ -134073,9 +134286,9 @@ pBb
 hrT
 qcT
 mrP
+qzF
+qzF
 daq
-daq
-iZU
 egG
 iEf
 hrT
@@ -134617,9 +134830,9 @@ hdV
 bhn
 evV
 oKM
-jYr
+rMt
 wCx
-qNw
+ejv
 oDZ
 bau
 nkc
@@ -134874,9 +135087,9 @@ moL
 ojN
 enq
 bgZ
-hMn
-tRh
 gCp
+tRh
+nrP
 oyx
 mRP
 eZT
@@ -135630,7 +135843,7 @@ adw
 adw
 adw
 wjD
-vSu
+iIP
 cgv
 owM
 ekM
@@ -136133,7 +136346,7 @@ jlK
 tEF
 tne
 cEZ
-uEv
+wYv
 iGS
 ciX
 jau
@@ -136915,13 +137128,13 @@ tEF
 sHQ
 dpc
 sHQ
-rnx
 blv
+kci
 sqb
 uck
 sqb
+klw
 hQQ
-uHN
 qTx
 bUU
 iky
@@ -137187,7 +137400,7 @@ doE
 doE
 doE
 lgU
-lNf
+ntV
 mhm
 doE
 mnD
@@ -137685,7 +137898,7 @@ wwi
 aYN
 wwi
 lfm
-uUp
+mqn
 tZn
 oyb
 nAM
@@ -137703,7 +137916,7 @@ oyb
 bzt
 bzt
 rcq
-bzG
+ghp
 tYK
 wtC
 wtC
@@ -138719,7 +138932,7 @@ xNR
 rMP
 nAi
 vfr
-oUT
+iDw
 rDd
 jcO
 iNE
@@ -139233,7 +139446,7 @@ xNR
 oYv
 cGN
 vzT
-iDw
+hji
 oVN
 cdA
 jTf
@@ -139476,7 +139689,7 @@ tRk
 vdt
 rwG
 srt
-aKm
+wHb
 dOS
 rfL
 qsE
@@ -139733,7 +139946,7 @@ aSY
 uum
 lVS
 srt
-wHb
+meu
 uos
 gTB
 kst
@@ -140450,14 +140663,14 @@ yaE
 ffS
 aev
 yaE
-qgt
+vTX
 yaE
 aqg
 aqg
 aqg
 mlH
 yaE
-qgt
+vTX
 yaE
 eeB
 ffS
@@ -140504,7 +140717,7 @@ kBq
 biv
 pED
 bNa
-ouM
+hjU
 kIU
 lBN
 yeY
@@ -140761,7 +140974,7 @@ dtM
 fty
 abG
 vLv
-ouM
+hjU
 kIU
 jVV
 ekm
@@ -141478,7 +141691,7 @@ yaE
 ffS
 eeB
 yaE
-qgt
+vTX
 yaE
 mlH
 nhe
@@ -142529,11 +142742,11 @@ dbB
 idn
 fRR
 ofi
-mlH
+tES
 miI
 ffS
 jjY
-aqg
+tzi
 wwi
 pkS
 wwi
@@ -143082,7 +143295,7 @@ iSv
 xXt
 vAu
 ogP
-hlV
+mOH
 bAS
 nvi
 rnH
@@ -143098,7 +143311,7 @@ qbj
 qbj
 tmk
 ldb
-rMX
+rGB
 ogP
 iSi
 amv
@@ -143125,7 +143338,7 @@ vpT
 xei
 bFh
 vpT
-tgN
+ixp
 vIl
 olx
 frM
@@ -143293,7 +143506,7 @@ plf
 brw
 mko
 jsL
-dMN
+ggd
 ffX
 hbE
 sTt
@@ -143562,7 +143775,7 @@ gHT
 alc
 vDr
 fDL
-jrE
+gSv
 iwy
 xXt
 gNR
@@ -144068,10 +144281,10 @@ fYS
 slo
 ffS
 pLB
-mlH
+tES
 dDs
 acf
-dDs
+ecQ
 aSq
 ffS
 gvF
@@ -144343,17 +144556,17 @@ hXb
 hXb
 hXb
 che
-iRQ
-iLy
-iRQ
-iRQ
-iRQ
-iRQ
-iRQ
-iRQ
-iRQ
-feq
-iRQ
+rTs
+kgH
+rTs
+rTs
+rTs
+rTs
+rTs
+rTs
+rTs
+cTx
+rTs
 vos
 did
 did
@@ -144562,7 +144775,7 @@ kHU
 kHU
 kHU
 yaE
-hGn
+eUa
 yaE
 kHU
 plf
@@ -144847,7 +145060,7 @@ kHU
 yaE
 hkD
 fYS
-mkn
+rlL
 wts
 mge
 qed
@@ -145127,13 +145340,13 @@ mpN
 uQg
 tJq
 oFm
-lTq
+ucx
 xsb
-lTq
-lTq
-lTq
+ucx
+ucx
+ucx
 mtf
-lTq
+ucx
 jpq
 bsc
 mfI
@@ -145361,7 +145574,7 @@ plf
 yaE
 vDr
 fYS
-fTZ
+tie
 tEo
 nIB
 iEL
@@ -145618,7 +145831,7 @@ kHU
 yaE
 csG
 fYS
-rfF
+gYs
 wts
 npC
 txi
@@ -145641,13 +145854,13 @@ cCx
 mES
 tJq
 ikZ
-asZ
+cvJ
 oki
-fYw
-fYw
-ejv
+ikk
+ikk
+dOg
 tWH
-ejv
+dOg
 qcF
 bRX
 qSi
@@ -145898,7 +146111,7 @@ tJq
 ucP
 tJq
 fSC
-cMf
+cdw
 ktM
 uuo
 djH
@@ -146381,10 +146594,10 @@ fYS
 jNI
 ffS
 ylK
-fRR
+wjz
 cmX
 fRR
-fRR
+hkH
 ryG
 ffS
 uAC
@@ -146618,14 +146831,14 @@ xjr
 xjr
 kHU
 dhU
-hGn
+eUa
 yaE
 kHU
 plf
 plf
 kHU
 yaE
-hGn
+eUa
 yaE
 plf
 plf
@@ -147406,7 +147619,7 @@ yaE
 yaE
 csG
 fYS
-fLG
+diN
 alc
 gHT
 gHT
@@ -147415,7 +147628,7 @@ gHT
 gHT
 gHT
 alc
-gRv
+gKs
 fYS
 sEX
 srs
@@ -147665,12 +147878,12 @@ lrr
 fYS
 wtr
 sDu
-tVy
-tVy
-tVy
-tVy
-tVy
-tVy
+qgf
+qGH
+qGH
+qGH
+qGH
+fYP
 xao
 csG
 fYS
@@ -148674,14 +148887,14 @@ xjr
 xjr
 kHU
 dhU
-hGn
+eUa
 yaE
 kHU
 plf
 plf
 kHU
 yaE
-hGn
+eUa
 yaE
 plf
 plf
@@ -148931,14 +149144,14 @@ xjr
 xjr
 plf
 yaE
-qYg
+ctv
 yaE
 yaE
 yaE
 yaE
 yaE
 yaE
-qYg
+ctv
 yaE
 plf
 plf
@@ -152350,7 +152563,7 @@ mXl
 mXl
 mXl
 wLD
-snN
+vDW
 iwm
 mXl
 pRS
@@ -152368,7 +152581,7 @@ oNU
 mXl
 uxx
 xMc
-fpE
+pzl
 nvi
 rnH
 cLM
@@ -152377,7 +152590,7 @@ nvi
 tOH
 mfI
 ogP
-dqP
+tPS
 sBG
 wjc
 wjc
@@ -152680,7 +152893,7 @@ xQo
 xQo
 xQo
 nKU
-rVJ
+fOp
 xQo
 oPI
 mRu
@@ -152847,7 +153060,7 @@ cpR
 gtK
 cpR
 pxL
-wWB
+iUC
 ffJ
 ape
 fZz
@@ -152866,7 +153079,7 @@ hRd
 ckx
 fZz
 lMB
-oGm
+oQP
 kzb
 vAu
 psV
@@ -152880,7 +153093,7 @@ vAu
 kRo
 vAu
 kCI
-fOp
+fuL
 ogP
 lwr
 mLS
@@ -153121,9 +153334,9 @@ erD
 erD
 cmN
 act
-ucx
-xsY
 uuf
+xsY
+kak
 jTW
 jTW
 jTW
@@ -153603,7 +153816,7 @@ fnT
 miA
 ojm
 lPc
-onT
+nMh
 gaF
 rpV
 qSe
@@ -153860,11 +154073,11 @@ nkb
 adb
 hzP
 cpR
-qZr
+eEH
 oOk
 uXI
 oOk
-srz
+yaF
 xqF
 aAF
 iqI
@@ -156971,8 +157184,8 @@ plf
 xyC
 cFp
 klH
-alL
-alL
+oms
+oms
 hGr
 aRu
 xyC
@@ -157475,11 +157688,11 @@ plf
 plf
 plf
 uRO
-hwE
+vih
 uRO
 plf
 uRO
-hwE
+vih
 uRO
 plf
 xyC
@@ -157496,8 +157709,8 @@ dnn
 aEr
 wPw
 jQy
-sVK
-wGo
+xhz
+beh
 jcX
 fJg
 nPU
@@ -157989,11 +158202,11 @@ plf
 cHH
 cHH
 jxX
-iZd
+hwE
 bjt
 stv
 jxX
-iZd
+hwE
 jxX
 adp
 kMq
@@ -158004,7 +158217,7 @@ xyC
 xyC
 xyC
 xyC
-vnc
+uaw
 jtG
 wpm
 fJg
@@ -158250,7 +158463,7 @@ opt
 kms
 cHH
 eow
-cKz
+gTo
 goK
 hYT
 nsn
@@ -158503,7 +158716,7 @@ leA
 cHH
 adG
 iGB
-sYl
+uNw
 tTk
 qMX
 aZz
@@ -158764,7 +158977,7 @@ ikW
 qXE
 rjb
 utF
-xiB
+gdh
 uLd
 lat
 nsn
@@ -159563,7 +159776,7 @@ kIM
 vst
 mDV
 vKG
-lPW
+hrw
 xoq
 tAM
 uQA
@@ -160282,14 +160495,14 @@ fAF
 fgx
 diq
 fAF
-cHV
+eWA
 eTq
 fAF
 wNM
 oPD
 tif
 rHZ
-lUe
+ovd
 czU
 tqK
 hsq
@@ -160546,7 +160759,7 @@ qZx
 qZx
 fXG
 qZx
-wvg
+pSR
 czU
 uvV
 kMw
@@ -161052,13 +161265,13 @@ blh
 cra
 hlv
 dVr
-gQC
+lKE
 hlv
 fBm
 bvC
 hlv
 vqQ
-poO
+gQC
 qZx
 tnw
 fLE
@@ -162076,7 +162289,7 @@ aXC
 bZu
 pLw
 unD
-uNw
+mri
 oAx
 ulK
 eyO
@@ -162628,9 +162841,9 @@ ilq
 uKd
 sxG
 uOc
+oIo
+oIo
 hur
-hur
-xIL
 ekd
 lZw
 gqC
@@ -162884,7 +163097,7 @@ ixl
 mme
 uKd
 gRX
-gGC
+brr
 sRa
 nUj
 wUB
@@ -162913,13 +163126,13 @@ ncp
 ncp
 hbR
 mWz
-hNq
+xey
 kLd
 syX
 tHk
 tHk
 dbf
-tGm
+bFL
 ram
 mWz
 lNQ
@@ -163176,7 +163389,7 @@ eFl
 aRb
 nDG
 jjN
-bFL
+aeA
 ram
 mWz
 ucd
@@ -163383,7 +163596,7 @@ afw
 nDf
 mZo
 qUR
-wEd
+lVN
 mzV
 aSh
 mpR
@@ -163684,13 +163897,13 @@ ncp
 ncp
 hbR
 mWz
-hlZ
+lix
 sIY
 qls
 uOM
 uOM
 aeG
-jxV
+fmg
 ram
 mWz
 hPr
@@ -163880,7 +164093,7 @@ lhK
 wVg
 aFN
 jKZ
-tws
+ckp
 rBo
 hlv
 qxh
@@ -164144,7 +164357,7 @@ xIO
 jps
 xIO
 qZx
-fkA
+rZd
 tbS
 sZR
 kHU
@@ -164156,7 +164369,7 @@ fwH
 qoH
 vOW
 qoH
-hHQ
+nBM
 umQ
 gYp
 kHU
@@ -164394,7 +164607,7 @@ jvm
 hlv
 fVW
 fPH
-tws
+ckp
 rnI
 hlv
 pHz
@@ -164409,11 +164622,11 @@ kHU
 plf
 cYc
 ueE
-hkq
+rgf
 wcJ
 iRz
 nez
-oLH
+eae
 hlh
 gYp
 plf
@@ -164666,11 +164879,11 @@ kHU
 kHU
 cYc
 nfj
-rcc
+ekf
 eaE
 nRk
 rZh
-bGI
+qYG
 hmN
 gYp
 kHU
@@ -164714,7 +164927,7 @@ dJL
 nRG
 oXA
 oXA
-fdb
+ccR
 dJL
 plf
 cdR
@@ -164923,11 +165136,11 @@ plf
 kHU
 huz
 sIx
-pRG
-qdK
+hQm
+xEe
 kjv
-qdK
-bBs
+xEe
+bih
 tEU
 huz
 plf
@@ -166972,7 +167185,7 @@ plf
 kHU
 hlv
 lrm
-sAu
+szm
 jno
 hlv
 cBu
@@ -168052,7 +168265,7 @@ kHU
 fMh
 plf
 dJL
-fdb
+ccR
 oXA
 oXA
 nJn

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -682,7 +682,7 @@
 /area/station/maintenance/atmos)
 "adw" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -1134,6 +1134,13 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"agQ" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_right"
+	},
+/turf/simulated/floor,
+/area/station/storage/tech)
 "agS" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/smart{
@@ -1752,6 +1759,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 1
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "yellow"
@@ -2351,16 +2362,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
-"asa" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "asj" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2742,7 +2743,7 @@
 /obj/machinery/light/smart{
 	dir = 8
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -3349,6 +3350,17 @@
 	icon_state = "wooden"
 	},
 /area/station/civilian/library)
+"aEz" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "aEB" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3492,15 +3504,26 @@
 	icon_state = "vaultfull"
 	},
 /area/station/hallway/primary/starboard)
-"aFk" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
+"aFq" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "grimy"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
 	},
-/area/station/security/hos)
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "aFr" = (
 /obj/machinery/photocopier,
 /obj/effect/decal/cleanable/dirt,
@@ -3965,6 +3988,10 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "aKv" = (
@@ -4342,6 +4369,10 @@
 	dir = 1;
 	icon_state = "warn"
 	},
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
 /turf/simulated/floor,
 /area/station/engineering/break_room)
 "aPP" = (
@@ -4385,6 +4416,15 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/break_room)
+"aQd" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "aQh" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -5771,6 +5811,10 @@
 	dir = 1;
 	name = "Port Mix to Starboard Ports"
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -6105,13 +6149,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig)
-"bjz" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "bjB" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
@@ -6341,6 +6378,9 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "escape"
@@ -6416,12 +6456,19 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
 "bmj" = (
 /obj/structure/closet/radiation,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "yellow"
 	},
@@ -6708,14 +6755,23 @@
 	icon_state = "wooden"
 	},
 /area/station/medical/psych)
-"bpB" = (
+"bpI" = (
 /obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-FC";
-	location = "DS"
+	codes_txt = "patrol;next_patrol=DN";
+	location = "SSE-FC"
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "bluecorner"
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
+"bpJ" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-B";
+	location = "SSW-B"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
 "bpO" = (
@@ -8000,6 +8056,10 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "yellowcorner"
@@ -8261,13 +8321,6 @@
 /obj/structure/stool/bed/chair/metal/white{
 	dir = 1
 	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
 /obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "siding_line";
 	dir = 1
@@ -8525,6 +8578,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
 	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -8905,8 +8961,7 @@
 "bLn" = (
 /obj/structure/dispenser,
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutral"
+	icon_state = "dark"
 	},
 /area/station/engineering/atmos/atmos_office)
 "bLz" = (
@@ -9032,7 +9087,9 @@
 	dir = 8;
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos/distribution)
 "bNy" = (
 /obj/structure/object_wall/mining{
@@ -9145,6 +9202,10 @@
 	dir = 1;
 	name = "Port Mix to Port Ports"
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -9225,8 +9286,15 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "dark"
 	},
 /area/station/engineering/break_room)
 "bQa" = (
@@ -9496,9 +9564,11 @@
 /obj/structure/table/reinforced,
 /obj/item/device/analyzer,
 /obj/item/weapon/wrench,
-/turf/simulated/floor{
-	icon_state = "yellowcorner"
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
 	},
+/turf/simulated/floor,
 /area/station/engineering/atmos)
 "bTG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -9583,16 +9653,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/cargo/qm)
-"bUB" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Central Access"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "bUI" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -10738,6 +10798,10 @@
 /area/station/engineering/atmos/supermatter)
 "cgv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 8
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -10822,6 +10886,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
 "chl" = (
@@ -10839,6 +10907,19 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/chapel)
+"cht" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/flasher{
+	id = "Cell 3 perma";
+	pixel_y = -28
+	},
+/turf/simulated/floor,
+/area/station/security/prison)
 "chv" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor,
@@ -10861,14 +10942,6 @@
 	icon_state = "red"
 	},
 /area/station/security/brig)
-"chC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/security/prison)
 "chU" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/light/small{
@@ -11007,9 +11080,12 @@
 	pixel_y = -6
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
+	icon_state = "box_white"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos/distribution)
 "cje" = (
 /obj/structure/cable{
@@ -11477,6 +11553,17 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
+"cou" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos/atmos_office)
 "cox" = (
 /obj/structure/table/woodentable,
 /obj/item/device/radio/intercom,
@@ -11567,6 +11654,18 @@
 	},
 /turf/simulated/floor/engine/airmix,
 /area/station/engineering/atmos)
+"cpK" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "cpL" = (
 /obj/machinery/light/smart{
 	dir = 4
@@ -11585,13 +11684,6 @@
 "cpR" = (
 /turf/simulated/wall,
 /area/station/cargo/storage)
-"cqu" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=CS-AR";
-	location = "SWW-FC"
-	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
 "cqB" = (
 /obj/item/weapon/flora/random,
 /obj/item/device/radio/intercom{
@@ -11950,17 +12042,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/engi)
-"cvN" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "loadingarea"
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "arrow"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "cvO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -12039,6 +12120,26 @@
 	icon_state = "white"
 	},
 /area/station/rnd/hor)
+"cwk" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "cwt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -12314,6 +12415,12 @@
 	icon_state = "caution"
 	},
 /area/station/medical/chemistry)
+"cze" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "browncorner"
+	},
+/area/station/cargo/storage)
 "czg" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -12361,7 +12468,9 @@
 	dir = 10;
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "czm" = (
 /obj/machinery/door/firedoor,
@@ -12703,6 +12812,9 @@
 	name = "Station Intercom (General)";
 	pixel_y = -32
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -12833,7 +12945,10 @@
 	dir = 1;
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos/distribution)
 "cFh" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
@@ -13298,7 +13413,9 @@
 	dir = 6;
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "cKf" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
@@ -13312,17 +13429,6 @@
 	},
 /turf/environment/space,
 /area/shuttle/mining/station)
-"cKx" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "cKC" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/cleanable/dirt,
@@ -14370,16 +14476,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
-"cVH" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSE-FC";
-	location = "SEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "cVO" = (
 /obj/structure/object_wall/pod{
 	icon_state = "1,2"
@@ -14613,6 +14709,10 @@
 "daq" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -14723,25 +14823,6 @@
 /obj/item/weapon/storage/toolbox/electrical,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
-"dbK" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/main)
 "dcn" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -14876,7 +14957,10 @@
 	dir = 4;
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos)
 "ddJ" = (
 /turf/simulated/floor/engine{
@@ -15203,19 +15287,6 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge/captain_quarters)
-"dhd" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "dhg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor,
@@ -15696,6 +15767,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 10
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -15713,6 +15788,10 @@
 	name = "Station Intercom (General)";
 	pixel_x = 28;
 	pixel_y = -5
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 1
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -15827,15 +15906,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/cargo/recycler)
-"dnc" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "dnd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -15950,6 +16020,16 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/station/cargo/storage)
+"dpx" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NEE-FC";
+	location = "S-SV"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "dpF" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -16597,18 +16677,6 @@
 	icon_state = "bluecorner"
 	},
 /area/station/engineering/minisat_secure_area)
-"dwq" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "dwB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/visible{
@@ -16633,7 +16701,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/engineering/atmos/atmos_office)
 "dwT" = (
 /obj/structure/cable{
@@ -17037,6 +17107,17 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/hallway/primary/fore)
+"dDi" = (
+/obj/machinery/light/smart,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DS";
+	location = "DN-W"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "purplecorner"
+	},
+/area/station/hallway/primary/central)
 "dDn" = (
 /obj/structure/table/reinforced,
 /obj/item/device/plant_analyzer,
@@ -17385,13 +17466,6 @@
 	icon_state = "blackcorner"
 	},
 /area/station/hallway/primary/starboard)
-"dHi" = (
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/prison)
 "dHv" = (
 /obj/machinery/door/poddoor{
 	id = "armouryaccess";
@@ -18031,7 +18105,7 @@
 	name = "Waste to Filter"
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
+	icon_state = "box_white"
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/distribution)
@@ -18043,8 +18117,8 @@
 /area/station/medical/storage)
 "dPL" = (
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "cautioncorner"
+	dir = 9;
+	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
 "dPT" = (
@@ -18469,7 +18543,10 @@
 	dir = 8;
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos)
 "dVh" = (
 /obj/structure/stool/bed/chair/metal/red{
@@ -19654,13 +19731,11 @@
 /area/station/hallway/primary/starboard)
 "ejv" = (
 /obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Security";
-	location = "S-C"
+	codes_txt = "patrol;next_patrol=N-MB";
+	location = "NNW-B"
 	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "ejG" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 1
@@ -19871,6 +19946,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 10
+	},
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
 "elw" = (
@@ -19910,11 +19989,11 @@
 /obj/machinery/ai_status_display{
 	pixel_y = -32
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_white"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/engineering/atmos)
 "elI" = (
@@ -20026,13 +20105,6 @@
 	},
 /turf/simulated/floor,
 /area/station/medical/hallway)
-"enc" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "eni" = (
 /obj/structure/toilet{
 	dir = 8
@@ -20581,15 +20653,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
-"euj" = (
-/obj/effect/decal/turf_decal{
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "eum" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -20704,12 +20767,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
-"evT" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "cafeteria"
-	},
-/area/station/security/prison)
 "evV" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
@@ -20837,6 +20894,9 @@
 	frequency = 1441;
 	name = "Tank Monitor";
 	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon  Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous  Oxide","waste_sensor"="Gas  Mix  Tank")
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -20983,6 +21043,10 @@
 /obj/machinery/alarm{
 	pixel_x = -28;
 	pixel_y = -6
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -21383,18 +21447,6 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/engine)
-"eDh" = (
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Labor Camp Shuttle Airlock";
-	req_access = list(2)
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/brig)
 "eDr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -23807,6 +23859,16 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/starboard)
+"ffC" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "ffG" = (
 /obj/machinery/light/smart{
 	dir = 8
@@ -23883,7 +23945,7 @@
 	},
 /obj/machinery/light/smart,
 /turf/simulated/floor{
-	icon_state = "cautioncorner"
+	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
 "ffZ" = (
@@ -24019,6 +24081,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -24530,7 +24596,9 @@
 	dir = 8;
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos)
 "fpT" = (
 /obj/structure/table/woodentable/poker,
@@ -24788,6 +24856,10 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 1
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -25417,21 +25489,6 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/secondary/exit)
-"fyJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
 "fyL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -26472,6 +26529,10 @@
 /obj/machinery/firealarm{
 	pixel_y = 22
 	},
+/obj/effect/decal/turf_decal{
+	dir = 5;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -26612,6 +26673,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -26658,14 +26723,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "fOp" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
+/obj/effect/decal/turf_decal/alpha/orange{
 	icon_state = "siding_line";
-	dir = 1
+	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "grimy"
+	icon_state = "neutralfull"
 	},
-/area/station/security/hos)
+/area/station/hallway/primary/fore)
 "fOF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
@@ -26691,6 +26756,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 9
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -26742,6 +26811,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -26885,7 +26957,7 @@
 /area/station/security/armoury)
 "fRu" = (
 /obj/machinery/disposal,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -26980,6 +27052,9 @@
 /obj/machinery/light/smart{
 	dir = 8
 	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutral"
@@ -26997,6 +27072,26 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/primary/fore)
+"fSy" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "fSC" = (
 /obj/machinery/vending/theater,
 /turf/simulated/floor{
@@ -27749,19 +27844,6 @@
 "gbY" = (
 /turf/simulated/wall/r_wall,
 /area/station/ai_monitored/storage_secure)
-"gbZ" = (
-/obj/machinery/light/smart{
-	dir = 4
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NE-FC";
-	location = "NEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "gca" = (
 /obj/effect/landmark/start/security_cadet,
 /turf/simulated/floor{
@@ -28288,7 +28370,9 @@
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "giF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -28405,6 +28489,10 @@
 	},
 /obj/effect/decal/turf_decal{
 	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 2;
 	icon_state = "warn"
 	},
 /turf/simulated/floor,
@@ -28535,6 +28623,16 @@
 	icon_state = "red"
 	},
 /area/station/security/checkpoint)
+"gki" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSE-FC";
+	location = "SEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "gkn" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/turf_decal/alpha/gray{
@@ -28773,7 +28871,7 @@
 	},
 /turf/simulated/floor{
 	dir = 1;
-	icon_state = "cautioncorner"
+	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
 "gmg" = (
@@ -29118,7 +29216,7 @@
 /area/station/maintenance/cargo)
 "gpz" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -29670,11 +29768,11 @@
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 1
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_white"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/engineering/atmos)
 "gvF" = (
@@ -30185,6 +30283,9 @@
 /area/station/security/prison)
 "gAr" = (
 /obj/machinery/space_heater,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "yellow"
@@ -30667,13 +30768,6 @@
 /obj/item/weapon/folder/blue,
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories)
-"gHf" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=N-MB";
-	location = "NNW-B"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "gHh" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -30980,6 +31074,20 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"gKE" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "escape"
+	},
+/area/station/hallway/primary/port)
 "gKG" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -31167,6 +31275,13 @@
 /turf/environment/space,
 /area/shuttle/supply/station)
 "gMT" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -31272,6 +31387,9 @@
 	dir = 4;
 	pixel_x = 22
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "yellow"
@@ -31293,6 +31411,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 1
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -31349,9 +31471,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
 "gPF" = (
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
@@ -31558,6 +31688,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -32335,16 +32469,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/checkpoint/engi)
-"hac" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SWW-FC";
-	location = "SW-FC"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "had" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -32598,6 +32722,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 8
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -32660,6 +32788,16 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/checkpoint)
+"hek" = (
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "heo" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -32743,8 +32881,8 @@
 /area/station/civilian/barbershop)
 "hfu" = (
 /obj/machinery/vending/tool,
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -33059,12 +33197,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor,
 /area/station/maintenance/science)
-"hkh" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
-	},
-/turf/simulated/floor/carpet/red,
-/area/station/security/detectives_office)
 "hkj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -33668,6 +33800,9 @@
 	pixel_y = -24;
 	req_access = list(24)
 	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
 "hqw" = (
@@ -33861,7 +33996,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -34042,6 +34177,12 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
 	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -34300,7 +34441,7 @@
 	req_access = list(2)
 	},
 /obj/effect/decal/turf_decal{
-	dir = 8;
+	dir = 4;
 	icon_state = "warn"
 	},
 /turf/simulated/floor/plating,
@@ -34550,6 +34691,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 8
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -34743,8 +34888,12 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_white"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -34846,8 +34995,14 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 5
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "dark"
 	},
 /area/station/engineering/break_room)
 "hBi" = (
@@ -35117,8 +35272,12 @@
 	name = "Atmospherics";
 	req_access = list(24)
 	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "dark"
 	},
 /area/station/engineering/break_room)
 "hEd" = (
@@ -35267,6 +35426,17 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/chapel)
+"hGc" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "hGd" = (
 /obj/machinery/power/solar_control{
 	id = "aftport";
@@ -35339,6 +35509,23 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/barbershop)
+"hGG" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "caution"
+	},
+/area/station/engineering/atmos/distribution)
 "hGJ" = (
 /obj/structure/closet/secure_closet/brig{
 	name = "Prisoner Locker"
@@ -36170,6 +36357,9 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/powered/pump,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "arrival"
@@ -37604,11 +37794,6 @@
 /obj/machinery/atmospherics/components/trinary/tvalve/mirrored/digital,
 /turf/simulated/floor/plating,
 /area/station/maintenance/incinerator)
-"iha" = (
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "ihd" = (
 /obj/structure/table/woodentable,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -37693,15 +37878,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/engineering/chiefs_office)
-"ihQ" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "ihW" = (
 /obj/machinery/computer/cryopod{
 	density = 0;
@@ -37954,6 +38130,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 9
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -38148,15 +38327,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/bridge)
-"imQ" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DN";
-	location = "SSE-FC"
-	},
-/turf/simulated/floor{
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "imR" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -38166,11 +38336,11 @@
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 1
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_white"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/engineering/atmos)
 "ina" = (
@@ -38272,6 +38442,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
 	},
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
@@ -38591,15 +38764,6 @@
 	},
 /turf/simulated/floor,
 /area/station/gateway)
-"isu" = (
-/obj/effect/decal/turf_decal/alpha/blue{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "isB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
@@ -39021,7 +39185,7 @@
 /area/station/rnd/misc_lab)
 "ixG" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -39508,6 +39672,19 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
+"iCX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "iDi" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -39544,7 +39721,7 @@
 "iDw" = (
 /obj/item/weapon/flora/random,
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_right"
+	icon_state = "bot_left"
 	},
 /turf/simulated/floor,
 /area/station/storage/tech)
@@ -39594,6 +39771,10 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/atmos_office)
@@ -39967,7 +40148,10 @@
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos/distribution)
 "iGZ" = (
 /obj/structure/cable{
@@ -39995,6 +40179,13 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
+"iHz" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=CS-AR";
+	location = "SWW-FC"
+	},
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "iHJ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -40074,8 +40265,12 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "dark"
 	},
 /area/station/engineering/break_room)
 "iIJ" = (
@@ -41343,6 +41538,19 @@
 "iXs" = (
 /turf/simulated/floor,
 /area/station/rnd/hor)
+"iXu" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "iXC" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -41548,7 +41756,10 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/blue{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos/distribution)
 "jax" = (
 /obj/structure/table/reinforced,
@@ -41827,6 +42038,16 @@
 	},
 /turf/environment/space,
 /area/shuttle/escape_pod5/station)
+"jcW" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-C";
+	location = "CS-AR"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "jcX" = (
 /obj/machinery/alarm{
 	pixel_y = -32
@@ -43163,19 +43384,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry)
-"jsR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 9
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "jtc" = (
 /obj/structure/morgue{
 	dir = 8
@@ -44429,8 +44637,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "dark"
 	},
 /area/station/engineering/break_room)
 "jGA" = (
@@ -45092,7 +45307,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -46438,6 +46653,9 @@
 	name = "Atmos Blast Door";
 	opacity = 0
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
 "kbE" = (
@@ -46942,15 +47160,23 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "kgH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/decal/turf_decal/alpha/dark_red{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
 	icon_state = "siding_line";
-	dir = 1
+	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "grimy"
+	icon_state = "neutralfull"
 	},
-/area/station/security/hos)
+/area/station/hallway/primary/fore)
 "khm" = (
 /obj/machinery/power/apc{
 	name = "apc down";
@@ -47011,6 +47237,10 @@
 /area/station/rnd/misc_lab)
 "khK" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
 	dir = 8
 	},
 /turf/simulated/floor{
@@ -48206,6 +48436,13 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge/hop_office)
+"kuv" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-MB";
+	location = "N-MB"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "kuF" = (
 /obj/structure/rack,
 /obj/item/clothing/head/helmet/space/skrell/black,
@@ -48356,7 +48593,7 @@
 	},
 /obj/machinery/light/smart,
 /obj/effect/decal/turf_decal{
-	icon_state = "warn_corner"
+	icon_state = "warn"
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
@@ -48842,7 +49079,7 @@
 /obj/machinery/computer/drone_control{
 	dir = 8
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -49051,9 +49288,28 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/supermatter)
+"kFF" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/main)
 "kFI" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -49072,6 +49328,13 @@
 	},
 /obj/structure/drain{
 	drainage = 2
+	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "box_white"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -49304,6 +49567,13 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 8
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "yellowcorner"
@@ -49346,6 +49616,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/emergency)
+"kIc" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SEE-FC";
+	location = "SE-FC"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "kIf" = (
 /obj/structure/window/shuttle/reinforced/mining{
 	icon_state = "5-4"
@@ -50100,13 +50380,12 @@
 	},
 /area/station/security/checkpoint/medbay)
 "kQi" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-FC";
+	location = "SSW-FC"
 	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
+/turf/simulated/floor,
+/area/station/hallway/primary/starboard)
 "kQr" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 1
@@ -51393,8 +51672,7 @@
 	dir = 9
 	},
 /obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
+	icon_state = "warn"
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
@@ -52037,6 +52315,15 @@
 	icon_state = "darkred"
 	},
 /area/station/security/execution)
+"lmx" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "lmF" = (
 /obj/machinery/computer/crew{
 	dir = 8
@@ -52656,16 +52943,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
-"luy" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
 "luA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -53095,6 +53372,9 @@
 	id = "atmos";
 	name = "Atmos Blast Door";
 	opacity = 0
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
@@ -53624,7 +53904,7 @@
 	},
 /obj/effect/decal/turf_decal{
 	dir = 1;
-	icon_state = "warn"
+	icon_state = "warn_corner"
 	},
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
@@ -53889,7 +54169,9 @@
 	dir = 8;
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/atmos)
 "lIJ" = (
 /obj/machinery/atmospherics/components/trinary/filter/on{
@@ -54541,24 +54823,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
-"lPo" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
 "lPy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -54609,7 +54873,7 @@
 	network = list("Engineering");
 	pixel_y = -30
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -54631,6 +54895,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
 	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -54771,7 +55038,7 @@
 	name = "Mix to Filter"
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
+	icon_state = "box_white"
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/distribution)
@@ -55208,6 +55475,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"lYd" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "cafeteria"
+	},
+/area/station/security/prison)
 "lYm" = (
 /obj/structure/window/thin/reinforced{
 	dir = 8
@@ -55546,26 +55819,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
-"mdb" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "mdk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/stool/bed/chair/office/dark,
@@ -56229,6 +56482,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
 "mkX" = (
@@ -56394,16 +56650,6 @@
 	},
 /turf/simulated/floor,
 /area/station/gateway)
-"mmJ" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NNW-B";
-	location = "NW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "mmN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -56872,6 +57118,10 @@
 "mrP" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "neutral"
 	},
@@ -57282,15 +57532,6 @@
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/space)
-"mww" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 5
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "mwy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -57970,6 +58211,16 @@
 "mDI" = (
 /turf/simulated/wall,
 /area/station/civilian/chapel/office)
+"mDN" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NNW-B";
+	location = "NW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "mDV" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -58039,6 +58290,19 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/cargo)
+"mEQ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "mES" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -58195,16 +58459,6 @@
 /obj/structure/sign/departments/science,
 /turf/simulated/wall/r_wall,
 /area/station/rnd/telesci)
-"mGw" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkred"
-	},
-/area/station/security/brig)
 "mGz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -58559,7 +58813,8 @@
 "mMv" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor{
-	icon_state = "cautioncorner"
+	dir = 5;
+	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
 "mMz" = (
@@ -58614,6 +58869,9 @@
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
 	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -58722,6 +58980,16 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/sleeper)
+"mOK" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "mOU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -59097,6 +59365,18 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/range)
+"mSh" = (
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Labor Camp Shuttle Airlock";
+	req_access = list(2)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
 "mSl" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -59977,20 +60257,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"nbY" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 10;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "ncb" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -60074,6 +60340,10 @@
 	dir = 1;
 	icon_state = "warn"
 	},
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
 /turf/simulated/floor,
 /area/station/engineering/break_room)
 "ndh" = (
@@ -60090,7 +60360,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -60892,6 +61162,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -61192,6 +61465,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -61434,6 +61710,17 @@
 /obj/item/weapon/folder/white,
 /turf/simulated/floor/carpet,
 /area/station/bridge/meeting_room)
+"ntx" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "ntM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -61708,6 +61995,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -61795,12 +62086,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/incinerator)
-"nxO" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "browncorner"
-	},
-/area/station/cargo/storage)
 "nxQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -62496,6 +62781,10 @@
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 5
+	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/atmos_office)
 "nFZ" = (
@@ -62516,6 +62805,9 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "caution_white"
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
@@ -62965,6 +63257,10 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "nLP" = (
@@ -63123,16 +63419,6 @@
 /obj/structure/girder/reinforced,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
-"nOH" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-B";
-	location = "SSW-B"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "nOJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -63377,6 +63663,10 @@
 /area/station/security/prison)
 "nQI" = (
 /obj/machinery/pipedispenser,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "yellow"
@@ -63547,6 +63837,10 @@
 "nRV" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -63794,6 +64088,15 @@
 	icon_state = "white"
 	},
 /area/station/medical/virology)
+"nUD" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "nUE" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -64572,7 +64875,7 @@
 	network = list("Singularity");
 	pixel_x = -30
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -64915,6 +65218,16 @@
 	icon_state = "browncorner"
 	},
 /area/station/cargo/storage)
+"ohC" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "ohG" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -64946,7 +65259,7 @@
 /obj/machinery/computer/security/engineering/drone{
 	dir = 8
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -65252,7 +65565,7 @@
 	name = "Mix to Distro"
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
+	icon_state = "box_white"
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/distribution)
@@ -65401,7 +65714,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/turf_decal{
-	dir = 9;
+	dir = 10;
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
@@ -65716,7 +66029,13 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 8
 	},
-/turf/simulated/floor,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos/distribution)
 "otq" = (
 /obj/machinery/light/small{
@@ -65972,6 +66291,10 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 8
+	},
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
 "oxs" = (
@@ -66159,6 +66482,10 @@
 	},
 /area/station/rnd/tox_launch)
 "oAn" = (
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 1
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "yellow"
@@ -66429,8 +66756,11 @@
 	name = "Atmospherics";
 	req_access = list(24)
 	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "dark"
 	},
 /area/station/engineering/atmos)
 "oDV" = (
@@ -66458,18 +66788,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/engineering/engine)
-"oEe" = (
-/obj/machinery/door_timer/cell_3{
-	pixel_x = 32;
-	pixel_y = 0;
-	dir = 4;
-	id = "Cell 3 perma"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "oEf" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -67054,6 +67372,10 @@
 "oKV" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold4w/visible/fuel,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -67217,13 +67539,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
-"oMc" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-MB";
-	location = "N-MB"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "oMd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/stool/bar,
@@ -67444,7 +67759,7 @@
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	dir = 6;
+	dir = 4;
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
@@ -67932,6 +68247,10 @@
 /obj/machinery/alarm{
 	pixel_x = -28;
 	pixel_y = -6
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 1
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -68564,26 +68883,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/port)
-"pcM" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "pcR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -68994,6 +69293,20 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/reception)
+"phP" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor,
+/area/station/engineering/monitoring)
 "phV" = (
 /turf/simulated/floor{
 	icon_state = "yellowcorner"
@@ -69157,6 +69470,14 @@
 	icon_state = "dark"
 	},
 /area/station/bridge/ai_upload)
+"pjH" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/security/prison)
 "pjO" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -69574,6 +69895,11 @@
 /obj/item/weapon/caution,
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
+"pnV" = (
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "pnY" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -69682,13 +70008,6 @@
 	icon_state = "red"
 	},
 /area/station/security/checkpoint/engi)
-"poQ" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "poS" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/turf_decal{
@@ -70183,6 +70502,16 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
+"pvp" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Central Access"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "pvu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -70532,6 +70861,10 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 8
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -70595,6 +70928,20 @@
 "pyL" = (
 /turf/environment/space,
 /area/shuttle/syndicate/north)
+"pyM" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 9;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "pyX" = (
 /obj/machinery/light/small,
 /obj/effect/decal/turf_decal/alpha/white{
@@ -71797,7 +72144,7 @@
 	},
 /obj/item/clothing/gloves/black,
 /obj/item/weapon/storage/box/lights/mixed,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -71868,6 +72215,15 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/medical/virology)
+"pNX" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Security";
+	location = "S-C"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "pOh" = (
 /obj/effect/decal/turf_decal/alpha/blue{
 	icon_state = "siding_line"
@@ -72096,14 +72452,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
-"pPX" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/civilian/gym)
 "pPY" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -72564,6 +72912,15 @@
 	icon_state = "grimy"
 	},
 /area/station/security/detectives_office)
+"pVw" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-B";
+	location = "S-MB"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry)
 "pVE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -72725,6 +73082,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboardsolar)
+"pXD" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/pump,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "arrival"
+	},
+/area/station/hallway/primary/port)
 "pXL" = (
 /obj/structure/stool/bed/chair/comfy/beige{
 	dir = 8
@@ -73218,6 +73589,10 @@
 	icon_state = "pipe-j2s";
 	name = "Atmospherics";
 	sortType = "Atmospherics"
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/atmos_office)
@@ -73761,6 +74136,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 8
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -74229,19 +74608,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/rnd/xenobiology)
-"qoe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "qom" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 8
@@ -74342,15 +74708,6 @@
 /obj/item/weapon/flora/random,
 /turf/simulated/floor,
 /area/station/security/prison)
-"qpY" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-B";
-	location = "S-MB"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/secondary/entry)
 "qqm" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -74670,6 +75027,16 @@
 	icon_state = "floor"
 	},
 /area/shuttle/escape_pod3/station)
+"qtL" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "qtS" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -74833,7 +75200,10 @@
 	dir = 1;
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos/distribution)
 "quV" = (
 /obj/machinery/door/firedoor,
@@ -74860,19 +75230,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/misc_lab)
-"qvz" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "qvQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -74965,6 +75322,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/security/prison)
+"qxz" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "qxK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -75030,6 +75396,16 @@
 	icon_state = "dark"
 	},
 /area/station/bridge/ai_upload)
+"qyu" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/station/security/brig)
 "qyx" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	frequency = 1444;
@@ -76140,6 +76516,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 1
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -76175,16 +76555,6 @@
 	icon_state = "red"
 	},
 /area/station/security/brig/equipment)
-"qMn" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SEE-FC";
-	location = "SE-FC"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "qMt" = (
 /obj/structure/morgue,
 /obj/structure/extinguisher_cabinet{
@@ -76347,16 +76717,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
-"qOt" = (
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "qOV" = (
 /obj/structure/table,
 /obj/item/seeds/appleseed,
@@ -76387,6 +76747,13 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/secondary/exit)
+"qPK" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "qPO" = (
 /obj/structure/sign/nanotrasen{
 	pixel_y = -32
@@ -76683,6 +77050,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
 	},
 /turf/simulated/floor{
 	icon_state = "yellow"
@@ -77675,16 +78045,6 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/lobby)
-"rei" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NEE-FC";
-	location = "S-SV"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "rel" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -78115,6 +78475,16 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"rkt" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SWW-FC";
+	location = "SW-FC"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "rkx" = (
 /turf/simulated/wall,
 /area/station/engineering/drone_fabrication)
@@ -78738,6 +79108,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
 /turf/simulated/floor{
 	icon_state = "yellow"
 	},
@@ -79115,6 +79488,10 @@
 /area/station/engineering/atmos/supermatter)
 "rwr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 1
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "yellow"
@@ -79842,6 +80219,14 @@
 /area/station/security/prison)
 "rDL" = (
 /obj/machinery/drone_fabricator,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkyellow"
@@ -80146,6 +80531,9 @@
 /area/station/bridge/captain_quarters)
 "rHG" = (
 /obj/structure/closet/radiation,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "yellow"
@@ -81658,6 +82046,9 @@
 "rYi" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner"
 	},
 /turf/simulated/floor{
 	icon_state = "yellow"
@@ -83615,6 +84006,26 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/reception)
+"svg" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "svl" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/grass,
@@ -83665,6 +84076,10 @@
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -84539,6 +84954,12 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/toilet)
+"sGo" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
+	},
+/turf/simulated/floor/carpet/red,
+/area/station/security/detectives_office)
 "sGy" = (
 /obj/structure/table/woodentable,
 /obj/item/stack/sheet/cloth{
@@ -85477,6 +85898,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/maintenance/incinerator)
+"sSA" = (
+/obj/machinery/light/smart{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NE-FC";
+	location = "NEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "sSE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -86686,6 +87120,16 @@
 	icon_state = "black"
 	},
 /area/station/hallway/primary/fore)
+"thY" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SE-FC";
+	location = "SW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "tif" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -86827,9 +87271,13 @@
 	dir = 8;
 	icon_state = "loadingarea"
 	},
-/obj/effect/decal/turf_decal/alpha/black{
+/obj/effect/decal/turf_decal{
 	dir = 8;
-	icon_state = "arrow"
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "arrow";
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
@@ -87078,7 +87526,7 @@
 	pixel_y = 22
 	},
 /turf/simulated/floor{
-	dir = 1;
+	dir = 5;
 	icon_state = "caution"
 	},
 /area/station/engineering/atmos/distribution)
@@ -87231,6 +87679,16 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"toM" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "toN" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -87776,6 +88234,18 @@
 	icon_state = "redfull"
 	},
 /area/station/security/prison)
+"twh" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "twi" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -88332,6 +88802,9 @@
 /area/station/maintenance/cargo)
 "tCz" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/cyan,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
 /turf/simulated/floor{
 	icon_state = "yellow"
 	},
@@ -89009,6 +89482,10 @@
 /area/station/rnd/mixing)
 "tLi" = (
 /obj/structure/closet/firecloset,
+/obj/effect/decal/turf_decal{
+	dir = 9;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -89187,16 +89664,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
-"tMO" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-C";
-	location = "CS-AR"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "tMS" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/structure/window/thin,
@@ -89296,18 +89763,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
-"tOt" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "tOH" = (
 /obj/structure/sign/directions/evac{
 	pixel_x = -32;
@@ -89697,10 +90152,11 @@
 	pixel_y = -5
 	},
 /obj/machinery/pipedispenser/disposal,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "yellow"
+/obj/effect/decal/turf_decal{
+	dir = 10;
+	icon_state = "warn"
 	},
+/turf/simulated/floor,
 /area/station/engineering/atmos)
 "tUn" = (
 /obj/item/weapon/flora/random,
@@ -89990,16 +90446,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"tXZ" = (
-/obj/machinery/light/smart,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "tYa" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -90237,7 +90683,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "caution"
+	},
 /area/station/engineering/atmos/distribution)
 "ubb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -90304,6 +90752,16 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/distribution)
+"ubX" = (
+/obj/machinery/light/smart,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "ucd" = (
 /obj/structure/table,
 /obj/item/device/tagger/shop,
@@ -90366,15 +90824,14 @@
 	},
 /area/station/rnd/hallway)
 "ucx" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SE-FC";
-	location = "SW-B"
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "grimy"
 	},
-/area/station/hallway/primary/central)
+/area/station/security/hos)
 "ucF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -91447,6 +91904,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 8
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -91612,6 +92073,13 @@
 "uqj" = (
 /turf/simulated/wall,
 /area/station/bridge/cmf_room)
+"uqq" = (
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/prison)
 "uqt" = (
 /obj/effect/decal/turf_decal{
 	dir = 8;
@@ -92881,6 +93349,29 @@
 	icon_state = "darkblue"
 	},
 /area/station/security/iaa_office)
+"uHt" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
+"uHw" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-FC";
+	location = "DS"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
+/area/station/hallway/primary/central)
 "uHA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/trinary/filter{
@@ -92889,16 +93380,18 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "uHN" = (
-/obj/machinery/light/smart,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DS";
-	location = "DN-W"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "purplecorner"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/area/station/hallway/primary/central)
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "uHX" = (
 /turf/simulated/floor/wood,
 /area/station/maintenance/chapel)
@@ -92945,13 +93438,6 @@
 "uJi" = (
 /turf/simulated/wall,
 /area/station/rnd/chargebay)
-"uJw" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-FC";
-	location = "SSW-FC"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/starboard)
 "uJK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/binary/valve,
@@ -93300,8 +93786,12 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "uNw" = (
-/turf/simulated/floor,
-/area/station/engineering/atmos)
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "uNx" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -94534,7 +95024,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -94821,8 +95311,11 @@
 	name = "Atmospherics";
 	req_access = list(24)
 	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "dark"
 	},
 /area/station/engineering/atmos)
 "vgR" = (
@@ -94992,15 +95485,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/tcommsat/computer)
-"viH" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_right"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/civilian/cold_room)
 "viI" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -95252,8 +95736,12 @@
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 4
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_white"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 6;
+	icon_state = "warn"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -95285,6 +95773,14 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
+"vlS" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/civilian/gym)
 "vme" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -95336,6 +95832,17 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
+"vmz" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "loadingarea"
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "arrow"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "vmG" = (
 /obj/effect/landmark/start/paramedic,
 /obj/structure/stool/bed/chair/comfy/brown{
@@ -95973,6 +96480,21 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/security/prison)
+"vub" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "vuj" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 29
@@ -96701,6 +97223,18 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
+"vDE" = (
+/obj/machinery/door_timer/cell_3{
+	pixel_x = 32;
+	pixel_y = 0;
+	dir = 4;
+	id = "Cell 3 perma"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "vDQ" = (
 /obj/structure/sign/warning/securearea,
 /turf/simulated/wall/r_wall,
@@ -96942,19 +97476,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
-"vGg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/flasher{
-	id = "Cell 3 perma";
-	pixel_y = -28
-	},
-/turf/simulated/floor,
-/area/station/security/prison)
 "vGh" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -97234,7 +97755,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/monitoring)
 "vKe" = (
 /obj/structure/stool/bed/chair/office/dark,
@@ -97678,27 +98201,6 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/drone_fabrication)
-"vPU" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "vPX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -98012,18 +98514,13 @@
 	},
 /area/station/bridge/teleporter)
 "vTX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/turf/simulated/floor{
+	icon_state = "grimy"
 	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
+/area/station/security/hos)
 "vUe" = (
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
@@ -98252,6 +98749,10 @@
 	c_tag = "Atmospherics Access";
 	dir = 4;
 	network = list("SS13","Engineering")
+	},
+/obj/effect/decal/turf_decal{
+	dir = 10;
+	icon_state = "warn"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -98618,6 +99119,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner"
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -98708,6 +99212,15 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/reception)
+"wcw" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_right"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/cold_room)
 "wcD" = (
 /obj/structure/table/glass,
 /obj/machinery/light/smart{
@@ -99043,6 +99556,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
+"wgw" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "wgE" = (
 /obj/machinery/mass_driver{
 	dir = 8;
@@ -99794,6 +100314,27 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/security/lobby)
+"wpK" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "wpM" = (
 /obj/structure/table/woodentable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -99988,6 +100529,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/security/prison)
+"wsf" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "wsk" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1
@@ -100289,26 +100843,6 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge/captain_quarters)
-"wxb" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "wxc" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -100406,6 +100940,15 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/incinerator)
+"wyj" = (
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "wyL" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -100937,7 +101480,7 @@
 	dir = 4
 	},
 /obj/machinery/light/smart,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -101321,6 +101864,18 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/engine)
+"wHw" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "wHy" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/suit_jacket/red,
@@ -101537,6 +102092,15 @@
 	icon_state = "grimy"
 	},
 /area/station/storage/tools)
+"wKa" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 5
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "wKd" = (
 /obj/machinery/computer/cargo/request,
 /turf/simulated/floor/grass,
@@ -102587,7 +103151,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/engineering/atmos/atmos_office)
 "wYR" = (
 /obj/structure/table/reinforced,
@@ -103109,8 +103675,15 @@
 /area/station/tcommsat/chamber)
 "xeD" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn_corner"
+	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "dark"
 	},
 /area/station/engineering/break_room)
 "xeF" = (
@@ -103760,6 +104333,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 8
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -104275,16 +104852,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"xsi" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "xsj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -104529,15 +105096,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/misc_lab)
-"xuL" = (
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
 "xuQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -104712,13 +105270,6 @@
 /obj/item/weapon/caution,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"xwH" = (
-/obj/item/weapon/flora/random,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_left"
-	},
-/turf/simulated/floor,
-/area/station/storage/tech)
 "xwJ" = (
 /mob/living/simple_animal/hostile/retaliate/goat{
 	name = "Pete"
@@ -105547,6 +106098,18 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/kitchen)
+"xFt" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/engineering/atmos/atmos_office)
 "xFy" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/box/cups{
@@ -105703,6 +106266,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
 /turf/simulated/floor{
 	icon_state = "yellow"
 	},
@@ -106170,17 +106736,18 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
-"xNx" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+"xNr" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
 	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "grimy"
+	icon_state = "neutralfull"
 	},
-/area/station/security/hos)
+/area/station/engineering/atmos)
 "xNJ" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /turf/simulated/floor/engine,
@@ -106967,6 +107534,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn_corner"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -107224,11 +107798,11 @@
 /obj/machinery/status_display{
 	pixel_y = -32
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_white"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/engineering/atmos)
 "xZa" = (
@@ -130686,7 +131260,7 @@ cFh
 wQz
 gmf
 gis
-uNw
+aWD
 ffY
 vPk
 tuv
@@ -130943,7 +131517,7 @@ flf
 oMm
 ddG
 cKe
-uNw
+aWD
 tmX
 vPk
 xFF
@@ -131445,7 +132019,7 @@ bOJ
 oKV
 dup
 dup
-nRV
+iXu
 bOD
 cmG
 xqQ
@@ -131710,7 +132284,7 @@ oLJ
 kFc
 kFc
 cEO
-flf
+ntx
 azQ
 pfp
 imT
@@ -131964,8 +132538,8 @@ bfy
 cmG
 dup
 htY
-dEp
-dEp
+mOK
+mOK
 nwM
 tCz
 gRR
@@ -132220,7 +132794,7 @@ nLs
 bTE
 tUm
 oPF
-rJU
+iCX
 rSb
 umn
 svw
@@ -132984,7 +133558,7 @@ bsZ
 fZH
 cTK
 whA
-iDO
+xFt
 iDO
 iDO
 iDO
@@ -132993,8 +133567,8 @@ vCV
 lFG
 waB
 fMO
-hZG
-gVm
+cpK
+xNr
 kHT
 vPk
 vPk
@@ -133243,7 +133817,7 @@ qcT
 mrP
 daq
 daq
-daq
+cou
 egG
 iEf
 hrT
@@ -134541,7 +135115,7 @@ gpz
 nds
 gpz
 wjD
-gPB
+phP
 bbv
 awp
 odu
@@ -135301,7 +135875,7 @@ jlK
 tEF
 tne
 cEZ
-raY
+hGG
 iGS
 ciX
 jau
@@ -136083,12 +136657,12 @@ tEF
 sHQ
 dpc
 sHQ
-blv
+gKE
 blv
 sqb
 uck
 sqb
-hQQ
+pXD
 hQQ
 qTx
 bUU
@@ -136355,7 +136929,7 @@ doE
 doE
 doE
 lgU
-qMn
+kIc
 mhm
 doE
 mnD
@@ -136853,7 +137427,7 @@ wwi
 aYN
 wwi
 lfm
-cVH
+gki
 tZn
 oyb
 nAM
@@ -136871,7 +137445,7 @@ oyb
 bzt
 bzt
 rcq
-imQ
+bpI
 tYK
 wtC
 wtC
@@ -137887,7 +138461,7 @@ xNR
 rMP
 nAi
 vfr
-xwH
+iDw
 rDd
 jcO
 iNE
@@ -138401,7 +138975,7 @@ xNR
 oYv
 cGN
 vzT
-iDw
+agQ
 oVN
 cdA
 jTf
@@ -138644,7 +139218,7 @@ tRk
 vdt
 rwG
 srt
-viH
+wcw
 dOS
 rfL
 qsE
@@ -139672,7 +140246,7 @@ kBq
 biv
 pED
 bNa
-luy
+toM
 kIU
 lBN
 yeY
@@ -139929,7 +140503,7 @@ dtM
 fty
 abG
 vLv
-luy
+toM
 kIU
 jVV
 ekm
@@ -142250,7 +142824,7 @@ iSv
 xXt
 vAu
 ogP
-nOH
+bpJ
 bAS
 nvi
 rnH
@@ -142266,7 +142840,7 @@ qbj
 qbj
 tmk
 ldb
-ucx
+thY
 ogP
 iSi
 amv
@@ -142293,7 +142867,7 @@ vpT
 xei
 bFh
 vpT
-uHN
+dDi
 vIl
 olx
 frM
@@ -142461,7 +143035,7 @@ plf
 brw
 mko
 jsL
-qpY
+pVw
 ffX
 hbE
 sTt
@@ -142730,7 +143304,7 @@ gHT
 alc
 vDr
 fDL
-mmJ
+mDN
 iwy
 xXt
 gNR
@@ -143511,17 +144085,17 @@ hXb
 hXb
 hXb
 che
-xuL
-lPo
-xuL
-xuL
-xuL
-xuL
-xuL
-xuL
-xuL
-fyJ
-xuL
+fOp
+kgH
+fOp
+fOp
+fOp
+fOp
+fOp
+fOp
+fOp
+vub
+fOp
 vos
 did
 did
@@ -144015,7 +144589,7 @@ kHU
 yaE
 hkD
 fYS
-euj
+wyj
 wts
 mge
 qed
@@ -144295,13 +144869,13 @@ mpN
 uQg
 tJq
 oFm
-poQ
+qPK
 xsb
-poQ
-poQ
-poQ
+qPK
+qPK
+qPK
 mtf
-poQ
+qPK
 jpq
 bsc
 mfI
@@ -144529,7 +145103,7 @@ plf
 yaE
 vDr
 fYS
-qOt
+hek
 tEo
 nIB
 iEL
@@ -144786,7 +145360,7 @@ kHU
 yaE
 csG
 fYS
-tXZ
+ubX
 wts
 npC
 txi
@@ -144809,13 +145383,13 @@ cCx
 mES
 tJq
 ikZ
-jsR
+mEQ
 oki
-bjz
-bjz
-vTX
+uNw
+uNw
+uHN
 tWH
-vTX
+uHN
 qcF
 bRX
 qSi
@@ -145066,7 +145640,7 @@ tJq
 ucP
 tJq
 fSC
-qoe
+uHt
 ktM
 uuo
 djH
@@ -146574,7 +147148,7 @@ yaE
 yaE
 csG
 fYS
-oMc
+kuv
 alc
 gHT
 gHT
@@ -146583,7 +147157,7 @@ gHT
 gHT
 gHT
 alc
-gHf
+ejv
 fYS
 sEX
 srs
@@ -151518,7 +152092,7 @@ mXl
 mXl
 mXl
 wLD
-rei
+dpx
 iwm
 mXl
 pRS
@@ -151536,7 +152110,7 @@ oNU
 mXl
 uxx
 xMc
-hac
+rkt
 nvi
 rnH
 cLM
@@ -151545,7 +152119,7 @@ nvi
 tOH
 mfI
 ogP
-bpB
+uHw
 sBG
 wjc
 wjc
@@ -151848,7 +152422,7 @@ xQo
 xQo
 xQo
 nKU
-uJw
+kQi
 xQo
 oPI
 mRu
@@ -152015,7 +152589,7 @@ cpR
 gtK
 cpR
 pxL
-gbZ
+sSA
 ffJ
 ape
 fZz
@@ -152034,7 +152608,7 @@ hRd
 ckx
 fZz
 lMB
-ejv
+pNX
 kzb
 vAu
 psV
@@ -152048,7 +152622,7 @@ vAu
 kRo
 vAu
 kCI
-tMO
+jcW
 ogP
 lwr
 mLS
@@ -152289,7 +152863,7 @@ erD
 erD
 cmN
 act
-bUB
+pvp
 xsY
 uuf
 jTW
@@ -152771,7 +153345,7 @@ fnT
 miA
 ojm
 lPc
-nxO
+cze
 gaF
 rpV
 qSe
@@ -153028,11 +153602,11 @@ nkb
 adb
 hzP
 cpR
-xsi
-asa
-uXI
-asa
+qtL
 oOk
+uXI
+oOk
+ohC
 xqF
 aAF
 iqI
@@ -156139,8 +156713,8 @@ plf
 xyC
 cFp
 klH
-hkh
-hkh
+sGo
+sGo
 hGr
 aRu
 xyC
@@ -156643,11 +157217,11 @@ plf
 plf
 plf
 uRO
-eDh
+hwE
 uRO
 plf
 uRO
-eDh
+hwE
 uRO
 plf
 xyC
@@ -156664,8 +157238,8 @@ dnn
 aEr
 wPw
 jQy
-isu
-iha
+aQd
+pnV
 jcX
 fJg
 nPU
@@ -157157,11 +157731,11 @@ plf
 cHH
 cHH
 jxX
-hwE
+mSh
 bjt
 stv
 jxX
-hwE
+mSh
 jxX
 adp
 kMq
@@ -157172,7 +157746,7 @@ xyC
 xyC
 xyC
 xyC
-enc
+wgw
 jtG
 wpm
 fJg
@@ -157414,11 +157988,11 @@ wVt
 cHH
 cjS
 bNB
-nbY
+opt
 kms
 cHH
 eow
-opt
+pyM
 goK
 hYT
 nsn
@@ -157671,7 +158245,7 @@ leA
 cHH
 adG
 iGB
-mGw
+qyu
 tTk
 qMX
 aZz
@@ -157932,7 +158506,7 @@ ikW
 qXE
 rjb
 utF
-cvN
+vmz
 uLd
 lat
 nsn
@@ -158731,7 +159305,7 @@ kIM
 vst
 mDV
 vKG
-cqu
+iHz
 xoq
 tAM
 uQA
@@ -159450,14 +160024,14 @@ fAF
 fgx
 diq
 fAF
-oEe
+vDE
 eTq
 fAF
 wNM
 oPD
 tif
 rHZ
-pcM
+fSy
 czU
 tqK
 hsq
@@ -159714,7 +160288,7 @@ qZx
 qZx
 fXG
 qZx
-wxb
+cwk
 czU
 uvV
 kMw
@@ -160220,7 +160794,7 @@ blh
 cra
 hlv
 dVr
-vGg
+cht
 hlv
 fBm
 bvC
@@ -161244,7 +161818,7 @@ aXC
 bZu
 pLw
 unD
-chC
+pjH
 oAx
 ulK
 eyO
@@ -161798,7 +162372,7 @@ sxG
 uOc
 hur
 hur
-qvz
+wsf
 ekd
 lZw
 gqC
@@ -162052,7 +162626,7 @@ ixl
 mme
 uKd
 gRX
-tOt
+wHw
 sRa
 nUj
 wUB
@@ -162081,13 +162655,13 @@ ncp
 ncp
 hbR
 mWz
-dwq
+twh
 kLd
 syX
 tHk
 tHk
 dbf
-vPU
+wpK
 ram
 mWz
 lNQ
@@ -162344,7 +162918,7 @@ eFl
 aRb
 nDG
 jjN
-dhd
+bFL
 ram
 mWz
 ucd
@@ -162551,7 +163125,7 @@ afw
 nDf
 mZo
 qUR
-dbK
+kFF
 mzV
 aSh
 mpR
@@ -162852,13 +163426,13 @@ ncp
 ncp
 hbR
 mWz
-cKx
+hGc
 sIY
 qls
 uOM
 uOM
 aeG
-bFL
+aFq
 ram
 mWz
 hPr
@@ -163048,7 +163622,7 @@ lhK
 wVg
 aFN
 jKZ
-evT
+lYd
 rBo
 hlv
 qxh
@@ -163312,7 +163886,7 @@ xIO
 jps
 xIO
 qZx
-mdb
+svg
 tbS
 sZR
 kHU
@@ -163324,7 +163898,7 @@ fwH
 qoH
 vOW
 qoH
-kQi
+vTX
 umQ
 gYp
 kHU
@@ -163562,7 +164136,7 @@ jvm
 hlv
 fVW
 fPH
-evT
+lYd
 rnI
 hlv
 pHz
@@ -163577,11 +164151,11 @@ kHU
 plf
 cYc
 ueE
-kgH
+ffC
 wcJ
 iRz
 nez
-xNx
+aEz
 hlh
 gYp
 plf
@@ -163834,11 +164408,11 @@ kHU
 kHU
 cYc
 nfj
-fOp
+ucx
 eaE
 nRk
 rZh
-dnc
+nUD
 hmN
 gYp
 kHU
@@ -163882,7 +164456,7 @@ dJL
 nRG
 oXA
 oXA
-pPX
+vlS
 dJL
 plf
 cdR
@@ -164091,11 +164665,11 @@ plf
 kHU
 huz
 sIx
-mww
-aFk
+wKa
+qxz
 kjv
-aFk
-ihQ
+qxz
+lmx
 tEU
 huz
 plf
@@ -166140,7 +166714,7 @@ plf
 kHU
 hlv
 lrm
-dHi
+uqq
 jno
 hlv
 cBu
@@ -167220,7 +167794,7 @@ kHU
 fMh
 plf
 dJL
-pPX
+vlS
 oXA
 oXA
 nJn

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -6257,15 +6257,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/tcommsat/chamber)
-"bmb" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/rnd/hor)
 "bme" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -6564,20 +6555,6 @@
 	icon_state = "wooden"
 	},
 /area/station/medical/psych)
-"bpI" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "neutral"
-	},
-/area/station/rnd/xenobiology)
 "bpO" = (
 /obj/effect/landmark/start/assistant/test_subject,
 /obj/machinery/light/smart{
@@ -11765,15 +11742,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/range)
-"cwW" = (
-/obj/effect/decal/turf_decal/alpha/blue{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/rnd/xenobiology)
 "cwX" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -16005,6 +15973,13 @@
 	},
 /turf/simulated/floor,
 /area/station/bridge/captain_quarters)
+"dvX" = (
+/obj/effect/decal/turf_decal{
+	dir = 6;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "dvZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -16423,13 +16398,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/bridge/corp_lounge)
-"dBr" = (
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "dBv" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -17836,16 +17804,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/brig)
-"dUG" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "whitepurplecorner"
-	},
-/area/station/rnd/xenobiology)
 "dUJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -18904,6 +18862,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"ehI" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/xenobiology)
 "ehM" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -19616,26 +19583,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
-"epu" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha{
-	icon_state = "warn_end";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "white"
-	},
-/area/station/rnd/xenobiology)
 "eqn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
@@ -21623,6 +21570,15 @@
 	icon_state = "caution"
 	},
 /area/station/medical/chemistry)
+"eOk" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/hor)
 "eOt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -24840,12 +24796,6 @@
 	},
 /turf/simulated/floor/engine/oxygen,
 /area/station/engineering/atmos)
-"fBk" = (
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "fBl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -25067,15 +25017,6 @@
 /obj/structure/rack,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
-"fEc" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/rnd/xenobiology)
 "fEl" = (
 /obj/structure/window/thin{
 	dir = 8
@@ -28434,13 +28375,6 @@
 	},
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
-"gsU" = (
-/obj/effect/decal/turf_decal{
-	dir = 5;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "gsX" = (
 /obj/machinery/door/airlock/external{
 	dock_tag = "supply_dock";
@@ -30278,6 +30212,16 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
+"gOo" = (
+/obj/effect/decal/turf_decal{
+	dir = 9;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "gOs" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/brig/storage)
@@ -31087,13 +31031,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/cmo)
-"gWV" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "gXb" = (
 /obj/item/weapon/caution,
 /turf/simulated/floor/plating,
@@ -32294,6 +32231,15 @@
 	icon_state = "neutralfull"
 	},
 /area/station/cargo/miningoffice)
+"hmX" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/hor)
 "hmY" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -37352,6 +37298,17 @@
 	icon_state = "dark"
 	},
 /area/station/aisat/ai_chamber)
+"irH" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "irL" = (
 /obj/machinery/light/smart{
 	dir = 4
@@ -37378,17 +37335,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/rnd/test_area)
-"irX" = (
-/obj/structure/window/thin/reinforced{
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "box_corners_white"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/rnd/xenobiology)
 "isb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -37400,17 +37346,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
-"isq" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "iss" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
@@ -38051,6 +37986,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"izK" = (
+/obj/effect/decal/turf_decal{
+	dir = 10;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "izS" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/status_display{
@@ -39323,6 +39269,15 @@
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/station/civilian/dormitories)
+"iOf" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/xenobiology)
 "iOl" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -39363,16 +39318,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
-"iOG" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "purple"
-	},
-/area/station/rnd/xenobiology)
 "iOK" = (
 /obj/structure/stool/bed/chair/metal/yellow{
 	dir = 8
@@ -39772,6 +39717,20 @@
 "iTl" = (
 /turf/simulated/wall,
 /area/station/security/range)
+"iTp" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
+/area/station/rnd/xenobiology)
 "iTw" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 10
@@ -41303,7 +41262,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot_left"
 	},
 /turf/simulated/floor{
@@ -44252,15 +44211,6 @@
 	temperature = 80
 	},
 /area/station/tcommsat/chamber)
-"jRF" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/rnd/xenobiology)
 "jSg" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor,
@@ -47597,15 +47547,6 @@
 "kFd" = (
 /turf/simulated/wall,
 /area/station/rnd/scibreak)
-"kFf" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/rnd/hor)
 "kFj" = (
 /obj/machinery/door/airlock{
 	name = "Mime's Backstage Room";
@@ -48374,15 +48315,14 @@
 	},
 /area/station/rnd/tox_launch)
 "kMa" = (
-/obj/effect/decal/turf_decal{
-	dir = 9;
-	icon_state = "warn"
+/obj/structure/reagent_dispensers/aqueous_foam_tank,
+/obj/effect/decal/turf_decal/alpha/red{
+	icon_state = "bot"
 	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
+/turf/simulated/floor{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
+/area/station/rnd/xenobiology)
 "kMb" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
@@ -50206,6 +50146,13 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/fore)
+"liV" = (
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "ljb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 9
@@ -51462,17 +51409,6 @@
 	},
 /turf/environment/space,
 /area/shuttle/escape_pod5/station)
-"lxU" = (
-/obj/effect/decal/turf_decal{
-	dir = 10;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "lyd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/alarm{
@@ -52448,16 +52384,6 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/dormitories)
-"lKe" = (
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "lKf" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -53884,21 +53810,6 @@
 	icon_state = "barber"
 	},
 /area/station/medical/storage)
-"mbT" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/station/rnd/xenobiology)
 "mbV" = (
 /obj/structure/displaycase/captain,
 /turf/simulated/floor{
@@ -54052,13 +53963,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/armoury)
-"mes" = (
-/obj/effect/decal/turf_decal{
-	dir = 6;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "mev" = (
 /obj/structure/displaycase_chassis,
 /obj/effect/decal/cleanable/dirt,
@@ -56211,7 +56115,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -56598,6 +56502,15 @@
 	icon_state = "orange"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
+"mHE" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/xenobiology)
 "mHM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -56606,18 +56519,6 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/library)
-"mHQ" = (
-/obj/structure/window/thin/reinforced{
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/rnd/xenobiology)
 "mIw" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/simulated/wall,
@@ -56902,6 +56803,20 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/chapel)
+"mMs" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
+/area/station/rnd/xenobiology)
 "mMt" = (
 /obj/item/device/radio/beacon,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -59772,6 +59687,16 @@
 	icon_state = "wooden"
 	},
 /area/station/civilian/library)
+"nuM" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "whitepurplecorner"
+	},
+/area/station/rnd/xenobiology)
 "nuP" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -65204,15 +65129,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
-"oLh" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/rnd/hor)
 "oLl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -68154,16 +68070,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/civilian/cold_room)
-"puk" = (
-/mob/living/carbon/monkey,
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/rnd/xenobiology)
 "pux" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -70928,6 +70834,16 @@
 	icon_state = "darkred"
 	},
 /area/station/security/brig)
+"pZK" = (
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "pZR" = (
 /turf/simulated/floor{
 	icon_state = "blackcorner"
@@ -71086,6 +71002,21 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/atmos)
+"qbz" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/station/rnd/xenobiology)
 "qbA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -72406,6 +72337,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/chargebay)
+"qsg" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/xenobiology)
 "qsh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark{
@@ -73504,6 +73444,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/cmo)
+"qFt" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/xenobiology)
 "qFO" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -75910,14 +75858,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/rnd/robotics)
-"rjS" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "box_corners_white"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/rnd/xenobiology)
 "rkr" = (
 /obj/structure/rack,
 /obj/random/cloth/gloves_safe,
@@ -77247,6 +77187,16 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hor)
+"rzG" = (
+/mob/living/carbon/monkey,
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/xenobiology)
 "rzL" = (
 /obj/random/vending/snack,
 /turf/simulated/floor/wood,
@@ -77659,7 +77609,7 @@
 	set_temperature = 73;
 	use_power = 1
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/red{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -78416,6 +78366,18 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/warden)
+"rLa" = (
+/obj/structure/window/thin/reinforced{
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/xenobiology)
 "rLi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -81002,21 +80964,6 @@
 	icon_state = "darkredcorners"
 	},
 /area/station/security/checkpoint/escape)
-"src" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/station/rnd/xenobiology)
 "srf" = (
 /obj/effect/decal/turf_decal{
 	dir = 6;
@@ -84786,20 +84733,6 @@
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/starboard)
-"tnZ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "neutral"
-	},
-/area/station/rnd/xenobiology)
 "tok" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
@@ -85998,14 +85931,11 @@
 /turf/simulated/floor/plating,
 /area/station/medical/reception)
 "tDm" = (
-/obj/structure/reagent_dispensers/aqueous_foam_tank,
-/obj/effect/decal/turf_decal/alpha/red{
-	icon_state = "bot"
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/rnd/xenobiology)
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "tDn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -86452,6 +86382,15 @@
 "tJr" = (
 /turf/simulated/wall/r_wall,
 /area/station/rnd/server)
+"tJz" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/hor)
 "tJH" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -91348,6 +91287,13 @@
 	icon_state = "dark"
 	},
 /area/station/cargo/recycleroffice)
+"uUZ" = (
+/obj/effect/decal/turf_decal{
+	dir = 5;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "uVc" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -93199,6 +93145,17 @@
 	icon_state = "neutralfull"
 	},
 /area/station/rnd/misc_lab)
+"vsp" = (
+/obj/structure/window/thin/reinforced{
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/xenobiology)
 "vsr" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -94414,12 +94371,13 @@
 /turf/simulated/floor,
 /area/station/engineering/engine)
 "vHf" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "box_corners_white";
-	dir = 1
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	dir = 1;
+	icon_state = "purple"
 	},
 /area/station/rnd/xenobiology)
 "vHR" = (
@@ -94466,6 +94424,13 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/hallway/lobby)
+"vIq" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "vIu" = (
 /obj/effect/decal/cleanable/generic,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -96210,6 +96175,21 @@
 "wdO" = (
 /turf/simulated/floor,
 /area/station/maintenance/escape)
+"wdP" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/station/rnd/xenobiology)
 "wej" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -100085,6 +100065,26 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
+"xbT" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha{
+	icon_state = "warn_end";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/station/rnd/xenobiology)
 "xbY" = (
 /turf/simulated/floor,
 /area/station/maintenance/medbay)
@@ -125257,7 +125257,7 @@ cRA
 jYs
 hXe
 gVW
-cwW
+mHE
 cfJ
 cjx
 xRM
@@ -126533,7 +126533,7 @@ waU
 ctb
 vUH
 fRJ
-fEc
+qsg
 fXd
 bJD
 gdS
@@ -126541,7 +126541,7 @@ rWY
 gdS
 ecA
 hTC
-rjS
+qFt
 fRJ
 pyX
 cFK
@@ -126793,9 +126793,9 @@ kfd
 xdW
 rIz
 stV
-src
+wdP
 sjW
-bpI
+iTp
 iag
 jum
 mph
@@ -127045,7 +127045,7 @@ jwI
 hBT
 cMM
 jwI
-puk
+rzG
 fGG
 idF
 rNV
@@ -127057,7 +127057,7 @@ tMM
 cUf
 qkA
 fRJ
-vHf
+iOf
 cjx
 aJp
 uvO
@@ -127304,7 +127304,7 @@ gPy
 jwI
 huv
 nCm
-mHQ
+rLa
 mBU
 jie
 ccq
@@ -127312,7 +127312,7 @@ sdC
 fGy
 afj
 uUJ
-irX
+vsp
 nCm
 nyM
 cjx
@@ -128075,7 +128075,7 @@ gPy
 jwI
 huv
 nCm
-mHQ
+rLa
 czg
 lNl
 ccq
@@ -128083,7 +128083,7 @@ sdC
 fGy
 jrf
 qxf
-irX
+vsp
 nCm
 nyM
 cjx
@@ -128587,7 +128587,7 @@ nsa
 waU
 buY
 jwI
-jRF
+ehI
 fRJ
 vpb
 vYM
@@ -128599,7 +128599,7 @@ tMM
 uWb
 qkA
 fRJ
-vHf
+iOf
 cjx
 lsw
 juy
@@ -128846,15 +128846,15 @@ wTL
 jwI
 huv
 nCm
-mHQ
+rLa
 kSz
 aog
 ccq
-epu
+xbT
 fGy
 goU
 qWU
-irX
+vsp
 nCm
 nyM
 cjx
@@ -129106,9 +129106,9 @@ wYO
 mph
 qob
 bGW
-mbT
+qbz
 vGh
-tnZ
+mMs
 iag
 gbO
 mph
@@ -129358,7 +129358,7 @@ jBe
 jwI
 gPy
 ctb
-jRF
+ehI
 fRJ
 vpb
 vFZ
@@ -129370,7 +129370,7 @@ tMM
 gSL
 qkA
 fRJ
-vHf
+iOf
 cFK
 juy
 fVu
@@ -129619,7 +129619,7 @@ jwI
 gVW
 wBr
 gVW
-tDm
+kMa
 gdS
 wgr
 gdS
@@ -129876,8 +129876,8 @@ jwI
 tIm
 uWZ
 iMl
-dUG
-dUG
+nuM
+nuM
 oCo
 tMi
 fau
@@ -130903,7 +130903,7 @@ jwI
 nUw
 vCS
 xOr
-iOG
+vHf
 bfh
 qiE
 cjx
@@ -135011,9 +135011,9 @@ ylt
 omz
 vil
 lhp
-kMa
+gOo
 ldt
-lxU
+izK
 ekl
 svQ
 nxb
@@ -135270,7 +135270,7 @@ evL
 bOA
 saw
 tVQ
-fBk
+tDm
 jwK
 svQ
 vxf
@@ -135525,14 +135525,14 @@ wtC
 ijY
 evL
 lhp
-isq
+irH
 bks
-lKe
+pZK
 mkl
 svQ
 vxf
 kiL
-kFf
+tJz
 mKy
 hzm
 vaP
@@ -135782,9 +135782,9 @@ wtC
 hBT
 npX
 fbt
-gWV
+vIq
 bks
-fBk
+tDm
 fte
 uly
 vxf
@@ -136039,15 +136039,15 @@ dyG
 bwi
 evL
 lhp
-gWV
+vIq
 bks
-fBk
+tDm
 mkl
 svQ
 vxf
 kiL
-oLh
-bmb
+eOk
+hmX
 blq
 syE
 qbC
@@ -136298,7 +136298,7 @@ lud
 bOA
 saw
 bks
-fBk
+tDm
 bYy
 svQ
 vxf
@@ -136553,9 +136553,9 @@ oZa
 daK
 pPD
 lhp
-gsU
-dBr
-mes
+uUZ
+liV
+dvX
 vmY
 svQ
 jHw

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -88,11 +88,6 @@
 	icon_state = "neutral"
 	},
 /area/station/hallway/secondary/entry)
-"aaM" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet6-2"
-	},
-/area/station/bridge)
 "aaP" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor{
@@ -2343,14 +2338,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/tox_launch)
-"asp" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/primary/central)
 "asq" = (
 /obj/structure/object_wall/pod{
 	dir = 4;
@@ -10258,6 +10245,19 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/hallway/primary/starboard)
+"cej" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/station/tcommsat/chamber)
 "ceI" = (
 /obj/machinery/camera{
 	c_tag = "Port Primary Hallway South";
@@ -10685,7 +10685,7 @@
 	},
 /obj/effect/decal/turf_decal/wood{
 	icon_state = "siding_wood_line";
-	dir = 4
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "wooden"
@@ -12733,6 +12733,11 @@
 	icon_state = "darkbrown"
 	},
 /area/station/medical/virology)
+"cHQ" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet6-2"
+	},
+/area/station/bridge)
 "cHR" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -13253,7 +13258,7 @@
 "cOS" = (
 /obj/machinery/teleport/hub,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/teleporter)
 "cOU" = (
@@ -25622,18 +25627,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/checkpoint)
-"fMt" = (
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line"
-	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "fMw" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -27069,15 +27062,6 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/break_room)
-"gfw" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "purplefull"
-	},
-/area/station/hallway/primary/central)
 "gfI" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -28272,6 +28256,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"gsQ" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "purplefull"
+	},
+/area/station/hallway/primary/central)
 "gsT" = (
 /obj/structure/dispenser/oxygen,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -28382,7 +28376,7 @@
 "gtQ" = (
 /obj/machinery/teleport/station,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/teleporter)
 "gtT" = (
@@ -30697,7 +30691,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/bridge/teleporter)
 "gVe" = (
 /obj/effect/landmark/dealer_spawn,
@@ -37361,6 +37357,25 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/chapel/mass_driver)
+"ivd" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "ivk" = (
 /obj/structure/object_wall/cargo{
 	dir = 1;
@@ -38747,15 +38762,6 @@
 	icon_state = "wooden-2"
 	},
 /area/station/civilian/gym)
-"iLd" = (
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "iLk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
@@ -39116,7 +39122,7 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge/teleporter)
 "iOW" = (
@@ -40998,16 +41004,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/server)
-"jln" = (
-/obj/item/weapon/flora/random,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "purplefull"
-	},
-/area/station/hallway/primary/central)
 "jlx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -41147,15 +41143,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/medical/morgue)
-"jnF" = (
-/obj/effect/decal/turf_decal{
-	dir = 6;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/rnd/robotics)
 "jnQ" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel,
 /turf/simulated/floor,
@@ -41607,6 +41594,14 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/checkpoint/escape_custom_desk)
+"jte" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "purplefull"
+	},
+/area/station/hallway/primary/central)
 "jtl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -44050,6 +44045,15 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
+"jTv" = (
+/obj/effect/decal/turf_decal{
+	dir = 6;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/robotics)
 "jTw" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -53313,19 +53317,6 @@
 	icon_state = "gcircuit"
 	},
 /area/station/aisat/ai_chamber)
-"lYE" = (
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "lYH" = (
 /turf/simulated/wall/r_wall,
 /area/station/bridge)
@@ -55081,11 +55072,11 @@
 /area/station/maintenance/chapel)
 "mue" = (
 /obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner"
+	icon_state = "siding_wood_line"
 	},
 /obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner";
-	dir = 4
+	icon_state = "siding_wood_line";
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "wooden"
@@ -59733,6 +59724,18 @@
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/space)
+"nzH" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner"
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "nzK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -62096,6 +62099,16 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/dormitories/courtroom)
+"oaW" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/station/bridge/corp_lounge)
 "oba" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -62726,6 +62739,15 @@
 	icon_state = "grimy"
 	},
 /area/station/engineering/chiefs_office)
+"oiL" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "oiR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -73203,6 +73225,16 @@
 	icon_state = "dark"
 	},
 /area/station/security/iaa_office)
+"qJt" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/bluegrid{
+	icon_state = "gcircuit"
+	},
+/area/station/tcommsat/chamber)
 "qJx" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -78044,19 +78076,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/checkpoint/escape_custom_desk)
-"rOL" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/bluegrid{
-	name = "Server Base";
-	nitrogen = 500;
-	oxygen = 0;
-	temperature = 80
-	},
-/area/station/tcommsat/chamber)
 "rOO" = (
 /obj/structure/stool/bed/chair/comfy/black,
 /turf/simulated/floor{
@@ -83115,6 +83134,15 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/hallway)
+"tbk" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "purplefull"
+	},
+/area/station/hallway/primary/central)
 "tbt" = (
 /obj/machinery/door/airlock/vault{
 	name = "Supermatter";
@@ -85526,25 +85554,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/bridge/hop_office)
-"tFY" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "tGH" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/light/smart{
@@ -86256,16 +86265,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/hallway)
-"tQV" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "gcircuit"
-	},
-/area/station/tcommsat/chamber)
 "tRh" = (
 /obj/item/device/radio/beacon,
 /obj/structure/cable{
@@ -94598,7 +94597,7 @@
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	icon_state = "purplefull"
+	icon_state = "vaultfull"
 	},
 /area/station/hallway/primary/central)
 "vUn" = (
@@ -101742,11 +101741,6 @@
 	icon_state = "darkred"
 	},
 /area/station/hallway/primary/fore)
-"xDz" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet9-4"
-	},
-/area/station/bridge/captain_quarters)
 "xDD" = (
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/simulated/floor{
@@ -102324,6 +102318,19 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/locker)
+"xLj" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "xLl" = (
 /obj/machinery/light/smart{
 	dir = 8
@@ -103053,16 +103060,6 @@
 	icon_state = "bluefull"
 	},
 /area/station/hallway/primary/starboard)
-"xUs" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkblue"
-	},
-/area/station/bridge/corp_lounge)
 "xUx" = (
 /turf/simulated/wall,
 /area/station/civilian/dormitories)
@@ -103126,7 +103123,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/bridge/teleporter)
 "xUX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -103367,6 +103366,11 @@
 	temperature = 80
 	},
 /area/station/tcommsat/chamber)
+"xXi" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet9-4"
+	},
+/area/station/bridge/captain_quarters)
 "xXk" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -136526,7 +136530,7 @@ bNg
 cLW
 rjR
 qgs
-jnF
+jTv
 cVA
 wrb
 chV
@@ -138315,13 +138319,13 @@ pHa
 pHa
 pbn
 yhw
-gfw
-gfw
+tbk
+tbk
 qQu
-gfw
-jln
+tbk
+gsQ
 bwA
-vUh
+jte
 eKK
 oZa
 oZa
@@ -139598,7 +139602,7 @@ fFk
 hWY
 hWY
 giW
-asp
+vUh
 mby
 oXw
 rdN
@@ -142166,7 +142170,7 @@ pQD
 gIC
 gIC
 gIC
-rOL
+cej
 gIC
 gIC
 keH
@@ -142940,7 +142944,7 @@ xMO
 raJ
 cCX
 vyg
-tQV
+qJt
 lwt
 raJ
 eXe
@@ -142951,9 +142955,9 @@ siM
 mKJ
 mMA
 bLg
-mue
+nzH
 lGH
-cje
+ivd
 nHg
 fZz
 ogP
@@ -143183,7 +143187,7 @@ gCE
 imK
 lEC
 wnY
-aaM
+cHQ
 akc
 lZx
 gWd
@@ -143208,7 +143212,7 @@ jEs
 mKJ
 mMA
 vEH
-fMt
+mue
 rOO
 mzL
 nHg
@@ -143722,7 +143726,7 @@ wMM
 fgA
 mMA
 joF
-fMt
+mue
 eZe
 wAA
 nHg
@@ -143967,7 +143971,7 @@ knC
 aty
 wEV
 fAH
-tQV
+qJt
 aEE
 lwt
 wEV
@@ -143978,10 +143982,10 @@ pQD
 amY
 fgA
 mMA
-iLd
-lYE
+oiL
+xLj
 lBF
-tFY
+cje
 nHg
 nvi
 ogP
@@ -144494,7 +144498,7 @@ xVa
 mMA
 eIB
 pYl
-xUs
+oaW
 jVM
 mMA
 elI
@@ -144736,9 +144740,9 @@ pQD
 gIC
 gIC
 gIC
-rOL
+cej
 gIC
-rOL
+cej
 gIC
 gIC
 aty
@@ -146018,7 +146022,7 @@ ibm
 adM
 sTY
 bIZ
-xDz
+xXi
 iaL
 cHR
 jKD

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -2014,7 +2014,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/item/weapon/gun/energy/laser/practice,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -4931,7 +4931,7 @@
 /obj/structure/rack,
 /obj/item/device/multitool,
 /obj/item/weapon/stock_parts/cell/high,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -6932,11 +6932,12 @@
 	},
 /area/station/engineering/atmos)
 "bur" = (
-/obj/effect/landmark/start/scientist,
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
 	},
-/area/station/rnd/misc_lab)
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "buv" = (
 /obj/structure/table,
 /obj/item/rig_module/grenade_launcher/smoke,
@@ -7024,7 +7025,7 @@
 "bvj" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -10037,6 +10038,15 @@
 	icon_state = "greenblue"
 	},
 /area/station/civilian/hydroponics)
+"ccg" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/hor)
 "cci" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -11235,7 +11245,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -12177,6 +12187,13 @@
 /obj/structure/sign/nanotrasen,
 /turf/simulated/wall/r_wall,
 /area/station/bridge/ai_upload)
+"cBG" = (
+/obj/effect/decal/turf_decal{
+	dir = 6;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "cBU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/structure/window/fulltile/reinforced/phoron{
@@ -15096,7 +15113,7 @@
 "dkg" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -15973,13 +15990,6 @@
 	},
 /turf/simulated/floor,
 /area/station/bridge/captain_quarters)
-"dvX" = (
-/obj/effect/decal/turf_decal{
-	dir = 6;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "dvZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18862,15 +18872,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"ehI" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/rnd/xenobiology)
 "ehM" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -20153,7 +20154,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/autolathe,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -20964,6 +20965,12 @@
 	dir = 5;
 	network = list("SS13","Research")
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "arrow"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "loadingarea"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -21570,15 +21577,6 @@
 	icon_state = "caution"
 	},
 /area/station/medical/chemistry)
-"eOk" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/rnd/hor)
 "eOt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -22912,6 +22910,16 @@
 	icon_state = "red"
 	},
 /area/station/security/brig)
+"fed" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "purple"
+	},
+/area/station/rnd/xenobiology)
 "feh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23191,8 +23199,8 @@
 	},
 /area/station/bridge/corp_lounge)
 "fgI" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot_right"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -27750,6 +27758,15 @@
 	icon_state = "white"
 	},
 /area/station/medical/reception)
+"gln" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/xenobiology)
 "gls" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -28041,7 +28058,7 @@
 	dir = 5;
 	network = list("SS13","Research")
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -30061,7 +30078,7 @@
 /obj/structure/closet/crate,
 /obj/item/target/alien,
 /obj/item/target/syndicate,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -30212,16 +30229,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
-"gOo" = (
-/obj/effect/decal/turf_decal{
-	dir = 9;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "gOs" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/brig/storage)
@@ -32231,15 +32238,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/cargo/miningoffice)
-"hmX" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/rnd/hor)
 "hmY" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -37298,17 +37296,6 @@
 	icon_state = "dark"
 	},
 /area/station/aisat/ai_chamber)
-"irH" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "irL" = (
 /obj/machinery/light/smart{
 	dir = 4
@@ -37986,17 +37973,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"izK" = (
-/obj/effect/decal/turf_decal{
-	dir = 10;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "izS" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/status_display{
@@ -38302,6 +38278,9 @@
 "iDy" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "whitepurple"
@@ -39269,15 +39248,6 @@
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/station/civilian/dormitories)
-"iOf" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/rnd/xenobiology)
 "iOl" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -39717,20 +39687,6 @@
 "iTl" = (
 /turf/simulated/wall,
 /area/station/security/range)
-"iTp" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "neutral"
-	},
-/area/station/rnd/xenobiology)
 "iTw" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 10
@@ -41398,6 +41354,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison)
+"jnv" = (
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "jnw" = (
 /turf/simulated/wall/r_wall,
 /area/station/engineering/atmos/distribution)
@@ -47030,6 +46993,21 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
+"kza" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/station/rnd/xenobiology)
 "kzb" = (
 /obj/structure/sign/directions/medical{
 	pixel_x = 32
@@ -48315,12 +48293,17 @@
 	},
 /area/station/rnd/tox_launch)
 "kMa" = (
-/obj/structure/reagent_dispensers/aqueous_foam_tank,
-/obj/effect/decal/turf_decal/alpha/red{
-	icon_state = "bot"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "neutral"
 	},
 /area/station/rnd/xenobiology)
 "kMb" = (
@@ -49161,6 +49144,12 @@
 	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
+"kWx" = (
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "kWA" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -49519,6 +49508,26 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/mixing)
+"kZS" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha{
+	icon_state = "warn_end";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/station/rnd/xenobiology)
 "kZT" = (
 /obj/structure/table/reinforced,
 /obj/item/device/radio/headset,
@@ -50146,13 +50155,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/fore)
-"liV" = (
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "ljb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 9
@@ -51027,6 +51029,15 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/hydroponics)
+"lte" = (
+/obj/structure/stool/bed/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/landmark/start/scientist,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/misc_lab)
 "ltn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -56185,6 +56196,18 @@
 	icon_state = "vaultfull"
 	},
 /area/station/hallway/primary/central)
+"mCN" = (
+/obj/structure/window/thin/reinforced{
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/xenobiology)
 "mDd" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -56502,15 +56525,6 @@
 	icon_state = "orange"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
-"mHE" = (
-/obj/effect/decal/turf_decal/alpha/blue{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/rnd/xenobiology)
 "mHM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -56803,20 +56817,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/chapel)
-"mMs" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "neutral"
-	},
-/area/station/rnd/xenobiology)
 "mMt" = (
 /obj/item/device/radio/beacon,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -56924,6 +56924,16 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
+"mOm" = (
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "mOn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -59687,16 +59697,6 @@
 	icon_state = "wooden"
 	},
 /area/station/civilian/library)
-"nuM" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "whitepurplecorner"
-	},
-/area/station/rnd/xenobiology)
 "nuP" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -61375,6 +61375,15 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/engine)
+"nPy" = (
+/obj/structure/reagent_dispensers/aqueous_foam_tank,
+/obj/effect/decal/turf_decal/alpha/red{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/xenobiology)
 "nPD" = (
 /obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor,
@@ -64163,6 +64172,16 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
+"oyK" = (
+/mob/living/carbon/monkey,
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/xenobiology)
 "ozc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -64934,8 +64953,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot_left"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -65838,6 +65857,20 @@
 	},
 /turf/environment/space,
 /area/shuttle/escape_pod5/station)
+"oTg" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
+/area/station/rnd/xenobiology)
 "oTt" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -67201,7 +67234,7 @@
 /obj/item/stack/sheet/metal{
 	amount = 10
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -69446,6 +69479,15 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/gym)
+"pJI" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/xenobiology)
 "pJW" = (
 /turf/simulated/floor{
 	dir = 9;
@@ -70834,16 +70876,6 @@
 	icon_state = "darkred"
 	},
 /area/station/security/brig)
-"pZK" = (
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "pZR" = (
 /turf/simulated/floor{
 	icon_state = "blackcorner"
@@ -71002,21 +71034,6 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/atmos)
-"qbz" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/station/rnd/xenobiology)
 "qbA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -72215,6 +72232,17 @@
 /obj/item/weapon/flora/random,
 /turf/simulated/floor,
 /area/station/security/prison)
+"qqe" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "qqm" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -72337,15 +72365,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/chargebay)
-"qsg" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/rnd/xenobiology)
 "qsh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark{
@@ -73444,14 +73463,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/cmo)
-"qFt" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "box_corners_white"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/rnd/xenobiology)
 "qFO" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -74807,7 +74818,7 @@
 /area/station/maintenance/science)
 "qWc" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -76320,6 +76331,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/barbershop)
+"rqN" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/xenobiology)
 "rqZ" = (
 /obj/structure/scrap_beacon,
 /turf/simulated/floor/airless/ceiling,
@@ -77187,16 +77206,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hor)
-"rzG" = (
-/mob/living/carbon/monkey,
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/rnd/xenobiology)
 "rzL" = (
 /obj/random/vending/snack,
 /turf/simulated/floor/wood,
@@ -78366,18 +78375,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/warden)
-"rLa" = (
-/obj/structure/window/thin/reinforced{
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/rnd/xenobiology)
 "rLi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -79283,14 +79280,14 @@
 /turf/environment/space,
 /area/shuttle/supply/station)
 "rWY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/window/thin/reinforced{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/rnd/xenobiology)
 "rXo" = (
@@ -82005,6 +82002,16 @@
 	icon_state = "redchecker"
 	},
 /area/station/hallway/primary/fore)
+"sEK" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "whitepurplecorner"
+	},
+/area/station/rnd/xenobiology)
 "sEV" = (
 /obj/structure/table/glass,
 /obj/machinery/vending/wallmed1{
@@ -83796,6 +83803,17 @@
 	icon_state = "white"
 	},
 /area/station/security/main)
+"tbP" = (
+/obj/effect/decal/turf_decal{
+	dir = 10;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "tbR" = (
 /obj/structure/dresser,
 /turf/simulated/floor/wood,
@@ -84733,6 +84751,15 @@
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/starboard)
+"tnW" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/xenobiology)
 "tok" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
@@ -85931,11 +85958,16 @@
 /turf/simulated/floor/plating,
 /area/station/medical/reception)
 "tDm" = (
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/xenobiology)
 "tDn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -86330,6 +86362,21 @@
 "tIo" = (
 /turf/simulated/wall,
 /area/station/maintenance/medbay)
+"tIq" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/station/rnd/xenobiology)
 "tIH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -86382,15 +86429,6 @@
 "tJr" = (
 /turf/simulated/wall/r_wall,
 /area/station/rnd/server)
-"tJz" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/rnd/hor)
 "tJH" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -86615,7 +86653,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	dir = 8;
+	dir = 1;
 	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/xenobiology)
@@ -88042,6 +88080,17 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/storage)
+"ufk" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "arrow"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "loadingarea"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/misc_lab)
 "ufr" = (
 /obj/machinery/light/smart,
 /turf/simulated/floor{
@@ -91287,13 +91336,6 @@
 	icon_state = "dark"
 	},
 /area/station/cargo/recycleroffice)
-"uUZ" = (
-/obj/effect/decal/turf_decal{
-	dir = 5;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "uVc" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -93145,17 +93187,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/rnd/misc_lab)
-"vsp" = (
-/obj/structure/window/thin/reinforced{
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "box_corners_white"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/rnd/xenobiology)
 "vsr" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -94372,14 +94403,14 @@
 /area/station/engineering/engine)
 "vHf" = (
 /obj/effect/decal/turf_decal{
-	dir = 1;
+	dir = 9;
 	icon_state = "warn"
 	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "purple"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
 	},
-/area/station/rnd/xenobiology)
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "vHR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/window/northright{
@@ -94424,13 +94455,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/hallway/lobby)
-"vIq" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "vIu" = (
 /obj/effect/decal/cleanable/generic,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -94568,6 +94592,13 @@
 	icon_state = "vaultfull"
 	},
 /area/station/medical/genetics)
+"vJX" = (
+/obj/effect/decal/turf_decal{
+	dir = 5;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "vKa" = (
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -95430,6 +95461,15 @@
 /obj/structure/window/thin,
 /turf/simulated/floor,
 /area/station/security/prison)
+"vVR" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/hor)
 "vVY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -95759,7 +95799,7 @@
 /obj/structure/rack,
 /obj/item/weapon/wirecutters,
 /obj/item/weapon/screwdriver,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -96175,21 +96215,6 @@
 "wdO" = (
 /turf/simulated/floor,
 /area/station/maintenance/escape)
-"wdP" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/station/rnd/xenobiology)
 "wej" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -98343,7 +98368,7 @@
 /area/station/bridge/corp_lounge)
 "wFq" = (
 /obj/machinery/mecha_part_fabricator/mining_fabricator,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -99618,6 +99643,15 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/fore)
+"wWi" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/xenobiology)
 "wWj" = (
 /obj/structure/sink{
 	pixel_y = 24
@@ -100065,26 +100099,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
-"xbT" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha{
-	icon_state = "warn_end";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "white"
-	},
-/area/station/rnd/xenobiology)
 "xbY" = (
 /turf/simulated/floor,
 /area/station/maintenance/medbay)
@@ -101449,6 +101463,15 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
+"xrX" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/hor)
 "xsb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -125257,7 +125280,7 @@ cRA
 jYs
 hXe
 gVW
-mHE
+wWi
 cfJ
 cjx
 xRM
@@ -126023,7 +126046,7 @@ uhT
 frn
 aAZ
 gdS
-rWY
+tDm
 gdS
 xZd
 siE
@@ -126533,15 +126556,15 @@ waU
 ctb
 vUH
 fRJ
-qsg
+tnW
 fXd
 bJD
 gdS
-rWY
+tDm
 gdS
 ecA
 hTC
-qFt
+rqN
 fRJ
 pyX
 cFK
@@ -126793,9 +126816,9 @@ kfd
 xdW
 rIz
 stV
-wdP
+kza
 sjW
-iTp
+oTg
 iag
 jum
 mph
@@ -127045,7 +127068,7 @@ jwI
 hBT
 cMM
 jwI
-rzG
+oyK
 fGG
 idF
 rNV
@@ -127057,7 +127080,7 @@ tMM
 cUf
 qkA
 fRJ
-iOf
+pJI
 cjx
 aJp
 uvO
@@ -127304,7 +127327,7 @@ gPy
 jwI
 huv
 nCm
-rLa
+mCN
 mBU
 jie
 ccq
@@ -127312,7 +127335,7 @@ sdC
 fGy
 afj
 uUJ
-vsp
+rWY
 nCm
 nyM
 cjx
@@ -128075,7 +128098,7 @@ gPy
 jwI
 huv
 nCm
-rLa
+mCN
 czg
 lNl
 ccq
@@ -128083,7 +128106,7 @@ sdC
 fGy
 jrf
 qxf
-vsp
+rWY
 nCm
 nyM
 cjx
@@ -128587,7 +128610,7 @@ nsa
 waU
 buY
 jwI
-ehI
+gln
 fRJ
 vpb
 vYM
@@ -128599,7 +128622,7 @@ tMM
 uWb
 qkA
 fRJ
-iOf
+pJI
 cjx
 lsw
 juy
@@ -128846,15 +128869,15 @@ wTL
 jwI
 huv
 nCm
-rLa
+mCN
 kSz
 aog
 ccq
-xbT
+kZS
 fGy
 goU
 qWU
-vsp
+rWY
 nCm
 nyM
 cjx
@@ -129106,9 +129129,9 @@ wYO
 mph
 qob
 bGW
-qbz
+tIq
 vGh
-mMs
+kMa
 iag
 gbO
 mph
@@ -129358,7 +129381,7 @@ jBe
 jwI
 gPy
 ctb
-ehI
+gln
 fRJ
 vpb
 vFZ
@@ -129370,7 +129393,7 @@ tMM
 gSL
 qkA
 fRJ
-iOf
+pJI
 cFK
 juy
 fVu
@@ -129619,7 +129642,7 @@ jwI
 gVW
 wBr
 gVW
-kMa
+nPy
 gdS
 wgr
 gdS
@@ -129876,10 +129899,10 @@ jwI
 tIm
 uWZ
 iMl
-nuM
-nuM
-oCo
 tMi
+tMi
+oCo
+sEK
 fau
 oEf
 rAU
@@ -130903,7 +130926,7 @@ jwI
 nUw
 vCS
 xOr
-vHf
+fed
 bfh
 qiE
 cjx
@@ -135011,9 +135034,9 @@ ylt
 omz
 vil
 lhp
-gOo
+vHf
 ldt
-izK
+tbP
 ekl
 svQ
 nxb
@@ -135270,7 +135293,7 @@ evL
 bOA
 saw
 tVQ
-tDm
+kWx
 jwK
 svQ
 vxf
@@ -135525,14 +135548,14 @@ wtC
 ijY
 evL
 lhp
-irH
+qqe
 bks
-pZK
+mOm
 mkl
 svQ
 vxf
 kiL
-tJz
+xrX
 mKy
 hzm
 vaP
@@ -135545,7 +135568,7 @@ jVk
 jdg
 qWc
 jVk
-bur
+jVk
 jVk
 jVk
 fsp
@@ -135782,9 +135805,9 @@ wtC
 hBT
 npX
 fbt
-vIq
+bur
 bks
-tDm
+kWx
 fte
 uly
 vxf
@@ -135803,7 +135826,7 @@ snA
 nmq
 jVk
 jVk
-jVk
+lte
 jVk
 dNy
 due
@@ -136039,15 +136062,15 @@ dyG
 bwi
 evL
 lhp
-vIq
+bur
 bks
-tDm
+kWx
 mkl
 svQ
 vxf
 kiL
-eOk
-hmX
+ccg
+vVR
 blq
 syE
 qbC
@@ -136055,7 +136078,7 @@ mvv
 iVU
 agq
 wFq
-jVk
+ufk
 pNy
 khz
 cpL
@@ -136298,7 +136321,7 @@ lud
 bOA
 saw
 bks
-tDm
+kWx
 bYy
 svQ
 vxf
@@ -136553,9 +136576,9 @@ oZa
 daK
 pPD
 lhp
-uUZ
-liV
-dvX
+vJX
+jnv
+cBG
 vmY
 svQ
 jHw

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -3146,6 +3146,11 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
+"aBM" = (
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "aBP" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -5613,6 +5618,13 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/robotics)
+"beM" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-MB";
+	location = "N-MB"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "beO" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -6340,6 +6352,16 @@
 	icon_state = "vaultfull"
 	},
 /area/station/tcommsat/chamber)
+"blY" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SEE-FC";
+	location = "SE-FC"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "bme" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -7048,6 +7070,14 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/storage)
+"buA" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/civilian/gym)
 "buH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -7596,6 +7626,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"bAB" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "bAC" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -8162,10 +8204,11 @@
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "box_corners_white";
-	dir = 4
+	dir = 1
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
+	icon_state = "box_corners_white";
+	dir = 8
 	},
 /obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "siding_line";
@@ -10412,6 +10455,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NW-B";
+	location = "NE-FC"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -12335,15 +12382,6 @@
 	icon_state = "darkbluecorners"
 	},
 /area/station/medical/genetics)
-"cBc" = (
-/obj/effect/decal/turf_decal/alpha/blue{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "cBp" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -15647,6 +15685,12 @@
 /obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"dod" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
+	},
+/turf/simulated/floor/carpet/red,
+/area/station/security/detectives_office)
 "doE" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -15770,6 +15814,16 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/fore)
+"dqD" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSE-FC";
+	location = "SEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "dqI" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -18312,6 +18366,26 @@
 	icon_state = "brown"
 	},
 /area/station/engineering/break_room)
+"dWC" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "dWD" = (
 /obj/structure/table/woodentable/fancy,
 /obj/item/stack/sheet/wood{
@@ -18815,6 +18889,19 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"ecv" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "ecA" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/thin/reinforced{
@@ -19013,14 +19100,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
-"eeP" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/civilian/gym)
 "eeT" = (
 /obj/machinery/computer/operating,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -23756,13 +23835,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/station/security/range)
-"fjs" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "fjy" = (
 /obj/structure/sign/directions/supply{
 	dir = 4
@@ -25032,6 +25104,16 @@
 	icon_state = "darkblue"
 	},
 /area/station/medical/genetics)
+"fys" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-B";
+	location = "SSW-B"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "fyx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -26280,15 +26362,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "fOp" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Central Access"
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Security";
+	location = "S-C"
 	},
 /turf/simulated/floor{
-	dir = 4;
 	icon_state = "neutralcorner"
 	},
-/area/station/security/lobby)
+/area/station/hallway/primary/central)
 "fOF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
@@ -28557,19 +28638,6 @@
 	icon_state = "black"
 	},
 /area/station/hallway/secondary/exit)
-"gnI" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "gnJ" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -31989,11 +32057,6 @@
 	temperature = 80
 	},
 /area/station/tcommsat/chamber)
-"hbd" = (
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "hbe" = (
 /obj/machinery/r_n_d/circuit_imprinter,
 /obj/item/weapon/reagent_containers/glass/beaker/sulphuric,
@@ -34378,6 +34441,16 @@
 /obj/effect/decal/cleanable/blood/gibs/robot,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"hAP" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SWW-FC";
+	location = "SW-FC"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "hAR" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
@@ -34666,6 +34739,13 @@
 	icon_state = "vaultfull"
 	},
 /area/station/engineering/break_room)
+"hDU" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=N-MB";
+	location = "NNW-B"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "hEd" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/box/matches,
@@ -36858,6 +36938,13 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
+"idX" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "ier" = (
 /turf/simulated/floor{
 	icon_state = "black"
@@ -39459,17 +39546,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/distribution)
-"iGX" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "iGZ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -41918,6 +41994,19 @@
 /obj/item/device/paicard,
 /turf/simulated/floor,
 /area/station/rnd/robotics)
+"jjX" = (
+/obj/machinery/light/smart{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NE-FC";
+	location = "NEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "jjY" = (
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
@@ -46498,27 +46587,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/robotics)
-"kik" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "kin" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -48979,6 +49047,16 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/supermatter)
+"kJp" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SE-FC";
+	location = "SW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "kJq" = (
 /obj/machinery/computer/secure_data/detective_computer,
 /turf/simulated/floor/carpet/red,
@@ -56832,6 +56910,19 @@
 	icon_state = "white"
 	},
 /area/station/medical/cryo)
+"mzy" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "mzF" = (
 /obj/machinery/hologram/holopad{
 	pixel_y = -16
@@ -62307,18 +62398,6 @@
 	icon_state = "neutral"
 	},
 /area/station/medical/chemistry)
-"nMY" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "nNa" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
@@ -62861,19 +62940,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/bridge)
-"nSs" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "nSC" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots,
@@ -63735,6 +63801,13 @@
 	icon_state = "wooden-2"
 	},
 /area/station/civilian/gym)
+"obU" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-FC";
+	location = "SSW-FC"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/starboard)
 "oci" = (
 /obj/structure/stool/bed/chair/comfy/brown{
 	dir = 4
@@ -72129,6 +72202,15 @@
 	icon_state = "blackcorner"
 	},
 /area/station/hallway/primary/starboard)
+"qas" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "qaF" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red,
 /obj/machinery/meter,
@@ -73214,6 +73296,16 @@
 	icon_state = "gcircuit"
 	},
 /area/station/aisat/ai_chamber)
+"qmV" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Central Access"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "qmZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -74272,6 +74364,17 @@
 	icon_state = "neutral"
 	},
 /area/station/engineering/chiefs_office)
+"qAo" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "qAy" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/incinerator)
@@ -76520,6 +76623,13 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
+"rbJ" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=CS-AR";
+	location = "SWW-FC"
+	},
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "rbK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -78807,18 +78917,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
-"rCk" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "rCn" = (
 /turf/environment/space,
 /area/shuttle/vox/southeast_solars)
@@ -78956,6 +79054,10 @@
 "rEr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DN-W";
+	location = "DN"
 	},
 /turf/simulated/floor{
 	icon_state = "bluecorner"
@@ -84918,6 +85020,16 @@
 	icon_state = "vaultfull"
 	},
 /area/station/storage/tech)
+"sXA" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NNW-B";
+	location = "NW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "sXD" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -91323,6 +91435,16 @@
 	icon_state = "darkblue"
 	},
 /area/station/bridge)
+"uAk" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NEE-FC";
+	location = "S-SV"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "uAq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -94348,6 +94470,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/supermatter)
+"vng" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-B";
+	location = "S-MB"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry)
 "vnt" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/firstaid/regular,
@@ -96020,6 +96151,16 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/hallway/lobby)
+"vIr" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-FC";
+	location = "DS"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
+/area/station/hallway/primary/central)
 "vIu" = (
 /obj/effect/decal/cleanable/generic,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -96959,6 +97100,18 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/hallway)
+"vUt" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "vUH" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -97790,6 +97943,17 @@
 "wdO" = (
 /turf/simulated/floor,
 /area/station/maintenance/escape)
+"wei" = (
+/obj/machinery/light/smart,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DS";
+	location = "DN-W"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "purplecorner"
+	},
+/area/station/hallway/primary/central)
 "wej" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -98665,6 +98829,16 @@
 	icon_state = "white"
 	},
 /area/station/medical/hallway)
+"woX" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-C";
+	location = "CS-AR"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "wpa" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -99987,6 +100161,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
+"wFz" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DN";
+	location = "SSE-FC"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "wFU" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -100256,6 +100439,10 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-SV";
+	location = "Security"
 	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -101984,12 +102171,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor,
 /area/station/maintenance/science)
-"xeU" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
-	},
-/turf/simulated/floor/carpet/red,
-/area/station/security/detectives_office)
 "xfr" = (
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -135114,7 +135295,7 @@ doE
 doE
 doE
 lgU
-doE
+blY
 mhm
 doE
 mnD
@@ -135612,7 +135793,7 @@ wwi
 aYN
 wwi
 lfm
-bzt
+dqD
 tZn
 oyb
 nAM
@@ -135630,7 +135811,7 @@ oyb
 bzt
 bzt
 rcq
-tYK
+wFz
 tYK
 wtC
 wtC
@@ -141009,7 +141190,7 @@ iSv
 xXt
 vAu
 ogP
-fZz
+fys
 bAS
 nvi
 rnH
@@ -141025,7 +141206,7 @@ qbj
 qbj
 tmk
 ldb
-nvi
+kJp
 ogP
 iSi
 amv
@@ -141052,7 +141233,7 @@ vpT
 xei
 bFh
 vpT
-njw
+wei
 vIl
 olx
 frM
@@ -141220,7 +141401,7 @@ plf
 brw
 mko
 jsL
-fYS
+vng
 ffX
 hbE
 sTt
@@ -141489,7 +141670,7 @@ gHT
 alc
 vDr
 fDL
-hkD
+sXA
 iwy
 xXt
 gNR
@@ -145333,7 +145514,7 @@ yaE
 yaE
 csG
 fYS
-gHT
+beM
 alc
 gHT
 gHT
@@ -145342,7 +145523,7 @@ gHT
 gHT
 gHT
 alc
-gHT
+hDU
 fYS
 sEX
 srs
@@ -150277,7 +150458,7 @@ mXl
 mXl
 mXl
 wLD
-mXl
+uAk
 iwm
 mXl
 pRS
@@ -150295,7 +150476,7 @@ oNU
 mXl
 uxx
 xMc
-nvi
+hAP
 nvi
 rnH
 cLM
@@ -150304,7 +150485,7 @@ nvi
 tOH
 mfI
 ogP
-oZq
+vIr
 sBG
 wjc
 wjc
@@ -150607,7 +150788,7 @@ xQo
 xQo
 xQo
 nKU
-xQo
+obU
 xQo
 oPI
 mRu
@@ -150774,7 +150955,7 @@ cpR
 gtK
 cpR
 pxL
-hRd
+jjX
 ffJ
 ape
 fZz
@@ -150793,7 +150974,7 @@ hRd
 ckx
 fZz
 lMB
-vAu
+fOp
 kzb
 vAu
 psV
@@ -150807,7 +150988,7 @@ vAu
 kRo
 vAu
 kCI
-fZz
+woX
 ogP
 lwr
 mLS
@@ -151048,7 +151229,7 @@ erD
 erD
 cmN
 act
-fOp
+qmV
 xsY
 uuf
 jTW
@@ -154898,8 +155079,8 @@ plf
 xyC
 cFp
 klH
-xeU
-xeU
+dod
+dod
 hGr
 aRu
 xyC
@@ -155423,8 +155604,8 @@ dnn
 aEr
 wPw
 jQy
-cBc
-hbd
+qas
+aBM
 jcX
 fJg
 nPU
@@ -155931,7 +156112,7 @@ xyC
 xyC
 xyC
 xyC
-fjs
+idX
 jtG
 wpm
 fJg
@@ -157490,7 +157671,7 @@ kIM
 vst
 mDV
 vKG
-vKG
+rbJ
 xoq
 tAM
 uQA
@@ -160557,7 +160738,7 @@ sxG
 uOc
 hur
 hur
-nSs
+ecv
 ekd
 lZw
 gqC
@@ -160811,7 +160992,7 @@ ixl
 mme
 uKd
 gRX
-nMY
+bAB
 sRa
 nUj
 wUB
@@ -160840,13 +161021,13 @@ ncp
 ncp
 hbR
 mWz
-rCk
+vUt
 kLd
 syX
 tHk
 tHk
 dbf
-kik
+bFL
 ram
 mWz
 lNQ
@@ -161103,7 +161284,7 @@ eFl
 aRb
 nDG
 jjN
-gnI
+mzy
 ram
 mWz
 ucd
@@ -161611,13 +161792,13 @@ ncp
 ncp
 hbR
 mWz
-iGX
+qAo
 sIY
 qls
 uOM
 uOM
 aeG
-bFL
+dWC
 ram
 mWz
 hPr
@@ -162641,7 +162822,7 @@ dJL
 nRG
 oXA
 oXA
-eeP
+buA
 dJL
 plf
 cdR
@@ -165979,7 +166160,7 @@ kHU
 fMh
 plf
 dJL
-eeP
+buA
 oXA
 oXA
 nJn

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -2074,6 +2074,15 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway)
+"apz" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "purplefull"
+	},
+/area/station/hallway/primary/central)
 "apA" = (
 /obj/effect/landmark{
 	name = "blobstart"
@@ -7934,6 +7943,18 @@
 	icon_state = "purplecorner"
 	},
 /area/station/hallway/primary/central)
+"bFk" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line"
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "bFm" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/ai_status_display{
@@ -10245,19 +10266,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/hallway/primary/starboard)
-"cej" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/bluegrid{
-	name = "Server Base";
-	nitrogen = 500;
-	oxygen = 0;
-	temperature = 80
-	},
-/area/station/tcommsat/chamber)
 "ceI" = (
 /obj/machinery/camera{
 	c_tag = "Port Primary Hallway South";
@@ -10685,7 +10693,7 @@
 	},
 /obj/effect/decal/turf_decal/wood{
 	icon_state = "siding_wood_line";
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "wooden"
@@ -12662,6 +12670,16 @@
 	},
 /turf/simulated/floor,
 /area/station/gateway)
+"cHi" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "purplefull"
+	},
+/area/station/hallway/primary/central)
 "cHl" = (
 /obj/machinery/door/airlock/glass{
 	autoclose = 0;
@@ -12733,11 +12751,6 @@
 	icon_state = "darkbrown"
 	},
 /area/station/medical/virology)
-"cHQ" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet6-2"
-	},
-/area/station/bridge)
 "cHR" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -14429,7 +14442,7 @@
 /area/station/engineering/atmos)
 "dfg" = (
 /turf/simulated/floor/carpet{
-	icon_state = "carpet10-8"
+	icon_state = "carpet6-2"
 	},
 /area/station/bridge)
 "dfo" = (
@@ -15422,6 +15435,9 @@
 /obj/structure/dispenser/oxygen,
 /obj/machinery/light/smart{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor,
 /area/station/gateway)
@@ -18933,6 +18949,11 @@
 	icon_state = "dark"
 	},
 /area/station/aisat/ai_chamber)
+"eiZ" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet9-4"
+	},
+/area/station/bridge/captain_quarters)
 "ejc" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -28163,6 +28184,19 @@
 "gqV" = (
 /turf/simulated/wall/r_wall,
 /area/station/rnd/scibreak)
+"gqX" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/station/tcommsat/chamber)
 "grm" = (
 /obj/machinery/power/solar_control{
 	dir = 8;
@@ -28256,16 +28290,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"gsQ" = (
-/obj/item/weapon/flora/random,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "purplefull"
-	},
-/area/station/hallway/primary/central)
 "gsT" = (
 /obj/structure/dispenser/oxygen,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -30849,6 +30873,15 @@
 	},
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
+"gWy" = (
+/obj/effect/decal/turf_decal{
+	dir = 6;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/robotics)
 "gWA" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -37357,25 +37390,6 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/chapel/mass_driver)
-"ivd" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "ivk" = (
 /obj/structure/object_wall/cargo{
 	dir = 1;
@@ -39144,6 +39158,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"iPA" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner"
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "iPB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -40242,6 +40268,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
+"jcB" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "jcC" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -41594,14 +41633,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/checkpoint/escape_custom_desk)
-"jte" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "purplefull"
-	},
-/area/station/hallway/primary/central)
 "jtl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -41621,7 +41652,7 @@
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/gateway)
 "jtq" = (
@@ -44045,15 +44076,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
-"jTv" = (
-/obj/effect/decal/turf_decal{
-	dir = 6;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/rnd/robotics)
 "jTw" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -48694,6 +48716,9 @@
 	icon_state = "1-4"
 	},
 /obj/structure/closet/l3closet/scientist,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_right"
+	},
 /turf/simulated/floor,
 /area/station/gateway)
 "kUo" = (
@@ -49446,7 +49471,7 @@
 	icon_state = "bot_left"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/gateway)
 "lcI" = (
@@ -52806,7 +52831,7 @@
 	icon_state = "bot_right"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/gateway)
 "lRD" = (
@@ -55072,11 +55097,8 @@
 /area/station/maintenance/chapel)
 "mue" = (
 /obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line"
-	},
-/obj/effect/decal/turf_decal/wood{
 	icon_state = "siding_wood_line";
-	dir = 1
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "wooden"
@@ -55874,7 +55896,7 @@
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/gateway)
 "mDB" = (
@@ -58911,7 +58933,7 @@
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/gateway)
 "npX" = (
@@ -59724,18 +59746,6 @@
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/space)
-"nzH" = (
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner"
-	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "nzK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -62099,16 +62109,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/dormitories/courtroom)
-"oaW" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkblue"
-	},
-/area/station/bridge/corp_lounge)
 "oba" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -62739,15 +62739,6 @@
 	icon_state = "grimy"
 	},
 /area/station/engineering/chiefs_office)
-"oiL" = (
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "oiR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -67919,7 +67910,7 @@
 	icon_state = "bot_left"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/gateway)
 "pxK" = (
@@ -73225,16 +73216,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/iaa_office)
-"qJt" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "gcircuit"
-	},
-/area/station/tcommsat/chamber)
 "qJx" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -76202,7 +76183,7 @@
 	icon_state = "bot_right"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/gateway)
 "rvT" = (
@@ -78634,7 +78615,7 @@
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/gateway)
 "rWu" = (
@@ -80078,6 +80059,11 @@
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
+	},
+/area/station/bridge)
+"smZ" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet10-8"
 	},
 /area/station/bridge)
 "snp" = (
@@ -82272,6 +82258,16 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/brig)
+"sPP" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/station/bridge/corp_lounge)
 "sPU" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/rglass{
@@ -83134,15 +83130,6 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/hallway)
-"tbk" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "purplefull"
-	},
-/area/station/hallway/primary/central)
 "tbt" = (
 /obj/machinery/door/airlock/vault{
 	name = "Supermatter";
@@ -84941,6 +84928,14 @@
 	icon_state = "dark"
 	},
 /area/station/medical/virology)
+"tzk" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/primary/central)
 "tzm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light/small{
@@ -94597,7 +94592,7 @@
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "purplefull"
 	},
 /area/station/hallway/primary/central)
 "vUn" = (
@@ -94685,6 +94680,9 @@
 	name = "Station Intercom (General)";
 	pixel_x = 28;
 	pixel_y = -5
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor,
 /area/station/gateway)
@@ -100493,6 +100491,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/miningoffice)
+"xqL" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/bluegrid{
+	icon_state = "gcircuit"
+	},
+/area/station/tcommsat/chamber)
 "xqN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -102318,19 +102326,6 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/locker)
-"xLj" = (
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "xLl" = (
 /obj/machinery/light/smart{
 	dir = 8
@@ -103163,6 +103158,25 @@
 	icon_state = "carpet14-10"
 	},
 /area/station/bridge)
+"xVl" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "xVm" = (
 /obj/machinery/alarm{
 	pixel_y = -32
@@ -103366,11 +103380,6 @@
 	temperature = 80
 	},
 /area/station/tcommsat/chamber)
-"xXi" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet9-4"
-	},
-/area/station/bridge/captain_quarters)
 "xXk" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -136530,7 +136539,7 @@ bNg
 cLW
 rjR
 qgs
-jTv
+gWy
 cVA
 wrb
 chV
@@ -138319,13 +138328,13 @@ pHa
 pHa
 pbn
 yhw
-tbk
-tbk
+apz
+apz
 qQu
-tbk
-gsQ
+apz
+cHi
 bwA
-jte
+vUh
 eKK
 oZa
 oZa
@@ -139602,7 +139611,7 @@ fFk
 hWY
 hWY
 giW
-vUh
+tzk
 mby
 oXw
 rdN
@@ -142170,7 +142179,7 @@ pQD
 gIC
 gIC
 gIC
-cej
+gqX
 gIC
 gIC
 keH
@@ -142944,7 +142953,7 @@ xMO
 raJ
 cCX
 vyg
-qJt
+xqL
 lwt
 raJ
 eXe
@@ -142955,9 +142964,9 @@ siM
 mKJ
 mMA
 bLg
-nzH
+iPA
 lGH
-ivd
+cje
 nHg
 fZz
 ogP
@@ -143187,7 +143196,7 @@ gCE
 imK
 lEC
 wnY
-cHQ
+dfg
 akc
 lZx
 gWd
@@ -143212,7 +143221,7 @@ jEs
 mKJ
 mMA
 vEH
-mue
+bFk
 rOO
 mzL
 nHg
@@ -143701,7 +143710,7 @@ gCE
 imK
 lEC
 mrs
-dfg
+smZ
 nSo
 lZx
 oay
@@ -143726,7 +143735,7 @@ wMM
 fgA
 mMA
 joF
-mue
+bFk
 eZe
 wAA
 nHg
@@ -143971,7 +143980,7 @@ knC
 aty
 wEV
 fAH
-qJt
+xqL
 aEE
 lwt
 wEV
@@ -143982,10 +143991,10 @@ pQD
 amY
 fgA
 mMA
-oiL
-xLj
+mue
+jcB
 lBF
-cje
+xVl
 nHg
 nvi
 ogP
@@ -144498,7 +144507,7 @@ xVa
 mMA
 eIB
 pYl
-oaW
+sPP
 jVM
 mMA
 elI
@@ -144740,9 +144749,9 @@ pQD
 gIC
 gIC
 gIC
-cej
+gqX
 gIC
-cej
+gqX
 gIC
 gIC
 aty
@@ -146022,7 +146031,7 @@ ibm
 adM
 sTY
 bIZ
-xXi
+eiZ
 iaL
 cHR
 jKD

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -88,11 +88,6 @@
 	icon_state = "neutral"
 	},
 /area/station/hallway/secondary/entry)
-"aaG" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet6-2"
-	},
-/area/station/bridge)
 "aaP" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor{
@@ -3729,19 +3724,6 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
-"aJb" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/bluegrid{
-	name = "Server Base";
-	nitrogen = 500;
-	oxygen = 0;
-	temperature = 80
-	},
-/area/station/tcommsat/chamber)
 "aJe" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -7529,12 +7511,12 @@
 /area/station/cargo/storage)
 "bAN" = (
 /obj/machinery/computer/scan_consolenew,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_right"
+	},
 /obj/effect/decal/turf_decal{
 	dir = 8;
 	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_right"
 	},
 /turf/simulated/floor{
 	dir = 9;
@@ -13378,7 +13360,7 @@
 /area/station/hallway/primary/fore)
 "cPN" = (
 /turf/simulated/floor/carpet{
-	icon_state = "carpet9-4"
+	icon_state = "carpet6-2"
 	},
 /area/station/bridge/captain_quarters)
 "cPY" = (
@@ -14447,7 +14429,7 @@
 /area/station/engineering/atmos)
 "dfg" = (
 /turf/simulated/floor/carpet{
-	icon_state = "carpet10-8"
+	icon_state = "carpet6-2"
 	},
 /area/station/bridge)
 "dfo" = (
@@ -18464,6 +18446,19 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"ecp" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/station/tcommsat/chamber)
 "ecA" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/thin/reinforced{
@@ -19531,15 +19526,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
-"epm" = (
-/obj/effect/decal/turf_decal{
-	dir = 6;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/rnd/robotics)
 "epp" = (
 /obj/machinery/light/smart{
 	dir = 4
@@ -24507,6 +24493,23 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
+"fxW" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "caution"
+	},
+/area/station/medical/chemistry)
 "fym" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -24842,12 +24845,12 @@
 	dir = 1;
 	pixel_y = 6
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /obj/effect/decal/turf_decal{
 	dir = 8;
 	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	dir = 10;
@@ -28825,16 +28828,6 @@
 	icon_state = "yellowpatch"
 	},
 /area/station/engineering/atmos/supermatter)
-"gxp" = (
-/obj/item/weapon/flora/random,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "purplefull"
-	},
-/area/station/hallway/primary/central)
 "gxv" = (
 /obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -40061,6 +40054,11 @@
 	icon_state = "dark"
 	},
 /area/station/cargo/recycleroffice)
+"jaq" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet10-8"
+	},
+/area/station/bridge)
 "jat" = (
 /obj/machinery/porta_turret/station_default{
 	dir = 4
@@ -42170,6 +42168,16 @@
 	icon_state = "darkblue"
 	},
 /area/station/bridge)
+"jxO" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/bluegrid{
+	icon_state = "gcircuit"
+	},
+/area/station/tcommsat/chamber)
 "jxP" = (
 /obj/machinery/vending/barbervend,
 /turf/simulated/floor/wood,
@@ -42652,6 +42660,16 @@
 	icon_state = "yellowpatch"
 	},
 /area/station/engineering/atmos/supermatter)
+"jEb" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "purplefull"
+	},
+/area/station/hallway/primary/central)
 "jEc" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
@@ -42902,6 +42920,15 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/hallway)
+"jHG" = (
+/obj/effect/decal/turf_decal{
+	dir = 6;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/robotics)
 "jHQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -43075,6 +43102,11 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
+"jJf" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet9-4"
+	},
+/area/station/bridge/captain_quarters)
 "jJh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -43357,6 +43389,25 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/primary/starboard)
+"jLb" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "jLh" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
@@ -43626,6 +43677,15 @@
 	icon_state = "dark"
 	},
 /area/station/security/brig)
+"jNW" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "jNY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -46286,15 +46346,6 @@
 	icon_state = "neutral"
 	},
 /area/station/hallway/primary/fore)
-"krH" = (
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "krJ" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -46986,18 +47037,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/station/civilian/cold_room)
-"kAR" = (
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line"
-	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "kAU" = (
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
@@ -50262,6 +50301,14 @@
 	icon_state = "darkred"
 	},
 /area/station/security/execution)
+"lmC" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "purplefull"
+	},
+/area/station/hallway/primary/central)
 "lmF" = (
 /obj/machinery/computer/crew{
 	dir = 8
@@ -55151,11 +55198,11 @@
 /area/station/maintenance/chapel)
 "mue" = (
 /obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner"
+	icon_state = "siding_wood_line"
 	},
 /obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner";
-	dir = 4
+	icon_state = "siding_wood_line";
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "wooden"
@@ -62826,6 +62873,15 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/maintenance/cargo)
+"oiU" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "purplefull"
+	},
+/area/station/hallway/primary/central)
 "ojc" = (
 /obj/effect/landmark/start/assistant/test_subject,
 /obj/structure/stool/bed/chair/metal/blue{
@@ -66418,19 +66474,6 @@
 /obj/effect/decal/cleanable/vomit,
 /turf/simulated/floor,
 /area/station/maintenance/medbay)
-"pfz" = (
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "pfA" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Delivery Office";
@@ -68724,6 +68767,19 @@
 	icon_state = "white"
 	},
 /area/station/rnd/hallway/lobby)
+"pFg" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "pFv" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -73167,12 +73223,11 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/decal/turf_decal{
-	dir = 5;
-	icon_state = "warn"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /obj/effect/decal/turf_decal{
-	dir = 4;
+	dir = 5;
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
@@ -73455,25 +73510,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
-"qLs" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "qLu" = (
 /obj/structure/window/thin/reinforced{
 	dir = 4
@@ -74662,6 +74698,18 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/janitor)
+"raA" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner"
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "raB" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor{
@@ -74812,14 +74860,6 @@
 "rbY" = (
 /turf/simulated/floor,
 /area/station/security/main)
-"rcg" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "purplefull"
-	},
-/area/station/hallway/primary/central)
 "rcq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -78381,16 +78421,6 @@
 	icon_state = "dark"
 	},
 /area/station/cargo/recycleroffice)
-"rRm" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkblue"
-	},
-/area/station/bridge/corp_lounge)
 "rRo" = (
 /obj/machinery/recharger,
 /obj/structure/table/woodentable,
@@ -88652,16 +88682,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/cargo/qm)
-"usC" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "gcircuit"
-	},
-/area/station/tcommsat/chamber)
 "usJ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -89943,11 +89963,6 @@
 	icon_state = "neutral"
 	},
 /area/station/engineering/chiefs_office)
-"uLl" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet6-2"
-	},
-/area/station/bridge/captain_quarters)
 "uLo" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -100136,6 +100151,16 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"xkM" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/station/bridge/corp_lounge)
 "xlj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -102325,20 +102350,6 @@
 /obj/structure/stool/bed/chair,
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
-"xJQ" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "caution"
-	},
-/area/station/medical/chemistry)
 "xJS" = (
 /turf/simulated/floor{
 	dir = 10;
@@ -103425,15 +103436,6 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/library)
-"xWe" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "purplefull"
-	},
-/area/station/hallway/primary/central)
 "xWl" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -136689,7 +136691,7 @@ bNg
 cLW
 rjR
 qgs
-epm
+jHG
 cVA
 wrb
 chV
@@ -138478,13 +138480,13 @@ pHa
 pHa
 pbn
 yhw
-xWe
-xWe
+oiU
+oiU
 qQu
-xWe
-gxp
+oiU
+jEb
 bwA
-rcg
+lmC
 eKK
 oZa
 oZa
@@ -142329,7 +142331,7 @@ pQD
 gIC
 gIC
 gIC
-aJb
+ecp
 gIC
 gIC
 keH
@@ -143103,7 +143105,7 @@ xMO
 raJ
 cCX
 vyg
-usC
+jxO
 lwt
 raJ
 eXe
@@ -143114,7 +143116,7 @@ siM
 mKJ
 mMA
 bLg
-mue
+raA
 lGH
 cje
 nHg
@@ -143346,7 +143348,7 @@ gCE
 imK
 lEC
 wnY
-aaG
+dfg
 akc
 lZx
 gWd
@@ -143371,7 +143373,7 @@ jEs
 mKJ
 mMA
 vEH
-kAR
+mue
 rOO
 mzL
 nHg
@@ -143860,7 +143862,7 @@ gCE
 imK
 lEC
 mrs
-dfg
+jaq
 nSo
 lZx
 oay
@@ -143885,7 +143887,7 @@ wMM
 fgA
 mMA
 joF
-kAR
+mue
 eZe
 wAA
 nHg
@@ -144130,7 +144132,7 @@ knC
 aty
 wEV
 fAH
-usC
+jxO
 aEE
 lwt
 wEV
@@ -144141,10 +144143,10 @@ pQD
 amY
 fgA
 mMA
-krH
-pfz
+jNW
+pFg
 lBF
-qLs
+jLb
 nHg
 nvi
 ogP
@@ -144413,7 +144415,7 @@ sew
 rHU
 rHU
 sew
-xJQ
+fxW
 cyz
 eOj
 sew
@@ -144657,7 +144659,7 @@ xVa
 mMA
 eIB
 pYl
-rRm
+xkM
 jVM
 mMA
 elI
@@ -144899,9 +144901,9 @@ pQD
 gIC
 gIC
 gIC
-aJb
+ecp
 gIC
-aJb
+ecp
 gIC
 gIC
 aty
@@ -146181,7 +146183,7 @@ ibm
 adM
 sTY
 bIZ
-cPN
+jJf
 iaL
 cHR
 jKD
@@ -147213,7 +147215,7 @@ cjq
 nac
 hrj
 pEa
-uLl
+cPN
 cqG
 iaL
 pst

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -1,6 +1,9 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aac" = (
 /obj/random/vending/snack,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -3413,6 +3416,10 @@
 "aFa" = (
 /obj/structure/stool/bed/chair/metal/black{
 	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -31786,7 +31793,8 @@
 "hdN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
 "hdP" = (
@@ -35109,7 +35117,9 @@
 /area/station/security/vacantoffice)
 "hPG" = (
 /obj/item/weapon/flora/random,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/hallway/primary/starboard)
 "hPH" = (
 /obj/structure/table/reinforced,
@@ -37209,7 +37219,8 @@
 	network = list("SS13","Medical")
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whitebluecorner"
 	},
 /area/station/medical/hallway)
 "inj" = (
@@ -43017,6 +43028,10 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/assistant/test_subject,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -50219,7 +50234,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/hallway/primary/starboard)
 "leA" = (
 /obj/item/weapon/flora/random,
@@ -63529,6 +63546,10 @@
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = 32
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
@@ -83046,7 +83067,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/hallway/primary/starboard)
 "sLV" = (
 /obj/effect/landmark/start/roboticist,
@@ -91465,6 +91488,10 @@
 	pixel_x = 28;
 	pixel_y = -5
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -95774,7 +95801,7 @@
 /area/station/aisat)
 "vTJ" = (
 /obj/machinery/disposal,
-/obj/effect/decal/turf_decal/alpha/blue{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -145861,7 +145888,7 @@ oGJ
 sXO
 leI
 sBD
-qQK
+gOn
 xZn
 kpr
 adj
@@ -146375,7 +146402,7 @@ jPQ
 elA
 mQw
 sbr
-pxa
+gOn
 yey
 meR
 mYS

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -155,7 +155,7 @@
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "engdoor";
 	name = "Engineering Cell";
-	req_access = list(1)
+	req_access = list(2)
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -1002,7 +1002,7 @@
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyerOut";
 	name = "Medbay";
-	req_access = list(5)
+	req_one_access = list(2,5)
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -1303,6 +1303,14 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/station/maintenance/cargo)
+"aia" = (
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/break_room)
 "aij" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/box/lights/tubes,
@@ -1698,18 +1706,6 @@
 	icon_state = "redyellowfull"
 	},
 /area/station/hallway/primary/fore)
-"alW" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "amg" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 4
@@ -2839,19 +2835,6 @@
 	icon_state = "whitehall"
 	},
 /area/station/rnd/hallway/lobby)
-"axC" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "axI" = (
 /obj/machinery/camera{
 	c_tag = "Mining Shuttle Dock";
@@ -3061,6 +3044,16 @@
 	icon_state = "darkredfull"
 	},
 /area/station/security/brig)
+"aAz" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "aAA" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -3637,6 +3630,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"aGr" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/station/security/brig)
 "aGz" = (
 /obj/structure/sign/poster/ripped{
 	pixel_y = -32
@@ -3759,6 +3762,16 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/brig)
+"aHB" = (
+/obj/machinery/light/smart,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "aHT" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3942,18 +3955,6 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/chapel/office)
-"aJZ" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "aKa" = (
 /obj/effect/landmark/start/station_engineer,
 /obj/effect/decal/turf_decal{
@@ -5572,15 +5573,6 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/locker)
-"bdl" = (
-/obj/effect/decal/turf_decal{
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "bdo" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -7332,6 +7324,15 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
+"bwk" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "bwm" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -7567,23 +7568,6 @@
 	icon_state = "dark"
 	},
 /area/station/medical/virology)
-"byD" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "caution"
-	},
-/area/station/engineering/atmos/distribution)
 "byG" = (
 /obj/machinery/photocopier,
 /obj/effect/decal/turf_decal/alpha/white{
@@ -8200,25 +8184,6 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/chapel/crematorium)
-"bEi" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/main)
 "bEB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -8263,7 +8228,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Post - Science";
-	req_access = list(1)
+	req_access = list(2)
 	},
 /turf/simulated/floor{
 	icon_state = "redfull"
@@ -8374,6 +8339,14 @@
 "bFL" = (
 /obj/structure/stool/bed/chair/metal/white{
 	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
 	},
 /obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "siding_line";
@@ -8628,6 +8601,18 @@
 	},
 /turf/simulated/floor,
 /area/station/gateway)
+"bHi" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "bHs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/cable{
@@ -9266,15 +9251,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
-"bOE" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "bOJ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -9571,6 +9547,13 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
+"bSL" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-MB";
+	location = "N-MB"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "bSM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -9735,6 +9718,17 @@
 	icon_state = "dark"
 	},
 /area/station/security/interrogation)
+"bUJ" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "bUL" = (
 /obj/effect/landmark/start/assistant/test_subject,
 /obj/structure/stool/bed/chair{
@@ -9913,7 +9907,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Post - Medbay";
-	req_access = list(1)
+	req_access = list(2)
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -10056,7 +10050,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access";
-	req_access = list(47)
+	req_one_access = list(2,47)
 	},
 /turf/simulated/floor{
 	icon_state = "whitepurplefull"
@@ -10420,6 +10414,14 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/station/engineering/atmos)
+"cbB" = (
+/obj/machinery/atm{
+	pixel_y = -28
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "cbM" = (
 /obj/structure/closet/crate,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -11031,19 +11033,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
-"cij" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "cin" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -11233,12 +11222,6 @@
 	icon_state = "darkbluefull"
 	},
 /area/station/security/blueshield)
-"cjO" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "cjS" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/alarm{
@@ -11716,21 +11699,6 @@
 	},
 /turf/simulated/floor/engine/airmix,
 /area/station/engineering/atmos)
-"cpA" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/engineering/monitoring)
 "cpL" = (
 /obj/machinery/light/smart{
 	dir = 4
@@ -12938,19 +12906,6 @@
 	icon_state = "darkbrown"
 	},
 /area/station/medical/virology)
-"cEM" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "cEO" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/green,
 /turf/simulated/floor{
@@ -13068,6 +13023,15 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
+"cFG" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "cFK" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -13199,15 +13163,6 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/hor)
-"cGU" = (
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
 "cHg" = (
 /obj/machinery/atmospherics/components/binary/pump,
 /obj/effect/decal/turf_decal{
@@ -13539,23 +13494,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"cLH" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Entry Shuttle Airlock";
-	req_one_access = list(13)
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
 "cLM" = (
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway South-East";
@@ -13833,18 +13771,6 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/chapel)
-"cNS" = (
-/obj/structure/stool/bed/chair/metal/black{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "cNU" = (
 /obj/effect/decal/turf_decal{
 	dir = 10;
@@ -14267,16 +14193,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
-"cSk" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SE-FC";
-	location = "SW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "cSl" = (
 /obj/structure/stool/bed/chair/office/dark,
 /obj/effect/landmark/start/internal_affairs_agent,
@@ -14614,6 +14530,13 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
+"cVY" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=CS-AR";
+	location = "SWW-FC"
+	},
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "cWi" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -16690,17 +16613,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/lobby)
-"dvu" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "loadingarea"
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "arrow"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "dvy" = (
 /obj/effect/landmark/start/bartender,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -17246,7 +17158,7 @@
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "box_corners_white";
-	dir = 8
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -17269,6 +17181,13 @@
 	},
 /turf/environment/space,
 /area/shuttle/supply/station)
+"dDL" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_left"
+	},
+/turf/simulated/floor,
+/area/station/storage/tech)
 "dDO" = (
 /obj/machinery/computer/crew{
 	dir = 1
@@ -17612,7 +17531,7 @@
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "cardoor";
 	name = "Cargo Cell";
-	req_access = list(1)
+	req_access = list(2)
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -18300,20 +18219,11 @@
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/engineering/atmos)
-"dRw" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-FC";
-	location = "DS"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "bluecorner"
-	},
-/area/station/hallway/primary/central)
 "dRG" = (
 /obj/machinery/door/window/brigdoor{
 	id = "cargocell";
-	name = "Cargo Cell"
+	name = "Cargo Cell";
+	req_access = list(2)
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -18853,6 +18763,18 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"dXk" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "dXp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -19459,6 +19381,20 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/chargebay)
+"eek" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 9;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "eel" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -19586,6 +19522,26 @@
 	icon_state = "vaultfull"
 	},
 /area/station/tcommsat/computer)
+"efG" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "efR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/trinary/filter{
@@ -19859,17 +19815,12 @@
 	},
 /area/station/hallway/primary/starboard)
 "ejv" = (
-/obj/machinery/door_timer/cell_3{
-	pixel_x = 32;
-	pixel_y = 0;
-	dir = 4;
-	id = "Cell 3 perma"
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-FC";
+	location = "SSW-FC"
 	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
+/turf/simulated/floor,
+/area/station/hallway/primary/starboard)
 "ejG" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 1
@@ -19882,7 +19833,8 @@
 /obj/machinery/door/window/brigdoor{
 	dir = 1;
 	id = "engcell";
-	name = "Engineering Cell"
+	name = "Engineering Cell";
+	req_access = list(2)
 	},
 /obj/structure/cable{
 	d1 = 1;
@@ -20139,6 +20091,21 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"elJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "elV" = (
 /obj/structure/rack,
 /obj/item/weapon/book/manual/wiki/security_space_law,
@@ -20239,6 +20206,17 @@
 	},
 /turf/simulated/floor,
 /area/station/medical/hallway)
+"ene" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos/atmos_office)
 "eni" = (
 /obj/structure/toilet{
 	dir = 8
@@ -23103,16 +23081,6 @@
 	icon_state = "red"
 	},
 /area/station/security/checkpoint/medbay)
-"eUX" = (
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "eUY" = (
 /obj/machinery/power/apc{
 	name = "apc down";
@@ -25669,16 +25637,6 @@
 	icon_state = "blackchecker"
 	},
 /area/station/security/interrogation)
-"fzc" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NEE-FC";
-	location = "S-SV"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "fzd" = (
 /obj/effect/decal/turf_decal{
 	dir = 1;
@@ -25927,6 +25885,14 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry)
+"fBN" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/civilian/gym)
 "fBO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
@@ -25991,26 +25957,6 @@
 	icon_state = "purple"
 	},
 /area/station/engineering/atmos)
-"fCx" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "fCz" = (
 /obj/structure/table,
 /turf/simulated/floor{
@@ -26407,6 +26353,19 @@
 	},
 /turf/environment/space,
 /area/shuttle/escape_pod5/station)
+"fHS" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "fIc" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -26507,18 +26466,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/engineering/atmos)
-"fJq" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "fJr" = (
 /obj/structure/closet{
 	name = "evidence closet"
@@ -26884,11 +26831,6 @@
 	icon_state = "darkbrown"
 	},
 /area/station/medical/virology)
-"fNv" = (
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "fNA" = (
 /obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "box_corners_white";
@@ -26919,15 +26861,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "fOp" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
+/obj/structure/closet/emcloset,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
 	},
 /turf/simulated/floor{
-	icon_state = "neutralfull"
+	icon_state = "vaultfull"
 	},
-/area/station/engineering/atmos)
+/area/station/hallway/secondary/entry)
 "fOF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
@@ -27646,14 +27587,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"fXu" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/security/prison)
 "fXD" = (
 /obj/structure/closet/wardrobe/black,
 /obj/item/device/radio/intercom{
@@ -27678,16 +27611,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
-"fXH" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-C";
-	location = "CS-AR"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "fXS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -29506,16 +29429,6 @@
 "gqV" = (
 /turf/simulated/wall/r_wall,
 /area/station/rnd/scibreak)
-"gqY" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "grm" = (
 /obj/machinery/power/solar_control{
 	dir = 8;
@@ -30587,20 +30500,6 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/port)
-"gBu" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 10;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "gBw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -30720,6 +30619,18 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/chapel)
+"gDk" = (
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Labor Camp Shuttle Airlock";
+	req_access = list(2)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
 "gDm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -31646,26 +31557,6 @@
 	icon_state = "foam_plating"
 	},
 /area/station/maintenance/science)
-"gPn" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "gPx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -31700,7 +31591,8 @@
 	dir = 4
 	},
 /obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
+	icon_state = "siding_corner";
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
@@ -31794,7 +31686,7 @@
 	dir = 4
 	},
 /obj/machinery/flasher{
-	id = "Cell 3 perma";
+	id = "Cell 1 perma";
 	pixel_y = -28
 	},
 /turf/simulated/floor,
@@ -31831,17 +31723,6 @@
 	},
 /turf/environment/space,
 /area/shuttle/supply/station)
-"gRl" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "yellow"
-	},
-/area/station/engineering/atmos)
 "gRp" = (
 /obj/effect/decal/turf_decal{
 	dir = 8;
@@ -32013,6 +31894,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
+"gSN" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Antechamber";
+	req_one_access = list(66)
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/aisat/teleport)
 "gSP" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 29
@@ -32713,17 +32615,12 @@
 	},
 /turf/simulated/floor,
 /area/station/security/checkpoint/engi)
-"gZZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+"hab" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
 	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
+/turf/simulated/floor/carpet/red,
+/area/station/security/detectives_office)
 "had" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -33344,6 +33241,18 @@
 /obj/structure/sign/warning/nosmoking,
 /turf/simulated/wall,
 /area/station/engineering/break_room)
+"hiK" = (
+/obj/structure/stool/bed/chair/metal/black{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "hjc" = (
 /turf/simulated/floor{
 	dir = 9;
@@ -33394,6 +33303,19 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
+"hjv" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "hjF" = (
 /obj/structure/stool/bed/chair{
 	dir = 8
@@ -34413,14 +34335,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/lab)
-"htR" = (
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "yellow"
-	},
-/area/station/engineering/break_room)
 "htY" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -34482,18 +34396,10 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
-"hum" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/turf/simulated/floor{
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "hur" = (
 /obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
+	dir = 1;
+	icon_state = "warn_corner"
 	},
 /obj/effect/decal/turf_decal{
 	dir = 4;
@@ -35192,6 +35098,19 @@
 "hAz" = (
 /turf/simulated/floor/engine,
 /area/station/engineering/atmos/supermatter)
+"hAA" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "hAE" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1
@@ -35367,16 +35286,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
-"hCk" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "black"
-	},
-/area/station/hallway/secondary/entry)
 "hCo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -35585,6 +35494,20 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/prison)
+"hEM" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_corner";
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "arrows_white";
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/hallway/secondary/entry)
 "hER" = (
 /obj/machinery/porta_turret/station_default{
 	dir = 4
@@ -35719,11 +35642,11 @@
 	req_one_access = list(13)
 	},
 /obj/effect/decal/turf_decal{
-	dir = 1;
+	dir = 2;
 	icon_state = "warn"
 	},
 /obj/effect/decal/turf_decal{
-	dir = 2;
+	dir = 1;
 	icon_state = "warn"
 	},
 /turf/simulated/floor/plating,
@@ -36188,19 +36111,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/bridge/cmf_room)
-"hLM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/flasher{
-	id = "Cell 1 perma";
-	pixel_y = -28
-	},
-/turf/simulated/floor,
-/area/station/security/prison)
 "hLO" = (
 /obj/effect/landmark/start/paramedic,
 /obj/structure/cable{
@@ -36624,8 +36534,7 @@
 	},
 /obj/machinery/portable_atmospherics/powered/pump,
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
+	icon_state = "box_corners_white"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -37703,16 +37612,6 @@
 	icon_state = "bluefull"
 	},
 /area/station/security/checkpoint/escape_custom_desk)
-"idg" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
 "idn" = (
 /obj/effect/landmark/start/assistant/test_subject,
 /obj/structure/stool/bed/chair/metal/black{
@@ -38660,6 +38559,18 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
+"inG" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "inM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -39000,19 +38911,6 @@
 	icon_state = "dark"
 	},
 /area/station/aisat/ai_chamber)
-"irH" = (
-/obj/machinery/light/smart{
-	dir = 4
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NE-FC";
-	location = "NEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "irL" = (
 /obj/machinery/light/smart{
 	dir = 4
@@ -39099,15 +38997,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/security/iaa_office)
-"isL" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 29
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "blackcorner"
-	},
-/area/station/hallway/primary/starboard)
 "isO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -39480,16 +39369,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/brig/storage)
-"ixt" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkred"
-	},
-/area/station/security/brig)
 "ixC" = (
 /obj/item/target/syndicate,
 /turf/simulated/floor{
@@ -40907,6 +40786,24 @@
 /obj/structure/flora/junglebush/large,
 /turf/simulated/floor/grass,
 /area/station/civilian/kitchen)
+"iNd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "iNg" = (
 /obj/structure/table/woodentable,
 /obj/item/clothing/head/that,
@@ -41016,16 +40913,6 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/locker)
-"iNX" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "iOa" = (
 /obj/item/stack/cable_coil,
 /turf/simulated/floor/plating/airless/catwalk,
@@ -41140,6 +41027,18 @@
 	icon_state = "whitered"
 	},
 /area/station/security/main)
+"iPC" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/engineering/atmos/atmos_office)
 "iPD" = (
 /obj/structure/sink{
 	dir = 4;
@@ -41189,6 +41088,16 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/primary/fore)
+"iQd" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "iQj" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -41986,6 +41895,19 @@
 	icon_state = "darkblue"
 	},
 /area/station/security/iaa_office)
+"iZp" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_corner"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "arrows_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/hallway/secondary/entry)
 "iZs" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8
@@ -42206,6 +42128,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
+"jbL" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "jbM" = (
 /obj/machinery/light/smart,
 /obj/structure/sign/departments/chemistry{
@@ -42396,21 +42338,6 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/medical/chemistry)
-"jdZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
 "jee" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass,
@@ -43283,12 +43210,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/rnd/mixing)
-"joo" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "cafeteria"
-	},
-/area/station/security/prison)
 "jor" = (
 /obj/effect/landmark{
 	name = "carpspawn"
@@ -43324,6 +43245,22 @@
 	icon_state = "white"
 	},
 /area/station/bridge/corp_lounge)
+"joR" = (
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Entry Shuttle Airlock";
+	req_one_access = list(13)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "joW" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -44617,19 +44554,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/rnd/robotics)
-"jBy" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "jBD" = (
 /turf/simulated/floor,
 /area/station/maintenance/science)
@@ -45833,6 +45757,16 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/tox_launch)
+"jOF" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SE-FC";
+	location = "SW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "jOJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -46396,6 +46330,18 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
+"jUP" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "jUW" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -46637,27 +46583,6 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/reception)
-"jXm" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "jXo" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -46914,28 +46839,18 @@
 	icon_state = "neutralfull"
 	},
 /area/station/gateway)
+"kaa" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "cafeteria"
+	},
+/area/station/security/prison)
 "kaf" = (
 /obj/structure/rack,
 /obj/item/weapon/storage/box/lights/mixed,
 /obj/item/weapon/wrench,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"kar" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "kav" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
@@ -47533,18 +47448,18 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "kgH" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_corner"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "arrows_white";
+/obj/machinery/light/smart{
 	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NE-FC";
+	location = "NEE-FC"
 	},
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "black"
+	icon_state = "neutralcorner"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/primary/central)
 "khm" = (
 /obj/machinery/power/apc{
 	name = "apc down";
@@ -47755,16 +47670,6 @@
 	icon_state = "black"
 	},
 /area/station/civilian/gym)
-"kjq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "kjv" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -48105,7 +48010,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
 	name = "Medsci Airlock";
-	req_access = list(5)
+	req_one_access = list(2,5)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -48786,18 +48691,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
-"kub" = (
-/obj/structure/stool/bed/chair/metal/black{
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "kuh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
@@ -49085,24 +48978,6 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge/captain_quarters)
-"kyE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
 "kyV" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -49313,16 +49188,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/station/civilian/cold_room)
-"kAT" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SWW-FC";
-	location = "SW-FC"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "kAU" = (
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
@@ -50017,15 +49882,6 @@
 	},
 /turf/environment/space,
 /area/shuttle/mining/station)
-"kIh" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "kIq" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -50256,13 +50112,6 @@
 	icon_state = "grimy"
 	},
 /area/station/maintenance/chapel)
-"kKa" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "kKb" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/pickaxe/drill{
@@ -51452,7 +51301,7 @@
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyerOut";
 	name = "Medbay";
-	req_access = list(5)
+	req_one_access = list(2,5)
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -52612,18 +52461,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/rnd/xenobiology)
-"llL" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "llM" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -52794,6 +52631,20 @@
 	icon_state = "white"
 	},
 /area/station/medical/hallway)
+"lnt" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor,
+/area/station/engineering/monitoring)
 "lnK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -53928,7 +53779,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Security Post - Engineering";
-	req_access = list(1)
+	req_access = list(2)
 	},
 /turf/simulated/floor{
 	icon_state = "redfull"
@@ -54689,27 +54540,6 @@
 	icon_state = "barber"
 	},
 /area/station/medical/cmo)
-"lKx" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Antechamber";
-	req_one_access = list(66)
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/aisat/teleport)
 "lKD" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/turf_decal/alpha/blue{
@@ -55026,6 +54856,16 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
+"lNm" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SWW-FC";
+	location = "SW-FC"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "lNr" = (
 /obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "siding_corner";
@@ -55914,19 +55754,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/engineering/minisat_secure_area)
-"lYy" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "lYB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -55958,6 +55785,16 @@
 "lYH" = (
 /turf/simulated/wall/r_wall,
 /area/station/bridge)
+"lYQ" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-C";
+	location = "CS-AR"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "lYU" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -56133,16 +55970,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/hallway/primary/central)
-"mbB" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NNW-B";
-	location = "NW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "mbI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56319,16 +56146,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/armoury)
-"mdR" = (
-/obj/machinery/light/smart,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "mev" = (
 /obj/structure/displaycase_chassis,
 /obj/effect/decal/cleanable/dirt,
@@ -57544,6 +57361,15 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/hor)
+"mrB" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_right"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/cold_room)
 "mrH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -57922,15 +57748,6 @@
 	icon_state = "purplecorner"
 	},
 /area/station/rnd/hor)
-"mvz" = (
-/obj/item/weapon/flora/random,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "mvD" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -58139,6 +57956,17 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/primary/fore)
+"mym" = (
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "myv" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	dir = 8;
@@ -58968,16 +58796,6 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/library)
-"mIh" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SEE-FC";
-	location = "SE-FC"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "mIw" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/simulated/wall,
@@ -59100,6 +58918,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/dormitories/courtroom)
+"mKe" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "mKl" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -59455,15 +59282,6 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/hor)
-"mPj" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-B";
-	location = "S-MB"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/secondary/entry)
 "mPo" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -61288,6 +61106,15 @@
 	icon_state = "purplecorner"
 	},
 /area/station/hallway/primary/central)
+"njy" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "njz" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
@@ -61349,6 +61176,15 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/medical/chemistry)
+"nkJ" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "nkK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -61530,19 +61366,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
-"nmY" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 9
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "nna" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -61638,15 +61461,6 @@
 /obj/item/weapon/reagent_containers/food/drinks/bottle/wine,
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories)
-"nol" = (
-/obj/item/weapon/flora/random,
-/obj/machinery/light/smart{
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "white"
-	},
-/area/station/rnd/hallway/lobby)
 "non" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -61768,6 +61582,15 @@
 	icon_state = "green"
 	},
 /area/station/engineering/atmos)
+"npp" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-B";
+	location = "S-MB"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry)
 "npv" = (
 /obj/structure/table/glass,
 /obj/item/weapon/folder/white,
@@ -61836,17 +61659,6 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/atmos)
-"npO" = (
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
 "npW" = (
 /obj/machinery/gateway,
 /obj/effect/decal/turf_decal/alpha/gray{
@@ -61945,15 +61757,6 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/break_room)
-"nqC" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_right"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/civilian/cold_room)
 "nqD" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -62020,6 +61823,16 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/kitchen)
+"nra" = (
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "nrh" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -62206,17 +62019,6 @@
 /obj/item/weapon/folder/white,
 /turf/simulated/floor/carpet,
 /area/station/bridge/meeting_room)
-"ntx" = (
-/obj/machinery/light/smart,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DS";
-	location = "DN-W"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "purplecorner"
-	},
-/area/station/hallway/primary/central)
 "ntM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -62237,6 +62039,12 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/hallway)
+"ntU" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "browncorner"
+	},
+/area/station/cargo/storage)
 "nub" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -64258,6 +64066,26 @@
 	icon_state = "grimy"
 	},
 /area/station/security/hos)
+"nRo" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "nRr" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -65026,13 +64854,6 @@
 	icon_state = "darkred"
 	},
 /area/station/security/execution)
-"nZw" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=N-MB";
-	location = "NNW-B"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "nZA" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/directions/science{
@@ -65787,6 +65608,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"oib" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/main)
 "oid" = (
 /obj/machinery/alarm{
 	pixel_y = -32
@@ -66012,15 +65852,6 @@
 /obj/item/device/violin,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"olJ" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "olO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -66216,7 +66047,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/turf_decal{
-	dir = 9;
+	dir = 10;
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
@@ -66563,17 +66394,6 @@
 	icon_state = "black"
 	},
 /area/station/civilian/chapel)
-"otD" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "otI" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -67975,13 +67795,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/hallway)
-"oLC" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-FC";
-	location = "SSW-FC"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/starboard)
 "oLD" = (
 /obj/machinery/meter,
 /obj/structure/cable{
@@ -68293,7 +68106,7 @@
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	dir = 4;
+	dir = 6;
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
@@ -68663,6 +68476,16 @@
 	},
 /turf/environment/space,
 /area/shuttle/escape_pod5/station)
+"oTb" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NNW-B";
+	location = "NW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "oTt" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -68745,7 +68568,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Foyer";
-	req_one_access = list(1,71)
+	req_one_access = list(2,71)
 	},
 /obj/structure/cable{
 	d1 = 4;
@@ -69096,6 +68919,13 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"oYy" = (
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/prison)
 "oYI" = (
 /obj/item/weapon/crowbar/red,
 /obj/item/device/radio/intercom{
@@ -69360,13 +69190,6 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/chapel)
-"pbU" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=CS-AR";
-	location = "SWW-FC"
-	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
 "pbV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/stool/bed/chair/office/dark,
@@ -71665,14 +71488,13 @@
 	},
 /area/station/engineering/atmos)
 "pBf" = (
-/obj/effect/decal/turf_decal/alpha/blue{
-	icon_state = "siding_line";
-	dir = 1
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
 	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "yellowcorner"
 	},
-/area/station/security/blueshield)
+/area/station/hallway/primary/port)
 "pBn" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -72062,7 +71884,7 @@
 "pFz" = (
 /obj/machinery/door/airlock/research{
 	name = "Medsci Airlock";
-	req_access = list(47)
+	req_one_access = list(2,47)
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
@@ -72150,7 +71972,7 @@
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyerIn";
 	name = "Medbay";
-	req_access = list(5)
+	req_one_access = list(2,5)
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -72415,6 +72237,16 @@
 	icon_state = "dark"
 	},
 /area/station/bridge/captain_quarters)
+"pKi" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "pKm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -72454,26 +72286,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/main)
-"pKG" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "pKL" = (
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
@@ -72867,6 +72679,13 @@
 "pPp" = (
 /turf/simulated/floor/wood,
 /area/station/maintenance/medbay)
+"pPw" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=N-MB";
+	location = "NNW-B"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "pPA" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -73216,6 +73035,26 @@
 	},
 /turf/simulated/floor{
 	icon_state = "cafeteria"
+	},
+/area/station/security/prison)
+"pSu" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
 	},
 /area/station/security/prison)
 "pSP" = (
@@ -74057,18 +73896,6 @@
 /obj/item/clothing/glasses/sunglasses,
 /turf/simulated/floor/carpet/red,
 /area/station/security/vacantoffice)
-"qco" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "qcD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -74360,11 +74187,11 @@
 	req_one_access = list(13)
 	},
 /obj/effect/decal/turf_decal{
-	dir = 2;
+	dir = 1;
 	icon_state = "warn"
 	},
 /obj/effect/decal/turf_decal{
-	dir = 1;
+	dir = 2;
 	icon_state = "warn"
 	},
 /turf/simulated/floor/plating,
@@ -75793,16 +75620,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/misc_lab)
-"qwQ" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSE-FC";
-	location = "SEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "qxf" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -76163,15 +75980,6 @@
 	icon_state = "wooden-2"
 	},
 /area/station/civilian/gym)
-"qCu" = (
-/obj/structure/closet/emcloset,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "qCA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -76866,6 +76674,16 @@
 	icon_state = "vaultfull"
 	},
 /area/station/medical/morgue)
+"qJQ" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "qJS" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/firstaid/small_firstaid_kit,
@@ -77066,17 +76884,6 @@
 	icon_state = "red"
 	},
 /area/station/security/brig/equipment)
-"qMd" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos/atmos_office)
 "qMt" = (
 /obj/structure/morgue,
 /obj/structure/extinguisher_cabinet{
@@ -79280,15 +79087,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison)
-"rod" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 5
+"roq" = (
+/obj/structure/stool/bed/chair/metal/black{
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "grimy"
+	icon_state = "vaultfull"
 	},
-/area/station/security/hos)
+/area/station/hallway/secondary/entry)
 "rot" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -79886,13 +79696,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
-"rvn" = (
-/obj/item/weapon/flora/random,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_left"
-	},
-/turf/simulated/floor,
-/area/station/storage/tech)
 "rvt" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -80270,13 +80073,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/reception)
-"ryB" = (
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/prison)
 "ryD" = (
 /obj/structure/object_wall/pod{
 	dir = 4;
@@ -80902,6 +80698,16 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"rET" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSE-FC";
+	location = "SEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "rEX" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -81644,15 +81450,6 @@
 	},
 /turf/environment/space,
 /area/shuttle/supply/station)
-"rLR" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Security";
-	location = "S-C"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "rLY" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -82170,6 +81967,14 @@
 	icon_state = "vaultfull"
 	},
 /area/station/engineering/atmos)
+"rSh" = (
+/obj/machinery/atm{
+	pixel_y = -28
+	},
+/turf/simulated/floor{
+	icon_state = "redyellowfull"
+	},
+/area/station/hallway/primary/fore)
 "rSm" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -82290,15 +82095,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
-"rUa" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DN";
-	location = "SSE-FC"
-	},
-/turf/simulated/floor{
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "rUh" = (
 /obj/machinery/alarm{
 	pixel_x = 29;
@@ -83007,18 +82803,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/engineering/chiefs_office)
-"scZ" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/engineering/atmos/atmos_office)
 "sda" = (
 /obj/structure/stool/bar,
 /turf/simulated/floor/wood,
@@ -83082,16 +82866,6 @@
 	icon_state = "neutral"
 	},
 /area/station/maintenance/medbay)
-"sej" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Central Access"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "seo" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
@@ -84065,6 +83839,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/hallway/primary/fore)
+"snV" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Security";
+	location = "S-C"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "snW" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/disposalpipe/segment{
@@ -84478,20 +84261,6 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
-"sty" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_corner";
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "arrows_white";
-	dir = 8
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "black"
-	},
-/area/station/hallway/secondary/entry)
 "stz" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -84592,6 +84361,20 @@
 	icon_state = "dark"
 	},
 /area/station/security/brig)
+"suI" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "escape"
+	},
+/area/station/hallway/primary/port)
 "suL" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/brig/solitary_confinement)
@@ -84860,6 +84643,18 @@
 	icon_state = "white"
 	},
 /area/station/rnd/hor)
+"syF" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "syI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -85575,6 +85370,19 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/library)
+"sHg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "sHo" = (
 /obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor{
@@ -86432,6 +86240,19 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
+"sRT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "sSh" = (
 /obj/machinery/cell_charger{
 	pixel_y = 5
@@ -86507,7 +86328,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining/glass{
 	name = "Cargo Office";
-	req_one_access = list(1,31,48)
+	req_one_access = list(2,31,48)
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -87245,17 +87066,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"tci" = (
-/obj/structure/stool/bed/chair/metal/black{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "tcq" = (
 /obj/structure/sign/nanotrasen{
 	pixel_y = -32
@@ -87692,6 +87502,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/emergency)
+"thS" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "thU" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -87948,6 +87764,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"tll" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "tlq" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -88389,15 +88218,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison)
-"tqN" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "tqX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/stool/bed/chair{
@@ -89058,6 +88878,15 @@
 	icon_state = "dark"
 	},
 /area/station/medical/virology)
+"tzl" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DN";
+	location = "SSE-FC"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "tzm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light/small{
@@ -89143,14 +88972,6 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/library)
-"tAe" = (
-/obj/machinery/atm{
-	pixel_y = -28
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "tAg" = (
 /obj/effect/landmark/start/clown,
 /obj/structure/stool,
@@ -89696,6 +89517,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/bridge/hop_office)
+"tGa" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NEE-FC";
+	location = "S-SV"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "tGH" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/light/smart{
@@ -89922,14 +89753,6 @@
 "tJr" = (
 /turf/simulated/wall/r_wall,
 /area/station/rnd/server)
-"tJB" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/civilian/gym)
 "tJH" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -91384,6 +91207,16 @@
 	icon_state = "caution"
 	},
 /area/station/hallway/primary/port)
+"uct" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-B";
+	location = "SSW-B"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "ucu" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
@@ -91392,17 +91225,22 @@
 	},
 /area/station/rnd/hallway)
 "ucx" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Entry Shuttle Airlock";
+	req_one_access = list(13)
 	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
 	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
 	},
-/area/station/engineering/atmos)
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "ucF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -91595,6 +91433,17 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/hos)
+"ueH" = (
+/obj/machinery/light/smart,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DS";
+	location = "DN-W"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "purplecorner"
+	},
+/area/station/hallway/primary/central)
 "ufi" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/effect/decal/turf_decal/alpha/gray{
@@ -91614,7 +91463,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Security Post - Cargo";
-	req_access = list(1)
+	req_access = list(2)
 	},
 /turf/simulated/floor{
 	icon_state = "redfull"
@@ -91876,6 +91725,15 @@
 	icon_state = "black"
 	},
 /area/station/civilian/chapel)
+"uiu" = (
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "uix" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -92160,6 +92018,17 @@
 	icon_state = "dark"
 	},
 /area/station/aisat/ai_chamber)
+"uld" = (
+/obj/structure/stool/bed/chair/metal/black{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "ulk" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -92963,6 +92832,7 @@
 	name = "Central Access"
 	},
 /turf/simulated/floor{
+	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/station/security/lobby)
@@ -93055,12 +92925,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/escape)
-"uvh" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "browncorner"
-	},
-/area/station/cargo/storage)
 "uvm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -93299,19 +93163,6 @@
 	icon_state = "neutral"
 	},
 /area/station/hallway/primary/central)
-"uyu" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/powered/pump,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "arrival"
-	},
-/area/station/hallway/primary/port)
 "uyI" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
@@ -93701,6 +93552,11 @@
 	},
 /turf/simulated/wall,
 /area/station/hallway/secondary/entry)
+"uEp" = (
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "uEC" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced/phoron{
@@ -93905,6 +93761,13 @@
 	},
 /turf/simulated/floor/carpet/purple,
 /area/station/civilian/dormitories)
+"uGW" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "uHd" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -32
@@ -93942,12 +93805,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "uHN" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 4
+/obj/machinery/door_timer/cell_3{
+	pixel_x = 32;
+	pixel_y = 0;
+	dir = 4;
+	id = "Cell 3 perma"
 	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "uHX" = (
 /turf/simulated/floor/wood,
 /area/station/maintenance/chapel)
@@ -93994,12 +93862,6 @@
 "uJi" = (
 /turf/simulated/wall,
 /area/station/rnd/chargebay)
-"uJw" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
-	},
-/turf/simulated/floor/carpet/red,
-/area/station/security/detectives_office)
 "uJK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/binary/valve,
@@ -94340,6 +94202,16 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
+"uNq" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/hallway/secondary/entry)
 "uNs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -94348,21 +94220,15 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "uNw" = (
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Entry Shuttle Airlock";
-	req_one_access = list(13)
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-FC";
+	location = "DS"
 	},
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "bluecorner"
 	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
+/area/station/hallway/primary/central)
 "uNx" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -94405,6 +94271,14 @@
 /obj/machinery/cell_charger,
 /turf/simulated/floor,
 /area/station/gateway)
+"uOh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/security/prison)
 "uOm" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -95078,6 +94952,17 @@
 /obj/effect/spawner/lootdrop/maintenance/four,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"uWs" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "uWw" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -95134,18 +95019,6 @@
 	icon_state = "purple"
 	},
 /area/station/rnd/xenobiology)
-"uXj" = (
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Labor Camp Shuttle Airlock";
-	req_access = list(2)
-	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/brig)
 "uXz" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor{
@@ -95904,9 +95777,22 @@
 "vgR" = (
 /turf/simulated/floor/plating/airless,
 /area/space)
+"vhb" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "loadingarea"
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "arrow"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "vhk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/window/brigdoor,
+/obj/machinery/door/window/brigdoor{
+	req_access = list(2)
+	},
 /turf/simulated/floor{
 	icon_state = "redfull"
 	},
@@ -96453,6 +96339,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/supermatter)
+"vnk" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "vnt" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/firstaid/regular,
@@ -97942,6 +97840,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
+"vFf" = (
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "vFo" = (
 /obj/structure/table,
 /obj/item/device/flashlight/lamp{
@@ -98198,6 +98105,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/toilet)
+"vJg" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "vJh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -99050,15 +98968,12 @@
 	},
 /area/station/bridge/teleporter)
 "vTX" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-B";
-	location = "SSW-B"
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "vUe" = (
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
@@ -99744,7 +99659,7 @@
 /obj/machinery/door/airlock/medical/glass{
 	id_tag = "MedbayFoyerIn";
 	name = "Medbay";
-	req_access = list(5)
+	req_one_access = list(2,5)
 	},
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
@@ -100150,6 +100065,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"wic" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "caution"
+	},
+/area/station/engineering/atmos/distribution)
 "wii" = (
 /obj/machinery/ai_status_display{
 	pixel_y = 32
@@ -101176,6 +101108,16 @@
 /obj/machinery/deployable/barrier,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
+"wuc" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SEE-FC";
+	location = "SE-FC"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "wud" = (
 /obj/machinery/light/smart{
 	dir = 4
@@ -101936,6 +101878,19 @@
 /obj/item/clothing/mask/surgical,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"wCR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/flasher{
+	id = "Cell 3 perma";
+	pixel_y = -28
+	},
+/turf/simulated/floor,
+/area/station/security/prison)
 "wDh" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -102096,6 +102051,15 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
+"wEP" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "wES" = (
 /obj/structure/closet/bombclosetsecurity,
 /turf/simulated/floor{
@@ -102831,7 +102795,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
 	name = "Research Division Access";
-	req_access = list(47)
+	req_one_access = list(2,47)
 	},
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -102979,14 +102943,6 @@
 	icon_state = "white"
 	},
 /area/station/rnd/hallway)
-"wPX" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "wQz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
@@ -103129,6 +103085,14 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/chargebay)
+"wSO" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "wST" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -103878,6 +103842,16 @@
 	icon_state = "yellowfull"
 	},
 /area/station/engineering/engine)
+"xbt" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "xby" = (
 /obj/machinery/firealarm{
 	pixel_y = 22
@@ -104943,6 +104917,22 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/medical/chemistry)
+"xou" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "xov" = (
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/bluegrid{
@@ -105307,6 +105297,19 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
+"xrX" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "xsb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -106518,14 +106521,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/break_room)
-"xEG" = (
-/obj/machinery/atm{
-	pixel_y = -28
-	},
-/turf/simulated/floor{
-	icon_state = "redyellowfull"
-	},
-/area/station/hallway/primary/fore)
 "xEL" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/light/small{
@@ -106726,6 +106721,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"xHi" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/pump,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "arrival"
+	},
+/area/station/hallway/primary/port)
 "xHu" = (
 /obj/structure/rack,
 /obj/item/weapon/circuitboard/solar_control,
@@ -106844,20 +106853,6 @@
 	icon_state = "greenblue"
 	},
 /area/station/hallway/primary/fore)
-"xJt" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "escape"
-	},
-/area/station/hallway/primary/port)
 "xJv" = (
 /obj/effect/landmark{
 	name = "xeno_spawn";
@@ -107336,6 +107331,15 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
+"xOX" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 29
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "blackcorner"
+	},
+/area/station/hallway/primary/starboard)
 "xPl" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -107379,13 +107383,6 @@
 	icon_state = "darkredcorners"
 	},
 /area/station/security/checkpoint/escape)
-"xPL" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-MB";
-	location = "N-MB"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "xPO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/table_parts/wood,
@@ -107725,6 +107722,15 @@
 	icon_state = "gcircuit"
 	},
 /area/station/aisat/ai_chamber)
+"xSU" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 5
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "xTi" = (
 /obj/structure/closet/crate,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -108183,6 +108189,15 @@
 /obj/machinery/atmospherics/components/unary/portables_connector,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage_secure)
+"xXH" = (
+/obj/item/weapon/flora/random,
+/obj/machinery/light/smart{
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/station/rnd/hallway/lobby)
 "xXL" = (
 /obj/machinery/light/smart,
 /obj/item/device/radio/electropack,
@@ -108359,6 +108374,15 @@
 /obj/effect/decal/cleanable/spiderling_remains,
 /turf/simulated/floor/airless/ceiling,
 /area/station/cargo/recycler)
+"xZI" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Central Access"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "xZR" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -109067,26 +109091,6 @@
 	icon_state = "dark"
 	},
 /area/station/bridge)
-"yjr" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "yjy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -118679,7 +118683,7 @@ eXX
 pGn
 fBB
 pGn
-lKx
+gSN
 pGn
 pGn
 oer
@@ -132034,7 +132038,7 @@ xFF
 xFG
 flb
 uDn
-htR
+aia
 ude
 ehA
 geB
@@ -132291,7 +132295,7 @@ qnQ
 hEd
 fDg
 owf
-htR
+aia
 hkb
 ehA
 fUz
@@ -132794,7 +132798,7 @@ oLJ
 kFc
 kFc
 cEO
-gRl
+uWs
 azQ
 pfp
 imT
@@ -133040,7 +133044,7 @@ qSk
 qdn
 naA
 kdJ
-jBy
+xrX
 xqQ
 fmh
 mNB
@@ -133048,8 +133052,8 @@ bfy
 cmG
 dup
 htY
-fOp
-fOp
+aAz
+aAz
 nwM
 tCz
 gRR
@@ -133304,7 +133308,7 @@ nLs
 bTE
 tUm
 oPF
-cEM
+tll
 rSb
 umn
 svw
@@ -134068,7 +134072,7 @@ bsZ
 fZH
 cTK
 whA
-scZ
+iPC
 iDO
 iDO
 iDO
@@ -134077,8 +134081,8 @@ vCV
 lFG
 waB
 fMO
-ucx
-llL
+dXk
+jUP
 kHT
 vPk
 vPk
@@ -134327,7 +134331,7 @@ qcT
 mrP
 daq
 daq
-qMd
+ene
 egG
 iEf
 hrT
@@ -134869,9 +134873,9 @@ hdV
 bhn
 evV
 oKM
-qco
+syF
 wCx
-fJq
+vnk
 oDZ
 bau
 nkc
@@ -135128,7 +135132,7 @@ enq
 bgZ
 gCp
 tRh
-kar
+xou
 oyx
 mRP
 eZT
@@ -135625,7 +135629,7 @@ gpz
 nds
 gpz
 wjD
-gPB
+lnt
 bbv
 awp
 odu
@@ -135882,7 +135886,7 @@ adw
 adw
 adw
 wjD
-cpA
+gPB
 cgv
 owM
 ekM
@@ -136385,7 +136389,7 @@ jlK
 tEF
 tne
 cEZ
-byD
+wic
 iGS
 ciX
 jau
@@ -136920,7 +136924,7 @@ qTx
 qTx
 lGc
 rjD
-hum
+pBf
 uSc
 uib
 uSc
@@ -137167,13 +137171,13 @@ tEF
 sHQ
 dpc
 sHQ
-xJt
+suI
 blv
 sqb
 uck
 sqb
+xHi
 hQQ
-uyu
 qTx
 bUU
 iky
@@ -137439,7 +137443,7 @@ doE
 doE
 doE
 lgU
-mIh
+wuc
 mhm
 doE
 mnD
@@ -137937,7 +137941,7 @@ wwi
 aYN
 wwi
 lfm
-qwQ
+rET
 tZn
 oyb
 nAM
@@ -137955,7 +137959,7 @@ oyb
 bzt
 bzt
 rcq
-rUa
+tzl
 tYK
 wtC
 wtC
@@ -138971,7 +138975,7 @@ xNR
 rMP
 nAi
 vfr
-rvn
+dDL
 rDd
 jcO
 iNE
@@ -139728,7 +139732,7 @@ tRk
 vdt
 rwG
 srt
-nqC
+mrB
 dOS
 rfL
 qsE
@@ -140188,14 +140192,14 @@ kHU
 kHU
 kHU
 yaE
-hGn
+joR
 yaE
 kHU
 plf
 plf
 kHU
 yaE
-hGn
+joR
 yaE
 kHU
 kHU
@@ -140702,14 +140706,14 @@ yaE
 ffS
 aev
 yaE
-cLH
+qgt
 yaE
 aqg
 aqg
 aqg
 mlH
 yaE
-cLH
+qgt
 yaE
 eeB
 ffS
@@ -140756,7 +140760,7 @@ kBq
 biv
 pED
 bNa
-idg
+qJQ
 kIU
 lBN
 yeY
@@ -141013,7 +141017,7 @@ dtM
 fty
 abG
 vLv
-idg
+qJQ
 kIU
 jVV
 ekm
@@ -141730,7 +141734,7 @@ yaE
 ffS
 eeB
 yaE
-cLH
+qgt
 yaE
 mlH
 nhe
@@ -142089,7 +142093,7 @@ oZa
 xyx
 dJC
 gjY
-nol
+xXH
 kdp
 xfI
 eIi
@@ -142244,7 +142248,7 @@ kHU
 kHU
 kHU
 yaE
-hGn
+joR
 yaE
 kHU
 plf
@@ -142781,11 +142785,11 @@ dbB
 idn
 fRR
 ofi
-mvz
+bwk
 miI
 ffS
 jjY
-qCu
+fOp
 wwi
 pkS
 wwi
@@ -143334,7 +143338,7 @@ iSv
 xXt
 vAu
 ogP
-vTX
+uct
 bAS
 nvi
 rnH
@@ -143350,7 +143354,7 @@ qbj
 qbj
 tmk
 ldb
-cSk
+jOF
 ogP
 iSi
 amv
@@ -143377,7 +143381,7 @@ vpT
 xei
 bFh
 vpT
-ntx
+ueH
 vIl
 olx
 frM
@@ -143545,7 +143549,7 @@ plf
 brw
 mko
 jsL
-mPj
+npp
 ffX
 hbE
 sTt
@@ -143814,7 +143818,7 @@ gHT
 alc
 vDr
 fDL
-mbB
+oTb
 iwy
 xXt
 gNR
@@ -144320,10 +144324,10 @@ fYS
 slo
 ffS
 pLB
-mvz
-kub
-acf
+bwk
 dDs
+acf
+roq
 aSq
 ffS
 gvF
@@ -144595,17 +144599,17 @@ hXb
 hXb
 hXb
 che
-cGU
-kyE
-cGU
-cGU
-cGU
-cGU
-cGU
-cGU
-cGU
-jdZ
-cGU
+uiu
+iNd
+uiu
+uiu
+uiu
+uiu
+uiu
+uiu
+uiu
+elJ
+uiu
 vos
 did
 did
@@ -144814,7 +144818,7 @@ kHU
 kHU
 kHU
 yaE
-uNw
+hGn
 yaE
 kHU
 plf
@@ -144862,7 +144866,7 @@ fjB
 qSx
 dtr
 czE
-xEG
+rSh
 tJq
 gIl
 rdY
@@ -145099,7 +145103,7 @@ kHU
 yaE
 hkD
 fYS
-bdl
+vFf
 wts
 mge
 qed
@@ -145328,7 +145332,7 @@ yaE
 ffS
 aev
 yaE
-qgt
+ucx
 yaE
 ygh
 cPq
@@ -145379,13 +145383,13 @@ mpN
 uQg
 tJq
 oFm
-uHN
+uGW
 xsb
-uHN
-uHN
-uHN
+uGW
+uGW
+uGW
 mtf
-uHN
+uGW
 jpq
 bsc
 mfI
@@ -145613,7 +145617,7 @@ plf
 yaE
 vDr
 fYS
-eUX
+nra
 tEo
 nIB
 iEL
@@ -145870,7 +145874,7 @@ kHU
 yaE
 csG
 fYS
-mdR
+aHB
 wts
 npC
 txi
@@ -145893,13 +145897,13 @@ cCx
 mES
 tJq
 ikZ
-nmY
+sRT
 oki
-kKa
-kKa
-axC
+vTX
+vTX
+hjv
 tWH
-axC
+hjv
 qcF
 bRX
 qSi
@@ -146127,7 +146131,7 @@ kHU
 yaE
 csG
 fYS
-tAe
+cbB
 wts
 bCJ
 euO
@@ -146150,7 +146154,7 @@ tJq
 ucP
 tJq
 fSC
-cij
+sHg
 ktM
 uuo
 djH
@@ -146356,14 +146360,14 @@ yaE
 ffS
 eeB
 yaE
-qgt
+ucx
 yaE
 mlH
 iOK
 iOK
 iOK
 yaE
-qgt
+ucx
 yaE
 aev
 ffS
@@ -146633,10 +146637,10 @@ fYS
 jNI
 ffS
 ylK
-cNS
+hiK
 cmX
 fRR
-tci
+uld
 ryG
 ffS
 uAC
@@ -146870,14 +146874,14 @@ xjr
 xjr
 kHU
 dhU
-uNw
+hGn
 yaE
 kHU
 plf
 plf
 kHU
 yaE
-uNw
+hGn
 yaE
 plf
 plf
@@ -147658,7 +147662,7 @@ yaE
 yaE
 csG
 fYS
-xPL
+bSL
 alc
 gHT
 gHT
@@ -147667,7 +147671,7 @@ gHT
 gHT
 gHT
 alc
-nZw
+pPw
 fYS
 sEX
 srs
@@ -147917,12 +147921,12 @@ lrr
 fYS
 wtr
 sDu
-kgH
-hCk
-hCk
-hCk
-hCk
-sty
+iZp
+uNq
+uNq
+uNq
+uNq
+hEM
 xao
 csG
 fYS
@@ -148926,14 +148930,14 @@ xjr
 xjr
 kHU
 dhU
-uNw
+hGn
 yaE
 kHU
 plf
 plf
 kHU
 yaE
-uNw
+hGn
 yaE
 plf
 plf
@@ -149183,14 +149187,14 @@ xjr
 xjr
 plf
 yaE
-npO
+mym
 yaE
 yaE
 yaE
 yaE
 yaE
 yaE
-npO
+mym
 yaE
 plf
 plf
@@ -149440,14 +149444,14 @@ yaE
 ffS
 aev
 yaE
-qgt
+ucx
 yaE
 aqg
 aqg
 aqg
 mlH
 yaE
-qgt
+ucx
 yaE
 eeB
 ffS
@@ -151126,7 +151130,7 @@ sbN
 uKh
 sHC
 npd
-isL
+xOX
 xQo
 mUL
 rmY
@@ -152602,7 +152606,7 @@ mXl
 mXl
 mXl
 wLD
-fzc
+tGa
 iwm
 mXl
 pRS
@@ -152620,7 +152624,7 @@ oNU
 mXl
 uxx
 xMc
-kAT
+lNm
 nvi
 rnH
 cLM
@@ -152629,7 +152633,7 @@ nvi
 tOH
 mfI
 ogP
-dRw
+uNw
 sBG
 wjc
 wjc
@@ -152932,7 +152936,7 @@ xQo
 xQo
 xQo
 nKU
-oLC
+ejv
 xQo
 oPI
 mRu
@@ -153099,7 +153103,7 @@ cpR
 gtK
 cpR
 pxL
-irH
+kgH
 ffJ
 ape
 fZz
@@ -153118,7 +153122,7 @@ hRd
 ckx
 fZz
 lMB
-rLR
+snV
 kzb
 vAu
 psV
@@ -153132,7 +153136,7 @@ vAu
 kRo
 vAu
 kCI
-fXH
+lYQ
 ogP
 lwr
 mLS
@@ -153373,9 +153377,9 @@ erD
 erD
 cmN
 act
-sej
-xsY
 uuf
+xsY
+xZI
 jTW
 jTW
 jTW
@@ -153855,7 +153859,7 @@ fnT
 miA
 ojm
 lPc
-uvh
+ntU
 gaF
 rpV
 qSe
@@ -154112,11 +154116,11 @@ nkb
 adb
 hzP
 cpR
-iNX
-oOk
+xbt
+pKi
 uXI
+pKi
 oOk
-gqY
 xqF
 aAF
 iqI
@@ -157223,8 +157227,8 @@ plf
 xyC
 cFp
 klH
-uJw
-uJw
+hab
+hab
 hGr
 aRu
 xyC
@@ -157748,8 +157752,8 @@ dnn
 aEr
 wPw
 jQy
-pBf
-fNv
+njy
+uEp
 jcX
 fJg
 nPU
@@ -158241,11 +158245,11 @@ plf
 cHH
 cHH
 jxX
-uXj
+gDk
 bjt
 stv
 jxX
-uXj
+gDk
 jxX
 adp
 kMq
@@ -158258,7 +158262,7 @@ xyC
 xyC
 wpm
 jtG
-cjO
+thS
 fJg
 fJg
 fJg
@@ -158498,11 +158502,11 @@ wVt
 cHH
 cjS
 bNB
-gBu
+opt
 kms
 cHH
 eow
-opt
+eek
 goK
 hYT
 nsn
@@ -158755,7 +158759,7 @@ leA
 cHH
 adG
 iGB
-ixt
+aGr
 tTk
 qMX
 aZz
@@ -159016,7 +159020,7 @@ ikW
 qXE
 rjb
 utF
-dvu
+vhb
 uLd
 lat
 nsn
@@ -159815,7 +159819,7 @@ kIM
 vst
 mDV
 vKG
-pbU
+cVY
 xoq
 tAM
 uQA
@@ -160534,14 +160538,14 @@ fAF
 fgx
 diq
 fAF
-ejv
+uHN
 eTq
 fAF
 wNM
 oPD
 tif
 rHZ
-gPn
+efG
 czU
 tqK
 hsq
@@ -160798,7 +160802,7 @@ qZx
 qZx
 fXG
 qZx
-pKG
+pSu
 czU
 uvV
 kMw
@@ -161304,13 +161308,13 @@ blh
 cra
 hlv
 dVr
-gQC
+wCR
 hlv
 fBm
 bvC
 hlv
 vqQ
-hLM
+gQC
 qZx
 tnw
 fLE
@@ -162328,7 +162332,7 @@ aXC
 bZu
 pLw
 unD
-fXu
+uOh
 oAx
 ulK
 eyO
@@ -162880,9 +162884,9 @@ ilq
 uKd
 sxG
 uOc
+hAA
+hAA
 hur
-hur
-lYy
 ekd
 lZw
 gqC
@@ -163136,7 +163140,7 @@ ixl
 mme
 uKd
 gRX
-aJZ
+inG
 sRa
 nUj
 wUB
@@ -163165,13 +163169,13 @@ ncp
 ncp
 hbR
 mWz
-alW
+bHi
 kLd
 syX
 tHk
 tHk
 dbf
-jXm
+bFL
 ram
 mWz
 lNQ
@@ -163428,7 +163432,7 @@ eFl
 aRb
 nDG
 jjN
-bFL
+fHS
 ram
 mWz
 ucd
@@ -163635,7 +163639,7 @@ afw
 nDf
 mZo
 qUR
-bEi
+oib
 mzV
 aSh
 mpR
@@ -163936,13 +163940,13 @@ ncp
 ncp
 hbR
 mWz
-otD
+bUJ
 sIY
 qls
 uOM
 uOM
 aeG
-fCx
+jbL
 ram
 mWz
 hPr
@@ -164132,7 +164136,7 @@ lhK
 wVg
 aFN
 jKZ
-joo
+kaa
 rBo
 hlv
 qxh
@@ -164396,7 +164400,7 @@ xIO
 jps
 xIO
 qZx
-yjr
+nRo
 tbS
 sZR
 kHU
@@ -164408,7 +164412,7 @@ fwH
 qoH
 vOW
 qoH
-wPX
+wSO
 umQ
 gYp
 kHU
@@ -164646,7 +164650,7 @@ jvm
 hlv
 fVW
 fPH
-joo
+kaa
 rnI
 hlv
 pHz
@@ -164661,11 +164665,11 @@ kHU
 plf
 cYc
 ueE
-kjq
+iQd
 wcJ
 iRz
 nez
-gZZ
+vJg
 hlh
 gYp
 plf
@@ -164918,11 +164922,11 @@ kHU
 kHU
 cYc
 nfj
-olJ
+wEP
 eaE
 nRk
 rZh
-bOE
+mKe
 hmN
 gYp
 kHU
@@ -164966,7 +164970,7 @@ dJL
 nRG
 oXA
 oXA
-tJB
+fBN
 dJL
 plf
 cdR
@@ -165175,11 +165179,11 @@ plf
 kHU
 huz
 sIx
-rod
-kIh
+xSU
+nkJ
 kjv
-kIh
-tqN
+nkJ
+cFG
 tEU
 huz
 plf
@@ -167224,7 +167228,7 @@ plf
 kHU
 hlv
 lrm
-ryB
+oYy
 jno
 hlv
 cBu
@@ -168304,7 +168308,7 @@ kHU
 fMh
 plf
 dJL
-tJB
+fBN
 oXA
 oXA
 nJn

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -478,7 +478,9 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet10-8"
+	},
 /area/station/bridge/captain_quarters)
 "acM" = (
 /obj/structure/closet/athletic_mixed,
@@ -1527,7 +1529,9 @@
 	c_tag = "Bridge";
 	dir = 1
 	},
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet5-1"
+	},
 /area/station/bridge)
 "akg" = (
 /obj/machinery/door/firedoor,
@@ -2077,7 +2081,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "apV" = (
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet5-1"
+	},
 /area/station/bridge/meeting_room)
 "apX" = (
 /turf/simulated/wall,
@@ -2413,7 +2419,9 @@
 /obj/structure/stool/bed/chair/comfy/black{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet13-5"
+	},
 /area/station/bridge/meeting_room)
 "atv" = (
 /turf/simulated/floor{
@@ -3310,8 +3318,8 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
+/turf/simulated/floor/bluegrid{
+	icon_state = "gcircuit"
 	},
 /area/station/tcommsat/chamber)
 "aEM" = (
@@ -4084,7 +4092,9 @@
 /obj/machinery/computer/communications{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet5-1"
+	},
 /area/station/bridge/captain_quarters)
 "aNW" = (
 /obj/machinery/smartfridge/chemistry,
@@ -6624,7 +6634,9 @@
 /area/station/storage/primary)
 "bre" = (
 /obj/structure/dresser,
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet9-4"
+	},
 /area/station/bridge/captain_quarters)
 "brg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
@@ -8354,7 +8366,9 @@
 "bIZ" = (
 /obj/machinery/computer/security/wooden_tv,
 /obj/structure/table/woodentable,
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet11-12"
+	},
 /area/station/bridge/captain_quarters)
 "bJb" = (
 /obj/machinery/turretid/stun{
@@ -11207,7 +11221,9 @@
 /area/station/civilian/chapel)
 "cqG" = (
 /obj/structure/filingcabinet/security,
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet5-1"
+	},
 /area/station/bridge/captain_quarters)
 "cqJ" = (
 /obj/structure/table/woodentable,
@@ -13317,7 +13333,9 @@
 	},
 /area/station/hallway/primary/fore)
 "cPN" = (
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet6-2"
+	},
 /area/station/bridge/captain_quarters)
 "cPY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -14384,7 +14402,9 @@
 	},
 /area/station/engineering/atmos)
 "dfg" = (
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet6-2"
+	},
 /area/station/bridge)
 "dfo" = (
 /obj/machinery/power/apc{
@@ -16559,6 +16579,16 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/qm)
+"dFC" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/bluegrid{
+	icon_state = "gcircuit"
+	},
+/area/station/tcommsat/chamber)
 "dFV" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -17805,7 +17835,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet14-10"
+	},
 /area/station/bridge/meeting_room)
 "dVF" = (
 /obj/machinery/vending/cigarette,
@@ -20003,7 +20035,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet7-3"
+	},
 /area/station/bridge/meeting_room)
 "ewN" = (
 /obj/machinery/computer/general_air_control{
@@ -29585,7 +29619,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet13-5"
+	},
 /area/station/bridge/meeting_room)
 "gIl" = (
 /obj/machinery/door/window/eastleft{
@@ -38245,7 +38281,9 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet10-8"
+	},
 /area/station/bridge/meeting_room)
 "iGx" = (
 /obj/machinery/door/firedoor,
@@ -40685,7 +40723,9 @@
 /obj/machinery/door/window/brigdoor/northleft{
 	req_access = list(20)
 	},
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet14-10"
+	},
 /area/station/bridge/captain_quarters)
 "jjk" = (
 /obj/structure/cable{
@@ -44725,7 +44765,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet14-10"
+	},
 /area/station/bridge/meeting_room)
 "kdA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -44856,7 +44898,10 @@
 	name = "lightsout"
 	},
 /turf/simulated/floor/bluegrid{
-	icon_state = "gcircuit"
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
 	},
 /area/station/tcommsat/chamber)
 "keK" = (
@@ -50841,8 +50886,8 @@
 /obj/machinery/telescience_jammer{
 	radius = 5
 	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
+/turf/simulated/floor/bluegrid{
+	icon_state = "gcircuit"
 	},
 /area/station/tcommsat/chamber)
 "lwv" = (
@@ -56003,6 +56048,11 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/checkpoint/engi)
+"mID" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet9-4"
+	},
+/area/station/bridge/captain_quarters)
 "mIP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -59065,7 +59115,9 @@
 	icon_state = "4-8"
 	},
 /obj/item/weapon/folder/white,
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet15-15"
+	},
 /area/station/bridge/meeting_room)
 "ntM" = (
 /obj/structure/cable{
@@ -61131,7 +61183,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet9-4"
+	},
 /area/station/bridge)
 "nSC" = (
 /obj/structure/rack,
@@ -66296,7 +66350,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet13-5"
+	},
 /area/station/bridge/captain_quarters)
 "pis" = (
 /obj/structure/cable{
@@ -67403,7 +67459,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet6-2"
+	},
 /area/station/bridge/meeting_room)
 "puz" = (
 /obj/machinery/door/firedoor,
@@ -67741,6 +67799,11 @@
 /obj/item/device/flashlight/lamp,
 /turf/simulated/floor/carpet/red,
 /area/station/civilian/dormitories/service_bedrooms)
+"pyh" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet10-8"
+	},
+/area/station/bridge)
 "pyk" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -73715,7 +73778,9 @@
 	icon_state = "4-8"
 	},
 /obj/item/toy/figure/dsquad,
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet15-15"
+	},
 /area/station/bridge/meeting_room)
 "qSZ" = (
 /obj/machinery/door/firedoor,
@@ -74340,8 +74405,8 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
+/turf/simulated/floor/bluegrid{
+	icon_state = "gcircuit"
 	},
 /area/station/tcommsat/chamber)
 "raM" = (
@@ -77755,7 +77820,9 @@
 /obj/structure/table/woodentable,
 /obj/item/weapon/clipboard,
 /obj/item/weapon/pen,
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet9-4"
+	},
 /area/station/bridge/meeting_room)
 "rOC" = (
 /obj/machinery/airlock_sensor{
@@ -77899,7 +77966,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet15-15"
+	},
 /area/station/bridge/captain_quarters)
 "rPS" = (
 /obj/effect/landmark/start/roboticist,
@@ -77955,7 +78024,10 @@
 "rQV" = (
 /obj/machinery/telecomms/receiver/preset_right,
 /turf/simulated/floor/bluegrid{
-	icon_state = "gcircuit"
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
 	},
 /area/station/tcommsat/chamber)
 "rQX" = (
@@ -82330,7 +82402,9 @@
 /obj/structure/window/thin/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet10-8"
+	},
 /area/station/bridge/captain_quarters)
 "sTZ" = (
 /obj/machinery/photocopier,
@@ -86485,7 +86559,10 @@
 "tWZ" = (
 /obj/machinery/telecomms/receiver/preset_left,
 /turf/simulated/floor/bluegrid{
-	icon_state = "gcircuit"
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
 	},
 /area/station/tcommsat/chamber)
 "tXl" = (
@@ -87368,7 +87445,9 @@
 	dir = 4
 	},
 /obj/item/device/radio/intercom,
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet11-12"
+	},
 /area/station/bridge/meeting_room)
 "uiQ" = (
 /obj/structure/cable{
@@ -87887,7 +87966,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/carpet/blue2,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet15-15"
+	},
 /area/station/bridge/meeting_room)
 "unL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -91961,6 +92042,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"vpL" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/station/tcommsat/chamber)
 "vpT" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -92830,7 +92924,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet13-5"
+	},
 /area/station/bridge)
 "vBe" = (
 /obj/effect/decal/turf_decal{
@@ -96300,7 +96396,9 @@
 /obj/machinery/keycard_auth{
 	pixel_x = -28
 	},
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet7-3"
+	},
 /area/station/bridge/captain_quarters)
 "wtW" = (
 /obj/machinery/deployable/barrier,
@@ -97221,8 +97319,8 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
+/turf/simulated/floor/bluegrid{
+	icon_state = "gcircuit"
 	},
 /area/station/tcommsat/chamber)
 "wFj" = (
@@ -100958,7 +101056,9 @@
 /obj/structure/window/thin/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet6-2"
+	},
 /area/station/bridge/captain_quarters)
 "xze" = (
 /obj/effect/decal/cleanable/dirt,
@@ -102812,7 +102912,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet/black,
+/turf/simulated/floor/carpet{
+	icon_state = "carpet14-10"
+	},
 /area/station/bridge)
 "xVm" = (
 /obj/machinery/alarm{
@@ -141806,14 +141908,14 @@ lZx
 lZx
 lZx
 pQD
-geq
-geq
-geq
-kxd
-geq
-geq
+gIC
+gIC
+gIC
+vpL
+gIC
+gIC
 keH
-vyg
+gIC
 xMO
 aMC
 kHU
@@ -142063,7 +142165,7 @@ efE
 mSV
 fSr
 jfu
-vyg
+gIC
 cki
 dXr
 kxd
@@ -142320,7 +142422,7 @@ kQr
 jIL
 cdc
 eXe
-vyg
+gIC
 hbc
 eSi
 kxd
@@ -142582,8 +142684,8 @@ knC
 xMO
 raJ
 cCX
-geq
-xMO
+vyg
+dFC
 lwt
 raJ
 eXe
@@ -142837,7 +142939,7 @@ eXe
 eXe
 eXe
 nqJ
-geq
+vyg
 rHn
 swz
 oKD
@@ -143340,7 +143442,7 @@ gCE
 imK
 lEC
 mrs
-dfg
+pyh
 nSo
 lZx
 oay
@@ -143351,7 +143453,7 @@ eXe
 eXe
 eXe
 nqJ
-geq
+vyg
 gIt
 swz
 xdv
@@ -143610,7 +143712,7 @@ knC
 aty
 wEV
 fAH
-xMO
+dFC
 aEE
 lwt
 wEV
@@ -143862,7 +143964,7 @@ djT
 vKe
 gTC
 eXe
-vyg
+gIC
 jRz
 eZL
 kxd
@@ -144119,7 +144221,7 @@ nQC
 tHI
 uzb
 pQD
-vyg
+gIC
 klE
 flz
 kxd
@@ -144376,14 +144478,14 @@ lZx
 lZx
 lZx
 pQD
-geq
-geq
-geq
-kxd
-geq
-kxd
-geq
-geq
+gIC
+gIC
+gIC
+vpL
+gIC
+vpL
+gIC
+gIC
 aty
 aMC
 kHU
@@ -145661,7 +145763,7 @@ ibm
 adM
 sTY
 bIZ
-cPN
+mID
 iaL
 cHR
 jKD

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -7365,6 +7365,9 @@
 /area/station/medical/virology)
 "byG" = (
 /obj/machinery/photocopier,
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -13310,6 +13313,9 @@
 /obj/machinery/light/smart{
 	dir = 1
 	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -16117,7 +16123,7 @@
 /area/station/engineering/break_room)
 "duM" = (
 /obj/structure/filingcabinet,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -19924,6 +19930,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 28;
+	pixel_y = -5
+	},
 /turf/simulated/floor/plating,
 /area/station/civilian/toilet)
 "erQ" = (
@@ -22256,6 +22267,9 @@
 /area/station/rnd/xenobiology)
 "eSP" = (
 /obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -23246,9 +23260,6 @@
 	name = "Station Intercom (General)";
 	pixel_x = 28;
 	pixel_y = -5
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
 	},
 /turf/simulated/floor{
 	icon_state = "wooden"
@@ -24664,10 +24675,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 22
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
@@ -25679,6 +25686,10 @@
 "fIj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 22
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -40113,6 +40124,11 @@
 /obj/structure/table/woodentable,
 /obj/item/weapon/clipboard,
 /obj/item/weapon/pen,
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 28;
+	pixel_y = -5
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -41506,6 +41522,9 @@
 /area/station/rnd/xenobiology)
 "jia" = (
 /obj/machinery/bookbinder,
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -41860,6 +41879,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 28;
+	pixel_y = -5
+	},
 /turf/simulated/floor/plating,
 /area/station/civilian/toilet)
 "jlU" = (
@@ -42261,6 +42285,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 1;
 	icon_state = "pipe-c"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
 	},
 /turf/simulated/floor{
 	dir = 6;
@@ -45490,7 +45517,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -57254,6 +57281,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -32
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -59049,7 +59079,7 @@
 /area/station/engineering/break_room)
 "ndh" = (
 /obj/machinery/disposal,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -60439,6 +60469,9 @@
 	pixel_x = 29;
 	pixel_y = -6
 	},
+/obj/machinery/firealarm{
+	pixel_y = 22
+	},
 /turf/simulated/floor{
 	icon_state = "wooden"
 	},
@@ -61082,6 +61115,9 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -73196,6 +73232,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -1303,14 +1303,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/station/maintenance/cargo)
-"aia" = (
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "yellow"
-	},
-/area/station/engineering/break_room)
 "aij" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/box/lights/tubes,
@@ -1578,6 +1570,17 @@
 	},
 /turf/simulated/floor,
 /area/station/medical/cryo)
+"akr" = (
+/obj/structure/stool/bed/chair/metal/black{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "akv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -1836,7 +1839,7 @@
 	dir = 4;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "anh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -2137,6 +2140,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"apO" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "apV" = (
 /turf/simulated/floor/carpet,
 /area/station/bridge/meeting_room)
@@ -2640,6 +2655,13 @@
 "auA" = (
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
+"auB" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_left"
+	},
+/turf/simulated/floor,
+/area/station/storage/tech)
 "auG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -2816,6 +2838,15 @@
 	icon_state = "darkbrown"
 	},
 /area/station/medical/virology)
+"axf" = (
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "axg" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -3044,16 +3075,6 @@
 	icon_state = "darkredfull"
 	},
 /area/station/security/brig)
-"aAz" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "aAA" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -3630,16 +3651,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
-"aGr" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkred"
-	},
-/area/station/security/brig)
 "aGz" = (
 /obj/structure/sign/poster/ripped{
 	pixel_y = -32
@@ -3762,16 +3773,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/brig)
-"aHB" = (
-/obj/machinery/light/smart,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "aHT" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -5006,6 +5007,24 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
+"aWN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "aWR" = (
 /obj/structure/stool/bed/chair/metal/green{
 	dir = 8
@@ -5554,6 +5573,13 @@
 	icon_state = "2-3"
 	},
 /area/shuttle/mining/station)
+"bcT" = (
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/prison)
 "bcW" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced/phoron{
@@ -5851,7 +5877,7 @@
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "bfT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6555,6 +6581,14 @@
 /obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"bmL" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/civilian/gym)
 "bmM" = (
 /turf/simulated/floor{
 	icon_state = "grimy"
@@ -7057,7 +7091,7 @@
 	dir = 8;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "bsZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
@@ -7089,6 +7123,18 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
+"btz" = (
+/obj/structure/stool/bed/chair/metal/black{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "btA" = (
 /obj/structure/table/woodentable/fancy,
 /turf/simulated/floor,
@@ -7324,15 +7370,6 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
-"bwk" = (
-/obj/item/weapon/flora/random,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "bwm" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -8342,11 +8379,10 @@
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "box_corners_white";
-	dir = 1
+	dir = 4
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
+	icon_state = "box_corners_white"
 	},
 /obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "siding_line";
@@ -8601,18 +8637,6 @@
 	},
 /turf/simulated/floor,
 /area/station/gateway)
-"bHi" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "bHs" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/cable{
@@ -8795,6 +8819,15 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/hor)
+"bJx" = (
+/obj/item/weapon/flora/random,
+/obj/machinery/light/smart{
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/station/rnd/hallway/lobby)
 "bJz" = (
 /obj/effect/landmark{
 	name = "blobstart"
@@ -9547,13 +9580,6 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
-"bSL" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-MB";
-	location = "N-MB"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "bSM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -9718,17 +9744,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/interrogation)
-"bUJ" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "bUL" = (
 /obj/effect/landmark/start/assistant/test_subject,
 /obj/structure/stool/bed/chair{
@@ -10000,7 +10015,7 @@
 	dir = 8;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "bXu" = (
 /obj/machinery/meter,
 /obj/structure/cable{
@@ -10414,14 +10429,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/station/engineering/atmos)
-"cbB" = (
-/obj/machinery/atm{
-	pixel_y = -28
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "cbM" = (
 /obj/structure/closet/crate,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -10572,6 +10579,14 @@
 	icon_state = "grimy"
 	},
 /area/station/tcommsat/computer)
+"cdd" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/security/prison)
 "cde" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -10671,10 +10686,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NW-B";
-	location = "NE-FC"
-	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -10745,7 +10756,7 @@
 	dir = 8;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "cfk" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Customs Post";
@@ -11917,6 +11928,16 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"cul" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-B";
+	location = "SSW-B"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "cum" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
 /obj/machinery/embedded_controller/radio/airlock_controller{
@@ -13023,15 +13044,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
-"cFG" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "cFK" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -13850,7 +13862,7 @@
 	icon_state = "warn_corner"
 	},
 /turf/simulated/floor,
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "cOS" = (
 /obj/machinery/teleport/hub,
 /turf/simulated/floor{
@@ -14530,13 +14542,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
-"cVY" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=CS-AR";
-	location = "SWW-FC"
-	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
 "cWi" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -14713,6 +14718,19 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/miningoffice)
+"cZj" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "cZC" = (
 /obj/machinery/shieldwallgen,
 /turf/simulated/floor,
@@ -15581,7 +15599,7 @@
 	dir = 4;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "diQ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -16725,7 +16743,7 @@
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "dwK" = (
 /obj/structure/closet/secure_closet/atmos_personal,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -17158,7 +17176,7 @@
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "box_corners_white";
-	dir = 1
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -17181,13 +17199,6 @@
 	},
 /turf/environment/space,
 /area/shuttle/supply/station)
-"dDL" = (
-/obj/item/weapon/flora/random,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_left"
-	},
-/turf/simulated/floor,
-/area/station/storage/tech)
 "dDO" = (
 /obj/machinery/computer/crew{
 	dir = 1
@@ -17817,7 +17828,7 @@
 	dir = 1;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "dKO" = (
 /obj/structure/table/reinforced/stall,
 /obj/machinery/door/firedoor,
@@ -18763,18 +18774,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
-"dXk" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "dXp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -19230,7 +19229,7 @@
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "ecm" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -19381,20 +19380,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/chargebay)
-"eek" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 9;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "eel" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
@@ -19522,26 +19507,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/tcommsat/computer)
-"efG" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "efR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/trinary/filter{
@@ -19815,12 +19780,21 @@
 	},
 /area/station/hallway/primary/starboard)
 "ejv" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-FC";
-	location = "SSW-FC"
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Entry Shuttle Airlock";
+	req_one_access = list(13)
 	},
-/turf/simulated/floor,
-/area/station/hallway/primary/starboard)
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "ejG" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 1
@@ -20091,21 +20065,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
-"elJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
 "elV" = (
 /obj/structure/rack,
 /obj/item/weapon/book/manual/wiki/security_space_law,
@@ -20206,17 +20165,6 @@
 	},
 /turf/simulated/floor,
 /area/station/medical/hallway)
-"ene" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos/atmos_office)
 "eni" = (
 /obj/structure/toilet{
 	dir = 8
@@ -20579,17 +20527,16 @@
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/engineering)
 "esZ" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "loadingarea"
 	},
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "arrow"
 	},
-/turf/simulated/floor/plating,
-/area/station/bridge/corp_lounge)
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "etb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -21431,6 +21378,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
+"eBc" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-C";
+	location = "CS-AR"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "eBe" = (
 /obj/machinery/camera{
 	c_tag = "Mining Shuttle Preparation";
@@ -23363,6 +23320,15 @@
 	icon_state = "purplecorner"
 	},
 /area/station/rnd/hor)
+"eZG" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "eZH" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -24123,7 +24089,7 @@
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "fgI" = (
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
@@ -25258,9 +25224,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
+/turf/simulated/floor,
 /area/station/hallway/primary/central)
 "fuN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -25885,14 +25849,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry)
-"fBN" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/civilian/gym)
 "fBO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
@@ -26353,19 +26309,6 @@
 	},
 /turf/environment/space,
 /area/shuttle/escape_pod5/station)
-"fHS" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "fIc" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -26638,6 +26581,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison)
+"fKC" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "fKP" = (
 /obj/effect/decal/turf_decal{
 	dir = 1;
@@ -26861,13 +26816,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "fOp" = (
-/obj/structure/closet/emcloset,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-MB";
+	location = "N-MB"
 	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
+/turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "fOF" = (
 /obj/structure/table/reinforced,
@@ -27279,6 +27232,13 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/station/civilian/dormitories)
+"fTx" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "fTz" = (
 /turf/simulated/wall,
 /area/station/cargo/recycler)
@@ -27304,6 +27264,18 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/mixing)
+"fUo" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/engineering/atmos/atmos_office)
 "fUu" = (
 /obj/effect/landmark/start/chief_engineer,
 /obj/structure/stool/bed/chair/office/light{
@@ -27527,6 +27499,16 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
+"fWL" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "fWT" = (
 /obj/machinery/smartfridge/chemistry,
 /turf/simulated/wall/r_wall,
@@ -27885,6 +27867,16 @@
 	},
 /turf/simulated/floor,
 /area/station/storage/primary)
+"gba" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NNW-B";
+	location = "NW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "gbj" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/pen,
@@ -28419,6 +28411,13 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/minisat_secure_area)
+"ghB" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-FC";
+	location = "SSW-FC"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/starboard)
 "ghI" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable{
@@ -28839,6 +28838,15 @@
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"glf" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "gli" = (
 /obj/structure/rack,
 /obj/item/weapon/tank/oxygen,
@@ -29339,6 +29347,16 @@
 	icon_state = "redyellowfull"
 	},
 /area/station/hallway/primary/fore)
+"gpJ" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SEE-FC";
+	location = "SE-FC"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "gpM" = (
 /obj/structure/particle_accelerator/end_cap{
 	dir = 8
@@ -29449,6 +29467,15 @@
 	icon_state = "neutralfull"
 	},
 /area/station/storage/primary)
+"grs" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_right"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/cold_room)
 "grP" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -29659,6 +29686,23 @@
 	icon_state = "floor"
 	},
 /area/shuttle/escape_pod3/station)
+"guc" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Entry Shuttle Airlock";
+	req_one_access = list(13)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "gui" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -30619,18 +30663,6 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/chapel)
-"gDk" = (
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Labor Camp Shuttle Airlock";
-	req_access = list(2)
-	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/brig)
 "gDm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -30640,6 +30672,19 @@
 	icon_state = "red"
 	},
 /area/station/security/brig)
+"gDv" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/pump,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "arrival"
+	},
+/area/station/hallway/primary/port)
 "gDL" = (
 /obj/effect/landmark/start/bartender,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -31346,6 +31391,17 @@
 	icon_state = "wooden"
 	},
 /area/station/hallway/secondary/exit)
+"gMq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "gMr" = (
 /turf/simulated/floor{
 	icon_state = "whiteblue"
@@ -31591,8 +31647,7 @@
 	dir = 4
 	},
 /obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 8
+	icon_state = "siding_line"
 	},
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
@@ -31691,6 +31746,13 @@
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
+"gQW" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "gRg" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -31762,6 +31824,15 @@
 	icon_state = "neutralfull"
 	},
 /area/station/cargo/miningoffice)
+"gRB" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 5
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "gRG" = (
 /obj/machinery/computer/station_alert{
 	dir = 4
@@ -31894,27 +31965,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
-"gSN" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Antechamber";
-	req_one_access = list(66)
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/aisat/teleport)
 "gSP" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 29
@@ -32572,6 +32622,15 @@
 	icon_state = "yellow"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
+"gZr" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Security";
+	location = "S-C"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "gZz" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -32615,12 +32674,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/checkpoint/engi)
-"hab" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
-	},
-/turf/simulated/floor/carpet/red,
-/area/station/security/detectives_office)
 "had" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -33241,18 +33294,15 @@
 /obj/structure/sign/warning/nosmoking,
 /turf/simulated/wall,
 /area/station/engineering/break_room)
-"hiK" = (
-/obj/structure/stool/bed/chair/metal/black{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
+"hiT" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 6
 	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "grimy"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/security/hos)
 "hjc" = (
 /turf/simulated/floor{
 	dir = 9;
@@ -33303,19 +33353,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
-"hjv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "hjF" = (
 /obj/structure/stool/bed/chair{
 	dir = 8
@@ -33572,7 +33609,7 @@
 	icon_state = "warn_corner"
 	},
 /turf/simulated/floor,
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "hmp" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -33806,7 +33843,7 @@
 	icon_state = "bot"
 	},
 /turf/simulated/floor,
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "hpg" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -34398,8 +34435,8 @@
 /area/station/maintenance/science)
 "hur" = (
 /obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
+	dir = 8;
+	icon_state = "warn"
 	},
 /obj/effect/decal/turf_decal{
 	dir = 4;
@@ -34492,6 +34529,19 @@
 	icon_state = "white"
 	},
 /area/station/civilian/gym)
+"hve" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "hvk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -35098,19 +35148,6 @@
 "hAz" = (
 /turf/simulated/floor/engine,
 /area/station/engineering/atmos/supermatter)
-"hAA" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "hAE" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1
@@ -35494,20 +35531,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/prison)
-"hEM" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_corner";
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "arrows_white";
-	dir = 8
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "black"
-	},
-/area/station/hallway/secondary/entry)
 "hER" = (
 /obj/machinery/porta_turret/station_default{
 	dir = 4
@@ -35980,7 +36003,7 @@
 	dir = 1;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "hKc" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1
@@ -36534,7 +36557,8 @@
 	},
 /obj/machinery/portable_atmospherics/powered/pump,
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
+	icon_state = "box_corners_white";
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -37360,6 +37384,16 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
+"ian" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/station/security/brig)
 "iau" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -37720,7 +37754,7 @@
 	dir = 8;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "ieA" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -38110,7 +38144,7 @@
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "iih" = (
 /obj/structure/stool/bed/chair/lectern{
 	dir = 1
@@ -38559,18 +38593,6 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
-"inG" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "inM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -39328,6 +39350,26 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
+"iwN" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "ixa" = (
 /obj/machinery/status_display{
 	pixel_y = 32
@@ -39336,7 +39378,7 @@
 	dir = 1;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "ixe" = (
 /obj/machinery/door/airlock/command{
 	name = "Head of Personnel's Quarters";
@@ -40786,24 +40828,6 @@
 /obj/structure/flora/junglebush/large,
 /turf/simulated/floor/grass,
 /area/station/civilian/kitchen)
-"iNd" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
 "iNg" = (
 /obj/structure/table/woodentable,
 /obj/item/clothing/head/that,
@@ -41027,18 +41051,6 @@
 	icon_state = "whitered"
 	},
 /area/station/security/main)
-"iPC" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/engineering/atmos/atmos_office)
 "iPD" = (
 /obj/structure/sink{
 	dir = 4;
@@ -41088,16 +41100,6 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/primary/fore)
-"iQd" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "iQj" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -41513,6 +41515,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
+"iUJ" = (
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Labor Camp Shuttle Airlock";
+	req_access = list(2)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
 "iUS" = (
 /obj/machinery/door_control{
 	id = "Singularity";
@@ -41846,6 +41860,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"iYG" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "iYX" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -41895,19 +41921,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/security/iaa_office)
-"iZp" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_corner"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "arrows_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "black"
-	},
-/area/station/hallway/secondary/entry)
 "iZs" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8
@@ -42128,26 +42141,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
-"jbL" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "jbM" = (
 /obj/machinery/light/smart,
 /obj/structure/sign/departments/chemistry{
@@ -43245,22 +43238,6 @@
 	icon_state = "white"
 	},
 /area/station/bridge/corp_lounge)
-"joR" = (
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Entry Shuttle Airlock";
-	req_one_access = list(13)
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
 "joW" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -44153,7 +44130,7 @@
 	dir = 1;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "jxs" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -44710,11 +44687,19 @@
 	},
 /area/station/hallway/primary/starboard)
 "jEs" = (
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
 	},
-/area/station/bridge/corp_lounge)
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "escape"
+	},
+/area/station/hallway/primary/port)
 "jEB" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
@@ -45249,6 +45234,16 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge/captain_quarters)
+"jKe" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/hallway/secondary/entry)
 "jKp" = (
 /obj/effect/decal/turf_decal{
 	dir = 5;
@@ -45604,6 +45599,16 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/engine)
+"jNh" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SWW-FC";
+	location = "SW-FC"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "jNo" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -45678,6 +45683,19 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
+"jNN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "jNO" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -45742,7 +45760,7 @@
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "jOD" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -45757,16 +45775,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/tox_launch)
-"jOF" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SE-FC";
-	location = "SW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "jOJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -46330,18 +46338,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
-"jUP" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "jUW" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -46839,12 +46835,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/gateway)
-"kaa" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "cafeteria"
-	},
-/area/station/security/prison)
 "kaf" = (
 /obj/structure/rack,
 /obj/item/weapon/storage/box/lights/mixed,
@@ -47414,6 +47404,19 @@
 /obj/effect/decal/cleanable/cobweb2,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"kgh" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "kgj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -47448,18 +47451,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "kgH" = (
-/obj/machinery/light/smart{
-	dir = 4
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NE-FC";
-	location = "NEE-FC"
-	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
 	},
-/area/station/hallway/primary/central)
+/area/station/security/lobby)
 "khm" = (
 /obj/machinery/power/apc{
 	name = "apc down";
@@ -48749,6 +48746,17 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/lobby)
+"kvi" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos/atmos_office)
 "kvu" = (
 /turf/simulated/wall,
 /area/station/civilian/bar)
@@ -49255,6 +49263,16 @@
 	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry)
+"kBE" = (
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
 "kBF" = (
@@ -50543,6 +50561,26 @@
 	icon_state = "white"
 	},
 /area/station/civilian/dormitories)
+"kOo" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "kOx" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(25)
@@ -51502,7 +51540,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor,
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "kYF" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -51795,6 +51833,11 @@
 	icon_state = "vaultfull"
 	},
 /area/station/gateway)
+"lcG" = (
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "lcI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -52298,12 +52341,14 @@
 	},
 /area/station/cargo/office)
 "lki" = (
-/obj/machinery/vending/coffee,
+/obj/structure/closet/emcloset,
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
+	icon_state = "delivery"
 	},
-/turf/simulated/floor,
-/area/station/bridge/corp_lounge)
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "lkl" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -52631,20 +52676,6 @@
 	icon_state = "white"
 	},
 /area/station/medical/hallway)
-"lnt" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor,
-/area/station/engineering/monitoring)
 "lnK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -52822,6 +52853,16 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
+"lqu" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSE-FC";
+	location = "SEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "lqF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -54856,16 +54897,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
-"lNm" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SWW-FC";
-	location = "SW-FC"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "lNr" = (
 /obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "siding_corner";
@@ -55439,7 +55470,7 @@
 	dir = 4;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "lUh" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -55785,16 +55816,6 @@
 "lYH" = (
 /turf/simulated/wall/r_wall,
 /area/station/bridge)
-"lYQ" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-C";
-	location = "CS-AR"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "lYU" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -56093,6 +56114,16 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
+"mdd" = (
+/obj/machinery/light/smart,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "mdk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/stool/bed/chair/office/dark,
@@ -56926,6 +56957,19 @@
 	},
 /turf/simulated/floor,
 /area/station/gateway)
+"mmK" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_corner"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "arrows_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/hallway/secondary/entry)
 "mmN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -57361,15 +57405,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/hor)
-"mrB" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_right"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/civilian/cold_room)
 "mrH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -57633,6 +57668,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"mub" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-B";
+	location = "S-MB"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry)
 "mue" = (
 /obj/effect/decal/turf_decal/wood/dark{
 	icon_state = "siding_wood_corner";
@@ -57956,17 +58000,6 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/primary/fore)
-"mym" = (
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
 "myv" = (
 /obj/machinery/computer/general_air_control/large_tank_control{
 	dir = 8;
@@ -58918,15 +58951,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/dormitories/courtroom)
-"mKe" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "mKl" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -59004,7 +59028,7 @@
 	dir = 8;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "mKN" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -59881,6 +59905,19 @@
 /obj/structure/filingcabinet/medical,
 /turf/simulated/floor/wood,
 /area/station/bridge/hop_office)
+"mUy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NW-B";
+	location = "NE-FC"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "mUL" = (
 /obj/machinery/atm{
 	pixel_y = -28
@@ -59964,6 +60001,17 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
+"mVn" = (
+/obj/machinery/light/smart,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DS";
+	location = "DN-W"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "purplecorner"
+	},
+/area/station/hallway/primary/central)
 "mVt" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -60207,6 +60255,13 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
+"mYf" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=N-MB";
+	location = "NNW-B"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "mYj" = (
 /turf/simulated/wall/r_wall,
 /area/station/rnd/mixing)
@@ -60985,6 +61040,15 @@
 	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
+"nip" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 29
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "blackcorner"
+	},
+/area/station/hallway/primary/starboard)
 "niq" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -61106,15 +61170,6 @@
 	icon_state = "purplecorner"
 	},
 /area/station/hallway/primary/central)
-"njy" = (
-/obj/effect/decal/turf_decal/alpha/blue{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "njz" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
@@ -61176,15 +61231,6 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/medical/chemistry)
-"nkJ" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "nkK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -61509,6 +61555,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
 /area/station/maintenance/chapel)
+"noE" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "noM" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -61582,15 +61638,6 @@
 	icon_state = "green"
 	},
 /area/station/engineering/atmos)
-"npp" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-B";
-	location = "S-MB"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/secondary/entry)
 "npv" = (
 /obj/structure/table/glass,
 /obj/item/weapon/folder/white,
@@ -61823,16 +61870,6 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/kitchen)
-"nra" = (
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "nrh" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -62039,12 +62076,12 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/hallway)
-"ntU" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "browncorner"
+"ntN" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
 	},
-/area/station/cargo/storage)
+/turf/simulated/floor/carpet/red,
+/area/station/security/detectives_office)
 "nub" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -62228,6 +62265,15 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"nwD" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DN";
+	location = "SSE-FC"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "nwF" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable{
@@ -62738,6 +62784,17 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/reception)
+"nBW" = (
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "nCa" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -63443,6 +63500,18 @@
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall,
 /area/station/engineering/engine)
+"nJx" = (
+/obj/structure/stool/bed/chair/metal/black{
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "nJB" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -64066,26 +64135,6 @@
 	icon_state = "grimy"
 	},
 /area/station/security/hos)
-"nRo" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "nRr" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -64629,6 +64678,19 @@
 	icon_state = "vaultfull"
 	},
 /area/station/rnd/scibreak)
+"nXk" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "nXl" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/wood,
@@ -65608,25 +65670,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"oib" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/main)
 "oid" = (
 /obj/machinery/alarm{
 	pixel_y = -32
@@ -65881,6 +65924,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
+"omc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "omd" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -65952,7 +66008,7 @@
 /turf/simulated/floor{
 	icon_state = "neutral"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "omV" = (
 /turf/simulated/wall,
 /area/station/security/checkpoint)
@@ -67052,6 +67108,18 @@
 	icon_state = "dark"
 	},
 /area/station/security/brig)
+"oCX" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "oCZ" = (
 /turf/simulated/wall,
 /area/station/bridge/teleporter)
@@ -67314,6 +67382,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"oGg" = (
+/obj/machinery/light/smart{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NE-FC";
+	location = "NEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "oGh" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
@@ -67515,6 +67596,16 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
+"oIs" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "oIK" = (
 /turf/simulated/wall/r_wall,
 /area/station/rnd/tox_launch)
@@ -67949,7 +68040,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor,
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "oMG" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -68106,7 +68197,7 @@
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	dir = 6;
+	dir = 4;
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
@@ -68476,16 +68567,6 @@
 	},
 /turf/environment/space,
 /area/shuttle/escape_pod5/station)
-"oTb" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NNW-B";
-	location = "NW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "oTt" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -68775,6 +68856,19 @@
 /obj/item/weapon/flora/random,
 /turf/simulated/floor,
 /area/station/gateway)
+"oWR" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "oXd" = (
 /obj/structure/closet/secure_closet/injection,
 /turf/simulated/floor{
@@ -68810,6 +68904,26 @@
 	icon_state = "neutralfull"
 	},
 /area/station/storage/primary)
+"oXz" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "oXA" = (
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -68919,13 +69033,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
-"oYy" = (
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/prison)
 "oYI" = (
 /obj/item/weapon/crowbar/red,
 /obj/item/device/radio/intercom{
@@ -69344,7 +69451,7 @@
 	dir = 8;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "pek" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -69754,7 +69861,7 @@
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "pji" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -70019,6 +70126,16 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/minisat_secure_area)
+"plo" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "plp" = (
 /obj/structure/stool/bed/chair,
 /turf/simulated/floor{
@@ -70619,7 +70736,7 @@
 	dir = 8;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "psn" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Permabrig Visitation";
@@ -71172,7 +71289,7 @@
 	dir = 8;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "pyv" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -71479,7 +71596,7 @@
 	dir = 4;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "pBb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/structure/disposalpipe/segment,
@@ -71488,13 +71605,17 @@
 	},
 /area/station/engineering/atmos)
 "pBf" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
 	},
 /turf/simulated/floor{
-	icon_state = "yellowcorner"
+	icon_state = "dark"
 	},
-/area/station/hallway/primary/port)
+/area/station/engineering/engine)
 "pBn" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -71616,7 +71737,7 @@
 	icon_state = "bot"
 	},
 /turf/simulated/floor,
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "pCr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -71677,6 +71798,14 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/cargo/recycler)
+"pDr" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "pDB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -72237,16 +72366,6 @@
 	icon_state = "dark"
 	},
 /area/station/bridge/captain_quarters)
-"pKi" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "pKm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -72679,13 +72798,6 @@
 "pPp" = (
 /turf/simulated/floor/wood,
 /area/station/maintenance/medbay)
-"pPw" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=N-MB";
-	location = "NNW-B"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "pPA" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -73037,26 +73149,6 @@
 	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
-"pSu" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "pSP" = (
 /obj/structure/table,
 /turf/simulated/floor{
@@ -73095,6 +73187,15 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/break_room)
+"pSV" = (
+/obj/machinery/vending/coffee,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/primary/central)
 "pSX" = (
 /obj/structure/stool/bed/roller,
 /turf/simulated/floor{
@@ -73328,7 +73429,7 @@
 	dir = 4;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "pWq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -73997,7 +74098,7 @@
 	dir = 8;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "qea" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -74187,11 +74288,11 @@
 	req_one_access = list(13)
 	},
 /obj/effect/decal/turf_decal{
-	dir = 1;
+	dir = 2;
 	icon_state = "warn"
 	},
 /obj/effect/decal/turf_decal{
-	dir = 2;
+	dir = 1;
 	icon_state = "warn"
 	},
 /turf/simulated/floor/plating,
@@ -74841,6 +74942,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
+"qnv" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "qnB" = (
 /obj/item/clothing/gloves/boxing/green,
 /obj/item/clothing/gloves/boxing/yellow,
@@ -75750,7 +75860,7 @@
 	dir = 8;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "qyW" = (
 /obj/machinery/light/smart{
 	dir = 1
@@ -76246,7 +76356,7 @@
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "qEY" = (
 /mob/living/simple_animal/mouse,
 /obj/structure/cable{
@@ -76674,16 +76784,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/medical/morgue)
-"qJQ" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
 "qJS" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/firstaid/small_firstaid_kit,
@@ -78998,6 +79098,27 @@
 	icon_state = "neutral"
 	},
 /area/station/rnd/xenobiology)
+"rmR" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Antechamber";
+	req_one_access = list(66)
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/aisat/teleport)
 "rmU" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -79087,18 +79208,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison)
-"roq" = (
-/obj/structure/stool/bed/chair/metal/black{
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "rot" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -79717,7 +79826,7 @@
 	dir = 8;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "rvA" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 29
@@ -79920,6 +80029,16 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
+"rxv" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NEE-FC";
+	location = "S-SV"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "rxw" = (
 /obj/structure/table,
 /obj/item/device/paicard,
@@ -80563,6 +80682,15 @@
 	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
+"rDD" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "rDL" = (
 /obj/machinery/drone_fabricator,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -80698,16 +80826,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
-"rET" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSE-FC";
-	location = "SEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "rEX" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -81172,7 +81290,7 @@
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "rIW" = (
 /obj/structure/window/thin/reinforced{
 	dir = 4
@@ -81967,14 +82085,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/engineering/atmos)
-"rSh" = (
-/obj/machinery/atm{
-	pixel_y = -28
-	},
-/turf/simulated/floor{
-	icon_state = "redyellowfull"
-	},
-/area/station/hallway/primary/fore)
 "rSm" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -82086,6 +82196,21 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
+"rTC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "rTL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -83292,14 +83417,14 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "siM" = (
-/obj/machinery/alarm{
-	pixel_y = 22
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutralfull"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/fore)
 "siU" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
@@ -83605,7 +83730,7 @@
 	dir = 8;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "slb" = (
 /mob/living/simple_animal/fox/Renault,
 /turf/simulated/floor{
@@ -83839,15 +83964,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/hallway/primary/fore)
-"snV" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Security";
-	location = "S-C"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "snW" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/disposalpipe/segment{
@@ -84361,20 +84477,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/brig)
-"suI" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "escape"
-	},
-/area/station/hallway/primary/port)
 "suL" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/brig/solitary_confinement)
@@ -84563,6 +84665,18 @@
 /obj/structure/closet/crate/secure/woodseccrate,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"sxe" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "sxB" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -84643,18 +84757,6 @@
 	icon_state = "white"
 	},
 /area/station/rnd/hor)
-"syF" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "syI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -84754,6 +84856,17 @@
 	icon_state = "gcircuit"
 	},
 /area/station/maintenance/science)
+"szH" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "szQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -85370,19 +85483,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/library)
-"sHg" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "sHo" = (
 /obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor{
@@ -86017,6 +86117,14 @@
 	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
+"sOy" = (
+/obj/machinery/atm{
+	pixel_y = -28
+	},
+/turf/simulated/floor{
+	icon_state = "redyellowfull"
+	},
+/area/station/hallway/primary/fore)
 "sOD" = (
 /obj/effect/decal/turf_decal{
 	dir = 8;
@@ -86240,19 +86348,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
-"sRT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 9
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "sSh" = (
 /obj/machinery/cell_charger{
 	pixel_y = 5
@@ -86607,6 +86702,12 @@
 	icon_state = "vaultfull"
 	},
 /area/station/engineering/atmos)
+"sVN" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "browncorner"
+	},
+/area/station/cargo/storage)
 "sWq" = (
 /obj/item/weapon/flora/random,
 /obj/structure/window/thin{
@@ -87502,12 +87603,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/emergency)
-"thS" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "thU" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -87539,7 +87634,7 @@
 	dir = 4;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "tiC" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
@@ -87764,19 +87859,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
-"tll" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "tlq" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -88255,6 +88337,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"tro" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "caution"
+	},
+/area/station/engineering/atmos/distribution)
 "try" = (
 /obj/structure/closet/secure_closet/medical1,
 /obj/structure/cable{
@@ -88878,15 +88977,6 @@
 	icon_state = "dark"
 	},
 /area/station/medical/virology)
-"tzl" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DN";
-	location = "SSE-FC"
-	},
-/turf/simulated/floor{
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "tzm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/light/small{
@@ -88919,6 +89009,14 @@
 	icon_state = "vaultfull"
 	},
 /area/station/rnd/xenobiology)
+"tzx" = (
+/obj/machinery/atm{
+	pixel_y = -28
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "tzH" = (
 /obj/machinery/power/solar_control{
 	id = "aftstarboard";
@@ -89517,16 +89615,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/bridge/hop_office)
-"tGa" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NEE-FC";
-	location = "S-SV"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "tGH" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/light/smart{
@@ -90120,6 +90208,17 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/library)
+"tNo" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "tNE" = (
 /obj/structure/sink{
 	dir = 4;
@@ -90989,6 +91088,13 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/port)
+"tZu" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=CS-AR";
+	location = "SWW-FC"
+	},
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "tZz" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -91207,16 +91313,6 @@
 	icon_state = "caution"
 	},
 /area/station/hallway/primary/port)
-"uct" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-B";
-	location = "SSW-B"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "ucu" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
@@ -91225,22 +91321,11 @@
 	},
 /area/station/rnd/hallway)
 "ucx" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Entry Shuttle Airlock";
-	req_one_access = list(13)
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "cafeteria"
 	},
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
+/area/station/security/prison)
 "ucF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -91253,6 +91338,16 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/engineering/chiefs_office)
+"ucG" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "ucP" = (
 /obj/machinery/door/airlock{
 	name = "Bar";
@@ -91433,17 +91528,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/hos)
-"ueH" = (
-/obj/machinery/light/smart,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DS";
-	location = "DN-W"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "purplecorner"
-	},
-/area/station/hallway/primary/central)
 "ufi" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/effect/decal/turf_decal/alpha/gray{
@@ -91725,15 +91809,6 @@
 	icon_state = "black"
 	},
 /area/station/civilian/chapel)
-"uiu" = (
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
 "uix" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -92018,17 +92093,6 @@
 	icon_state = "dark"
 	},
 /area/station/aisat/ai_chamber)
-"uld" = (
-/obj/structure/stool/bed/chair/metal/black{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "ulk" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -93309,7 +93373,7 @@
 	dir = 1;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "uBo" = (
 /turf/environment/space,
 /area/shuttle/syndicate/southeast)
@@ -93552,11 +93616,6 @@
 	},
 /turf/simulated/wall,
 /area/station/hallway/secondary/entry)
-"uEp" = (
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "uEC" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced/phoron{
@@ -93633,6 +93692,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/medical/medbreak)
+"uFa" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Central Access"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "uFj" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor,
@@ -93761,13 +93829,6 @@
 	},
 /turf/simulated/floor/carpet/purple,
 /area/station/civilian/dormitories)
-"uGW" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "uHd" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -32
@@ -93805,17 +93866,24 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "uHN" = (
-/obj/machinery/door_timer/cell_3{
-	pixel_x = 32;
-	pixel_y = 0;
-	dir = 4;
-	id = "Cell 3 perma"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "redcorner"
+	icon_state = "vaultfull"
 	},
-/area/station/security/prison)
+/area/station/security/main)
 "uHX" = (
 /turf/simulated/floor/wood,
 /area/station/maintenance/chapel)
@@ -94125,6 +94193,15 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"uMf" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "uMg" = (
 /obj/machinery/power/solar{
 	id = "auxsolareast";
@@ -94202,16 +94279,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
-"uNq" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "black"
-	},
-/area/station/hallway/secondary/entry)
 "uNs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -94271,14 +94338,6 @@
 /obj/machinery/cell_charger,
 /turf/simulated/floor,
 /area/station/gateway)
-"uOh" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/security/prison)
 "uOm" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -94550,6 +94609,20 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
+"uRs" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_corner";
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "arrows_white";
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/hallway/secondary/entry)
 "uRx" = (
 /obj/structure/stool/bed/chair/metal{
 	dir = 1
@@ -94782,6 +94855,22 @@
 	icon_state = "darkred"
 	},
 /area/station/hallway/primary/fore)
+"uUF" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "uUJ" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -94952,17 +95041,6 @@
 /obj/effect/spawner/lootdrop/maintenance/four,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"uWs" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "yellow"
-	},
-/area/station/engineering/atmos)
 "uWw" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -95777,17 +95855,6 @@
 "vgR" = (
 /turf/simulated/floor/plating/airless,
 /area/space)
-"vhb" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "loadingarea"
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "arrow"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "vhk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/window/brigdoor{
@@ -96339,18 +96406,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/supermatter)
-"vnk" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "vnt" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/firstaid/regular,
@@ -97840,15 +97895,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/bridge/ai_upload)
-"vFf" = (
-/obj/effect/decal/turf_decal{
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "vFo" = (
 /obj/structure/table,
 /obj/item/device/flashlight/lamp{
@@ -98024,14 +98070,26 @@
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/auxstarboard)
 "vIk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
+	dir = 1;
+	icon_state = "black"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/civilian/gym)
 "vIl" = (
 /turf/simulated/wall,
 /area/station/rnd/hallway/lobby)
@@ -98105,17 +98163,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/toilet)
-"vJg" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "vJh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -98767,7 +98814,7 @@
 	dir = 1;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "vSe" = (
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -98968,12 +99015,17 @@
 	},
 /area/station/bridge/teleporter)
 "vTX" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 8
+/obj/machinery/door_timer/cell_3{
+	pixel_x = 32;
+	pixel_y = 0;
+	dir = 4;
+	id = "Cell 3 perma"
 	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "vUe" = (
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
@@ -99904,6 +99956,14 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/science)
+"weD" = (
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/break_room)
 "weQ" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor{
@@ -100065,23 +100125,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
-"wic" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "caution"
-	},
-/area/station/engineering/atmos/distribution)
 "wii" = (
 /obj/machinery/ai_status_display{
 	pixel_y = 32
@@ -100515,10 +100558,15 @@
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "wmh" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SE-FC";
+	location = "SW-B"
+	},
 /turf/simulated/floor{
+	dir = 1;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "wmj" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -100612,7 +100660,7 @@
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "wnb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/binary/valve,
@@ -100746,6 +100794,21 @@
 	icon_state = "white"
 	},
 /area/station/medical/hallway)
+"woY" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/engineering/monitoring)
 "wpa" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -100765,7 +100828,6 @@
 "wpm" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/station/security/lobby)
@@ -101108,16 +101170,6 @@
 /obj/machinery/deployable/barrier,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
-"wuc" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SEE-FC";
-	location = "SE-FC"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "wud" = (
 /obj/machinery/light/smart{
 	dir = 4
@@ -101232,6 +101284,19 @@
 "wwi" = (
 /turf/simulated/wall,
 /area/station/maintenance/atmos)
+"wwn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/flasher{
+	id = "Cell 3 perma";
+	pixel_y = -28
+	},
+/turf/simulated/floor,
+/area/station/security/prison)
 "wwp" = (
 /obj/structure/table/reinforced,
 /obj/item/device/aicard,
@@ -101300,6 +101365,20 @@
 	icon_state = "vaultfull"
 	},
 /area/station/maintenance/science)
+"wxp" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 9;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "wxA" = (
 /obj/machinery/door/airlock/glass{
 	name = "Holodeck Door"
@@ -101382,7 +101461,7 @@
 	dir = 1;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "wyP" = (
 /obj/machinery/light/smart,
 /obj/item/device/radio/intercom{
@@ -101618,7 +101697,7 @@
 	dir = 1;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "wAK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -101878,19 +101957,6 @@
 /obj/item/clothing/mask/surgical,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
-"wCR" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/flasher{
-	id = "Cell 3 perma";
-	pixel_y = -28
-	},
-/turf/simulated/floor,
-/area/station/security/prison)
 "wDh" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -102051,15 +102117,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
-"wEP" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "wES" = (
 /obj/structure/closet/bombclosetsecurity,
 /turf/simulated/floor{
@@ -102102,7 +102159,7 @@
 	dir = 4;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "wFq" = (
 /obj/machinery/mecha_part_fabricator/mining_fabricator,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -102692,7 +102749,7 @@
 	dir = 4;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "wMZ" = (
 /obj/structure/window/fulltile{
 	grilled = 1;
@@ -103085,14 +103142,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/chargebay)
-"wSO" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "wST" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -103463,6 +103512,14 @@
 	icon_state = "barber"
 	},
 /area/station/medical/storage)
+"wXl" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/simulated/floor{
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "wXp" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -103568,7 +103625,7 @@
 	dir = 1;
 	icon_state = "neutral"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "wYO" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -103772,7 +103829,7 @@
 	dir = 8;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "xax" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -103842,16 +103899,6 @@
 	icon_state = "yellowfull"
 	},
 /area/station/engineering/engine)
-"xbt" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "xby" = (
 /obj/machinery/firealarm{
 	pixel_y = 22
@@ -104917,22 +104964,6 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/medical/chemistry)
-"xou" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "xov" = (
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/bluegrid{
@@ -105297,19 +105328,6 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
-"xrX" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "xsb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -106013,7 +106031,7 @@
 	dir = 1;
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "xzC" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/simulated/floor/wood,
@@ -106721,20 +106739,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
-"xHi" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/powered/pump,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "arrival"
-	},
-/area/station/hallway/primary/port)
 "xHu" = (
 /obj/structure/rack,
 /obj/item/weapon/circuitboard/solar_control,
@@ -107331,15 +107335,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
-"xOX" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 29
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "blackcorner"
-	},
-/area/station/hallway/primary/starboard)
 "xPl" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -107722,15 +107717,6 @@
 	icon_state = "gcircuit"
 	},
 /area/station/aisat/ai_chamber)
-"xSU" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 5
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "xTi" = (
 /obj/structure/closet/crate,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -107891,7 +107877,7 @@
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
-/area/station/bridge/corp_lounge)
+/area/station/hallway/primary/central)
 "xVj" = (
 /obj/structure/stool/bed/chair/comfy/black{
 	dir = 1
@@ -108189,15 +108175,6 @@
 /obj/machinery/atmospherics/components/unary/portables_connector,
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage_secure)
-"xXH" = (
-/obj/item/weapon/flora/random,
-/obj/machinery/light/smart{
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "white"
-	},
-/area/station/rnd/hallway/lobby)
 "xXL" = (
 /obj/machinery/light/smart,
 /obj/item/device/radio/electropack,
@@ -108374,15 +108351,6 @@
 /obj/effect/decal/cleanable/spiderling_remains,
 /turf/simulated/floor/airless/ceiling,
 /area/station/cargo/recycler)
-"xZI" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Central Access"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "xZR" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -118683,7 +118651,7 @@ eXX
 pGn
 fBB
 pGn
-gSN
+rmR
 pGn
 pGn
 oer
@@ -132038,7 +132006,7 @@ xFF
 xFG
 flb
 uDn
-aia
+weD
 ude
 ehA
 geB
@@ -132295,7 +132263,7 @@ qnQ
 hEd
 fDg
 owf
-aia
+weD
 hkb
 ehA
 fUz
@@ -132798,7 +132766,7 @@ oLJ
 kFc
 kFc
 cEO
-uWs
+szH
 azQ
 pfp
 imT
@@ -133044,7 +133012,7 @@ qSk
 qdn
 naA
 kdJ
-xrX
+oWR
 xqQ
 fmh
 mNB
@@ -133052,8 +133020,8 @@ bfy
 cmG
 dup
 htY
-aAz
-aAz
+oIs
+oIs
 nwM
 tCz
 gRR
@@ -133308,7 +133276,7 @@ nLs
 bTE
 tUm
 oPF
-tll
+kgh
 rSb
 umn
 svw
@@ -134072,7 +134040,7 @@ bsZ
 fZH
 cTK
 whA
-iPC
+fUo
 iDO
 iDO
 iDO
@@ -134081,8 +134049,8 @@ vCV
 lFG
 waB
 fMO
-dXk
-jUP
+sxe
+fKC
 kHT
 vPk
 vPk
@@ -134331,7 +134299,7 @@ qcT
 mrP
 daq
 daq
-ene
+kvi
 egG
 iEf
 hrT
@@ -134873,9 +134841,9 @@ hdV
 bhn
 evV
 oKM
-syF
+iYG
 wCx
-vnk
+pBf
 oDZ
 bau
 nkc
@@ -135132,7 +135100,7 @@ enq
 bgZ
 gCp
 tRh
-xou
+uUF
 oyx
 mRP
 eZT
@@ -135629,7 +135597,7 @@ gpz
 nds
 gpz
 wjD
-lnt
+gPB
 bbv
 awp
 odu
@@ -135886,7 +135854,7 @@ adw
 adw
 adw
 wjD
-gPB
+woY
 cgv
 owM
 ekM
@@ -136389,7 +136357,7 @@ jlK
 tEF
 tne
 cEZ
-wic
+tro
 iGS
 ciX
 jau
@@ -136924,7 +136892,7 @@ qTx
 qTx
 lGc
 rjD
-pBf
+wXl
 uSc
 uib
 uSc
@@ -137171,13 +137139,13 @@ tEF
 sHQ
 dpc
 sHQ
-suI
+jEs
 blv
 sqb
 uck
 sqb
-xHi
 hQQ
+gDv
 qTx
 bUU
 iky
@@ -137443,7 +137411,7 @@ doE
 doE
 doE
 lgU
-wuc
+gpJ
 mhm
 doE
 mnD
@@ -137941,7 +137909,7 @@ wwi
 aYN
 wwi
 lfm
-rET
+lqu
 tZn
 oyb
 nAM
@@ -137959,7 +137927,7 @@ oyb
 bzt
 bzt
 rcq
-tzl
+nwD
 tYK
 wtC
 wtC
@@ -138975,7 +138943,7 @@ xNR
 rMP
 nAi
 vfr
-dDL
+auB
 rDd
 jcO
 iNE
@@ -139732,7 +139700,7 @@ tRk
 vdt
 rwG
 srt
-mrB
+grs
 dOS
 rfL
 qsE
@@ -140192,14 +140160,14 @@ kHU
 kHU
 kHU
 yaE
-joR
+ejv
 yaE
 kHU
 plf
 plf
 kHU
 yaE
-joR
+ejv
 yaE
 kHU
 kHU
@@ -140706,14 +140674,14 @@ yaE
 ffS
 aev
 yaE
-qgt
+guc
 yaE
 aqg
 aqg
 aqg
 mlH
 yaE
-qgt
+guc
 yaE
 eeB
 ffS
@@ -140760,7 +140728,7 @@ kBq
 biv
 pED
 bNa
-qJQ
+noE
 kIU
 lBN
 yeY
@@ -141017,7 +140985,7 @@ dtM
 fty
 abG
 vLv
-qJQ
+noE
 kIU
 jVV
 ekm
@@ -141734,7 +141702,7 @@ yaE
 ffS
 eeB
 yaE
-qgt
+guc
 yaE
 mlH
 nhe
@@ -142093,7 +142061,7 @@ oZa
 xyx
 dJC
 gjY
-xXH
+bJx
 kdp
 xfI
 eIi
@@ -142248,7 +142216,7 @@ kHU
 kHU
 kHU
 yaE
-joR
+ejv
 yaE
 kHU
 plf
@@ -142785,11 +142753,11 @@ dbB
 idn
 fRR
 ofi
-bwk
+glf
 miI
 ffS
 jjY
-fOp
+lki
 wwi
 pkS
 wwi
@@ -143079,7 +143047,7 @@ gNR
 fZQ
 nIu
 qMb
-fuM
+pSV
 jxa
 egV
 aaz
@@ -143338,7 +143306,7 @@ iSv
 xXt
 vAu
 ogP
-uct
+cul
 bAS
 nvi
 rnH
@@ -143354,7 +143322,7 @@ qbj
 qbj
 tmk
 ldb
-jOF
+wmh
 ogP
 iSi
 amv
@@ -143381,7 +143349,7 @@ vpT
 xei
 bFh
 vpT
-ueH
+mVn
 vIl
 olx
 frM
@@ -143549,7 +143517,7 @@ plf
 brw
 mko
 jsL
-npp
+mub
 ffX
 hbE
 sTt
@@ -143818,7 +143786,7 @@ gHT
 alc
 vDr
 fDL
-oTb
+gba
 iwy
 xXt
 gNR
@@ -143850,7 +143818,7 @@ hAK
 kne
 twi
 xXt
-cdQ
+mUy
 ogP
 nvi
 kRo
@@ -144324,10 +144292,10 @@ fYS
 slo
 ffS
 pLB
-bwk
-dDs
+glf
+nJx
 acf
-roq
+dDs
 aSq
 ffS
 gvF
@@ -144396,8 +144364,8 @@ dAL
 aCF
 xvF
 mmd
-jEs
-vIk
+nvi
+cdQ
 aVg
 jWO
 lrQ
@@ -144599,17 +144567,17 @@ hXb
 hXb
 hXb
 che
-uiu
-iNd
-uiu
-uiu
-uiu
-uiu
-uiu
-uiu
-uiu
-elJ
-uiu
+siM
+aWN
+siM
+siM
+siM
+siM
+siM
+siM
+siM
+rTC
+siM
 vos
 did
 did
@@ -144653,7 +144621,7 @@ ofA
 uQo
 gER
 mmd
-jEs
+nvi
 qdX
 aVg
 ssF
@@ -144866,7 +144834,7 @@ fjB
 qSx
 dtr
 czE
-rSh
+sOy
 tJq
 gIl
 rdY
@@ -144910,7 +144878,7 @@ gkV
 ixe
 wfH
 mmd
-jEs
+nvi
 bXp
 hvB
 bCO
@@ -145103,7 +145071,7 @@ kHU
 yaE
 hkD
 fYS
-vFf
+axf
 wts
 mge
 qed
@@ -145332,7 +145300,7 @@ yaE
 ffS
 aev
 yaE
-ucx
+qgt
 yaE
 ygh
 cPq
@@ -145383,13 +145351,13 @@ mpN
 uQg
 tJq
 oFm
-uGW
+gQW
 xsb
-uGW
-uGW
-uGW
+gQW
+gQW
+gQW
 mtf
-uGW
+gQW
 jpq
 bsc
 mfI
@@ -145617,7 +145585,7 @@ plf
 yaE
 vDr
 fYS
-nra
+kBE
 tEo
 nIB
 iEL
@@ -145681,7 +145649,7 @@ dAL
 skM
 aFt
 mmd
-jEs
+nvi
 qyR
 aVg
 wqk
@@ -145874,7 +145842,7 @@ kHU
 yaE
 csG
 fYS
-aHB
+mdd
 wts
 npC
 txi
@@ -145897,13 +145865,13 @@ cCx
 mES
 tJq
 ikZ
-sRT
+omc
 oki
-vTX
-vTX
-hjv
+fTx
+fTx
+hve
 tWH
-hjv
+hve
 qcF
 bRX
 qSi
@@ -146131,7 +146099,7 @@ kHU
 yaE
 csG
 fYS
-cbB
+tzx
 wts
 bCJ
 euO
@@ -146154,7 +146122,7 @@ tJq
 ucP
 tJq
 fSC
-sHg
+jNN
 ktM
 uuo
 djH
@@ -146195,7 +146163,7 @@ gGp
 plZ
 mUn
 mmd
-jEs
+nvi
 mKJ
 aVg
 vkR
@@ -146360,14 +146328,14 @@ yaE
 ffS
 eeB
 yaE
-ucx
+qgt
 yaE
 mlH
 iOK
 iOK
 iOK
 yaE
-ucx
+qgt
 yaE
 aev
 ffS
@@ -146637,10 +146605,10 @@ fYS
 jNI
 ffS
 ylK
-hiK
+btz
 cmX
 fRR
-uld
+akr
 ryG
 ffS
 uAC
@@ -146708,7 +146676,7 @@ geq
 pQD
 plf
 plf
-mMA
+oXw
 dKM
 skY
 aVg
@@ -146965,7 +146933,7 @@ xMO
 aMC
 kHU
 kHU
-esZ
+rNH
 hJJ
 rvt
 uLu
@@ -147222,7 +147190,7 @@ kxd
 pQD
 plf
 plf
-mMA
+oXw
 ixa
 iex
 mMA
@@ -147662,7 +147630,7 @@ yaE
 yaE
 csG
 fYS
-bSL
+fOp
 alc
 gHT
 gHT
@@ -147671,7 +147639,7 @@ gHT
 gHT
 gHT
 alc
-pPw
+mYf
 fYS
 sEX
 srs
@@ -147737,7 +147705,7 @@ eXe
 gsq
 uoS
 pQD
-siM
+oHl
 mKJ
 mMA
 bLg
@@ -147921,12 +147889,12 @@ lrr
 fYS
 wtr
 sDu
-iZp
-uNq
-uNq
-uNq
-uNq
-hEM
+mmK
+jKe
+jKe
+jKe
+jKe
+uRs
 xao
 csG
 fYS
@@ -147994,7 +147962,7 @@ eXe
 hfS
 pDU
 pQD
-jEs
+nvi
 mKJ
 mMA
 vEH
@@ -149187,14 +149155,14 @@ xjr
 xjr
 plf
 yaE
-mym
+nBW
 yaE
 yaE
 yaE
 yaE
 yaE
 yaE
-mym
+nBW
 yaE
 plf
 plf
@@ -149278,7 +149246,7 @@ kxd
 pQD
 plf
 plf
-mMA
+oXw
 wFk
 xVa
 mMA
@@ -149444,14 +149412,14 @@ yaE
 ffS
 aev
 yaE
-ucx
+qgt
 yaE
 aqg
 aqg
 aqg
 mlH
 yaE
-ucx
+qgt
 yaE
 eeB
 ffS
@@ -149535,7 +149503,7 @@ aty
 aMC
 kHU
 kHU
-esZ
+rNH
 tit
 wmZ
 uLu
@@ -149792,7 +149760,7 @@ geq
 pQD
 plf
 plf
-mMA
+oXw
 lTU
 iic
 rZn
@@ -150822,7 +150790,7 @@ bEH
 aaw
 hEr
 hmn
-wmh
+vAu
 rZn
 oWQ
 ffV
@@ -151130,7 +151098,7 @@ sbN
 uKh
 sHC
 npd
-xOX
+nip
 xQo
 mUL
 rmY
@@ -151593,7 +151561,7 @@ vTS
 vIR
 hEr
 cOD
-wmh
+vAu
 pCp
 rZn
 lRo
@@ -151850,8 +151818,8 @@ tJR
 dqK
 fus
 wMM
-wmh
-lki
+vAu
+fuM
 rZn
 rWn
 xWS
@@ -152107,7 +152075,7 @@ gtQ
 iOV
 hEr
 wMM
-wmh
+vAu
 hpf
 rZn
 lcn
@@ -152365,7 +152333,7 @@ hEr
 xCJ
 pAS
 qEV
-mMA
+oXw
 rZn
 rZn
 rZn
@@ -152606,7 +152574,7 @@ mXl
 mXl
 mXl
 wLD
-tGa
+rxv
 iwm
 mXl
 pRS
@@ -152624,7 +152592,7 @@ oNU
 mXl
 uxx
 xMc
-lNm
+jNh
 nvi
 rnH
 cLM
@@ -152936,7 +152904,7 @@ xQo
 xQo
 xQo
 nKU
-ejv
+ghB
 xQo
 oPI
 mRu
@@ -153103,7 +153071,7 @@ cpR
 gtK
 cpR
 pxL
-kgH
+oGg
 ffJ
 ape
 fZz
@@ -153122,7 +153090,7 @@ hRd
 ckx
 fZz
 lMB
-snV
+gZr
 kzb
 vAu
 psV
@@ -153136,7 +153104,7 @@ vAu
 kRo
 vAu
 kCI
-lYQ
+eBc
 ogP
 lwr
 mLS
@@ -153379,7 +153347,7 @@ cmN
 act
 uuf
 xsY
-xZI
+uFa
 jTW
 jTW
 jTW
@@ -153859,7 +153827,7 @@ fnT
 miA
 ojm
 lPc
-ntU
+sVN
 gaF
 rpV
 qSe
@@ -154116,11 +154084,11 @@ nkb
 adb
 hzP
 cpR
-xbt
-pKi
-uXI
-pKi
+plo
 oOk
+uXI
+oOk
+fWL
 xqF
 aAF
 iqI
@@ -157227,8 +157195,8 @@ plf
 xyC
 cFp
 klH
-hab
-hab
+ntN
+ntN
 hGr
 aRu
 xyC
@@ -157752,8 +157720,8 @@ dnn
 aEr
 wPw
 jQy
-njy
-uEp
+uMf
+lcG
 jcX
 fJg
 nPU
@@ -158245,11 +158213,11 @@ plf
 cHH
 cHH
 jxX
-gDk
+iUJ
 bjt
 stv
 jxX
-gDk
+iUJ
 jxX
 adp
 kMq
@@ -158260,9 +158228,9 @@ xyC
 xyC
 xyC
 xyC
-wpm
+kgH
 jtG
-thS
+wpm
 fJg
 fJg
 fJg
@@ -158506,7 +158474,7 @@ opt
 kms
 cHH
 eow
-eek
+wxp
 goK
 hYT
 nsn
@@ -158759,7 +158727,7 @@ leA
 cHH
 adG
 iGB
-aGr
+ian
 tTk
 qMX
 aZz
@@ -159020,7 +158988,7 @@ ikW
 qXE
 rjb
 utF
-vhb
+esZ
 uLd
 lat
 nsn
@@ -159819,7 +159787,7 @@ kIM
 vst
 mDV
 vKG
-cVY
+tZu
 xoq
 tAM
 uQA
@@ -160538,14 +160506,14 @@ fAF
 fgx
 diq
 fAF
-uHN
+vTX
 eTq
 fAF
 wNM
 oPD
 tif
 rHZ
-efG
+iwN
 czU
 tqK
 hsq
@@ -160802,7 +160770,7 @@ qZx
 qZx
 fXG
 qZx
-pSu
+oXz
 czU
 uvV
 kMw
@@ -161308,7 +161276,7 @@ blh
 cra
 hlv
 dVr
-wCR
+wwn
 hlv
 fBm
 bvC
@@ -162332,7 +162300,7 @@ aXC
 bZu
 pLw
 unD
-uOh
+cdd
 oAx
 ulK
 eyO
@@ -162884,9 +162852,9 @@ ilq
 uKd
 sxG
 uOc
-hAA
-hAA
 hur
+hur
+nXk
 ekd
 lZw
 gqC
@@ -163140,7 +163108,7 @@ ixl
 mme
 uKd
 gRX
-inG
+oCX
 sRa
 nUj
 wUB
@@ -163169,13 +163137,13 @@ ncp
 ncp
 hbR
 mWz
-bHi
+apO
 kLd
 syX
 tHk
 tHk
 dbf
-bFL
+vIk
 ram
 mWz
 lNQ
@@ -163432,7 +163400,7 @@ eFl
 aRb
 nDG
 jjN
-fHS
+cZj
 ram
 mWz
 ucd
@@ -163639,7 +163607,7 @@ afw
 nDf
 mZo
 qUR
-oib
+uHN
 mzV
 aSh
 mpR
@@ -163940,13 +163908,13 @@ ncp
 ncp
 hbR
 mWz
-bUJ
+tNo
 sIY
 qls
 uOM
 uOM
 aeG
-jbL
+bFL
 ram
 mWz
 hPr
@@ -164136,7 +164104,7 @@ lhK
 wVg
 aFN
 jKZ
-kaa
+ucx
 rBo
 hlv
 qxh
@@ -164400,7 +164368,7 @@ xIO
 jps
 xIO
 qZx
-nRo
+kOo
 tbS
 sZR
 kHU
@@ -164412,7 +164380,7 @@ fwH
 qoH
 vOW
 qoH
-wSO
+pDr
 umQ
 gYp
 kHU
@@ -164650,7 +164618,7 @@ jvm
 hlv
 fVW
 fPH
-kaa
+ucx
 rnI
 hlv
 pHz
@@ -164665,11 +164633,11 @@ kHU
 plf
 cYc
 ueE
-iQd
+ucG
 wcJ
 iRz
 nez
-vJg
+gMq
 hlh
 gYp
 plf
@@ -164922,11 +164890,11 @@ kHU
 kHU
 cYc
 nfj
-wEP
+qnv
 eaE
 nRk
 rZh
-mKe
+eZG
 hmN
 gYp
 kHU
@@ -164970,7 +164938,7 @@ dJL
 nRG
 oXA
 oXA
-fBN
+bmL
 dJL
 plf
 cdR
@@ -165179,11 +165147,11 @@ plf
 kHU
 huz
 sIx
-xSU
-nkJ
+gRB
+rDD
 kjv
-nkJ
-cFG
+rDD
+hiT
 tEU
 huz
 plf
@@ -167228,7 +167196,7 @@ plf
 kHU
 hlv
 lrm
-oYy
+bcT
 jno
 hlv
 cBu
@@ -168308,7 +168276,7 @@ kHU
 fMh
 plf
 dJL
-fBN
+bmL
 oXA
 oXA
 nJn

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -204,6 +204,20 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/bridge/meeting_room)
+"abm" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 9;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "abp" = (
 /obj/structure/easel,
 /obj/effect/decal/cleanable/dirt,
@@ -471,6 +485,10 @@
 	layer = 4;
 	name = "Observation Screen";
 	network = list("Interrogation")
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "blackchecker"
@@ -1582,6 +1600,16 @@
 /obj/structure/dumbbells_rack,
 /turf/simulated/floor,
 /area/station/security/prison)
+"akI" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-B";
+	location = "SSW-B"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "akJ" = (
 /obj/item/device/radio/beacon,
 /turf/simulated/floor,
@@ -3252,6 +3280,19 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/minisat_secure_area)
+"aDH" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "aDL" = (
 /obj/item/weapon/caution,
 /turf/simulated/floor/plating,
@@ -3327,9 +3368,14 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/door_timer/cell_5{
+/obj/machinery/door_control{
+	desc = "A remote control switch for the brig foyer.";
+	id = "cell5";
+	name = "Cell 5 Doors";
+	normaldoorcontrol = 0;
 	pixel_x = 32;
-	pixel_y = 0
+	range = 10;
+	req_access = list(2)
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
@@ -4942,6 +4988,7 @@
 /obj/effect/decal/cleanable/cobweb,
 /obj/item/weapon/reagent_containers/glass/bucket,
 /obj/structure/window/thin,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/security/prison)
 "aXN" = (
@@ -6212,7 +6259,7 @@
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/brig{
-	id = "Cell 4";
+	id = "Cell 4 perma";
 	name = "Cell 4 Locker"
 	},
 /turf/simulated/floor,
@@ -7141,6 +7188,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/machinery/flasher{
+	id = "Cell 2 perma";
+	pixel_y = -28
+	},
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "bvG" = (
@@ -7178,16 +7229,6 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
-"bwk" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-C";
-	location = "CS-AR"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "bwm" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -7224,6 +7265,10 @@
 	},
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "blackchecker"
@@ -7685,6 +7730,16 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"bBc" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/station/security/brig)
 "bBe" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/window/thin{
@@ -11513,6 +11568,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/machinery/flasher{
+	id = "Cell 4 perma";
+	pixel_y = -28
+	},
 /turf/simulated/floor,
 /area/station/security/prison)
 "crx" = (
@@ -12743,6 +12802,15 @@
 	},
 /turf/simulated/floor/carpet/red,
 /area/station/security/detectives_office)
+"cFx" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "cFz" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13767,6 +13835,15 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
+"cQQ" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "cQR" = (
 /obj/structure/sign/poster/official/work_for_a_future{
 	pixel_y = -32
@@ -15435,18 +15512,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/brig)
-"dkx" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "dkB" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
@@ -15704,6 +15769,18 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/port)
+"doY" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "dpc" = (
 /obj/machinery/door/firedoor,
 /obj/structure/plasticflaps{
@@ -16712,13 +16789,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/medbay)
-"dAK" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=CS-AR";
-	location = "SWW-FC"
-	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
 "dAL" = (
 /turf/simulated/floor{
 	icon_state = "grimy"
@@ -18276,7 +18346,7 @@
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/brig{
-	id = "Cell 3";
+	id = "Cell 3 perma";
 	name = "Cell 3 Locker"
 	},
 /turf/simulated/floor,
@@ -19978,28 +20048,20 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
-/obj/machinery/door_timer/cell_4{
+/obj/machinery/door_control{
+	desc = "A remote control switch for the brig foyer.";
+	id = "cell4";
+	name = "Cell 4 Doors";
+	normaldoorcontrol = 0;
 	pixel_x = 32;
-	pixel_y = 0
+	range = 10;
+	req_access = list(2)
 	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
-"epU" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "eqn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
@@ -20255,20 +20317,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/civilian/dormitories)
-"etB" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 10;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "etL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -20305,6 +20353,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/security/prison)
 "etS" = (
@@ -20894,6 +20943,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/security/prison)
 "eAq" = (
@@ -21563,7 +21613,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
-	id = "Cell 5";
+	id = "Cell 5 perma";
 	name = "Cell 5";
 	req_access = list(2)
 	},
@@ -22483,9 +22533,14 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
-/obj/machinery/door_timer/cell_2{
+/obj/machinery/door_control{
+	desc = "A remote control switch for the brig foyer.";
+	id = "cell2";
+	name = "Cell 2 Doors";
+	normaldoorcontrol = 0;
 	pixel_x = 32;
-	pixel_y = 0
+	range = 10;
+	req_access = list(2)
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -23552,7 +23607,7 @@
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/clothing/mask/muzzle,
 /turf/simulated/floor{
-	icon_state = "redfull"
+	icon_state = "vaultfull"
 	},
 /area/station/security/prison)
 "ffL" = (
@@ -23638,14 +23693,11 @@
 /turf/simulated/floor,
 /area/station/medical/storage)
 "fgx" = (
-/obj/machinery/door_control{
-	desc = "A remote control switch for the brig foyer.";
-	id = "cell4";
-	name = "Cell 4 Doors";
-	normaldoorcontrol = 0;
+/obj/machinery/door_timer/cell_4{
 	pixel_x = 32;
-	range = 10;
-	req_access = list(2)
+	pixel_y = 0;
+	dir = 4;
+	id = "Cell 4 perma"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -24284,13 +24336,6 @@
 /obj/item/device/healthanalyzer,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
-"fql" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "fqo" = (
 /obj/machinery/light/smart{
 	dir = 8
@@ -24764,13 +24809,6 @@
 	},
 /turf/environment/space,
 /area/shuttle/mining/station)
-"fum" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-FC";
-	location = "SSW-FC"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/starboard)
 "fus" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -24982,6 +25020,10 @@
 /area/station/rnd/tox_launch)
 "fwH" = (
 /mob/living/simple_animal/corgi/borgi,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -25298,6 +25340,7 @@
 /area/station/hallway/primary/fore)
 "fAy" = (
 /obj/machinery/hydroponics/constructable,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "greencorner"
@@ -25376,7 +25419,7 @@
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/brig{
-	id = "Cell 2";
+	id = "Cell 2 perma";
 	name = "Cell 2 Locker"
 	},
 /turf/simulated/floor,
@@ -26368,10 +26411,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "fOp" = (
-/turf/simulated/floor{
-	icon_state = "vaultfull"
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Labor Camp Shuttle Airlock";
+	req_access = list(2)
 	},
-/area/station/security/blueshield)
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
 "fOF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
@@ -26412,7 +26462,6 @@
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
 "fOV" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/security/prison/toilet)
@@ -27099,7 +27148,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
-	id = "Cell 1";
+	id = "Cell 1 perma";
 	name = "Cell 1";
 	req_access = list(2)
 	},
@@ -27977,6 +28026,16 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway/lobby)
+"giq" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NEE-FC";
+	location = "S-SV"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "gis" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/green,
@@ -29853,6 +29912,14 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge/captain_quarters)
+"gAh" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/civilian/gym)
 "gAj" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced/tinted{
@@ -30614,6 +30681,19 @@
 	icon_state = "black"
 	},
 /area/station/hallway/secondary/exit)
+"gKc" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "gKj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -31118,6 +31198,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/flasher{
+	id = "Cell 3 perma";
+	pixel_y = -28
+	},
 /turf/simulated/floor,
 /area/station/security/prison)
 "gRg" = (
@@ -31139,15 +31223,6 @@
 	icon_state = "white"
 	},
 /area/station/medical/hallway)
-"gRh" = (
-/obj/effect/decal/turf_decal/alpha/blue{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "gRi" = (
 /obj/machinery/door/airlock{
 	id_tag = "Arrivals_Toilet3";
@@ -32227,6 +32302,7 @@
 "hcP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/window/southright,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/security/prison)
 "hcX" = (
@@ -33142,19 +33218,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/civilian/locker)
-"hoT" = (
-/obj/machinery/light/smart{
-	dir = 4
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NE-FC";
-	location = "NEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "hpb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/decal/turf_decal/alpha/dark_red{
@@ -33574,6 +33637,9 @@
 	id = "Prison Lockdown";
 	name = "Prison Lockdown";
 	opacity = 0
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -35009,7 +35075,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/security/prison)
 "hGQ" = (
 /obj/structure/disposalpipe/segment{
@@ -35099,6 +35167,11 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/hallway)
+"hHC" = (
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "hHI" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/cleanable/dirt,
@@ -36631,6 +36704,15 @@
 "hZU" = (
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
+"iab" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "iag" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -40778,6 +40860,15 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/distribution)
+"iVF" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "iVK" = (
 /obj/structure/rack,
 /obj/item/weapon/mop,
@@ -41193,6 +41284,10 @@
 	dir = 6;
 	network = list("SS13","Security")
 	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn_corner"
+	},
 /turf/simulated/floor{
 	icon_state = "redcorner"
 	},
@@ -41521,25 +41616,6 @@
 	icon_state = "yellow"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
-"jem" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/main)
 "jeq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -41561,6 +41637,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/alarm{
+	pixel_y = -32
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -41631,16 +41710,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
-"jfC" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SEE-FC";
-	location = "SE-FC"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "jfD" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -41710,6 +41779,9 @@
 	id = "Prison Lockdown";
 	name = "Prison Lockdown";
 	opacity = 0
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -42319,6 +42391,10 @@
 /obj/structure/stool/bed/chair{
 	dir = 1
 	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "jnw" = (
@@ -42612,17 +42688,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
-"jrm" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "jrs" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
@@ -43014,6 +43079,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"juH" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
+	},
+/turf/simulated/floor/carpet/red,
+/area/station/security/detectives_office)
 "juQ" = (
 /obj/structure/object_wall/cargo{
 	icon_state = "0,0"
@@ -43985,7 +44056,7 @@
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/brig{
-	id = "Cell 5";
+	id = "Cell 5 perma";
 	name = "Cell 5 Locker"
 	},
 /turf/simulated/floor,
@@ -44389,16 +44460,6 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge/captain_quarters)
-"jJP" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-B";
-	location = "SSW-B"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "jKp" = (
 /obj/effect/decal/turf_decal{
 	dir = 5;
@@ -44741,17 +44802,6 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/locker)
-"jNf" = (
-/obj/machinery/light/smart,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DS";
-	location = "DN-W"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "purplecorner"
-	},
-/area/station/hallway/primary/central)
 "jNg" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -44812,7 +44862,9 @@
 /obj/structure/table/reinforced,
 /obj/item/weapon/clipboard,
 /obj/item/weapon/pen,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/security/prison)
 "jNI" = (
 /obj/structure/sign/nanotrasen{
@@ -45449,7 +45501,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
-	id = "Cell 4";
+	id = "Cell 4 perma";
 	name = "Cell 4";
 	req_access = list(2)
 	},
@@ -45487,6 +45539,13 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/science)
+"jVb" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=N-MB";
+	location = "NNW-B"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "jVh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/stool/bed/chair/wood/normal{
@@ -46774,6 +46833,15 @@
 	icon_state = "black"
 	},
 /area/station/civilian/gym)
+"kjh" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Security";
+	location = "S-C"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "kjv" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -46784,6 +46852,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -47195,6 +47267,15 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/central)
+"kod" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "koi" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -48181,6 +48262,9 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -22
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
 	},
 /turf/simulated/floor{
 	icon_state = "grimy"
@@ -49480,6 +49564,9 @@
 	name = "Prison Lockdown";
 	opacity = 0
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -49529,6 +49616,7 @@
 /area/station/maintenance/science)
 "kNn" = (
 /obj/structure/window/thin,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/security/prison)
 "kNx" = (
@@ -49621,6 +49709,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
+"kOB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "kOM" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -50046,6 +50145,13 @@
 	icon_state = "dark"
 	},
 /area/station/security/checkpoint/escape)
+"kTQ" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-MB";
+	location = "N-MB"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "kUa" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/food/condiment/saltshaker{
@@ -50588,6 +50694,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/security/prison)
 "kYZ" = (
@@ -51503,18 +51610,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
-"llg" = (
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Labor Camp Shuttle Airlock";
-	req_access = list(2)
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/brig)
 "lli" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -51718,19 +51813,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
-"lnQ" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "lnS" = (
 /obj/effect/landmark/start/recycler,
 /obj/machinery/hologram/holopad,
@@ -51999,6 +52081,10 @@
 /area/station/security/checkpoint/medbay)
 "lrm" = (
 /obj/structure/closet/emcloset,
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "lrp" = (
@@ -52549,6 +52635,26 @@
 	icon_state = "neutralfull"
 	},
 /area/station/cargo/storage)
+"lxA" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "lxE" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -52608,6 +52714,16 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/medbay)
+"lyl" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-FC";
+	location = "DS"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
+/area/station/hallway/primary/central)
 "lyr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -52773,8 +52889,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/alarm{
-	pixel_y = -32
+/obj/machinery/flasher{
+	id = "Cell 5 perma";
+	pixel_y = -28
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
@@ -53332,6 +53449,18 @@
 	icon_state = "wooden"
 	},
 /area/station/bridge/corp_lounge)
+"lGM" = (
+/obj/machinery/door_timer/cell_3{
+	pixel_x = 32;
+	pixel_y = 0;
+	dir = 4;
+	id = "Cell 3 perma"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "lGS" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -54066,6 +54195,7 @@
 	dir = 9;
 	network = list("SS13","Security")
 	},
+/obj/item/device/plant_analyzer,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "lOJ" = (
@@ -54440,18 +54570,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
-"lTG" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "lTH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -55409,6 +55527,15 @@
 	icon_state = "dark"
 	},
 /area/station/security/iaa_office)
+"mgH" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 5
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "mgK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56432,15 +56559,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/storage/tech)
-"msh" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Security";
-	location = "S-C"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "msk" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -57050,10 +57168,6 @@
 /area/station/medical/cryo)
 "mzF" = (
 /obj/machinery/hologram/holopad{
-	pixel_y = -16
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot";
 	pixel_y = -16
 	},
 /turf/simulated/floor{
@@ -58243,6 +58357,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -58896,6 +59011,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel)
+"mUV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/flasher{
+	id = "Cell 1 perma";
+	pixel_y = -28
+	},
+/turf/simulated/floor,
+/area/station/security/prison)
 "mVg" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -58932,14 +59060,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/machinery/door_control{
-	desc = "A remote control switch for the brig foyer.";
-	id = "cell5";
-	name = "Cell 5 Doors";
-	normaldoorcontrol = 0;
+/obj/machinery/door_timer/cell_5{
 	pixel_x = 32;
-	range = 10;
-	req_access = list(2)
+	pixel_y = 0;
+	dir = 4;
+	id = "Cell 5 perma"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -59553,6 +59678,17 @@
 	icon_state = "vaultfull"
 	},
 /area/station/maintenance/engineering)
+"ncX" = (
+/obj/machinery/light/smart,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DS";
+	location = "DN-W"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "purplecorner"
+	},
+/area/station/hallway/primary/central)
 "nda" = (
 /obj/structure/table/reinforced,
 /obj/item/device/radio/intercom{
@@ -62453,6 +62589,26 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"nLu" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "nLP" = (
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
@@ -62568,15 +62724,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
-"nNx" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-B";
-	location = "S-MB"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/secondary/entry)
 "nNG" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
@@ -62634,6 +62781,25 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/reception)
+"nOT" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/main)
 "nOU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -63349,6 +63515,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"nWe" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "nWf" = (
 /obj/machinery/iv_drip,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -64879,7 +65055,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/turf_decal{
-	dir = 9;
+	dir = 10;
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
@@ -65162,7 +65338,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -65441,7 +65617,9 @@
 "owL" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/box/ids,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/security/prison)
 "owM" = (
 /obj/structure/stool/bed/chair/office/dark{
@@ -65477,6 +65655,26 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/wood,
 /area/station/maintenance/medbay)
+"oxM" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "oxO" = (
 /obj/structure/sign/warning/secure_area,
 /turf/simulated/wall/r_wall,
@@ -66129,7 +66327,7 @@
 	pixel_y = 22
 	},
 /turf/simulated/floor{
-	icon_state = "redfull"
+	icon_state = "vaultfull"
 	},
 /area/station/security/prison)
 "oGp" = (
@@ -66529,6 +66727,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
+"oLj" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "oLl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -66995,6 +67201,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "greencorner"
@@ -67038,9 +67245,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/machinery/door_timer/cell_1{
+/obj/machinery/door_control{
+	desc = "A remote control switch for the brig foyer.";
+	id = "cell1";
+	name = "Cell 1 Doors";
+	normaldoorcontrol = 0;
 	pixel_x = 32;
-	pixel_y = 0
+	range = 10;
+	req_access = list(2)
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -67640,7 +67852,7 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor{
-	icon_state = "redfull"
+	icon_state = "vaultfull"
 	},
 /area/station/security/prison)
 "oYq" = (
@@ -68382,6 +68594,16 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/secondary/exit)
+"pho" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SWW-FC";
+	location = "SW-FC"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "pht" = (
 /obj/structure/table/woodentable/fancy/black,
 /obj/structure/window/thin/reinforced{
@@ -69126,12 +69348,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
-"ppk" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
-	},
-/turf/simulated/floor/carpet/red,
-/area/station/security/detectives_office)
 "ppl" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -69195,6 +69411,10 @@
 "ppD" = (
 /obj/structure/stool/bed,
 /obj/item/weapon/bedsheet/medical,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "whitered"
@@ -70379,7 +70599,7 @@
 	pixel_y = 20;
 	req_one_access = list(13,45,1)
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating/airless/catwalk,
 /area/space)
 "pDa" = (
 /obj/machinery/nuclearbomb{
@@ -71621,6 +71841,13 @@
 	icon_state = "vaultfull"
 	},
 /area/station/tcommsat/chamber)
+"pQJ" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=CS-AR";
+	location = "SWW-FC"
+	},
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "pQK" = (
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = -32
@@ -72100,6 +72327,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "greencorner"
@@ -72742,6 +72970,14 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/library)
+"qew" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/security/prison)
 "qeL" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -73506,6 +73742,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
+"qnx" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-B";
+	location = "S-MB"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry)
 "qnB" = (
 /obj/item/clothing/gloves/boxing/green,
 /obj/item/clothing/gloves/boxing/yellow,
@@ -74308,6 +74553,7 @@
 /area/station/medical/psych)
 "qxx" = (
 /mob/living/simple_animal/mouse,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/security/prison)
 "qxK" = (
@@ -74909,6 +75155,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/security/prison)
 "qEZ" = (
@@ -74964,6 +75211,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/cmo)
+"qFB" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-C";
+	location = "CS-AR"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "qFO" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -75775,8 +76032,21 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/security/prison)
+"qQs" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "qQt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -76206,14 +76476,6 @@
 	icon_state = "redchecker"
 	},
 /area/station/hallway/primary/fore)
-"qUu" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/civilian/gym)
 "qUz" = (
 /obj/structure/sink{
 	dir = 8;
@@ -76313,6 +76575,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "qVM" = (
@@ -76405,17 +76668,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
-"qXj" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "loadingarea"
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "arrow"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "qXu" = (
 /obj/machinery/portable_atmospherics/powered/pump,
 /obj/machinery/atmospherics/components/unary/portables_connector{
@@ -77011,16 +77263,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
-"reK" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Central Access"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "rfw" = (
 /obj/machinery/camera{
 	c_tag = "Port Primary Hallway East"
@@ -78895,6 +79137,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	icon_state = "redcorner"
 	},
@@ -79313,16 +79559,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
-"rFz" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSE-FC";
-	location = "SEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "rFB" = (
 /obj/machinery/light/smart,
 /obj/effect/decal/turf_decal{
@@ -79495,17 +79731,14 @@
 	name = "Prison Lockdown";
 	opacity = 0
 	},
-/obj/machinery/door_control{
-	desc = "A remote control switch for the brig foyer.";
-	id = "cell1";
-	name = "Cell 1 Doors";
-	normaldoorcontrol = 0;
-	pixel_x = 32;
-	range = 10;
-	req_access = list(2)
-	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
+	},
+/obj/machinery/door_timer/cell_1{
+	pixel_x = 32;
+	pixel_y = 0;
+	dir = 4;
+	id = "Cell 1 perma"
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
@@ -81575,6 +81808,13 @@
 	icon_state = "gcircuit"
 	},
 /area/station/bridge/ai_upload)
+"sfB" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "sfJ" = (
 /obj/structure/object_wall/mining{
 	icon_state = "3-1"
@@ -81839,7 +82079,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
-	id = "Cell 2";
+	id = "Cell 2 perma";
 	name = "Cell 2";
 	req_access = list(2)
 	},
@@ -82755,16 +82995,6 @@
 	icon_state = "wooden"
 	},
 /area/station/bridge/corp_lounge)
-"ssN" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NEE-FC";
-	location = "S-SV"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "sta" = (
 /obj/structure/table/reinforced,
 /obj/item/device/flashlight/lamp,
@@ -83577,6 +83807,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -83841,6 +84075,16 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/toilet)
+"sGt" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NNW-B";
+	location = "NW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "sGy" = (
 /obj/structure/table/woodentable,
 /obj/item/stack/sheet/cloth{
@@ -84216,6 +84460,16 @@
 /obj/item/weapon/circuitboard/space_heater,
 /turf/simulated/floor,
 /area/station/maintenance/science)
+"sLt" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SEE-FC";
+	location = "SE-FC"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "sLC" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -84567,13 +84821,6 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/sleeper)
-"sPC" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=N-MB";
-	location = "NNW-B"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "sPM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -86312,6 +86559,12 @@
 	icon_state = "neutralfull"
 	},
 /area/station/medical/cryo)
+"tmj" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "cafeteria"
+	},
+/area/station/security/prison)
 "tmk" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -86558,6 +86811,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
+"tpk" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-FC";
+	location = "SSW-FC"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/starboard)
 "tpp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -89067,15 +89327,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/bridge)
-"tVh" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DN";
-	location = "SSE-FC"
-	},
-/turf/simulated/floor{
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "tVx" = (
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -89106,27 +89357,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/reception)
-"tVJ" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "tVO" = (
 /obj/machinery/vending/security,
 /obj/structure/reagent_dispensers/peppertank{
@@ -89397,16 +89627,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories)
-"tZc" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SE-FC";
-	location = "SW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "tZe" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/decal/turf_decal/alpha/orange{
@@ -89661,15 +89881,25 @@
 	},
 /area/station/rnd/hallway)
 "ucx" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SWW-FC";
-	location = "SW-FC"
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "loadingarea"
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "arrow"
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "dark"
 	},
-/area/station/hallway/primary/central)
+/area/station/security/brig)
+"ucC" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DN";
+	location = "SSE-FC"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "ucF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -90123,6 +90353,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/window/southleft,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/security/prison)
 "uio" = (
@@ -92174,15 +92405,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "uHN" = (
-/obj/machinery/door_timer/cell_3{
-	pixel_x = 32;
-	pixel_y = 0
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Central Access"
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "redcorner"
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
-/area/station/security/prison)
+/area/station/security/lobby)
 "uHX" = (
 /turf/simulated/floor/wood,
 /area/station/maintenance/chapel)
@@ -92573,6 +92804,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/security/prison)
 "uNw" = (
@@ -94757,6 +94989,16 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
+"voF" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSE-FC";
+	location = "SEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "voI" = (
 /obj/machinery/disposal,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -94947,7 +95189,7 @@
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/brig{
-	id = "Cell 1";
+	id = "Cell 1 perma";
 	name = "Cell 1 Locker"
 	},
 /turf/simulated/floor/plating,
@@ -95227,6 +95469,7 @@
 /area/station/ai_monitored/storage_secure)
 "vtZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/security/prison)
 "vuj" = (
@@ -96427,7 +96670,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
-	id = "Cell 3";
+	id = "Cell 3 perma";
 	name = "Cell 3";
 	req_access = list(2)
 	},
@@ -96875,6 +97118,7 @@
 /area/station/engineering/atmos)
 "vPF" = (
 /obj/machinery/hydroponics/constructable,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
 	icon_state = "greencorner"
 	},
@@ -97214,15 +97458,15 @@
 	},
 /area/station/bridge/teleporter)
 "vTX" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SE-FC";
+	location = "SW-B"
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkred"
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
-/area/station/security/brig)
+/area/station/hallway/primary/central)
 "vUe" = (
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
@@ -97398,6 +97642,13 @@
 	icon_state = "greenblue"
 	},
 /area/station/civilian/hydroponics)
+"vWA" = (
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/prison)
 "vWF" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
@@ -97456,13 +97707,6 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/break_room)
-"vWV" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-MB";
-	location = "N-MB"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "vXb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -98337,7 +98581,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/security/prison)
 "wir" = (
 /obj/effect/decal/turf_decal{
@@ -99072,6 +99318,10 @@
 /turf/simulated/floor,
 /area/station/gateway)
 "wra" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "whitered"
@@ -99179,6 +99429,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/security/prison)
 "wsk" = (
@@ -99232,16 +99483,6 @@
 	icon_state = "darkred"
 	},
 /area/station/security/warden)
-"wsJ" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NNW-B";
-	location = "NW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "wsS" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -99676,6 +99917,10 @@
 	name = "Prison Wing Lockdown";
 	pixel_y = 26;
 	req_access = list(2)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -100903,14 +101148,11 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/supermatter)
 "wNM" = (
-/obj/machinery/door_control{
-	desc = "A remote control switch for the brig foyer.";
-	id = "cell2";
-	name = "Cell 2 Doors";
-	normaldoorcontrol = 0;
+/obj/machinery/door_timer/cell_2{
 	pixel_x = 32;
-	range = 10;
-	req_access = list(2)
+	pixel_y = 0;
+	dir = 4;
+	id = "Cell 2 perma"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -101109,6 +101351,27 @@
 	icon_state = "white"
 	},
 /area/station/rnd/hallway)
+"wQb" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "wQz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
@@ -102220,6 +102483,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/hallway)
+"xel" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "xer" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -103962,16 +104237,6 @@
 	icon_state = "bluecorner"
 	},
 /area/station/engineering/minisat_secure_area)
-"xxW" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-FC";
-	location = "DS"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "bluecorner"
-	},
-/area/station/hallway/primary/central)
 "xyb" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -105064,6 +105329,19 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
+"xKZ" = (
+/obj/machinery/light/smart{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NE-FC";
+	location = "NEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "xLe" = (
 /obj/machinery/portable_atmospherics/powered/pump,
 /obj/machinery/light/smart{
@@ -105172,6 +105450,7 @@
 	pixel_y = 22
 	},
 /obj/structure/window/thin,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/security/prison)
 "xLZ" = (
@@ -106707,6 +106986,10 @@
 	pixel_y = -6
 	},
 /obj/item/weapon/bedsheet/medical,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "whitered"
@@ -106977,6 +107260,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/security/prison)
 "yhv" = (
@@ -135444,7 +135728,7 @@ doE
 doE
 doE
 lgU
-jfC
+sLt
 mhm
 doE
 mnD
@@ -135942,7 +136226,7 @@ wwi
 aYN
 wwi
 lfm
-rFz
+voF
 tZn
 oyb
 nAM
@@ -135960,7 +136244,7 @@ oyb
 bzt
 bzt
 rcq
-tVh
+ucC
 tYK
 wtC
 wtC
@@ -141339,7 +141623,7 @@ iSv
 xXt
 vAu
 ogP
-jJP
+akI
 bAS
 nvi
 rnH
@@ -141355,7 +141639,7 @@ qbj
 qbj
 tmk
 ldb
-tZc
+vTX
 ogP
 iSi
 amv
@@ -141382,7 +141666,7 @@ vpT
 xei
 bFh
 vpT
-jNf
+ncX
 vIl
 olx
 frM
@@ -141550,7 +141834,7 @@ plf
 brw
 mko
 jsL
-nNx
+qnx
 ffX
 hbE
 sTt
@@ -141819,7 +142103,7 @@ gHT
 alc
 vDr
 fDL
-wsJ
+sGt
 iwy
 xXt
 gNR
@@ -145663,7 +145947,7 @@ yaE
 yaE
 csG
 fYS
-vWV
+kTQ
 alc
 gHT
 gHT
@@ -145672,7 +145956,7 @@ gHT
 gHT
 gHT
 alc
-sPC
+jVb
 fYS
 sEX
 srs
@@ -150607,7 +150891,7 @@ mXl
 mXl
 mXl
 wLD
-ssN
+giq
 iwm
 mXl
 pRS
@@ -150625,7 +150909,7 @@ oNU
 mXl
 uxx
 xMc
-ucx
+pho
 nvi
 rnH
 cLM
@@ -150634,7 +150918,7 @@ nvi
 tOH
 mfI
 ogP
-xxW
+lyl
 sBG
 wjc
 wjc
@@ -150937,7 +151221,7 @@ xQo
 xQo
 xQo
 nKU
-fum
+tpk
 xQo
 oPI
 mRu
@@ -151104,7 +151388,7 @@ cpR
 gtK
 cpR
 pxL
-hoT
+xKZ
 ffJ
 ape
 fZz
@@ -151123,7 +151407,7 @@ hRd
 ckx
 fZz
 lMB
-msh
+kjh
 kzb
 vAu
 psV
@@ -151137,7 +151421,7 @@ vAu
 kRo
 vAu
 kCI
-bwk
+qFB
 ogP
 lwr
 mLS
@@ -151378,7 +151662,7 @@ erD
 erD
 cmN
 act
-reK
+uHN
 xsY
 uuf
 jTW
@@ -155228,8 +155512,8 @@ plf
 xyC
 cFp
 klH
-ppk
-ppk
+juH
+juH
 hGr
 aRu
 xyC
@@ -155732,11 +156016,11 @@ plf
 plf
 plf
 uRO
-llg
+fOp
 uRO
 plf
 uRO
-llg
+fOp
 uRO
 plf
 xyC
@@ -155753,8 +156037,8 @@ dnn
 aEr
 wPw
 jQy
-gRh
-fOp
+kod
+hHC
 jcX
 fJg
 nPU
@@ -156261,7 +156545,7 @@ xyC
 xyC
 xyC
 xyC
-fql
+sfB
 jtG
 wpm
 fJg
@@ -156503,11 +156787,11 @@ wVt
 cHH
 cjS
 bNB
-etB
+opt
 kms
 cHH
 eow
-opt
+abm
 goK
 hYT
 nsn
@@ -156760,7 +157044,7 @@ leA
 cHH
 adG
 iGB
-vTX
+bBc
 tTk
 qMX
 aZz
@@ -157021,7 +157305,7 @@ ikW
 qXE
 rjb
 utF
-qXj
+ucx
 uLd
 lat
 nsn
@@ -157820,7 +158104,7 @@ kIM
 vst
 mDV
 vKG
-dAK
+pQJ
 xoq
 tAM
 uQA
@@ -158537,16 +158821,16 @@ mVk
 epp
 fAF
 fgx
-uHN
-fAF
 diq
+fAF
+lGM
 eTq
 fAF
 wNM
 oPD
 tif
 rHZ
-tnw
+oxM
 czU
 tqK
 hsq
@@ -158803,7 +159087,7 @@ qZx
 qZx
 fXG
 qZx
-tnw
+lxA
 czU
 uvV
 kMw
@@ -159315,7 +159599,7 @@ fBm
 bvC
 hlv
 vqQ
-gQC
+mUV
 qZx
 tnw
 fLE
@@ -160333,7 +160617,7 @@ aXC
 bZu
 pLw
 unD
-unD
+qew
 oAx
 ulK
 eyO
@@ -160887,7 +161171,7 @@ sxG
 uOc
 hur
 hur
-lnQ
+aDH
 ekd
 lZw
 gqC
@@ -161141,7 +161425,7 @@ ixl
 mme
 uKd
 gRX
-dkx
+xel
 sRa
 nUj
 wUB
@@ -161170,13 +161454,13 @@ ncp
 ncp
 hbR
 mWz
-lTG
+doY
 kLd
 syX
 tHk
 tHk
 dbf
-tVJ
+wQb
 ram
 mWz
 lNQ
@@ -161433,7 +161717,7 @@ eFl
 aRb
 nDG
 jjN
-epU
+gKc
 ram
 mWz
 ucd
@@ -161640,7 +161924,7 @@ afw
 nDf
 mZo
 qUR
-jem
+nOT
 mzV
 aSh
 mpR
@@ -161941,7 +162225,7 @@ ncp
 ncp
 hbR
 mWz
-jrm
+qQs
 sIY
 qls
 uOM
@@ -162137,7 +162421,7 @@ lhK
 wVg
 aFN
 jKZ
-bsD
+tmj
 rBo
 hlv
 qxh
@@ -162401,7 +162685,7 @@ xIO
 jps
 xIO
 qZx
-tnw
+nLu
 tbS
 sZR
 kHU
@@ -162413,7 +162697,7 @@ fwH
 qoH
 vOW
 qoH
-eaE
+oLj
 umQ
 gYp
 kHU
@@ -162651,7 +162935,7 @@ jvm
 hlv
 fVW
 fPH
-bsD
+tmj
 rnI
 hlv
 pHz
@@ -162666,11 +162950,11 @@ kHU
 plf
 cYc
 ueE
-aMp
+nWe
 wcJ
 iRz
 nez
-uym
+kOB
 hlh
 gYp
 plf
@@ -162923,11 +163207,11 @@ kHU
 kHU
 cYc
 nfj
-eaE
+iVF
 eaE
 nRk
 rZh
-rZh
+cFx
 hmN
 gYp
 kHU
@@ -162971,7 +163255,7 @@ dJL
 nRG
 oXA
 oXA
-qUu
+gAh
 dJL
 plf
 cdR
@@ -163180,11 +163464,11 @@ plf
 kHU
 huz
 sIx
-eaE
-eaE
+mgH
+cQQ
 kjv
-eaE
-eaE
+cQQ
+iab
 tEU
 huz
 plf
@@ -163434,7 +163718,7 @@ cdI
 qZx
 qZx
 qZx
-quq
+nHd
 huz
 huz
 xlU
@@ -163692,7 +163976,7 @@ xsU
 ffr
 rnT
 pCL
-quq
+nHd
 huz
 hgX
 sps
@@ -163948,7 +164232,7 @@ xVn
 qZx
 hlv
 qZx
-quq
+nHd
 kHU
 huz
 jqN
@@ -165229,7 +165513,7 @@ plf
 kHU
 hlv
 lrm
-onb
+vWA
 jno
 hlv
 cBu
@@ -166309,7 +166593,7 @@ kHU
 fMh
 plf
 dJL
-qUu
+gAh
 oXA
 oXA
 nJn

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -418,6 +418,15 @@
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/space)
+"acr" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "act" = (
 /obj/structure/sign/directions/command{
 	dir = 1
@@ -1134,13 +1143,6 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
-"agQ" = (
-/obj/item/weapon/flora/random,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_right"
-	},
-/turf/simulated/floor,
-/area/station/storage/tech)
 "agS" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/smart{
@@ -1168,6 +1170,19 @@
 	icon_state = "grimy"
 	},
 /area/station/tcommsat/computer)
+"ahc" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "ahh" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -1655,6 +1670,18 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
+"alh" = (
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Labor Camp Shuttle Airlock";
+	req_access = list(2)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
 "alj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -3350,17 +3377,6 @@
 	icon_state = "wooden"
 	},
 /area/station/civilian/library)
-"aEz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "aEB" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3504,26 +3520,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/hallway/primary/starboard)
-"aFq" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "aFr" = (
 /obj/machinery/photocopier,
 /obj/effect/decal/cleanable/dirt,
@@ -4409,22 +4405,13 @@
 /obj/item/device/multitool,
 /obj/item/device/multitool,
 /obj/item/clothing/gloves/insulated,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
 /area/station/engineering/break_room)
-"aQd" = (
-/obj/effect/decal/turf_decal/alpha/blue{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "aQh" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -4718,6 +4705,13 @@
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/station/security/vacantoffice)
+"aTm" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-MB";
+	location = "N-MB"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "aTn" = (
 /turf/simulated/floor{
 	icon_state = "white"
@@ -4904,6 +4898,9 @@
 	name = "Station Intercom (General)";
 	pixel_x = -28;
 	pixel_y = -5
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
 	},
 /turf/simulated/floor{
 	icon_state = "yellow"
@@ -5952,6 +5949,10 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -6755,25 +6756,6 @@
 	icon_state = "wooden"
 	},
 /area/station/medical/psych)
-"bpI" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DN";
-	location = "SSE-FC"
-	},
-/turf/simulated/floor{
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
-"bpJ" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-B";
-	location = "SSW-B"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "bpO" = (
 /obj/effect/landmark/start/assistant/test_subject,
 /obj/machinery/light/smart{
@@ -7130,6 +7112,10 @@
 	},
 /obj/machinery/alarm{
 	pixel_y = 22
+	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -8320,6 +8306,13 @@
 "bFL" = (
 /obj/structure/stool/bed/chair/metal/white{
 	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
 	},
 /obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "siding_line";
@@ -10907,19 +10900,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/chapel)
-"cht" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/flasher{
-	id = "Cell 3 perma";
-	pixel_y = -28
-	},
-/turf/simulated/floor,
-/area/station/security/prison)
 "chv" = (
 /obj/effect/decal/cleanable/blood,
 /turf/simulated/floor,
@@ -11553,17 +11533,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
-"cou" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos/atmos_office)
 "cox" = (
 /obj/structure/table/woodentable,
 /obj/item/device/radio/intercom,
@@ -11635,6 +11604,16 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/dormitories/courtroom)
+"cpg" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "cpj" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/sparker{
@@ -11653,18 +11632,6 @@
 	name = "(A) Air Vent"
 	},
 /turf/simulated/floor/engine/airmix,
-/area/station/engineering/atmos)
-"cpK" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
 /area/station/engineering/atmos)
 "cpL" = (
 /obj/machinery/light/smart{
@@ -12120,26 +12087,6 @@
 	icon_state = "white"
 	},
 /area/station/rnd/hor)
-"cwk" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "cwt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -12257,6 +12204,9 @@
 	},
 /obj/structure/drain{
 	drainage = 2
+	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "box_white"
 	},
 /obj/effect/decal/turf_decal{
 	dir = 8;
@@ -12415,12 +12365,6 @@
 	icon_state = "caution"
 	},
 /area/station/medical/chemistry)
-"cze" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "browncorner"
-	},
-/area/station/cargo/storage)
 "czg" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -12521,6 +12465,10 @@
 	},
 /obj/item/device/cardpay{
 	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "warn";
+	dir = 9
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -13947,6 +13895,17 @@
 	icon_state = "grimy"
 	},
 /area/station/maintenance/medbay)
+"cQh" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "loadingarea"
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "arrow"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "cQi" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -14476,6 +14435,16 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
+"cVK" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-B";
+	location = "SSW-B"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "cVO" = (
 /obj/structure/object_wall/pod{
 	icon_state = "1,2"
@@ -14583,6 +14552,20 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/civilian/locker)
+"cWX" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "escape"
+	},
+/area/station/hallway/primary/port)
 "cXg" = (
 /obj/structure/table/woodentable,
 /obj/item/device/flashlight/lamp{
@@ -15273,6 +15256,10 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -16020,16 +16007,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/station/cargo/storage)
-"dpx" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NEE-FC";
-	location = "S-SV"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "dpF" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -17107,17 +17084,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/hallway/primary/fore)
-"dDi" = (
-/obj/machinery/light/smart,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DS";
-	location = "DN-W"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "purplecorner"
-	},
-/area/station/hallway/primary/central)
 "dDn" = (
 /obj/structure/table/reinforced,
 /obj/item/device/plant_analyzer,
@@ -17466,6 +17432,26 @@
 	icon_state = "blackcorner"
 	},
 /area/station/hallway/primary/starboard)
+"dHf" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "dHv" = (
 /obj/machinery/door/poddoor{
 	id = "armouryaccess";
@@ -17738,6 +17724,16 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/warden)
+"dKl" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-FC";
+	location = "DS"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
+/area/station/hallway/primary/central)
 "dKn" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -18356,6 +18352,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
+"dTm" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSE-FC";
+	location = "SEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "dTp" = (
 /obj/structure/sign/warning/secure_area{
 	pixel_y = -14
@@ -19730,12 +19736,14 @@
 	},
 /area/station/hallway/primary/starboard)
 "ejv" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=N-MB";
-	location = "NNW-B"
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "ejG" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 1
@@ -20129,6 +20137,10 @@
 	opacity = 0
 	},
 /obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
 	icon_state = "warn"
 	},
 /turf/simulated/floor,
@@ -20779,6 +20791,10 @@
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
 	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
 /turf/simulated/floor,
 /area/station/engineering/break_room)
 "evW" = (
@@ -21076,6 +21092,19 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
+"eyA" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "eyD" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -21447,6 +21476,16 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/engine)
+"eDn" = (
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "eDr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -21470,6 +21509,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"eDV" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/civilian/gym)
 "eDZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -21788,6 +21835,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -22190,6 +22240,19 @@
 	icon_state = "purple"
 	},
 /area/station/rnd/xenobiology)
+"eMZ" = (
+/obj/machinery/light/smart{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NE-FC";
+	location = "NEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "eNj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
@@ -22844,6 +22907,9 @@
 	},
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -23106,9 +23172,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
-	},
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -23859,16 +23922,16 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/starboard)
-"ffC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/decal/turf_decal/alpha/dark_red{
+"ffD" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/effect/decal/turf_decal/alpha/orange{
 	icon_state = "siding_line";
-	dir = 1
+	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "grimy"
+	icon_state = "neutralfull"
 	},
-/area/station/security/hos)
+/area/station/engineering/atmos)
 "ffG" = (
 /obj/machinery/light/smart{
 	dir = 8
@@ -24347,6 +24410,9 @@
 	},
 /area/station/civilian/dormitories/courtroom)
 "flb" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line"
+	},
 /turf/simulated/floor/wood,
 /area/station/engineering/break_room)
 "flf" = (
@@ -24434,6 +24500,16 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/lobby)
+"fmd" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "fmh" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 1
@@ -24565,6 +24641,21 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
+"fog" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/engineering/monitoring)
 "foh" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor,
@@ -24988,6 +25079,10 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "warn";
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -25863,6 +25958,9 @@
 /area/station/security/checkpoint/cargo)
 "fDg" = (
 /obj/machinery/photocopier,
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line"
+	},
 /turf/simulated/floor/wood,
 /area/station/engineering/break_room)
 "fDm" = (
@@ -26723,14 +26821,16 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "fOp" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/structure/disposalpipe/segment,
 /obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
+	icon_state = "siding_corner";
 	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
-/area/station/hallway/primary/fore)
+/area/station/engineering/atmos/atmos_office)
 "fOF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
@@ -27072,26 +27172,6 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/primary/fore)
-"fSy" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "fSC" = (
 /obj/machinery/vending/theater,
 /turf/simulated/floor{
@@ -28341,6 +28421,9 @@
 	name = "Station Intercom (General)";
 	pixel_y = -32
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -28623,16 +28706,6 @@
 	icon_state = "red"
 	},
 /area/station/security/checkpoint)
-"gki" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSE-FC";
-	location = "SEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "gkn" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/turf_decal/alpha/gray{
@@ -29864,6 +29937,10 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 6
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -30433,6 +30510,15 @@
 /obj/structure/girder,
 /turf/simulated/floor,
 /area/station/maintenance/medbay)
+"gBU" = (
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "gBV" = (
 /obj/machinery/computer/borgupload,
 /turf/simulated/floor{
@@ -30457,8 +30543,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "dark"
 	},
 /area/station/engineering/engine)
 "gCE" = (
@@ -31074,20 +31166,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
-"gKE" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "escape"
-	},
-/area/station/hallway/primary/port)
 "gKG" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -31472,8 +31550,7 @@
 	dir = 4
 	},
 /obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 8
+	icon_state = "siding_line"
 	},
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
@@ -31662,6 +31739,9 @@
 	c_tag = "Chief Engineer's Office";
 	dir = 5;
 	network = list("SS13","Engineering")
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -32203,6 +32283,9 @@
 /obj/structure/rack,
 /obj/item/weapon/storage/lockbox/anti_singulo,
 /obj/machinery/light/smart,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -32788,16 +32871,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/checkpoint)
-"hek" = (
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "heo" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -33269,7 +33342,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -33773,6 +33846,18 @@
 	icon_state = "darkred"
 	},
 /area/station/security/brig)
+"hqr" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "hqu" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/structure/stool/bed/chair/office/dark{
@@ -34373,6 +34458,26 @@
 	},
 /turf/simulated/floor,
 /area/station/bridge/captain_quarters)
+"hvW" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "hvY" = (
 /obj/machinery/light/smart{
 	dir = 4
@@ -35426,17 +35531,6 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/chapel)
-"hGc" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "hGd" = (
 /obj/machinery/power/solar_control{
 	id = "aftport";
@@ -35509,23 +35603,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/barbershop)
-"hGG" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "caution"
-	},
-/area/station/engineering/atmos/distribution)
 "hGJ" = (
 /obj/structure/closet/secure_closet/brig{
 	name = "Prisoner Locker"
@@ -37723,6 +37800,16 @@
 	icon_state = "vaultfull"
 	},
 /area/station/bridge)
+"igB" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "igF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -39672,19 +39759,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
-"iCX" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "iDi" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -39773,7 +39847,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
+	icon_state = "siding_corner";
 	dir = 8
 	},
 /turf/simulated/floor,
@@ -40179,13 +40253,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
-"iHz" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=CS-AR";
-	location = "SWW-FC"
-	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
 "iHJ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -40477,6 +40544,19 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"iLO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "iLP" = (
 /obj/machinery/power/rad_collector{
 	anchored = 1
@@ -41538,19 +41618,6 @@
 "iXs" = (
 /turf/simulated/floor,
 /area/station/rnd/hor)
-"iXu" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "iXC" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -42038,16 +42105,6 @@
 	},
 /turf/environment/space,
 /area/shuttle/escape_pod5/station)
-"jcW" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-C";
-	location = "CS-AR"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "jcX" = (
 /obj/machinery/alarm{
 	pixel_y = -32
@@ -45561,6 +45618,13 @@
 	icon_state = "blackchecker"
 	},
 /area/station/civilian/barbershop)
+"jPg" = (
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/prison)
 "jPt" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -45989,6 +46053,10 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -46586,6 +46654,18 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/dormitories/courtroom)
+"kaJ" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "kaL" = (
 /obj/effect/decal/turf_decal/metal{
 	icon_state = "siding_thinplating_line";
@@ -46636,6 +46716,16 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/secondary/exit)
+"kbs" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/station/security/brig)
 "kbD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -46838,6 +46928,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/scibreak)
+"kdX" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-FC";
+	location = "SSW-FC"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/starboard)
 "kdY" = (
 /obj/machinery/flasher/portable,
 /obj/machinery/light/smart{
@@ -47160,23 +47257,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "kgH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "khm" = (
 /obj/machinery/power/apc{
 	name = "apc down";
@@ -48436,13 +48522,6 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge/hop_office)
-"kuv" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-MB";
-	location = "N-MB"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "kuF" = (
 /obj/structure/rack,
 /obj/item/clothing/head/helmet/space/skrell/black,
@@ -49288,25 +49367,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/supermatter)
-"kFF" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/main)
 "kFI" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -49616,16 +49676,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/emergency)
-"kIc" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SEE-FC";
-	location = "SE-FC"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "kIf" = (
 /obj/structure/window/shuttle/reinforced/mining{
 	icon_state = "5-4"
@@ -50038,6 +50088,13 @@
 	icon_state = "vaultfull"
 	},
 /area/station/medical/genetics)
+"kLy" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "kLE" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engine Room";
@@ -50309,6 +50366,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
+"kOC" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "kOM" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -50379,13 +50445,6 @@
 	icon_state = "red"
 	},
 /area/station/security/checkpoint/medbay)
-"kQi" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-FC";
-	location = "SSW-FC"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/starboard)
 "kQr" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 1
@@ -52315,15 +52374,6 @@
 	icon_state = "darkred"
 	},
 /area/station/security/execution)
-"lmx" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "lmF" = (
 /obj/machinery/computer/crew{
 	dir = 8
@@ -53347,6 +53397,10 @@
 	pixel_x = 25
 	},
 /obj/machinery/light/smart,
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "warn";
+	dir = 10
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -53714,6 +53768,24 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/lobby)
+"lDN" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "lDO" = (
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/incinerator)
@@ -55205,6 +55277,13 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/fore)
+"lUJ" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_right"
+	},
+/turf/simulated/floor,
+/area/station/storage/tech)
 "lUT" = (
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -55475,12 +55554,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"lYd" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "cafeteria"
-	},
-/area/station/security/prison)
 "lYm" = (
 /obj/structure/window/thin/reinforced{
 	dir = 8
@@ -56700,6 +56773,14 @@
 "mne" = (
 /turf/simulated/wall,
 /area/station/medical/sleeper)
+"mnf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/security/prison)
 "mnm" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -56754,6 +56835,18 @@
 	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
+"mnJ" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "mnK" = (
 /obj/machinery/camera{
 	c_tag = "Captain's Office";
@@ -57495,6 +57588,19 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/medbay)
+"mvK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "mvQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -58211,16 +58317,6 @@
 "mDI" = (
 /turf/simulated/wall,
 /area/station/civilian/chapel/office)
-"mDN" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NNW-B";
-	location = "NW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "mDV" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -58290,19 +58386,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/cargo)
-"mEQ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 9
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "mES" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -58980,16 +59063,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/sleeper)
-"mOK" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "mOU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -59094,6 +59167,10 @@
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -59365,18 +59442,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/range)
-"mSh" = (
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Labor Camp Shuttle Airlock";
-	req_access = list(2)
-	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/brig)
 "mSl" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -60530,6 +60595,17 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/storage)
+"nfX" = (
+/obj/machinery/light/smart,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DS";
+	location = "DN-W"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "purplecorner"
+	},
+/area/station/hallway/primary/central)
 "nfY" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -61453,6 +61529,9 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "yellow"
@@ -61710,17 +61789,6 @@
 /obj/item/weapon/folder/white,
 /turf/simulated/floor/carpet,
 /area/station/bridge/meeting_room)
-"ntx" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "yellow"
-	},
-/area/station/engineering/atmos)
 "ntM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -62856,6 +62924,16 @@
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
+"nGE" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Central Access"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "nGM" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Upper Cells";
@@ -63324,6 +63402,12 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
+"nMG" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "browncorner"
+	},
+/area/station/cargo/storage)
 "nMJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
@@ -63994,6 +64078,18 @@
 	icon_state = "dark"
 	},
 /area/station/medical/morgue)
+"nTE" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "nTN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -64088,15 +64184,6 @@
 	icon_state = "white"
 	},
 /area/station/medical/virology)
-"nUD" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "nUE" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -64621,6 +64708,20 @@
 	icon_state = "grimy"
 	},
 /area/station/tcommsat/computer)
+"oat" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 10;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "oay" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -65123,6 +65224,18 @@
 	icon_state = "vaultfull"
 	},
 /area/station/tcommsat/chamber)
+"ogG" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "ogL" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -65216,16 +65329,6 @@
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "browncorner"
-	},
-/area/station/cargo/storage)
-"ohC" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "brown"
 	},
 /area/station/cargo/storage)
 "ohG" = (
@@ -65419,6 +65522,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall/r_wall,
 /area/station/rnd/tox_launch)
+"ojH" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 5
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "ojN" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -65714,7 +65826,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/turf_decal{
-	dir = 10;
+	dir = 9;
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
@@ -65889,6 +66001,20 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/civilian/locker)
+"orX" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/pump,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "arrival"
+	},
+/area/station/hallway/primary/port)
 "osg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -66367,8 +66493,12 @@
 	name = "Engine Room";
 	req_access = list(10)
 	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "dark"
 	},
 /area/station/engineering/engine)
 "oyG" = (
@@ -66784,8 +66914,12 @@
 	name = "Engine Room";
 	req_access = list(10)
 	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "dark"
 	},
 /area/station/engineering/engine)
 "oEf" = (
@@ -66908,6 +67042,10 @@
 	name = "MiniSat Monitor";
 	network = list("MiniSat");
 	pixel_y = -30
+	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -67352,6 +67490,10 @@
 	name = "Engine Room";
 	req_access = list(10)
 	},
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -67759,7 +67901,7 @@
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	dir = 4;
+	dir = 6;
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
@@ -69293,20 +69435,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/reception)
-"phP" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor,
-/area/station/engineering/monitoring)
 "phV" = (
 /turf/simulated/floor{
 	icon_state = "yellowcorner"
@@ -69379,6 +69507,9 @@
 	},
 /obj/machinery/keycard_auth{
 	pixel_x = -24
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -69455,6 +69586,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/break_room)
+"pjr" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_right"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/cold_room)
 "pjw" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/folder/blue,
@@ -69470,14 +69610,6 @@
 	icon_state = "dark"
 	},
 /area/station/bridge/ai_upload)
-"pjH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/security/prison)
 "pjO" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -69690,6 +69822,18 @@
 	icon_state = "vaultfull"
 	},
 /area/station/storage/tech)
+"plD" = (
+/obj/machinery/door_timer/cell_3{
+	pixel_x = 32;
+	pixel_y = 0;
+	dir = 4;
+	id = "Cell 3 perma"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "plL" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -69895,11 +70039,6 @@
 /obj/item/weapon/caution,
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
-"pnV" = (
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "pnY" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -70502,16 +70641,6 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
-"pvp" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Central Access"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "pvu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -70641,8 +70770,8 @@
 /area/station/maintenance/auxsolarstarboard)
 "pwz" = (
 /obj/machinery/vending/cigarette,
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -70928,20 +71057,6 @@
 "pyL" = (
 /turf/environment/space,
 /area/shuttle/syndicate/north)
-"pyM" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 9;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "pyX" = (
 /obj/machinery/light/small,
 /obj/effect/decal/turf_decal/alpha/white{
@@ -71015,6 +71130,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/minisat_secure_area)
+"pzC" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "pzD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -72215,15 +72341,6 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/medical/virology)
-"pNX" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Security";
-	location = "S-C"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "pOh" = (
 /obj/effect/decal/turf_decal/alpha/blue{
 	icon_state = "siding_line"
@@ -72912,15 +73029,6 @@
 	icon_state = "grimy"
 	},
 /area/station/security/detectives_office)
-"pVw" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-B";
-	location = "S-MB"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/secondary/entry)
 "pVE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -73082,20 +73190,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboardsolar)
-"pXD" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/powered/pump,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "arrival"
-	},
-/area/station/hallway/primary/port)
 "pXL" = (
 /obj/structure/stool/bed/chair/comfy/beige{
 	dir = 8
@@ -73776,6 +73870,16 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/toilet)
+"qfo" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "qfC" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -74431,6 +74535,14 @@
 	icon_state = "gcircuit"
 	},
 /area/station/aisat/ai_chamber)
+"qmR" = (
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/break_room)
 "qmZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -74670,6 +74782,15 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hor)
+"qpn" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "qpp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -75014,6 +75135,19 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/misc_lab)
+"qtx" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/flasher{
+	id = "Cell 3 perma";
+	pixel_y = -28
+	},
+/turf/simulated/floor,
+/area/station/security/prison)
 "qtC" = (
 /obj/item/device/radio/intercom/pod{
 	dir = 4;
@@ -75027,16 +75161,6 @@
 	icon_state = "floor"
 	},
 /area/shuttle/escape_pod3/station)
-"qtL" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "qtS" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -75322,15 +75446,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/security/prison)
-"qxz" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "qxK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -75396,16 +75511,6 @@
 	icon_state = "dark"
 	},
 /area/station/bridge/ai_upload)
-"qyu" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkred"
-	},
-/area/station/security/brig)
 "qyx" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	frequency = 1444;
@@ -76314,6 +76419,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
 /turf/simulated/floor{
 	icon_state = "yellow"
 	},
@@ -76747,13 +76855,6 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/secondary/exit)
-"qPK" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "qPO" = (
 /obj/structure/sign/nanotrasen{
 	pixel_y = -32
@@ -77699,6 +77800,9 @@
 	dir = 8
 	},
 /obj/structure/bookcase/manuals/engineering,
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line"
+	},
 /turf/simulated/floor/wood,
 /area/station/engineering/break_room)
 "raz" = (
@@ -77865,6 +77969,13 @@
 "rbY" = (
 /turf/simulated/floor,
 /area/station/security/main)
+"rcj" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=CS-AR";
+	location = "SWW-FC"
+	},
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "rcq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -78061,6 +78172,16 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
+"rfp" = (
+/obj/machinery/light/smart,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "rfw" = (
 /obj/machinery/camera{
 	c_tag = "Port Primary Hallway East"
@@ -78146,6 +78267,15 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/dormitories/courtroom)
+"rgj" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "rgp" = (
 /obj/structure/closet/wardrobe/black,
 /obj/machinery/light/smart{
@@ -78475,16 +78605,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
-"rkt" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SWW-FC";
-	location = "SW-FC"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "rkx" = (
 /turf/simulated/wall,
 /area/station/engineering/drone_fabrication)
@@ -78719,6 +78839,9 @@
 "rnA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
 	},
 /turf/simulated/floor{
 	icon_state = "yellow"
@@ -79193,6 +79316,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/medbay)
+"rts" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "rtt" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -80281,6 +80417,15 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/server)
+"rEm" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Security";
+	location = "S-C"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "rEr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -81162,6 +81307,14 @@
 	},
 /turf/simulated/floor,
 /area/station/storage/tech)
+"rMQ" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "rMR" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 4
@@ -81310,7 +81463,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/engineering/minisat_secure_area)
 "rOF" = (
@@ -83287,6 +83440,23 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/range)
+"slH" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "slU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -83351,6 +83521,13 @@
 /obj/item/weapon/flora/random,
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
+"smm" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=N-MB";
+	location = "NNW-B"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "smv" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
@@ -84006,26 +84183,6 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/reception)
-"svg" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "svl" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/grass,
@@ -84236,6 +84393,16 @@
 	icon_state = "neutralfull"
 	},
 /area/station/storage/primary)
+"sxZ" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SWW-FC";
+	location = "SW-FC"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "syg" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -84455,6 +84622,16 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/chapel)
+"sAT" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SE-FC";
+	location = "SW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "sBe" = (
 /obj/structure/stool/bed/chair,
 /obj/structure/cable{
@@ -84954,12 +85131,6 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/toilet)
-"sGo" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
-	},
-/turf/simulated/floor/carpet/red,
-/area/station/security/detectives_office)
 "sGy" = (
 /obj/structure/table/woodentable,
 /obj/item/stack/sheet/cloth{
@@ -85036,6 +85207,23 @@
 /obj/machinery/status_display,
 /turf/simulated/wall,
 /area/station/storage/tech)
+"sHN" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "caution"
+	},
+/area/station/engineering/atmos/distribution)
 "sHQ" = (
 /turf/simulated/wall/r_wall,
 /area/station/engineering/monitoring)
@@ -85616,6 +85804,15 @@
 	icon_state = "blue"
 	},
 /area/station/civilian/dormitories/courtroom)
+"sOr" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DN";
+	location = "SSE-FC"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "sOu" = (
 /obj/structure/stool,
 /obj/item/device/radio/intercom{
@@ -85745,6 +85942,15 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/hallway)
+"sQk" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "sQq" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/window/thin{
@@ -85898,19 +86104,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/maintenance/incinerator)
-"sSA" = (
-/obj/machinery/light/smart{
-	dir = 4
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NE-FC";
-	location = "NEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "sSE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -86172,6 +86365,12 @@
 	icon_state = "1,6"
 	},
 /area/shuttle/supply/station)
+"sVk" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
+	},
+/turf/simulated/floor/carpet/red,
+/area/station/security/detectives_office)
 "sVo" = (
 /obj/machinery/door/airlock{
 	id_tag = "commissarydoor";
@@ -87120,16 +87319,6 @@
 	icon_state = "black"
 	},
 /area/station/hallway/primary/fore)
-"thY" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SE-FC";
-	location = "SW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "tif" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -87409,6 +87598,9 @@
 /obj/item/device/megaphone,
 /obj/item/weapon/stock_parts/cell/super,
 /obj/item/weapon/stock_parts/cell/super,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -87679,16 +87871,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
-"toM" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
 "toN" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -88234,18 +88416,6 @@
 	icon_state = "redfull"
 	},
 /area/station/security/prison)
-"twh" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "twi" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -88458,6 +88628,12 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/rnd/mixing)
+"tyv" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "cafeteria"
+	},
+/area/station/security/prison)
 "tyB" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -89126,6 +89302,36 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/bridge/hop_office)
+"tGk" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/main)
+"tGw" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "tGH" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/light/smart{
@@ -89653,6 +89859,18 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/xenobiology)
+"tMI" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "tMM" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
@@ -90752,16 +90970,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/distribution)
-"ubX" = (
-/obj/machinery/light/smart,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "ucd" = (
 /obj/structure/table,
 /obj/item/device/tagger/shop,
@@ -90824,14 +91032,16 @@
 	},
 /area/station/rnd/hallway)
 "ucx" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 1
 	},
-/turf/simulated/floor{
-	icon_state = "grimy"
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
 	},
-/area/station/security/hos)
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "ucF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -90958,6 +91168,16 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
+"ueg" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-C";
+	location = "CS-AR"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "uei" = (
 /obj/structure/filingcabinet,
 /obj/machinery/status_display{
@@ -90990,7 +91210,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/engineering/minisat_secure_area)
 "ueD" = (
@@ -91320,6 +91540,12 @@
 /obj/item/device/radio/intercom,
 /turf/simulated/floor/carpet,
 /area/station/bridge/meeting_room)
+"uiG" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "uiQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -91647,6 +91873,11 @@
 	icon_state = "3,1"
 	},
 /area/shuttle/supply/station)
+"ulF" = (
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "ulH" = (
 /obj/machinery/vending/boozeomat,
 /turf/simulated/floor{
@@ -92073,13 +92304,6 @@
 "uqj" = (
 /turf/simulated/wall,
 /area/station/bridge/cmf_room)
-"uqq" = (
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/prison)
 "uqt" = (
 /obj/effect/decal/turf_decal{
 	dir = 8;
@@ -93349,29 +93573,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/security/iaa_office)
-"uHt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
-"uHw" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-FC";
-	location = "DS"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "bluecorner"
-	},
-/area/station/hallway/primary/central)
 "uHA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/trinary/filter{
@@ -93386,12 +93587,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 8
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
 	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "uHX" = (
 /turf/simulated/floor/wood,
 /area/station/maintenance/chapel)
@@ -93786,12 +93989,18 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "uNw" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 8
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "uNx" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -95773,14 +95982,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
-"vlS" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/civilian/gym)
 "vme" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -95832,17 +96033,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
-"vmz" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "loadingarea"
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "arrow"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "vmG" = (
 /obj/effect/landmark/start/paramedic,
 /obj/structure/stool/bed/chair/comfy/brown{
@@ -96480,21 +96670,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/security/prison)
-"vub" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
 "vuj" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 29
@@ -97175,6 +97350,18 @@
 	icon_state = "whitepurplefull"
 	},
 /area/station/rnd/lab)
+"vDe" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/engineering/atmos/atmos_office)
 "vDf" = (
 /obj/machinery/dna_scannernew,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -97223,18 +97410,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
-"vDE" = (
-/obj/machinery/door_timer/cell_3{
-	pixel_x = 32;
-	pixel_y = 0;
-	dir = 4;
-	id = "Cell 3 perma"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "vDQ" = (
 /obj/structure/sign/warning/securearea,
 /turf/simulated/wall/r_wall,
@@ -97971,6 +98146,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -98514,13 +98693,26 @@
 	},
 /area/station/bridge/teleporter)
 "vTX" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "grimy"
+	dir = 1;
+	icon_state = "black"
 	},
-/area/station/security/hos)
+/area/station/civilian/gym)
 "vUe" = (
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
@@ -99212,15 +99404,6 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/reception)
-"wcw" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_right"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/civilian/cold_room)
 "wcD" = (
 /obj/structure/table/glass,
 /obj/machinery/light/smart{
@@ -99556,13 +99739,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
-"wgw" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "wgE" = (
 /obj/machinery/mass_driver{
 	dir = 8;
@@ -100311,30 +100487,10 @@
 "wpm" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
+	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/station/security/lobby)
-"wpK" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "wpM" = (
 /obj/structure/table/woodentable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -100529,19 +100685,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/security/prison)
-"wsf" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "wsk" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1
@@ -100940,15 +101083,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/incinerator)
-"wyj" = (
-/obj/effect/decal/turf_decal{
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "wyL" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -101840,6 +101974,10 @@
 /obj/machinery/requests_console/ce{
 	pixel_y = 32
 	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 5
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -101864,18 +102002,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/engine)
-"wHw" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "wHy" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/under/suit_jacket/red,
@@ -101895,6 +102021,16 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/main)
+"wHN" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SEE-FC";
+	location = "SE-FC"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "wHR" = (
 /obj/machinery/vending/sustenance,
 /turf/simulated/floor{
@@ -101944,6 +102080,9 @@
 /obj/structure/rack,
 /obj/item/weapon/storage/toolbox/mechanical,
 /obj/item/clothing/glasses/meson,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -102059,6 +102198,9 @@
 /obj/item/weapon/rcd_ammo,
 /obj/item/weapon/rcd_ammo,
 /obj/item/weapon/rcd_ammo,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -102092,15 +102234,6 @@
 	icon_state = "grimy"
 	},
 /area/station/storage/tools)
-"wKa" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 5
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "wKd" = (
 /obj/machinery/computer/cargo/request,
 /turf/simulated/floor/grass,
@@ -104135,7 +104268,7 @@
 	tag_interior_door = "engineering_aux_inner"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/engineering/minisat_secure_area)
 "xkE" = (
@@ -104393,6 +104526,19 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/storage)
+"xnX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "xob" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -105519,6 +105665,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -105590,6 +105739,16 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
+"xzW" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NEE-FC";
+	location = "S-SV"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "xAc" = (
 /obj/structure/closet,
 /obj/structure/cable{
@@ -106098,18 +106257,6 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/kitchen)
-"xFt" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/engineering/atmos/atmos_office)
 "xFy" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/box/cups{
@@ -106736,18 +106883,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
-"xNr" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "xNJ" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /turf/simulated/floor/engine,
@@ -107350,6 +107485,16 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/storage)
+"xUG" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NNW-B";
+	location = "NW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "xUM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -107706,7 +107851,7 @@
 "xXN" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/engineering/minisat_secure_area)
 "xXS" = (
@@ -107991,6 +108136,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"ybA" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-B";
+	location = "S-MB"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry)
 "ybG" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
@@ -108627,6 +108781,26 @@
 	icon_state = "neutralfull"
 	},
 /area/station/civilian/locker)
+"ykj" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "ykt" = (
 /obj/structure/sign/nanotrasen,
 /turf/simulated/wall/r_wall,
@@ -131524,7 +131698,7 @@ xFF
 xFG
 flb
 uDn
-bhn
+qmR
 ude
 ehA
 geB
@@ -131781,7 +131955,7 @@ qnQ
 hEd
 fDg
 owf
-bhn
+qmR
 hkb
 ehA
 fUz
@@ -132019,7 +132193,7 @@ bOJ
 oKV
 dup
 dup
-iXu
+eyA
 bOD
 cmG
 xqQ
@@ -132284,7 +132458,7 @@ oLJ
 kFc
 kFc
 cEO
-ntx
+ucx
 azQ
 pfp
 imT
@@ -132538,8 +132712,8 @@ bfy
 cmG
 dup
 htY
-mOK
-mOK
+ffD
+ffD
 nwM
 tCz
 gRR
@@ -132794,7 +132968,7 @@ nLs
 bTE
 tUm
 oPF
-iCX
+uNw
 rSb
 umn
 svw
@@ -133558,17 +133732,17 @@ bsZ
 fZH
 cTK
 whA
-xFt
 iDO
-iDO
-iDO
+vDe
+vDe
+vDe
 xnu
 vCV
 lFG
 waB
 fMO
-cpK
-xNr
+kaJ
+mnJ
 kHT
 vPk
 vPk
@@ -133817,7 +133991,7 @@ qcT
 mrP
 daq
 daq
-cou
+fOp
 egG
 iEf
 hrT
@@ -134359,9 +134533,9 @@ hdV
 bhn
 evV
 oKM
+ogG
 wCx
-wCx
-wCx
+hqr
 oDZ
 bau
 nkc
@@ -134616,7 +134790,7 @@ moL
 ojN
 enq
 bgZ
-gCp
+slH
 tRh
 gCp
 oyx
@@ -135115,7 +135289,7 @@ gpz
 nds
 gpz
 wjD
-phP
+gPB
 bbv
 awp
 odu
@@ -135372,7 +135546,7 @@ adw
 adw
 adw
 wjD
-gPB
+fog
 cgv
 owM
 ekM
@@ -135875,7 +136049,7 @@ jlK
 tEF
 tne
 cEZ
-hGG
+sHN
 iGS
 ciX
 jau
@@ -136657,12 +136831,12 @@ tEF
 sHQ
 dpc
 sHQ
-gKE
+cWX
 blv
 sqb
 uck
 sqb
-pXD
+orX
 hQQ
 qTx
 bUU
@@ -136929,7 +137103,7 @@ doE
 doE
 doE
 lgU
-kIc
+wHN
 mhm
 doE
 mnD
@@ -137427,7 +137601,7 @@ wwi
 aYN
 wwi
 lfm
-gki
+dTm
 tZn
 oyb
 nAM
@@ -137445,7 +137619,7 @@ oyb
 bzt
 bzt
 rcq
-bpI
+sOr
 tYK
 wtC
 wtC
@@ -138975,7 +139149,7 @@ xNR
 oYv
 cGN
 vzT
-agQ
+lUJ
 oVN
 cdA
 jTf
@@ -139218,7 +139392,7 @@ tRk
 vdt
 rwG
 srt
-wcw
+pjr
 dOS
 rfL
 qsE
@@ -140246,7 +140420,7 @@ kBq
 biv
 pED
 bNa
-toM
+fmd
 kIU
 lBN
 yeY
@@ -140503,7 +140677,7 @@ dtM
 fty
 abG
 vLv
-toM
+fmd
 kIU
 jVV
 ekm
@@ -142824,7 +142998,7 @@ iSv
 xXt
 vAu
 ogP
-bpJ
+cVK
 bAS
 nvi
 rnH
@@ -142840,7 +143014,7 @@ qbj
 qbj
 tmk
 ldb
-thY
+sAT
 ogP
 iSi
 amv
@@ -142867,7 +143041,7 @@ vpT
 xei
 bFh
 vpT
-dDi
+nfX
 vIl
 olx
 frM
@@ -143035,7 +143209,7 @@ plf
 brw
 mko
 jsL
-pVw
+ybA
 ffX
 hbE
 sTt
@@ -143304,7 +143478,7 @@ gHT
 alc
 vDr
 fDL
-mDN
+xUG
 iwy
 xXt
 gNR
@@ -144085,17 +144259,17 @@ hXb
 hXb
 hXb
 che
-fOp
-kgH
-fOp
-fOp
-fOp
-fOp
-fOp
-fOp
-fOp
-vub
-fOp
+ejv
+lDN
+ejv
+ejv
+ejv
+ejv
+ejv
+ejv
+ejv
+uHN
+ejv
 vos
 did
 did
@@ -144589,7 +144763,7 @@ kHU
 yaE
 hkD
 fYS
-wyj
+gBU
 wts
 mge
 qed
@@ -144869,13 +145043,13 @@ mpN
 uQg
 tJq
 oFm
-qPK
+kgH
 xsb
-qPK
-qPK
-qPK
+kgH
+kgH
+kgH
 mtf
-qPK
+kgH
 jpq
 bsc
 mfI
@@ -145103,7 +145277,7 @@ plf
 yaE
 vDr
 fYS
-hek
+eDn
 tEo
 nIB
 iEL
@@ -145360,7 +145534,7 @@ kHU
 yaE
 csG
 fYS
-ubX
+rfp
 wts
 npC
 txi
@@ -145383,13 +145557,13 @@ cCx
 mES
 tJq
 ikZ
-mEQ
+iLO
 oki
-uNw
-uNw
-uHN
+kLy
+kLy
+xnX
 tWH
-uHN
+xnX
 qcF
 bRX
 qSi
@@ -145640,7 +145814,7 @@ tJq
 ucP
 tJq
 fSC
-uHt
+mvK
 ktM
 uuo
 djH
@@ -147148,7 +147322,7 @@ yaE
 yaE
 csG
 fYS
-kuv
+aTm
 alc
 gHT
 gHT
@@ -147157,7 +147331,7 @@ gHT
 gHT
 gHT
 alc
-ejv
+smm
 fYS
 sEX
 srs
@@ -152092,7 +152266,7 @@ mXl
 mXl
 mXl
 wLD
-dpx
+xzW
 iwm
 mXl
 pRS
@@ -152110,7 +152284,7 @@ oNU
 mXl
 uxx
 xMc
-rkt
+sxZ
 nvi
 rnH
 cLM
@@ -152119,7 +152293,7 @@ nvi
 tOH
 mfI
 ogP
-uHw
+dKl
 sBG
 wjc
 wjc
@@ -152422,7 +152596,7 @@ xQo
 xQo
 xQo
 nKU
-kQi
+kdX
 xQo
 oPI
 mRu
@@ -152589,7 +152763,7 @@ cpR
 gtK
 cpR
 pxL
-sSA
+eMZ
 ffJ
 ape
 fZz
@@ -152608,7 +152782,7 @@ hRd
 ckx
 fZz
 lMB
-pNX
+rEm
 kzb
 vAu
 psV
@@ -152622,7 +152796,7 @@ vAu
 kRo
 vAu
 kCI
-jcW
+ueg
 ogP
 lwr
 mLS
@@ -152863,7 +153037,7 @@ erD
 erD
 cmN
 act
-pvp
+nGE
 xsY
 uuf
 jTW
@@ -153345,7 +153519,7 @@ fnT
 miA
 ojm
 lPc
-cze
+nMG
 gaF
 rpV
 qSe
@@ -153602,11 +153776,11 @@ nkb
 adb
 hzP
 cpR
-qtL
-oOk
+igB
+cpg
 uXI
+cpg
 oOk
-ohC
 xqF
 aAF
 iqI
@@ -156713,8 +156887,8 @@ plf
 xyC
 cFp
 klH
-sGo
-sGo
+sVk
+sVk
 hGr
 aRu
 xyC
@@ -157238,8 +157412,8 @@ dnn
 aEr
 wPw
 jQy
-aQd
-pnV
+rgj
+ulF
 jcX
 fJg
 nPU
@@ -157731,11 +157905,11 @@ plf
 cHH
 cHH
 jxX
-mSh
+alh
 bjt
 stv
 jxX
-mSh
+alh
 jxX
 adp
 kMq
@@ -157746,9 +157920,9 @@ xyC
 xyC
 xyC
 xyC
-wgw
-jtG
 wpm
+jtG
+uiG
 fJg
 fJg
 fJg
@@ -157988,11 +158162,11 @@ wVt
 cHH
 cjS
 bNB
-opt
+oat
 kms
 cHH
 eow
-pyM
+opt
 goK
 hYT
 nsn
@@ -158245,7 +158419,7 @@ leA
 cHH
 adG
 iGB
-qyu
+kbs
 tTk
 qMX
 aZz
@@ -158506,7 +158680,7 @@ ikW
 qXE
 rjb
 utF
-vmz
+cQh
 uLd
 lat
 nsn
@@ -159305,7 +159479,7 @@ kIM
 vst
 mDV
 vKG
-iHz
+rcj
 xoq
 tAM
 uQA
@@ -160024,14 +160198,14 @@ fAF
 fgx
 diq
 fAF
-vDE
+plD
 eTq
 fAF
 wNM
 oPD
 tif
 rHZ
-fSy
+ykj
 czU
 tqK
 hsq
@@ -160288,7 +160462,7 @@ qZx
 qZx
 fXG
 qZx
-cwk
+hvW
 czU
 uvV
 kMw
@@ -160794,7 +160968,7 @@ blh
 cra
 hlv
 dVr
-cht
+qtx
 hlv
 fBm
 bvC
@@ -161818,7 +161992,7 @@ aXC
 bZu
 pLw
 unD
-pjH
+mnf
 oAx
 ulK
 eyO
@@ -162372,7 +162546,7 @@ sxG
 uOc
 hur
 hur
-wsf
+ahc
 ekd
 lZw
 gqC
@@ -162626,7 +162800,7 @@ ixl
 mme
 uKd
 gRX
-wHw
+nTE
 sRa
 nUj
 wUB
@@ -162655,13 +162829,13 @@ ncp
 ncp
 hbR
 mWz
-twh
+tMI
 kLd
 syX
 tHk
 tHk
 dbf
-wpK
+vTX
 ram
 mWz
 lNQ
@@ -162918,7 +163092,7 @@ eFl
 aRb
 nDG
 jjN
-bFL
+rts
 ram
 mWz
 ucd
@@ -163125,7 +163299,7 @@ afw
 nDf
 mZo
 qUR
-kFF
+tGk
 mzV
 aSh
 mpR
@@ -163426,13 +163600,13 @@ ncp
 ncp
 hbR
 mWz
-hGc
+tGw
 sIY
 qls
 uOM
 uOM
 aeG
-aFq
+bFL
 ram
 mWz
 hPr
@@ -163622,7 +163796,7 @@ lhK
 wVg
 aFN
 jKZ
-lYd
+tyv
 rBo
 hlv
 qxh
@@ -163886,7 +164060,7 @@ xIO
 jps
 xIO
 qZx
-svg
+dHf
 tbS
 sZR
 kHU
@@ -163898,7 +164072,7 @@ fwH
 qoH
 vOW
 qoH
-vTX
+rMQ
 umQ
 gYp
 kHU
@@ -164136,7 +164310,7 @@ jvm
 hlv
 fVW
 fPH
-lYd
+tyv
 rnI
 hlv
 pHz
@@ -164151,11 +164325,11 @@ kHU
 plf
 cYc
 ueE
-ffC
+qfo
 wcJ
 iRz
 nez
-aEz
+pzC
 hlh
 gYp
 plf
@@ -164408,11 +164582,11 @@ kHU
 kHU
 cYc
 nfj
-ucx
+qpn
 eaE
 nRk
 rZh
-nUD
+acr
 hmN
 gYp
 kHU
@@ -164456,7 +164630,7 @@ dJL
 nRG
 oXA
 oXA
-vlS
+eDV
 dJL
 plf
 cdR
@@ -164665,11 +164839,11 @@ plf
 kHU
 huz
 sIx
-wKa
-qxz
+ojH
+sQk
 kjv
-qxz
-lmx
+sQk
+kOC
 tEU
 huz
 plf
@@ -166714,7 +166888,7 @@ plf
 kHU
 hlv
 lrm
-uqq
+jPg
 jno
 hlv
 cBu
@@ -167794,7 +167968,7 @@ kHU
 fMh
 plf
 dJL
-vlS
+eDV
 oXA
 oXA
 nJn

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -88,6 +88,11 @@
 	icon_state = "neutral"
 	},
 /area/station/hallway/secondary/entry)
+"aaM" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet6-2"
+	},
+/area/station/bridge)
 "aaP" = (
 /obj/machinery/photocopier,
 /turf/simulated/floor{
@@ -1681,7 +1686,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "amp" = (
@@ -2338,6 +2343,14 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/tox_launch)
+"asp" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/primary/central)
 "asq" = (
 /obj/structure/object_wall/pod{
 	dir = 4;
@@ -4774,7 +4787,7 @@
 	req_access = list(19)
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "aWb" = (
@@ -4983,15 +4996,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
-"aYE" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "purplefull"
-	},
-/area/station/hallway/primary/central)
 "aYN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/hydrant{
@@ -6696,7 +6700,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "brM" = (
@@ -6709,7 +6713,7 @@
 	dir = 6
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "brV" = (
@@ -8836,11 +8840,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
-"bNZ" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet6-2"
-	},
-/area/station/bridge/captain_quarters)
 "bOd" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 4;
@@ -8927,25 +8926,6 @@
 /obj/machinery/vending/medical,
 /turf/simulated/floor,
 /area/station/medical/storage)
-"bPj" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "bPp" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -12549,19 +12529,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
-"cFN" = (
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "cFP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -13391,7 +13358,7 @@
 /area/station/hallway/primary/fore)
 "cPN" = (
 /turf/simulated/floor/carpet{
-	icon_state = "carpet9-4"
+	icon_state = "carpet6-2"
 	},
 /area/station/bridge/captain_quarters)
 "cPY" = (
@@ -14012,9 +13979,6 @@
 /area/station/civilian/locker)
 "cXg" = (
 /obj/structure/table/woodentable,
-/obj/machinery/keycard_auth{
-	pixel_x = -24
-	},
 /obj/item/device/flashlight/lamp{
 	on = 0;
 	pixel_y = 6
@@ -18778,7 +18742,7 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "egG" = (
@@ -23684,14 +23648,6 @@
 /obj/item/toy/cards,
 /turf/simulated/floor/carpet/green,
 /area/station/hallway/primary/fore)
-"fqf" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/primary/central)
 "fqg" = (
 /obj/item/weapon/table_parts/wood/fancy,
 /turf/simulated/floor/plating,
@@ -25666,6 +25622,18 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/checkpoint)
+"fMt" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line"
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "fMw" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -27101,6 +27069,15 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/break_room)
+"gfw" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "purplefull"
+	},
+/area/station/hallway/primary/central)
 "gfI" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -27810,7 +27787,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "gms" = (
@@ -29287,7 +29264,7 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "gCM" = (
@@ -30047,7 +30024,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "gNg" = (
@@ -31809,7 +31786,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "hju" = (
@@ -32234,16 +32211,6 @@
 	icon_state = "yellow"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
-"hoE" = (
-/obj/item/weapon/flora/random,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "purplefull"
-	},
-/area/station/hallway/primary/central)
 "hoM" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots,
@@ -33217,16 +33184,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
-"hyB" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkblue"
-	},
-/area/station/bridge/corp_lounge)
 "hyD" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -35211,15 +35168,6 @@
 /obj/random/foods/food_trash,
 /turf/simulated/floor,
 /area/station/maintenance/escape)
-"hVS" = (
-/obj/effect/decal/turf_decal{
-	dir = 6;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/rnd/robotics)
 "hVZ" = (
 /obj/structure/closet/wardrobe/chaplain_black,
 /obj/item/device/cardpay{
@@ -35464,7 +35412,7 @@
 	req_access = list(19)
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "hXN" = (
@@ -36192,7 +36140,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "igF" = (
@@ -36775,7 +36723,7 @@
 /area/station/rnd/mixing)
 "imK" = (
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "imR" = (
@@ -37782,11 +37730,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/gateway)
-"izk" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet6-2"
-	},
-/area/station/bridge)
 "izp" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -38804,6 +38747,15 @@
 	icon_state = "wooden-2"
 	},
 /area/station/civilian/gym)
+"iLd" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "iLk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
@@ -39276,7 +39228,7 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "iQw" = (
@@ -39301,7 +39253,7 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "iQz" = (
@@ -39446,7 +39398,7 @@
 	req_access = list(19)
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "iSb" = (
@@ -41046,6 +40998,16 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/server)
+"jln" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "purplefull"
+	},
+/area/station/hallway/primary/central)
 "jlx" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -41185,6 +41147,15 @@
 	icon_state = "darkblue"
 	},
 /area/station/medical/morgue)
+"jnF" = (
+/obj/effect/decal/turf_decal{
+	dir = 6;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/robotics)
 "jnQ" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel,
 /turf/simulated/floor,
@@ -41838,7 +41809,7 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "juW" = (
@@ -43325,7 +43296,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "jKZ" = (
@@ -43558,7 +43529,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "jNB" = (
@@ -43937,18 +43908,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
-"jQL" = (
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line"
-	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "jQT" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/simulated/floor{
@@ -44625,7 +44584,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "jYR" = (
@@ -45532,7 +45491,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "kjL" = (
@@ -50173,7 +50132,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "llZ" = (
@@ -52023,7 +51982,7 @@
 	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "lIF" = (
@@ -53354,6 +53313,19 @@
 	icon_state = "gcircuit"
 	},
 /area/station/aisat/ai_chamber)
+"lYE" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "lYH" = (
 /turf/simulated/wall/r_wall,
 /area/station/bridge)
@@ -54042,7 +54014,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "miI" = (
@@ -55109,8 +55081,11 @@
 /area/station/maintenance/chapel)
 "mue" = (
 /obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line";
-	dir = 8
+	icon_state = "siding_wood_corner"
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner";
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "wooden"
@@ -55628,7 +55603,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "mBe" = (
@@ -58746,19 +58721,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/interrogation)
-"nnQ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/bluegrid{
-	name = "Server Base";
-	nitrogen = 500;
-	oxygen = 0;
-	temperature = 80
-	},
-/area/station/tcommsat/chamber)
 "nnZ" = (
 /obj/machinery/computer/atmos_alert{
 	dir = 8
@@ -61607,7 +61569,7 @@
 	req_access = list(19)
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "nVH" = (
@@ -63407,7 +63369,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "otl" = (
@@ -68373,7 +68335,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "pBO" = (
@@ -77791,7 +77753,7 @@
 "rLi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "rLk" = (
@@ -78082,6 +78044,19 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/checkpoint/escape_custom_desk)
+"rOL" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/station/tcommsat/chamber)
 "rOO" = (
 /obj/structure/stool/bed/chair/comfy/black,
 /turf/simulated/floor{
@@ -81874,7 +81849,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "sKL" = (
@@ -83525,7 +83500,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "tgp" = (
@@ -83603,18 +83578,6 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/kitchen)
-"tho" = (
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner"
-	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "thA" = (
 /obj/structure/object_wall/pod{
 	dir = 4;
@@ -84593,7 +84556,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "tvk" = (
@@ -85563,6 +85526,25 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/bridge/hop_office)
+"tFY" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "tGH" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/light/smart{
@@ -86274,6 +86256,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/hallway)
+"tQV" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/bluegrid{
+	icon_state = "gcircuit"
+	},
+/area/station/tcommsat/chamber)
 "tRh" = (
 /obj/item/device/radio/beacon,
 /obj/structure/cable{
@@ -86645,7 +86637,7 @@
 	opacity = 0
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "tVx" = (
@@ -89985,6 +89977,9 @@
 /obj/item/weapon/storage/box/PDAs{
 	pixel_x = 4;
 	pixel_y = 4
+	},
+/obj/machinery/keycard_auth{
+	pixel_x = -24
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -94429,7 +94424,7 @@
 "vSo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "vSs" = (
@@ -94658,16 +94653,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
-"vVq" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "gcircuit"
-	},
-/area/station/tcommsat/chamber)
 "vVA" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -96590,7 +96575,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/bridge)
 "wtr" = (
@@ -101757,6 +101742,11 @@
 	icon_state = "darkred"
 	},
 /area/station/hallway/primary/fore)
+"xDz" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet9-4"
+	},
+/area/station/bridge/captain_quarters)
 "xDD" = (
 /obj/machinery/atmospherics/components/binary/pump,
 /turf/simulated/floor{
@@ -103063,6 +103053,16 @@
 	icon_state = "bluefull"
 	},
 /area/station/hallway/primary/starboard)
+"xUs" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/station/bridge/corp_lounge)
 "xUx" = (
 /turf/simulated/wall,
 /area/station/civilian/dormitories)
@@ -136526,7 +136526,7 @@ bNg
 cLW
 rjR
 qgs
-hVS
+jnF
 cVA
 wrb
 chV
@@ -138315,11 +138315,11 @@ pHa
 pHa
 pbn
 yhw
-aYE
-aYE
+gfw
+gfw
 qQu
-aYE
-hoE
+gfw
+jln
 bwA
 vUh
 eKK
@@ -139598,7 +139598,7 @@ fFk
 hWY
 hWY
 giW
-fqf
+asp
 mby
 oXw
 rdN
@@ -142166,7 +142166,7 @@ pQD
 gIC
 gIC
 gIC
-nnQ
+rOL
 gIC
 gIC
 keH
@@ -142940,7 +142940,7 @@ xMO
 raJ
 cCX
 vyg
-vVq
+tQV
 lwt
 raJ
 eXe
@@ -142951,7 +142951,7 @@ siM
 mKJ
 mMA
 bLg
-tho
+mue
 lGH
 cje
 nHg
@@ -143183,7 +143183,7 @@ gCE
 imK
 lEC
 wnY
-izk
+aaM
 akc
 lZx
 gWd
@@ -143208,7 +143208,7 @@ jEs
 mKJ
 mMA
 vEH
-jQL
+fMt
 rOO
 mzL
 nHg
@@ -143722,7 +143722,7 @@ wMM
 fgA
 mMA
 joF
-jQL
+fMt
 eZe
 wAA
 nHg
@@ -143967,7 +143967,7 @@ knC
 aty
 wEV
 fAH
-vVq
+tQV
 aEE
 lwt
 wEV
@@ -143978,10 +143978,10 @@ pQD
 amY
 fgA
 mMA
-mue
-cFN
+iLd
+lYE
 lBF
-bPj
+tFY
 nHg
 nvi
 ogP
@@ -144494,7 +144494,7 @@ xVa
 mMA
 eIB
 pYl
-hyB
+xUs
 jVM
 mMA
 elI
@@ -144736,9 +144736,9 @@ pQD
 gIC
 gIC
 gIC
-nnQ
+rOL
 gIC
-nnQ
+rOL
 gIC
 gIC
 aty
@@ -146018,7 +146018,7 @@ ibm
 adM
 sTY
 bIZ
-cPN
+xDz
 iaL
 cHR
 jKD
@@ -147050,7 +147050,7 @@ cjq
 nac
 hrj
 pEa
-bNZ
+cPN
 cqG
 iaL
 pst

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -14,6 +14,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/item/clothing/head/soft/mime,
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line"
+	},
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "aaj" = (
@@ -2651,6 +2654,14 @@
 	icon_state = "gcircuit"
 	},
 /area/station/rnd/server)
+"avu" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/civilian/gym)
 "avU" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -3055,6 +3066,15 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/miningoffice)
+"aAH" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "aAP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3954,16 +3974,6 @@
 	icon_state = "grimy"
 	},
 /area/station/storage/tools)
-"aKR" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NNW-B";
-	location = "NW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "aKS" = (
 /obj/machinery/vending/coffee,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -4286,16 +4296,6 @@
 	icon_state = "darkredcorners"
 	},
 /area/station/security/execution)
-"aPp" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NEE-FC";
-	location = "S-SV"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "aPB" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/clipboard,
@@ -5156,16 +5156,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/checkpoint)
-"aZD" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "aZF" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -7650,6 +7640,26 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/locker)
+"bAi" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "bAn" = (
 /obj/structure/disposalpipe/junction,
 /turf/simulated/floor{
@@ -8230,11 +8240,10 @@
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "box_corners_white";
-	dir = 1
+	dir = 4
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
+	icon_state = "box_corners_white"
 	},
 /obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "siding_line";
@@ -8562,6 +8571,17 @@
 	icon_state = "greenblue"
 	},
 /area/station/civilian/hydroponics)
+"bIF" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "loadingarea"
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "arrow"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "bIH" = (
 /obj/structure/table/woodentable,
 /obj/machinery/door_control{
@@ -10759,6 +10779,25 @@
 	icon_state = "neutral"
 	},
 /area/station/security/main)
+"chi" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/main)
 "chj" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Atmospherics Desk";
@@ -10876,15 +10915,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/mixing)
-"ciz" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "ciD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -13640,15 +13670,6 @@
 "cOU" = (
 /turf/simulated/floor,
 /area/station/engineering/engine)
-"cOV" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "cOZ" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -15226,6 +15247,10 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "did" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "vault"
@@ -15964,17 +15989,6 @@
 	icon_state = "caution"
 	},
 /area/station/hallway/primary/port)
-"drb" = (
-/obj/machinery/light/smart,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DS";
-	location = "DN-W"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "purplecorner"
-	},
-/area/station/hallway/primary/central)
 "dre" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -15996,18 +16010,6 @@
 	icon_state = "blue"
 	},
 /area/station/civilian/toilet)
-"drh" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "drn" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -18674,6 +18676,19 @@
 	icon_state = "dark"
 	},
 /area/station/security/checkpoint/escape)
+"dZu" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "dZC" = (
 /obj/structure/lattice,
 /obj/structure/sign/nanotrasen{
@@ -19339,7 +19354,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/hallway/primary/central)
 "ehd" = (
 /obj/item/weapon/flora/random,
@@ -19502,22 +19519,12 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard)
-"ejq" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "loadingarea"
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "arrow"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "ejv" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "cafeteria"
 	},
-/area/station/security/blueshield)
+/area/station/security/prison)
 "ejG" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 1
@@ -20246,6 +20253,16 @@
 /obj/structure/sign/warning,
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/engineering)
+"esV" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SEE-FC";
+	location = "SE-FC"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "esZ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -20507,12 +20524,6 @@
 	icon_state = "dark"
 	},
 /area/station/bridge/ai_upload)
-"evv" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "cafeteria"
-	},
-/area/station/security/prison)
 "evz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -20571,6 +20582,27 @@
 	icon_state = "dark"
 	},
 /area/station/bridge/ai_upload)
+"evX" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "ewd" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -21857,6 +21889,17 @@
 	icon_state = "wooden"
 	},
 /area/station/medical/psych)
+"eLr" = (
+/obj/machinery/light/smart,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DS";
+	location = "DN-W"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "purplecorner"
+	},
+/area/station/hallway/primary/central)
 "eLs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -22016,6 +22059,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
+"eNC" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 10;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "eND" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -22882,6 +22939,17 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/break_room)
+"eXO" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "eXS" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
@@ -23875,18 +23943,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/maintenance/cargo)
-"fiK" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "fiP" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -24901,7 +24957,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/hallway/primary/central)
 "fuN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -25361,6 +25419,14 @@
 	icon_state = "neutralfull"
 	},
 /area/station/medical/reception)
+"fAc" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/security/prison)
 "fAf" = (
 /obj/effect/decal/turf_decal{
 	dir = 6;
@@ -25423,16 +25489,6 @@
 	icon_state = "gcircuit"
 	},
 /area/station/tcommsat/chamber)
-"fAK" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SWW-FC";
-	location = "SW-FC"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "fAN" = (
 /obj/item/device/radio/intercom{
 	frequency = 1475;
@@ -26386,14 +26442,6 @@
 	icon_state = "neutral"
 	},
 /area/station/engineering/chiefs_office)
-"fLR" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "fLY" = (
 /turf/simulated/floor{
 	icon_state = "redcorner"
@@ -26488,17 +26536,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "fOp" = (
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Labor Camp Shuttle Airlock";
-	req_access = list(2)
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
 	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
 	},
-/turf/simulated/floor/plating,
-/area/station/security/brig)
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "fOF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
@@ -28047,6 +28095,16 @@
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/auxport)
+"ghL" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-C";
+	location = "CS-AR"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "ghN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/effect/decal/turf_decal{
@@ -28936,15 +28994,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/cargo)
-"gpq" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "gpz" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/effect/decal/turf_decal/alpha/gray{
@@ -29380,17 +29429,6 @@
 	icon_state = "black"
 	},
 /area/station/hallway/secondary/exit)
-"guP" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "guR" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -31126,19 +31164,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
-"gOX" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "gPd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
@@ -32453,15 +32478,6 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/dormitories)
-"hdS" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Security";
-	location = "S-C"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "hdU" = (
 /obj/structure/table/reinforced,
 /obj/item/device/analyzer,
@@ -33121,6 +33137,19 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/kitchen)
+"hmB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/flasher{
+	id = "Cell 3 perma";
+	pixel_y = -28
+	},
+/turf/simulated/floor,
+/area/station/security/prison)
 "hmC" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -33926,18 +33955,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/armoury)
-"hus" = (
-/obj/machinery/door_timer/cell_3{
-	pixel_x = 32;
-	pixel_y = 0;
-	dir = 4;
-	id = "Cell 3 perma"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "huv" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -34283,6 +34300,11 @@
 	icon_state = "vaultfull"
 	},
 /area/station/maintenance/engineering)
+"hxZ" = (
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "hyh" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -34982,17 +35004,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/prison)
-"hED" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "hER" = (
 /obj/machinery/porta_turret/station_default{
 	dir = 4
@@ -36387,13 +36398,6 @@
 /obj/random/foods/food_trash,
 /turf/simulated/floor,
 /area/station/maintenance/escape)
-"hVQ" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=N-MB";
-	location = "NNW-B"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "hVZ" = (
 /obj/structure/closet/wardrobe/chaplain_black,
 /obj/item/device/cardpay{
@@ -38582,6 +38586,19 @@
 	icon_state = "dark"
 	},
 /area/station/bridge/ai_upload)
+"iut" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "iuu" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -39170,14 +39187,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/medical/genetics)
-"iAV" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/civilian/gym)
 "iBa" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid,
@@ -39452,16 +39461,6 @@
 	icon_state = "white"
 	},
 /area/station/medical/hallway)
-"iEa" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-B";
-	location = "SSW-B"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "iEb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -40651,6 +40650,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/medical/genetics)
+"iRj" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 5
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "iRo" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/door/firedoor,
@@ -41324,6 +41332,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
+"iZG" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "iZP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -42650,6 +42669,10 @@
 	dir = 4
 	},
 /obj/structure/window/thin/reinforced,
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_corner";
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "jps" = (
@@ -43437,7 +43460,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/hallway/primary/central)
 "jxd" = (
 /obj/item/device/radio/intercom{
@@ -44613,6 +44638,16 @@
 	},
 /turf/simulated/floor,
 /area/station/storage/primary)
+"jKy" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-B";
+	location = "SSW-B"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "jKB" = (
 /turf/simulated/floor/bluegrid{
 	icon_state = "gcircuit"
@@ -45706,6 +45741,15 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
+"jVv" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "jVF" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/structure/disposalpipe/segment{
@@ -46733,25 +46777,18 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "kgH" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/light/smart{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NE-FC";
+	location = "NEE-FC"
 	},
 /turf/simulated/floor{
-	icon_state = "redcorner"
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
-/area/station/security/prison)
+/area/station/hallway/primary/central)
 "khm" = (
 /obj/machinery/power/apc{
 	name = "apc down";
@@ -47571,6 +47608,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories)
+"kpy" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "browncorner"
+	},
+/area/station/cargo/storage)
 "kpD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -48466,19 +48509,6 @@
 	icon_state = "showroomfloor"
 	},
 /area/station/civilian/cold_room)
-"kAK" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "kAU" = (
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
@@ -49638,6 +49668,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage_secure)
+"kMe" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "kMi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -49969,6 +50009,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"kRx" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=CS-AR";
+	location = "SWW-FC"
+	},
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "kRI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -51206,6 +51253,16 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
+"let" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SWW-FC";
+	location = "SW-FC"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "lez" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -51884,6 +51941,15 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor,
 /area/station/civilian/toilet)
+"lng" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Central Access"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "lnl" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -52573,6 +52639,13 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
+"lvL" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "lvS" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 10
@@ -54888,6 +54961,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/incinerator)
+"lXv" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "lXA" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Starboard Quarter Solar Access";
@@ -56157,6 +56239,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/qm)
+"mmQ" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
+	},
+/turf/simulated/floor/carpet/red,
+/area/station/security/detectives_office)
 "mmV" = (
 /obj/structure/musician/piano,
 /obj/effect/decal/cleanable/dirt,
@@ -56692,6 +56780,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "mti" = (
@@ -56707,16 +56799,6 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/dormitories)
-"mtk" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-FC";
-	location = "DS"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "bluecorner"
-	},
-/area/station/hallway/primary/central)
 "mtn" = (
 /obj/machinery/light/smart{
 	dir = 4
@@ -57456,19 +57538,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
-"mBt" = (
-/obj/machinery/light/smart{
-	dir = 4
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NE-FC";
-	location = "NEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "mBw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -58212,16 +58281,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
-"mKW" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-C";
-	location = "CS-AR"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "mLq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58372,6 +58431,13 @@
 /obj/effect/spawner/lootdrop/gloves,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"mNP" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-FC";
+	location = "SSW-FC"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/starboard)
 "mNU" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
@@ -58678,16 +58744,6 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating/airless,
 /area/station/cargo/recycler)
-"mRa" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSE-FC";
-	location = "SEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "mRc" = (
 /obj/structure/table/glass,
 /obj/item/clothing/accessory/stethoscope,
@@ -58838,16 +58894,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/range)
-"mSh" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "mSl" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -59726,6 +59772,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"nbV" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "ncb" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -59953,13 +60009,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/hos)
-"nfm" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=CS-AR";
-	location = "SWW-FC"
-	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
 "nft" = (
 /obj/machinery/ai_status_display{
 	pixel_x = 32
@@ -61900,13 +61949,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/rnd/xenobiology)
-"nCx" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "nCD" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -62249,6 +62291,14 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
+"nGe" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "nGh" = (
 /obj/machinery/computer/station_alert{
 	dir = 4
@@ -62369,6 +62419,9 @@
 /obj/structure/mirror{
 	pixel_y = 32
 	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line"
+	},
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "nHx" = (
@@ -62462,16 +62515,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/fore)
-"nIw" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SEE-FC";
-	location = "SE-FC"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "nIB" = (
 /turf/simulated/floor{
 	icon_state = "blackchecker"
@@ -62700,6 +62743,16 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"nLE" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "nLP" = (
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
@@ -62797,6 +62850,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/misc_lab)
+"nNj" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "nNm" = (
 /obj/structure/stool,
 /obj/machinery/alarm{
@@ -63374,15 +63434,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/cargo/recycler)
-"nSQ" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DN";
-	location = "SSE-FC"
-	},
-/turf/simulated/floor{
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "nSV" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/skills,
@@ -63934,15 +63985,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/escape_custom_desk)
-"nYO" = (
-/obj/effect/decal/turf_decal/alpha/blue{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "nYQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/alarm{
@@ -64051,13 +64093,6 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/chapel/crematorium)
-"oak" = (
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/prison)
 "oap" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -64709,6 +64744,9 @@
 /obj/item/clothing/suit/santa,
 /obj/item/weapon/storage/backpack/santabag,
 /obj/item/clothing/head/santahat,
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line"
+	},
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "ohW" = (
@@ -64877,6 +64915,10 @@
 /area/station/hallway/primary/starboard)
 "oki" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
 	dir = 8
 	},
 /turf/simulated/floor/wood,
@@ -66303,6 +66345,9 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_corner"
+	},
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "oFq" = (
@@ -66712,6 +66757,26 @@
 	icon_state = "neutral"
 	},
 /area/station/hallway/primary/fore)
+"oJQ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "oKu" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -66990,6 +67055,16 @@
 /obj/structure/table,
 /turf/simulated/floor,
 /area/station/storage/tools)
+"oMy" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSE-FC";
+	location = "SEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "oME" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -67159,7 +67234,7 @@
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	dir = 5;
+	dir = 4;
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
@@ -67406,22 +67481,6 @@
 "oRy" = (
 /turf/simulated/wall,
 /area/station/rnd/hallway)
-"oRF" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-B";
-	location = "S-MB"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/secondary/entry)
-"oRL" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-FC";
-	location = "SSW-FC"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/starboard)
 "oRS" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -68675,6 +68734,15 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/secondary/exit)
+"phr" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Security";
+	location = "S-C"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "pht" = (
 /obj/structure/table/woodentable/fancy/black,
 /obj/structure/window/thin/reinforced{
@@ -70974,6 +71042,16 @@
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
+"pGu" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SE-FC";
+	location = "SW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "pGv" = (
 /obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor{
@@ -71274,6 +71352,18 @@
 	icon_state = "black"
 	},
 /area/station/civilian/chapel)
+"pKs" = (
+/obj/machinery/door_timer/cell_3{
+	pixel_x = 32;
+	pixel_y = 0;
+	dir = 4;
+	id = "Cell 3 perma"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "pKu" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -72203,6 +72293,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/chiefs_office)
+"pUI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "pUK" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -72889,6 +72992,10 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_corner";
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
@@ -73921,6 +74028,15 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/mixing)
+"qoq" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DN";
+	location = "SSE-FC"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "qou" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -75312,6 +75428,16 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/cargo/recycler)
+"qGM" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/station/security/brig)
 "qGO" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -75455,7 +75581,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/hallway/primary/central)
 "qIw" = (
 /obj/structure/cable{
@@ -76756,6 +76884,9 @@
 	pixel_y = 6
 	},
 /obj/structure/table/woodentable/fancy/black,
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line"
+	},
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "qYx" = (
@@ -77384,26 +77515,6 @@
 	icon_state = "bluefull"
 	},
 /area/station/civilian/locker)
-"rgx" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "rgE" = (
 /obj/structure/object_wall/mining{
 	icon_state = "5-2"
@@ -77714,14 +77825,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/rnd/robotics)
-"rjU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/security/prison)
 "rkr" = (
 /obj/structure/rack,
 /obj/random/cloth/gloves_safe,
@@ -80665,6 +80768,13 @@
 	icon_state = "whitehall"
 	},
 /area/station/rnd/robotics)
+"rPV" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=N-MB";
+	location = "NNW-B"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "rPX" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -81715,6 +81825,15 @@
 	icon_state = "neutral"
 	},
 /area/station/maintenance/medbay)
+"sel" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-B";
+	location = "S-MB"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry)
 "seo" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
@@ -82077,6 +82196,15 @@
 	icon_state = "black"
 	},
 /area/station/hallway/secondary/exit)
+"sie" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "sif" = (
 /obj/machinery/door_control{
 	id = "AI Blast Door";
@@ -84132,12 +84260,6 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/toilet)
-"sGt" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "browncorner"
-	},
-/area/station/cargo/storage)
 "sGy" = (
 /obj/structure/table/woodentable,
 /obj/item/stack/sheet/cloth{
@@ -85802,6 +85924,9 @@
 /area/station/security/main)
 "tbR" = (
 /obj/structure/dresser,
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line"
+	},
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "tbS" = (
@@ -86451,6 +86576,13 @@
 	icon_state = "dark"
 	},
 /area/station/medical/genetics)
+"tjV" = (
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/prison)
 "tkc" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -88870,16 +89002,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
-"tOF" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkred"
-	},
-/area/station/security/brig)
 "tOH" = (
 /obj/structure/sign/directions/evac{
 	pixel_x = -32;
@@ -88985,26 +89107,6 @@
 /obj/item/weapon/reagent_containers/food/snacks/soap,
 /turf/simulated/floor,
 /area/station/civilian/toilet)
-"tQF" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "tQM" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
@@ -89492,6 +89594,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "tWL" = (
@@ -89942,10 +90048,8 @@
 /area/station/rnd/hallway)
 "ucx" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Central Access"
-	},
 /turf/simulated/floor{
+	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/station/security/lobby)
@@ -90141,20 +90245,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/hos)
-"ueI" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 10;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "ufi" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/effect/decal/turf_decal/alpha/gray{
@@ -92469,24 +92559,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "uHN" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NNW-B";
+	location = "NW-B"
 	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
-/area/station/security/main)
+/area/station/hallway/secondary/entry)
 "uHX" = (
 /turf/simulated/floor/wood,
 /area/station/maintenance/chapel)
@@ -93245,6 +93326,18 @@
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
+"uRZ" = (
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Labor Camp Shuttle Airlock";
+	req_access = list(2)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig)
@@ -94108,6 +94201,13 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/tox_launch)
+"vbV" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-MB";
+	location = "N-MB"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "vbZ" = (
 /obj/machinery/computer/atmos_alert,
 /obj/structure/cable{
@@ -94161,12 +94261,6 @@
 	icon_state = "caution"
 	},
 /area/station/medical/chemistry)
-"vdk" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
-	},
-/turf/simulated/floor/carpet/red,
-/area/station/security/detectives_office)
 "vdm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -96131,6 +96225,26 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/engine)
+"vBR" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "vBV" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/stamp/internalaffairs,
@@ -97535,25 +97649,18 @@
 	},
 /area/station/bridge/teleporter)
 "vTX" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn_corner"
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
 	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "vUe" = (
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
@@ -99765,16 +99872,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
-"wwe" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SE-FC";
-	location = "SW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "wwi" = (
 /turf/simulated/wall,
 /area/station/maintenance/atmos)
@@ -100847,16 +100944,6 @@
 	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
-"wHU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "wIf" = (
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
@@ -101801,19 +101888,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/atmos/supermatter)
-"wUZ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/flasher{
-	id = "Cell 3 perma";
-	pixel_y = -28
-	},
-/turf/simulated/floor,
-/area/station/security/prison)
 "wVg" = (
 /obj/structure/stool,
 /obj/structure/window/thin{
@@ -101856,6 +101930,15 @@
 	icon_state = "yellowpatch"
 	},
 /area/station/engineering/atmos/supermatter)
+"wVl" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "wVt" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -102959,15 +103042,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/armoury)
-"xiT" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "xiX" = (
 /obj/machinery/light/small,
 /obj/structure/closet/l3closet/general,
@@ -103173,6 +103247,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/tcommsat/chamber)
+"xmt" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NEE-FC";
+	location = "S-SV"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "xmz" = (
 /obj/structure/object_wall/mining{
 	icon_state = "1-3"
@@ -103486,6 +103570,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/maintenance/escape)
+"xpm" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "xpn" = (
 /obj/item/device/flashlight/lamp,
 /obj/structure/table/woodentable,
@@ -103776,6 +103872,10 @@
 /area/station/aisat)
 "xsb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
 	dir = 4
 	},
 /turf/simulated/floor/wood,
@@ -104304,6 +104404,16 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
+"xxA" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-FC";
+	location = "DS"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
+/area/station/hallway/primary/central)
 "xxE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -105164,6 +105274,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"xGT" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "xHu" = (
 /obj/structure/rack,
 /obj/item/weapon/circuitboard/solar_control,
@@ -106367,13 +106490,6 @@
 	icon_state = "darkbrown"
 	},
 /area/station/medical/virology)
-"xVH" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-MB";
-	location = "N-MB"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "xVN" = (
 /turf/simulated/wall,
 /area/station/civilian/dormitories/service_bedrooms)
@@ -107470,15 +107586,6 @@
 	icon_state = "dark"
 	},
 /area/station/bridge)
-"yjm" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 5
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "yjy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -135829,7 +135936,7 @@ doE
 doE
 doE
 lgU
-nIw
+esV
 mhm
 doE
 mnD
@@ -136327,7 +136434,7 @@ wwi
 aYN
 wwi
 lfm
-mRa
+oMy
 tZn
 oyb
 nAM
@@ -136345,7 +136452,7 @@ oyb
 bzt
 bzt
 rcq
-nSQ
+qoq
 tYK
 wtC
 wtC
@@ -141724,7 +141831,7 @@ iSv
 xXt
 vAu
 ogP
-iEa
+jKy
 bAS
 nvi
 rnH
@@ -141740,7 +141847,7 @@ qbj
 qbj
 tmk
 ldb
-wwe
+pGu
 ogP
 iSi
 amv
@@ -141767,7 +141874,7 @@ vpT
 xei
 bFh
 vpT
-drb
+eLr
 vIl
 olx
 frM
@@ -141935,7 +142042,7 @@ plf
 brw
 mko
 jsL
-oRF
+sel
 ffX
 hbE
 sTt
@@ -142204,7 +142311,7 @@ gHT
 alc
 vDr
 fDL
-aKR
+uHN
 iwy
 xXt
 gNR
@@ -143769,13 +143876,13 @@ mpN
 uQg
 tJq
 oFm
-ncg
+nNj
 xsb
-ncg
-ncg
-ncg
+nNj
+nNj
+nNj
 mtf
-ncg
+nNj
 jpq
 bsc
 mfI
@@ -144283,13 +144390,13 @@ cCx
 mES
 tJq
 ikZ
-mOU
+pUI
 oki
-ncg
-ncg
-mOU
+lvL
+lvL
+vTX
 tWH
-mOU
+vTX
 qcF
 bRX
 qSi
@@ -144540,7 +144647,7 @@ tJq
 ucP
 tJq
 fSC
-mOU
+iut
 ktM
 uuo
 djH
@@ -146048,7 +146155,7 @@ yaE
 yaE
 csG
 fYS
-xVH
+vbV
 alc
 gHT
 gHT
@@ -146057,7 +146164,7 @@ gHT
 gHT
 gHT
 alc
-hVQ
+rPV
 fYS
 sEX
 srs
@@ -150992,7 +151099,7 @@ mXl
 mXl
 mXl
 wLD
-aPp
+xmt
 iwm
 mXl
 pRS
@@ -151010,7 +151117,7 @@ oNU
 mXl
 uxx
 xMc
-fAK
+let
 nvi
 rnH
 cLM
@@ -151019,7 +151126,7 @@ nvi
 tOH
 mfI
 ogP
-mtk
+xxA
 sBG
 wjc
 wjc
@@ -151322,7 +151429,7 @@ xQo
 xQo
 xQo
 nKU
-oRL
+mNP
 xQo
 oPI
 mRu
@@ -151489,7 +151596,7 @@ cpR
 gtK
 cpR
 pxL
-mBt
+kgH
 ffJ
 ape
 fZz
@@ -151508,7 +151615,7 @@ hRd
 ckx
 fZz
 lMB
-hdS
+phr
 kzb
 vAu
 psV
@@ -151522,7 +151629,7 @@ vAu
 kRo
 vAu
 kCI
-mKW
+ghL
 ogP
 lwr
 mLS
@@ -151765,7 +151872,7 @@ cmN
 act
 uuf
 xsY
-ucx
+lng
 jTW
 jTW
 jTW
@@ -152245,7 +152352,7 @@ fnT
 miA
 ojm
 lPc
-sGt
+kpy
 gaF
 rpV
 qSe
@@ -152502,11 +152609,11 @@ nkb
 adb
 hzP
 cpR
+nLE
 oOk
-aZD
 uXI
-aZD
-mSh
+oOk
+nbV
 xqF
 aAF
 iqI
@@ -155613,8 +155720,8 @@ plf
 xyC
 cFp
 klH
-vdk
-vdk
+mmQ
+mmQ
 hGr
 aRu
 xyC
@@ -156138,8 +156245,8 @@ dnn
 aEr
 wPw
 jQy
-nYO
-ejv
+lXv
+hxZ
 jcX
 fJg
 nPU
@@ -156631,11 +156738,11 @@ plf
 cHH
 cHH
 jxX
-fOp
+uRZ
 bjt
 stv
 jxX
-fOp
+uRZ
 jxX
 adp
 kMq
@@ -156646,7 +156753,7 @@ xyC
 xyC
 xyC
 xyC
-nCx
+ucx
 jtG
 wpm
 fJg
@@ -156888,7 +156995,7 @@ wVt
 cHH
 cjS
 bNB
-ueI
+eNC
 kms
 cHH
 eow
@@ -157145,7 +157252,7 @@ leA
 cHH
 adG
 iGB
-tOF
+qGM
 tTk
 qMX
 aZz
@@ -157406,7 +157513,7 @@ ikW
 qXE
 rjb
 utF
-ejq
+bIF
 uLd
 lat
 nsn
@@ -158205,7 +158312,7 @@ kIM
 vst
 mDV
 vKG
-nfm
+kRx
 xoq
 tAM
 uQA
@@ -158924,14 +159031,14 @@ fAF
 fgx
 diq
 fAF
-hus
+pKs
 eTq
 fAF
 wNM
 oPD
 tif
 rHZ
-kgH
+bAi
 czU
 tqK
 hsq
@@ -159188,7 +159295,7 @@ qZx
 qZx
 fXG
 qZx
-rgx
+vBR
 czU
 uvV
 kMw
@@ -159694,7 +159801,7 @@ blh
 cra
 hlv
 dVr
-wUZ
+hmB
 hlv
 fBm
 bvC
@@ -160718,7 +160825,7 @@ aXC
 bZu
 pLw
 unD
-rjU
+fAc
 oAx
 ulK
 eyO
@@ -161272,7 +161379,7 @@ sxG
 uOc
 hur
 hur
-kAK
+xGT
 ekd
 lZw
 gqC
@@ -161526,7 +161633,7 @@ ixl
 mme
 uKd
 gRX
-fiK
+xpm
 sRa
 nUj
 wUB
@@ -161555,13 +161662,13 @@ ncp
 ncp
 hbR
 mWz
-drh
+fOp
 kLd
 syX
 tHk
 tHk
 dbf
-bFL
+evX
 ram
 mWz
 lNQ
@@ -161818,7 +161925,7 @@ eFl
 aRb
 nDG
 jjN
-gOX
+dZu
 ram
 mWz
 ucd
@@ -162025,7 +162132,7 @@ afw
 nDf
 mZo
 qUR
-uHN
+chi
 mzV
 aSh
 mpR
@@ -162326,13 +162433,13 @@ ncp
 ncp
 hbR
 mWz
-guP
+eXO
 sIY
 qls
 uOM
 uOM
 aeG
-tQF
+bFL
 ram
 mWz
 hPr
@@ -162522,7 +162629,7 @@ lhK
 wVg
 aFN
 jKZ
-evv
+ejv
 rBo
 hlv
 qxh
@@ -162786,7 +162893,7 @@ xIO
 jps
 xIO
 qZx
-vTX
+oJQ
 tbS
 sZR
 kHU
@@ -162798,7 +162905,7 @@ fwH
 qoH
 vOW
 qoH
-fLR
+nGe
 umQ
 gYp
 kHU
@@ -163036,7 +163143,7 @@ jvm
 hlv
 fVW
 fPH
-evv
+ejv
 rnI
 hlv
 pHz
@@ -163051,11 +163158,11 @@ kHU
 plf
 cYc
 ueE
-wHU
+kMe
 wcJ
 iRz
 nez
-hED
+iZG
 hlh
 gYp
 plf
@@ -163308,11 +163415,11 @@ kHU
 kHU
 cYc
 nfj
-xiT
+aAH
 eaE
 nRk
 rZh
-cOV
+jVv
 hmN
 gYp
 kHU
@@ -163356,7 +163463,7 @@ dJL
 nRG
 oXA
 oXA
-iAV
+avu
 dJL
 plf
 cdR
@@ -163565,11 +163672,11 @@ plf
 kHU
 huz
 sIx
-yjm
-gpq
+iRj
+sie
 kjv
-gpq
-ciz
+sie
+wVl
 tEU
 huz
 plf
@@ -165614,7 +165721,7 @@ plf
 kHU
 hlv
 lrm
-oak
+tjV
 jno
 hlv
 cBu
@@ -166694,7 +166801,7 @@ kHU
 fMh
 plf
 dJL
-iAV
+avu
 oXA
 oXA
 nJn

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -2129,23 +2129,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
-"apD" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "caution"
-	},
-/area/station/engineering/atmos/distribution)
 "apV" = (
 /turf/simulated/floor/carpet,
 /area/station/bridge/meeting_room)
@@ -3819,6 +3802,18 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/drone_fabrication)
+"aIN" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "aIO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -3860,6 +3855,17 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway/lobby)
+"aJf" = (
+/obj/structure/stool/bed/chair/metal/black{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "aJg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -4005,6 +4011,19 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/dormitories/courtroom)
+"aKW" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "aLa" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
@@ -4179,18 +4198,6 @@
 /obj/machinery/status_display,
 /turf/simulated/wall,
 /area/station/security/checkpoint/escape)
-"aNp" = (
-/obj/machinery/door_timer/cell_3{
-	pixel_x = 32;
-	pixel_y = 0;
-	dir = 4;
-	id = "Cell 3 perma"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "aNv" = (
 /obj/structure/stool,
 /turf/simulated/floor{
@@ -4594,16 +4601,6 @@
 	},
 /turf/simulated/floor/bluegrid,
 /area/station/security/main)
-"aSi" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSE-FC";
-	location = "SEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "aSl" = (
 /obj/machinery/computer/gravity_control_computer,
 /obj/effect/decal/turf_decal/alpha/gray{
@@ -5002,34 +4999,6 @@
 /obj/structure/mopbucket,
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
-"aWz" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
-"aWC" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Entry Shuttle Airlock";
-	req_one_access = list(13)
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
 "aWD" = (
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -5249,6 +5218,16 @@
 	icon_state = "vaultfull"
 	},
 /area/station/storage/tools)
+"aZN" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "baa" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -5496,19 +5475,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/sleeper)
-"bcl" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "escape"
-	},
-/area/station/hallway/primary/port)
 "bcv" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -6024,6 +5990,18 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/engine)
+"bhk" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "bhn" = (
 /turf/simulated/floor{
 	icon_state = "yellow"
@@ -6069,6 +6047,15 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/tox_launch)
+"bhH" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Central Access"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "bhS" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -6364,15 +6351,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/maintenance/science)
-"blc" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_left"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/civilian/cold_room)
 "blh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/machinery/light/small{
@@ -6448,8 +6426,7 @@
 	},
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
+	icon_state = "box_corners_white"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -6851,6 +6828,19 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor,
 /area/station/maintenance/medbay)
+"bpT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "bpV" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -7321,6 +7311,15 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/misc_lab)
+"bvv" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DN";
+	location = "SSE-FC"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "bvx" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(8)
@@ -7553,15 +7552,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/miningoffice)
-"byc" = (
-/obj/effect/decal/turf_decal{
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "bye" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 1
@@ -9255,6 +9245,17 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/science)
+"bOn" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos/atmos_office)
 "bOy" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/turretid/stun/AI_special{
@@ -11914,25 +11915,6 @@
 	},
 /turf/simulated/shuttle/floor/wagon,
 /area/shuttle/supply/station)
-"cue" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/main)
 "cug" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -12292,14 +12274,6 @@
 "cxI" = (
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/supermatter)
-"cxQ" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/civilian/gym)
 "cxU" = (
 /obj/machinery/shower/free{
 	dir = 4
@@ -12438,17 +12412,6 @@
 	icon_state = "caution"
 	},
 /area/station/medical/chemistry)
-"cyD" = (
-/obj/machinery/light/smart,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DS";
-	location = "DN-W"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "purplecorner"
-	},
-/area/station/hallway/primary/central)
 "cyQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -12560,6 +12523,19 @@
 	},
 /turf/simulated/floor/carpet/green,
 /area/station/civilian/library)
+"czK" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/pump,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "arrival"
+	},
+/area/station/hallway/primary/port)
 "czL" = (
 /obj/structure/closet/secure_closet/engineering_chief,
 /obj/structure/cable{
@@ -12711,18 +12687,6 @@
 /obj/structure/sign/nanotrasen,
 /turf/simulated/wall/r_wall,
 /area/station/bridge/ai_upload)
-"cBK" = (
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Labor Camp Shuttle Airlock";
-	req_access = list(2)
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/brig)
 "cBU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/structure/window/fulltile/reinforced/phoron{
@@ -14037,6 +14001,16 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
+"cQm" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NEE-FC";
+	location = "S-SV"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "cQt" = (
 /obj/item/device/flash,
 /obj/item/clothing/glasses/sunglasses,
@@ -14756,6 +14730,15 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/miningoffice)
+"cZp" = (
+/obj/machinery/vending/coffee,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/primary/central)
 "cZC" = (
 /obj/machinery/shieldwallgen,
 /turf/simulated/floor,
@@ -17201,7 +17184,7 @@
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "box_corners_white";
-	dir = 1
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -17584,6 +17567,13 @@
 /obj/structure/coatrack,
 /turf/simulated/floor/carpet/red,
 /area/station/security/detectives_office)
+"dHT" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-FC";
+	location = "SSW-FC"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/starboard)
 "dHU" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -19068,6 +19058,20 @@
 	icon_state = "vaultfull"
 	},
 /area/station/engineering/minisat_secure_area)
+"eaw" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor,
+/area/station/engineering/monitoring)
 "eax" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -19179,12 +19183,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/misc_lab)
-"ebs" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "browncorner"
-	},
-/area/station/cargo/storage)
 "ebv" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -19811,15 +19809,17 @@
 	},
 /area/station/hallway/primary/starboard)
 "ejv" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-FC";
-	location = "DS"
+/obj/structure/stool/bed/chair/metal/black{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "bluecorner"
+	icon_state = "vaultfull"
 	},
-/area/station/hallway/primary/central)
+/area/station/hallway/secondary/entry)
 "ejG" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 1
@@ -20445,15 +20445,6 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/library)
-"eqV" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 29
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "blackcorner"
-	},
-/area/station/hallway/primary/starboard)
 "ern" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -20561,16 +20552,15 @@
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/engineering)
 "esZ" = (
-/obj/structure/stool/bed/chair/metal/black{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	dir = 5;
+	icon_state = "cafeteria"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/civilian/kitchen)
 "etb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -20784,6 +20774,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/janitor)
+"euT" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "evk" = (
 /obj/machinery/door/airlock/security{
 	name = "Brig";
@@ -21440,6 +21439,19 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
+"eBE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "eBJ" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/firealarm{
@@ -22181,6 +22193,19 @@
 	icon_state = "wooden"
 	},
 /area/station/medical/psych)
+"eLq" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "eLs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -22271,6 +22296,14 @@
 /obj/item/weapon/kitchen/rollingpin,
 /turf/simulated/floor,
 /area/station/maintenance/cargo)
+"eMH" = (
+/obj/machinery/atm{
+	pixel_y = -28
+	},
+/turf/simulated/floor{
+	icon_state = "redyellowfull"
+	},
+/area/station/hallway/primary/fore)
 "eMU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/decal/turf_decal{
@@ -22446,16 +22479,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/surgeryobs)
-"eOf" = (
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "eOj" = (
 /obj/machinery/chem_dispenser,
 /obj/effect/decal/turf_decal{
@@ -23302,6 +23325,19 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/locker)
+"eYv" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "eYy" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -24663,24 +24699,30 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
-"foe" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/powered/pump,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "arrival"
-	},
-/area/station/hallway/primary/port)
 "foh" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor,
 /area/station/maintenance/medbay)
+"fos" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NNW-B";
+	location = "NW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
+"foE" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSE-FC";
+	location = "SEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "foK" = (
 /obj/machinery/computer/security,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -25182,16 +25224,6 @@
 	icon_state = "blue"
 	},
 /area/station/engineering/atmos)
-"ftN" = (
-/obj/machinery/light/smart,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "ftS" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/structure/cable{
@@ -26820,17 +26852,6 @@
 	icon_state = "darkbrown"
 	},
 /area/station/medical/virology)
-"fNf" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "loadingarea"
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "arrow"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "fNA" = (
 /obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "box_corners_white";
@@ -26861,19 +26882,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "fOp" = (
-/obj/machinery/atm{
-	pixel_y = -28
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 5
 	},
 /turf/simulated/floor{
-	icon_state = "neutralcorner"
+	icon_state = "grimy"
 	},
-/area/station/hallway/secondary/entry)
-"fOt" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "cafeteria"
-	},
-/area/station/security/prison)
+/area/station/security/hos)
 "fOF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
@@ -27221,14 +27237,6 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/theatre)
-"fSI" = (
-/obj/machinery/atm{
-	pixel_y = -28
-	},
-/turf/simulated/floor{
-	icon_state = "redyellowfull"
-	},
-/area/station/hallway/primary/fore)
 "fSK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor,
@@ -27391,6 +27399,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"fVz" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "fVB" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/green,
@@ -29368,6 +29385,19 @@
 	icon_state = "grimy"
 	},
 /area/station/tcommsat/computer)
+"gqo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/flasher{
+	id = "Cell 1 perma";
+	pixel_y = -28
+	},
+/turf/simulated/floor,
+/area/station/security/prison)
 "gqs" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
@@ -29462,18 +29492,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/storage/primary)
-"grp" = (
-/obj/structure/stool/bed/chair/metal/black{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "grP" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -29532,6 +29550,15 @@
 /obj/structure/window/thin/reinforced,
 /turf/environment/space,
 /area/space)
+"gsC" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-B";
+	location = "S-MB"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry)
 "gsM" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/decal/cleanable/dirt,
@@ -30211,8 +30238,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line"
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 10
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/barbershop)
@@ -31604,7 +31632,8 @@
 	dir = 4
 	},
 /obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
+	icon_state = "siding_corner";
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
@@ -31698,7 +31727,7 @@
 	dir = 4
 	},
 /obj/machinery/flasher{
-	id = "Cell 1 perma";
+	id = "Cell 3 perma";
 	pixel_y = -28
 	},
 /turf/simulated/floor,
@@ -31979,6 +32008,13 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
+"gTK" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "gTM" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/handcuffs,
@@ -32660,19 +32696,6 @@
 	icon_state = "whitehall"
 	},
 /area/station/rnd/hallway)
-"haL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "hba" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32865,6 +32888,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/emergency)
+"hdA" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 29
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "blackcorner"
+	},
+/area/station/hallway/primary/starboard)
 "hdG" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -33015,6 +33047,10 @@
 /area/space)
 "hfj" = (
 /obj/structure/window/thin{
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
 	dir = 8
 	},
 /turf/simulated/floor/wood,
@@ -34617,16 +34653,6 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/chapel)
-"hxc" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "hxf" = (
 /turf/simulated/floor/bluegrid{
 	icon_state = "rcircuit"
@@ -34755,6 +34781,13 @@
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
+/area/station/civilian/locker)
+"hym" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=CS-AR";
+	location = "SWW-FC"
+	},
+/turf/simulated/floor,
 /area/station/civilian/locker)
 "hyx" = (
 /obj/machinery/bodyscanner,
@@ -35651,7 +35684,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/effect/decal/turf_decal/wood{
+/obj/effect/decal/turf_decal/wood/dark{
 	icon_state = "siding_wood_line"
 	},
 /turf/simulated/floor/wood,
@@ -35748,6 +35781,23 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboardsolar)
+"hHA" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "caution"
+	},
+/area/station/engineering/atmos/distribution)
 "hHB" = (
 /obj/structure/sign/poster/official/anniversary_vintage_reprint{
 	pixel_y = -32
@@ -36002,16 +36052,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
-"hKr" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NNW-B";
-	location = "NW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "hKs" = (
 /obj/structure/object_wall/pod{
 	icon_state = "2,2"
@@ -36300,7 +36340,7 @@
 	c_tag = "Barbershop";
 	dir = 1
 	},
-/obj/effect/decal/turf_decal/wood{
+/obj/effect/decal/turf_decal/wood/dark{
 	icon_state = "siding_wood_line"
 	},
 /turf/simulated/floor/wood,
@@ -36500,7 +36540,8 @@
 	},
 /obj/machinery/portable_atmospherics/powered/pump,
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
+	icon_state = "box_corners_white";
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -39282,6 +39323,14 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
+"iwP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/security/prison)
 "ixa" = (
 /obj/machinery/status_display{
 	pixel_y = 32
@@ -39552,14 +39601,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"izL" = (
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "yellow"
-	},
-/area/station/engineering/break_room)
 "izS" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/status_display{
@@ -39802,6 +39843,13 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/brig)
+"iCA" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_right"
+	},
+/turf/simulated/floor,
+/area/station/storage/tech)
 "iCR" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -39971,15 +40019,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/engineering/atmos/atmos_office)
-"iEs" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "iEA" = (
 /obj/structure/rack,
 /obj/item/weapon/reagent_containers/watertank_backpack,
@@ -40594,19 +40633,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/robotics)
-"iLH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "iLJ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -40727,6 +40753,13 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/xenobiology)
+"iMr" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-MB";
+	location = "N-MB"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "iMs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -44517,6 +44550,26 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/dormitories/courtroom)
+"jCr" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "jCA" = (
 /obj/machinery/newscaster{
 	pixel_y = 28
@@ -44585,6 +44638,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
+"jDZ" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "browncorner"
+	},
+/area/station/cargo/storage)
 "jEa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -44605,17 +44664,15 @@
 	},
 /area/station/hallway/primary/starboard)
 "jEs" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "neutralfull"
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
-/area/station/engineering/atmos)
+/area/station/hallway/secondary/entry)
 "jEB" = (
 /obj/machinery/air_sensor{
 	frequency = 1441;
@@ -44733,16 +44790,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
-"jFY" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "jFZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/light/small{
@@ -44930,15 +44977,6 @@
 	icon_state = "darkbrown"
 	},
 /area/station/bridge)
-"jIr" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "jIt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -45130,15 +45168,6 @@
 	},
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
-"jJx" = (
-/obj/item/weapon/flora/random,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "jJB" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -47348,29 +47377,17 @@
 /obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"kgF" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
+"kgH" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
 	dir = 4
 	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos/atmos_office)
-"kgH" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 8
-	},
 /turf/simulated/floor,
-/area/station/engineering/atmos/atmos_office)
+/area/station/civilian/gym)
 "khm" = (
 /obj/machinery/power/apc{
 	name = "apc down";
@@ -48595,6 +48612,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/supermatter)
+"ktK" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/simulated/floor{
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "ktM" = (
 /obj/machinery/alarm{
 	pixel_x = 29;
@@ -48653,20 +48678,6 @@
 	icon_state = "darkred"
 	},
 /area/station/security/checkpoint/escape)
-"kvc" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_corner";
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "arrows_white";
-	dir = 8
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "black"
-	},
-/area/station/hallway/secondary/entry)
 "kvh" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -48850,21 +48861,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
-"kyb" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/engineering/monitoring)
 "kyd" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable{
@@ -49234,6 +49230,14 @@
 /obj/item/weapon/flora/random,
 /turf/simulated/floor/carpet/red,
 /area/station/security/vacantoffice)
+"kBW" = (
+/obj/machinery/atm{
+	pixel_y = -28
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "kCb" = (
 /obj/item/weapon/flora/random,
 /obj/structure/cable{
@@ -49953,19 +49957,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/maintenance/incinerator)
-"kIT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 9
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "kIU" = (
 /turf/simulated/wall,
 /area/station/civilian/cold_room)
@@ -50381,21 +50372,6 @@
 "kMA" = (
 /turf/simulated/floor/carpet,
 /area/station/bridge/captain_quarters)
-"kMI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
 "kMJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/turf_decal{
@@ -50836,13 +50812,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/storage/tech)
-"kSL" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=CS-AR";
-	location = "SWW-FC"
-	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
 "kSN" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -52112,6 +52081,17 @@
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
+"lhY" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "loadingarea"
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "arrow"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "lij" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -52210,21 +52190,14 @@
 	},
 /area/station/cargo/storage)
 "ljq" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn_corner"
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Security";
+	location = "S-C"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "neutralcorner"
 	},
-/area/station/engineering/engine)
+/area/station/hallway/primary/central)
 "ljv" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -52283,10 +52256,11 @@
 	},
 /area/station/cargo/office)
 "lki" = (
-/turf/simulated/floor{
-	icon_state = "vaultfull"
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
 	},
-/area/station/security/blueshield)
+/turf/simulated/floor/carpet/red,
+/area/station/security/detectives_office)
 "lkl" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -54763,6 +54737,19 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/secondary/exit)
+"lNa" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "lNc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -55129,6 +55116,24 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
+"lQo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "lQz" = (
 /obj/machinery/door_control{
 	id = "teleporter_in_shutter";
@@ -55229,15 +55234,6 @@
 	},
 /turf/simulated/floor,
 /area/station/medical/storage)
-"lRR" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "lRS" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -55283,6 +55279,21 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/dormitories/courtroom)
+"lSi" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "lSs" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -55572,15 +55583,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
-"lWG" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "lWH" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -55845,6 +55847,16 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
+"maM" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SWW-FC";
+	location = "SW-FC"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "maQ" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -56397,6 +56409,22 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/port)
+"mhn" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "mhs" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -57945,6 +57973,17 @@
 	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
+"myH" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "myI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -58315,6 +58354,18 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/reception)
+"mBE" = (
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Labor Camp Shuttle Airlock";
+	req_access = list(2)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
 "mBF" = (
 /obj/structure/stool/bed/chair{
 	dir = 1
@@ -58377,6 +58428,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
+"mBV" = (
+/obj/machinery/light/smart{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NE-FC";
+	location = "NEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "mCq" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -58453,6 +58517,16 @@
 "mDI" = (
 /turf/simulated/wall,
 /area/station/civilian/chapel/office)
+"mDQ" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-B";
+	location = "SSW-B"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "mDV" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -58923,13 +58997,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
-"mKE" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=N-MB";
-	location = "NNW-B"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "mKJ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -59572,6 +59639,18 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/tox_launch)
+"mRV" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "mRW" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -59823,26 +59902,6 @@
 /obj/structure/filingcabinet/medical,
 /turf/simulated/floor/wood,
 /area/station/bridge/hop_office)
-"mUz" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "mUL" = (
 /obj/machinery/atm{
 	pixel_y = -28
@@ -60019,17 +60078,6 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/chapel/mass_driver)
-"mWj" = (
-/obj/machinery/light/smart{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -28
-	},
-/turf/simulated/floor{
-	icon_state = "wooden-2"
-	},
-/area/station/civilian/gym)
 "mWq" = (
 /obj/structure/stool/bed/chair{
 	dir = 1
@@ -60524,13 +60572,6 @@
 	icon_state = "whitehall"
 	},
 /area/station/rnd/hallway)
-"ncd" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-MB";
-	location = "N-MB"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "ncg" = (
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
@@ -60705,6 +60746,13 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/main)
+"neM" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=N-MB";
+	location = "NNW-B"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "neO" = (
 /obj/structure/table,
 /obj/machinery/computer/libraryconsole/bookmanagement{
@@ -60787,15 +60835,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
-"ngf" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 5
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "ngn" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -61719,6 +61758,26 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/break_room)
+"nqB" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "nqD" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -61753,15 +61812,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/tcommsat/chamber)
-"nqP" = (
-/obj/item/weapon/flora/random,
-/obj/machinery/light/smart{
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "white"
-	},
-/area/station/rnd/hallway/lobby)
 "nqQ" = (
 /obj/structure/stool/bed,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -62183,6 +62233,18 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"nwx" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "nwF" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable{
@@ -62660,18 +62722,6 @@
 	icon_state = "greencorner"
 	},
 /area/station/civilian/hydroponics)
-"nBx" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "nBB" = (
 /obj/machinery/power/apc/largecell{
 	dir = 1;
@@ -63334,19 +63384,6 @@
 	icon_state = "greenblue"
 	},
 /area/station/civilian/hydroponics)
-"nJd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NW-B";
-	location = "NE-FC"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "nJf" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -65053,19 +65090,6 @@
 	icon_state = "wooden-2"
 	},
 /area/station/civilian/gym)
-"obM" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_corner"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "arrows_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "black"
-	},
-/area/station/hallway/secondary/entry)
 "oci" = (
 /obj/structure/stool/bed/chair/comfy/brown{
 	dir = 4
@@ -65245,27 +65269,9 @@
 "oer" = (
 /turf/simulated/wall/r_wall,
 /area/station/bridge/ai_upload)
-"oes" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
-	},
-/turf/simulated/floor/carpet/red,
-/area/station/security/detectives_office)
 "oex" = (
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/singularity)
-"oeE" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "oeN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -65761,22 +65767,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
-"okD" = (
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Entry Shuttle Airlock";
-	req_one_access = list(13)
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
 "okM" = (
 /turf/environment/space,
 /area/shuttle/syndicate/northeast)
@@ -66038,7 +66028,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/turf_decal{
-	dir = 10;
+	dir = 9;
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
@@ -66169,7 +66159,7 @@
 	},
 /area/station/rnd/hallway)
 "oqZ" = (
-/obj/effect/decal/turf_decal/wood{
+/obj/effect/decal/turf_decal/wood/dark{
 	icon_state = "siding_wood_line"
 	},
 /turf/simulated/floor/wood,
@@ -67290,16 +67280,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/chargebay)
-"oFY" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "oGb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -68107,7 +68087,7 @@
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	dir = 4;
+	dir = 6;
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
@@ -68132,15 +68112,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/qm)
-"oOx" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DN";
-	location = "SSE-FC"
-	},
-/turf/simulated/floor{
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "oOy" = (
 /obj/structure/sign/nanotrasen{
 	pixel_y = -32
@@ -69851,15 +69822,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/recycler)
-"pjY" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Security";
-	location = "S-C"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "pka" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -71073,6 +71035,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/bridge/hop_office)
+"pxs" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "pxC" = (
 /obj/machinery/gateway{
 	dir = 10
@@ -71482,6 +71454,16 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"pAU" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "pBb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/structure/disposalpipe/segment,
@@ -71490,17 +71472,23 @@
 	},
 /area/station/engineering/atmos)
 "pBf" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
+/obj/structure/kitchenspike,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_right"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
-/area/station/security/armoury)
+/area/station/civilian/cold_room)
+"pBg" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "pBn" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -71683,6 +71671,13 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/cargo/recycler)
+"pDv" = (
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/prison)
 "pDB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -72250,6 +72245,15 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hor)
+"pKn" = (
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "pKo" = (
 /obj/structure/big_bell,
 /turf/simulated/floor{
@@ -72708,18 +72712,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
-"pPI" = (
-/obj/structure/stool/bed/chair/metal/black{
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "pPK" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -73596,26 +73588,6 @@
 /obj/item/weapon/storage/wallet,
 /turf/simulated/floor/carpet/black,
 /area/station/maintenance/engineering)
-"pZy" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "pZC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -74618,16 +74590,6 @@
 /obj/machinery/ai_status_display,
 /turf/simulated/wall/r_wall,
 /area/station/engineering/monitoring)
-"qkZ" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkred"
-	},
-/area/station/security/brig)
 "qlc" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -74771,13 +74733,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/storage/tech)
-"qmD" = (
-/obj/item/weapon/flora/random,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_right"
-	},
-/turf/simulated/floor,
-/area/station/storage/tech)
 "qmP" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -74876,18 +74831,6 @@
 	icon_state = "dark"
 	},
 /area/station/maintenance/engineering)
-"qnH" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "qnN" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -75083,6 +75026,17 @@
 /obj/item/weapon/flora/random,
 /turf/simulated/floor,
 /area/station/security/prison)
+"qql" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "qqm" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -75879,13 +75833,6 @@
 "qAy" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/incinerator)
-"qAz" = (
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/prison)
 "qAA" = (
 /obj/structure/rack,
 /obj/effect/decal/cleanable/dirt,
@@ -76438,12 +76385,6 @@
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/station/security/vacantoffice)
-"qHb" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "qHh" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable{
@@ -76602,13 +76543,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/robotics)
-"qIM" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "qIO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -76756,6 +76690,15 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/qm)
+"qJY" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "qKc" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6
@@ -76880,6 +76823,15 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway/lobby)
+"qLM" = (
+/obj/item/weapon/flora/random,
+/obj/machinery/light/smart{
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/station/rnd/hallway/lobby)
 "qLO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -76937,20 +76889,6 @@
 	icon_state = "dark"
 	},
 /area/station/medical/morgue)
-"qMu" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 9;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "qMw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -77422,14 +77360,6 @@
 	},
 /turf/simulated/floor,
 /area/station/storage/emergency)
-"qSr" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "qSt" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -77679,14 +77609,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/main)
-"qVa" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/security/prison)
 "qVm" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -78464,18 +78386,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
-"reZ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "rfw" = (
 /obj/machinery/camera{
 	c_tag = "Port Primary Hallway East"
@@ -79362,7 +79272,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/decal/turf_decal/wood{
+/obj/effect/decal/turf_decal/wood/dark{
 	icon_state = "siding_wood_line";
 	dir = 6
 	},
@@ -79739,6 +79649,17 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"ruV" = (
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "rvc" = (
 /mob/living/simple_animal/hostile/mining_drone,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -79909,6 +79830,16 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/break_room)
+"rwt" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/station/security/brig)
 "rwA" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/atmospherics/pipe/simple/visible/green,
@@ -81636,19 +81567,6 @@
 	},
 /turf/simulated/floor/carpet/red,
 /area/station/security/detectives_office)
-"rNB" = (
-/obj/machinery/light/smart{
-	dir = 4
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NE-FC";
-	location = "NEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "rNG" = (
 /turf/environment/space,
 /area/shuttle/syndicate/northwest)
@@ -81854,6 +81772,19 @@
 /obj/effect/decal/cleanable/generic,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"rPP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NW-B";
+	location = "NE-FC"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "rPR" = (
 /obj/effect/landmark/start/captain,
 /obj/structure/stool/bed/chair/comfy/brown{
@@ -82212,16 +82143,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
-"rUV" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "rUY" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -82257,6 +82178,16 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/medical/chemistry)
+"rVm" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-C";
+	location = "CS-AR"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "rVw" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -82886,6 +82817,16 @@
 /obj/machinery/light/smart,
 /turf/simulated/floor/engine,
 /area/station/civilian/holodeck/alphadeck)
+"sdy" = (
+/obj/machinery/light/smart,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "sdC" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -83006,15 +82947,6 @@
 /mob/living/simple_animal/mouse,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
-"seG" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Central Access"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "seH" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
@@ -83376,14 +83308,10 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "siM" = (
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
 /turf/simulated/floor{
-	icon_state = "neutralfull"
+	icon_state = "vaultfull"
 	},
-/area/station/hallway/primary/fore)
+/area/station/security/blueshield)
 "siU" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
@@ -83972,6 +83900,19 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"soA" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "soF" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -84360,24 +84301,6 @@
 /obj/item/weapon/flora/random,
 /turf/simulated/floor,
 /area/station/civilian/chapel/mass_driver)
-"stH" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
 "stM" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red,
 /obj/structure/disposalpipe/segment,
@@ -84792,15 +84715,6 @@
 /obj/item/weapon/circuitboard/seed_extractor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
-"szp" = (
-/obj/structure/closet/emcloset,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "szq" = (
 /turf/simulated/floor{
 	icon_state = "darkbrown"
@@ -85487,16 +85401,6 @@
 /obj/machinery/status_display,
 /turf/simulated/wall,
 /area/station/storage/tech)
-"sHL" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-C";
-	location = "CS-AR"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "sHQ" = (
 /turf/simulated/wall/r_wall,
 /area/station/engineering/monitoring)
@@ -87676,17 +87580,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
-"tjl" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "yellow"
-	},
-/area/station/engineering/atmos)
 "tjn" = (
 /obj/structure/stool/bed/chair/metal{
 	dir = 4
@@ -88477,6 +88370,17 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/cmo)
+"tua" = (
+/obj/machinery/light/smart{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -28
+	},
+/turf/simulated/floor{
+	icon_state = "wooden-2"
+	},
+/area/station/civilian/gym)
 "tun" = (
 /obj/structure/stool/bed/chair/metal/white,
 /obj/effect/landmark/start/assistant/test_subject,
@@ -88917,6 +88821,22 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/carpet/blue2,
 /area/station/security/vacantoffice)
+"tyE" = (
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Entry Shuttle Airlock";
+	req_one_access = list(13)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "tyI" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/machinery/atmospherics/components/unary/portables_connector,
@@ -89234,19 +89154,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/maintenance/cargo)
-"tCv" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "tCz" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/cyan,
 /obj/effect/decal/turf_decal/alpha/orange{
@@ -89280,6 +89187,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/engineering/atmos)
+"tCW" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "tCX" = (
 /obj/machinery/vending/coffee,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -89733,6 +89649,15 @@
 "tIa" = (
 /turf/simulated/floor/carpet/green,
 /area/station/civilian/library)
+"tIf" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "tIm" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/mineral/phoron{
@@ -89793,16 +89718,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/range)
-"tJn" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SE-FC";
-	location = "SW-B"
+"tJj" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "escape"
 	},
-/area/station/hallway/primary/central)
+/area/station/hallway/primary/port)
 "tJq" = (
 /turf/simulated/wall,
 /area/station/hallway/primary/fore)
@@ -89862,26 +89791,6 @@
 	icon_state = "dark"
 	},
 /area/station/medical/virology)
-"tKf" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "tKg" = (
 /obj/machinery/camera{
 	c_tag = "Upper Atmospherics North";
@@ -90152,7 +90061,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/decal/turf_decal/wood{
+/obj/effect/decal/turf_decal/wood/dark{
 	icon_state = "siding_wood_line"
 	},
 /turf/simulated/floor/wood,
@@ -90512,6 +90421,17 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
+"tSI" = (
+/obj/machinery/light/smart,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DS";
+	location = "DN-W"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "purplecorner"
+	},
+/area/station/hallway/primary/central)
 "tST" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -91122,17 +91042,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
-"uaf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "ual" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -91302,18 +91211,13 @@
 	},
 /area/station/rnd/hallway)
 "ucx" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "yellow"
 	},
-/area/station/security/armoury)
+/area/station/engineering/break_room)
 "ucF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -92423,7 +92327,7 @@
 /obj/structure/sink{
 	pixel_y = 24
 	},
-/obj/effect/decal/turf_decal/wood{
+/obj/effect/decal/turf_decal/wood/dark{
 	icon_state = "siding_wood_line";
 	dir = 4
 	},
@@ -92889,13 +92793,6 @@
 	icon_state = "caution"
 	},
 /area/station/storage/emergency)
-"uul" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "uum" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -93334,6 +93231,12 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
+"uBc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "cafeteria"
+	},
+/area/station/security/prison)
 "uBd" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -93842,14 +93745,26 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "uHN" = (
-/obj/machinery/vending/coffee,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Antechamber";
+	req_one_access = list(66)
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
-/area/station/hallway/primary/central)
+/area/station/aisat/teleport)
 "uHX" = (
 /turf/simulated/floor/wood,
 /area/station/maintenance/chapel)
@@ -93928,15 +93843,6 @@
 	icon_state = "whitepurplefull"
 	},
 /area/station/rnd/xenobiology)
-"uJV" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-B";
-	location = "S-MB"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/secondary/entry)
 "uJW" = (
 /obj/structure/object_wall/pod{
 	icon_state = "1,2"
@@ -94100,16 +94006,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/bridge/corp_lounge)
-"uLx" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "black"
-	},
-/area/station/hallway/secondary/entry)
 "uLI" = (
 /obj/structure/sign/warning,
 /turf/simulated/wall/r_wall,
@@ -94263,15 +94159,13 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "uNw" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NEE-FC";
-	location = "S-SV"
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "grimy"
 	},
-/area/station/hallway/primary/central)
+/area/station/security/hos)
 "uNx" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -94314,19 +94208,6 @@
 /obj/machinery/cell_charger,
 /turf/simulated/floor,
 /area/station/gateway)
-"uOh" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "uOm" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -94359,6 +94240,25 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
+"uOF" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/main)
 "uOG" = (
 /obj/structure/sign/departments/engineering,
 /turf/simulated/wall,
@@ -96267,6 +96167,16 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
+"vlW" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "vme" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -96330,6 +96240,18 @@
 "vmR" = (
 /turf/simulated/floor/plating,
 /area/station/civilian/toilet)
+"vmT" = (
+/obj/machinery/door_timer/cell_3{
+	pixel_x = 32;
+	pixel_y = 0;
+	dir = 4;
+	id = "Cell 3 perma"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "vmY" = (
 /obj/structure/rack,
 /obj/item/device/suit_cooling_unit,
@@ -97395,6 +97317,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
+"vAp" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SEE-FC";
+	location = "SE-FC"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "vAu" = (
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
@@ -98029,26 +97961,12 @@
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/auxstarboard)
 "vIk" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 4
 	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "vIl" = (
 /turf/simulated/wall,
 /area/station/rnd/hallway/lobby)
@@ -98387,13 +98305,6 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/simulated/floor,
 /area/station/maintenance/science)
-"vLS" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-FC";
-	location = "SSW-FC"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/starboard)
 "vLX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -98982,11 +98893,11 @@
 /area/station/bridge/teleporter)
 "vTX" = (
 /obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-B";
-	location = "SSW-B"
+	codes_txt = "patrol;next_patrol=SE-FC";
+	location = "SW-B"
 	},
 /turf/simulated/floor{
-	dir = 4;
+	dir = 1;
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
@@ -99354,6 +99265,18 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/robotics)
+"vYf" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "vYg" = (
 /obj/structure/table/reinforced,
 /obj/item/device/tagger/shop,
@@ -100166,27 +100089,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/checkpoint/medbay)
-"wiC" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Antechamber";
-	req_one_access = list(66)
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/aisat/teleport)
 "wiG" = (
 /obj/structure/closet/secure_closet/barber,
 /obj/item/device/cardpay{
@@ -100535,15 +100437,25 @@
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "wmh" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SEE-FC";
-	location = "SE-FC"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn_corner"
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "yellowcorner"
+	icon_state = "redcorner"
 	},
-/area/station/hallway/primary/port)
+/area/station/security/prison)
 "wmj" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -100771,19 +100683,6 @@
 	icon_state = "white"
 	},
 /area/station/medical/hallway)
-"woW" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/flasher{
-	id = "Cell 3 perma";
-	pixel_y = -28
-	},
-/turf/simulated/floor,
-/area/station/security/prison)
 "wpa" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -100838,6 +100737,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
+"wqe" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_corner";
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "arrows_white";
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/hallway/secondary/entry)
 "wqg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -100858,6 +100771,16 @@
 	},
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
+"wqp" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/hallway/secondary/entry)
 "wqq" = (
 /obj/machinery/libraryscanner,
 /obj/machinery/camera{
@@ -101369,6 +101292,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/locker)
+"wxM" = (
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "wxS" = (
 /obj/structure/object_wall/mining{
 	icon_state = "5-9"
@@ -102267,7 +102199,7 @@
 "wHb" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_right"
+	icon_state = "bot_left"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -102814,6 +102746,18 @@
 	icon_state = "whitepurplefull"
 	},
 /area/station/rnd/hallway)
+"wOS" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "wOT" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/airlock_electronics,
@@ -102949,6 +102893,18 @@
 	icon_state = "white"
 	},
 /area/station/rnd/hallway)
+"wPT" = (
+/obj/structure/stool/bed/chair/metal/black{
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "wQz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
@@ -103215,6 +103171,16 @@
 	icon_state = "dark"
 	},
 /area/station/medical/virology)
+"wUf" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-FC";
+	location = "DS"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
+/area/station/hallway/primary/central)
 "wUp" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -104233,17 +104199,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"xfQ" = (
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
 "xfW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -105012,6 +104967,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
+"xpu" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "xpQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/hologram/holopad,
@@ -105484,16 +105460,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
-"xuq" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SWW-FC";
-	location = "SW-FC"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "xut" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -105875,6 +105841,18 @@
 	icon_state = "red"
 	},
 /area/station/security/checkpoint/engi)
+"xyd" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/engineering/atmos/atmos_office)
 "xyp" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -106073,6 +106051,12 @@
 	icon_state = "dark"
 	},
 /area/station/security/brig)
+"xAl" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "xAm" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -106081,6 +106065,14 @@
 	icon_state = "gr_window_reinforced"
 	},
 /turf/simulated/floor/plating,
+/area/station/civilian/gym)
+"xAq" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/civilian/gym)
 "xAA" = (
 /obj/structure/table/woodentable,
@@ -106440,16 +106432,6 @@
 	},
 /turf/simulated/wall,
 /area/station/hallway/primary/starboard)
-"xEa" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
 "xEl" = (
 /obj/structure/table,
 /obj/item/device/camera/polar,
@@ -106951,6 +106933,37 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
+"xKs" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 10;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
+"xKv" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Entry Shuttle Airlock";
+	req_one_access = list(13)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "xKF" = (
 /obj/machinery/light/smart,
 /turf/simulated/floor/grass,
@@ -107195,15 +107208,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
-"xMW" = (
-/obj/effect/decal/turf_decal/alpha/blue{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "xNJ" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /turf/simulated/floor/engine,
@@ -108185,6 +108189,15 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/secondary/exit)
+"xXT" = (
+/obj/structure/closet/emcloset,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "xXU" = (
 /obj/machinery/mecha_part_fabricator{
 	dir = 4
@@ -108246,19 +108259,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
-"xYF" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "xYP" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/cleanable/dirt,
@@ -108594,6 +108594,19 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
+"ycC" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_corner"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "arrows_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/hallway/secondary/entry)
 "ycQ" = (
 /obj/machinery/door/window{
 	dir = 1;
@@ -108783,14 +108796,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/hallway)
-"yeU" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/turf/simulated/floor{
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "yeY" = (
 /obj/effect/decal/turf_decal{
 	dir = 8;
@@ -118653,7 +118658,7 @@ eXX
 pGn
 fBB
 pGn
-wiC
+uHN
 pGn
 pGn
 oer
@@ -132008,7 +132013,7 @@ xFF
 xFG
 flb
 uDn
-izL
+ucx
 ude
 ehA
 geB
@@ -132265,7 +132270,7 @@ qnQ
 hEd
 fDg
 owf
-izL
+ucx
 hkb
 ehA
 fUz
@@ -132768,7 +132773,7 @@ oLJ
 kFc
 kFc
 cEO
-tjl
+qql
 azQ
 pfp
 imT
@@ -133014,7 +133019,7 @@ qSk
 qdn
 naA
 kdJ
-xYF
+eLq
 xqQ
 fmh
 mNB
@@ -133022,8 +133027,8 @@ bfy
 cmG
 dup
 htY
-jFY
-jFY
+pAU
+pAU
 nwM
 tCz
 gRR
@@ -133278,7 +133283,7 @@ nLs
 bTE
 tUm
 oPF
-uOh
+eYv
 rSb
 umn
 svw
@@ -134042,7 +134047,7 @@ bsZ
 fZH
 cTK
 whA
-kgH
+xyd
 iDO
 iDO
 iDO
@@ -134051,8 +134056,8 @@ vCV
 lFG
 waB
 fMO
-jEs
-reZ
+nwx
+vYf
 kHT
 vPk
 vPk
@@ -134301,7 +134306,7 @@ qcT
 mrP
 daq
 daq
-kgF
+bOn
 egG
 iEf
 hrT
@@ -134843,9 +134848,9 @@ hdV
 bhn
 evV
 oKM
-nBx
+wOS
 wCx
-oeE
+mRV
 oDZ
 bau
 nkc
@@ -135102,7 +135107,7 @@ enq
 bgZ
 gCp
 tRh
-ljq
+mhn
 oyx
 mRP
 eZT
@@ -135599,7 +135604,7 @@ gpz
 nds
 gpz
 wjD
-gPB
+eaw
 bbv
 awp
 odu
@@ -135856,7 +135861,7 @@ adw
 adw
 adw
 wjD
-kyb
+gPB
 cgv
 owM
 ekM
@@ -136359,7 +136364,7 @@ jlK
 tEF
 tne
 cEZ
-apD
+hHA
 iGS
 ciX
 jau
@@ -136894,7 +136899,7 @@ qTx
 qTx
 lGc
 rjD
-yeU
+ktK
 uSc
 uib
 uSc
@@ -137141,13 +137146,13 @@ tEF
 sHQ
 dpc
 sHQ
+tJj
 blv
-bcl
 sqb
 uck
 sqb
-foe
 hQQ
+czK
 qTx
 bUU
 iky
@@ -137413,7 +137418,7 @@ doE
 doE
 doE
 lgU
-wmh
+vAp
 mhm
 doE
 mnD
@@ -137911,7 +137916,7 @@ wwi
 aYN
 wwi
 lfm
-aSi
+foE
 tZn
 oyb
 nAM
@@ -137929,7 +137934,7 @@ oyb
 bzt
 bzt
 rcq
-oOx
+bvv
 tYK
 wtC
 wtC
@@ -139459,7 +139464,7 @@ xNR
 oYv
 cGN
 vzT
-qmD
+iCA
 oVN
 cdA
 jTf
@@ -139702,7 +139707,7 @@ tRk
 vdt
 rwG
 srt
-wHb
+pBf
 dOS
 rfL
 qsE
@@ -139959,7 +139964,7 @@ aSY
 uum
 lVS
 srt
-blc
+wHb
 uos
 gTB
 kst
@@ -140162,14 +140167,14 @@ kHU
 kHU
 kHU
 yaE
-okD
+tyE
 yaE
 kHU
 plf
 plf
 kHU
 yaE
-okD
+tyE
 yaE
 kHU
 kHU
@@ -140676,14 +140681,14 @@ yaE
 ffS
 aev
 yaE
-aWC
+xKv
 yaE
 aqg
 aqg
 aqg
 mlH
 yaE
-aWC
+xKv
 yaE
 eeB
 ffS
@@ -140730,7 +140735,7 @@ kBq
 biv
 pED
 bNa
-xEa
+esZ
 kIU
 lBN
 yeY
@@ -140987,7 +140992,7 @@ dtM
 fty
 abG
 vLv
-xEa
+esZ
 kIU
 jVV
 ekm
@@ -141704,7 +141709,7 @@ yaE
 ffS
 eeB
 yaE
-aWC
+xKv
 yaE
 mlH
 nhe
@@ -142063,7 +142068,7 @@ oZa
 xyx
 dJC
 gjY
-nqP
+qLM
 kdp
 xfI
 eIi
@@ -142218,7 +142223,7 @@ kHU
 kHU
 kHU
 yaE
-okD
+tyE
 yaE
 kHU
 plf
@@ -142755,11 +142760,11 @@ dbB
 idn
 fRR
 ofi
-jJx
+tIf
 miI
 ffS
 jjY
-szp
+xXT
 wwi
 pkS
 wwi
@@ -143049,7 +143054,7 @@ gNR
 fZQ
 nIu
 qMb
-uHN
+cZp
 jxa
 egV
 aaz
@@ -143308,7 +143313,7 @@ iSv
 xXt
 vAu
 ogP
-vTX
+mDQ
 bAS
 nvi
 rnH
@@ -143324,7 +143329,7 @@ qbj
 qbj
 tmk
 ldb
-tJn
+vTX
 ogP
 iSi
 amv
@@ -143351,7 +143356,7 @@ vpT
 xei
 bFh
 vpT
-cyD
+tSI
 vIl
 olx
 frM
@@ -143519,7 +143524,7 @@ plf
 brw
 mko
 jsL
-uJV
+gsC
 ffX
 hbE
 sTt
@@ -143788,7 +143793,7 @@ gHT
 alc
 vDr
 fDL
-hKr
+fos
 iwy
 xXt
 gNR
@@ -143820,7 +143825,7 @@ hAK
 kne
 twi
 xXt
-nJd
+rPP
 ogP
 nvi
 kRo
@@ -144294,10 +144299,10 @@ fYS
 slo
 ffS
 pLB
-jJx
-dDs
+tIf
+wPT
 acf
-pPI
+dDs
 aSq
 ffS
 gvF
@@ -144569,17 +144574,17 @@ hXb
 hXb
 hXb
 che
-siM
-stH
-siM
-siM
-siM
-siM
-siM
-siM
-siM
-kMI
-siM
+wxM
+lQo
+wxM
+wxM
+wxM
+wxM
+wxM
+wxM
+wxM
+lSi
+wxM
 vos
 did
 did
@@ -144836,7 +144841,7 @@ fjB
 qSx
 dtr
 czE
-fSI
+eMH
 tJq
 gIl
 rdY
@@ -145073,7 +145078,7 @@ kHU
 yaE
 hkD
 fYS
-byc
+pKn
 wts
 mge
 qed
@@ -145353,13 +145358,13 @@ mpN
 uQg
 tJq
 oFm
-qIM
+vIk
 xsb
-qIM
-qIM
-qIM
+vIk
+vIk
+vIk
 mtf
-qIM
+vIk
 jpq
 bsc
 mfI
@@ -145587,7 +145592,7 @@ plf
 yaE
 vDr
 fYS
-eOf
+jEs
 tEo
 nIB
 iEL
@@ -145844,7 +145849,7 @@ kHU
 yaE
 csG
 fYS
-ftN
+sdy
 wts
 npC
 txi
@@ -145867,13 +145872,13 @@ cCx
 mES
 tJq
 ikZ
-kIT
+aKW
 oki
-uul
-uul
-iLH
+gTK
+gTK
+eBE
 tWH
-iLH
+eBE
 qcF
 bRX
 qSi
@@ -146101,7 +146106,7 @@ kHU
 yaE
 csG
 fYS
-fOp
+kBW
 wts
 bCJ
 euO
@@ -146124,7 +146129,7 @@ tJq
 ucP
 tJq
 fSC
-haL
+bpT
 ktM
 uuo
 djH
@@ -146607,10 +146612,10 @@ fYS
 jNI
 ffS
 ylK
-grp
+ejv
 cmX
 fRR
-esZ
+aJf
 ryG
 ffS
 uAC
@@ -147632,7 +147637,7 @@ yaE
 yaE
 csG
 fYS
-ncd
+iMr
 alc
 gHT
 gHT
@@ -147641,7 +147646,7 @@ gHT
 gHT
 gHT
 alc
-mKE
+neM
 fYS
 sEX
 srs
@@ -147891,12 +147896,12 @@ lrr
 fYS
 wtr
 sDu
-obM
-uLx
-uLx
-uLx
-uLx
-kvc
+ycC
+wqp
+wqp
+wqp
+wqp
+wqe
 xao
 csG
 fYS
@@ -149157,14 +149162,14 @@ xjr
 xjr
 plf
 yaE
-xfQ
+ruV
 yaE
 yaE
 yaE
 yaE
 yaE
 yaE
-xfQ
+ruV
 yaE
 plf
 plf
@@ -151100,7 +151105,7 @@ sbN
 uKh
 sHC
 npd
-eqV
+hdA
 xQo
 mUL
 rmY
@@ -152576,7 +152581,7 @@ mXl
 mXl
 mXl
 wLD
-uNw
+cQm
 iwm
 mXl
 pRS
@@ -152594,7 +152599,7 @@ oNU
 mXl
 uxx
 xMc
-xuq
+maM
 nvi
 rnH
 cLM
@@ -152603,7 +152608,7 @@ nvi
 tOH
 mfI
 ogP
-ejv
+wUf
 sBG
 wjc
 wjc
@@ -152906,7 +152911,7 @@ xQo
 xQo
 xQo
 nKU
-vLS
+dHT
 xQo
 oPI
 mRu
@@ -153073,7 +153078,7 @@ cpR
 gtK
 cpR
 pxL
-rNB
+mBV
 ffJ
 ape
 fZz
@@ -153092,7 +153097,7 @@ hRd
 ckx
 fZz
 lMB
-pjY
+ljq
 kzb
 vAu
 psV
@@ -153106,7 +153111,7 @@ vAu
 kRo
 vAu
 kCI
-sHL
+rVm
 ogP
 lwr
 mLS
@@ -153349,7 +153354,7 @@ cmN
 act
 uuf
 xsY
-seG
+bhH
 jTW
 jTW
 jTW
@@ -153829,7 +153834,7 @@ fnT
 miA
 ojm
 lPc
-ebs
+jDZ
 gaF
 rpV
 qSe
@@ -154086,11 +154091,11 @@ nkb
 adb
 hzP
 cpR
-hxc
-oOk
+aZN
+pxs
 uXI
+pxs
 oOk
-oFY
 xqF
 aAF
 iqI
@@ -157197,8 +157202,8 @@ plf
 xyC
 cFp
 klH
-oes
-oes
+lki
+lki
 hGr
 aRu
 xyC
@@ -157701,11 +157706,11 @@ plf
 plf
 plf
 uRO
-cBK
+mBE
 uRO
 plf
 uRO
-cBK
+mBE
 uRO
 plf
 xyC
@@ -157722,8 +157727,8 @@ dnn
 aEr
 wPw
 jQy
-xMW
-lki
+qJY
+siM
 jcX
 fJg
 nPU
@@ -158232,7 +158237,7 @@ xyC
 xyC
 wpm
 jtG
-qHb
+xAl
 fJg
 fJg
 fJg
@@ -158472,11 +158477,11 @@ wVt
 cHH
 cjS
 bNB
-opt
+xKs
 kms
 cHH
 eow
-qMu
+opt
 goK
 hYT
 nsn
@@ -158729,7 +158734,7 @@ leA
 cHH
 adG
 iGB
-qkZ
+rwt
 tTk
 qMX
 aZz
@@ -158990,7 +158995,7 @@ ikW
 qXE
 rjb
 utF
-fNf
+lhY
 uLd
 lat
 nsn
@@ -159789,7 +159794,7 @@ kIM
 vst
 mDV
 vKG
-kSL
+hym
 xoq
 tAM
 uQA
@@ -160508,14 +160513,14 @@ fAF
 fgx
 diq
 fAF
-aNp
+vmT
 eTq
 fAF
 wNM
 oPD
 tif
 rHZ
-pZy
+jCr
 czU
 tqK
 hsq
@@ -160772,7 +160777,7 @@ qZx
 qZx
 fXG
 qZx
-tKf
+nqB
 czU
 uvV
 kMw
@@ -161278,13 +161283,13 @@ blh
 cra
 hlv
 dVr
-woW
+gQC
 hlv
 fBm
 bvC
 hlv
 vqQ
-gQC
+gqo
 qZx
 tnw
 fLE
@@ -162302,7 +162307,7 @@ aXC
 bZu
 pLw
 unD
-qVa
+iwP
 oAx
 ulK
 eyO
@@ -162622,7 +162627,7 @@ obL
 swQ
 mdF
 cwA
-mWj
+tua
 sOK
 pJx
 gej
@@ -162856,7 +162861,7 @@ sxG
 uOc
 hur
 hur
-ucx
+soA
 ekd
 lZw
 gqC
@@ -163110,7 +163115,7 @@ ixl
 mme
 uKd
 gRX
-pBf
+aIN
 sRa
 nUj
 wUB
@@ -163139,13 +163144,13 @@ ncp
 ncp
 hbR
 mWz
-qnH
+bhk
 kLd
 syX
 tHk
 tHk
 dbf
-vIk
+xpu
 ram
 mWz
 lNQ
@@ -163402,7 +163407,7 @@ eFl
 aRb
 nDG
 jjN
-tCv
+lNa
 ram
 mWz
 ucd
@@ -163609,7 +163614,7 @@ afw
 nDf
 mZo
 qUR
-cue
+uOF
 mzV
 aSh
 mpR
@@ -163910,7 +163915,7 @@ ncp
 ncp
 hbR
 mWz
-aWz
+kgH
 sIY
 qls
 uOM
@@ -164106,7 +164111,7 @@ lhK
 wVg
 aFN
 jKZ
-fOt
+uBc
 rBo
 hlv
 qxh
@@ -164370,7 +164375,7 @@ xIO
 jps
 xIO
 qZx
-mUz
+wmh
 tbS
 sZR
 kHU
@@ -164382,7 +164387,7 @@ fwH
 qoH
 vOW
 qoH
-qSr
+uNw
 umQ
 gYp
 kHU
@@ -164620,7 +164625,7 @@ jvm
 hlv
 fVW
 fPH
-fOt
+uBc
 rnI
 hlv
 pHz
@@ -164635,11 +164640,11 @@ kHU
 plf
 cYc
 ueE
-rUV
+vlW
 wcJ
 iRz
 nez
-uaf
+myH
 hlh
 gYp
 plf
@@ -164892,11 +164897,11 @@ kHU
 kHU
 cYc
 nfj
-lRR
+fVz
 eaE
 nRk
 rZh
-iEs
+pBg
 hmN
 gYp
 kHU
@@ -164940,7 +164945,7 @@ dJL
 nRG
 oXA
 oXA
-cxQ
+xAq
 dJL
 plf
 cdR
@@ -165149,11 +165154,11 @@ plf
 kHU
 huz
 sIx
-ngf
-jIr
+fOp
+euT
 kjv
-jIr
-lWG
+euT
+tCW
 tEU
 huz
 plf
@@ -167198,7 +167203,7 @@ plf
 kHU
 hlv
 lrm
-qAz
+pDv
 jno
 hlv
 cBu
@@ -168278,7 +168283,7 @@ kHU
 fMh
 plf
 dJL
-cxQ
+xAq
 oXA
 oXA
 nJn

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -1792,13 +1792,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/bridge/corp_lounge)
-"anb" = (
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "anh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -3074,10 +3067,6 @@
 	dir = 4;
 	pixel_x = 22
 	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
 "aBc" = (
@@ -3765,10 +3754,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -3974,7 +3959,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/rnd/xenobiology)
 "aMp" = (
@@ -4440,13 +4425,6 @@
 	icon_state = "darkredcorners"
 	},
 /area/station/security/checkpoint/escape)
-"aRH" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "aRK" = (
 /obj/structure/stool/bar,
 /obj/structure/disposalpipe/segment{
@@ -6279,6 +6257,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/tcommsat/chamber)
+"bmb" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/hor)
 "bme" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -6577,6 +6564,20 @@
 	icon_state = "wooden"
 	},
 /area/station/medical/psych)
+"bpI" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
+/area/station/rnd/xenobiology)
 "bpO" = (
 /obj/effect/landmark/start/assistant/test_subject,
 /obj/machinery/light/smart{
@@ -8087,8 +8088,8 @@
 	name = "Containment Blast Doors";
 	opacity = 0
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -10374,6 +10375,10 @@
 	internal_pressure_bound_default = 4000;
 	name = "Server (In) Air Vent"
 	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -11145,7 +11150,9 @@
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "purple"
+	},
 /area/station/rnd/xenobiology)
 "con" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -11758,6 +11765,15 @@
 	icon_state = "dark"
 	},
 /area/station/security/range)
+"cwW" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/xenobiology)
 "cwX" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -12769,15 +12785,6 @@
 	icon_state = "darkbrown"
 	},
 /area/station/medical/virology)
-"cHQ" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 10
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/rnd/hor)
 "cHR" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -12837,17 +12844,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
-"cIK" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "cIT" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -12866,6 +12862,10 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 22
+	},
+/obj/effect/decal/turf_decal/alpha/purple{
+	icon_state = "siding_line";
+	dir = 9
 	},
 /turf/simulated/floor{
 	dir = 9;
@@ -13837,7 +13837,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/decal/turf_decal{
-	dir = 1;
+	dir = 5;
 	icon_state = "warn"
 	},
 /turf/simulated/floor,
@@ -14341,6 +14341,9 @@
 /area/station/cargo/miningoffice)
 "ddl" = (
 /obj/machinery/monkey_recycler,
+/obj/effect/decal/turf_decal/alpha/red{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -16420,6 +16423,13 @@
 	icon_state = "darkblue"
 	},
 /area/station/bridge/corp_lounge)
+"dBr" = (
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "dBv" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -17826,6 +17836,16 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/brig)
+"dUG" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "whitepurplecorner"
+	},
+/area/station/rnd/xenobiology)
 "dUJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -19596,6 +19616,26 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
+"epu" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha{
+	icon_state = "warn_end";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/station/rnd/xenobiology)
 "eqn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
@@ -21404,7 +21444,10 @@
 	dir = 1;
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "purple"
+	},
 /area/station/rnd/xenobiology)
 "eNj" = (
 /obj/machinery/door/firedoor,
@@ -21855,6 +21898,10 @@
 /area/station/engineering/atmos)
 "eRn" = (
 /obj/machinery/chem_master,
+/obj/effect/decal/turf_decal/alpha/purple{
+	icon_state = "siding_line";
+	dir = 8
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "purple"
@@ -22514,7 +22561,8 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/xenobiology)
 "faz" = (
@@ -23876,10 +23924,6 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
 "frw" = (
@@ -24717,7 +24761,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/xenobiology)
 "fAi" = (
@@ -24796,6 +24840,12 @@
 	},
 /turf/simulated/floor/engine/oxygen,
 /area/station/engineering/atmos)
+"fBk" = (
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "fBl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -25017,6 +25067,15 @@
 /obj/structure/rack,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"fEc" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/xenobiology)
 "fEl" = (
 /obj/structure/window/thin{
 	dir = 8
@@ -25983,9 +26042,12 @@
 	},
 /area/station/security/brig)
 "fQK" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "warn";
+	dir = 5
+	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "darkred"
+	icon_state = "dark"
 	},
 /area/station/rnd/xenobiology)
 "fQR" = (
@@ -26815,6 +26877,9 @@
 /obj/machinery/door/window/brigdoor{
 	name = "Creature Pen";
 	req_access = list(55)
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -28369,6 +28434,13 @@
 	},
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
+"gsU" = (
+/obj/effect/decal/turf_decal{
+	dir = 5;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "gsX" = (
 /obj/machinery/door/airlock/external{
 	dock_tag = "supply_dock";
@@ -30131,6 +30203,9 @@
 /obj/structure/drain{
 	drainage = 2
 	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "box_white"
+	},
 /obj/effect/decal/turf_decal{
 	dir = 6;
 	icon_state = "warn"
@@ -31012,6 +31087,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/cmo)
+"gWV" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "gXb" = (
 /obj/item/weapon/caution,
 /turf/simulated/floor/plating,
@@ -32959,6 +33041,9 @@
 /obj/structure/window/thin/reinforced{
 	dir = 8
 	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -33238,6 +33323,10 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Freezer";
 	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -36020,6 +36109,10 @@
 /area/station/hallway/secondary/entry)
 "idF" = (
 /obj/machinery/clonepod,
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -36973,6 +37066,9 @@
 	name = "Creature Pen";
 	req_access = list(55)
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -37282,6 +37378,17 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/rnd/test_area)
+"irX" = (
+/obj/structure/window/thin/reinforced{
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/xenobiology)
 "isb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -37293,6 +37400,17 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
+"isq" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "iss" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
@@ -37527,9 +37645,12 @@
 /area/shuttle/supply/station)
 "ivl" = (
 /obj/structure/window/thin/reinforced,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "warn";
+	dir = 6
+	},
 /turf/simulated/floor{
-	dir = 6;
-	icon_state = "darkred"
+	icon_state = "dark"
 	},
 /area/station/rnd/xenobiology)
 "ivo" = (
@@ -38826,24 +38947,18 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "warn";
+	dir = 4
+	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "darkred"
+	icon_state = "dark"
 	},
 /area/station/rnd/xenobiology)
 "iKm" = (
 /obj/structure/bookcase/manuals/research_and_development,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
-"iKo" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/rnd/hor)
 "iKG" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -39042,7 +39157,8 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/xenobiology)
 "iMs" = (
@@ -39247,6 +39363,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
+"iOG" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "purple"
+	},
+/area/station/rnd/xenobiology)
 "iOK" = (
 /obj/structure/stool/bed/chair/metal/yellow{
 	dir = 8
@@ -40878,6 +41004,10 @@
 	dir = 1;
 	network = list("SS13","Research")
 	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -41922,6 +42052,9 @@
 	id = "xenobio4";
 	name = "Containment Blast Doors";
 	opacity = 0
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -44119,6 +44252,15 @@
 	temperature = 80
 	},
 /area/station/tcommsat/chamber)
+"jRF" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/xenobiology)
 "jSg" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor,
@@ -44876,17 +45018,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/dormitories/courtroom)
-"kaL" = (
-/obj/effect/decal/turf_decal{
-	dir = 10;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "kaM" = (
 /obj/structure/table/woodentable,
 /obj/structure/cable{
@@ -46690,13 +46821,6 @@
 	},
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
-"kuZ" = (
-/obj/effect/decal/turf_decal{
-	dir = 6;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "kvb" = (
 /obj/structure/stool/bed/chair/metal/red,
 /turf/simulated/floor{
@@ -47473,6 +47597,15 @@
 "kFd" = (
 /turf/simulated/wall,
 /area/station/rnd/scibreak)
+"kFf" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/hor)
 "kFj" = (
 /obj/machinery/door/airlock{
 	name = "Mime's Backstage Room";
@@ -48120,7 +48253,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/xenobiology)
 "kKU" = (
@@ -48242,13 +48375,14 @@
 /area/station/rnd/tox_launch)
 "kMa" = (
 /obj/effect/decal/turf_decal{
-	dir = 4;
+	dir = 9;
 	icon_state = "warn"
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
 	},
-/area/station/rnd/xenobiology)
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "kMb" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
@@ -49765,13 +49899,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
-"ldK" = (
-/obj/effect/decal/turf_decal{
-	dir = 5;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "ldN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -51335,6 +51462,17 @@
 	},
 /turf/environment/space,
 /area/shuttle/escape_pod5/station)
+"lxU" = (
+/obj/effect/decal/turf_decal{
+	dir = 10;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "lyd" = (
 /obj/structure/table/reinforced,
 /obj/machinery/alarm{
@@ -52310,6 +52448,16 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/dormitories)
+"lKe" = (
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "lKf" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -53736,6 +53884,21 @@
 	icon_state = "barber"
 	},
 /area/station/medical/storage)
+"mbT" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/station/rnd/xenobiology)
 "mbV" = (
 /obj/structure/displaycase/captain,
 /turf/simulated/floor{
@@ -53889,6 +54052,13 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/armoury)
+"mes" = (
+/obj/effect/decal/turf_decal{
+	dir = 6;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "mev" = (
 /obj/structure/displaycase_chassis,
 /obj/effect/decal/cleanable/dirt,
@@ -55951,6 +56121,9 @@
 	name = "Creature Pen";
 	req_access = list(55)
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -56433,6 +56606,18 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/library)
+"mHQ" = (
+/obj/structure/window/thin/reinforced{
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/xenobiology)
 "mIw" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/simulated/wall,
@@ -56582,7 +56767,7 @@
 "mKy" = (
 /obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "siding_line";
-	dir = 4
+	dir = 10
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -57543,7 +57728,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/rnd/xenobiology)
 "mVh" = (
@@ -58847,6 +59032,10 @@
 	dir = 4
 	},
 /obj/machinery/disposal,
+/obj/effect/decal/turf_decal/alpha/purple{
+	icon_state = "siding_line";
+	dir = 8
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "purple"
@@ -59966,6 +60155,10 @@
 /obj/structure/window/thin/reinforced{
 	dir = 8
 	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -60641,6 +60834,10 @@
 	c_tag = "Xenobiology Upper Cells";
 	network = list("SS13","Research")
 	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -60880,6 +61077,9 @@
 	name = "Creature Pen";
 	req_access = list(55)
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -61071,7 +61271,7 @@
 	dir = 1
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
+	icon_state = "box_white"
 	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
@@ -61791,9 +61991,12 @@
 	},
 /area/station/engineering/atmos/supermatter)
 "nUw" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "warn";
+	dir = 9
+	},
 /turf/simulated/floor{
-	dir = 9;
-	icon_state = "darkred"
+	icon_state = "dark"
 	},
 /area/station/rnd/xenobiology)
 "nUx" = (
@@ -62283,16 +62486,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hor)
-"nZN" = (
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "nZW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -63098,6 +63291,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -63354,7 +63554,8 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/xenobiology)
 "opq" = (
@@ -63585,6 +63786,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha{
+	icon_state = "warn_end";
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -64140,7 +64345,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/rnd/xenobiology)
 "oAJ" = (
@@ -64298,7 +64503,8 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "whitepurple"
 	},
 /area/station/rnd/xenobiology)
 "oCq" = (
@@ -64417,6 +64623,10 @@
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/effect/decal/turf_decal/alpha/purple{
+	icon_state = "siding_line";
+	dir = 1
 	},
 /turf/simulated/floor{
 	dir = 9;
@@ -64749,6 +64959,10 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/effect/decal/turf_decal/alpha/purple{
+	icon_state = "siding_line";
+	dir = 1
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "purple"
@@ -64990,6 +65204,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
+"oLh" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/hor)
 "oLl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -65644,6 +65867,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
 	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
@@ -67927,6 +68154,16 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/civilian/cold_room)
+"puk" = (
+/mob/living/carbon/monkey,
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/xenobiology)
 "pux" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -68392,6 +68629,10 @@
 /area/shuttle/syndicate/north)
 "pyX" = (
 /obj/machinery/light/small,
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -68615,6 +68856,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
 "pBv" = (
@@ -69930,6 +70175,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
 "pQD" = (
@@ -71393,7 +71642,9 @@
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "purple"
+	},
 /area/station/rnd/xenobiology)
 "qiK" = (
 /obj/machinery/door/firedoor,
@@ -71543,6 +71794,10 @@
 /obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white";
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -71920,6 +72175,9 @@
 	dir = 1;
 	name = "Creature Pen";
 	req_access = list(55)
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -73309,6 +73567,10 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 8
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -74453,10 +74715,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -75195,9 +75453,12 @@
 /obj/machinery/light/smart{
 	dir = 1
 	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "warn";
+	dir = 1
+	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "darkred"
+	icon_state = "dark"
 	},
 /area/station/rnd/xenobiology)
 "rdY" = (
@@ -75649,6 +75910,14 @@
 	icon_state = "vaultfull"
 	},
 /area/station/rnd/robotics)
+"rjS" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/xenobiology)
 "rkr" = (
 /obj/structure/rack,
 /obj/random/cloth/gloves_safe,
@@ -77473,6 +77742,10 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
 "rFe" = (
@@ -77832,6 +78105,9 @@
 	dir = 1;
 	name = "Creature Pen";
 	req_access = list(55)
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -79051,10 +79327,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -79508,6 +79780,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -79942,9 +80221,8 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
@@ -80013,6 +80291,9 @@
 /obj/machinery/door/window/brigdoor{
 	name = "Creature Pen";
 	req_access = list(55)
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -80164,6 +80445,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
 	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
@@ -80594,6 +80879,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "box_white"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -80714,6 +81002,21 @@
 	icon_state = "darkredcorners"
 	},
 /area/station/security/checkpoint/escape)
+"src" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/station/rnd/xenobiology)
 "srf" = (
 /obj/effect/decal/turf_decal{
 	dir = 6;
@@ -81076,7 +81379,8 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 1;
+	icon_state = "whitepurple"
 	},
 /area/station/rnd/xenobiology)
 "svQ" = (
@@ -84395,8 +84699,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
-	icon_state = "darkred"
+	icon_state = "dark"
 	},
 /area/station/rnd/xenobiology)
 "tni" = (
@@ -84479,6 +84786,20 @@
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/starboard)
+"tnZ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
+/area/station/rnd/xenobiology)
 "tok" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
@@ -85677,15 +85998,9 @@
 /turf/simulated/floor/plating,
 /area/station/medical/reception)
 "tDm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
+/obj/structure/reagent_dispensers/aqueous_foam_tank,
+/obj/effect/decal/turf_decal/alpha/red{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -86361,7 +86676,8 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 8;
+	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/xenobiology)
 "tMj" = (
@@ -86429,7 +86745,8 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 4;
+	icon_state = "whitepurple"
 	},
 /area/station/rnd/xenobiology)
 "tMM" = (
@@ -86502,6 +86819,10 @@
 /obj/structure/sink{
 	dir = 4;
 	pixel_x = 12
+	},
+/obj/effect/decal/turf_decal/alpha/purple{
+	icon_state = "siding_line";
+	dir = 1
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -87219,6 +87540,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden,
 /obj/effect/decal/turf_decal{
+	dir = 6;
 	icon_state = "warn"
 	},
 /turf/simulated/floor,
@@ -89645,7 +89967,10 @@
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 10;
+	icon_state = "purple"
+	},
 /area/station/rnd/xenobiology)
 "uCB" = (
 /obj/machinery/alarm{
@@ -89965,7 +90290,9 @@
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "purple"
+	},
 /area/station/rnd/xenobiology)
 "uGq" = (
 /obj/structure/cable{
@@ -90138,7 +90465,10 @@
 /obj/effect/landmark{
 	name = "lightsout"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "purple"
+	},
 /area/station/rnd/xenobiology)
 "uKd" = (
 /turf/simulated/wall/r_wall,
@@ -92649,6 +92979,10 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/trunk,
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -93683,9 +94017,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "warn";
+	dir = 8
+	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkred"
+	icon_state = "dark"
 	},
 /area/station/rnd/xenobiology)
 "vCV" = (
@@ -94021,6 +94358,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
 "vGp" = (
@@ -94073,12 +94414,12 @@
 /turf/simulated/floor,
 /area/station/engineering/engine)
 "vHf" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white";
+	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
 /area/station/rnd/xenobiology)
 "vHR" = (
@@ -95048,6 +95389,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -95646,7 +95990,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/xenobiology)
 "wbC" = (
@@ -96567,6 +96911,10 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
 "wmS" = (
@@ -96810,15 +97158,6 @@
 	},
 /turf/simulated/floor/carpet/red,
 /area/station/security/detectives_office)
-"wqN" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/rnd/hor)
 "wqS" = (
 /obj/structure/table,
 /obj/item/weapon/storage/belt/utility,
@@ -98146,16 +98485,6 @@
 	icon_state = "2,3"
 	},
 /area/shuttle/supply/station)
-"wGM" = (
-/obj/effect/decal/turf_decal{
-	dir = 9;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "wGW" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -99362,7 +99691,8 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "white"
+	dir = 2;
+	icon_state = "whitepurple"
 	},
 /area/station/rnd/xenobiology)
 "wXr" = (
@@ -102335,12 +102665,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/medical/genetics)
-"xFe" = (
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "xFi" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -103069,9 +103393,12 @@
 /area/station/engineering/break_room)
 "xOr" = (
 /obj/structure/window/thin/reinforced,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "warn";
+	dir = 10
+	},
 /turf/simulated/floor{
-	dir = 10;
-	icon_state = "darkred"
+	icon_state = "dark"
 	},
 /area/station/rnd/xenobiology)
 "xOC" = (
@@ -104027,9 +104354,8 @@
 	c_tag = "Miscellaneous Research";
 	dir = 9
 	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
@@ -124931,7 +125257,7 @@ cRA
 jYs
 hXe
 gVW
-fRJ
+cwW
 cfJ
 cjx
 xRM
@@ -125696,9 +126022,9 @@ gVW
 uhT
 frn
 aAZ
-vHf
-tDm
-vHf
+gdS
+rWY
+gdS
 xZd
 siE
 gVW
@@ -126207,15 +126533,15 @@ waU
 ctb
 vUH
 fRJ
-fRJ
+fEc
 fXd
 bJD
-kMa
+gdS
 rWY
-kMa
+gdS
 ecA
 hTC
-fRJ
+rjS
 fRJ
 pyX
 cFK
@@ -126467,9 +126793,9 @@ kfd
 xdW
 rIz
 stV
-iqa
+src
 sjW
-hOl
+bpI
 iag
 jum
 mph
@@ -126719,7 +127045,7 @@ jwI
 hBT
 cMM
 jwI
-fGG
+puk
 fGG
 idF
 rNV
@@ -126731,7 +127057,7 @@ tMM
 cUf
 qkA
 fRJ
-fRJ
+vHf
 cjx
 aJp
 uvO
@@ -126978,7 +127304,7 @@ gPy
 jwI
 huv
 nCm
-nCm
+mHQ
 mBU
 jie
 ccq
@@ -126986,7 +127312,7 @@ sdC
 fGy
 afj
 uUJ
-nCm
+irX
 nCm
 nyM
 cjx
@@ -127749,7 +128075,7 @@ gPy
 jwI
 huv
 nCm
-nCm
+mHQ
 czg
 lNl
 ccq
@@ -127757,7 +128083,7 @@ sdC
 fGy
 jrf
 qxf
-nCm
+irX
 nCm
 nyM
 cjx
@@ -128261,7 +128587,7 @@ nsa
 waU
 buY
 jwI
-fRJ
+jRF
 fRJ
 vpb
 vYM
@@ -128273,7 +128599,7 @@ tMM
 uWb
 qkA
 fRJ
-fRJ
+vHf
 cjx
 lsw
 juy
@@ -128520,15 +128846,15 @@ wTL
 jwI
 huv
 nCm
-nCm
+mHQ
 kSz
 aog
 ccq
-sdC
+epu
 fGy
 goU
 qWU
-nCm
+irX
 nCm
 nyM
 cjx
@@ -128780,9 +129106,9 @@ wYO
 mph
 qob
 bGW
-iqa
+mbT
 vGh
-hOl
+tnZ
 iag
 gbO
 mph
@@ -129032,19 +129358,19 @@ jBe
 jwI
 gPy
 ctb
-fRJ
+jRF
 fRJ
 vpb
 vFZ
 mTN
-vHf
+gdS
 qTT
 aJg
 tMM
 gSL
 qkA
 fRJ
-fRJ
+vHf
 cFK
 juy
 fVu
@@ -129293,7 +129619,7 @@ jwI
 gVW
 wBr
 gVW
-oGK
+tDm
 gdS
 wgr
 gdS
@@ -129550,8 +129876,8 @@ jwI
 tIm
 uWZ
 iMl
-tMi
-tMi
+dUG
+dUG
 oCo
 tMi
 fau
@@ -130577,7 +130903,7 @@ jwI
 nUw
 vCS
 xOr
-mhk
+iOG
 bfh
 qiE
 cjx
@@ -134685,9 +135011,9 @@ ylt
 omz
 vil
 lhp
-wGM
+kMa
 ldt
-kaL
+lxU
 ekl
 svQ
 nxb
@@ -134944,7 +135270,7 @@ evL
 bOA
 saw
 tVQ
-xFe
+fBk
 jwK
 svQ
 vxf
@@ -135199,15 +135525,15 @@ wtC
 ijY
 evL
 lhp
-cIK
+isq
 bks
-nZN
+lKe
 mkl
 svQ
 vxf
 kiL
-wqN
-cHQ
+kFf
+mKy
 hzm
 vaP
 wwp
@@ -135456,9 +135782,9 @@ wtC
 hBT
 npX
 fbt
-aRH
+gWV
 bks
-xFe
+fBk
 fte
 uly
 vxf
@@ -135713,15 +136039,15 @@ dyG
 bwi
 evL
 lhp
-aRH
+gWV
 bks
-xFe
+fBk
 mkl
 svQ
 vxf
 kiL
-mKy
-iKo
+oLh
+bmb
 blq
 syE
 qbC
@@ -135972,7 +136298,7 @@ lud
 bOA
 saw
 bks
-xFe
+fBk
 bYy
 svQ
 vxf
@@ -136227,9 +136553,9 @@ oZa
 daK
 pPD
 lhp
-ldK
-anb
-kuZ
+gsU
+dBr
+mes
 vmY
 svQ
 jHw

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -3492,6 +3492,17 @@
 	icon_state = "vaultfull"
 	},
 /area/station/hallway/primary/starboard)
+"aFn" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "aFr" = (
 /obj/machinery/photocopier,
 /obj/effect/decal/cleanable/dirt,
@@ -3988,6 +3999,13 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/dormitories/courtroom)
+"aKY" = (
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/prison)
 "aLa" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
@@ -4030,15 +4048,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
-"aLM" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "aMd" = (
 /obj/structure/object_wall/cargo{
 	icon_state = "5,0"
@@ -4297,6 +4306,27 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
+"aOX" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "aPm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -4637,16 +4667,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
-"aSI" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SEE-FC";
-	location = "SE-FC"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "aSP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5999,6 +6019,15 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/tox_launch)
+"bhB" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "bhS" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -6069,6 +6098,16 @@
 	icon_state = "dark"
 	},
 /area/station/bridge/nuke_storage)
+"biU" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "biZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -6188,6 +6227,12 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/starboard)
+"bjV" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
+	},
+/turf/simulated/floor/carpet/red,
+/area/station/security/detectives_office)
 "bjW" = (
 /obj/machinery/meter{
 	name = "Mixed Air Tank In"
@@ -7218,16 +7263,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
-"bva" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SWW-FC";
-	location = "SW-FC"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "bvb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -7589,20 +7624,6 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/hallway)
-"bze" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/powered/pump,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "arrival"
-	},
-/area/station/hallway/primary/port)
 "bzh" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -7867,6 +7888,16 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/library)
+"bBB" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-B";
+	location = "SSW-B"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "bBP" = (
 /obj/machinery/power/port_gen/pacman{
 	anchored = 1
@@ -8325,13 +8356,6 @@
 "bFL" = (
 /obj/structure/stool/bed/chair/metal/white{
 	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
 	},
 /obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "siding_line";
@@ -10320,16 +10344,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/engine)
-"caQ" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-C";
-	location = "CS-AR"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "caY" = (
 /obj/structure/closet/secure_closet/quartermaster,
 /obj/structure/cable{
@@ -11674,6 +11688,24 @@
 "cpR" = (
 /turf/simulated/wall,
 /area/station/cargo/storage)
+"cql" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "cqB" = (
 /obj/item/weapon/flora/random,
 /obj/item/device/radio/intercom{
@@ -13422,26 +13454,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/medical/genetics)
-"cKZ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "cLd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -14545,6 +14557,15 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/robotics)
+"cWF" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "cWM" = (
 /obj/effect/decal/turf_decal{
 	dir = 5;
@@ -14701,7 +14722,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
+	icon_state = "siding_corner";
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -15974,6 +15995,18 @@
 /obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"doa" = (
+/obj/machinery/door_timer/cell_3{
+	pixel_x = 32;
+	pixel_y = 0;
+	dir = 4;
+	id = "Cell 3 perma"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "doE" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -16366,6 +16399,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
+"dtn" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "dtr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -16934,6 +16977,13 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/psych)
+"dzS" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "dAb" = (
 /obj/structure/sign/nanotrasen,
 /turf/simulated/wall/r_wall,
@@ -17465,6 +17515,16 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"dHD" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "dHJ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
@@ -17549,6 +17609,26 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/dormitories/courtroom)
+"dIz" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "dID" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor{
@@ -18349,18 +18429,6 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/hallway)
-"dTC" = (
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Labor Camp Shuttle Airlock";
-	req_access = list(2)
-	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/brig)
 "dTH" = (
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
@@ -18810,23 +18878,6 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
-"dYr" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "caution"
-	},
-/area/station/engineering/atmos/distribution)
 "dYs" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -18856,6 +18907,13 @@
 /obj/effect/decal/cleanable/vomit,
 /turf/simulated/floor/wood,
 /area/station/maintenance/medbay)
+"dYF" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-MB";
+	location = "N-MB"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "dYH" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -18894,6 +18952,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
+"dZh" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "dZk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -19218,6 +19287,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"ecN" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "ecT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/woodentable,
@@ -19736,10 +19814,11 @@
 	},
 /area/station/hallway/primary/starboard)
 "ejv" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "cafeteria"
 	},
-/area/station/security/blueshield)
+/area/station/security/prison)
 "ejG" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 1
@@ -20869,6 +20948,15 @@
 	icon_state = "darkblue"
 	},
 /area/station/bridge/corp_lounge)
+"ewB" = (
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "ewE" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -20964,13 +21052,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/civilian/hydroponics)
-"exp" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "exw" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -21466,6 +21547,18 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/engine)
+"eCW" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "eDr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -22588,14 +22681,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
-"eQp" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "eQI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -22899,6 +22984,16 @@
 	icon_state = "bluecorner"
 	},
 /area/station/security/lobby)
+"eUc" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-FC";
+	location = "DS"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
+/area/station/hallway/primary/central)
 "eUf" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -23068,19 +23163,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/tox_launch)
-"eWO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "eXa" = (
 /obj/structure/rack,
 /obj/item/weapon/storage/belt/utility,
@@ -23379,6 +23461,16 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/xenobiology)
+"fay" = (
+/obj/machinery/light/smart,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "faz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -23427,16 +23519,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
-"faS" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SE-FC";
-	location = "SW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "faX" = (
 /obj/machinery/biogenerator,
 /obj/structure/window/thin{
@@ -24370,18 +24452,6 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge)
-"fkE" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "fkM" = (
 /obj/structure/window/fulltile/tinted{
 	grilled = 1;
@@ -25647,19 +25717,6 @@
 	icon_state = "greencorner"
 	},
 /area/station/civilian/hydroponics)
-"fzF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/flasher{
-	id = "Cell 3 perma";
-	pixel_y = -28
-	},
-/turf/simulated/floor,
-/area/station/security/prison)
 "fzP" = (
 /obj/structure/bookcase/manuals/medical,
 /turf/simulated/floor/wood,
@@ -26007,13 +26064,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/chapel)
-"fEw" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-FC";
-	location = "SSW-FC"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/starboard)
 "fEx" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
@@ -26544,6 +26594,18 @@
 	icon_state = "dark"
 	},
 /area/station/aisat/teleport)
+"fJZ" = (
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Labor Camp Shuttle Airlock";
+	req_access = list(2)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
 "fKh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/decal/turf_decal{
@@ -26809,14 +26871,11 @@
 /area/station/maintenance/brig)
 "fOp" = (
 /obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-B";
-	location = "SSW-B"
+	codes_txt = "patrol;next_patrol=SW-FC";
+	location = "SSW-FC"
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
+/turf/simulated/floor,
+/area/station/hallway/primary/starboard)
 "fOF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
@@ -27015,6 +27074,16 @@
 	icon_state = "red"
 	},
 /area/station/security/brig)
+"fQl" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "fQK" = (
 /obj/effect/decal/turf_decal/alpha/dark_red{
 	icon_state = "warn";
@@ -27123,15 +27192,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/library)
-"fSq" = (
-/obj/effect/decal/turf_decal/alpha/blue{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "fSr" = (
 /obj/structure/table/woodentable,
 /obj/machinery/kitchen_machine/microwave{
@@ -28028,15 +28088,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
-"gdj" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Central Access"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "gdx" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -31643,7 +31694,7 @@
 	dir = 4
 	},
 /obj/machinery/flasher{
-	id = "Cell 1 perma";
+	id = "Cell 3 perma";
 	pixel_y = -28
 	},
 /turf/simulated/floor,
@@ -32744,6 +32795,15 @@
 /obj/random/foods/food_trash,
 /turf/simulated/floor,
 /area/station/maintenance/medbay)
+"hcI" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Central Access"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "hcM" = (
 /obj/effect/landmark/start/assistant/test_subject,
 /obj/structure/stool/bed/chair/metal/blue{
@@ -32816,6 +32876,13 @@
 /obj/machinery/status_display,
 /turf/simulated/wall,
 /area/station/engineering/engine)
+"hdM" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "hdN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -33650,6 +33717,16 @@
 	icon_state = "yellow"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
+"hoG" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSE-FC";
+	location = "SEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "hoM" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots,
@@ -33688,6 +33765,19 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/civilian/locker)
+"hoX" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "hpb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/decal/turf_decal/alpha/dark_red{
@@ -34382,15 +34472,6 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/library)
-"huY" = (
-/obj/effect/decal/turf_decal{
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "huZ" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -34671,12 +34752,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/maintenance/engineering)
-"hyf" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
-	},
-/turf/simulated/floor/carpet/red,
-/area/station/security/detectives_office)
 "hyh" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -35795,6 +35870,14 @@
 	icon_state = "red"
 	},
 /area/station/engineering/atmos)
+"hIP" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/civilian/gym)
 "hIQ" = (
 /obj/structure/sign/nanotrasen{
 	pixel_x = -32;
@@ -36014,6 +36097,14 @@
 	icon_state = "neutral"
 	},
 /area/station/medical/storage)
+"hLU" = (
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/break_room)
 "hMb" = (
 /obj/structure/closet/wardrobe/red,
 /obj/structure/cable{
@@ -36475,16 +36566,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway)
-"hRG" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSE-FC";
-	location = "SEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "hRR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -36626,6 +36707,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
+"hTG" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "hUj" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -37087,6 +37180,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
+"hYh" = (
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "hYi" = (
 /obj/machinery/space_heater,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -37649,13 +37752,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
-"ieJ" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "ieL" = (
 /obj/effect/decal/turf_decal{
 	dir = 8;
@@ -38840,6 +38936,18 @@
 	},
 /turf/simulated/floor,
 /area/station/gateway)
+"isz" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "isB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
@@ -40666,14 +40774,6 @@
 	temperature = 80
 	},
 /area/station/tcommsat/chamber)
-"iMU" = (
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "yellow"
-	},
-/area/station/engineering/break_room)
 "iNc" = (
 /obj/structure/flora/junglebush/large,
 /turf/simulated/floor/grass,
@@ -41224,6 +41324,26 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/fore)
+"iSy" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "iSP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -41365,6 +41485,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
+"iUP" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SWW-FC";
+	location = "SW-FC"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "iUS" = (
 /obj/machinery/door_control{
 	id = "Singularity";
@@ -43386,6 +43516,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
+"jsg" = (
+/obj/machinery/light/smart{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NE-FC";
+	location = "NEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "jsn" = (
 /obj/structure/sign/poster/official/do_not_question{
 	pixel_y = -32
@@ -45363,17 +45506,6 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/monitoring)
-"jMF" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "jMG" = (
 /obj/structure/window/thin/reinforced{
 	dir = 8
@@ -47226,17 +47358,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "kgH" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
 	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
+/turf/simulated/floor{
+	icon_state = "neutralfull"
 	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
+/area/station/hallway/primary/fore)
 "khm" = (
 /obj/machinery/power/apc{
 	name = "apc down";
@@ -48091,15 +48220,6 @@
 /obj/item/weapon/storage/box/cdeathalarm_kit,
 /turf/simulated/floor,
 /area/station/medical/storage)
-"kpY" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DN";
-	location = "SSE-FC"
-	},
-/turf/simulated/floor{
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "kqa" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -48432,14 +48552,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
-"kts" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/security/prison)
 "ktv" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor{
@@ -48769,20 +48881,6 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge/captain_quarters)
-"kyB" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor,
-/area/station/engineering/monitoring)
 "kyV" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -49347,16 +49445,6 @@
 "kFd" = (
 /turf/simulated/wall,
 /area/station/rnd/scibreak)
-"kFh" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "kFj" = (
 /obj/machinery/door/airlock{
 	name = "Mime's Backstage Room";
@@ -50475,16 +50563,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/bridge/hop_office)
-"kQJ" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "kRe" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -52456,16 +52534,6 @@
 	icon_state = "white"
 	},
 /area/station/medical/hallway)
-"lnI" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkred"
-	},
-/area/station/security/brig)
 "lnK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -52552,18 +52620,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
-"loW" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "lpw" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -53127,17 +53183,6 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/security/prison)
-"lvd" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "yellow"
-	},
-/area/station/engineering/atmos)
 "lvz" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/alarm{
@@ -53411,6 +53456,17 @@
 	icon_state = "red"
 	},
 /area/station/security/brig)
+"lyJ" = (
+/obj/machinery/light/smart,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DS";
+	location = "DN-W"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "purplecorner"
+	},
+/area/station/hallway/primary/central)
 "lyZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -53424,18 +53480,6 @@
 	icon_state = "whitered"
 	},
 /area/station/security/prison)
-"lzh" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "lzo" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots,
@@ -53796,6 +53840,14 @@
 	icon_state = "dark"
 	},
 /area/station/aisat/ai_chamber)
+"lDA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/security/prison)
 "lDB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55375,6 +55427,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/supermatter)
+"lVm" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "lVq" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -55583,17 +55648,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"lXZ" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "loadingarea"
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "arrow"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "lYm" = (
 /obj/structure/window/thin/reinforced{
 	dir = 8
@@ -55985,6 +56039,19 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/armoury)
+"meb" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "escape"
+	},
+/area/station/hallway/primary/port)
 "mev" = (
 /obj/structure/displaycase_chassis,
 /obj/effect/decal/cleanable/dirt,
@@ -56393,15 +56460,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/rnd/scibreak)
-"miL" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-B";
-	location = "S-MB"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/secondary/entry)
 "miU" = (
 /obj/machinery/media/jukebox,
 /turf/simulated/floor{
@@ -57358,15 +57416,6 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/dormitories)
-"mtl" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Security";
-	location = "S-C"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "mtn" = (
 /obj/machinery/light/smart{
 	dir = 4
@@ -57511,16 +57560,6 @@
 	icon_state = "darkred"
 	},
 /area/station/security/checkpoint/medbay)
-"muo" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NNW-B";
-	location = "NW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "muv" = (
 /obj/machinery/optable,
 /obj/machinery/status_display{
@@ -58260,27 +58299,6 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/cold_room)
-"mBS" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "mBU" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -58375,15 +58393,6 @@
 "mDI" = (
 /turf/simulated/wall,
 /area/station/civilian/chapel/office)
-"mDM" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_left"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/civilian/cold_room)
 "mDV" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -58605,13 +58614,6 @@
 	icon_state = "yellowfull"
 	},
 /area/station/engineering/engine)
-"mGo" = (
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/prison)
 "mGu" = (
 /obj/structure/sign/departments/science,
 /turf/simulated/wall/r_wall,
@@ -58753,19 +58755,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
-"mJl" = (
-/obj/machinery/light/smart{
-	dir = 4
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NE-FC";
-	location = "NEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "mJs" = (
 /obj/item/weapon/flora/random,
 /obj/structure/window/thin/reinforced,
@@ -58821,6 +58810,9 @@
 /area/station/civilian/locker)
 "mKv" = (
 /obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -60409,18 +60401,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"nca" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "ncb" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -61691,26 +61671,6 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/kitchen)
-"nqW" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "nrh" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -61938,6 +61898,13 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
+"nur" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=CS-AR";
+	location = "SWW-FC"
+	},
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "nuA" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/alarm{
@@ -63418,12 +63385,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
-"nLm" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "browncorner"
-	},
-/area/station/cargo/storage)
 "nLr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/gourd,
@@ -63773,6 +63734,16 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/storage/emergency)
+"nQm" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NEE-FC";
+	location = "S-SV"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "nQo" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -64023,7 +63994,7 @@
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "box_corners_white";
-	dir = 8
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -64608,16 +64579,6 @@
 "nYz" = (
 /turf/simulated/wall/r_wall,
 /area/station/rnd/test_area)
-"nYF" = (
-/obj/machinery/light/smart,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "nYJ" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -65137,6 +65098,15 @@
 "oex" = (
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/singularity)
+"oeF" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "oeN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -66161,6 +66131,19 @@
 	icon_state = "neutral"
 	},
 /area/station/engineering/chiefs_office)
+"ote" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "oti" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -66213,16 +66196,6 @@
 	icon_state = "caution"
 	},
 /area/station/engineering/atmos/distribution)
-"otm" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-FC";
-	location = "DS"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "bluecorner"
-	},
-/area/station/hallway/primary/central)
 "otq" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -66483,19 +66456,22 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
-"oxd" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
-	dir = 4
+"owP" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
 	},
 /turf/simulated/floor{
-	icon_state = "neutralfull"
+	icon_state = "dark"
 	},
-/area/station/engineering/atmos)
+/area/station/engineering/engine)
 "oxs" = (
 /obj/structure/closet/athletic_mixed,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -67974,7 +67950,7 @@
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	dir = 4;
+	dir = 6;
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
@@ -68165,26 +68141,6 @@
 	icon_state = "blackchecker"
 	},
 /area/station/civilian/locker)
-"oQu" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "oQG" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
@@ -68653,6 +68609,12 @@
 /obj/item/weapon/flora/random,
 /turf/simulated/floor,
 /area/station/gateway)
+"oXc" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "browncorner"
+	},
+/area/station/cargo/storage)
 "oXd" = (
 /obj/structure/closet/secure_closet/injection,
 /turf/simulated/floor{
@@ -70851,19 +70813,6 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/break_room)
-"pwC" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "pwE" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/box/donkpockets,
@@ -71959,6 +71908,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
+"pHD" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SE-FC";
+	location = "SW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "pHK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -72887,16 +72846,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
-"pSk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "pSr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -73514,20 +73463,6 @@
 	icon_state = "blackcorner"
 	},
 /area/station/hallway/primary/starboard)
-"qal" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 10;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "qaF" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red,
 /obj/machinery/meter,
@@ -73663,22 +73598,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"qbv" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "qbw" = (
 /obj/structure/object_wall/cargo{
 	icon_state = "1,0"
@@ -74414,33 +74333,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/engine)
-"qjU" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/civilian/gym)
-"qjY" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/main)
 "qkc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -75051,6 +74943,15 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
+"qrB" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Security";
+	location = "S-C"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "qrH" = (
 /obj/structure/object_wall/pod{
 	dir = 4;
@@ -75869,15 +75770,19 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
-"qCl" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 5
+"qCc" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
 	},
 /turf/simulated/floor{
-	icon_state = "grimy"
+	icon_state = "neutralfull"
 	},
-/area/station/security/hos)
+/area/station/engineering/atmos)
 "qCm" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -75971,15 +75876,6 @@
 	icon_state = "dark"
 	},
 /area/station/medical/cryo)
-"qDn" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "qDw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -76276,21 +76172,6 @@
 /obj/structure/closet,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"qGp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
 "qGy" = (
 /obj/machinery/recycler,
 /obj/machinery/conveyor{
@@ -78206,6 +78087,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/server)
+"rdF" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "rdK" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
@@ -78714,6 +78602,20 @@
 	icon_state = "vaultfull"
 	},
 /area/station/rnd/robotics)
+"rjT" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/pump,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "arrival"
+	},
+/area/station/hallway/primary/port)
 "rkr" = (
 /obj/structure/rack,
 /obj/random/cloth/gloves_safe,
@@ -78751,17 +78653,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
-"rkP" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos/atmos_office)
 "rkR" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -79216,13 +79107,6 @@
 "rrj" = (
 /turf/environment/space,
 /area/shuttle/syndicate/southwest)
-"rrk" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=CS-AR";
-	location = "SWW-FC"
-	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
 "rrl" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -79757,18 +79641,6 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/break_room)
-"rwy" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/engineering/atmos/atmos_office)
 "rwA" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/atmospherics/pipe/simple/visible/green,
@@ -80028,6 +79900,16 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
+"ryN" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/station/security/brig)
 "rzd" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -80377,6 +80259,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/incinerator)
+"rBK" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "rBN" = (
 /obj/structure/window/thin/reinforced{
 	dir = 8
@@ -81827,6 +81717,23 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
+"rRt" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "caution"
+	},
+/area/station/engineering/atmos/distribution)
 "rRv" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -81843,6 +81750,16 @@
 	icon_state = "dark"
 	},
 /area/station/security/brig/storage)
+"rRC" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SEE-FC";
+	location = "SE-FC"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "rRF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -81862,6 +81779,15 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/civilian/locker)
+"rRM" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "rRQ" = (
 /obj/structure/filingcabinet,
 /obj/machinery/light/small{
@@ -81969,15 +81895,6 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/primary/fore)
-"rTd" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "rTk" = (
 /obj/effect/decal/turf_decal{
 	dir = 1;
@@ -85001,6 +84918,13 @@
 	icon_state = "darkred"
 	},
 /area/station/security/checkpoint/medbay)
+"sEj" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_left"
+	},
+/turf/simulated/floor,
+/area/station/storage/tech)
 "sEp" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
@@ -85702,12 +85626,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/science)
-"sMH" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "cafeteria"
-	},
-/area/station/security/prison)
 "sMR" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -87232,6 +87150,20 @@
 	icon_state = "dark"
 	},
 /area/station/medical/cryo)
+"tfZ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor,
+/area/station/engineering/monitoring)
 "tgi" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -88254,19 +88186,6 @@
 	icon_state = "red"
 	},
 /area/station/security/checkpoint/engi)
-"ttY" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "ttZ" = (
 /obj/structure/table/woodentable,
 /obj/machinery/light/small,
@@ -89651,6 +89570,20 @@
 	icon_state = "vaultfull"
 	},
 /area/station/engineering/atmos)
+"tKo" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 10;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "tKs" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
@@ -89955,19 +89888,6 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/library)
-"tNn" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 9
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "tNE" = (
 /obj/structure/sink{
 	dir = 4;
@@ -90098,6 +90018,26 @@
 	},
 /turf/simulated/floor,
 /area/station/medical/hallway)
+"tQo" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "tQu" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
@@ -90548,6 +90488,13 @@
 /obj/machinery/telepad,
 /turf/simulated/floor/engine,
 /area/station/rnd/telesci)
+"tWd" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=N-MB";
+	location = "NNW-B"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "tWr" = (
 /obj/structure/table/reinforced,
 /obj/item/device/mmi,
@@ -91063,12 +91010,25 @@
 	},
 /area/station/rnd/hallway)
 "ucx" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 8
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "ucF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -91261,19 +91221,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/hos)
-"ueZ" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "ufi" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/effect/decal/turf_decal/alpha/gray{
@@ -93068,6 +93015,18 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
+"uAG" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "uAM" = (
 /obj/structure/sign/directions/engineering{
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
@@ -93504,15 +93463,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/civilian/kitchen)
-"uFP" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "uFR" = (
 /obj/structure/table/woodentable,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -93557,6 +93507,15 @@
 	icon_state = "purple"
 	},
 /area/station/rnd/xenobiology)
+"uGh" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DN";
+	location = "SSE-FC"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "uGq" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -93610,23 +93569,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "uHN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
+	icon_state = "siding_corner";
+	dir = 8
 	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
+/turf/simulated/floor,
+/area/station/engineering/atmos/atmos_office)
 "uHX" = (
 /turf/simulated/floor/wood,
 /area/station/maintenance/chapel)
@@ -94021,16 +93974,14 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "uNw" = (
-/obj/machinery/light/smart,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DS";
-	location = "DN-W"
+/obj/structure/kitchenspike,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_left"
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "purplecorner"
+	icon_state = "dark"
 	},
-/area/station/hallway/primary/central)
+/area/station/civilian/cold_room)
 "uNx" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -95883,18 +95834,6 @@
 	icon_state = "3,5"
 	},
 /area/shuttle/supply/station)
-"vkI" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "vkK" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -96010,19 +95949,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/rnd/robotics)
-"vlM" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "escape"
-	},
-/area/station/hallway/primary/port)
 "vlN" = (
 /obj/machinery/autolathe,
 /obj/machinery/alarm{
@@ -96467,6 +96393,21 @@
 	icon_state = "3-2"
 	},
 /area/shuttle/mining/station)
+"vrr" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "vrt" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil/random,
@@ -97038,6 +96979,19 @@
 /obj/structure/cable/yellow,
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/singularity)
+"vyT" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/flasher{
+	id = "Cell 1 perma";
+	pixel_y = -28
+	},
+/turf/simulated/floor,
+/area/station/security/prison)
 "vyY" = (
 /turf/simulated/shuttle/floor/cargo{
 	icon_state = "2,1"
@@ -98148,6 +98102,17 @@
 /obj/effect/spawner/lootdrop/maintenance/three,
 /turf/simulated/floor,
 /area/station/maintenance/science)
+"vLT" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos/atmos_office)
 "vLX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -98310,13 +98275,6 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/drone_fabrication)
-"vOC" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=N-MB";
-	location = "NNW-B"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "vOQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -98742,18 +98700,16 @@
 	},
 /area/station/bridge/teleporter)
 "vTX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "loadingarea"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "arrow"
 	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 8
+/turf/simulated/floor{
+	icon_state = "dark"
 	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
+/area/station/security/brig)
 "vUe" = (
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
@@ -99691,6 +99647,19 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
+"weV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "wfp" = (
 /obj/machinery/light/smart,
 /obj/structure/table/glass,
@@ -100130,13 +100099,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"wkl" = (
-/obj/item/weapon/flora/random,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_left"
-	},
-/turf/simulated/floor,
-/area/station/storage/tech)
 "wkD" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 5
@@ -100763,18 +100725,6 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/reception)
-"wsq" = (
-/obj/machinery/door_timer/cell_3{
-	pixel_x = 32;
-	pixel_y = 0;
-	dir = 4;
-	id = "Cell 3 perma"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "wsw" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/smart{
@@ -101256,13 +101206,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
-"wzy" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-MB";
-	location = "N-MB"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "wzH" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
@@ -101532,6 +101475,11 @@
 	icon_state = "darkredcorners"
 	},
 /area/station/security/checkpoint/escape)
+"wBE" = (
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "wBF" = (
 /obj/machinery/mech_bay_recharge_port{
 	dir = 1
@@ -101880,16 +101828,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
-"wFS" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
 "wFU" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -102401,16 +102339,6 @@
 	icon_state = "grimy"
 	},
 /area/station/aisat/antechamber_interior)
-"wLH" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "wLR" = (
 /obj/structure/object_wall/pod{
 	dir = 4;
@@ -103514,6 +103442,15 @@
 	},
 /turf/simulated/floor,
 /area/station/medical/storage)
+"xak" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-B";
+	location = "S-MB"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry)
 "xao" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -103813,6 +103750,16 @@
 	icon_state = "vaultfull"
 	},
 /area/station/rnd/xenobiology)
+"xee" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "xef" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/multi_tile/glass,
@@ -103974,6 +103921,16 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/tox_launch)
+"xfK" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-C";
+	location = "CS-AR"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "xfO" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Treatment Center";
@@ -104005,16 +103962,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"xfV" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NEE-FC";
-	location = "S-SV"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "xfW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -104783,17 +104730,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
-"xpG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "xpQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/hologram/holopad,
@@ -105353,16 +105289,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
-"xuW" = (
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "xuY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -105668,6 +105594,17 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway)
+"xys" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "xyt" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -105833,6 +105770,15 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
+"xzW" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 5
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "xAc" = (
 /obj/structure/closet,
 /obj/structure/cable{
@@ -106115,6 +106061,18 @@
 /obj/structure/table,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"xCl" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "xCq" = (
 /obj/structure/sink{
 	dir = 4;
@@ -107078,6 +107036,18 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
+"xPk" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "xPl" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -107121,15 +107091,6 @@
 	icon_state = "darkredcorners"
 	},
 /area/station/security/checkpoint/escape)
-"xPB" = (
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
 "xPO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/table_parts/wood,
@@ -107156,6 +107117,25 @@
 	icon_state = "dark"
 	},
 /area/station/security/blueshield)
+"xPS" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/main)
 "xPV" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -108561,6 +108541,16 @@
 "yfc" = (
 /turf/simulated/floor/plating/airless,
 /area/station/rnd/test_area)
+"yfe" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NNW-B";
+	location = "NW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "yfv" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -108807,6 +108797,19 @@
 	icon_state = "dark"
 	},
 /area/station/bridge)
+"yjm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "yjy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -131752,7 +131755,7 @@ xFF
 xFG
 flb
 uDn
-iMU
+hLU
 ude
 ehA
 geB
@@ -132009,7 +132012,7 @@ qnQ
 hEd
 fDg
 owf
-iMU
+hLU
 hkb
 ehA
 fUz
@@ -132247,7 +132250,7 @@ bOJ
 oKV
 dup
 dup
-nRV
+lVm
 bOD
 cmG
 xqQ
@@ -132512,7 +132515,7 @@ oLJ
 kFc
 kFc
 cEO
-lvd
+xys
 azQ
 pfp
 imT
@@ -132758,7 +132761,7 @@ qSk
 qdn
 naA
 kdJ
-oxd
+nRV
 xqQ
 fmh
 mNB
@@ -132766,8 +132769,8 @@ bfy
 cmG
 dup
 htY
-kFh
-kFh
+dHD
+dHD
 nwM
 tCz
 gRR
@@ -133022,7 +133025,7 @@ nLs
 bTE
 tUm
 oPF
-pwC
+qCc
 rSb
 umn
 svw
@@ -133786,7 +133789,7 @@ bsZ
 fZH
 cTK
 whA
-rwy
+uHN
 iDO
 iDO
 iDO
@@ -133795,8 +133798,8 @@ vCV
 lFG
 waB
 fMO
-vkI
-loW
+xCl
+xPk
 kHT
 vPk
 vPk
@@ -134043,9 +134046,9 @@ pBb
 hrT
 qcT
 mrP
+vLT
+vLT
 daq
-daq
-rkP
 egG
 iEf
 hrT
@@ -134587,9 +134590,9 @@ hdV
 bhn
 evV
 oKM
-fkE
+uAG
 wCx
-lzh
+isz
 oDZ
 bau
 nkc
@@ -134846,7 +134849,7 @@ enq
 bgZ
 gCp
 tRh
-qbv
+owP
 oyx
 mRP
 eZT
@@ -135343,7 +135346,7 @@ gpz
 nds
 gpz
 wjD
-kyB
+tfZ
 bbv
 awp
 odu
@@ -136103,7 +136106,7 @@ jlK
 tEF
 tne
 cEZ
-dYr
+rRt
 iGS
 ciX
 jau
@@ -136886,11 +136889,11 @@ sHQ
 dpc
 sHQ
 blv
-vlM
+meb
 sqb
 uck
 sqb
-bze
+rjT
 hQQ
 qTx
 bUU
@@ -137157,7 +137160,7 @@ doE
 doE
 doE
 lgU
-aSI
+rRC
 mhm
 doE
 mnD
@@ -137655,7 +137658,7 @@ wwi
 aYN
 wwi
 lfm
-hRG
+hoG
 tZn
 oyb
 nAM
@@ -137673,7 +137676,7 @@ oyb
 bzt
 bzt
 rcq
-kpY
+uGh
 tYK
 wtC
 wtC
@@ -138689,7 +138692,7 @@ xNR
 rMP
 nAi
 vfr
-wkl
+sEj
 rDd
 jcO
 iNE
@@ -139703,7 +139706,7 @@ aSY
 uum
 lVS
 srt
-mDM
+uNw
 uos
 gTB
 kst
@@ -140474,7 +140477,7 @@ kBq
 biv
 pED
 bNa
-wFS
+dtn
 kIU
 lBN
 yeY
@@ -140731,7 +140734,7 @@ dtM
 fty
 abG
 vLv
-wFS
+dtn
 kIU
 jVV
 ekm
@@ -143052,7 +143055,7 @@ iSv
 xXt
 vAu
 ogP
-fOp
+bBB
 bAS
 nvi
 rnH
@@ -143068,7 +143071,7 @@ qbj
 qbj
 tmk
 ldb
-faS
+pHD
 ogP
 iSi
 amv
@@ -143095,7 +143098,7 @@ vpT
 xei
 bFh
 vpT
-uNw
+lyJ
 vIl
 olx
 frM
@@ -143263,7 +143266,7 @@ plf
 brw
 mko
 jsL
-miL
+xak
 ffX
 hbE
 sTt
@@ -143532,7 +143535,7 @@ gHT
 alc
 vDr
 fDL
-muo
+yfe
 iwy
 xXt
 gNR
@@ -144313,17 +144316,17 @@ hXb
 hXb
 hXb
 che
-xPB
-uHN
-xPB
-xPB
-xPB
-xPB
-xPB
-xPB
-xPB
-qGp
-xPB
+kgH
+cql
+kgH
+kgH
+kgH
+kgH
+kgH
+kgH
+kgH
+vrr
+kgH
 vos
 did
 did
@@ -144817,7 +144820,7 @@ kHU
 yaE
 hkD
 fYS
-huY
+ewB
 wts
 mge
 qed
@@ -145097,13 +145100,13 @@ mpN
 uQg
 tJq
 oFm
-ieJ
+dzS
 xsb
-ieJ
-ieJ
-ieJ
+dzS
+dzS
+dzS
 mtf
-ieJ
+dzS
 jpq
 bsc
 mfI
@@ -145331,7 +145334,7 @@ plf
 yaE
 vDr
 fYS
-xuW
+hYh
 tEo
 nIB
 iEL
@@ -145588,7 +145591,7 @@ kHU
 yaE
 csG
 fYS
-nYF
+fay
 wts
 npC
 txi
@@ -145611,13 +145614,13 @@ cCx
 mES
 tJq
 ikZ
-tNn
+weV
 oki
-ucx
-ucx
-vTX
+hdM
+hdM
+hoX
 tWH
-vTX
+hoX
 qcF
 bRX
 qSi
@@ -145868,7 +145871,7 @@ tJq
 ucP
 tJq
 fSC
-eWO
+yjm
 ktM
 uuo
 djH
@@ -147376,7 +147379,7 @@ yaE
 yaE
 csG
 fYS
-wzy
+dYF
 alc
 gHT
 gHT
@@ -147385,7 +147388,7 @@ gHT
 gHT
 gHT
 alc
-vOC
+tWd
 fYS
 sEX
 srs
@@ -152320,7 +152323,7 @@ mXl
 mXl
 mXl
 wLD
-xfV
+nQm
 iwm
 mXl
 pRS
@@ -152338,7 +152341,7 @@ oNU
 mXl
 uxx
 xMc
-bva
+iUP
 nvi
 rnH
 cLM
@@ -152347,7 +152350,7 @@ nvi
 tOH
 mfI
 ogP
-otm
+eUc
 sBG
 wjc
 wjc
@@ -152650,7 +152653,7 @@ xQo
 xQo
 xQo
 nKU
-fEw
+fOp
 xQo
 oPI
 mRu
@@ -152817,7 +152820,7 @@ cpR
 gtK
 cpR
 pxL
-mJl
+jsg
 ffJ
 ape
 fZz
@@ -152836,7 +152839,7 @@ hRd
 ckx
 fZz
 lMB
-mtl
+qrB
 kzb
 vAu
 psV
@@ -152850,7 +152853,7 @@ vAu
 kRo
 vAu
 kCI
-caQ
+xfK
 ogP
 lwr
 mLS
@@ -153093,7 +153096,7 @@ cmN
 act
 uuf
 xsY
-gdj
+hcI
 jTW
 jTW
 jTW
@@ -153573,7 +153576,7 @@ fnT
 miA
 ojm
 lPc
-nLm
+oXc
 gaF
 rpV
 qSe
@@ -153830,11 +153833,11 @@ nkb
 adb
 hzP
 cpR
-kQJ
-oOk
+fQl
+biU
 uXI
+biU
 oOk
-wLH
 xqF
 aAF
 iqI
@@ -156941,8 +156944,8 @@ plf
 xyC
 cFp
 klH
-hyf
-hyf
+bjV
+bjV
 hGr
 aRu
 xyC
@@ -157466,8 +157469,8 @@ dnn
 aEr
 wPw
 jQy
-fSq
-ejv
+ecN
+wBE
 jcX
 fJg
 nPU
@@ -157959,11 +157962,11 @@ plf
 cHH
 cHH
 jxX
-dTC
+fJZ
 bjt
 stv
 jxX
-dTC
+fJZ
 jxX
 adp
 kMq
@@ -157974,7 +157977,7 @@ xyC
 xyC
 xyC
 xyC
-exp
+rdF
 jtG
 wpm
 fJg
@@ -158216,7 +158219,7 @@ wVt
 cHH
 cjS
 bNB
-qal
+tKo
 kms
 cHH
 eow
@@ -158473,7 +158476,7 @@ leA
 cHH
 adG
 iGB
-lnI
+ryN
 tTk
 qMX
 aZz
@@ -158734,7 +158737,7 @@ ikW
 qXE
 rjb
 utF
-lXZ
+vTX
 uLd
 lat
 nsn
@@ -159533,7 +159536,7 @@ kIM
 vst
 mDV
 vKG
-rrk
+nur
 xoq
 tAM
 uQA
@@ -160252,14 +160255,14 @@ fAF
 fgx
 diq
 fAF
-wsq
+doa
 eTq
 fAF
 wNM
 oPD
 tif
 rHZ
-cKZ
+tQo
 czU
 tqK
 hsq
@@ -160516,7 +160519,7 @@ qZx
 qZx
 fXG
 qZx
-oQu
+ucx
 czU
 uvV
 kMw
@@ -161022,13 +161025,13 @@ blh
 cra
 hlv
 dVr
-fzF
+gQC
 hlv
 fBm
 bvC
 hlv
 vqQ
-gQC
+vyT
 qZx
 tnw
 fLE
@@ -162046,7 +162049,7 @@ aXC
 bZu
 pLw
 unD
-kts
+lDA
 oAx
 ulK
 eyO
@@ -162598,8 +162601,8 @@ ilq
 uKd
 sxG
 uOc
-ttY
-ttY
+ote
+ote
 hur
 ekd
 lZw
@@ -162854,7 +162857,7 @@ ixl
 mme
 uKd
 gRX
-nca
+eCW
 sRa
 nUj
 wUB
@@ -162883,13 +162886,13 @@ ncp
 ncp
 hbR
 mWz
-kgH
+hTG
 kLd
 syX
 tHk
 tHk
 dbf
-mBS
+aOX
 ram
 mWz
 lNQ
@@ -163146,7 +163149,7 @@ eFl
 aRb
 nDG
 jjN
-ueZ
+bFL
 ram
 mWz
 ucd
@@ -163353,7 +163356,7 @@ afw
 nDf
 mZo
 qUR
-qjY
+xPS
 mzV
 aSh
 mpR
@@ -163654,13 +163657,13 @@ ncp
 ncp
 hbR
 mWz
-jMF
+dZh
 sIY
 qls
 uOM
 uOM
 aeG
-bFL
+dIz
 ram
 mWz
 hPr
@@ -163850,7 +163853,7 @@ lhK
 wVg
 aFN
 jKZ
-sMH
+ejv
 rBo
 hlv
 qxh
@@ -164114,7 +164117,7 @@ xIO
 jps
 xIO
 qZx
-nqW
+iSy
 tbS
 sZR
 kHU
@@ -164126,7 +164129,7 @@ fwH
 qoH
 vOW
 qoH
-eQp
+rBK
 umQ
 gYp
 kHU
@@ -164364,7 +164367,7 @@ jvm
 hlv
 fVW
 fPH
-sMH
+ejv
 rnI
 hlv
 pHz
@@ -164379,11 +164382,11 @@ kHU
 plf
 cYc
 ueE
-pSk
+xee
 wcJ
 iRz
 nez
-xpG
+aFn
 hlh
 gYp
 plf
@@ -164636,11 +164639,11 @@ kHU
 kHU
 cYc
 nfj
-rTd
+bhB
 eaE
 nRk
 rZh
-aLM
+rRM
 hmN
 gYp
 kHU
@@ -164684,7 +164687,7 @@ dJL
 nRG
 oXA
 oXA
-qjU
+hIP
 dJL
 plf
 cdR
@@ -164893,11 +164896,11 @@ plf
 kHU
 huz
 sIx
-qCl
-qDn
+xzW
+cWF
 kjv
-qDn
-uFP
+cWF
+oeF
 tEU
 huz
 plf
@@ -166942,7 +166945,7 @@ plf
 kHU
 hlv
 lrm
-mGo
+aKY
 jno
 hlv
 cBu
@@ -168022,7 +168025,7 @@ kHU
 fMh
 plf
 dJL
-qjU
+hIP
 oXA
 oXA
 nJn

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -5972,8 +5972,12 @@
 	dir = 2;
 	icon_state = "warn"
 	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "dark"
 	},
 /area/station/engineering/break_room)
 "bhh" = (
@@ -35449,6 +35453,10 @@
 	dir = 1;
 	icon_state = "warn"
 	},
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -40439,6 +40447,10 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/turf_decal{
 	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 2;
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
@@ -66671,6 +66683,10 @@
 	dir = 1;
 	icon_state = "warn"
 	},
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -67063,6 +67079,10 @@
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
 	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -67090,6 +67110,10 @@
 	},
 /obj/effect/decal/turf_decal{
 	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 2;
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
@@ -67666,8 +67690,12 @@
 	dir = 2;
 	icon_state = "warn"
 	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "dark"
 	},
 /area/station/engineering/break_room)
 "oKR" = (
@@ -95691,6 +95719,10 @@
 	req_access = list(24)
 	},
 /obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
 	icon_state = "warn"
 	},
 /turf/simulated/floor{

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -17386,6 +17386,7 @@
 /area/station/civilian/chapel)
 "dFv" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/light/smart,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "brown"
@@ -29087,7 +29088,6 @@
 	},
 /area/station/hallway/primary/fore)
 "gng" = (
-/obj/machinery/light/smart,
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
 	freq = 1400;
@@ -29105,6 +29105,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
+/obj/machinery/light/smart,
 /turf/simulated/floor{
 	icon_state = "brown"
 	},
@@ -34035,12 +34036,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/gateway)
-"hqS" = (
-/obj/machinery/light/smart{
-	dir = 1
-	},
-/turf/simulated/floor/engine,
-/area/station/civilian/holodeck/alphadeck)
 "hqT" = (
 /obj/machinery/color_mixer,
 /turf/simulated/floor{
@@ -63920,6 +63915,11 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor{
 	icon_state = "wooden"
 	},
@@ -67217,6 +67217,15 @@
 /obj/effect/decal/turf_decal/wood/dark{
 	icon_state = "siding_wood_line";
 	dir = 8
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 1;
+	name = "apc top";
+	pixel_y = 28
 	},
 /turf/simulated/floor{
 	icon_state = "wooden"
@@ -82827,10 +82836,6 @@
 /obj/structure/stool/bar,
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
-"sdo" = (
-/obj/machinery/light/smart,
-/turf/simulated/floor/engine,
-/area/station/civilian/holodeck/alphadeck)
 "sdy" = (
 /obj/machinery/light/smart,
 /obj/effect/decal/turf_decal{
@@ -165978,7 +165983,7 @@ pVo
 adB
 kHU
 kVf
-hqS
+jjS
 jjS
 jjS
 jjS
@@ -167015,7 +167020,7 @@ jjS
 jjS
 jjS
 jjS
-sdo
+jjS
 pVE
 kHU
 dJL

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -724,6 +724,10 @@
 /area/station/security/execution)
 "adG" = (
 /obj/structure/filingcabinet/chestdrawer,
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "darkred"
@@ -2540,10 +2544,12 @@
 	},
 /obj/machinery/light/smart,
 /obj/machinery/computer/station_alert,
-/obj/effect/decal/turf_decal/alpha/yellow{
+/obj/effect/decal/turf_decal/alpha/red{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/security/main)
 "aua" = (
 /obj/machinery/power/smes,
@@ -3146,11 +3152,6 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
-"aBM" = (
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "aBP" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -3714,8 +3715,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/donut/classic,
 /obj/random/foods/donuts,
 /turf/simulated/floor{
-	dir = 10;
-	icon_state = "red"
+	icon_state = "dark"
 	},
 /area/station/security/main)
 "aIb" = (
@@ -5618,13 +5618,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/robotics)
-"beM" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-MB";
-	location = "N-MB"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "beO" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -6352,16 +6345,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/tcommsat/chamber)
-"blY" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SEE-FC";
-	location = "SE-FC"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "bme" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -7070,14 +7053,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/storage)
-"buA" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/civilian/gym)
 "buH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -7203,6 +7178,16 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
+"bwk" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-C";
+	location = "CS-AR"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "bwm" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -7554,7 +7539,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/security/main)
 "bzR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume{
@@ -7626,18 +7613,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
-"bAB" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "bAC" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -8204,11 +8179,10 @@
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "box_corners_white";
-	dir = 1
+	dir = 4
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
+	icon_state = "box_corners_white"
 	},
 /obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "siding_line";
@@ -9629,6 +9603,21 @@
 /obj/structure/stool/bed/chair/metal/black{
 	dir = 1
 	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "darkred"
@@ -11000,7 +10989,7 @@
 	network = list("SS13","Security")
 	},
 /obj/effect/decal/turf_decal{
-	dir = 8;
+	dir = 9;
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
@@ -13786,6 +13775,14 @@
 	dir = 1
 	},
 /obj/machinery/light/smart,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "darkred"
 	},
@@ -15060,6 +15057,10 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "darkred"
@@ -15434,6 +15435,18 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/brig)
+"dkx" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "dkB" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
@@ -15685,12 +15698,6 @@
 /obj/structure/girder,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"dod" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
-	},
-/turf/simulated/floor/carpet/red,
-/area/station/security/detectives_office)
 "doE" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -15814,16 +15821,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/fore)
-"dqD" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSE-FC";
-	location = "SEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "dqI" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -16715,6 +16712,13 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/medbay)
+"dAK" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=CS-AR";
+	location = "SWW-FC"
+	},
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "dAL" = (
 /turf/simulated/floor{
 	icon_state = "grimy"
@@ -17481,19 +17485,19 @@
 "dKV" = (
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 6
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -18366,26 +18370,6 @@
 	icon_state = "brown"
 	},
 /area/station/engineering/break_room)
-"dWC" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "dWD" = (
 /obj/structure/table/woodentable/fancy,
 /obj/item/stack/sheet/wood{
@@ -18889,19 +18873,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"ecv" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "ecA" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/thin/reinforced{
@@ -19925,9 +19896,8 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -20017,6 +19987,19 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
+"epU" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "eqn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
@@ -20272,6 +20255,20 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/civilian/dormitories)
+"etB" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 10;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "etL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -23119,7 +23116,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/security/hos)
 "fbt" = (
 /obj/machinery/door/airlock/maintenance{
@@ -24285,6 +24284,13 @@
 /obj/item/device/healthanalyzer,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
+"fql" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "fqo" = (
 /obj/machinery/light/smart{
 	dir = 8
@@ -24758,6 +24764,13 @@
 	},
 /turf/environment/space,
 /area/shuttle/mining/station)
+"fum" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-FC";
+	location = "SSW-FC"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/starboard)
 "fus" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -25104,16 +25117,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/medical/genetics)
-"fys" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-B";
-	location = "SSW-B"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "fyx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -26151,7 +26154,10 @@
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "fKP" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "darkred"
@@ -26362,14 +26368,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "fOp" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Security";
-	location = "S-C"
-	},
 /turf/simulated/floor{
-	icon_state = "neutralcorner"
+	icon_state = "vaultfull"
 	},
-/area/station/hallway/primary/central)
+/area/station/security/blueshield)
 "fOF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
@@ -29286,6 +29288,17 @@
 /obj/structure/stool/bed/chair/metal/black{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	icon_state = "darkred"
 	},
@@ -30297,6 +30310,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -31123,6 +31139,15 @@
 	icon_state = "white"
 	},
 /area/station/medical/hallway)
+"gRh" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "gRi" = (
 /obj/machinery/door/airlock{
 	id_tag = "Arrivals_Toilet3";
@@ -32865,10 +32890,12 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/computer/cargo/request,
-/obj/effect/decal/turf_decal/alpha/yellow{
+/obj/effect/decal/turf_decal/alpha/red{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/security/main)
 "hlQ" = (
 /obj/effect/decal/turf_decal{
@@ -32954,7 +32981,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -33115,8 +33142,25 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/civilian/locker)
+"hoT" = (
+/obj/machinery/light/smart{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NE-FC";
+	location = "NEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "hpb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "whitered"
@@ -33920,6 +33964,10 @@
 	name = "Labor Camp Shuttle Airlock";
 	req_access = list(2)
 	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "hwF" = (
@@ -33985,7 +34033,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/security/main)
 "hxo" = (
 /obj/structure/cable{
@@ -34441,16 +34491,6 @@
 /obj/effect/decal/cleanable/blood/gibs/robot,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"hAP" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SWW-FC";
-	location = "SW-FC"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "hAR" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
@@ -34739,13 +34779,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/engineering/break_room)
-"hDU" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=N-MB";
-	location = "NNW-B"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "hEd" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/box/matches,
@@ -36503,7 +36536,7 @@
 	pixel_y = -6
 	},
 /obj/effect/decal/turf_decal{
-	dir = 8;
+	dir = 10;
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
@@ -36938,13 +36971,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
-"idX" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "ier" = (
 /turf/simulated/floor{
 	icon_state = "black"
@@ -38599,10 +38625,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/effect/decal/turf_decal/alpha/yellow{
+/obj/effect/decal/turf_decal/alpha/red{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/security/brig/storage)
 "ixC" = (
 /obj/item/target/syndicate,
@@ -39251,8 +39279,14 @@
 	},
 /area/station/civilian/hydroponics)
 "iEF" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "caution_white"
+	},
 /obj/effect/decal/turf_decal{
-	dir = 8;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
 	icon_state = "warn"
 	},
 /turf/simulated/floor/plating,
@@ -40208,6 +40242,10 @@
 /area/station/engineering/engine)
 "iPB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "whitered"
@@ -41129,8 +41167,7 @@
 	name = "Station Intercom (Security)"
 	},
 /turf/simulated/floor{
-	dir = 9;
-	icon_state = "red"
+	icon_state = "dark"
 	},
 /area/station/security/main)
 "jaz" = (
@@ -41321,7 +41358,9 @@
 	icon_state = "2-8"
 	},
 /obj/structure/table/reinforced,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/security/main)
 "jcs" = (
 /obj/machinery/door/airlock/maintenance{
@@ -41482,6 +41521,25 @@
 	icon_state = "yellow"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
+"jem" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/main)
 "jeq" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -41573,6 +41631,16 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"jfC" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SEE-FC";
+	location = "SE-FC"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "jfD" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -41994,19 +42062,6 @@
 /obj/item/device/paicard,
 /turf/simulated/floor,
 /area/station/rnd/robotics)
-"jjX" = (
-/obj/machinery/light/smart{
-	dir = 4
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NE-FC";
-	location = "NEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "jjY" = (
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
@@ -42515,10 +42570,11 @@
 /area/station/security/brig/solitary_confinement)
 "jqN" = (
 /obj/structure/dresser,
-/turf/simulated/floor{
-	dir = 10;
-	icon_state = "red"
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 10
 	},
+/turf/simulated/floor,
 /area/station/security/hos)
 "jqQ" = (
 /obj/machinery/door/firedoor,
@@ -42556,6 +42612,17 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
+"jrm" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "jrs" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=8";
@@ -44322,6 +44389,16 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge/captain_quarters)
+"jJP" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-B";
+	location = "SSW-B"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "jKp" = (
 /obj/effect/decal/turf_decal{
 	dir = 5;
@@ -44664,6 +44741,17 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/locker)
+"jNf" = (
+/obj/machinery/light/smart,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DS";
+	location = "DN-W"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "purplecorner"
+	},
+/area/station/hallway/primary/central)
 "jNg" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -46979,9 +47067,8 @@
 	icon_state = "1-4"
 	},
 /obj/structure/closet/emcloset,
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -47456,7 +47543,9 @@
 	},
 /obj/structure/table/reinforced,
 /obj/item/weapon/book/manual/wiki/security_space_law,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/security/main)
 "krn" = (
 /turf/simulated/floor{
@@ -49047,16 +49136,6 @@
 /obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/supermatter)
-"kJp" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SE-FC";
-	location = "SW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "kJq" = (
 /obj/machinery/computer/secure_data/detective_computer,
 /turf/simulated/floor/carpet/red,
@@ -50593,10 +50672,17 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor{
 	icon_state = "darkred"
@@ -51417,6 +51503,18 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
+"llg" = (
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Labor Camp Shuttle Airlock";
+	req_access = list(2)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
 "lli" = (
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
@@ -51620,6 +51718,19 @@
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
+"lnQ" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "lnS" = (
 /obj/effect/landmark/start/recycler,
 /obj/machinery/hologram/holopad,
@@ -52630,7 +52741,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/security/main)
 "lAw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -54327,6 +54440,18 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
+"lTG" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "lTH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -55774,10 +55899,12 @@
 /obj/item/clothing/mask/breath,
 /obj/item/clothing/head/helmet/space/rig/security,
 /obj/machinery/light/small,
-/obj/effect/decal/turf_decal/alpha/yellow{
+/obj/effect/decal/turf_decal/alpha/red{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/security/brig/storage)
 "mmf" = (
 /obj/structure/cable{
@@ -56100,7 +56227,9 @@
 /obj/effect/decal/turf_decal{
 	icon_state = "recharge_floor"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/security/main)
 "mpS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -56303,6 +56432,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/storage/tech)
+"msh" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Security";
+	location = "S-C"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "msk" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -56910,21 +57048,12 @@
 	icon_state = "white"
 	},
 /area/station/medical/cryo)
-"mzy" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "mzF" = (
 /obj/machinery/hologram/holopad{
+	pixel_y = -16
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot";
 	pixel_y = -16
 	},
 /turf/simulated/floor{
@@ -59154,7 +59283,9 @@
 /obj/item/weapon/clipboard,
 /obj/item/weapon/pen,
 /obj/structure/table/reinforced,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/security/main)
 "mZr" = (
 /obj/structure/cable{
@@ -59595,7 +59726,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/photocopier,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -61617,7 +61748,9 @@
 	pixel_y = 22
 	},
 /obj/item/weapon/storage/secure/briefcase,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/security/main)
 "nDw" = (
 /turf/simulated/floor{
@@ -61670,7 +61803,9 @@
 	name = "Security Office APC";
 	pixel_y = -28
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/security/main)
 "nEi" = (
 /obj/structure/cable{
@@ -61960,7 +62095,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/security/main)
 "nHd" = (
 /turf/simulated/floor/plating/airless/catwalk,
@@ -62431,6 +62568,15 @@
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
+"nNx" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-B";
+	location = "S-MB"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry)
 "nNG" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
@@ -62768,7 +62914,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/security/main)
 "nRf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -62949,10 +63097,12 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/decal/turf_decal/alpha/yellow{
+/obj/effect/decal/turf_decal/alpha/red{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/security/brig/storage)
 "nSF" = (
 /obj/machinery/door/firedoor,
@@ -63801,13 +63951,6 @@
 	icon_state = "wooden-2"
 	},
 /area/station/civilian/gym)
-"obU" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-FC";
-	location = "SSW-FC"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/starboard)
 "oci" = (
 /obj/structure/stool/bed/chair/comfy/brown{
 	dir = 4
@@ -64736,7 +64879,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/turf_decal{
-	dir = 8;
+	dir = 9;
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
@@ -64777,9 +64920,10 @@
 	network = list("SS13","Security")
 	},
 /obj/item/weapon/bedsheet/hos,
-/turf/simulated/floor{
-	icon_state = "red"
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
 	},
+/turf/simulated/floor,
 /area/station/security/hos)
 "oqc" = (
 /obj/machinery/door/firedoor,
@@ -65440,7 +65584,7 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor{
 	dir = 5;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
 /area/station/security/main)
 "ozK" = (
@@ -68039,6 +68183,10 @@
 "pfc" = (
 /obj/machinery/iv_drip,
 /obj/structure/stool/bed/roller,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "whitered"
@@ -68978,6 +69126,12 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
+"ppk" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
+	},
+/turf/simulated/floor/carpet/red,
+/area/station/security/detectives_office)
 "ppl" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -72202,15 +72356,6 @@
 	icon_state = "blackcorner"
 	},
 /area/station/hallway/primary/starboard)
-"qas" = (
-/obj/effect/decal/turf_decal/alpha/blue{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "qaF" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red,
 /obj/machinery/meter,
@@ -73296,16 +73441,6 @@
 	icon_state = "gcircuit"
 	},
 /area/station/aisat/ai_chamber)
-"qmV" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Central Access"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "qmZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -74364,17 +74499,6 @@
 	icon_state = "neutral"
 	},
 /area/station/engineering/chiefs_office)
-"qAo" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "qAy" = (
 /turf/simulated/floor/plating,
 /area/station/maintenance/incinerator)
@@ -76082,6 +76206,14 @@
 	icon_state = "redchecker"
 	},
 /area/station/hallway/primary/fore)
+"qUu" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/civilian/gym)
 "qUz" = (
 /obj/structure/sink{
 	dir = 8;
@@ -76104,7 +76236,9 @@
 /area/station/rnd/misc_lab)
 "qUR" = (
 /obj/item/weapon/flora/random,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/security/main)
 "qVm" = (
 /turf/simulated/floor{
@@ -76271,6 +76405,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
+"qXj" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "loadingarea"
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "arrow"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "qXu" = (
 /obj/machinery/portable_atmospherics/powered/pump,
 /obj/machinery/atmospherics/components/unary/portables_connector{
@@ -76623,13 +76768,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
-"rbJ" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=CS-AR";
-	location = "SWW-FC"
-	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
 "rbK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -76873,6 +77011,16 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
+"reK" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Central Access"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "rfw" = (
 /obj/machinery/camera{
 	c_tag = "Port Primary Hallway East"
@@ -79165,6 +79313,16 @@
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
+"rFz" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSE-FC";
+	location = "SEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "rFB" = (
 /obj/machinery/light/smart,
 /obj/effect/decal/turf_decal{
@@ -82597,6 +82755,16 @@
 	icon_state = "wooden"
 	},
 /area/station/bridge/corp_lounge)
+"ssN" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NEE-FC";
+	location = "S-SV"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "sta" = (
 /obj/structure/table/reinforced,
 /obj/item/device/flashlight/lamp,
@@ -82730,18 +82898,10 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "suB" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -84407,6 +84567,13 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/sleeper)
+"sPC" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=N-MB";
+	location = "NNW-B"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "sPM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -85020,16 +85187,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/storage/tech)
-"sXA" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NNW-B";
-	location = "NW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "sXD" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -86350,6 +86507,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -88907,6 +89067,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/bridge)
+"tVh" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DN";
+	location = "SSE-FC"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "tVx" = (
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -88937,6 +89106,27 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/reception)
+"tVJ" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "tVO" = (
 /obj/machinery/vending/security,
 /obj/structure/reagent_dispensers/peppertank{
@@ -89147,8 +89337,8 @@
 	name = "Range Access";
 	req_access = list(63)
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -89207,6 +89397,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories)
+"tZc" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SE-FC";
+	location = "SW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "tZe" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/decal/turf_decal/alpha/orange{
@@ -89461,21 +89661,15 @@
 	},
 /area/station/rnd/hallway)
 "ucx" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SWW-FC";
+	location = "SW-FC"
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
-/area/station/security/brig)
+/area/station/hallway/primary/central)
 "ucF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -91435,16 +91629,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/bridge)
-"uAk" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NEE-FC";
-	location = "S-SV"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "uAq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -92174,17 +92358,7 @@
 	},
 /area/station/bridge/nuke_storage)
 "uLd" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -94470,15 +94644,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/supermatter)
-"vng" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-B";
-	location = "S-MB"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/secondary/entry)
 "vnt" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/firstaid/regular,
@@ -96151,16 +96316,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/hallway/lobby)
-"vIr" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-FC";
-	location = "DS"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "bluecorner"
-	},
-/area/station/hallway/primary/central)
 "vIu" = (
 /obj/effect/decal/cleanable/generic,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -97059,8 +97214,9 @@
 	},
 /area/station/bridge/teleporter)
 "vTX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -97100,18 +97256,6 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/hallway)
-"vUt" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "vUH" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -97312,6 +97456,13 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/break_room)
+"vWV" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-MB";
+	location = "N-MB"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "vXb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -97943,17 +98094,6 @@
 "wdO" = (
 /turf/simulated/floor,
 /area/station/maintenance/escape)
-"wei" = (
-/obj/machinery/light/smart,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DS";
-	location = "DN-W"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "purplecorner"
-	},
-/area/station/hallway/primary/central)
 "wej" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -98490,10 +98630,11 @@
 "wlk" = (
 /obj/structure/table/woodentable,
 /obj/item/device/flashlight/lamp,
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "red"
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 6
 	},
+/turf/simulated/floor,
 /area/station/security/hos)
 "wln" = (
 /obj/machinery/door/unpowered/shuttle/wagon,
@@ -98829,16 +98970,6 @@
 	icon_state = "white"
 	},
 /area/station/medical/hallway)
-"woX" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-C";
-	location = "CS-AR"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "wpa" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -99101,6 +99232,16 @@
 	icon_state = "darkred"
 	},
 /area/station/security/warden)
+"wsJ" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NNW-B";
+	location = "NW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "wsS" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -100161,15 +100302,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
-"wFz" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DN";
-	location = "SSE-FC"
-	},
-/turf/simulated/floor{
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "wFU" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -102629,6 +102761,9 @@
 /obj/structure/filingcabinet{
 	req_access = list(58)
 	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -103331,6 +103466,10 @@
 	pixel_x = 29;
 	pixel_y = -6
 	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "whitered"
@@ -103823,6 +103962,16 @@
 	icon_state = "bluecorner"
 	},
 /area/station/engineering/minisat_secure_area)
+"xxW" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-FC";
+	location = "DS"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
+/area/station/hallway/primary/central)
 "xyb" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -106390,7 +106539,7 @@
 	},
 /turf/simulated/floor{
 	dir = 6;
-	icon_state = "red"
+	icon_state = "darkred"
 	},
 /area/station/security/main)
 "ybW" = (
@@ -135295,7 +135444,7 @@ doE
 doE
 doE
 lgU
-blY
+jfC
 mhm
 doE
 mnD
@@ -135793,7 +135942,7 @@ wwi
 aYN
 wwi
 lfm
-dqD
+rFz
 tZn
 oyb
 nAM
@@ -135811,7 +135960,7 @@ oyb
 bzt
 bzt
 rcq
-wFz
+tVh
 tYK
 wtC
 wtC
@@ -141190,7 +141339,7 @@ iSv
 xXt
 vAu
 ogP
-fys
+jJP
 bAS
 nvi
 rnH
@@ -141206,7 +141355,7 @@ qbj
 qbj
 tmk
 ldb
-kJp
+tZc
 ogP
 iSi
 amv
@@ -141233,7 +141382,7 @@ vpT
 xei
 bFh
 vpT
-wei
+jNf
 vIl
 olx
 frM
@@ -141401,7 +141550,7 @@ plf
 brw
 mko
 jsL
-vng
+nNx
 ffX
 hbE
 sTt
@@ -141670,7 +141819,7 @@ gHT
 alc
 vDr
 fDL
-sXA
+wsJ
 iwy
 xXt
 gNR
@@ -145514,7 +145663,7 @@ yaE
 yaE
 csG
 fYS
-beM
+vWV
 alc
 gHT
 gHT
@@ -145523,7 +145672,7 @@ gHT
 gHT
 gHT
 alc
-hDU
+sPC
 fYS
 sEX
 srs
@@ -150458,7 +150607,7 @@ mXl
 mXl
 mXl
 wLD
-uAk
+ssN
 iwm
 mXl
 pRS
@@ -150476,7 +150625,7 @@ oNU
 mXl
 uxx
 xMc
-hAP
+ucx
 nvi
 rnH
 cLM
@@ -150485,7 +150634,7 @@ nvi
 tOH
 mfI
 ogP
-vIr
+xxW
 sBG
 wjc
 wjc
@@ -150788,7 +150937,7 @@ xQo
 xQo
 xQo
 nKU
-obU
+fum
 xQo
 oPI
 mRu
@@ -150955,7 +151104,7 @@ cpR
 gtK
 cpR
 pxL
-jjX
+hoT
 ffJ
 ape
 fZz
@@ -150974,7 +151123,7 @@ hRd
 ckx
 fZz
 lMB
-fOp
+msh
 kzb
 vAu
 psV
@@ -150988,7 +151137,7 @@ vAu
 kRo
 vAu
 kCI
-woX
+bwk
 ogP
 lwr
 mLS
@@ -151229,7 +151378,7 @@ erD
 erD
 cmN
 act
-qmV
+reK
 xsY
 uuf
 jTW
@@ -155079,8 +155228,8 @@ plf
 xyC
 cFp
 klH
-dod
-dod
+ppk
+ppk
 hGr
 aRu
 xyC
@@ -155583,11 +155732,11 @@ plf
 plf
 plf
 uRO
-hwE
+llg
 uRO
 plf
 uRO
-hwE
+llg
 uRO
 plf
 xyC
@@ -155604,8 +155753,8 @@ dnn
 aEr
 wPw
 jQy
-qas
-aBM
+gRh
+fOp
 jcX
 fJg
 nPU
@@ -156112,7 +156261,7 @@ xyC
 xyC
 xyC
 xyC
-idX
+fql
 jtG
 wpm
 fJg
@@ -156354,7 +156503,7 @@ wVt
 cHH
 cjS
 bNB
-opt
+etB
 kms
 cHH
 eow
@@ -156611,12 +156760,12 @@ leA
 cHH
 adG
 iGB
-qJx
+vTX
 tTk
 qMX
 aZz
 fKP
-vTX
+qJx
 dhy
 iWK
 hTu
@@ -156872,7 +157021,7 @@ ikW
 qXE
 rjb
 utF
-bDv
+qXj
 uLd
 lat
 nsn
@@ -157387,7 +157536,7 @@ kGr
 rjb
 bXA
 rfz
-ucx
+bDv
 gvj
 cHH
 pQo
@@ -157671,7 +157820,7 @@ kIM
 vst
 mDV
 vKG
-rbJ
+dAK
 xoq
 tAM
 uQA
@@ -160738,7 +160887,7 @@ sxG
 uOc
 hur
 hur
-ecv
+lnQ
 ekd
 lZw
 gqC
@@ -160992,7 +161141,7 @@ ixl
 mme
 uKd
 gRX
-bAB
+dkx
 sRa
 nUj
 wUB
@@ -161021,13 +161170,13 @@ ncp
 ncp
 hbR
 mWz
-vUt
+lTG
 kLd
 syX
 tHk
 tHk
 dbf
-bFL
+tVJ
 ram
 mWz
 lNQ
@@ -161284,7 +161433,7 @@ eFl
 aRb
 nDG
 jjN
-mzy
+epU
 ram
 mWz
 ucd
@@ -161491,8 +161640,8 @@ afw
 nDf
 mZo
 qUR
-cal
-rbY
+jem
+mzV
 aSh
 mpR
 gHu
@@ -161792,13 +161941,13 @@ ncp
 ncp
 hbR
 mWz
-qAo
+jrm
 sIY
 qls
 uOM
 uOM
 aeG
-dWC
+bFL
 ram
 mWz
 hPr
@@ -162822,7 +162971,7 @@ dJL
 nRG
 oXA
 oXA
-buA
+qUu
 dJL
 plf
 cdR
@@ -166160,7 +166309,7 @@ kHU
 fMh
 plf
 dJL
-buA
+qUu
 oXA
 oXA
 nJn

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -272,7 +272,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/civilian/kitchen)
 "abI" = (
 /obj/machinery/door/firedoor,
@@ -2133,6 +2135,9 @@
 	pixel_x = -28;
 	pixel_y = -6
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -2346,6 +2351,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"asa" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "asj" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2654,14 +2669,6 @@
 	icon_state = "gcircuit"
 	},
 /area/station/rnd/server)
-"avu" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/civilian/gym)
 "avU" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable,
@@ -3066,15 +3073,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/miningoffice)
-"aAH" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "aAP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -3494,6 +3492,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/hallway/primary/starboard)
+"aFk" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "aFr" = (
 /obj/machinery/photocopier,
 /obj/effect/decal/cleanable/dirt,
@@ -5969,6 +5976,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line"
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -6095,6 +6105,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig)
+"bjz" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "bjB" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
@@ -6105,6 +6122,9 @@
 /area/station/maintenance/atmos)
 "bjH" = (
 /obj/machinery/computer/arcade,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "redyellowfull"
 	},
@@ -6688,6 +6708,16 @@
 	icon_state = "wooden"
 	},
 /area/station/medical/psych)
+"bpB" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-FC";
+	location = "DS"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
+/area/station/hallway/primary/central)
 "bpO" = (
 /obj/effect/landmark/start/assistant/test_subject,
 /obj/machinery/light/smart{
@@ -7120,6 +7150,13 @@
 	},
 /area/station/hallway/primary/port)
 "buQ" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -7360,6 +7397,9 @@
 	id = "pr_kitch_shuttes";
 	name = "Privacy Shutters";
 	pixel_x = -26
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	icon_state = "yellowpatch_inv"
@@ -7640,26 +7680,6 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/locker)
-"bAi" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "bAn" = (
 /obj/structure/disposalpipe/junction,
 /turf/simulated/floor{
@@ -8046,6 +8066,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_corner"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -8571,17 +8594,6 @@
 	icon_state = "greenblue"
 	},
 /area/station/civilian/hydroponics)
-"bIF" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "loadingarea"
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "arrow"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "bIH" = (
 /obj/structure/table/woodentable,
 /obj/machinery/door_control{
@@ -8954,7 +8966,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/civilian/kitchen)
 "bNb" = (
 /obj/structure/filingcabinet/security,
@@ -9569,6 +9583,16 @@
 	icon_state = "neutralfull"
 	},
 /area/station/cargo/qm)
+"bUB" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Central Access"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "bUI" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -10033,7 +10057,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/hallway/primary/fore)
 "bYY" = (
 /turf/simulated/floor{
@@ -10769,6 +10795,9 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner"
+	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
 	},
@@ -10777,25 +10806,6 @@
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "neutral"
-	},
-/area/station/security/main)
-"chi" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
 	},
 /area/station/security/main)
 "chj" = (
@@ -10851,6 +10861,14 @@
 	icon_state = "red"
 	},
 /area/station/security/brig)
+"chC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/security/prison)
 "chU" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/light/small{
@@ -10900,6 +10918,10 @@
 /area/station/security/warden)
 "ciq" = (
 /obj/structure/stool/bed/chair/metal/yellow{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -11198,7 +11220,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -11386,8 +11408,11 @@
 /area/station/cargo/office)
 "cnk" = (
 /obj/structure/closet/emcloset,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
 /turf/simulated/floor{
-	icon_state = "neutralfull"
+	icon_state = "vaultfull"
 	},
 /area/station/hallway/primary/fore)
 "cno" = (
@@ -11560,6 +11585,13 @@
 "cpR" = (
 /turf/simulated/wall,
 /area/station/cargo/storage)
+"cqu" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=CS-AR";
+	location = "SWW-FC"
+	},
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "cqB" = (
 /obj/item/weapon/flora/random,
 /obj/item/device/radio/intercom{
@@ -11918,6 +11950,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/engi)
+"cvN" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "loadingarea"
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "arrow"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "cvO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -13269,6 +13312,17 @@
 	},
 /turf/environment/space,
 /area/shuttle/mining/station)
+"cKx" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "cKC" = (
 /obj/machinery/hydroponics/soil,
 /obj/effect/decal/cleanable/dirt,
@@ -13416,6 +13470,10 @@
 	pixel_y = -5
 	},
 /obj/effect/landmark/start/technical_assistant,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "caution"
@@ -14312,6 +14370,16 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
+"cVH" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSE-FC";
+	location = "SEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "cVO" = (
 /obj/structure/object_wall/pod{
 	icon_state = "1,2"
@@ -14580,6 +14648,10 @@
 	dir = 4
 	},
 /obj/effect/landmark/start/technical_assistant,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "caution"
@@ -14651,6 +14723,25 @@
 /obj/item/weapon/storage/toolbox/electrical,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"dbK" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/main)
 "dcn" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -15045,6 +15136,9 @@
 /area/station/aisat/ai_chamber)
 "dgr" = (
 /obj/machinery/vending/assist,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -15109,6 +15203,19 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge/captain_quarters)
+"dhd" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "dhg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor,
@@ -15720,6 +15827,15 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/cargo/recycler)
+"dnc" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "dnd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -15914,7 +16030,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/hallway/primary/fore)
 "dqI" = (
 /obj/structure/window/thin/reinforced{
@@ -16301,6 +16419,9 @@
 /area/station/maintenance/cargo)
 "duo" = (
 /obj/structure/closet/secure_closet/hydroponics,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "greenblue"
@@ -16387,6 +16508,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 6
+	},
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -16472,6 +16597,18 @@
 	icon_state = "bluecorner"
 	},
 /area/station/engineering/minisat_secure_area)
+"dwq" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "dwB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/visible{
@@ -17248,6 +17385,13 @@
 	icon_state = "blackcorner"
 	},
 /area/station/hallway/primary/starboard)
+"dHi" = (
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/prison)
 "dHv" = (
 /obj/machinery/door/poddoor{
 	id = "armouryaccess";
@@ -17794,7 +17938,9 @@
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/civilian/cold_room)
 "dOV" = (
 /obj/structure/cable/yellow{
@@ -18676,19 +18822,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/checkpoint/escape)
-"dZu" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "dZC" = (
 /obj/structure/lattice,
 /obj/structure/sign/nanotrasen{
@@ -19520,11 +19653,14 @@
 	},
 /area/station/hallway/primary/starboard)
 "ejv" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "cafeteria"
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Security";
+	location = "S-C"
 	},
-/area/station/security/prison)
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "ejG" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 1
@@ -19665,7 +19801,12 @@
 /obj/machinery/chem_master/condimaster{
 	name = "CondiMaster Neo"
 	},
-/turf/simulated/floor,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/civilian/cold_room)
 "ekv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -19885,6 +20026,13 @@
 	},
 /turf/simulated/floor,
 /area/station/medical/hallway)
+"enc" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "eni" = (
 /obj/structure/toilet{
 	dir = 8
@@ -20253,16 +20401,6 @@
 /obj/structure/sign/warning,
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/engineering)
-"esV" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SEE-FC";
-	location = "SE-FC"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "esZ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -20443,6 +20581,15 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"euj" = (
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "eum" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -20557,6 +20704,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"evT" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "cafeteria"
+	},
+/area/station/security/prison)
 "evV" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
@@ -20582,27 +20735,6 @@
 	icon_state = "dark"
 	},
 /area/station/bridge/ai_upload)
-"evX" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "ewd" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -21251,6 +21383,18 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/engine)
+"eDh" = (
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Labor Camp Shuttle Airlock";
+	req_access = list(2)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
 "eDr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -21611,8 +21755,12 @@
 	name = "Kitchen Maintenance";
 	req_access = list(28)
 	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 4
+	},
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
+	icon_state = "delivery"
 	},
 /turf/simulated/floor,
 /area/station/civilian/cold_room)
@@ -21889,17 +22037,6 @@
 	icon_state = "wooden"
 	},
 /area/station/medical/psych)
-"eLr" = (
-/obj/machinery/light/smart,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DS";
-	location = "DN-W"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "purplecorner"
-	},
-/area/station/hallway/primary/central)
 "eLs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -22059,20 +22196,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
-"eNC" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 10;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "eND" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -22939,17 +23062,6 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/break_room)
-"eXO" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "eXS" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
@@ -24839,6 +24951,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line"
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -25302,6 +25417,21 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/secondary/exit)
+"fyJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "fyL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -25419,14 +25549,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/medical/reception)
-"fAc" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/security/prison)
 "fAf" = (
 /obj/effect/decal/turf_decal{
 	dir = 6;
@@ -26536,17 +26658,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "fOp" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
 	dir = 1
 	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "fOF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
@@ -27630,6 +27749,19 @@
 "gbY" = (
 /turf/simulated/wall/r_wall,
 /area/station/ai_monitored/storage_secure)
+"gbZ" = (
+/obj/machinery/light/smart{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NE-FC";
+	location = "NEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "gca" = (
 /obj/effect/landmark/start/security_cadet,
 /turf/simulated/floor{
@@ -28095,16 +28227,6 @@
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/auxport)
-"ghL" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-C";
-	location = "CS-AR"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "ghN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/effect/decal/turf_decal{
@@ -29357,11 +29479,12 @@
 /area/station/tcommsat/computer)
 "gul" = (
 /obj/structure/closet/secure_closet/freezer/fridge,
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/civilian/cold_room)
 "gun" = (
 /obj/machinery/computer/station_alert{
@@ -30287,6 +30410,9 @@
 /obj/effect/landmark/start/bartender,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -30541,6 +30667,13 @@
 /obj/item/weapon/folder/blue,
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories)
+"gHf" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=N-MB";
+	location = "NNW-B"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "gHh" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -31516,6 +31649,9 @@
 /area/station/civilian/dormitories)
 "gST" = (
 /obj/structure/stool/bed/chair/metal/green,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "neutral"
@@ -31546,6 +31682,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 3;
+	icon_state = "warn"
 	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
@@ -32195,6 +32335,16 @@
 	},
 /turf/simulated/floor,
 /area/station/security/checkpoint/engi)
+"hac" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SWW-FC";
+	location = "SW-FC"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "had" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -32909,6 +33059,12 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor,
 /area/station/maintenance/science)
+"hkh" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
+	},
+/turf/simulated/floor/carpet/red,
+/area/station/security/detectives_office)
 "hkj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -33132,24 +33288,14 @@
 "hmz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/kitchen)
-"hmB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/flasher{
-	id = "Cell 3 perma";
-	pixel_y = -28
-	},
-/turf/simulated/floor,
-/area/station/security/prison)
 "hmC" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -33998,6 +34144,9 @@
 /obj/structure/window/thin{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -34151,7 +34300,7 @@
 	req_access = list(2)
 	},
 /obj/effect/decal/turf_decal{
-	dir = 4;
+	dir = 8;
 	icon_state = "warn"
 	},
 /turf/simulated/floor/plating,
@@ -34300,11 +34449,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/maintenance/engineering)
-"hxZ" = (
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "hyh" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -34885,6 +35029,13 @@
 "hDh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
 	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
@@ -36991,7 +37142,7 @@
 /area/station/hallway/secondary/entry)
 "ibt" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -37453,6 +37604,11 @@
 /obj/machinery/atmospherics/components/trinary/tvalve/mirrored/digital,
 /turf/simulated/floor/plating,
 /area/station/maintenance/incinerator)
+"iha" = (
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "ihd" = (
 /obj/structure/table/woodentable,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -37537,6 +37693,15 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/engineering/chiefs_office)
+"ihQ" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "ihW" = (
 /obj/machinery/computer/cryopod{
 	density = 0;
@@ -37983,6 +38148,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/bridge)
+"imQ" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DN";
+	location = "SSE-FC"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "imR" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
@@ -38417,6 +38591,15 @@
 	},
 /turf/simulated/floor,
 /area/station/gateway)
+"isu" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "isB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
@@ -38586,19 +38769,6 @@
 	icon_state = "dark"
 	},
 /area/station/bridge/ai_upload)
-"iut" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "iuu" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -39332,6 +39502,10 @@
 "iCW" = (
 /obj/structure/table/woodentable,
 /obj/machinery/computer/forensic_scanning/detective,
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 1
+	},
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
 "iDi" = (
@@ -39370,7 +39544,7 @@
 "iDw" = (
 /obj/item/weapon/flora/random,
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
+	icon_state = "bot_right"
 	},
 /turf/simulated/floor,
 /area/station/storage/tech)
@@ -39483,6 +39657,10 @@
 /obj/structure/window/thin,
 /obj/structure/window/thin{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
 	},
 /turf/simulated/floor{
 	dir = 6;
@@ -40650,15 +40828,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/medical/genetics)
-"iRj" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 5
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "iRo" = (
 /obj/structure/barricade/wooden,
 /obj/machinery/door/firedoor,
@@ -41087,8 +41256,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/effect/decal/turf_decal/alpha/green{
+	icon_state = "siding_line"
+	},
 /turf/simulated/floor{
-	icon_state = "darkgreen"
+	icon_state = "dark"
 	},
 /area/station/civilian/hydroponics)
 "iWu" = (
@@ -41332,17 +41504,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
-"iZG" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "iZP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -42025,6 +42186,10 @@
 /area/station/engineering/engine)
 "jhc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -42998,6 +43163,19 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry)
+"jsR" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "jtc" = (
 /obj/structure/morgue{
 	dir = 8
@@ -43484,6 +43662,10 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -44638,16 +44820,6 @@
 	},
 /turf/simulated/floor,
 /area/station/storage/primary)
-"jKy" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-B";
-	location = "SSW-B"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "jKB" = (
 /turf/simulated/floor/bluegrid{
 	icon_state = "gcircuit"
@@ -45741,15 +45913,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
-"jVv" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "jVF" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/structure/disposalpipe/segment{
@@ -45789,7 +45952,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 28
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/civilian/cold_room)
 "jWf" = (
 /obj/structure/stool/bed/chair/office/dark,
@@ -46777,18 +46942,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "kgH" = (
-/obj/machinery/light/smart{
-	dir = 4
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NE-FC";
-	location = "NEE-FC"
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "grimy"
 	},
-/area/station/hallway/primary/central)
+/area/station/security/hos)
 "khm" = (
 /obj/machinery/power/apc{
 	name = "apc down";
@@ -47608,12 +47770,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories)
-"kpy" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "browncorner"
-	},
-/area/station/cargo/storage)
 "kpD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -47844,7 +48000,7 @@
 "kst" = (
 /obj/machinery/gibber,
 /turf/simulated/floor{
-	icon_state = "showroomfloor"
+	icon_state = "dark"
 	},
 /area/station/civilian/cold_room)
 "ksv" = (
@@ -48505,6 +48661,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_corner"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn_corner"
+	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -49009,6 +49172,9 @@
 /area/station/security/checkpoint/cargo)
 "kGW" = (
 /obj/structure/closet/secure_closet/hydroponics,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "greenblue"
@@ -49087,7 +49253,7 @@
 	pixel_y = -28
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
+	icon_state = "bot_right"
 	},
 /turf/simulated/floor,
 /area/station/storage/tech)
@@ -49156,7 +49322,9 @@
 /obj/machinery/light/smart{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "blackchecker"
+	},
 /area/station/civilian/hydroponics)
 "kHZ" = (
 /obj/machinery/power/apc{
@@ -49668,16 +49836,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/storage_secure)
-"kMe" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "kMi" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -49941,6 +50099,14 @@
 	icon_state = "red"
 	},
 /area/station/security/checkpoint/medbay)
+"kQi" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "kQr" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 1
@@ -50009,13 +50175,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
-"kRx" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=CS-AR";
-	location = "SWW-FC"
-	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
 "kRI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -51253,16 +51412,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
-"let" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SWW-FC";
-	location = "SW-FC"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "lez" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -51941,15 +52090,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor,
 /area/station/civilian/toilet)
-"lng" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Central Access"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "lnl" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -52516,6 +52656,16 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
+"luy" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "luA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -52639,13 +52789,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
-"lvL" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "lvS" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 10
@@ -52737,7 +52880,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/hallway/primary/fore)
 "lwz" = (
 /obj/machinery/hydroponics/constructable,
@@ -53116,7 +53261,9 @@
 	dir = 8;
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/civilian/cold_room)
 "lBQ" = (
 /obj/structure/stool,
@@ -54394,6 +54541,24 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"lPo" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "lPy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -54938,6 +55103,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line"
+	},
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -54961,15 +55129,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/incinerator)
-"lXv" = (
-/obj/effect/decal/turf_decal/alpha/blue{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "lXA" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Starboard Quarter Solar Access";
@@ -55387,6 +55546,26 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
+"mdb" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "mdk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/stool/bed/chair/office/dark,
@@ -55617,6 +55796,10 @@
 	name = "Shutters";
 	pixel_y = 26
 	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn_corner"
+	},
 /turf/simulated/floor{
 	icon_state = "blackchecker"
 	},
@@ -55845,10 +56028,7 @@
 	},
 /area/station/rnd/scibreak)
 "miU" = (
-/obj/machinery/chem_master/condimaster{
-	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
-	name = "HoochMaster Deluxe"
-	},
+/obj/machinery/media/jukebox,
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "darkred"
@@ -56214,6 +56394,16 @@
 	},
 /turf/simulated/floor,
 /area/station/gateway)
+"mmJ" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NNW-B";
+	location = "NW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "mmN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -56239,12 +56429,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/qm)
-"mmQ" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
-	},
-/turf/simulated/floor/carpet/red,
-/area/station/security/detectives_office)
 "mmV" = (
 /obj/structure/musician/piano,
 /obj/effect/decal/cleanable/dirt,
@@ -56771,9 +56955,12 @@
 /area/station/security/lobby)
 "mtd" = (
 /obj/effect/landmark/start/botanist,
+/obj/effect/decal/turf_decal/alpha/green{
+	icon_state = "siding_line";
+	dir = 9
+	},
 /turf/simulated/floor{
-	dir = 9;
-	icon_state = "darkgreen"
+	icon_state = "dark"
 	},
 /area/station/civilian/hydroponics)
 "mtf" = (
@@ -57095,6 +57282,15 @@
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/space)
+"mww" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 5
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "mwy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -57999,6 +58195,16 @@
 /obj/structure/sign/departments/science,
 /turf/simulated/wall/r_wall,
 /area/station/rnd/telesci)
+"mGw" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/station/security/brig)
 "mGz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -58431,13 +58637,6 @@
 /obj/effect/spawner/lootdrop/gloves,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"mNP" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-FC";
-	location = "SSW-FC"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/starboard)
 "mNU" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
@@ -58806,6 +59005,10 @@
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -22
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_corner";
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -59693,7 +59896,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/storage/tech)
 "naF" = (
 /obj/structure/sign/poster/official/build{
@@ -59772,16 +59977,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"nbV" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
+"nbY" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 10;
+	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	dir = 6;
-	icon_state = "brown"
+	icon_state = "dark"
 	},
-/area/station/cargo/storage)
+/area/station/security/brig)
 "ncb" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -60335,11 +60544,12 @@
 /area/station/maintenance/atmos)
 "nja" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
-/obj/effect/decal/turf_decal{
-	dir = 9;
-	icon_state = "warn"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/civilian/cold_room)
 "njm" = (
 /obj/machinery/power/solar{
@@ -60790,6 +61000,10 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -60838,6 +61052,14 @@
 "npC" = (
 /obj/structure/sink{
 	pixel_y = 24
+	},
+/obj/effect/decal/turf_decal/alpha/purple{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
 	},
 /turf/simulated/floor{
 	icon_state = "blackchecker"
@@ -61573,6 +61795,12 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/incinerator)
+"nxO" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "browncorner"
+	},
+/area/station/cargo/storage)
 "nxQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -62291,14 +62519,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
-"nGe" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "nGh" = (
 /obj/machinery/computer/station_alert{
 	dir = 4
@@ -62516,6 +62736,10 @@
 	},
 /area/station/hallway/primary/fore)
 "nIB" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	icon_state = "blackchecker"
 	},
@@ -62743,16 +62967,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
-"nLE" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "nLP" = (
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
@@ -62850,13 +63064,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/misc_lab)
-"nNj" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "nNm" = (
 /obj/structure/stool,
 /obj/machinery/alarm{
@@ -62916,6 +63123,16 @@
 /obj/structure/girder/reinforced,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"nOH" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-B";
+	location = "SSW-B"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "nOJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -66059,6 +66276,10 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "neutral"
@@ -66237,6 +66458,18 @@
 	icon_state = "vaultfull"
 	},
 /area/station/engineering/engine)
+"oEe" = (
+/obj/machinery/door_timer/cell_3{
+	pixel_x = 32;
+	pixel_y = 0;
+	dir = 4;
+	id = "Cell 3 perma"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "oEf" = (
 /obj/machinery/power/apc{
 	dir = 8;
@@ -66757,26 +66990,6 @@
 	icon_state = "neutral"
 	},
 /area/station/hallway/primary/fore)
-"oJQ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "oKu" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -67004,6 +67217,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
+"oMc" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-MB";
+	location = "N-MB"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "oMd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/stool/bar,
@@ -67055,16 +67275,6 @@
 /obj/structure/table,
 /turf/simulated/floor,
 /area/station/storage/tools)
-"oMy" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSE-FC";
-	location = "SEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "oME" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -67234,7 +67444,7 @@
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	dir = 4;
+	dir = 6;
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
@@ -68354,6 +68564,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/port)
+"pcM" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "pcR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -68734,15 +68964,6 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/secondary/exit)
-"phr" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Security";
-	location = "S-C"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "pht" = (
 /obj/structure/table/woodentable/fancy/black,
 /obj/structure/window/thin/reinforced{
@@ -69161,9 +69382,12 @@
 /area/station/maintenance/escape)
 "plT" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/effect/decal/turf_decal/alpha/green{
+	icon_state = "siding_line";
+	dir = 1
+	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "darkgreen"
+	icon_state = "dark"
 	},
 /area/station/civilian/hydroponics)
 "plZ" = (
@@ -69458,6 +69682,13 @@
 	icon_state = "red"
 	},
 /area/station/security/checkpoint/engi)
+"poQ" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "poS" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/turf_decal{
@@ -70309,6 +70540,10 @@
 /obj/structure/mopbucket,
 /obj/item/weapon/mop,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	icon_state = "blackchecker"
 	},
@@ -70870,7 +71105,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/civilian/kitchen)
 "pEM" = (
 /obj/effect/decal/cleanable/dirt,
@@ -71042,16 +71279,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible,
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
-"pGu" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SE-FC";
-	location = "SW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "pGv" = (
 /obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor{
@@ -71352,18 +71579,6 @@
 	icon_state = "black"
 	},
 /area/station/civilian/chapel)
-"pKs" = (
-/obj/machinery/door_timer/cell_3{
-	pixel_x = 32;
-	pixel_y = 0;
-	dir = 4;
-	id = "Cell 3 perma"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "pKu" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -71881,6 +72096,14 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"pPX" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/civilian/gym)
 "pPY" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -72293,19 +72516,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/chiefs_office)
-"pUI" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 9
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "pUK" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -72677,8 +72887,6 @@
 	},
 /area/station/engineering/chiefs_office)
 "pZq" = (
-/obj/item/weapon/book/manual/wiki/jukebox,
-/obj/machinery/media/jukebox,
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "darkred"
@@ -72717,6 +72925,10 @@
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 22
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -74017,6 +74229,19 @@
 	icon_state = "vaultfull"
 	},
 /area/station/rnd/xenobiology)
+"qoe" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "qom" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 8
@@ -74028,15 +74253,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/mixing)
-"qoq" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DN";
-	location = "SSE-FC"
-	},
-/turf/simulated/floor{
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "qou" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -74126,6 +74342,15 @@
 /obj/item/weapon/flora/random,
 /turf/simulated/floor,
 /area/station/security/prison)
+"qpY" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-B";
+	location = "S-MB"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry)
 "qqm" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -74346,6 +74571,10 @@
 	dir = 8;
 	pixel_x = -22
 	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -74555,6 +74784,10 @@
 /obj/structure/window/thin{
 	dir = 8
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "greenblue"
@@ -74627,6 +74860,19 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/misc_lab)
+"qvz" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "qvQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -74947,6 +75193,9 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -75428,16 +75677,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/cargo/recycler)
-"qGM" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkred"
-	},
-/area/station/security/brig)
 "qGO" = (
 /obj/structure/grille,
 /obj/machinery/door/firedoor,
@@ -75815,6 +76054,10 @@
 /obj/structure/stool/bed/chair/metal/blue{
 	dir = 1
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "neutral"
@@ -75932,6 +76175,16 @@
 	icon_state = "red"
 	},
 /area/station/security/brig/equipment)
+"qMn" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SEE-FC";
+	location = "SE-FC"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "qMt" = (
 /obj/structure/morgue,
 /obj/structure/extinguisher_cabinet{
@@ -76094,6 +76347,16 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
+"qOt" = (
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "qOV" = (
 /obj/structure/table,
 /obj/item/seeds/appleseed,
@@ -76172,6 +76435,9 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha{
+	icon_state = "warn_box"
 	},
 /turf/simulated/floor{
 	icon_state = "blackchecker"
@@ -76449,6 +76715,9 @@
 /obj/item/weapon/reagent_containers/glass/bucket,
 /obj/structure/window/thin{
 	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -77033,7 +77302,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
 /area/station/civilian/bar)
 "raf" = (
 /obj/structure/disposalpipe/segment,
@@ -77404,6 +77675,16 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/lobby)
+"rei" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NEE-FC";
+	location = "S-SV"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "rel" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -77470,6 +77751,9 @@
 /obj/machinery/camera{
 	c_tag = "Kitchen Cold Room";
 	dir = 5
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
 	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
@@ -78391,6 +78675,10 @@
 /obj/structure/table/woodentable,
 /obj/item/toy/figure/assistant,
 /obj/machinery/light/small,
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
 "rrR" = (
@@ -80768,13 +81056,6 @@
 	icon_state = "whitehall"
 	},
 /area/station/rnd/robotics)
-"rPV" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=N-MB";
-	location = "NNW-B"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "rPX" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -81336,6 +81617,9 @@
 /obj/effect/landmark/start/janitor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "blackchecker"
 	},
@@ -81825,15 +82109,6 @@
 	icon_state = "neutral"
 	},
 /area/station/maintenance/medbay)
-"sel" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-B";
-	location = "S-MB"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/secondary/entry)
 "seo" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
@@ -82196,15 +82471,6 @@
 	icon_state = "black"
 	},
 /area/station/hallway/secondary/exit)
-"sie" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "sif" = (
 /obj/machinery/door_control{
 	id = "AI Blast Door";
@@ -82804,6 +83070,14 @@
 	},
 /area/station/cargo/storage)
 "snU" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	dir = 4;
+	icon_state = "loadingarea"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "arrow";
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -83838,6 +84112,10 @@
 /area/station/rnd/misc_lab)
 "sBP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -83904,13 +84182,10 @@
 	},
 /area/station/civilian/kitchen)
 "sCO" = (
-/obj/structure/closet,
-/obj/item/stack/sheet/glass{
-	amount = 30
+/obj/machinery/chem_master/condimaster{
+	desc = "Looks like a knock-off chem-master. Perhaps useful for separating liquids when mixing drinks precisely. Also dispenses condiments.";
+	name = "HoochMaster Deluxe"
 	},
-/obj/item/stack/cable_coil,
-/obj/item/device/cardpay,
-/obj/item/device/tagger/shop,
 /turf/simulated/floor{
 	icon_state = "blackchecker"
 	},
@@ -84120,6 +84395,10 @@
 /area/station/medical/virology)
 "sEW" = (
 /obj/structure/stool/bed/chair/metal/green,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "neutral"
@@ -85514,6 +85793,10 @@
 /obj/structure/window/thin{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "greenblue"
@@ -86367,6 +86650,10 @@
 "thi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -86576,13 +86863,6 @@
 	icon_state = "dark"
 	},
 /area/station/medical/genetics)
-"tjV" = (
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/prison)
 "tkc" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -87577,6 +87857,10 @@
 "txi" = (
 /obj/effect/landmark/start/janitor,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/turf_decal/alpha/purple{
+	icon_state = "siding_line";
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "blackchecker"
 	},
@@ -88903,6 +89187,16 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
+"tMO" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-C";
+	location = "CS-AR"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "tMS" = (
 /obj/structure/closet/secure_closet/hydroponics,
 /obj/structure/window/thin,
@@ -89002,6 +89296,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
+"tOt" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "tOH" = (
 /obj/structure/sign/directions/evac{
 	pixel_x = -32;
@@ -89436,7 +89742,7 @@
 	pixel_y = -22
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
+	icon_state = "bot_left"
 	},
 /turf/simulated/floor,
 /area/station/storage/tech)
@@ -89684,6 +89990,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"tXZ" = (
+/obj/machinery/light/smart,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "tYa" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -89710,9 +90026,12 @@
 /area/station/civilian/locker)
 "tYi" = (
 /obj/effect/landmark/start/botanist,
+/obj/effect/decal/turf_decal/alpha/green{
+	icon_state = "siding_line";
+	dir = 10
+	},
 /turf/simulated/floor{
-	dir = 10;
-	icon_state = "darkgreen"
+	icon_state = "dark"
 	},
 /area/station/civilian/hydroponics)
 "tYn" = (
@@ -90047,12 +90366,15 @@
 	},
 /area/station/rnd/hallway)
 "ucx" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SE-FC";
+	location = "SW-B"
+	},
 /turf/simulated/floor{
-	dir = 4;
+	dir = 1;
 	icon_state = "neutralcorner"
 	},
-/area/station/security/lobby)
+/area/station/hallway/primary/central)
 "ucF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -91065,6 +91387,9 @@
 	dir = 8;
 	pixel_x = -12
 	},
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line"
+	},
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -91167,7 +91492,9 @@
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/civilian/cold_room)
 "uot" = (
 /obj/machinery/vending/assist,
@@ -91602,7 +91929,6 @@
 	name = "Central Access"
 	},
 /turf/simulated/floor{
-	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/station/security/lobby)
@@ -92254,6 +92580,10 @@
 /obj/structure/stool/bed/chair/metal/red{
 	dir = 8
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -92559,15 +92889,16 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "uHN" = (
+/obj/machinery/light/smart,
 /obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NNW-B";
-	location = "NW-B"
+	codes_txt = "patrol;next_patrol=DS";
+	location = "DN-W"
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "purplecorner"
 	},
-/area/station/hallway/secondary/entry)
+/area/station/hallway/primary/central)
 "uHX" = (
 /turf/simulated/floor/wood,
 /area/station/maintenance/chapel)
@@ -92614,6 +92945,13 @@
 "uJi" = (
 /turf/simulated/wall,
 /area/station/rnd/chargebay)
+"uJw" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-FC";
+	location = "SSW-FC"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/starboard)
 "uJK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/binary/valve,
@@ -93326,18 +93664,6 @@
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/brig)
-"uRZ" = (
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Labor Camp Shuttle Airlock";
-	req_access = list(2)
-	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
 	},
 /turf/simulated/floor/plating,
 /area/station/security/brig)
@@ -94201,13 +94527,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/tox_launch)
-"vbV" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-MB";
-	location = "N-MB"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "vbZ" = (
 /obj/machinery/computer/atmos_alert,
 /obj/structure/cable{
@@ -94673,6 +94992,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/tcommsat/computer)
+"viH" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_right"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/cold_room)
 "viI" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -95148,6 +95476,10 @@
 	pixel_x = 22
 	},
 /obj/machinery/light/smart{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -96064,6 +96396,9 @@
 	dir = 6
 	},
 /obj/structure/closet/emcloset,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -96225,26 +96560,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/engine)
-"vBR" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "vBV" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/stamp/internalaffairs,
@@ -96519,6 +96834,15 @@
 /obj/structure/closet/gmcloset{
 	name = "formal wardrobe"
 	},
+/obj/item/device/cardpay{
+	dir = 1
+	},
+/obj/item/stack/sheet/glass{
+	amount = 30
+	},
+/obj/item/stack/cable_coil,
+/obj/item/device/tagger/shop,
+/obj/item/weapon/book/manual/wiki/jukebox,
 /turf/simulated/floor{
 	icon_state = "blackchecker"
 	},
@@ -96618,6 +96942,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
+"vGg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/flasher{
+	id = "Cell 3 perma";
+	pixel_y = -28
+	},
+/turf/simulated/floor,
+/area/station/security/prison)
 "vGh" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -97038,7 +97375,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/civilian/kitchen)
 "vLy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -97339,6 +97678,27 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/drone_fabrication)
+"vPU" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "vPX" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -97359,6 +97719,9 @@
 	pixel_y = -6
 	},
 /obj/structure/disposalpipe/trunk,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "redyellowfull"
 	},
@@ -97928,9 +98291,12 @@
 /area/station/hallway/primary/starboard)
 "vXo" = (
 /obj/effect/landmark/start/botanist,
+/obj/effect/decal/turf_decal/alpha/green{
+	icon_state = "siding_line";
+	dir = 5
+	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "darkgreen"
+	icon_state = "dark"
 	},
 /area/station/civilian/hydroponics)
 "vXq" = (
@@ -98163,6 +98529,9 @@
 	},
 /obj/structure/window/thin{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -99676,7 +100045,9 @@
 	name = "Hydroponics";
 	req_access = list(35)
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "greenblue"
+	},
 /area/station/civilian/hydroponics)
 "wtb" = (
 /obj/structure/filingcabinet/chestdrawer,
@@ -99733,9 +100104,12 @@
 /area/station/rnd/test_area)
 "wtJ" = (
 /obj/effect/landmark/start/botanist,
+/obj/effect/decal/turf_decal/alpha/green{
+	icon_state = "siding_line";
+	dir = 6
+	},
 /turf/simulated/floor{
-	dir = 6;
-	icon_state = "darkgreen"
+	icon_state = "dark"
 	},
 /area/station/civilian/hydroponics)
 "wtL" = (
@@ -99915,6 +100289,26 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge/captain_quarters)
+"wxb" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "wxc" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -100581,7 +100975,10 @@
 	name = "Hydroponics";
 	req_access = list(35)
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "greenblue"
+	},
 /area/station/civilian/hydroponics)
 "wDE" = (
 /obj/machinery/door/airlock/command/glass{
@@ -100878,7 +101275,12 @@
 /area/station/civilian/dormitories)
 "wHb" = (
 /obj/structure/kitchenspike,
-/turf/simulated/floor,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_left"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/civilian/cold_room)
 "wHm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -101069,7 +101471,9 @@
 	dir = 8;
 	pixel_x = -22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "blackchecker"
+	},
 /area/station/civilian/hydroponics)
 "wJy" = (
 /obj/structure/cable{
@@ -101930,15 +102334,6 @@
 	icon_state = "yellowpatch"
 	},
 /area/station/engineering/atmos/supermatter)
-"wVl" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "wVt" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -102353,11 +102748,12 @@
 /area/station/hallway/secondary/entry)
 "xas" = (
 /obj/structure/closet/secure_closet/freezer/meat,
-/obj/effect/decal/turf_decal{
-	dir = 5;
-	icon_state = "warn"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/civilian/cold_room)
 "xau" = (
 /obj/machinery/door/firedoor,
@@ -102623,6 +103019,9 @@
 	name = "Station Intercom (General)";
 	pixel_x = 28;
 	pixel_y = -5
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line"
 	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
@@ -103177,6 +103576,10 @@
 /obj/machinery/light/smart{
 	dir = 8
 	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -103247,16 +103650,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/tcommsat/chamber)
-"xmt" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NEE-FC";
-	location = "S-SV"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "xmz" = (
 /obj/structure/object_wall/mining{
 	icon_state = "1-3"
@@ -103570,18 +103963,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/maintenance/escape)
-"xpm" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "xpn" = (
 /obj/item/device/flashlight/lamp,
 /obj/structure/table/woodentable,
@@ -103739,6 +104120,10 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/effect/decal/turf_decal/alpha/purple{
+	icon_state = "siding_corner";
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "blackchecker"
 	},
@@ -103890,6 +104275,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"xsi" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "xsj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -104134,6 +104529,15 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/misc_lab)
+"xuL" = (
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "xuQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -104143,6 +104547,10 @@
 	},
 /area/station/cargo/storage)
 "xuT" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 9
+	},
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
 "xuU" = (
@@ -104304,6 +104712,13 @@
 /obj/item/weapon/caution,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"xwH" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_left"
+	},
+/turf/simulated/floor,
+/area/station/storage/tech)
 "xwJ" = (
 /mob/living/simple_animal/hostile/retaliate/goat{
 	name = "Pete"
@@ -104404,16 +104819,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
-"xxA" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-FC";
-	location = "DS"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "bluecorner"
-	},
-/area/station/hallway/primary/central)
 "xxE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
@@ -104822,6 +105227,9 @@
 /obj/structure/window/thin{
 	dir = 1
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "greenblue"
@@ -105000,6 +105408,9 @@
 /obj/structure/window/thin{
 	dir = 8
 	},
+/obj/effect/decal/turf_decal/alpha{
+	icon_state = "warn_box"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -105094,6 +105505,10 @@
 	},
 /obj/machinery/alarm{
 	pixel_y = 22
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
 	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
@@ -105274,19 +105689,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
-"xGT" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "xHu" = (
 /obj/structure/rack,
 /obj/item/weapon/circuitboard/solar_control,
@@ -105768,6 +106170,17 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
+"xNx" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "xNJ" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /turf/simulated/floor/engine,
@@ -105934,6 +106347,10 @@
 /obj/machinery/camera{
 	c_tag = "Bar Backroom";
 	dir = 7
+	},
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "grimy"
@@ -107323,7 +107740,9 @@
 	dir = 8;
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/civilian/cold_room)
 "yfb" = (
 /obj/structure/table,
@@ -135936,7 +136355,7 @@ doE
 doE
 doE
 lgU
-esV
+qMn
 mhm
 doE
 mnD
@@ -136434,7 +136853,7 @@ wwi
 aYN
 wwi
 lfm
-oMy
+cVH
 tZn
 oyb
 nAM
@@ -136452,7 +136871,7 @@ oyb
 bzt
 bzt
 rcq
-qoq
+imQ
 tYK
 wtC
 wtC
@@ -137468,7 +137887,7 @@ xNR
 rMP
 nAi
 vfr
-iDw
+xwH
 rDd
 jcO
 iNE
@@ -138225,7 +138644,7 @@ tRk
 vdt
 rwG
 srt
-wHb
+viH
 dOS
 rfL
 qsE
@@ -139253,7 +139672,7 @@ kBq
 biv
 pED
 bNa
-aSY
+luy
 kIU
 lBN
 yeY
@@ -139510,7 +139929,7 @@ dtM
 fty
 abG
 vLv
-aSY
+luy
 kIU
 jVV
 ekm
@@ -141831,7 +142250,7 @@ iSv
 xXt
 vAu
 ogP
-jKy
+nOH
 bAS
 nvi
 rnH
@@ -141847,7 +142266,7 @@ qbj
 qbj
 tmk
 ldb
-pGu
+ucx
 ogP
 iSi
 amv
@@ -141874,7 +142293,7 @@ vpT
 xei
 bFh
 vpT
-eLr
+uHN
 vIl
 olx
 frM
@@ -142042,7 +142461,7 @@ plf
 brw
 mko
 jsL
-sel
+qpY
 ffX
 hbE
 sTt
@@ -142311,7 +142730,7 @@ gHT
 alc
 vDr
 fDL
-uHN
+mmJ
 iwy
 xXt
 gNR
@@ -143092,17 +143511,17 @@ hXb
 hXb
 hXb
 che
-hXb
-cIy
-hXb
-hXb
-hXb
-hXb
-hXb
-hXb
-hXb
-fLj
-hXb
+xuL
+lPo
+xuL
+xuL
+xuL
+xuL
+xuL
+xuL
+xuL
+fyJ
+xuL
 vos
 did
 did
@@ -143596,7 +144015,7 @@ kHU
 yaE
 hkD
 fYS
-vDr
+euj
 wts
 mge
 qed
@@ -143876,13 +144295,13 @@ mpN
 uQg
 tJq
 oFm
-nNj
+poQ
 xsb
-nNj
-nNj
-nNj
+poQ
+poQ
+poQ
 mtf
-nNj
+poQ
 jpq
 bsc
 mfI
@@ -144110,7 +144529,7 @@ plf
 yaE
 vDr
 fYS
-hkD
+qOt
 tEo
 nIB
 iEL
@@ -144367,7 +144786,7 @@ kHU
 yaE
 csG
 fYS
-tjv
+tXZ
 wts
 npC
 txi
@@ -144390,10 +144809,10 @@ cCx
 mES
 tJq
 ikZ
-pUI
+jsR
 oki
-lvL
-lvL
+bjz
+bjz
 vTX
 tWH
 vTX
@@ -144647,7 +145066,7 @@ tJq
 ucP
 tJq
 fSC
-iut
+qoe
 ktM
 uuo
 djH
@@ -146155,7 +146574,7 @@ yaE
 yaE
 csG
 fYS
-vbV
+oMc
 alc
 gHT
 gHT
@@ -146164,7 +146583,7 @@ gHT
 gHT
 gHT
 alc
-rPV
+gHf
 fYS
 sEX
 srs
@@ -151099,7 +151518,7 @@ mXl
 mXl
 mXl
 wLD
-xmt
+rei
 iwm
 mXl
 pRS
@@ -151117,7 +151536,7 @@ oNU
 mXl
 uxx
 xMc
-let
+hac
 nvi
 rnH
 cLM
@@ -151126,7 +151545,7 @@ nvi
 tOH
 mfI
 ogP
-xxA
+bpB
 sBG
 wjc
 wjc
@@ -151429,7 +151848,7 @@ xQo
 xQo
 xQo
 nKU
-mNP
+uJw
 xQo
 oPI
 mRu
@@ -151596,7 +152015,7 @@ cpR
 gtK
 cpR
 pxL
-kgH
+gbZ
 ffJ
 ape
 fZz
@@ -151615,7 +152034,7 @@ hRd
 ckx
 fZz
 lMB
-phr
+ejv
 kzb
 vAu
 psV
@@ -151629,7 +152048,7 @@ vAu
 kRo
 vAu
 kCI
-ghL
+tMO
 ogP
 lwr
 mLS
@@ -151870,9 +152289,9 @@ erD
 erD
 cmN
 act
-uuf
+bUB
 xsY
-lng
+uuf
 jTW
 jTW
 jTW
@@ -152352,7 +152771,7 @@ fnT
 miA
 ojm
 lPc
-kpy
+nxO
 gaF
 rpV
 qSe
@@ -152609,11 +153028,11 @@ nkb
 adb
 hzP
 cpR
-nLE
-oOk
+xsi
+asa
 uXI
+asa
 oOk
-nbV
 xqF
 aAF
 iqI
@@ -155720,8 +156139,8 @@ plf
 xyC
 cFp
 klH
-mmQ
-mmQ
+hkh
+hkh
 hGr
 aRu
 xyC
@@ -156224,11 +156643,11 @@ plf
 plf
 plf
 uRO
-hwE
+eDh
 uRO
 plf
 uRO
-hwE
+eDh
 uRO
 plf
 xyC
@@ -156245,8 +156664,8 @@ dnn
 aEr
 wPw
 jQy
-lXv
-hxZ
+isu
+iha
 jcX
 fJg
 nPU
@@ -156738,11 +157157,11 @@ plf
 cHH
 cHH
 jxX
-uRZ
+hwE
 bjt
 stv
 jxX
-uRZ
+hwE
 jxX
 adp
 kMq
@@ -156753,7 +157172,7 @@ xyC
 xyC
 xyC
 xyC
-ucx
+enc
 jtG
 wpm
 fJg
@@ -156995,7 +157414,7 @@ wVt
 cHH
 cjS
 bNB
-eNC
+nbY
 kms
 cHH
 eow
@@ -157252,7 +157671,7 @@ leA
 cHH
 adG
 iGB
-qGM
+mGw
 tTk
 qMX
 aZz
@@ -157513,7 +157932,7 @@ ikW
 qXE
 rjb
 utF
-bIF
+cvN
 uLd
 lat
 nsn
@@ -158312,7 +158731,7 @@ kIM
 vst
 mDV
 vKG
-kRx
+cqu
 xoq
 tAM
 uQA
@@ -159031,14 +159450,14 @@ fAF
 fgx
 diq
 fAF
-pKs
+oEe
 eTq
 fAF
 wNM
 oPD
 tif
 rHZ
-bAi
+pcM
 czU
 tqK
 hsq
@@ -159295,7 +159714,7 @@ qZx
 qZx
 fXG
 qZx
-vBR
+wxb
 czU
 uvV
 kMw
@@ -159801,7 +160220,7 @@ blh
 cra
 hlv
 dVr
-hmB
+vGg
 hlv
 fBm
 bvC
@@ -160825,7 +161244,7 @@ aXC
 bZu
 pLw
 unD
-fAc
+chC
 oAx
 ulK
 eyO
@@ -161379,7 +161798,7 @@ sxG
 uOc
 hur
 hur
-xGT
+qvz
 ekd
 lZw
 gqC
@@ -161633,7 +162052,7 @@ ixl
 mme
 uKd
 gRX
-xpm
+tOt
 sRa
 nUj
 wUB
@@ -161662,13 +162081,13 @@ ncp
 ncp
 hbR
 mWz
-fOp
+dwq
 kLd
 syX
 tHk
 tHk
 dbf
-evX
+vPU
 ram
 mWz
 lNQ
@@ -161925,7 +162344,7 @@ eFl
 aRb
 nDG
 jjN
-dZu
+dhd
 ram
 mWz
 ucd
@@ -162132,7 +162551,7 @@ afw
 nDf
 mZo
 qUR
-chi
+dbK
 mzV
 aSh
 mpR
@@ -162433,7 +162852,7 @@ ncp
 ncp
 hbR
 mWz
-eXO
+cKx
 sIY
 qls
 uOM
@@ -162629,7 +163048,7 @@ lhK
 wVg
 aFN
 jKZ
-ejv
+evT
 rBo
 hlv
 qxh
@@ -162893,7 +163312,7 @@ xIO
 jps
 xIO
 qZx
-oJQ
+mdb
 tbS
 sZR
 kHU
@@ -162905,7 +163324,7 @@ fwH
 qoH
 vOW
 qoH
-nGe
+kQi
 umQ
 gYp
 kHU
@@ -163143,7 +163562,7 @@ jvm
 hlv
 fVW
 fPH
-ejv
+evT
 rnI
 hlv
 pHz
@@ -163158,11 +163577,11 @@ kHU
 plf
 cYc
 ueE
-kMe
+kgH
 wcJ
 iRz
 nez
-iZG
+xNx
 hlh
 gYp
 plf
@@ -163415,11 +163834,11 @@ kHU
 kHU
 cYc
 nfj
-aAH
+fOp
 eaE
 nRk
 rZh
-jVv
+dnc
 hmN
 gYp
 kHU
@@ -163463,7 +163882,7 @@ dJL
 nRG
 oXA
 oXA
-avu
+pPX
 dJL
 plf
 cdR
@@ -163672,11 +164091,11 @@ plf
 kHU
 huz
 sIx
-iRj
-sie
+mww
+aFk
 kjv
-sie
-wVl
+aFk
+ihQ
 tEU
 huz
 plf
@@ -165721,7 +166140,7 @@ plf
 kHU
 hlv
 lrm
-tjV
+dHi
 jno
 hlv
 cBu
@@ -166801,7 +167220,7 @@ kHU
 fMh
 plf
 dJL
-avu
+pPX
 oXA
 oXA
 nJn

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -339,7 +339,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/engineering/engine)
 "acc" = (
 /obj/structure/table/reinforced,
@@ -418,15 +420,6 @@
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/space)
-"acr" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "act" = (
 /obj/structure/sign/directions/command{
 	dir = 1
@@ -477,7 +470,9 @@
 	name = "Engine Room";
 	req_access = list(10)
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/engineering/engine)
 "acH" = (
 /obj/structure/table/woodentable,
@@ -1170,19 +1165,6 @@
 	icon_state = "grimy"
 	},
 /area/station/tcommsat/computer)
-"ahc" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "ahh" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -1670,18 +1652,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
-"alh" = (
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Labor Camp Shuttle Airlock";
-	req_access = list(2)
-	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/brig)
 "alj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
@@ -3349,7 +3319,9 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/engineering/engine)
 "aEr" = (
 /obj/machinery/door/firedoor,
@@ -3620,6 +3592,9 @@
 	network = list("SS13","Security")
 	},
 /obj/structure/closet/secure_closet/security,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "red"
@@ -4055,6 +4030,15 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
+"aLM" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "aMd" = (
 /obj/structure/object_wall/cargo{
 	icon_state = "5,0"
@@ -4653,6 +4637,16 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
+"aSI" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SEE-FC";
+	location = "SE-FC"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "aSP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4705,13 +4699,6 @@
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/station/security/vacantoffice)
-"aTm" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-MB";
-	location = "N-MB"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "aTn" = (
 /turf/simulated/floor{
 	icon_state = "white"
@@ -5229,7 +5216,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/engineering/engine)
 "baj" = (
 /obj/effect/decal/turf_decal{
@@ -6380,7 +6369,8 @@
 	},
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
+	icon_state = "box_corners_white";
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -6392,6 +6382,9 @@
 	pixel_x = 28
 	},
 /obj/machinery/vending/eva/engineering,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
 "blI" = (
@@ -7225,6 +7218,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"bva" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SWW-FC";
+	location = "SW-FC"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "bvb" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -7586,6 +7589,20 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/hallway)
+"bze" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/pump,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "arrival"
+	},
+/area/station/hallway/primary/port)
 "bzh" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -8081,7 +8098,9 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/engineering/engine)
 "bDS" = (
 /obj/machinery/door/firedoor,
@@ -8410,7 +8429,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/engineering/engine)
 "bGo" = (
 /obj/effect/decal/cleanable/dirt,
@@ -9518,7 +9539,9 @@
 	pixel_y = -5
 	},
 /obj/structure/cable,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/engineering/engine)
 "bTd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -10297,6 +10320,16 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/engine)
+"caQ" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-C";
+	location = "CS-AR"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "caY" = (
 /obj/structure/closet/secure_closet/quartermaster,
 /obj/structure/cable{
@@ -11604,16 +11637,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/dormitories/courtroom)
-"cpg" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "cpj" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/sparker{
@@ -13399,6 +13422,26 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/medical/genetics)
+"cKZ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "cLd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -13895,17 +13938,6 @@
 	icon_state = "grimy"
 	},
 /area/station/maintenance/medbay)
-"cQh" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "loadingarea"
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "arrow"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "cQi" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -14435,16 +14467,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
-"cVK" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-B";
-	location = "SSW-B"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "cVO" = (
 /obj/structure/object_wall/pod{
 	icon_state = "1,2"
@@ -14552,20 +14574,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/civilian/locker)
-"cWX" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "escape"
-	},
-/area/station/hallway/primary/port)
 "cXg" = (
 /obj/structure/table/woodentable,
 /obj/item/device/flashlight/lamp{
@@ -17432,26 +17440,6 @@
 	icon_state = "blackcorner"
 	},
 /area/station/hallway/primary/starboard)
-"dHf" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "dHv" = (
 /obj/machinery/door/poddoor{
 	id = "armouryaccess";
@@ -17724,16 +17712,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/warden)
-"dKl" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-FC";
-	location = "DS"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "bluecorner"
-	},
-/area/station/hallway/primary/central)
 "dKn" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -18352,16 +18330,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
-"dTm" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSE-FC";
-	location = "SEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "dTp" = (
 /obj/structure/sign/warning/secure_area{
 	pixel_y = -14
@@ -18381,6 +18349,18 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/hallway)
+"dTC" = (
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Labor Camp Shuttle Airlock";
+	req_access = list(2)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
 "dTH" = (
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
@@ -18728,6 +18708,9 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
 "dXp" = (
@@ -18827,6 +18810,23 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
+"dYr" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "caution"
+	},
+/area/station/engineering/atmos/distribution)
 "dYs" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -19736,14 +19736,10 @@
 	},
 /area/station/hallway/primary/starboard)
 "ejv" = (
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
 /turf/simulated/floor{
-	icon_state = "neutralfull"
+	icon_state = "vaultfull"
 	},
-/area/station/hallway/primary/fore)
+/area/station/security/blueshield)
 "ejG" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 1
@@ -20968,6 +20964,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/civilian/hydroponics)
+"exp" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "exw" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -21092,19 +21095,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
-"eyA" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "eyD" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -21476,16 +21466,6 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/engine)
-"eDn" = (
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "eDr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -21509,14 +21489,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
-"eDV" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/civilian/gym)
 "eDZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -22240,19 +22212,6 @@
 	icon_state = "purple"
 	},
 /area/station/rnd/xenobiology)
-"eMZ" = (
-/obj/machinery/light/smart{
-	dir = 4
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NE-FC";
-	location = "NEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "eNj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
@@ -22629,6 +22588,14 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"eQp" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "eQI" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -23101,6 +23068,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/tox_launch)
+"eWO" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "eXa" = (
 /obj/structure/rack,
 /obj/item/weapon/storage/belt/utility,
@@ -23447,6 +23427,16 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
+"faS" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SE-FC";
+	location = "SW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "faX" = (
 /obj/machinery/biogenerator,
 /obj/structure/window/thin{
@@ -23922,16 +23912,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/starboard)
-"ffD" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "ffG" = (
 /obj/machinery/light/smart{
 	dir = 8
@@ -24390,6 +24370,18 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge)
+"fkE" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "fkM" = (
 /obj/structure/window/fulltile/tinted{
 	grilled = 1;
@@ -24500,16 +24492,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/lobby)
-"fmd" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
 "fmh" = (
 /obj/machinery/atmospherics/components/trinary/filter{
 	dir = 1
@@ -24641,21 +24623,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
-"fog" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/engineering/monitoring)
 "foh" = (
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor,
@@ -25680,6 +25647,19 @@
 	icon_state = "greencorner"
 	},
 /area/station/civilian/hydroponics)
+"fzF" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/flasher{
+	id = "Cell 3 perma";
+	pixel_y = -28
+	},
+/turf/simulated/floor,
+/area/station/security/prison)
 "fzP" = (
 /obj/structure/bookcase/manuals/medical,
 /turf/simulated/floor/wood,
@@ -26027,6 +26007,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/chapel)
+"fEw" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-FC";
+	location = "SSW-FC"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/starboard)
 "fEx" = (
 /obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
@@ -26821,16 +26808,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "fOp" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 4
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-B";
+	location = "SSW-B"
 	},
 /turf/simulated/floor{
-	icon_state = "neutralfull"
+	dir = 4;
+	icon_state = "neutralcorner"
 	},
-/area/station/engineering/atmos/atmos_office)
+/area/station/hallway/primary/central)
 "fOF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
@@ -27137,6 +27123,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/library)
+"fSq" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "fSr" = (
 /obj/structure/table/woodentable,
 /obj/machinery/kitchen_machine/microwave{
@@ -28033,6 +28028,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
+"gdj" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Central Access"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "gdx" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -29662,7 +29666,9 @@
 	dir = 1
 	},
 /obj/machinery/light/smart,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/engineering/engine)
 "gux" = (
 /obj/random/scrap/safe_even,
@@ -30510,15 +30516,6 @@
 /obj/structure/girder,
 /turf/simulated/floor,
 /area/station/maintenance/medbay)
-"gBU" = (
-/obj/effect/decal/turf_decal{
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "gBV" = (
 /obj/machinery/computer/borgupload,
 /turf/simulated/floor{
@@ -30547,6 +30544,7 @@
 	icon_state = "delivery"
 	},
 /obj/effect/decal/turf_decal{
+	dir = 4;
 	icon_state = "warn_corner"
 	},
 /turf/simulated/floor{
@@ -31550,7 +31548,8 @@
 	dir = 4
 	},
 /obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
+	icon_state = "siding_corner";
+	dir = 8
 	},
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
@@ -33846,18 +33845,6 @@
 	icon_state = "darkred"
 	},
 /area/station/security/brig)
-"hqr" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "hqu" = (
 /obj/effect/landmark/start/atmospheric_technician,
 /obj/structure/stool/bed/chair/office/dark{
@@ -34316,8 +34303,8 @@
 /area/station/maintenance/science)
 "hur" = (
 /obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
+	dir = 1;
+	icon_state = "warn_corner"
 	},
 /obj/effect/decal/turf_decal{
 	dir = 4;
@@ -34395,6 +34382,15 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/library)
+"huY" = (
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "huZ" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -34458,26 +34454,6 @@
 	},
 /turf/simulated/floor,
 /area/station/bridge/captain_quarters)
-"hvW" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "hvY" = (
 /obj/machinery/light/smart{
 	dir = 4
@@ -34695,6 +34671,12 @@
 	icon_state = "vaultfull"
 	},
 /area/station/maintenance/engineering)
+"hyf" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
+	},
+/turf/simulated/floor/carpet/red,
+/area/station/security/detectives_office)
 "hyh" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -36493,6 +36475,16 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway)
+"hRG" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSE-FC";
+	location = "SEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "hRR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -36970,7 +36962,7 @@
 "hXd" = (
 /obj/machinery/vending/tool,
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
+	icon_state = "delivery"
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
@@ -37657,6 +37649,13 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
+"ieJ" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 4
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "ieL" = (
 /obj/effect/decal/turf_decal{
 	dir = 8;
@@ -37800,16 +37799,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/bridge)
-"igB" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "igF" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -38582,7 +38571,7 @@
 	},
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "bluecorner"
+	icon_state = "blue"
 	},
 /area/station/engineering/break_room)
 "ioH" = (
@@ -39795,7 +39784,7 @@
 "iDw" = (
 /obj/item/weapon/flora/random,
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_left"
+	icon_state = "bot_right"
 	},
 /turf/simulated/floor,
 /area/station/storage/tech)
@@ -39847,7 +39836,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
+	icon_state = "siding_line";
 	dir = 8
 	},
 /turf/simulated/floor,
@@ -40542,21 +40531,10 @@
 	dir = 9;
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/engineering/engine)
-"iLO" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 9
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "iLP" = (
 /obj/machinery/power/rad_collector{
 	anchored = 1
@@ -40688,6 +40666,14 @@
 	temperature = 80
 	},
 /area/station/tcommsat/chamber)
+"iMU" = (
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/break_room)
 "iNc" = (
 /obj/structure/flora/junglebush/large,
 /turf/simulated/floor/grass,
@@ -42460,7 +42446,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/engineering/engine)
 "jhc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -44290,7 +44278,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/engineering/engine)
 "jBf" = (
 /obj/structure/rack,
@@ -44622,7 +44612,9 @@
 	dir = 1;
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/engineering/engine)
 "jFR" = (
 /turf/simulated/floor/carpet/green,
@@ -45371,6 +45363,17 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/monitoring)
+"jMF" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "jMG" = (
 /obj/structure/window/thin/reinforced{
 	dir = 8
@@ -45408,7 +45411,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/engineering/engine)
 "jNo" = (
 /obj/machinery/door/firedoor,
@@ -45618,13 +45623,6 @@
 	icon_state = "blackchecker"
 	},
 /area/station/civilian/barbershop)
-"jPg" = (
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/prison)
 "jPt" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
@@ -46087,8 +46085,8 @@
 	req_access = list(10)
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "yellowcorner"
+	dir = 6;
+	icon_state = "red"
 	},
 /area/station/engineering/break_room)
 "jUt" = (
@@ -46654,18 +46652,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/dormitories/courtroom)
-"kaJ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "kaL" = (
 /obj/effect/decal/turf_decal/metal{
 	icon_state = "siding_thinplating_line";
@@ -46716,16 +46702,6 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/secondary/exit)
-"kbs" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkred"
-	},
-/area/station/security/brig)
 "kbD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -46928,13 +46904,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/scibreak)
-"kdX" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-FC";
-	location = "SSW-FC"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/starboard)
 "kdY" = (
 /obj/machinery/flasher/portable,
 /obj/machinery/light/smart{
@@ -47257,12 +47226,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "kgH" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 4
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
 	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "khm" = (
 /obj/machinery/power/apc{
 	name = "apc down";
@@ -48117,6 +48091,15 @@
 /obj/item/weapon/storage/box/cdeathalarm_kit,
 /turf/simulated/floor,
 /area/station/medical/storage)
+"kpY" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DN";
+	location = "SSE-FC"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "kqa" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -48449,6 +48432,14 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
+"kts" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/security/prison)
 "ktv" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor{
@@ -48778,6 +48769,20 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge/captain_quarters)
+"kyB" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor,
+/area/station/engineering/monitoring)
 "kyV" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -49342,6 +49347,16 @@
 "kFd" = (
 /turf/simulated/wall,
 /area/station/rnd/scibreak)
+"kFh" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "kFj" = (
 /obj/machinery/door/airlock{
 	name = "Mime's Backstage Room";
@@ -50088,13 +50103,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/medical/genetics)
-"kLy" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "kLE" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engine Room";
@@ -50366,15 +50374,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
-"kOC" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "kOM" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -50476,6 +50475,16 @@
 	icon_state = "vaultfull"
 	},
 /area/station/bridge/hop_office)
+"kQJ" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "kRe" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -52447,6 +52456,16 @@
 	icon_state = "white"
 	},
 /area/station/medical/hallway)
+"lnI" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/station/security/brig)
 "lnK" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -52533,6 +52552,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
+"loW" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "lpw" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -53096,6 +53127,17 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/security/prison)
+"lvd" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "lvz" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/alarm{
@@ -53382,6 +53424,18 @@
 	icon_state = "whitered"
 	},
 /area/station/security/prison)
+"lzh" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "lzo" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots,
@@ -53768,24 +53822,6 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/lobby)
-"lDN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
 "lDO" = (
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/incinerator)
@@ -55277,13 +55313,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/fore)
-"lUJ" = (
-/obj/item/weapon/flora/random,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_right"
-	},
-/turf/simulated/floor,
-/area/station/storage/tech)
 "lUT" = (
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -55554,6 +55583,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"lXZ" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "loadingarea"
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "arrow"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "lYm" = (
 /obj/structure/window/thin/reinforced{
 	dir = 8
@@ -56353,6 +56393,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/rnd/scibreak)
+"miL" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-B";
+	location = "S-MB"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry)
 "miU" = (
 /obj/machinery/media/jukebox,
 /turf/simulated/floor{
@@ -56773,14 +56822,6 @@
 "mne" = (
 /turf/simulated/wall,
 /area/station/medical/sleeper)
-"mnf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/security/prison)
 "mnm" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12)
@@ -56835,18 +56876,6 @@
 	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
-"mnJ" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "mnK" = (
 /obj/machinery/camera{
 	c_tag = "Captain's Office";
@@ -57329,6 +57358,15 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/dormitories)
+"mtl" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Security";
+	location = "S-C"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "mtn" = (
 /obj/machinery/light/smart{
 	dir = 4
@@ -57473,6 +57511,16 @@
 	icon_state = "darkred"
 	},
 /area/station/security/checkpoint/medbay)
+"muo" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NNW-B";
+	location = "NW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "muv" = (
 /obj/machinery/optable,
 /obj/machinery/status_display{
@@ -57588,19 +57636,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/medbay)
-"mvK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "mvQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -57841,7 +57876,9 @@
 	dir = 5;
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/engineering/engine)
 "mzd" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -58223,6 +58260,27 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/cold_room)
+"mBS" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "mBU" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -58317,6 +58375,15 @@
 "mDI" = (
 /turf/simulated/wall,
 /area/station/civilian/chapel/office)
+"mDM" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_left"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/cold_room)
 "mDV" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -58453,7 +58520,7 @@
 	},
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "yellowcorner"
+	icon_state = "red"
 	},
 /area/station/engineering/break_room)
 "mFB" = (
@@ -58538,6 +58605,13 @@
 	icon_state = "yellowfull"
 	},
 /area/station/engineering/engine)
+"mGo" = (
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/prison)
 "mGu" = (
 /obj/structure/sign/departments/science,
 /turf/simulated/wall/r_wall,
@@ -58679,6 +58753,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"mJl" = (
+/obj/machinery/light/smart{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NE-FC";
+	location = "NEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "mJs" = (
 /obj/item/weapon/flora/random,
 /obj/structure/window/thin/reinforced,
@@ -60322,6 +60409,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"nca" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "ncb" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -60595,17 +60694,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/storage)
-"nfX" = (
-/obj/machinery/light/smart,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DS";
-	location = "DN-W"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "purplecorner"
-	},
-/area/station/hallway/primary/central)
 "nfY" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -60683,7 +60771,7 @@
 	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "yellowcorner"
+	icon_state = "yellow"
 	},
 /area/station/engineering/break_room)
 "nhe" = (
@@ -61603,6 +61691,26 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/kitchen)
+"nqW" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "nrh" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -62924,16 +63032,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
-"nGE" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Central Access"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "nGM" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Upper Cells";
@@ -63320,6 +63418,12 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
+"nLm" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "browncorner"
+	},
+/area/station/cargo/storage)
 "nLr" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/gourd,
@@ -63402,12 +63506,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
-"nMG" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "browncorner"
-	},
-/area/station/cargo/storage)
 "nMJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
@@ -63925,7 +64023,7 @@
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "box_corners_white";
-	dir = 4
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -64078,18 +64176,6 @@
 	icon_state = "dark"
 	},
 /area/station/medical/morgue)
-"nTE" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "nTN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -64522,6 +64608,16 @@
 "nYz" = (
 /turf/simulated/wall/r_wall,
 /area/station/rnd/test_area)
+"nYF" = (
+/obj/machinery/light/smart,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "nYJ" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -64565,6 +64661,9 @@
 /obj/structure/closet/wardrobe/engineering_yellow,
 /obj/item/device/cardpay{
 	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -64708,20 +64807,6 @@
 	icon_state = "grimy"
 	},
 /area/station/tcommsat/computer)
-"oat" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 10;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "oay" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -65224,18 +65309,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/tcommsat/chamber)
-"ogG" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "ogL" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -65522,15 +65595,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/wall/r_wall,
 /area/station/rnd/tox_launch)
-"ojH" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 5
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "ojN" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -66001,20 +66065,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/civilian/locker)
-"orX" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/powered/pump,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "arrival"
-	},
-/area/station/hallway/primary/port)
 "osg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -66163,6 +66213,16 @@
 	icon_state = "caution"
 	},
 /area/station/engineering/atmos/distribution)
+"otm" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-FC";
+	location = "DS"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
+/area/station/hallway/primary/central)
 "otq" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -66423,6 +66483,19 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
+"oxd" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "oxs" = (
 /obj/structure/closet/athletic_mixed,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -67901,7 +67974,7 @@
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	dir = 6;
+	dir = 4;
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
@@ -68092,6 +68165,26 @@
 	icon_state = "blackchecker"
 	},
 /area/station/civilian/locker)
+"oQu" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "oQG" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
@@ -69138,7 +69231,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/engineering/engine)
 "pey" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -69586,15 +69681,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/break_room)
-"pjr" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_right"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/civilian/cold_room)
 "pjw" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/folder/blue,
@@ -69822,18 +69908,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/storage/tech)
-"plD" = (
-/obj/machinery/door_timer/cell_3{
-	pixel_x = 32;
-	pixel_y = 0;
-	dir = 4;
-	id = "Cell 3 perma"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "plL" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -70777,6 +70851,19 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/break_room)
+"pwC" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "pwE" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/box/donkpockets,
@@ -71130,17 +71217,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/minisat_secure_area)
-"pzC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "pzD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -72811,6 +72887,16 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"pSk" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "pSr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -73428,6 +73514,20 @@
 	icon_state = "blackcorner"
 	},
 /area/station/hallway/primary/starboard)
+"qal" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 10;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "qaF" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red,
 /obj/machinery/meter,
@@ -73563,6 +73663,22 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"qbv" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "qbw" = (
 /obj/structure/object_wall/cargo{
 	icon_state = "1,0"
@@ -73617,6 +73733,9 @@
 /area/station/rnd/hor)
 "qbF" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /obj/effect/decal/turf_decal{
 	dir = 1;
 	icon_state = "warn"
@@ -73870,16 +73989,6 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/toilet)
-"qfo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "qfC" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -74301,8 +74410,37 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/engineering/engine)
+"qjU" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/civilian/gym)
+"qjY" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/main)
 "qkc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -74535,14 +74673,6 @@
 	icon_state = "gcircuit"
 	},
 /area/station/aisat/ai_chamber)
-"qmR" = (
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "yellow"
-	},
-/area/station/engineering/break_room)
 "qmZ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -74782,15 +74912,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hor)
-"qpn" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "qpp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -75135,19 +75256,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/misc_lab)
-"qtx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/flasher{
-	id = "Cell 3 perma";
-	pixel_y = -28
-	},
-/turf/simulated/floor,
-/area/station/security/prison)
 "qtC" = (
 /obj/item/device/radio/intercom/pod{
 	dir = 4;
@@ -75761,6 +75869,15 @@
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
+"qCl" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 5
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "qCm" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -75854,6 +75971,15 @@
 	icon_state = "dark"
 	},
 /area/station/medical/cryo)
+"qDn" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "qDw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -76150,6 +76276,21 @@
 /obj/structure/closet,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"qGp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "qGy" = (
 /obj/machinery/recycler,
 /obj/machinery/conveyor{
@@ -77969,13 +78110,6 @@
 "rbY" = (
 /turf/simulated/floor,
 /area/station/security/main)
-"rcj" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=CS-AR";
-	location = "SWW-FC"
-	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
 "rcq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -78172,16 +78306,6 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
-"rfp" = (
-/obj/machinery/light/smart,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "rfw" = (
 /obj/machinery/camera{
 	c_tag = "Port Primary Hallway East"
@@ -78267,15 +78391,6 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/dormitories/courtroom)
-"rgj" = (
-/obj/effect/decal/turf_decal/alpha/blue{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "rgp" = (
 /obj/structure/closet/wardrobe/black,
 /obj/machinery/light/smart{
@@ -78623,7 +78738,9 @@
 	dir = 10;
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/engineering/engine)
 "rkE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -78634,6 +78751,17 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
+"rkP" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos/atmos_office)
 "rkR" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -79088,6 +79216,13 @@
 "rrj" = (
 /turf/environment/space,
 /area/shuttle/syndicate/southwest)
+"rrk" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=CS-AR";
+	location = "SWW-FC"
+	},
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "rrl" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
@@ -79316,19 +79451,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/medbay)
-"rts" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "rtt" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -79376,7 +79498,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
 /area/station/engineering/engine)
 "rtQ" = (
 /obj/machinery/door/firedoor,
@@ -79633,6 +79757,18 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/break_room)
+"rwy" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/engineering/atmos/atmos_office)
 "rwA" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/atmospherics/pipe/simple/visible/green,
@@ -80273,7 +80409,9 @@
 	dir = 6;
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/engineering/engine)
 "rCn" = (
 /turf/environment/space,
@@ -80417,15 +80555,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/server)
-"rEm" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Security";
-	location = "S-C"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "rEr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -80484,7 +80613,9 @@
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/engineering/engine)
 "rEP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -81307,14 +81438,6 @@
 	},
 /turf/simulated/floor,
 /area/station/storage/tech)
-"rMQ" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "rMR" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 4
@@ -81846,6 +81969,15 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/primary/fore)
+"rTd" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "rTk" = (
 /obj/effect/decal/turf_decal{
 	dir = 1;
@@ -83440,23 +83572,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/range)
-"slH" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "slU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -83521,13 +83636,6 @@
 /obj/item/weapon/flora/random,
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
-"smm" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=N-MB";
-	location = "NNW-B"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "smv" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
@@ -84393,16 +84501,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/storage/primary)
-"sxZ" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SWW-FC";
-	location = "SW-FC"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "syg" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -84622,16 +84720,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/chapel)
-"sAT" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SE-FC";
-	location = "SW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "sBe" = (
 /obj/structure/stool/bed/chair,
 /obj/structure/cable{
@@ -85207,23 +85295,6 @@
 /obj/machinery/status_display,
 /turf/simulated/wall,
 /area/station/storage/tech)
-"sHN" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "caution"
-	},
-/area/station/engineering/atmos/distribution)
 "sHQ" = (
 /turf/simulated/wall/r_wall,
 /area/station/engineering/monitoring)
@@ -85631,6 +85702,12 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/science)
+"sMH" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "cafeteria"
+	},
+/area/station/security/prison)
 "sMR" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -85804,15 +85881,6 @@
 	icon_state = "blue"
 	},
 /area/station/civilian/dormitories/courtroom)
-"sOr" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DN";
-	location = "SSE-FC"
-	},
-/turf/simulated/floor{
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "sOu" = (
 /obj/structure/stool,
 /obj/item/device/radio/intercom{
@@ -85942,15 +86010,6 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/hallway)
-"sQk" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "sQq" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/window/thin{
@@ -86365,12 +86424,6 @@
 	icon_state = "1,6"
 	},
 /area/shuttle/supply/station)
-"sVk" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
-	},
-/turf/simulated/floor/carpet/red,
-/area/station/security/detectives_office)
 "sVo" = (
 /obj/machinery/door/airlock{
 	id_tag = "commissarydoor";
@@ -88201,6 +88254,19 @@
 	icon_state = "red"
 	},
 /area/station/security/checkpoint/engi)
+"ttY" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "ttZ" = (
 /obj/structure/table/woodentable,
 /obj/machinery/light/small,
@@ -88628,12 +88694,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/rnd/mixing)
-"tyv" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "cafeteria"
-	},
-/area/station/security/prison)
 "tyB" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -89302,36 +89362,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/bridge/hop_office)
-"tGk" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/main)
-"tGw" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "tGH" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/light/smart{
@@ -89859,18 +89889,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/xenobiology)
-"tMI" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "tMM" = (
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/disposal,
@@ -89937,6 +89955,19 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/library)
+"tNn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "tNE" = (
 /obj/structure/sink{
 	dir = 4;
@@ -91032,16 +91063,12 @@
 	},
 /area/station/rnd/hallway)
 "ucx" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 1
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
 	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "yellow"
-	},
-/area/station/engineering/atmos)
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "ucF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -91168,16 +91195,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
-"ueg" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-C";
-	location = "CS-AR"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "uei" = (
 /obj/structure/filingcabinet,
 /obj/machinery/status_display{
@@ -91244,6 +91261,19 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/hos)
+"ueZ" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "ufi" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/effect/decal/turf_decal/alpha/gray{
@@ -91540,12 +91570,6 @@
 /obj/item/device/radio/intercom,
 /turf/simulated/floor/carpet,
 /area/station/bridge/meeting_room)
-"uiG" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "uiQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -91873,11 +91897,6 @@
 	icon_state = "3,1"
 	},
 /area/shuttle/supply/station)
-"ulF" = (
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "ulH" = (
 /obj/machinery/vending/boozeomat,
 /turf/simulated/floor{
@@ -92621,6 +92640,7 @@
 	name = "Central Access"
 	},
 /turf/simulated/floor{
+	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/station/security/lobby)
@@ -93484,6 +93504,15 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/civilian/kitchen)
+"uFP" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "uFR" = (
 /obj/structure/table/woodentable,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -93585,6 +93614,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/decal/turf_decal/alpha/orange{
@@ -93989,18 +94021,16 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "uNw" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
+/obj/machinery/light/smart,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DS";
+	location = "DN-W"
 	},
 /turf/simulated/floor{
-	icon_state = "neutralfull"
+	dir = 8;
+	icon_state = "purplecorner"
 	},
-/area/station/engineering/atmos)
+/area/station/hallway/primary/central)
 "uNx" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -95650,8 +95680,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "bluecorner"
+	icon_state = "blue"
 	},
 /area/station/engineering/break_room)
 "vic" = (
@@ -95854,6 +95883,18 @@
 	icon_state = "3,5"
 	},
 /area/shuttle/supply/station)
+"vkI" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "vkK" = (
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -95969,6 +96010,19 @@
 	icon_state = "vaultfull"
 	},
 /area/station/rnd/robotics)
+"vlM" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "escape"
+	},
+/area/station/hallway/primary/port)
 "vlN" = (
 /obj/machinery/autolathe,
 /obj/machinery/alarm{
@@ -97350,18 +97404,6 @@
 	icon_state = "whitepurplefull"
 	},
 /area/station/rnd/lab)
-"vDe" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/engineering/atmos/atmos_office)
 "vDf" = (
 /obj/machinery/dna_scannernew,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -98268,6 +98310,13 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/drone_fabrication)
+"vOC" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=N-MB";
+	location = "NNW-B"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "vOQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -98693,26 +98742,18 @@
 	},
 /area/station/bridge/teleporter)
 "vTX" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
 	dir = 8
 	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "vUe" = (
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
@@ -99688,8 +99729,8 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "yellowcorner"
+	dir = 8;
+	icon_state = "yellow"
 	},
 /area/station/engineering/break_room)
 "wfP" = (
@@ -100089,6 +100130,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"wkl" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_left"
+	},
+/turf/simulated/floor,
+/area/station/storage/tech)
 "wkD" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 5
@@ -100487,7 +100535,6 @@
 "wpm" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/station/security/lobby)
@@ -100716,6 +100763,18 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/reception)
+"wsq" = (
+/obj/machinery/door_timer/cell_3{
+	pixel_x = 32;
+	pixel_y = 0;
+	dir = 4;
+	id = "Cell 3 perma"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "wsw" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light/smart{
@@ -101197,6 +101256,13 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
+"wzy" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-MB";
+	location = "N-MB"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "wzH" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
@@ -101814,6 +101880,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
+"wFS" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "wFU" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -101953,7 +102029,7 @@
 "wHb" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_left"
+	icon_state = "bot_right"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -102021,16 +102097,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/main)
-"wHN" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SEE-FC";
-	location = "SE-FC"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "wHR" = (
 /obj/machinery/vending/sustenance,
 /turf/simulated/floor{
@@ -102335,6 +102401,16 @@
 	icon_state = "grimy"
 	},
 /area/station/aisat/antechamber_interior)
+"wLH" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "wLR" = (
 /obj/structure/object_wall/pod{
 	dir = 4;
@@ -103929,6 +104005,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"xfV" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NEE-FC";
+	location = "S-SV"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "xfW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
@@ -104526,19 +104612,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/storage)
-"xnX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "xob" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -104710,6 +104783,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
+"xpG" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "xpQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/hologram/holopad,
@@ -105269,6 +105353,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
+"xuW" = (
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "xuY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -105739,16 +105833,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
-"xzW" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NEE-FC";
-	location = "S-SV"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "xAc" = (
 /obj/structure/closet,
 /obj/structure/cable{
@@ -105900,7 +105984,7 @@
 "xBg" = (
 /obj/structure/dispenser/phoron,
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
+	icon_state = "delivery"
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
@@ -107037,6 +107121,15 @@
 	icon_state = "darkredcorners"
 	},
 /area/station/security/checkpoint/escape)
+"xPB" = (
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "xPO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/table_parts/wood,
@@ -107485,16 +107578,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/storage)
-"xUG" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NNW-B";
-	location = "NW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "xUM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -108136,15 +108219,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
-"ybA" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-B";
-	location = "S-MB"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/secondary/entry)
 "ybG" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/plating,
@@ -108781,26 +108855,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/civilian/locker)
-"ykj" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "ykt" = (
 /obj/structure/sign/nanotrasen,
 /turf/simulated/wall/r_wall,
@@ -131698,7 +131752,7 @@ xFF
 xFG
 flb
 uDn
-qmR
+iMU
 ude
 ehA
 geB
@@ -131955,7 +132009,7 @@ qnQ
 hEd
 fDg
 owf
-qmR
+iMU
 hkb
 ehA
 fUz
@@ -132193,7 +132247,7 @@ bOJ
 oKV
 dup
 dup
-eyA
+nRV
 bOD
 cmG
 xqQ
@@ -132458,7 +132512,7 @@ oLJ
 kFc
 kFc
 cEO
-ucx
+lvd
 azQ
 pfp
 imT
@@ -132704,7 +132758,7 @@ qSk
 qdn
 naA
 kdJ
-nRV
+oxd
 xqQ
 fmh
 mNB
@@ -132712,8 +132766,8 @@ bfy
 cmG
 dup
 htY
-ffD
-ffD
+kFh
+kFh
 nwM
 tCz
 gRR
@@ -132968,7 +133022,7 @@ nLs
 bTE
 tUm
 oPF
-uNw
+pwC
 rSb
 umn
 svw
@@ -133732,17 +133786,17 @@ bsZ
 fZH
 cTK
 whA
+rwy
 iDO
-vDe
-vDe
-vDe
+iDO
+iDO
 xnu
 vCV
 lFG
 waB
 fMO
-kaJ
-mnJ
+vkI
+loW
 kHT
 vPk
 vPk
@@ -133991,7 +134045,7 @@ qcT
 mrP
 daq
 daq
-fOp
+rkP
 egG
 iEf
 hrT
@@ -134533,9 +134587,9 @@ hdV
 bhn
 evV
 oKM
-ogG
+fkE
 wCx
-hqr
+lzh
 oDZ
 bau
 nkc
@@ -134790,9 +134844,9 @@ moL
 ojN
 enq
 bgZ
-slH
-tRh
 gCp
+tRh
+qbv
 oyx
 mRP
 eZT
@@ -135289,7 +135343,7 @@ gpz
 nds
 gpz
 wjD
-gPB
+kyB
 bbv
 awp
 odu
@@ -135546,7 +135600,7 @@ adw
 adw
 adw
 wjD
-fog
+gPB
 cgv
 owM
 ekM
@@ -136049,7 +136103,7 @@ jlK
 tEF
 tne
 cEZ
-sHN
+dYr
 iGS
 ciX
 jau
@@ -136831,12 +136885,12 @@ tEF
 sHQ
 dpc
 sHQ
-cWX
 blv
+vlM
 sqb
 uck
 sqb
-orX
+bze
 hQQ
 qTx
 bUU
@@ -137103,7 +137157,7 @@ doE
 doE
 doE
 lgU
-wHN
+aSI
 mhm
 doE
 mnD
@@ -137601,7 +137655,7 @@ wwi
 aYN
 wwi
 lfm
-dTm
+hRG
 tZn
 oyb
 nAM
@@ -137619,7 +137673,7 @@ oyb
 bzt
 bzt
 rcq
-sOr
+kpY
 tYK
 wtC
 wtC
@@ -138635,7 +138689,7 @@ xNR
 rMP
 nAi
 vfr
-iDw
+wkl
 rDd
 jcO
 iNE
@@ -139149,7 +139203,7 @@ xNR
 oYv
 cGN
 vzT
-lUJ
+iDw
 oVN
 cdA
 jTf
@@ -139392,7 +139446,7 @@ tRk
 vdt
 rwG
 srt
-pjr
+wHb
 dOS
 rfL
 qsE
@@ -139649,7 +139703,7 @@ aSY
 uum
 lVS
 srt
-wHb
+mDM
 uos
 gTB
 kst
@@ -140420,7 +140474,7 @@ kBq
 biv
 pED
 bNa
-fmd
+wFS
 kIU
 lBN
 yeY
@@ -140677,7 +140731,7 @@ dtM
 fty
 abG
 vLv
-fmd
+wFS
 kIU
 jVV
 ekm
@@ -142998,7 +143052,7 @@ iSv
 xXt
 vAu
 ogP
-cVK
+fOp
 bAS
 nvi
 rnH
@@ -143014,7 +143068,7 @@ qbj
 qbj
 tmk
 ldb
-sAT
+faS
 ogP
 iSi
 amv
@@ -143041,7 +143095,7 @@ vpT
 xei
 bFh
 vpT
-nfX
+uNw
 vIl
 olx
 frM
@@ -143209,7 +143263,7 @@ plf
 brw
 mko
 jsL
-ybA
+miL
 ffX
 hbE
 sTt
@@ -143478,7 +143532,7 @@ gHT
 alc
 vDr
 fDL
-xUG
+muo
 iwy
 xXt
 gNR
@@ -144259,17 +144313,17 @@ hXb
 hXb
 hXb
 che
-ejv
-lDN
-ejv
-ejv
-ejv
-ejv
-ejv
-ejv
-ejv
+xPB
 uHN
-ejv
+xPB
+xPB
+xPB
+xPB
+xPB
+xPB
+xPB
+qGp
+xPB
 vos
 did
 did
@@ -144763,7 +144817,7 @@ kHU
 yaE
 hkD
 fYS
-gBU
+huY
 wts
 mge
 qed
@@ -145043,13 +145097,13 @@ mpN
 uQg
 tJq
 oFm
-kgH
+ieJ
 xsb
-kgH
-kgH
-kgH
+ieJ
+ieJ
+ieJ
 mtf
-kgH
+ieJ
 jpq
 bsc
 mfI
@@ -145277,7 +145331,7 @@ plf
 yaE
 vDr
 fYS
-eDn
+xuW
 tEo
 nIB
 iEL
@@ -145534,7 +145588,7 @@ kHU
 yaE
 csG
 fYS
-rfp
+nYF
 wts
 npC
 txi
@@ -145557,13 +145611,13 @@ cCx
 mES
 tJq
 ikZ
-iLO
+tNn
 oki
-kLy
-kLy
-xnX
+ucx
+ucx
+vTX
 tWH
-xnX
+vTX
 qcF
 bRX
 qSi
@@ -145814,7 +145868,7 @@ tJq
 ucP
 tJq
 fSC
-mvK
+eWO
 ktM
 uuo
 djH
@@ -147322,7 +147376,7 @@ yaE
 yaE
 csG
 fYS
-aTm
+wzy
 alc
 gHT
 gHT
@@ -147331,7 +147385,7 @@ gHT
 gHT
 gHT
 alc
-smm
+vOC
 fYS
 sEX
 srs
@@ -152266,7 +152320,7 @@ mXl
 mXl
 mXl
 wLD
-xzW
+xfV
 iwm
 mXl
 pRS
@@ -152284,7 +152338,7 @@ oNU
 mXl
 uxx
 xMc
-sxZ
+bva
 nvi
 rnH
 cLM
@@ -152293,7 +152347,7 @@ nvi
 tOH
 mfI
 ogP
-dKl
+otm
 sBG
 wjc
 wjc
@@ -152596,7 +152650,7 @@ xQo
 xQo
 xQo
 nKU
-kdX
+fEw
 xQo
 oPI
 mRu
@@ -152763,7 +152817,7 @@ cpR
 gtK
 cpR
 pxL
-eMZ
+mJl
 ffJ
 ape
 fZz
@@ -152782,7 +152836,7 @@ hRd
 ckx
 fZz
 lMB
-rEm
+mtl
 kzb
 vAu
 psV
@@ -152796,7 +152850,7 @@ vAu
 kRo
 vAu
 kCI
-ueg
+caQ
 ogP
 lwr
 mLS
@@ -153037,9 +153091,9 @@ erD
 erD
 cmN
 act
-nGE
-xsY
 uuf
+xsY
+gdj
 jTW
 jTW
 jTW
@@ -153519,7 +153573,7 @@ fnT
 miA
 ojm
 lPc
-nMG
+nLm
 gaF
 rpV
 qSe
@@ -153776,11 +153830,11 @@ nkb
 adb
 hzP
 cpR
-igB
-cpg
-uXI
-cpg
+kQJ
 oOk
+uXI
+oOk
+wLH
 xqF
 aAF
 iqI
@@ -156887,8 +156941,8 @@ plf
 xyC
 cFp
 klH
-sVk
-sVk
+hyf
+hyf
 hGr
 aRu
 xyC
@@ -157412,8 +157466,8 @@ dnn
 aEr
 wPw
 jQy
-rgj
-ulF
+fSq
+ejv
 jcX
 fJg
 nPU
@@ -157905,11 +157959,11 @@ plf
 cHH
 cHH
 jxX
-alh
+dTC
 bjt
 stv
 jxX
-alh
+dTC
 jxX
 adp
 kMq
@@ -157920,9 +157974,9 @@ xyC
 xyC
 xyC
 xyC
-wpm
+exp
 jtG
-uiG
+wpm
 fJg
 fJg
 fJg
@@ -158162,7 +158216,7 @@ wVt
 cHH
 cjS
 bNB
-oat
+qal
 kms
 cHH
 eow
@@ -158419,7 +158473,7 @@ leA
 cHH
 adG
 iGB
-kbs
+lnI
 tTk
 qMX
 aZz
@@ -158680,7 +158734,7 @@ ikW
 qXE
 rjb
 utF
-cQh
+lXZ
 uLd
 lat
 nsn
@@ -159479,7 +159533,7 @@ kIM
 vst
 mDV
 vKG
-rcj
+rrk
 xoq
 tAM
 uQA
@@ -160198,14 +160252,14 @@ fAF
 fgx
 diq
 fAF
-plD
+wsq
 eTq
 fAF
 wNM
 oPD
 tif
 rHZ
-ykj
+cKZ
 czU
 tqK
 hsq
@@ -160462,7 +160516,7 @@ qZx
 qZx
 fXG
 qZx
-hvW
+oQu
 czU
 uvV
 kMw
@@ -160968,7 +161022,7 @@ blh
 cra
 hlv
 dVr
-qtx
+fzF
 hlv
 fBm
 bvC
@@ -161992,7 +162046,7 @@ aXC
 bZu
 pLw
 unD
-mnf
+kts
 oAx
 ulK
 eyO
@@ -162544,9 +162598,9 @@ ilq
 uKd
 sxG
 uOc
+ttY
+ttY
 hur
-hur
-ahc
 ekd
 lZw
 gqC
@@ -162800,7 +162854,7 @@ ixl
 mme
 uKd
 gRX
-nTE
+nca
 sRa
 nUj
 wUB
@@ -162829,13 +162883,13 @@ ncp
 ncp
 hbR
 mWz
-tMI
+kgH
 kLd
 syX
 tHk
 tHk
 dbf
-vTX
+mBS
 ram
 mWz
 lNQ
@@ -163092,7 +163146,7 @@ eFl
 aRb
 nDG
 jjN
-rts
+ueZ
 ram
 mWz
 ucd
@@ -163299,7 +163353,7 @@ afw
 nDf
 mZo
 qUR
-tGk
+qjY
 mzV
 aSh
 mpR
@@ -163600,7 +163654,7 @@ ncp
 ncp
 hbR
 mWz
-tGw
+jMF
 sIY
 qls
 uOM
@@ -163796,7 +163850,7 @@ lhK
 wVg
 aFN
 jKZ
-tyv
+sMH
 rBo
 hlv
 qxh
@@ -164060,7 +164114,7 @@ xIO
 jps
 xIO
 qZx
-dHf
+nqW
 tbS
 sZR
 kHU
@@ -164072,7 +164126,7 @@ fwH
 qoH
 vOW
 qoH
-rMQ
+eQp
 umQ
 gYp
 kHU
@@ -164310,7 +164364,7 @@ jvm
 hlv
 fVW
 fPH
-tyv
+sMH
 rnI
 hlv
 pHz
@@ -164325,11 +164379,11 @@ kHU
 plf
 cYc
 ueE
-qfo
+pSk
 wcJ
 iRz
 nez
-pzC
+xpG
 hlh
 gYp
 plf
@@ -164582,11 +164636,11 @@ kHU
 kHU
 cYc
 nfj
-qpn
+rTd
 eaE
 nRk
 rZh
-acr
+aLM
 hmN
 gYp
 kHU
@@ -164630,7 +164684,7 @@ dJL
 nRG
 oXA
 oXA
-eDV
+qjU
 dJL
 plf
 cdR
@@ -164839,11 +164893,11 @@ plf
 kHU
 huz
 sIx
-ojH
-sQk
+qCl
+qDn
 kjv
-sQk
-kOC
+qDn
+uFP
 tEU
 huz
 plf
@@ -166888,7 +166942,7 @@ plf
 kHU
 hlv
 lrm
-jPg
+mGo
 jno
 hlv
 cBu
@@ -167968,7 +168022,7 @@ kHU
 fMh
 plf
 dJL
-eDV
+qjU
 oXA
 oXA
 nJn

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -4032,7 +4032,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/decal/turf_decal/alpha{
+/obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "siding_line";
 	dir = 5
 	},
@@ -8653,7 +8653,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 29
 	},
-/obj/effect/decal/turf_decal/wood{
+/obj/effect/decal/turf_decal/wood/dark{
 	icon_state = "siding_wood_line";
 	dir = 4
 	},
@@ -10697,7 +10697,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/decal/turf_decal/wood{
+/obj/effect/decal/turf_decal/wood/dark{
 	icon_state = "siding_wood_line";
 	dir = 4
 	},
@@ -16241,7 +16241,7 @@
 	name = "Chemistry APC";
 	pixel_y = 28
 	},
-/obj/effect/decal/turf_decal/alpha/yellow{
+/obj/effect/decal/turf_decal/alpha/orange{
 	icon_state = "siding_line";
 	dir = 8
 	},
@@ -25686,7 +25686,7 @@
 	},
 /area/station/medical/storage)
 "fMG" = (
-/obj/effect/decal/turf_decal/alpha{
+/obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "siding_line";
 	dir = 8
 	},
@@ -33400,7 +33400,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/effect/decal/turf_decal/alpha{
+/obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "siding_line";
 	dir = 9
 	},
@@ -33476,6 +33476,10 @@
 /area/station/storage/emergency2)
 "hzS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/effect/decal/turf_decal/alpha/purple{
+	icon_state = "siding_line";
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "whitepurple"
@@ -33815,7 +33819,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/decal/turf_decal/wood{
+/obj/effect/decal/turf_decal/wood/dark{
 	icon_state = "siding_wood_line";
 	dir = 8
 	},
@@ -39420,7 +39424,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/decal/turf_decal/alpha{
+/obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "siding_line";
 	dir = 4
 	},
@@ -40880,8 +40884,9 @@
 /obj/machinery/computer/area_atmos{
 	dir = 4
 	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
+/obj/effect/decal/turf_decal/alpha{
+	icon_state = "warn_end";
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "white"
@@ -42666,9 +42671,6 @@
 /area/station/hallway/secondary/entry)
 "jDw" = (
 /obj/machinery/portable_atmospherics/powered/scrubber/huge,
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -44133,7 +44135,7 @@
 /obj/structure/stool/bed/chair/office/light{
 	dir = 4
 	},
-/obj/effect/decal/turf_decal/alpha{
+/obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "siding_line";
 	dir = 4
 	},
@@ -45143,9 +45145,6 @@
 "keQ" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 1
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -48096,7 +48095,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/effect/decal/turf_decal/alpha{
+/obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "siding_line";
 	dir = 4
 	},
@@ -48610,10 +48609,10 @@
 	},
 /area/station/security/execution)
 "kSv" = (
-/obj/effect/decal/turf_decal/wood{
+/obj/effect/decal/turf_decal/wood/dark{
 	icon_state = "siding_wood_line"
 	},
-/obj/effect/decal/turf_decal/wood{
+/obj/effect/decal/turf_decal/wood/dark{
 	icon_state = "siding_wood_line";
 	dir = 1
 	},
@@ -50625,10 +50624,10 @@
 /area/station/ai_monitored/storage_secure)
 "lqU" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/turf_decal/wood{
+/obj/effect/decal/turf_decal/wood/dark{
 	icon_state = "siding_wood_line"
 	},
-/obj/effect/decal/turf_decal/wood{
+/obj/effect/decal/turf_decal/wood/dark{
 	icon_state = "siding_wood_line";
 	dir = 1
 	},
@@ -51507,7 +51506,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/effect/decal/turf_decal/wood{
+/obj/effect/decal/turf_decal/wood/dark{
 	icon_state = "siding_wood_line";
 	dir = 8
 	},
@@ -51997,7 +51996,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/effect/decal/turf_decal/wood{
+/obj/effect/decal/turf_decal/wood/dark{
 	icon_state = "siding_wood_line";
 	dir = 4
 	},
@@ -55224,11 +55223,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "mue" = (
-/obj/effect/decal/turf_decal/wood{
+/obj/effect/decal/turf_decal/wood/dark{
 	icon_state = "siding_wood_corner";
 	dir = 8
 	},
-/obj/effect/decal/turf_decal/wood{
+/obj/effect/decal/turf_decal/wood/dark{
 	icon_state = "siding_wood_corner";
 	dir = 1
 	},
@@ -56496,6 +56495,10 @@
 "mKB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/purple{
+	icon_state = "siding_line";
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 6;
@@ -60907,6 +60910,10 @@
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
 	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -60969,7 +60976,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/effect/decal/turf_decal/alpha/yellow{
+/obj/effect/decal/turf_decal/alpha/orange{
 	icon_state = "siding_line";
 	dir = 10
 	},
@@ -62524,7 +62531,7 @@
 /turf/simulated/floor/wood,
 /area/station/maintenance/medbay)
 "oen" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
+/obj/effect/decal/turf_decal/alpha/orange{
 	icon_state = "siding_line"
 	},
 /turf/simulated/floor{
@@ -64373,7 +64380,7 @@
 	},
 /area/station/security/iaa_office)
 "oFl" = (
-/obj/effect/decal/turf_decal/wood{
+/obj/effect/decal/turf_decal/wood/dark{
 	icon_state = "siding_wood_line";
 	dir = 8
 	},
@@ -68292,10 +68299,10 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "pzj" = (
-/obj/effect/decal/turf_decal/wood{
+/obj/effect/decal/turf_decal/wood/dark{
 	icon_state = "siding_wood_corner"
 	},
-/obj/effect/decal/turf_decal/wood{
+/obj/effect/decal/turf_decal/wood/dark{
 	icon_state = "siding_wood_corner";
 	dir = 4
 	},
@@ -72500,7 +72507,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/effect/decal/turf_decal/alpha{
+/obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "siding_line";
 	dir = 1
 	},
@@ -74293,6 +74300,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
+	},
+/obj/effect/decal/turf_decal/alpha/purple{
+	icon_state = "siding_line";
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -83325,7 +83336,7 @@
 /area/station/civilian/locker)
 "taF" = (
 /obj/effect/landmark/start/geneticist,
-/obj/effect/decal/turf_decal/alpha{
+/obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "siding_line";
 	dir = 8
 	},
@@ -87161,7 +87172,7 @@
 /area/station/civilian/dormitories)
 "tZe" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/effect/decal/turf_decal/alpha/yellow{
+/obj/effect/decal/turf_decal/alpha/orange{
 	icon_state = "siding_line"
 	},
 /turf/simulated/floor{
@@ -87376,7 +87387,7 @@
 /obj/item/device/cardpay{
 	dir = 1
 	},
-/obj/effect/decal/turf_decal/alpha/yellow{
+/obj/effect/decal/turf_decal/alpha/orange{
 	icon_state = "siding_line"
 	},
 /turf/simulated/floor{
@@ -94094,7 +94105,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/effect/decal/turf_decal/alpha{
+/obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -102138,7 +102149,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/decal/turf_decal/alpha{
+/obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "siding_line";
 	dir = 8
 	},
@@ -102280,6 +102291,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "barber"
@@ -103357,9 +103369,6 @@
 	},
 /area/station/security/checkpoint/cargo)
 "xUE" = (
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -1792,6 +1792,13 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/bridge/corp_lounge)
+"anb" = (
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "anh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -4433,6 +4440,13 @@
 	icon_state = "darkredcorners"
 	},
 /area/station/security/checkpoint/escape)
+"aRH" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "aRK" = (
 /obj/structure/stool/bar,
 /obj/structure/disposalpipe/segment{
@@ -10273,16 +10287,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/hallway/primary/starboard)
-"cek" = (
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "ceI" = (
 /obj/machinery/camera{
 	c_tag = "Port Primary Hallway South";
@@ -12765,6 +12769,15 @@
 	icon_state = "darkbrown"
 	},
 /area/station/medical/virology)
+"cHQ" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 10
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/hor)
 "cHR" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -12824,6 +12837,17 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
+"cIK" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "cIT" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -21376,6 +21400,10 @@
 /area/station/maintenance/cargo)
 "eMU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
 "eNj" = (
@@ -21702,7 +21730,9 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/maintenance/science)
 "ePS" = (
 /obj/machinery/light/small{
@@ -27467,17 +27497,6 @@
 	icon_state = "redyellowfull"
 	},
 /area/station/rnd/scibreak)
-"gjt" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "gjC" = (
 /turf/simulated/floor/wood,
 /area/station/maintenance/science)
@@ -29436,13 +29455,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/mixing)
-"gEW" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "gEX" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -35011,6 +35023,9 @@
 /obj/item/weapon/pen{
 	layer = 3.1
 	},
+/obj/effect/decal/turf_decal/alpha/purple{
+	icon_state = "siding_line"
+	},
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "purple"
@@ -38820,6 +38835,15 @@
 /obj/structure/bookcase/manuals/research_and_development,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
+"iKo" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/hor)
 "iKG" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -39415,15 +39439,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/brig/storage)
-"iQD" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 10
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/rnd/hor)
 "iQE" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/external{
@@ -41952,13 +41967,6 @@
 	},
 /turf/environment/space,
 /area/shuttle/supply/station)
-"juT" = (
-/obj/effect/decal/turf_decal{
-	dir = 5;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "juV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -44868,6 +44876,17 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/dormitories/courtroom)
+"kaL" = (
+/obj/effect/decal/turf_decal{
+	dir = 10;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "kaM" = (
 /obj/structure/table/woodentable,
 /obj/structure/cable{
@@ -46671,6 +46690,13 @@
 	},
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
+"kuZ" = (
+/obj/effect/decal/turf_decal{
+	dir = 6;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "kvb" = (
 /obj/structure/stool/bed/chair/metal/red,
 /turf/simulated/floor{
@@ -49739,6 +49765,13 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
+"ldK" = (
+/obj/effect/decal/turf_decal{
+	dir = 5;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "ldN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -54105,6 +54138,10 @@
 	},
 /area/station/security/brig)
 "mhk" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
 "mhm" = (
@@ -55794,6 +55831,9 @@
 	},
 /area/station/security/interrogation)
 "mAQ" = (
+/obj/effect/decal/turf_decal/alpha/purple{
+	icon_state = "siding_line"
+	},
 /turf/simulated/floor{
 	icon_state = "purple"
 	},
@@ -56542,7 +56582,7 @@
 "mKy" = (
 /obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "siding_line";
-	dir = 6
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -58770,6 +58810,10 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
+/obj/effect/decal/turf_decal{
+	dir = 5;
+	icon_state = "warn"
+	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
 "nlx" = (
@@ -59574,6 +59618,10 @@
 /obj/effect/decal/turf_decal{
 	icon_state = "warn_corner"
 	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn_corner"
+	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
 "nva" = (
@@ -59768,9 +59816,16 @@
 	dir = 4
 	},
 /obj/effect/decal/turf_decal{
-	icon_state = "warn"
+	dir = 8;
+	icon_state = "warn_corner"
 	},
-/turf/simulated/floor,
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
 /area/station/maintenance/science)
 "nxb" = (
 /obj/structure/cable{
@@ -62228,6 +62283,16 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hor)
+"nZN" = (
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "nZW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -68623,10 +68688,17 @@
 	icon_state = "pipe-c"
 	},
 /obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
+	dir = 1;
+	icon_state = "warn_corner"
 	},
-/turf/simulated/floor,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/station/maintenance/science)
 "pBY" = (
 /obj/structure/cable{
@@ -69904,6 +69976,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "box_white"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -73491,15 +73566,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/iaa_office)
-"qJt" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/rnd/hor)
 "qJx" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -75612,6 +75678,10 @@
 "rkE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
 "rkR" = (
@@ -78472,13 +78542,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
-"rQg" = (
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "rQp" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -82176,15 +82239,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/bridge)
-"sKx" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/rnd/hor)
 "sKL" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -86477,12 +86531,6 @@
 /obj/item/weapon/storage/box,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
-"tOj" = (
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "tOH" = (
 /obj/structure/sign/directions/evac{
 	pixel_x = -32;
@@ -87905,9 +87953,15 @@
 	},
 /obj/effect/decal/turf_decal{
 	dir = 4;
-	icon_state = "warn"
+	icon_state = "warn_corner"
 	},
-/turf/simulated/floor,
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/station/maintenance/science)
 "uhz" = (
 /obj/structure/cable{
@@ -88346,17 +88400,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway/lobby)
-"umg" = (
-/obj/effect/decal/turf_decal{
-	dir = 10;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "umi" = (
 /obj/machinery/door/airlock{
 	name = "Locker Room"
@@ -91127,6 +91170,9 @@
 	pixel_x = 5;
 	pixel_y = 2
 	},
+/obj/effect/decal/turf_decal/alpha/purple{
+	icon_state = "siding_line"
+	},
 /turf/simulated/floor{
 	icon_state = "purple"
 	},
@@ -91494,16 +91540,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
-"vaZ" = (
-/obj/effect/decal/turf_decal{
-	dir = 9;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "vbc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -96774,6 +96810,15 @@
 	},
 /turf/simulated/floor/carpet/red,
 /area/station/security/detectives_office)
+"wqN" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/hor)
 "wqS" = (
 /obj/structure/table,
 /obj/item/weapon/storage/belt/utility,
@@ -98101,6 +98146,16 @@
 	icon_state = "2,3"
 	},
 /area/shuttle/supply/station)
+"wGM" = (
+/obj/effect/decal/turf_decal{
+	dir = 9;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "wGW" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -102280,6 +102335,12 @@
 	icon_state = "vaultfull"
 	},
 /area/station/medical/genetics)
+"xFe" = (
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "xFi" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -102975,10 +103036,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
 /obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
+	dir = 4;
+	icon_state = "warn_corner"
 	},
-/turf/simulated/floor,
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
 /area/station/maintenance/science)
 "xOo" = (
 /obj/structure/cable{
@@ -103692,13 +103759,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
-"xWB" = (
-/obj/effect/decal/turf_decal{
-	dir = 6;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "xWF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -134625,9 +134685,9 @@ ylt
 omz
 vil
 lhp
-vaZ
+wGM
 ldt
-umg
+kaL
 ekl
 svQ
 nxb
@@ -134884,7 +134944,7 @@ evL
 bOA
 saw
 tVQ
-tOj
+xFe
 jwK
 svQ
 vxf
@@ -135139,15 +135199,15 @@ wtC
 ijY
 evL
 lhp
-gjt
+cIK
 bks
-cek
+nZN
 mkl
 svQ
 vxf
 kiL
-qJt
-iQD
+wqN
+cHQ
 hzm
 vaP
 wwp
@@ -135396,9 +135456,9 @@ wtC
 hBT
 npX
 fbt
-gEW
+aRH
 bks
-tOj
+xFe
 fte
 uly
 vxf
@@ -135653,15 +135713,15 @@ dyG
 bwi
 evL
 lhp
-gEW
+aRH
 bks
-tOj
+xFe
 mkl
 svQ
 vxf
 kiL
-sKx
 mKy
+iKo
 blq
 syE
 qbC
@@ -135912,7 +135972,7 @@ lud
 bOA
 saw
 bks
-tOj
+xFe
 bYy
 svQ
 vxf
@@ -136167,9 +136227,9 @@ oZa
 daK
 pPD
 lhp
-juT
-rQg
-xWB
+ldK
+anb
+kuZ
 vmY
 svQ
 jHw

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -2408,6 +2408,19 @@
 	icon_state = "4,3"
 	},
 /area/shuttle/supply/station)
+"ath" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/station/tcommsat/chamber)
 "ati" = (
 /obj/effect/landmark/start/paramedic,
 /obj/structure/disposalpipe/segment{
@@ -6283,7 +6296,10 @@
 	dir = 4;
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "blue"
+	},
 /area/station/medical/hallway)
 "bmq" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -7324,7 +7340,7 @@
 	},
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "whiteredcorner"
+	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/hallway)
 "bzh" = (
@@ -12474,6 +12490,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor,
 /area/station/security/checkpoint/medbay)
 "cFk" = (
@@ -13360,7 +13379,7 @@
 /area/station/hallway/primary/fore)
 "cPN" = (
 /turf/simulated/floor/carpet{
-	icon_state = "carpet6-2"
+	icon_state = "carpet9-4"
 	},
 /area/station/bridge/captain_quarters)
 "cPY" = (
@@ -14429,7 +14448,7 @@
 /area/station/engineering/atmos)
 "dfg" = (
 /turf/simulated/floor/carpet{
-	icon_state = "carpet6-2"
+	icon_state = "carpet10-8"
 	},
 /area/station/bridge)
 "dfo" = (
@@ -15092,6 +15111,9 @@
 	},
 /obj/machinery/firealarm{
 	pixel_y = 22
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /obj/effect/decal/turf_decal{
 	dir = 5;
@@ -18446,19 +18468,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
-"ecp" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/bluegrid{
-	name = "Server Base";
-	nitrogen = 500;
-	oxygen = 0;
-	temperature = 80
-	},
-/area/station/tcommsat/chamber)
 "ecA" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/thin/reinforced{
@@ -18682,6 +18691,12 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"efc" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "whitepurple"
+	},
+/area/station/rnd/hallway)
 "efk" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor,
@@ -19238,6 +19253,9 @@
 /obj/item/weapon/book/manual/wiki/security_space_law,
 /obj/machinery/firealarm{
 	pixel_y = 22
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -24493,23 +24511,6 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
-"fxW" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "caution"
-	},
-/area/station/medical/chemistry)
 "fym" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -27322,6 +27323,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -30875,7 +30880,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/rnd/scibreak)
 "gWl" = (
 /turf/simulated/floor{
@@ -33797,6 +33804,25 @@
 	icon_state = "vaultfull"
 	},
 /area/station/hallway/primary/starboard)
+"hDy" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "hDI" = (
 /obj/item/device/radio/beacon,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -33850,6 +33876,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/engineering/break_room)
+"hEn" = (
+/obj/effect/decal/turf_decal{
+	dir = 6;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/robotics)
 "hEr" = (
 /turf/simulated/wall/r_wall,
 /area/station/bridge/teleporter)
@@ -37074,6 +37109,16 @@
 /obj/random/foods/food_trash,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"iqA" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/bluegrid{
+	icon_state = "gcircuit"
+	},
+/area/station/tcommsat/chamber)
 "iqB" = (
 /obj/structure/sign/poster/official/foam_force_ad{
 	pixel_x = -32
@@ -37540,7 +37585,9 @@
 	dir = 6;
 	network = list("SS13","Research")
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/rnd/scibreak)
 "iwm" = (
 /obj/machinery/light/smart{
@@ -40054,11 +40101,6 @@
 	icon_state = "dark"
 	},
 /area/station/cargo/recycleroffice)
-"jaq" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet10-8"
-	},
-/area/station/bridge)
 "jat" = (
 /obj/machinery/porta_turret/station_default{
 	dir = 4
@@ -40128,6 +40170,23 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
+"jaF" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 5;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "caution"
+	},
+/area/station/medical/chemistry)
 "jaG" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/computer/general_air_control/large_tank_control{
@@ -40158,7 +40217,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/rnd/scibreak)
 "jaO" = (
 /turf/simulated/floor{
@@ -40512,7 +40573,7 @@
 	},
 /turf/simulated/floor{
 	dir = 4;
-	icon_state = "whitered"
+	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway)
 "jfz" = (
@@ -41950,6 +42011,11 @@
 	icon_state = "neutralfull"
 	},
 /area/station/cargo/lobby)
+"jvL" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet6-2"
+	},
+/area/station/bridge)
 "jvV" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -42168,16 +42234,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/bridge)
-"jxO" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "gcircuit"
-	},
-/area/station/tcommsat/chamber)
 "jxP" = (
 /obj/machinery/vending/barbervend,
 /turf/simulated/floor/wood,
@@ -42660,16 +42716,6 @@
 	icon_state = "yellowpatch"
 	},
 /area/station/engineering/atmos/supermatter)
-"jEb" = (
-/obj/item/weapon/flora/random,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "purplefull"
-	},
-/area/station/hallway/primary/central)
 "jEc" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
@@ -42840,7 +42886,9 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/rnd/scibreak)
 "jGw" = (
 /obj/structure/cable{
@@ -42920,15 +42968,6 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/hallway)
-"jHG" = (
-/obj/effect/decal/turf_decal{
-	dir = 6;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/rnd/robotics)
 "jHQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering/glass{
@@ -43102,11 +43141,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
-"jJf" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet9-4"
-	},
-/area/station/bridge/captain_quarters)
 "jJh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -43389,25 +43423,6 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/primary/starboard)
-"jLb" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "jLh" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
@@ -43677,15 +43692,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/brig)
-"jNW" = (
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "jNY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -48231,6 +48237,11 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/simulated/floor/grass,
 /area/station/civilian/kitchen)
+"kMA" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet6-2"
+	},
+/area/station/bridge/captain_quarters)
 "kMJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/turf_decal{
@@ -48598,6 +48609,18 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/execution)
+"kSv" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line"
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "kSw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -50301,14 +50324,6 @@
 	icon_state = "darkred"
 	},
 /area/station/security/execution)
-"lmC" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "purplefull"
-	},
-/area/station/hallway/primary/central)
 "lmF" = (
 /obj/machinery/computer/crew{
 	dir = 8
@@ -50654,6 +50669,9 @@
 	icon_state = "1-8"
 	},
 /obj/structure/closet/secure_closet/security,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "redfull"
 	},
@@ -53487,6 +53505,10 @@
 	},
 /area/station/hallway/primary/port)
 "map" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "whiteblue"
@@ -54153,7 +54175,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/rnd/scibreak)
 "miU" = (
 /obj/machinery/chem_master/condimaster{
@@ -54170,6 +54194,9 @@
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/light/smart{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -55198,10 +55225,11 @@
 /area/station/maintenance/chapel)
 "mue" = (
 /obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line"
+	icon_state = "siding_wood_corner";
+	dir = 8
 	},
 /obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line";
+	icon_state = "siding_wood_corner";
 	dir = 1
 	},
 /turf/simulated/floor{
@@ -55218,6 +55246,9 @@
 /obj/structure/closet/secure_closet/brig{
 	id = "scicell";
 	name = "Science Cell Locker"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -55506,7 +55537,7 @@
 	sensors = list("rnd_sensor"="Heat  Room")
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
+	icon_state = "bot_right"
 	},
 /turf/simulated/floor,
 /area/station/rnd/misc_lab)
@@ -55978,6 +56009,14 @@
 	icon_state = "white"
 	},
 /area/station/medical/hallway)
+"mCL" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/primary/central)
 "mDd" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -56492,6 +56531,12 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/bridge/corp_lounge)
+"mKN" = (
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "whiteblue"
+	},
+/area/station/rnd/hallway)
 "mKP" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 5
@@ -61849,7 +61894,9 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/rnd/scibreak)
 "nXl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -62873,15 +62920,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/maintenance/cargo)
-"oiU" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "purplefull"
-	},
-/area/station/hallway/primary/central)
 "ojc" = (
 /obj/effect/landmark/start/assistant/test_subject,
 /obj/structure/stool/bed/chair/metal/blue{
@@ -64334,6 +64372,15 @@
 	icon_state = "darkblue"
 	},
 /area/station/security/iaa_office)
+"oFl" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "oFm" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -67359,7 +67406,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/rnd/scibreak)
 "ppo" = (
 /obj/structure/cable{
@@ -67786,7 +67835,9 @@
 	},
 /area/station/aisat/ai_chamber)
 "puP" = (
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/rnd/scibreak)
 "puT" = (
 /obj/machinery/door/airlock/external{
@@ -67942,7 +67993,9 @@
 "pwE" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/box/donkpockets,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/rnd/scibreak)
 "pwK" = (
 /obj/machinery/door/firedoor,
@@ -68238,6 +68291,18 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
+"pzj" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner"
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "pzr" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -68767,19 +68832,6 @@
 	icon_state = "white"
 	},
 /area/station/rnd/hallway/lobby)
-"pFg" = (
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "pFv" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -71134,6 +71186,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn_corner"
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whitepurplecorner"
@@ -71610,6 +71666,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/closet/secure_closet/security,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "redfull"
 	},
@@ -72921,7 +72980,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/rnd/scibreak)
 "qEc" = (
 /obj/machinery/ai_status_display{
@@ -73227,7 +73288,7 @@
 	icon_state = "bot"
 	},
 /obj/effect/decal/turf_decal{
-	dir = 5;
+	dir = 1;
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
@@ -73517,6 +73578,16 @@
 /obj/structure/window/thin/reinforced,
 /turf/environment/space,
 /area/space)
+"qLv" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "purplefull"
+	},
+/area/station/hallway/primary/central)
 "qLw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -74698,18 +74769,6 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/janitor)
-"raA" = (
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner"
-	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "raB" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor{
@@ -75486,7 +75545,12 @@
 	pixel_y = -5
 	},
 /obj/structure/reagent_dispensers/water_cooler,
-/turf/simulated/floor,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/rnd/scibreak)
 "rkZ" = (
 /obj/structure/cable{
@@ -76378,6 +76442,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "whitepurple"
@@ -81470,6 +81537,9 @@
 	id = "medcell";
 	name = "Medical Cell Locker"
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "darkred"
@@ -81972,7 +82042,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/rnd/scibreak)
 "sJS" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -83277,6 +83349,10 @@
 	dir = 6;
 	network = list("SS13","Medical")
 	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "whitebluecorner"
@@ -84558,6 +84634,9 @@
 /obj/structure/drain{
 	drainage = 2
 	},
+/obj/effect/decal/turf_decal/alpha/cyan{
+	icon_state = "box_white"
+	},
 /obj/effect/decal/turf_decal{
 	dir = 9;
 	icon_state = "warn"
@@ -85629,6 +85708,9 @@
 "tEY" = (
 /obj/structure/closet/l3closet/scientist,
 /obj/machinery/light/small,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /obj/effect/decal/turf_decal{
 	dir = 10;
 	icon_state = "warn"
@@ -87661,6 +87743,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/hallway/lobby)
+"ugS" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "purplefull"
+	},
+/area/station/hallway/primary/central)
 "uhk" = (
 /turf/simulated/floor{
 	icon_state = "whitepurplefull"
@@ -88203,6 +88294,16 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/rnd/test_area)
+"umP" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/station/bridge/corp_lounge)
 "umQ" = (
 /obj/structure/table/woodentable,
 /obj/structure/cable{
@@ -90537,7 +90638,10 @@
 	dir = 8;
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "purple"
+	},
 /area/station/medical/hallway)
 "uSN" = (
 /turf/simulated/floor{
@@ -94751,7 +94855,7 @@
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "purplefull"
 	},
 /area/station/hallway/primary/central)
 "vUn" = (
@@ -95862,6 +95966,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "whitepurple"
@@ -100151,16 +100259,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
-"xkM" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkblue"
-	},
-/area/station/bridge/corp_lounge)
 "xlj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -136691,7 +136789,7 @@ bNg
 cLW
 rjR
 qgs
-jHG
+hEn
 cVA
 wrb
 chV
@@ -138480,13 +138578,13 @@ pHa
 pHa
 pbn
 yhw
-oiU
-oiU
+ugS
+ugS
 qQu
-oiU
-jEb
+ugS
+qLv
 bwA
-lmC
+vUh
 eKK
 oZa
 oZa
@@ -139763,7 +139861,7 @@ fFk
 hWY
 hWY
 giW
-vUh
+mCL
 mby
 oXw
 rdN
@@ -140570,9 +140668,9 @@ klG
 fes
 gLF
 hZu
+aTn
 uzK
-eSq
-eSq
+efc
 eSq
 bzc
 wAR
@@ -140827,7 +140925,7 @@ enN
 fes
 gLF
 som
-oRg
+gWl
 rSa
 hOR
 hOR
@@ -141335,13 +141433,13 @@ xEU
 taF
 fMG
 vqz
-cyt
+mKN
 aTn
 aTn
 tsT
 wPM
 haJ
-oRg
+rSG
 bFb
 enB
 iDE
@@ -142331,7 +142429,7 @@ pQD
 gIC
 gIC
 gIC
-ecp
+ath
 gIC
 gIC
 keH
@@ -143105,7 +143203,7 @@ xMO
 raJ
 cCX
 vyg
-jxO
+iqA
 lwt
 raJ
 eXe
@@ -143116,7 +143214,7 @@ siM
 mKJ
 mMA
 bLg
-raA
+pzj
 lGH
 cje
 nHg
@@ -143128,7 +143226,7 @@ ogP
 vof
 gUf
 rHU
-qIs
+jaF
 czd
 rVf
 xJb
@@ -143348,7 +143446,7 @@ gCE
 imK
 lEC
 wnY
-dfg
+jvL
 akc
 lZx
 gWd
@@ -143373,7 +143471,7 @@ jEs
 mKJ
 mMA
 vEH
-mue
+kSv
 rOO
 mzL
 nHg
@@ -143862,7 +143960,7 @@ gCE
 imK
 lEC
 mrs
-jaq
+dfg
 nSo
 lZx
 oay
@@ -143887,7 +143985,7 @@ wMM
 fgA
 mMA
 joF
-mue
+kSv
 eZe
 wAA
 nHg
@@ -144132,7 +144230,7 @@ knC
 aty
 wEV
 fAH
-jxO
+iqA
 aEE
 lwt
 wEV
@@ -144143,10 +144241,10 @@ pQD
 amY
 fgA
 mMA
-jNW
-pFg
+oFl
+mue
 lBF
-jLb
+hDy
 nHg
 nvi
 ogP
@@ -144415,7 +144513,7 @@ sew
 rHU
 rHU
 sew
-fxW
+qIs
 cyz
 eOj
 sew
@@ -144659,7 +144757,7 @@ xVa
 mMA
 eIB
 pYl
-xkM
+umP
 jVM
 mMA
 elI
@@ -144901,9 +144999,9 @@ pQD
 gIC
 gIC
 gIC
-ecp
+ath
 gIC
-ecp
+ath
 gIC
 gIC
 aty
@@ -146183,7 +146281,7 @@ ibm
 adM
 sTY
 bIZ
-jJf
+cPN
 iaL
 cHR
 jKD
@@ -147215,7 +147313,7 @@ cjq
 nac
 hrj
 pEa
-cPN
+kMA
 cqG
 iaL
 pst

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -4247,7 +4247,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/decal/turf_decal/alpha/yellow{
+/obj/effect/decal/turf_decal/alpha/red{
 	icon_state = "bot"
 	},
 /turf/simulated/floor,
@@ -4653,6 +4653,9 @@
 /obj/machinery/recharge_station,
 /obj/effect/landmark{
 	name = "blobstart"
+	},
+/obj/effect/decal/turf_decal/alpha/red{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -5507,19 +5510,6 @@
 	icon_state = "grimy"
 	},
 /area/station/security/hos)
-"beG" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/bluegrid{
-	name = "Server Base";
-	nitrogen = 500;
-	oxygen = 0;
-	temperature = 80
-	},
-/area/station/tcommsat/chamber)
 "beJ" = (
 /turf/simulated/wall,
 /area/station/medical/morgue)
@@ -12885,18 +12875,6 @@
 /obj/item/seeds/glowshroom,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
-"cKP" = (
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line"
-	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "cKQ" = (
 /obj/machinery/door/window/eastleft{
 	name = "Shrubbery";
@@ -13367,7 +13345,7 @@
 /area/station/hallway/primary/fore)
 "cPN" = (
 /turf/simulated/floor/carpet{
-	icon_state = "carpet6-2"
+	icon_state = "carpet9-4"
 	},
 /area/station/bridge/captain_quarters)
 "cPY" = (
@@ -14180,19 +14158,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/misc_lab)
-"daU" = (
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_corner";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "dbf" = (
 /obj/decal/boxingrope{
 	dir = 9
@@ -15968,11 +15933,14 @@
 	dir = 8;
 	icon_state = "loadingarea"
 	},
-/obj/effect/decal/turf_decal/alpha/black{
-	dir = 8;
-	icon_state = "arrow"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "arrow";
+	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
 /area/station/hallway/primary/central)
 "dwb" = (
 /obj/structure/sign/warning/securearea,
@@ -19141,7 +19109,7 @@
 /obj/effect/landmark{
 	name = "blobstart"
 	},
-/obj/effect/decal/turf_decal/alpha/yellow{
+/obj/effect/decal/turf_decal/alpha/red{
 	icon_state = "bot"
 	},
 /turf/simulated/floor,
@@ -21185,7 +21153,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "purplefull"
+	},
 /area/station/hallway/primary/central)
 "eKO" = (
 /mob/living/carbon/monkey,
@@ -21507,16 +21477,6 @@
 	icon_state = "caution"
 	},
 /area/station/medical/chemistry)
-"eOm" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/turf/simulated/floor/bluegrid{
-	icon_state = "gcircuit"
-	},
-/area/station/tcommsat/chamber)
 "eOt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -21604,11 +21564,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"ePt" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet6-2"
-	},
-/area/station/bridge)
 "ePG" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -25018,7 +24973,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/hallway/primary/central)
 "fFp" = (
 /obj/structure/sign/warning/securearea{
@@ -27334,7 +27291,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/hallway/primary/central)
 "gjc" = (
 /obj/machinery/hologram/holopad,
@@ -27417,6 +27376,16 @@
 	icon_state = "redyellowfull"
 	},
 /area/station/rnd/scibreak)
+"gjq" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkblue"
+	},
+/area/station/bridge/corp_lounge)
 "gjC" = (
 /turf/simulated/floor/wood,
 /area/station/maintenance/science)
@@ -31833,7 +31802,7 @@
 /obj/effect/landmark{
 	name = "blobstart"
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/red{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -32686,7 +32655,7 @@
 /obj/effect/landmark{
 	name = "blobstart"
 	},
-/obj/effect/decal/turf_decal/alpha/yellow{
+/obj/effect/decal/turf_decal/alpha/red{
 	icon_state = "bot"
 	},
 /turf/simulated/floor,
@@ -34169,7 +34138,7 @@
 /obj/machinery/ai_status_display{
 	pixel_y = -32
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/red{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -35301,7 +35270,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/hallway/primary/central)
 "hXb" = (
 /turf/simulated/floor{
@@ -36029,6 +36000,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/break_room)
+"ift" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/bluegrid{
+	icon_state = "gcircuit"
+	},
+/area/station/tcommsat/chamber)
 "ifx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -37854,20 +37835,11 @@
 /obj/effect/landmark{
 	name = "blobstart"
 	},
-/obj/effect/decal/turf_decal/alpha/yellow{
+/obj/effect/decal/turf_decal/alpha/red{
 	icon_state = "bot"
 	},
 /turf/simulated/floor,
 /area/station/gateway)
-"iAw" = (
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "iAz" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -44413,6 +44385,9 @@
 /obj/effect/landmark{
 	name = "blobstart"
 	},
+/obj/effect/decal/turf_decal/alpha/red{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "red"
@@ -46684,6 +46659,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/dormitories/courtroom)
+"kyw" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "kyz" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -51426,7 +51410,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/bridge/meeting_room)
 "lCO" = (
 /obj/structure/closet/crate,
@@ -52384,6 +52370,25 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
+"lNo" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "lNr" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -53443,7 +53448,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/hallway/primary/central)
 "mbI" = (
 /obj/structure/disposalpipe/segment{
@@ -57745,7 +57752,7 @@
 /obj/effect/landmark{
 	name = "blobstart"
 	},
-/obj/effect/decal/turf_decal/alpha/yellow{
+/obj/effect/decal/turf_decal/alpha/red{
 	icon_state = "bot"
 	},
 /turf/simulated/floor,
@@ -64551,10 +64558,12 @@
 /obj/effect/landmark{
 	name = "blobstart"
 	},
-/obj/effect/decal/turf_decal/alpha/yellow{
+/obj/effect/decal/turf_decal/alpha/red{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/bridge/meeting_room)
 "oKD" = (
 /obj/structure/cable{
@@ -64649,6 +64658,9 @@
 /obj/machinery/recharge_station,
 /obj/effect/landmark{
 	name = "blobstart"
+	},
+/obj/effect/decal/turf_decal/alpha/red{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -64887,16 +64899,6 @@
 	},
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
-"oNP" = (
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkblue"
-	},
-/area/station/bridge/corp_lounge)
 "oNS" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -68084,6 +68086,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"pzL" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line"
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "pzM" = (
 /obj/structure/bookcase{
 	name = "bookcase (Non-Fiction)"
@@ -71589,6 +71603,11 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hor)
+"qoV" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet6-2"
+	},
+/area/station/bridge/captain_quarters)
 "qpp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
@@ -73642,6 +73661,10 @@
 "qQu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
 	},
 /turf/simulated/floor{
 	icon_state = "purplefull"
@@ -80390,6 +80413,19 @@
 	icon_state = "wooden"
 	},
 /area/station/bridge/corp_lounge)
+"ssN" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/bluegrid{
+	name = "Server Base";
+	nitrogen = 500;
+	oxygen = 0;
+	temperature = 80
+	},
+/area/station/tcommsat/chamber)
 "sta" = (
 /obj/structure/table/reinforced,
 /obj/item/device/flashlight/lamp,
@@ -80463,11 +80499,6 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/atmos)
-"stN" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet9-4"
-	},
-/area/station/bridge/captain_quarters)
 "stP" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -82720,7 +82751,7 @@
 /obj/effect/landmark{
 	name = "blobstart"
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/red{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -84248,25 +84279,6 @@
 	},
 /turf/simulated/floor,
 /area/station/gateway)
-"trE" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/effect/decal/turf_decal/wood{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/bridge/corp_lounge)
 "trR" = (
 /obj/machinery/door/airlock/external{
 	frequency = 1379;
@@ -85195,7 +85207,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/bridge/meeting_room)
 "tCY" = (
 /turf/simulated/floor/carpet/blue2,
@@ -87161,7 +87175,7 @@
 /obj/effect/landmark{
 	name = "blobstart"
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/red{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -92545,6 +92559,11 @@
 	icon_state = "greenblue"
 	},
 /area/station/hallway/primary/fore)
+"vut" = (
+/turf/simulated/floor/carpet{
+	icon_state = "carpet6-2"
+	},
+/area/station/bridge)
 "vux" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 1
@@ -92686,7 +92705,7 @@
 /obj/effect/landmark{
 	name = "blobstart"
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/red{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -93007,11 +93026,14 @@
 	dir = 4;
 	icon_state = "loadingarea"
 	},
-/obj/effect/decal/turf_decal/alpha/black{
-	dir = 4;
-	icon_state = "arrow"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "arrow";
+	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
 /area/station/hallway/primary/central)
 "vAK" = (
 /obj/machinery/door/firedoor,
@@ -94499,7 +94521,9 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/hallway/primary/central)
 "vUn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -94513,6 +94537,9 @@
 	name = "blobstart"
 	},
 /obj/machinery/recharge_station,
+/obj/effect/decal/turf_decal/alpha/red{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -96269,6 +96296,16 @@
 	},
 /turf/simulated/floor/carpet/red,
 /area/station/security/detectives_office)
+"wqw" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "purplefull"
+	},
+/area/station/hallway/primary/central)
 "wqS" = (
 /obj/structure/table,
 /obj/item/weapon/storage/belt/utility,
@@ -99722,6 +99759,14 @@
 	icon_state = "caution"
 	},
 /area/station/medical/chemistry)
+"xiG" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "purplefull"
+	},
+/area/station/hallway/primary/central)
 "xiI" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
@@ -100711,6 +100756,15 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"xty" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "purplefull"
+	},
+/area/station/hallway/primary/central)
 "xtC" = (
 /obj/structure/table/reinforced,
 /obj/item/toy/figure/borg,
@@ -102427,6 +102481,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/tech)
+"xNS" = (
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/wood{
+	icon_state = "siding_wood_corner";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/bridge/corp_lounge)
 "xNT" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -104101,6 +104168,13 @@
 	},
 /obj/machinery/light/smart{
 	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
 	},
 /turf/simulated/floor{
 	icon_state = "purplefull"
@@ -138187,13 +138261,13 @@ pHa
 pHa
 pbn
 yhw
-awU
-awU
+xty
+xty
 qQu
-awU
-siU
+xty
+wqw
 bwA
-vUh
+xiG
 eKK
 oZa
 oZa
@@ -142038,7 +142112,7 @@ pQD
 gIC
 gIC
 gIC
-beG
+ssN
 gIC
 gIC
 keH
@@ -142812,7 +142886,7 @@ xMO
 raJ
 cCX
 vyg
-eOm
+ift
 lwt
 raJ
 eXe
@@ -143055,7 +143129,7 @@ gCE
 imK
 lEC
 wnY
-ePt
+vut
 akc
 lZx
 gWd
@@ -143080,7 +143154,7 @@ jEs
 mKJ
 mMA
 vEH
-cKP
+pzL
 rOO
 mzL
 nHg
@@ -143594,7 +143668,7 @@ wMM
 fgA
 mMA
 joF
-cKP
+pzL
 eZe
 wAA
 nHg
@@ -143839,7 +143913,7 @@ knC
 aty
 wEV
 fAH
-eOm
+ift
 aEE
 lwt
 wEV
@@ -143850,10 +143924,10 @@ pQD
 amY
 fgA
 mMA
-iAw
-daU
+kyw
+xNS
 lBF
-trE
+lNo
 nHg
 nvi
 ogP
@@ -144366,7 +144440,7 @@ xVa
 mMA
 eIB
 pYl
-oNP
+gjq
 jVM
 mMA
 elI
@@ -144608,9 +144682,9 @@ pQD
 gIC
 gIC
 gIC
-beG
+ssN
 gIC
-beG
+ssN
 gIC
 gIC
 aty
@@ -145890,7 +145964,7 @@ ibm
 adM
 sTY
 bIZ
-stN
+cPN
 iaL
 cHR
 jKD
@@ -146922,7 +146996,7 @@ cjq
 nac
 hrj
 pEa
-cPN
+qoV
 cqG
 iaL
 pst

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -2155,10 +2155,10 @@
 "aqn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/turf_decal{
-	dir = 10;
+	dir = 4;
 	icon_state = "warn"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor,
 /area/station/storage/emergency)
 "aqx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2263,7 +2263,10 @@
 	dir = 6;
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "caution"
+	},
 /area/station/storage/emergency)
 "arm" = (
 /obj/structure/sign/nanotrasen{
@@ -2902,7 +2905,7 @@
 	icon_state = "0-4"
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
+	icon_state = "bot_left"
 	},
 /turf/simulated/floor,
 /area/station/storage/emergency)
@@ -4660,7 +4663,14 @@
 	dir = 4;
 	icon_state = "warn_corner"
 	},
-/turf/simulated/floor,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellowcorner"
+	},
 /area/station/storage/emergency)
 "aUl" = (
 /obj/item/weapon/coin/gold,
@@ -5850,7 +5860,13 @@
 	dir = 8;
 	icon_state = "warn_corner"
 	},
-/turf/simulated/floor,
+/obj/effect/decal/turf_decal{
+	dir = 5;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowcorner"
+	},
 /area/station/storage/emergency)
 "bhz" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
@@ -11208,6 +11224,15 @@
 	icon_state = "dark"
 	},
 /area/station/medical/morgue)
+"cnE" = (
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/chapel)
 "cnS" = (
 /obj/machinery/conveyor{
 	dir = 10;
@@ -11608,6 +11633,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"cuQ" = (
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/chapel/mass_driver)
 "cuX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -12783,7 +12813,9 @@
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "caution"
+	},
 /area/station/storage/emergency)
 "cHh" = (
 /obj/structure/cable{
@@ -13070,14 +13102,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "cKN" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/civilian/chapel/mass_driver)
+/turf/simulated/floor/carpet/blue2,
+/area/station/medical/psych)
 "cKQ" = (
 /obj/machinery/door/window/eastleft{
 	name = "Shrubbery";
@@ -13547,14 +13573,14 @@
 	},
 /area/station/hallway/primary/fore)
 "cPN" = (
-/obj/effect/decal/turf_decal/metal{
-	icon_state = "siding_thinplating_line";
-	dir = 9
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 5
 	},
 /turf/simulated/floor{
-	icon_state = "grimy"
+	icon_state = "wooden"
 	},
-/area/station/civilian/chapel)
+/area/station/hallway/secondary/exit)
 "cPY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
@@ -14645,8 +14671,14 @@
 	},
 /area/station/engineering/atmos)
 "dfg" = (
-/turf/simulated/floor/carpet,
-/area/station/bridge)
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 10
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/chapel)
 "dfo" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -22110,8 +22142,15 @@
 	},
 /area/station/rnd/xenobiology)
 "eRo" = (
-/turf/simulated/floor/carpet/blue2,
-/area/station/medical/psych)
+/obj/structure/table/woodentable/fancy,
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/chapel)
 "eRS" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -23930,10 +23969,6 @@
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/emergency)
@@ -29295,10 +29330,10 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/turf_decal{
-	dir = 9;
+	dir = 4;
 	icon_state = "warn"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor,
 /area/station/storage/emergency)
 "gyf" = (
 /obj/machinery/door/firedoor,
@@ -29949,8 +29984,8 @@
 	dir = 4
 	},
 /obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
+	dir = 4;
+	icon_state = "warn_corner"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -30254,7 +30289,14 @@
 /area/station/medical/hallway)
 "gJL" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellowcorner"
+	},
 /area/station/storage/emergency)
 "gJO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -30933,16 +30975,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/armoury)
-"gSp" = (
-/obj/structure/table/woodentable/fancy,
-/obj/effect/decal/turf_decal/metal{
-	icon_state = "siding_thinplating_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/civilian/chapel)
 "gSy" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -31914,10 +31946,6 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
 /turf/simulated/floor/plating,
 /area/station/storage/emergency)
 "hdG" = (
@@ -32689,6 +32717,15 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
+"hng" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/hallway/secondary/exit)
 "hno" = (
 /turf/simulated/floor{
 	dir = 9;
@@ -36008,6 +36045,15 @@
 	icon_state = "grimy"
 	},
 /area/station/storage/tools)
+"hXB" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/chapel/mass_driver)
 "hXC" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -37086,7 +37132,10 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "caution"
+	},
 /area/station/storage/emergency)
 "ikr" = (
 /obj/structure/cable{
@@ -37240,7 +37289,14 @@
 /obj/effect/decal/turf_decal{
 	icon_state = "warn_corner"
 	},
-/turf/simulated/floor,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellowcorner"
+	},
 /area/station/storage/emergency)
 "ilA" = (
 /turf/simulated/floor/plating,
@@ -41644,6 +41700,15 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/storage)
+"jld" = (
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 5
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/chapel)
 "jle" = (
 /obj/structure/table/woodentable,
 /obj/item/device/flashlight/lamp/green,
@@ -42418,15 +42483,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/lobby)
-"jtX" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/hallway/secondary/exit)
 "jug" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
@@ -42626,14 +42682,8 @@
 	},
 /area/station/cargo/lobby)
 "jvL" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/civilian/chapel/mass_driver)
+/turf/simulated/floor/carpet,
+/area/station/bridge)
 "jvV" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -43373,6 +43423,17 @@
 	oxygen = 0.01
 	},
 /area/station/engineering/atmos)
+"jEJ" = (
+/obj/structure/table/woodentable/fancy,
+/obj/item/device/flashlight/lantern,
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/chapel)
 "jEM" = (
 /obj/machinery/camera{
 	c_tag = "Bridge East";
@@ -44931,6 +44992,15 @@
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
+"jUD" = (
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 9
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/chapel)
 "jUE" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 8
@@ -44984,10 +45054,6 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/emergency)
@@ -46347,6 +46413,9 @@
 /turf/simulated/floor/engine/phoron,
 /area/station/engineering/atmos)
 "kkt" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "box_corners_white"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -48213,6 +48282,14 @@
 "kGI" = (
 /turf/simulated/wall,
 /area/station/hallway/primary/port)
+"kGJ" = (
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/chapel)
 "kGN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -48384,7 +48461,11 @@
 	dir = 1;
 	icon_state = "warn_corner"
 	},
-/turf/simulated/floor,
+/obj/effect/decal/turf_decal{
+	dir = 6;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
 /area/station/storage/emergency)
 "kIf" = (
 /obj/structure/window/shuttle/reinforced/mining{
@@ -48585,15 +48666,6 @@
 "kJs" = (
 /turf/simulated/floor,
 /area/station/security/brig)
-"kJC" = (
-/obj/effect/decal/turf_decal/metal{
-	icon_state = "siding_thinplating_line";
-	dir = 5
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/civilian/chapel)
 "kJD" = (
 /turf/simulated/floor{
 	icon_state = "greenblue"
@@ -49123,14 +49195,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
-"kPt" = (
-/obj/effect/decal/turf_decal/metal{
-	icon_state = "siding_thinplating_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/civilian/chapel)
 "kQf" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/crowbar,
@@ -50919,7 +50983,9 @@
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "caution"
+	},
 /area/station/storage/emergency)
 "lkU" = (
 /turf/simulated/wall,
@@ -52695,7 +52761,13 @@
 	dir = 1;
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellow"
+	},
 /area/station/storage/emergency)
 "lGF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -52750,7 +52822,7 @@
 "lHw" = (
 /obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "box_corners_white";
-	dir = 8
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -53716,10 +53788,6 @@
 	},
 /obj/structure/cable,
 /obj/machinery/light/small,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
 /turf/simulated/floor/plating,
 /area/station/storage/emergency)
 "lRY" = (
@@ -53915,7 +53983,13 @@
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
 /area/station/storage/emergency)
 "lUY" = (
 /obj/machinery/door/firedoor,
@@ -56285,6 +56359,9 @@
 /area/station/maintenance/engineering)
 "mxZ" = (
 /obj/machinery/power/port_gen/pacman,
+/obj/effect/decal/turf_decal/alpha/red{
+	icon_state = "bot"
+	},
 /turf/simulated/floor,
 /area/station/storage/emergency)
 "mye" = (
@@ -57891,7 +57968,10 @@
 	dir = 8;
 	icon_state = "warn_corner"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "caution"
+	},
 /area/station/storage/emergency)
 "mRE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -61313,7 +61393,7 @@
 	dir = 4
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
+	icon_state = "bot_left"
 	},
 /turf/simulated/floor,
 /area/station/storage/emergency)
@@ -62063,7 +62143,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "yellowcorner"
+	},
 /area/station/storage/emergency)
 "nQo" = (
 /obj/structure/cable{
@@ -64886,15 +64973,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/tox_launch)
-"oAm" = (
-/obj/effect/decal/turf_decal/metal{
-	icon_state = "siding_thinplating_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/civilian/chapel)
 "oAn" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -65402,16 +65480,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
-"oGE" = (
-/obj/structure/table/woodentable/fancy,
-/obj/effect/decal/turf_decal/metal{
-	icon_state = "siding_thinplating_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/civilian/chapel)
 "oGF" = (
 /obj/structure/table/reinforced,
 /obj/item/device/gps/engineering{
@@ -74403,6 +74471,15 @@
 	icon_state = "blackcorner"
 	},
 /area/station/hallway/primary/starboard)
+"qIy" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/chapel/mass_driver)
 "qIC" = (
 /obj/structure/window/fulltile/reinforced/phoron{
 	grilled = 1;
@@ -75484,7 +75561,10 @@
 	dir = 5;
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "caution"
+	},
 /area/station/storage/emergency)
 "qVx" = (
 /obj/effect/decal/turf_decal{
@@ -75542,6 +75622,15 @@
 	icon_state = "grimy"
 	},
 /area/station/maintenance/science)
+"qVZ" = (
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/chapel)
 "qWc" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -81152,7 +81241,10 @@
 	dir = 10;
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "caution"
+	},
 /area/station/storage/emergency)
 "sjQ" = (
 /obj/effect/landmark/start/station_engineer,
@@ -86370,6 +86462,15 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
+"tyg" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/hallway/secondary/exit)
 "tyn" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -86765,14 +86866,15 @@
 	},
 /area/station/bridge/meeting_room)
 "tCY" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 5
+/obj/structure/table/woodentable/fancy,
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "wooden"
+	icon_state = "grimy"
 	},
-/area/station/hallway/secondary/exit)
+/area/station/civilian/chapel)
 "tDb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -87651,14 +87753,6 @@
 	icon_state = "wooden-2"
 	},
 /area/station/civilian/gym)
-"tNU" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "box_corners_white"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/civilian/chapel/mass_driver)
 "tNX" = (
 /obj/item/stack/rods{
 	amount = 23
@@ -88559,7 +88653,7 @@
 	},
 /obj/effect/decal/turf_decal{
 	dir = 1;
-	icon_state = "warn"
+	icon_state = "warn_corner"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -89347,7 +89441,9 @@
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "caution"
+	},
 /area/station/storage/emergency)
 "ukc" = (
 /obj/structure/table,
@@ -89400,15 +89496,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
-"uku" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/hallway/secondary/exit)
 "ukD" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -90272,7 +90359,10 @@
 	dir = 5;
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "caution"
+	},
 /area/station/storage/emergency)
 "uum" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -91276,7 +91366,10 @@
 	dir = 4;
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "caution"
+	},
 /area/station/storage/emergency)
 "uJP" = (
 /obj/structure/cable{
@@ -94259,17 +94352,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor,
 /area/station/security/prison)
-"vuh" = (
-/obj/structure/table/woodentable/fancy,
-/obj/item/device/flashlight/lantern,
-/obj/effect/decal/turf_decal/metal{
-	icon_state = "siding_thinplating_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/civilian/chapel)
 "vuj" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 29
@@ -96460,7 +96542,7 @@
 /area/station/civilian/locker)
 "vWI" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/turf_decal/alpha/yellow{
+/obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "bot"
 	},
 /turf/simulated/floor,
@@ -97154,7 +97236,10 @@
 	dir = 9;
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "caution"
+	},
 /area/station/storage/emergency)
 "weB" = (
 /obj/structure/disposalpipe/segment{
@@ -97877,7 +97962,10 @@
 	dir = 8;
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "caution"
+	},
 /area/station/storage/emergency)
 "wnj" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -101013,6 +101101,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "black"
@@ -102057,15 +102148,6 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
-"xoK" = (
-/obj/effect/decal/turf_decal/metal{
-	icon_state = "siding_thinplating_line";
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/civilian/chapel)
 "xoM" = (
 /mob/living/simple_animal/chicken{
 	name = "Commander Clucky"
@@ -103616,6 +103698,9 @@
 	},
 /area/station/civilian/cold_room)
 "xES" = (
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/mass_driver)
 "xEU" = (
@@ -103838,10 +103923,6 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
 /turf/simulated/floor/plating,
 /area/station/storage/emergency)
 "xIA" = (
@@ -103907,9 +103988,6 @@
 /obj/effect/landmark{
 	name = "xeno_spawn";
 	pixel_x = -1
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
 	},
 /turf/simulated/floor/plating,
 /area/station/storage/emergency)
@@ -104271,15 +104349,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
-"xNt" = (
-/obj/effect/decal/turf_decal/metal{
-	icon_state = "siding_thinplating_line";
-	dir = 10
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/civilian/chapel)
 "xNJ" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /turf/simulated/floor/engine,
@@ -144958,7 +145027,7 @@ gCE
 imK
 lEC
 wnY
-dfg
+jvL
 akc
 lZx
 gWd
@@ -145472,7 +145541,7 @@ gCE
 imK
 lEC
 mrs
-dfg
+jvL
 nSo
 lZx
 oay
@@ -148377,9 +148446,9 @@ xQo
 ukM
 rmY
 kbr
-tCY
-jtX
-uku
+cPN
+hng
+tyg
 ryF
 nGt
 djc
@@ -148616,7 +148685,7 @@ sTP
 mzd
 kdH
 keK
-eRo
+cKN
 xnG
 tfW
 lij
@@ -149130,8 +149199,8 @@ omM
 gUd
 kdH
 gLL
-eRo
-eRo
+cKN
+cKN
 sOe
 fFv
 qxl
@@ -151978,10 +152047,10 @@ eCe
 mMq
 eCe
 wZE
-cPN
-oGE
+jUD
+eRo
 gEt
-xNt
+dfg
 huZ
 mUR
 mUR
@@ -152235,10 +152304,10 @@ sAQ
 tvk
 sAQ
 qus
-oAm
+qVZ
 mtw
 cUU
-kPt
+kGJ
 huZ
 kqE
 mUR
@@ -152492,10 +152561,10 @@ bYd
 nix
 nix
 bHx
-oAm
+qVZ
 iih
 jjD
-kPt
+kGJ
 pKo
 oJJ
 eiH
@@ -152749,10 +152818,10 @@ eCe
 mMq
 eCe
 wZE
-oAm
+qVZ
 mtw
 cUU
-kPt
+kGJ
 huZ
 kqE
 mUR
@@ -153006,10 +153075,10 @@ sAQ
 tvk
 sAQ
 qus
-kJC
-gSp
-vuh
-xoK
+jld
+tCY
+jEJ
+cnE
 huZ
 mUR
 mUR
@@ -155299,9 +155368,9 @@ bhy
 dLG
 iIt
 pne
-cKN
+hXB
+cuQ
 kkt
-tNU
 ptR
 rKR
 mWg
@@ -155813,9 +155882,9 @@ thM
 dLG
 iIt
 pne
-jvL
-kkt
 lHw
+cuQ
+qIy
 ivc
 fXD
 pne

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -3915,6 +3915,9 @@
 /area/station/storage/tools)
 "aKS" = (
 /obj/machinery/vending/coffee,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -20991,27 +20994,6 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/engine)
-"eDb" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "eDr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -23885,6 +23867,9 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -27781,6 +27766,26 @@
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/auxport)
+"ghK" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "ghN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/effect/decal/turf_decal{
@@ -30843,14 +30848,6 @@
 	icon_state = "foam_plating"
 	},
 /area/station/maintenance/science)
-"gPl" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/civilian/gym)
 "gPx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -30973,6 +30970,14 @@
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
+"gRf" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/civilian/gym)
 "gRg" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -31199,6 +31204,17 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/lobby)
+"gTv" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "gTw" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/grille,
@@ -47415,26 +47431,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/engineering/minisat_secure_area)
-"ksT" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "ksU" = (
 /obj/structure/closet/radiation,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -47794,6 +47790,9 @@
 /area/station/maintenance/science)
 "kyk" = (
 /obj/random/vending/snack,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -51210,18 +51209,6 @@
 	icon_state = "caution"
 	},
 /area/station/storage/emergency)
-"lkT" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "lkU" = (
 /turf/simulated/wall,
 /area/station/maintenance/starboardsolar)
@@ -54685,6 +54672,9 @@
 	pixel_x = -32
 	},
 /obj/machinery/vending/cigarette,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -84078,17 +84068,6 @@
 	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
-"sOy" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "sOD" = (
 /obj/effect/decal/turf_decal{
 	dir = 8;
@@ -90385,6 +90364,18 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
+"upw" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "upB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -102563,6 +102554,27 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
+"xoG" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "xoM" = (
 /mob/living/simple_animal/chicken{
 	name = "Commander Clucky"
@@ -160653,13 +160665,13 @@ ncp
 ncp
 hbR
 mWz
-lkT
+upw
 kLd
 syX
 tHk
 tHk
 dbf
-eDb
+xoG
 ram
 mWz
 lNQ
@@ -161424,13 +161436,13 @@ ncp
 ncp
 hbR
 mWz
-sOy
+gTv
 sIY
 qls
 uOM
 uOM
 aeG
-ksT
+ghK
 ram
 mWz
 hPr
@@ -162454,7 +162466,7 @@ dJL
 nRG
 oXA
 oXA
-gPl
+gRf
 dJL
 plf
 cdR
@@ -165792,7 +165804,7 @@ kHU
 fMh
 plf
 dJL
-gPl
+gRf
 oXA
 oXA
 nJn

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -1577,6 +1577,14 @@
 	},
 /area/station/aisat)
 "akz" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "arrow";
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	dir = 4;
+	icon_state = "loadingarea"
+	},
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "brown"
@@ -2748,6 +2756,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/warden)
+"awP" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
+	},
+/turf/simulated/floor/carpet/red,
+/area/station/security/detectives_office)
 "awS" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -3118,16 +3132,6 @@
 	icon_state = "grimy"
 	},
 /area/station/maintenance/medbay)
-"aBi" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSE-FC";
-	location = "SEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "aBv" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4
@@ -5332,6 +5336,14 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/monitoring)
+"bbJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/security/prison)
 "bbO" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -8200,6 +8212,14 @@
 /obj/structure/stool/bed/chair/metal/white{
 	dir = 1
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
 /obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "siding_line";
 	dir = 1
@@ -9783,6 +9803,16 @@
 	icon_state = "grimy"
 	},
 /area/station/security/hos)
+"bXo" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-C";
+	location = "CS-AR"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "bXp" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -10840,6 +10870,15 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/mixing)
+"ciy" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 5
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "ciD" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -13755,6 +13794,9 @@
 /obj/item/weapon/weldingtool{
 	pixel_x = 6
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "brown"
@@ -14442,16 +14484,6 @@
 /obj/machinery/shieldwallgen,
 /turf/simulated/floor,
 /area/station/storage/emergency2)
-"cZM" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SWW-FC";
-	location = "SW-FC"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "cZQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -15762,16 +15794,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/station/cargo/storage)
-"dpo" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "dpF" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -15965,6 +15987,11 @@
 	icon_state = "darkblue"
 	},
 /area/station/bridge/captain_quarters)
+"drr" = (
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "drz" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -16567,6 +16594,9 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	dir = 10;
@@ -17183,6 +17213,18 @@
 	icon_state = "blackcorner"
 	},
 /area/station/hallway/primary/starboard)
+"dHs" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "dHv" = (
 /obj/machinery/door/poddoor{
 	id = "armouryaccess";
@@ -17899,15 +17941,6 @@
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/engineering/atmos)
-"dRj" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DN";
-	location = "SSE-FC"
-	},
-/turf/simulated/floor{
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "dRG" = (
 /obj/machinery/door/window/brigdoor{
 	id = "cargocell";
@@ -19066,6 +19099,10 @@
 /obj/machinery/camera{
 	c_tag = "Cargo Lobby"
 	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "arrows_white";
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/cargo/lobby)
 "eeB" = (
@@ -19203,6 +19240,9 @@
 	},
 /obj/structure/window/thin/reinforced{
 	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	icon_state = "brown"
@@ -19442,14 +19482,25 @@
 	},
 /area/station/hallway/primary/starboard)
 "ejv" = (
-/obj/structure/disposaloutlet{
+/obj/structure/stool/bed/chair/metal/white{
 	dir = 1
 	},
-/obj/structure/disposalpipe/trunk{
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
 	dir = 1
 	},
-/turf/simulated/floor,
-/area/station/cargo/storage)
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "ejG" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 1
@@ -19657,18 +19708,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
-"ekZ" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "elw" = (
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
@@ -20042,6 +20081,15 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
+"epv" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "eqn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
@@ -20528,15 +20576,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/engineering/break_room)
-"ewl" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "ewm" = (
 /obj/machinery/space_heater,
 /turf/simulated/floor/plating,
@@ -21451,15 +21490,6 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/bar)
-"eHG" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-B";
-	location = "S-MB"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/secondary/entry)
 "eHM" = (
 /obj/machinery/camera{
 	c_tag = "Research Circuits Lab";
@@ -21662,15 +21692,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
-"eJA" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "eJQ" = (
 /obj/machinery/camera{
 	c_tag = "Port Primary Hallway Mid"
@@ -21871,6 +21892,15 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/singularity)
+"eLX" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Security";
+	location = "S-C"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "eMg" = (
 /obj/effect/decal/turf_decal/alpha/blue{
 	icon_state = "siding_line";
@@ -23267,15 +23297,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
-"fce" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "fcg" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -26432,18 +26453,25 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "fOp" = (
-/obj/machinery/light/smart{
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NE-FC";
-	location = "NEE-FC"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn_corner"
 	},
 /turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
+	icon_state = "redcorner"
 	},
-/area/station/hallway/primary/central)
+/area/station/security/prison)
 "fOF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
@@ -26621,13 +26649,6 @@
 	icon_state = "whiteredcorner"
 	},
 /area/station/rnd/hallway)
-"fQh" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-FC";
-	location = "SSW-FC"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/starboard)
 "fQi" = (
 /obj/structure/stool/bed/chair{
 	dir = 1
@@ -26876,6 +26897,17 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/mixing)
+"fUm" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "loadingarea"
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "arrow"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "fUu" = (
 /obj/effect/landmark/start/chief_engineer,
 /obj/structure/stool/bed/chair/office/light{
@@ -27715,14 +27747,6 @@
 	icon_state = "white"
 	},
 /area/station/medical/virology)
-"geb" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "gej" = (
 /obj/item/clothing/mask/luchador,
 /obj/item/clothing/mask/luchador/rudos,
@@ -30154,16 +30178,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
-"gCR" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NNW-B";
-	location = "NW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "gDg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -31370,6 +31384,13 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/armoury)
+"gSg" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-FC";
+	location = "SSW-FC"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/starboard)
 "gSy" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -32085,6 +32106,17 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/rnd/mixing)
+"gZR" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "gZU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
@@ -32922,19 +32954,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
-"hla" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "hlh" = (
 /obj/structure/table/woodentable,
 /obj/structure/cable{
@@ -33054,6 +33073,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"hmv" = (
+/obj/machinery/light/smart,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DS";
+	location = "DN-W"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "purplecorner"
+	},
+/area/station/hallway/primary/central)
 "hmz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
@@ -34212,16 +34242,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/maintenance/engineering)
-"hyc" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "hyh" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -35676,6 +35696,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"hOb" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=CS-AR";
+	location = "SWW-FC"
+	},
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "hOf" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
@@ -36260,6 +36287,9 @@
 /area/station/cargo/storage)
 "hVo" = (
 /obj/structure/filingcabinet/chestdrawer,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "redcorner"
@@ -36986,26 +37016,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
-"icE" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "icJ" = (
 /obj/structure/sign/departments/medbay,
 /turf/simulated/wall,
@@ -37194,6 +37204,16 @@
 	icon_state = "vaultfull"
 	},
 /area/station/engineering/chiefs_office)
+"ifd" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "ifo" = (
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/portsolar)
@@ -37837,6 +37857,13 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/lobby)
+"ilL" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-MB";
+	location = "N-MB"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "ilN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -38392,6 +38419,18 @@
 	icon_state = "darkblue"
 	},
 /area/station/security/iaa_office)
+"isK" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "isO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -38423,6 +38462,15 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
+"isZ" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Central Access"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "itb" = (
 /obj/structure/stool/bar,
 /turf/simulated/floor{
@@ -40724,6 +40772,26 @@
 	icon_state = "3"
 	},
 /area/shuttle/supply/station)
+"iTi" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "iTl" = (
 /turf/simulated/wall,
 /area/station/security/range)
@@ -41261,6 +41329,13 @@
 	icon_state = "dark"
 	},
 /area/station/cargo/recycleroffice)
+"jah" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=N-MB";
+	location = "NNW-B"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "jat" = (
 /obj/machinery/porta_turret/station_default{
 	dir = 4
@@ -41924,6 +41999,16 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"jgY" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NNW-B";
+	location = "NW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "jhc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
@@ -42671,12 +42756,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/misc_lab)
-"jqE" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "cafeteria"
-	},
-/area/station/security/prison)
 "jqH" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/computerframe{
@@ -43555,6 +43634,18 @@
 	icon_state = "neutralfull"
 	},
 /area/station/cargo/lobby)
+"jyM" = (
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Labor Camp Shuttle Airlock";
+	req_access = list(2)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
 "jzd" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Engineering Auxiliary Storage";
@@ -45569,6 +45660,15 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
+"jUJ" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "jUW" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -46659,15 +46759,13 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "kgH" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SE-FC";
-	location = "SW-B"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "vaultfull"
 	},
-/area/station/hallway/primary/central)
+/area/station/civilian/gym)
 "khm" = (
 /obj/machinery/power/apc{
 	name = "apc down";
@@ -47953,6 +48051,16 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/lobby)
+"kvs" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-FC";
+	location = "DS"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
+/area/station/hallway/primary/central)
 "kvu" = (
 /turf/simulated/wall,
 /area/station/civilian/bar)
@@ -48689,6 +48797,16 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry)
+"kEy" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/station/security/brig)
 "kEA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 6
@@ -49771,16 +49889,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/cargo/office)
-"kPh" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NEE-FC";
-	location = "S-SV"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "kPm" = (
 /obj/machinery/light/smart,
 /obj/machinery/status_display{
@@ -49822,6 +49930,17 @@
 	icon_state = "grimy"
 	},
 /area/station/tcommsat/computer)
+"kQw" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "kQB" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -49845,16 +49964,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/bridge/hop_office)
-"kRd" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Central Access"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "kRe" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -56787,6 +56896,13 @@
 	icon_state = "darkblue"
 	},
 /area/station/medical/morgue)
+"mux" = (
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/prison)
 "muF" = (
 /obj/machinery/computer/med_data,
 /obj/structure/cable{
@@ -60682,16 +60798,6 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/atmos)
-"npU" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-B";
-	location = "SSW-B"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "npW" = (
 /obj/machinery/gateway,
 /obj/effect/decal/turf_decal/alpha/gray{
@@ -62895,12 +63001,6 @@
 	icon_state = "wooden"
 	},
 /area/station/bridge/corp_lounge)
-"nQp" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "browncorner"
-	},
-/area/station/cargo/storage)
 "nQq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -64164,6 +64264,15 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/monitoring)
+"odB" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "odD" = (
 /obj/machinery/light/smart{
 	dir = 1
@@ -64979,7 +65088,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/turf_decal{
-	dir = 10;
+	dir = 9;
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
@@ -65296,13 +65405,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos/distribution)
-"otp" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-MB";
-	location = "N-MB"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "otq" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -65800,13 +65902,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/blueshield)
-"oAX" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=CS-AR";
-	location = "SWW-FC"
-	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
 "oBa" = (
 /obj/structure/closet/lawcloset,
 /obj/item/device/cardpay{
@@ -66716,6 +66811,25 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/storage)
+"oLI" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/main)
 "oLJ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -66995,17 +67109,6 @@
 	},
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
-"oOi" = (
-/obj/machinery/light/smart,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DS";
-	location = "DN-W"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "purplecorner"
 	},
 /area/station/hallway/primary/central)
 "oOj" = (
@@ -67571,14 +67674,6 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/secondary/exit)
-"oVJ" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/civilian/gym)
 "oVL" = (
 /obj/machinery/door_control{
 	id = "evacbar_shutters";
@@ -67684,6 +67779,12 @@
 /obj/item/weapon/flora/random,
 /turf/simulated/floor,
 /area/station/gateway)
+"oXb" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "cafeteria"
+	},
+/area/station/security/prison)
 "oXd" = (
 /obj/structure/closet/secure_closet/injection,
 /turf/simulated/floor{
@@ -68430,15 +68531,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
-"pfN" = (
-/obj/effect/decal/turf_decal/alpha/blue{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "pfR" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
@@ -68487,6 +68579,14 @@
 	},
 /turf/simulated/floor/carpet/red,
 /area/station/security/detectives_office)
+"pgK" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "pgT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -68573,20 +68673,6 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/engineering/atmos)
-"pii" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 9;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "pio" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -70879,6 +70965,19 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/reception)
+"pGJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/flasher{
+	id = "Cell 1 perma";
+	pixel_y = -28
+	},
+/turf/simulated/floor,
+/area/station/security/prison)
 "pGM" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -71080,9 +71179,9 @@
 /area/station/aisat/ai_chamber)
 "pJa" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal{
-	dir = 5;
-	icon_state = "warn"
+/obj/effect/decal/turf_decal/alpha{
+	icon_state = "warn_end";
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
@@ -71918,16 +72017,6 @@
 	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
-"pSy" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-FC";
-	location = "DS"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "bluecorner"
-	},
-/area/station/hallway/primary/central)
 "pSP" = (
 /obj/structure/table,
 /turf/simulated/floor{
@@ -74128,16 +74217,6 @@
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/starboard)
-"qsL" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SEE-FC";
-	location = "SE-FC"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "qsN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -75241,15 +75320,6 @@
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/station/security/vacantoffice)
-"qGY" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Security";
-	location = "S-C"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "qHh" = (
 /obj/structure/table/reinforced,
 /obj/structure/cable{
@@ -78441,8 +78511,21 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"ruZ" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SE-FC";
+	location = "SW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "rvc" = (
 /mob/living/simple_animal/hostile/mining_drone,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_white"
+	},
 /obj/effect/decal/turf_decal{
 	dir = 4;
 	icon_state = "warn"
@@ -78863,18 +78946,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
-"ryM" = (
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Labor Camp Shuttle Airlock";
-	req_access = list(2)
-	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/brig)
 "rzd" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -80227,27 +80298,6 @@
 	icon_state = "purplecorner"
 	},
 /area/station/rnd/hor)
-"rMH" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "rMI" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -81064,6 +81114,16 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/brig)
+"rWz" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "rWJ" = (
 /obj/structure/sign/warning/nosmoking,
 /turf/simulated/wall/r_wall,
@@ -81138,6 +81198,12 @@
 	icon_state = "blackchecker"
 	},
 /area/station/civilian/janitor)
+"rXI" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "browncorner"
+	},
+/area/station/cargo/storage)
 "rXM" = (
 /obj/structure/stool/bed/chair{
 	dir = 4
@@ -81814,25 +81880,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/science)
-"sfQ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/main)
 "sfV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -82993,6 +83040,16 @@
 	icon_state = "dark"
 	},
 /area/station/security/interrogation)
+"stf" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SEE-FC";
+	location = "SE-FC"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "stm" = (
 /obj/machinery/alarm{
 	pixel_x = 29;
@@ -83538,6 +83595,19 @@
 	icon_state = "grimy"
 	},
 /area/station/storage/tools)
+"sAt" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "sAP" = (
 /obj/structure/table/glass,
 /obj/item/device/radio/intercom{
@@ -83687,26 +83757,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/robotics)
-"sCe" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "sCh" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /turf/simulated/floor,
@@ -83722,13 +83772,6 @@
 	icon_state = "cafeteria"
 	},
 /area/station/civilian/kitchen)
-"sCJ" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "sCO" = (
 /obj/structure/closet,
 /obj/item/stack/sheet/glass{
@@ -84560,6 +84603,15 @@
 	icon_state = "dark"
 	},
 /area/station/cargo/recycleroffice)
+"sMC" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-B";
+	location = "S-MB"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry)
 "sME" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -85311,17 +85363,6 @@
 	icon_state = "red"
 	},
 /area/station/security/prison)
-"sVB" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "loadingarea"
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "arrow"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "sVD" = (
 /obj/structure/closet/toolcloset,
 /obj/machinery/light/small{
@@ -86972,6 +87013,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"trX" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "tsE" = (
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -89870,15 +89920,15 @@
 	},
 /area/station/rnd/hallway)
 "ucx" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SWW-FC";
+	location = "SW-FC"
 	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "brown"
+	dir = 1;
+	icon_state = "neutralcorner"
 	},
-/area/station/cargo/storage)
+/area/station/hallway/primary/central)
 "ucF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -90388,12 +90438,6 @@
 	icon_state = "white"
 	},
 /area/station/medical/hallway)
-"uiS" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
-	},
-/turf/simulated/floor/carpet/red,
-/area/station/security/detectives_office)
 "uiV" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -90661,6 +90705,16 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
+"ull" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "ulr" = (
 /obj/structure/table,
 /obj/item/stack/medical/bruise_pack,
@@ -90840,6 +90894,20 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/hos)
+"umS" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 10;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "umV" = (
 /obj/machinery/shieldgen,
 /obj/effect/decal/cleanable/dirt,
@@ -91254,18 +91322,6 @@
 	icon_state = "yellow"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
-"usd" = (
-/obj/machinery/door_timer/cell_3{
-	pixel_x = 32;
-	pixel_y = 0;
-	dir = 4;
-	id = "Cell 3 perma"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "usl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 10
@@ -91446,6 +91502,7 @@
 	name = "Central Access"
 	},
 /turf/simulated/floor{
+	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/station/security/lobby)
@@ -91557,14 +91614,6 @@
 	},
 /turf/environment/space,
 /area/shuttle/mining/station)
-"uvJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/security/prison)
 "uvL" = (
 /obj/structure/cable,
 /turf/simulated/floor/plating/airless/catwalk,
@@ -92410,16 +92459,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "uHN" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NEE-FC";
+	location = "S-SV"
 	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
 	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
+/area/station/hallway/primary/central)
 "uHX" = (
 /turf/simulated/floor/wood,
 /area/station/maintenance/chapel)
@@ -92738,6 +92786,15 @@
 	icon_state = "solarpanel"
 	},
 /area/station/solar/port)
+"uMp" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DN";
+	location = "SSE-FC"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "uMS" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -93169,18 +93226,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/maintenance/chapel)
-"uRM" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "uRO" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -93599,6 +93644,19 @@
 	icon_state = "purple"
 	},
 /area/station/rnd/xenobiology)
+"uXp" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "uXz" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor{
@@ -94090,15 +94148,6 @@
 	icon_state = "darkbluefull"
 	},
 /area/station/engineering/minisat_secure_area)
-"vcx" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 5
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "vcL" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -94223,6 +94272,9 @@
 "vex" = (
 /obj/structure/computerframe{
 	anchored = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -94360,13 +94412,6 @@
 "vgR" = (
 /turf/simulated/floor/plating/airless,
 /area/space)
-"vgU" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=N-MB";
-	location = "NNW-B"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "vhk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/window/brigdoor,
@@ -95126,16 +95171,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
-"vpn" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkred"
-	},
-/area/station/security/brig)
 "vpp" = (
 /obj/random/scrap/safe_even,
 /turf/simulated/floor/plating,
@@ -96213,16 +96248,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
-"vDx" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-C";
-	location = "CS-AR"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "vDC" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -96295,6 +96320,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/engineering/break_room)
+"vEw" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "vEF" = (
 /obj/machinery/door/airlock{
 	name = "Vacant Room";
@@ -97307,6 +97341,16 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/bridge/corp_lounge)
+"vRT" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-B";
+	location = "SSW-B"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "vSe" = (
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -97507,14 +97551,25 @@
 	},
 /area/station/bridge/teleporter)
 "vTX" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "grimy"
+	icon_state = "redcorner"
 	},
-/area/station/security/hos)
+/area/station/security/prison)
 "vUe" = (
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
@@ -98491,6 +98546,18 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/dormitories/service_bedrooms)
+"wgg" = (
+/obj/machinery/door_timer/cell_3{
+	pixel_x = 32;
+	pixel_y = 0;
+	dir = 4;
+	id = "Cell 3 perma"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "wgr" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -99276,6 +99343,7 @@
 "wpm" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
+	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/station/security/lobby)
@@ -100269,6 +100337,9 @@
 /area/station/bridge/cmf_room)
 "wBK" = (
 /mob/living/simple_animal/hostile/mining_drone,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_white"
+	},
 /obj/effect/decal/turf_decal{
 	dir = 8;
 	icon_state = "warn"
@@ -100716,6 +100787,12 @@
 	icon_state = "red"
 	},
 /area/station/security/main)
+"wGZ" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "wHa" = (
 /obj/item/device/flashlight/lamp/green,
 /obj/structure/table/woodentable,
@@ -101042,11 +101119,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/security/checkpoint/escape_custom_desk)
-"wLh" = (
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "wLD" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -101542,6 +101614,16 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/chargebay)
+"wSw" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSE-FC";
+	location = "SEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "wST" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -102723,19 +102805,6 @@
 /mob/living/simple_animal/mouse,
 /turf/simulated/floor/wood,
 /area/station/maintenance/medbay)
-"xgM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/flasher{
-	id = "Cell 1 perma";
-	pixel_y = -28
-	},
-/turf/simulated/floor,
-/area/station/security/prison)
 "xgN" = (
 /obj/machinery/seed_extractor,
 /obj/structure/window/thin{
@@ -103188,13 +103257,6 @@
 	},
 /turf/simulated/floor,
 /area/station/medical/hallway)
-"xnp" = (
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/prison)
 "xns" = (
 /obj/structure/grille{
 	destroyed = 1
@@ -105105,26 +105167,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
-"xHe" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "xHu" = (
 /obj/structure/rack,
 /obj/item/weapon/circuitboard/solar_control,
@@ -105717,26 +105759,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/mine_sci_shuttle)
-"xOJ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "xPl" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -106677,6 +106699,19 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"xZc" = (
+/obj/machinery/light/smart{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NE-FC";
+	location = "NEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "xZd" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -107238,17 +107273,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
-"ygd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "ygh" = (
 /obj/random/vending/snack,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -135805,7 +135829,7 @@ doE
 doE
 doE
 lgU
-qsL
+stf
 mhm
 doE
 mnD
@@ -136303,7 +136327,7 @@ wwi
 aYN
 wwi
 lfm
-aBi
+wSw
 tZn
 oyb
 nAM
@@ -136321,7 +136345,7 @@ oyb
 bzt
 bzt
 rcq
-dRj
+uMp
 tYK
 wtC
 wtC
@@ -141700,7 +141724,7 @@ iSv
 xXt
 vAu
 ogP
-npU
+vRT
 bAS
 nvi
 rnH
@@ -141716,7 +141740,7 @@ qbj
 qbj
 tmk
 ldb
-kgH
+ruZ
 ogP
 iSi
 amv
@@ -141743,7 +141767,7 @@ vpT
 xei
 bFh
 vpT
-oOi
+hmv
 vIl
 olx
 frM
@@ -141911,7 +141935,7 @@ plf
 brw
 mko
 jsL
-eHG
+sMC
 ffX
 hbE
 sTt
@@ -142180,7 +142204,7 @@ gHT
 alc
 vDr
 fDL
-gCR
+jgY
 iwy
 xXt
 gNR
@@ -146024,7 +146048,7 @@ yaE
 yaE
 csG
 fYS
-otp
+ilL
 alc
 gHT
 gHT
@@ -146033,7 +146057,7 @@ gHT
 gHT
 gHT
 alc
-vgU
+jah
 fYS
 sEX
 srs
@@ -150177,7 +150201,7 @@ iPW
 ojt
 tpx
 gtB
-ejv
+qIe
 cpR
 bzv
 lMB
@@ -150968,7 +150992,7 @@ mXl
 mXl
 mXl
 wLD
-kPh
+uHN
 iwm
 mXl
 pRS
@@ -150986,7 +151010,7 @@ oNU
 mXl
 uxx
 xMc
-cZM
+ucx
 nvi
 rnH
 cLM
@@ -150995,7 +151019,7 @@ nvi
 tOH
 mfI
 ogP
-pSy
+kvs
 sBG
 wjc
 wjc
@@ -151298,7 +151322,7 @@ xQo
 xQo
 xQo
 nKU
-fQh
+gSg
 xQo
 oPI
 mRu
@@ -151465,7 +151489,7 @@ cpR
 gtK
 cpR
 pxL
-fOp
+xZc
 ffJ
 ape
 fZz
@@ -151484,7 +151508,7 @@ hRd
 ckx
 fZz
 lMB
-qGY
+eLX
 kzb
 vAu
 psV
@@ -151498,7 +151522,7 @@ vAu
 kRo
 vAu
 kCI
-vDx
+bXo
 ogP
 lwr
 mLS
@@ -151739,9 +151763,9 @@ erD
 erD
 cmN
 act
-kRd
-xsY
 uuf
+xsY
+isZ
 jTW
 jTW
 jTW
@@ -152221,7 +152245,7 @@ fnT
 miA
 ojm
 lPc
-nQp
+rXI
 gaF
 rpV
 qSe
@@ -152463,7 +152487,7 @@ aGL
 uQb
 aGL
 weQ
-vke
+ojm
 ojt
 bGb
 mwy
@@ -152478,11 +152502,11 @@ nkb
 adb
 hzP
 cpR
-ucx
+ull
 oOk
 uXI
 oOk
-hyc
+ifd
 xqF
 aAF
 iqI
@@ -155589,8 +155613,8 @@ plf
 xyC
 cFp
 klH
-uiS
-uiS
+awP
+awP
 hGr
 aRu
 xyC
@@ -156114,8 +156138,8 @@ dnn
 aEr
 wPw
 jQy
-pfN
-wLh
+epv
+drr
 jcX
 fJg
 nPU
@@ -156607,11 +156631,11 @@ plf
 cHH
 cHH
 jxX
-ryM
+jyM
 bjt
 stv
 jxX
-ryM
+jyM
 jxX
 adp
 kMq
@@ -156622,9 +156646,9 @@ xyC
 xyC
 xyC
 xyC
-sCJ
-jtG
 wpm
+jtG
+wGZ
 fJg
 fJg
 fJg
@@ -156864,11 +156888,11 @@ wVt
 cHH
 cjS
 bNB
-opt
+umS
 kms
 cHH
 eow
-pii
+opt
 goK
 hYT
 nsn
@@ -157121,7 +157145,7 @@ leA
 cHH
 adG
 iGB
-vpn
+kEy
 tTk
 qMX
 aZz
@@ -157382,7 +157406,7 @@ ikW
 qXE
 rjb
 utF
-sVB
+fUm
 uLd
 lat
 nsn
@@ -158181,7 +158205,7 @@ kIM
 vst
 mDV
 vKG
-oAX
+hOb
 xoq
 tAM
 uQA
@@ -158900,14 +158924,14 @@ fAF
 fgx
 diq
 fAF
-usd
+wgg
 eTq
 fAF
 wNM
 oPD
 tif
 rHZ
-sCe
+vTX
 czU
 tqK
 hsq
@@ -159164,7 +159188,7 @@ qZx
 qZx
 fXG
 qZx
-xOJ
+iTi
 czU
 uvV
 kMw
@@ -159676,7 +159700,7 @@ fBm
 bvC
 hlv
 vqQ
-xgM
+pGJ
 qZx
 tnw
 fLE
@@ -160694,7 +160718,7 @@ aXC
 bZu
 pLw
 unD
-uvJ
+bbJ
 oAx
 ulK
 eyO
@@ -161248,7 +161272,7 @@ sxG
 uOc
 hur
 hur
-hla
+sAt
 ekd
 lZw
 gqC
@@ -161502,7 +161526,7 @@ ixl
 mme
 uKd
 gRX
-uRM
+dHs
 sRa
 nUj
 wUB
@@ -161531,13 +161555,13 @@ ncp
 ncp
 hbR
 mWz
-ekZ
+isK
 kLd
 syX
 tHk
 tHk
 dbf
-rMH
+bFL
 ram
 mWz
 lNQ
@@ -161794,7 +161818,7 @@ eFl
 aRb
 nDG
 jjN
-bFL
+uXp
 ram
 mWz
 ucd
@@ -162001,7 +162025,7 @@ afw
 nDf
 mZo
 qUR
-sfQ
+oLI
 mzV
 aSh
 mpR
@@ -162302,13 +162326,13 @@ ncp
 ncp
 hbR
 mWz
-uHN
+kQw
 sIY
 qls
 uOM
 uOM
 aeG
-xHe
+ejv
 ram
 mWz
 hPr
@@ -162498,7 +162522,7 @@ lhK
 wVg
 aFN
 jKZ
-jqE
+oXb
 rBo
 hlv
 qxh
@@ -162762,7 +162786,7 @@ xIO
 jps
 xIO
 qZx
-icE
+fOp
 tbS
 sZR
 kHU
@@ -162774,7 +162798,7 @@ fwH
 qoH
 vOW
 qoH
-geb
+pgK
 umQ
 gYp
 kHU
@@ -163012,7 +163036,7 @@ jvm
 hlv
 fVW
 fPH
-jqE
+oXb
 rnI
 hlv
 pHz
@@ -163027,11 +163051,11 @@ kHU
 plf
 cYc
 ueE
-dpo
+rWz
 wcJ
 iRz
 nez
-ygd
+gZR
 hlh
 gYp
 plf
@@ -163284,11 +163308,11 @@ kHU
 kHU
 cYc
 nfj
-vTX
+jUJ
 eaE
 nRk
 rZh
-eJA
+trX
 hmN
 gYp
 kHU
@@ -163332,7 +163356,7 @@ dJL
 nRG
 oXA
 oXA
-oVJ
+kgH
 dJL
 plf
 cdR
@@ -163541,11 +163565,11 @@ plf
 kHU
 huz
 sIx
-vcx
-ewl
+ciy
+odB
 kjv
-ewl
-fce
+odB
+vEw
 tEU
 huz
 plf
@@ -165590,7 +165614,7 @@ plf
 kHU
 hlv
 lrm
-xnp
+mux
 jno
 hlv
 cBu
@@ -166670,7 +166694,7 @@ kHU
 fMh
 plf
 dJL
-oVJ
+kgH
 oXA
 oXA
 nJn

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -2756,12 +2756,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/warden)
-"awP" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
-	},
-/turf/simulated/floor/carpet/red,
-/area/station/security/detectives_office)
 "awS" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -3960,6 +3954,16 @@
 	icon_state = "grimy"
 	},
 /area/station/storage/tools)
+"aKR" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NNW-B";
+	location = "NW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "aKS" = (
 /obj/machinery/vending/coffee,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -4282,6 +4286,16 @@
 	icon_state = "darkredcorners"
 	},
 /area/station/security/execution)
+"aPp" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NEE-FC";
+	location = "S-SV"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "aPB" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/clipboard,
@@ -5142,6 +5156,16 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/checkpoint)
+"aZD" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "aZF" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -5336,14 +5360,6 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/monitoring)
-"bbJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/security/prison)
 "bbO" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -9803,16 +9819,6 @@
 	icon_state = "grimy"
 	},
 /area/station/security/hos)
-"bXo" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-C";
-	location = "CS-AR"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "bXp" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -10870,10 +10876,10 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/mixing)
-"ciy" = (
+"ciz" = (
 /obj/effect/decal/turf_decal/alpha/dark_red{
 	icon_state = "siding_line";
-	dir = 5
+	dir = 6
 	},
 /turf/simulated/floor{
 	icon_state = "grimy"
@@ -13634,6 +13640,15 @@
 "cOU" = (
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"cOV" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "cOZ" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -15949,6 +15964,17 @@
 	icon_state = "caution"
 	},
 /area/station/hallway/primary/port)
+"drb" = (
+/obj/machinery/light/smart,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DS";
+	location = "DN-W"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "purplecorner"
+	},
+/area/station/hallway/primary/central)
 "dre" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -15970,6 +15996,18 @@
 	icon_state = "blue"
 	},
 /area/station/civilian/toilet)
+"drh" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "drn" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -15987,11 +16025,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/bridge/captain_quarters)
-"drr" = (
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "drz" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -17213,18 +17246,6 @@
 	icon_state = "blackcorner"
 	},
 /area/station/hallway/primary/starboard)
-"dHs" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "dHv" = (
 /obj/machinery/door/poddoor{
 	id = "armouryaccess";
@@ -19481,26 +19502,22 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/starboard)
-"ejv" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
+"ejq" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "loadingarea"
 	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "arrow"
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
+	icon_state = "dark"
 	},
-/area/station/civilian/gym)
+/area/station/security/brig)
+"ejv" = (
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "ejG" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 1
@@ -20081,15 +20098,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
-"epv" = (
-/obj/effect/decal/turf_decal/alpha/blue{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "eqn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
@@ -20499,6 +20507,12 @@
 	icon_state = "dark"
 	},
 /area/station/bridge/ai_upload)
+"evv" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "cafeteria"
+	},
+/area/station/security/prison)
 "evz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -21892,15 +21906,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/singularity)
-"eLX" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Security";
-	location = "S-C"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "eMg" = (
 /obj/effect/decal/turf_decal/alpha/blue{
 	icon_state = "siding_line";
@@ -23870,6 +23875,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/maintenance/cargo)
+"fiK" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "fiP" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -25406,6 +25423,16 @@
 	icon_state = "gcircuit"
 	},
 /area/station/tcommsat/chamber)
+"fAK" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SWW-FC";
+	location = "SW-FC"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "fAN" = (
 /obj/item/device/radio/intercom{
 	frequency = 1475;
@@ -26359,6 +26386,14 @@
 	icon_state = "neutral"
 	},
 /area/station/engineering/chiefs_office)
+"fLR" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "fLY" = (
 /turf/simulated/floor{
 	icon_state = "redcorner"
@@ -26453,25 +26488,17 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "fOp" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Labor Camp Shuttle Airlock";
+	req_access = list(2)
 	},
 /obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn_corner"
+	dir = 8;
+	icon_state = "warn"
 	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
+/turf/simulated/floor/plating,
+/area/station/security/brig)
 "fOF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
@@ -26897,17 +26924,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/mixing)
-"fUm" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "loadingarea"
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "arrow"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "fUu" = (
 /obj/effect/landmark/start/chief_engineer,
 /obj/structure/stool/bed/chair/office/light{
@@ -28920,6 +28936,15 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/cargo)
+"gpq" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "gpz" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/effect/decal/turf_decal/alpha/gray{
@@ -29169,9 +29194,9 @@
 	dir = 1;
 	icon_state = "loadingarea"
 	},
-/obj/effect/decal/turf_decal/alpha/black{
-	dir = 1;
-	icon_state = "arrow"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "arrow";
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
@@ -29355,6 +29380,17 @@
 	icon_state = "black"
 	},
 /area/station/hallway/secondary/exit)
+"guP" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "guR" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -31090,6 +31126,19 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
+"gOX" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "gPd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor{
@@ -31230,7 +31279,7 @@
 	dir = 4
 	},
 /obj/machinery/flasher{
-	id = "Cell 3 perma";
+	id = "Cell 1 perma";
 	pixel_y = -28
 	},
 /turf/simulated/floor,
@@ -31384,13 +31433,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/armoury)
-"gSg" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-FC";
-	location = "SSW-FC"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/starboard)
 "gSy" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -32106,17 +32148,6 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/rnd/mixing)
-"gZR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "gZU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/mining{
@@ -32422,6 +32453,15 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/dormitories)
+"hdS" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Security";
+	location = "S-C"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "hdU" = (
 /obj/structure/table/reinforced,
 /obj/item/device/analyzer,
@@ -33073,17 +33113,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
-"hmv" = (
-/obj/machinery/light/smart,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DS";
-	location = "DN-W"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "purplecorner"
-	},
-/area/station/hallway/primary/central)
 "hmz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
@@ -33897,6 +33926,18 @@
 	icon_state = "dark"
 	},
 /area/station/security/armoury)
+"hus" = (
+/obj/machinery/door_timer/cell_3{
+	pixel_x = 32;
+	pixel_y = 0;
+	dir = 4;
+	id = "Cell 3 perma"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "huv" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -34941,6 +34982,17 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/prison)
+"hED" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "hER" = (
 /obj/machinery/porta_turret/station_default{
 	dir = 4
@@ -35696,13 +35748,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
-"hOb" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=CS-AR";
-	location = "SWW-FC"
-	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
 "hOf" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
@@ -36342,6 +36387,13 @@
 /obj/random/foods/food_trash,
 /turf/simulated/floor,
 /area/station/maintenance/escape)
+"hVQ" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=N-MB";
+	location = "NNW-B"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "hVZ" = (
 /obj/structure/closet/wardrobe/chaplain_black,
 /obj/item/device/cardpay{
@@ -37204,16 +37256,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/engineering/chiefs_office)
-"ifd" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "ifo" = (
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/portsolar)
@@ -37857,13 +37899,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/lobby)
-"ilL" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-MB";
-	location = "N-MB"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "ilN" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -38419,18 +38454,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/security/iaa_office)
-"isK" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "isO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -38462,15 +38485,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
-"isZ" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Central Access"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "itb" = (
 /obj/structure/stool/bar,
 /turf/simulated/floor{
@@ -39156,6 +39170,14 @@
 	icon_state = "darkblue"
 	},
 /area/station/medical/genetics)
+"iAV" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/civilian/gym)
 "iBa" = (
 /obj/structure/table,
 /obj/item/weapon/storage/firstaid,
@@ -39430,6 +39452,16 @@
 	icon_state = "white"
 	},
 /area/station/medical/hallway)
+"iEa" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-B";
+	location = "SSW-B"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "iEb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -40772,26 +40804,6 @@
 	icon_state = "3"
 	},
 /area/shuttle/supply/station)
-"iTi" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "iTl" = (
 /turf/simulated/wall,
 /area/station/security/range)
@@ -41329,13 +41341,6 @@
 	icon_state = "dark"
 	},
 /area/station/cargo/recycleroffice)
-"jah" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=N-MB";
-	location = "NNW-B"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "jat" = (
 /obj/machinery/porta_turret/station_default{
 	dir = 4
@@ -41999,16 +42004,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
-"jgY" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NNW-B";
-	location = "NW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "jhc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
@@ -43634,18 +43629,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/cargo/lobby)
-"jyM" = (
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Labor Camp Shuttle Airlock";
-	req_access = list(2)
-	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/brig)
 "jzd" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Engineering Auxiliary Storage";
@@ -45660,15 +45643,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
-"jUJ" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "jUW" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -46759,13 +46733,25 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "kgH" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "redcorner"
 	},
-/area/station/civilian/gym)
+/area/station/security/prison)
 "khm" = (
 /obj/machinery/power/apc{
 	name = "apc down";
@@ -48051,16 +48037,6 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/lobby)
-"kvs" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-FC";
-	location = "DS"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "bluecorner"
-	},
-/area/station/hallway/primary/central)
 "kvu" = (
 /turf/simulated/wall,
 /area/station/civilian/bar)
@@ -48490,6 +48466,19 @@
 	icon_state = "showroomfloor"
 	},
 /area/station/civilian/cold_room)
+"kAK" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "kAU" = (
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
@@ -48797,16 +48786,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/secondary/entry)
-"kEy" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkred"
-	},
-/area/station/security/brig)
 "kEA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 6
@@ -49930,17 +49909,6 @@
 	icon_state = "grimy"
 	},
 /area/station/tcommsat/computer)
-"kQw" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "kQB" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -56739,6 +56707,16 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/dormitories)
+"mtk" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-FC";
+	location = "DS"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
+/area/station/hallway/primary/central)
 "mtn" = (
 /obj/machinery/light/smart{
 	dir = 4
@@ -56896,13 +56874,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/medical/morgue)
-"mux" = (
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/prison)
 "muF" = (
 /obj/machinery/computer/med_data,
 /obj/structure/cable{
@@ -57485,6 +57456,19 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
+"mBt" = (
+/obj/machinery/light/smart{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NE-FC";
+	location = "NEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "mBw" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -58228,6 +58212,16 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"mKW" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-C";
+	location = "CS-AR"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "mLq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -58684,6 +58678,16 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/plating/airless,
 /area/station/cargo/recycler)
+"mRa" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSE-FC";
+	location = "SEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "mRc" = (
 /obj/structure/table/glass,
 /obj/item/clothing/accessory/stethoscope,
@@ -58834,6 +58838,16 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/range)
+"mSh" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "mSl" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -59939,6 +59953,13 @@
 	icon_state = "dark"
 	},
 /area/station/security/hos)
+"nfm" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=CS-AR";
+	location = "SWW-FC"
+	},
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "nft" = (
 /obj/machinery/ai_status_display{
 	pixel_x = 32
@@ -61879,6 +61900,13 @@
 	icon_state = "vaultfull"
 	},
 /area/station/rnd/xenobiology)
+"nCx" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "nCD" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -62434,6 +62462,16 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/fore)
+"nIw" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SEE-FC";
+	location = "SE-FC"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "nIB" = (
 /turf/simulated/floor{
 	icon_state = "blackchecker"
@@ -63336,6 +63374,15 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/cargo/recycler)
+"nSQ" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DN";
+	location = "SSE-FC"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "nSV" = (
 /obj/structure/table/glass,
 /obj/machinery/computer/skills,
@@ -63887,6 +63934,15 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/escape_custom_desk)
+"nYO" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "nYQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/alarm{
@@ -63995,6 +64051,13 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/chapel/crematorium)
+"oak" = (
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/prison)
 "oap" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -64264,15 +64327,6 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/monitoring)
-"odB" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "odD" = (
 /obj/machinery/light/smart{
 	dir = 1
@@ -66811,25 +66865,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/storage)
-"oLI" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/main)
 "oLJ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -67124,7 +67159,7 @@
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	dir = 4;
+	dir = 5;
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
@@ -67371,6 +67406,22 @@
 "oRy" = (
 /turf/simulated/wall,
 /area/station/rnd/hallway)
+"oRF" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-B";
+	location = "S-MB"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry)
+"oRL" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-FC";
+	location = "SSW-FC"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/starboard)
 "oRS" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -67779,12 +67830,6 @@
 /obj/item/weapon/flora/random,
 /turf/simulated/floor,
 /area/station/gateway)
-"oXb" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "cafeteria"
-	},
-/area/station/security/prison)
 "oXd" = (
 /obj/structure/closet/secure_closet/injection,
 /turf/simulated/floor{
@@ -68579,14 +68624,6 @@
 	},
 /turf/simulated/floor/carpet/red,
 /area/station/security/detectives_office)
-"pgK" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "pgT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -70129,9 +70166,9 @@
 	dir = 1;
 	icon_state = "loadingarea"
 	},
-/obj/effect/decal/turf_decal/alpha/black{
-	dir = 1;
-	icon_state = "arrow"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "arrow";
+	dir = 1
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
@@ -70965,19 +71002,6 @@
 	icon_state = "whitebluefull"
 	},
 /area/station/medical/reception)
-"pGJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/flasher{
-	id = "Cell 1 perma";
-	pixel_y = -28
-	},
-/turf/simulated/floor,
-/area/station/security/prison)
 "pGM" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -77360,6 +77384,26 @@
 	icon_state = "bluefull"
 	},
 /area/station/civilian/locker)
+"rgx" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "rgE" = (
 /obj/structure/object_wall/mining{
 	icon_state = "5-2"
@@ -77670,6 +77714,14 @@
 	icon_state = "vaultfull"
 	},
 /area/station/rnd/robotics)
+"rjU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/security/prison)
 "rkr" = (
 /obj/structure/rack,
 /obj/random/cloth/gloves_safe,
@@ -78508,16 +78560,6 @@
 	},
 /turf/simulated/floor{
 	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
-"ruZ" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SE-FC";
-	location = "SW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
@@ -81114,16 +81156,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/brig)
-"rWz" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "rWJ" = (
 /obj/structure/sign/warning/nosmoking,
 /turf/simulated/wall/r_wall,
@@ -81198,12 +81230,6 @@
 	icon_state = "blackchecker"
 	},
 /area/station/civilian/janitor)
-"rXI" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "browncorner"
-	},
-/area/station/cargo/storage)
 "rXM" = (
 /obj/structure/stool/bed/chair{
 	dir = 4
@@ -83040,16 +83066,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/interrogation)
-"stf" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SEE-FC";
-	location = "SE-FC"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "stm" = (
 /obj/machinery/alarm{
 	pixel_x = 29;
@@ -83595,19 +83611,6 @@
 	icon_state = "grimy"
 	},
 /area/station/storage/tools)
-"sAt" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "sAP" = (
 /obj/structure/table/glass,
 /obj/item/device/radio/intercom{
@@ -84129,6 +84132,12 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/toilet)
+"sGt" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "browncorner"
+	},
+/area/station/cargo/storage)
 "sGy" = (
 /obj/structure/table/woodentable,
 /obj/item/stack/sheet/cloth{
@@ -84603,15 +84612,6 @@
 	icon_state = "dark"
 	},
 /area/station/cargo/recycleroffice)
-"sMC" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-B";
-	location = "S-MB"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/secondary/entry)
 "sME" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -87013,15 +87013,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
-"trX" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "tsE" = (
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -88879,6 +88870,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
+"tOF" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/station/security/brig)
 "tOH" = (
 /obj/structure/sign/directions/evac{
 	pixel_x = -32;
@@ -88984,6 +88985,26 @@
 /obj/item/weapon/reagent_containers/food/snacks/soap,
 /turf/simulated/floor,
 /area/station/civilian/toilet)
+"tQF" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "tQM" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
@@ -89920,15 +89941,14 @@
 	},
 /area/station/rnd/hallway)
 "ucx" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SWW-FC";
-	location = "SW-FC"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Central Access"
 	},
 /turf/simulated/floor{
-	dir = 1;
 	icon_state = "neutralcorner"
 	},
-/area/station/hallway/primary/central)
+/area/station/security/lobby)
 "ucF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -90121,6 +90141,20 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/hos)
+"ueI" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 10;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "ufi" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/effect/decal/turf_decal/alpha/gray{
@@ -90705,16 +90739,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
-"ull" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "ulr" = (
 /obj/structure/table,
 /obj/item/stack/medical/bruise_pack,
@@ -90894,20 +90918,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/hos)
-"umS" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 10;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "umV" = (
 /obj/machinery/shieldgen,
 /obj/effect/decal/cleanable/dirt,
@@ -92459,15 +92469,24 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "uHN" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NEE-FC";
-	location = "S-SV"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
+	icon_state = "vaultfull"
 	},
-/area/station/hallway/primary/central)
+/area/station/security/main)
 "uHX" = (
 /turf/simulated/floor/wood,
 /area/station/maintenance/chapel)
@@ -92786,15 +92805,6 @@
 	icon_state = "solarpanel"
 	},
 /area/station/solar/port)
-"uMp" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DN";
-	location = "SSE-FC"
-	},
-/turf/simulated/floor{
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "uMS" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -93644,19 +93654,6 @@
 	icon_state = "purple"
 	},
 /area/station/rnd/xenobiology)
-"uXp" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "uXz" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor{
@@ -94164,6 +94161,12 @@
 	icon_state = "caution"
 	},
 /area/station/medical/chemistry)
+"vdk" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
+	},
+/turf/simulated/floor/carpet/red,
+/area/station/security/detectives_office)
 "vdm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -96320,15 +96323,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/engineering/break_room)
-"vEw" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "vEF" = (
 /obj/machinery/door/airlock{
 	name = "Vacant Room";
@@ -97341,16 +97335,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/bridge/corp_lounge)
-"vRT" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-B";
-	location = "SSW-B"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "vSe" = (
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -97563,8 +97547,8 @@
 	dir = 4
 	},
 /obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
+	dir = 4;
+	icon_state = "warn_corner"
 	},
 /turf/simulated/floor{
 	icon_state = "redcorner"
@@ -98546,18 +98530,6 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/dormitories/service_bedrooms)
-"wgg" = (
-/obj/machinery/door_timer/cell_3{
-	pixel_x = 32;
-	pixel_y = 0;
-	dir = 4;
-	id = "Cell 3 perma"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "wgr" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -99343,7 +99315,6 @@
 "wpm" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
-	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/station/security/lobby)
@@ -99794,6 +99765,16 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"wwe" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SE-FC";
+	location = "SW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "wwi" = (
 /turf/simulated/wall,
 /area/station/maintenance/atmos)
@@ -100787,12 +100768,6 @@
 	icon_state = "red"
 	},
 /area/station/security/main)
-"wGZ" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "wHa" = (
 /obj/item/device/flashlight/lamp/green,
 /obj/structure/table/woodentable,
@@ -100872,6 +100847,16 @@
 	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
+"wHU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "wIf" = (
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
@@ -101614,16 +101599,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/chargebay)
-"wSw" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSE-FC";
-	location = "SEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "wST" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -101826,6 +101801,19 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/engineering/atmos/supermatter)
+"wUZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/flasher{
+	id = "Cell 3 perma";
+	pixel_y = -28
+	},
+/turf/simulated/floor,
+/area/station/security/prison)
 "wVg" = (
 /obj/structure/stool,
 /obj/structure/window/thin{
@@ -102971,6 +102959,15 @@
 	icon_state = "dark"
 	},
 /area/station/security/armoury)
+"xiT" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "xiX" = (
 /obj/machinery/light/small,
 /obj/structure/closet/l3closet/general,
@@ -106370,6 +106367,13 @@
 	icon_state = "darkbrown"
 	},
 /area/station/medical/virology)
+"xVH" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-MB";
+	location = "N-MB"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "xVN" = (
 /turf/simulated/wall,
 /area/station/civilian/dormitories/service_bedrooms)
@@ -106699,19 +106703,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
-"xZc" = (
-/obj/machinery/light/smart{
-	dir = 4
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NE-FC";
-	location = "NEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "xZd" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -107479,6 +107470,15 @@
 	icon_state = "dark"
 	},
 /area/station/bridge)
+"yjm" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 5
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "yjy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -135829,7 +135829,7 @@ doE
 doE
 doE
 lgU
-stf
+nIw
 mhm
 doE
 mnD
@@ -136327,7 +136327,7 @@ wwi
 aYN
 wwi
 lfm
-wSw
+mRa
 tZn
 oyb
 nAM
@@ -136345,7 +136345,7 @@ oyb
 bzt
 bzt
 rcq
-uMp
+nSQ
 tYK
 wtC
 wtC
@@ -141724,7 +141724,7 @@ iSv
 xXt
 vAu
 ogP
-vRT
+iEa
 bAS
 nvi
 rnH
@@ -141740,7 +141740,7 @@ qbj
 qbj
 tmk
 ldb
-ruZ
+wwe
 ogP
 iSi
 amv
@@ -141767,7 +141767,7 @@ vpT
 xei
 bFh
 vpT
-hmv
+drb
 vIl
 olx
 frM
@@ -141935,7 +141935,7 @@ plf
 brw
 mko
 jsL
-sMC
+oRF
 ffX
 hbE
 sTt
@@ -142204,7 +142204,7 @@ gHT
 alc
 vDr
 fDL
-jgY
+aKR
 iwy
 xXt
 gNR
@@ -146048,7 +146048,7 @@ yaE
 yaE
 csG
 fYS
-ilL
+xVH
 alc
 gHT
 gHT
@@ -146057,7 +146057,7 @@ gHT
 gHT
 gHT
 alc
-jah
+hVQ
 fYS
 sEX
 srs
@@ -150992,7 +150992,7 @@ mXl
 mXl
 mXl
 wLD
-uHN
+aPp
 iwm
 mXl
 pRS
@@ -151010,7 +151010,7 @@ oNU
 mXl
 uxx
 xMc
-ucx
+fAK
 nvi
 rnH
 cLM
@@ -151019,7 +151019,7 @@ nvi
 tOH
 mfI
 ogP
-kvs
+mtk
 sBG
 wjc
 wjc
@@ -151322,7 +151322,7 @@ xQo
 xQo
 xQo
 nKU
-gSg
+oRL
 xQo
 oPI
 mRu
@@ -151489,7 +151489,7 @@ cpR
 gtK
 cpR
 pxL
-xZc
+mBt
 ffJ
 ape
 fZz
@@ -151508,7 +151508,7 @@ hRd
 ckx
 fZz
 lMB
-eLX
+hdS
 kzb
 vAu
 psV
@@ -151522,7 +151522,7 @@ vAu
 kRo
 vAu
 kCI
-bXo
+mKW
 ogP
 lwr
 mLS
@@ -151765,7 +151765,7 @@ cmN
 act
 uuf
 xsY
-isZ
+ucx
 jTW
 jTW
 jTW
@@ -152245,7 +152245,7 @@ fnT
 miA
 ojm
 lPc
-rXI
+sGt
 gaF
 rpV
 qSe
@@ -152502,11 +152502,11 @@ nkb
 adb
 hzP
 cpR
-ull
 oOk
+aZD
 uXI
-oOk
-ifd
+aZD
+mSh
 xqF
 aAF
 iqI
@@ -155613,8 +155613,8 @@ plf
 xyC
 cFp
 klH
-awP
-awP
+vdk
+vdk
 hGr
 aRu
 xyC
@@ -156138,8 +156138,8 @@ dnn
 aEr
 wPw
 jQy
-epv
-drr
+nYO
+ejv
 jcX
 fJg
 nPU
@@ -156631,11 +156631,11 @@ plf
 cHH
 cHH
 jxX
-jyM
+fOp
 bjt
 stv
 jxX
-jyM
+fOp
 jxX
 adp
 kMq
@@ -156646,9 +156646,9 @@ xyC
 xyC
 xyC
 xyC
-wpm
+nCx
 jtG
-wGZ
+wpm
 fJg
 fJg
 fJg
@@ -156888,7 +156888,7 @@ wVt
 cHH
 cjS
 bNB
-umS
+ueI
 kms
 cHH
 eow
@@ -157145,7 +157145,7 @@ leA
 cHH
 adG
 iGB
-kEy
+tOF
 tTk
 qMX
 aZz
@@ -157406,7 +157406,7 @@ ikW
 qXE
 rjb
 utF
-fUm
+ejq
 uLd
 lat
 nsn
@@ -158205,7 +158205,7 @@ kIM
 vst
 mDV
 vKG
-hOb
+nfm
 xoq
 tAM
 uQA
@@ -158924,14 +158924,14 @@ fAF
 fgx
 diq
 fAF
-wgg
+hus
 eTq
 fAF
 wNM
 oPD
 tif
 rHZ
-vTX
+kgH
 czU
 tqK
 hsq
@@ -159188,7 +159188,7 @@ qZx
 qZx
 fXG
 qZx
-iTi
+rgx
 czU
 uvV
 kMw
@@ -159694,13 +159694,13 @@ blh
 cra
 hlv
 dVr
-gQC
+wUZ
 hlv
 fBm
 bvC
 hlv
 vqQ
-pGJ
+gQC
 qZx
 tnw
 fLE
@@ -160718,7 +160718,7 @@ aXC
 bZu
 pLw
 unD
-bbJ
+rjU
 oAx
 ulK
 eyO
@@ -161272,7 +161272,7 @@ sxG
 uOc
 hur
 hur
-sAt
+kAK
 ekd
 lZw
 gqC
@@ -161526,7 +161526,7 @@ ixl
 mme
 uKd
 gRX
-dHs
+fiK
 sRa
 nUj
 wUB
@@ -161555,7 +161555,7 @@ ncp
 ncp
 hbR
 mWz
-isK
+drh
 kLd
 syX
 tHk
@@ -161818,7 +161818,7 @@ eFl
 aRb
 nDG
 jjN
-uXp
+gOX
 ram
 mWz
 ucd
@@ -162025,7 +162025,7 @@ afw
 nDf
 mZo
 qUR
-oLI
+uHN
 mzV
 aSh
 mpR
@@ -162326,13 +162326,13 @@ ncp
 ncp
 hbR
 mWz
-kQw
+guP
 sIY
 qls
 uOM
 uOM
 aeG
-ejv
+tQF
 ram
 mWz
 hPr
@@ -162522,7 +162522,7 @@ lhK
 wVg
 aFN
 jKZ
-oXb
+evv
 rBo
 hlv
 qxh
@@ -162786,7 +162786,7 @@ xIO
 jps
 xIO
 qZx
-fOp
+vTX
 tbS
 sZR
 kHU
@@ -162798,7 +162798,7 @@ fwH
 qoH
 vOW
 qoH
-pgK
+fLR
 umQ
 gYp
 kHU
@@ -163036,7 +163036,7 @@ jvm
 hlv
 fVW
 fPH
-oXb
+evv
 rnI
 hlv
 pHz
@@ -163051,11 +163051,11 @@ kHU
 plf
 cYc
 ueE
-rWz
+wHU
 wcJ
 iRz
 nez
-gZR
+hED
 hlh
 gYp
 plf
@@ -163308,11 +163308,11 @@ kHU
 kHU
 cYc
 nfj
-jUJ
+xiT
 eaE
 nRk
 rZh
-trX
+cOV
 hmN
 gYp
 kHU
@@ -163356,7 +163356,7 @@ dJL
 nRG
 oXA
 oXA
-kgH
+iAV
 dJL
 plf
 cdR
@@ -163565,11 +163565,11 @@ plf
 kHU
 huz
 sIx
-ciy
-odB
+yjm
+gpq
 kjv
-odB
-vEw
+gpq
+ciz
 tEU
 huz
 plf
@@ -165614,7 +165614,7 @@ plf
 kHU
 hlv
 lrm
-mux
+oak
 jno
 hlv
 cBu
@@ -166694,7 +166694,7 @@ kHU
 fMh
 plf
 dJL
-kgH
+iAV
 oXA
 oXA
 nJn

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -5075,6 +5075,12 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"baj" = (
+/obj/effect/decal/turf_decal{
+	icon_state = "recharge_floor"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/mixing)
 "bal" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -5822,6 +5828,9 @@
 "bhz" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_white"
 	},
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
@@ -6932,12 +6941,16 @@
 	},
 /area/station/engineering/atmos)
 "bur" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
+/obj/structure/window/thin/reinforced{
+	dir = 8
 	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/xenobiology)
 "buv" = (
 /obj/structure/table,
 /obj/item/rig_module/grenade_launcher/smoke,
@@ -7178,6 +7191,20 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/checkpoint/medbay)
+"bxf" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
+/area/station/rnd/xenobiology)
 "bxl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 9
@@ -8803,8 +8830,8 @@
 /obj/structure/window/thin/reinforced{
 	dir = 1
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "box_white"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -9043,6 +9070,15 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/tox_launch)
+"bQR" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 10
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/hor)
 "bQV" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -9289,6 +9325,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/armoury)
+"bUp" = (
+/mob/living/carbon/monkey,
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/xenobiology)
 "bUt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -10038,15 +10084,6 @@
 	icon_state = "greenblue"
 	},
 /area/station/civilian/hydroponics)
-"ccg" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/rnd/hor)
 "cci" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -10615,7 +10652,7 @@
 /area/station/hallway/primary/fore)
 "cit" = (
 /obj/machinery/portable_atmospherics/canister,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -12187,13 +12224,6 @@
 /obj/structure/sign/nanotrasen,
 /turf/simulated/wall/r_wall,
 /area/station/bridge/ai_upload)
-"cBG" = (
-/obj/effect/decal/turf_decal{
-	dir = 6;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "cBU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/structure/window/fulltile/reinforced/phoron{
@@ -12269,6 +12299,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"cCO" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/hor)
 "cCT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -12581,7 +12620,7 @@
 /area/station/engineering/atmos/supermatter)
 "cGi" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -12829,6 +12868,13 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
+"cIK" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor,
+/area/station/rnd/xenobiology)
 "cIT" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -16103,6 +16149,9 @@
 "dxm" = (
 /obj/machinery/atmospherics/components/trinary/filter/m_filter{
 	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -20819,7 +20868,7 @@
 /area/station/security/checkpoint)
 "eFM" = (
 /obj/machinery/portable_atmospherics/powered/pump,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -22750,7 +22799,7 @@
 	pixel_y = 22
 	},
 /obj/machinery/portable_atmospherics/canister,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -22910,16 +22959,6 @@
 	icon_state = "red"
 	},
 /area/station/security/brig)
-"fed" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "purple"
-	},
-/area/station/rnd/xenobiology)
 "feh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23605,6 +23644,17 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"fmH" = (
+/obj/effect/decal/turf_decal{
+	dir = 10;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "fmI" = (
 /obj/structure/table,
 /obj/item/device/paicard,
@@ -27758,15 +27808,6 @@
 	icon_state = "white"
 	},
 /area/station/medical/reception)
-"gln" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/rnd/xenobiology)
 "gls" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -28051,6 +28092,16 @@
 	},
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
+"gnM" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "whitepurplecorner"
+	},
+/area/station/rnd/xenobiology)
 "gnR" = (
 /obj/machinery/vending/assist,
 /obj/machinery/camera{
@@ -28807,6 +28858,16 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
+"gwj" = (
+/obj/effect/decal/turf_decal{
+	dir = 9;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "gwm" = (
 /obj/structure/dresser,
 /obj/machinery/firealarm{
@@ -29272,6 +29333,21 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"gBf" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/station/rnd/xenobiology)
 "gBg" = (
 /obj/structure/stool/bed,
 /obj/item/weapon/bedsheet/purple,
@@ -31737,6 +31813,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 5
 	},
+/obj/effect/decal/turf_decal/alpha/purple{
+	icon_state = "siding_line";
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -31801,9 +31881,8 @@
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 1
 	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "box_white"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -36898,8 +36977,8 @@
 /obj/structure/window/thin/reinforced{
 	dir = 1
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "box_white"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -39044,6 +39123,9 @@
 /obj/machinery/light/smart,
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "box_white"
 	},
 /obj/effect/decal/turf_decal{
 	dir = 8;
@@ -41354,13 +41436,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison)
-"jnv" = (
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "jnw" = (
 /turf/simulated/wall/r_wall,
 /area/station/engineering/atmos/distribution)
@@ -45296,7 +45371,7 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
 	dir = 1
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/dark_red{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -45400,6 +45475,14 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/misc_lab)
+"kfG" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/xenobiology)
 "kfT" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -46993,21 +47076,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
-"kza" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/station/rnd/xenobiology)
 "kzb" = (
 /obj/structure/sign/directions/medical{
 	pixel_x = 32
@@ -48050,9 +48118,15 @@
 	},
 /obj/effect/decal/turf_decal{
 	dir = 4;
-	icon_state = "warn"
+	icon_state = "warn_corner"
 	},
-/turf/simulated/floor,
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutral"
+	},
 /area/station/maintenance/medbay)
 "kJO" = (
 /obj/effect/decal/cleanable/vomit,
@@ -48293,19 +48367,12 @@
 	},
 /area/station/rnd/tox_launch)
 "kMa" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/decal/turf_decal{
 	dir = 4;
 	icon_state = "warn"
 	},
-/turf/simulated/floor{
-	icon_state = "neutral"
-	},
-/area/station/rnd/xenobiology)
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "kMb" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
@@ -49096,14 +49163,14 @@
 	},
 /area/station/bridge/corp_lounge)
 "kVW" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white";
+	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "dark"
+	icon_state = "vaultfull"
 	},
-/area/station/rnd/mixing)
+/area/station/rnd/xenobiology)
 "kWf" = (
 /obj/structure/object_wall/mining{
 	icon_state = "1-2"
@@ -49144,12 +49211,6 @@
 	icon_state = "cafeteria"
 	},
 /area/station/security/prison)
-"kWx" = (
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "kWA" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -49504,30 +49565,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/effect/decal/turf_decal/alpha/purple{
+	icon_state = "siding_line";
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
 /area/station/rnd/mixing)
-"kZS" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha{
-	icon_state = "warn_end";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "white"
-	},
-/area/station/rnd/xenobiology)
 "kZT" = (
 /obj/structure/table/reinforced,
 /obj/item/device/radio/headset,
@@ -51029,15 +51074,6 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/hydroponics)
-"lte" = (
-/obj/structure/stool/bed/chair/office/dark{
-	dir = 4
-	},
-/obj/effect/landmark/start/scientist,
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/rnd/misc_lab)
 "ltn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -54227,7 +54263,10 @@
 	dir = 1;
 	icon_state = "warn"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "purple"
+	},
 /area/station/rnd/xenobiology)
 "mhm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -55456,6 +55495,13 @@
 	icon_state = "darkblue"
 	},
 /area/station/bridge)
+"muH" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "muK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56196,18 +56242,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/hallway/primary/central)
-"mCN" = (
-/obj/structure/window/thin/reinforced{
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/rnd/xenobiology)
 "mDd" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -56682,7 +56716,7 @@
 "mKy" = (
 /obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "siding_line";
-	dir = 10
+	dir = 6
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -56924,16 +56958,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
-"mOm" = (
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "mOn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -61375,15 +61399,6 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/engine)
-"nPy" = (
-/obj/structure/reagent_dispensers/aqueous_foam_tank,
-/obj/effect/decal/turf_decal/alpha/red{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/rnd/xenobiology)
 "nPD" = (
 /obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor,
@@ -61420,9 +61435,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/turf_decal{
-	icon_state = "warn"
+	dir = 8;
+	icon_state = "warn_corner"
 	},
-/turf/simulated/floor,
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
 /area/station/maintenance/medbay)
 "nPU" = (
 /obj/effect/decal/cleanable/dirt,
@@ -61638,6 +61660,10 @@
 	pixel_y = -28
 	},
 /obj/structure/cable,
+/obj/effect/decal/turf_decal/alpha/purple{
+	icon_state = "siding_line";
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -61876,6 +61902,10 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/effect/decal/turf_decal/alpha/purple{
+	icon_state = "siding_line";
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -62352,6 +62382,9 @@
 /obj/machinery/alarm{
 	pixel_x = 29;
 	pixel_y = -6
+	},
+/obj/effect/decal/turf_decal/alpha/purple{
+	icon_state = "siding_corner"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -64172,16 +64205,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/central)
-"oyK" = (
-/mob/living/carbon/monkey,
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/rnd/xenobiology)
 "ozc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -64267,6 +64290,9 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "box_white"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -65419,6 +65445,16 @@
 	},
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
+"oNQ" = (
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "oNS" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -65857,20 +65893,6 @@
 	},
 /turf/environment/space,
 /area/shuttle/escape_pod5/station)
-"oTg" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "neutral"
-	},
-/area/station/rnd/xenobiology)
 "oTt" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -66631,6 +66653,15 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
+"pdk" = (
+/obj/structure/reagent_dispensers/aqueous_foam_tank,
+/obj/effect/decal/turf_decal/alpha/red{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/xenobiology)
 "pdv" = (
 /obj/structure/table/reinforced,
 /obj/item/device/tagger/shop,
@@ -69320,6 +69351,15 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/chargebay)
+"pHu" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/hor)
 "pHv" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -69479,15 +69519,6 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/gym)
-"pJI" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/rnd/xenobiology)
 "pJW" = (
 /turf/simulated/floor{
 	dir = 9;
@@ -70561,6 +70592,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
+"pWt" = (
+/obj/effect/decal/turf_decal{
+	dir = 6;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "pWA" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 1
@@ -71508,6 +71546,15 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway/lobby)
+"qhJ" = (
+/obj/structure/stool/bed/chair/office/dark{
+	dir = 4
+	},
+/obj/effect/landmark/start/scientist,
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/misc_lab)
 "qhM" = (
 /obj/machinery/light/small,
 /turf/simulated/floor,
@@ -72135,9 +72182,8 @@
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 8
 	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "box_white"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -72232,17 +72278,6 @@
 /obj/item/weapon/flora/random,
 /turf/simulated/floor,
 /area/station/security/prison)
-"qqe" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "qqm" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -72344,6 +72379,17 @@
 	},
 /turf/environment/space,
 /area/shuttle/escape_pod6/station)
+"qrL" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "qrM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
@@ -76049,6 +76095,20 @@
 	icon_state = "darkbluecorners"
 	},
 /area/station/security/blueshield)
+"rmH" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
+/area/station/rnd/xenobiology)
 "rmU" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -76331,14 +76391,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/barbershop)
-"rqN" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "box_corners_white"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/rnd/xenobiology)
 "rqZ" = (
 /obj/structure/scrap_beacon,
 /turf/simulated/floor/airless/ceiling,
@@ -76758,6 +76810,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_white"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -79280,14 +79335,23 @@
 /turf/environment/space,
 /area/shuttle/supply/station)
 "rWY" = (
-/obj/structure/window/thin/reinforced{
-	dir = 8
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "box_corners_white"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha{
+	icon_state = "warn_end";
+	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "white"
 	},
 /area/station/rnd/xenobiology)
 "rXo" = (
@@ -79529,6 +79593,18 @@
 	icon_state = "red"
 	},
 /area/station/security/brig)
+"saj" = (
+/obj/structure/window/thin/reinforced{
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/xenobiology)
 "sak" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -79771,10 +79847,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
+	dir = 4;
+	icon_state = "warn_corner"
 	},
-/turf/simulated/floor,
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "neutral"
+	},
 /area/station/maintenance/medbay)
 "seo" = (
 /obj/machinery/door/firedoor,
@@ -80714,6 +80796,15 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/misc_lab)
+"snG" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/xenobiology)
 "snH" = (
 /obj/structure/door_assembly/door_assembly_fre,
 /turf/simulated/floor/plating,
@@ -81448,6 +81539,13 @@
 	icon_state = "1,4"
 	},
 /area/shuttle/supply/station)
+"sxT" = (
+/obj/effect/decal/turf_decal{
+	dir = 5;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/engine,
+/area/station/rnd/telesci)
 "sxV" = (
 /obj/item/device/radio/beacon,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -81696,8 +81794,8 @@
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 4
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "box_white"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -82002,16 +82100,6 @@
 	icon_state = "redchecker"
 	},
 /area/station/hallway/primary/fore)
-"sEK" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "whitepurplecorner"
-	},
-/area/station/rnd/xenobiology)
 "sEV" = (
 /obj/structure/table/glass,
 /obj/machinery/vending/wallmed1{
@@ -83331,7 +83419,7 @@
 /area/station/aisat/ai_chamber)
 "sVd" = (
 /obj/machinery/hologram/holopad,
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -83803,17 +83891,6 @@
 	icon_state = "white"
 	},
 /area/station/security/main)
-"tbP" = (
-/obj/effect/decal/turf_decal{
-	dir = 10;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "tbR" = (
 /obj/structure/dresser,
 /turf/simulated/floor/wood,
@@ -84751,15 +84828,6 @@
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/starboard)
-"tnW" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/rnd/xenobiology)
 "tok" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
@@ -86310,6 +86378,17 @@
 	icon_state = "boxing"
 	},
 /area/station/civilian/gym)
+"tHy" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "arrow"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "loadingarea"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/rnd/misc_lab)
 "tHA" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -86362,21 +86441,6 @@
 "tIo" = (
 /turf/simulated/wall,
 /area/station/maintenance/medbay)
-"tIq" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutral"
-	},
-/area/station/rnd/xenobiology)
 "tIH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -86653,7 +86717,7 @@
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
-	dir = 1;
+	dir = 8;
 	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/xenobiology)
@@ -88080,17 +88144,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/storage)
-"ufk" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "arrow"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "loadingarea"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/rnd/misc_lab)
 "ufr" = (
 /obj/machinery/light/smart,
 /turf/simulated/floor{
@@ -88469,6 +88522,21 @@
 	icon_state = "freezerfloor2"
 	},
 /area/station/bridge/captain_quarters)
+"ujR" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutral"
+	},
+/area/station/rnd/xenobiology)
 "ujY" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/drinks/flask/barflask{
@@ -90050,6 +90118,9 @@
 	output_tag = "rnd_out";
 	sensors = list("rnd_sensor"="Heat  Room")
 	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -90848,7 +90919,9 @@
 /obj/effect/landmark{
 	name = "blobstart"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
 /area/station/maintenance/medbay)
 "uOM" = (
 /obj/decal/boxingrope{
@@ -91987,10 +92060,6 @@
 "vcL" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
-	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -94403,11 +94472,7 @@
 /area/station/engineering/engine)
 "vHf" = (
 /obj/effect/decal/turf_decal{
-	dir = 9;
 	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
 	},
 /turf/simulated/floor/engine,
 /area/station/rnd/telesci)
@@ -94592,13 +94657,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/medical/genetics)
-"vJX" = (
-/obj/effect/decal/turf_decal{
-	dir = 5;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/engine,
-/area/station/rnd/telesci)
 "vKa" = (
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -94709,6 +94767,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/chapel)
+"vLf" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/xenobiology)
 "vLk" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/structure/window/fulltile/reinforced/phoron{
@@ -95140,10 +95207,6 @@
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 6
 	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -95461,15 +95524,6 @@
 /obj/structure/window/thin,
 /turf/simulated/floor,
 /area/station/security/prison)
-"vVR" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/rnd/hor)
 "vVY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -97008,9 +97062,16 @@
 	},
 /obj/effect/decal/turf_decal{
 	dir = 8;
-	icon_state = "warn"
+	icon_state = "warn_corner"
 	},
-/turf/simulated/floor,
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutral"
+	},
 /area/station/maintenance/medbay)
 "wnJ" = (
 /obj/effect/decal/turf_decal{
@@ -99236,9 +99297,8 @@
 /area/station/engineering/atmos/distribution)
 "wRs" = (
 /obj/structure/dispenser,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn"
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -99643,15 +99703,6 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/fore)
-"wWi" = (
-/obj/effect/decal/turf_decal/alpha/blue{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/rnd/xenobiology)
 "wWj" = (
 /obj/structure/sink{
 	pixel_y = 24
@@ -100630,7 +100681,7 @@
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 1
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/dark_red{
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
@@ -101463,15 +101514,6 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
-"xrX" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/rnd/hor)
 "xsb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -105066,6 +105108,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/gym)
+"yhZ" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/rnd/xenobiology)
 "yid" = (
 /obj/structure/rack,
 /obj/item/clothing/shoes/magboots,
@@ -125280,7 +125331,7 @@ cRA
 jYs
 hXe
 gVW
-wWi
+yhZ
 cfJ
 cjx
 xRM
@@ -126556,7 +126607,7 @@ waU
 ctb
 vUH
 fRJ
-tnW
+snG
 fXd
 bJD
 gdS
@@ -126564,7 +126615,7 @@ tDm
 gdS
 ecA
 hTC
-rqN
+kfG
 fRJ
 pyX
 cFK
@@ -126816,9 +126867,9 @@ kfd
 xdW
 rIz
 stV
-kza
+gBf
 sjW
-oTg
+bxf
 iag
 jum
 mph
@@ -127068,7 +127119,7 @@ jwI
 hBT
 cMM
 jwI
-oyK
+bUp
 fGG
 idF
 rNV
@@ -127080,7 +127131,7 @@ tMM
 cUf
 qkA
 fRJ
-pJI
+kVW
 cjx
 aJp
 uvO
@@ -127327,7 +127378,7 @@ gPy
 jwI
 huv
 nCm
-mCN
+saj
 mBU
 jie
 ccq
@@ -127335,7 +127386,7 @@ sdC
 fGy
 afj
 uUJ
-rWY
+bur
 nCm
 nyM
 cjx
@@ -128098,7 +128149,7 @@ gPy
 jwI
 huv
 nCm
-mCN
+saj
 czg
 lNl
 ccq
@@ -128106,7 +128157,7 @@ sdC
 fGy
 jrf
 qxf
-rWY
+bur
 nCm
 nyM
 cjx
@@ -128610,7 +128661,7 @@ nsa
 waU
 buY
 jwI
-gln
+vLf
 fRJ
 vpb
 vYM
@@ -128622,7 +128673,7 @@ tMM
 uWb
 qkA
 fRJ
-pJI
+kVW
 cjx
 lsw
 juy
@@ -128869,15 +128920,15 @@ wTL
 jwI
 huv
 nCm
-mCN
+saj
 kSz
 aog
 ccq
-kZS
+rWY
 fGy
 goU
 qWU
-rWY
+bur
 nCm
 nyM
 cjx
@@ -129129,9 +129180,9 @@ wYO
 mph
 qob
 bGW
-tIq
+ujR
 vGh
-kMa
+rmH
 iag
 gbO
 mph
@@ -129381,7 +129432,7 @@ jBe
 jwI
 gPy
 ctb
-gln
+vLf
 fRJ
 vpb
 vFZ
@@ -129393,7 +129444,7 @@ tMM
 gSL
 qkA
 fRJ
-pJI
+kVW
 cFK
 juy
 fVu
@@ -129642,7 +129693,7 @@ jwI
 gVW
 wBr
 gVW
-nPy
+pdk
 gdS
 wgr
 gdS
@@ -129899,10 +129950,10 @@ jwI
 tIm
 uWZ
 iMl
-tMi
-tMi
+gnM
+gnM
 oCo
-sEK
+tMi
 fau
 oEf
 rAU
@@ -130926,7 +130977,7 @@ jwI
 nUw
 vCS
 xOr
-fed
+mhk
 bfh
 qiE
 cjx
@@ -131440,7 +131491,7 @@ jwI
 fQK
 iJV
 ivl
-mhk
+cIK
 bfh
 uGd
 cjx
@@ -135034,9 +135085,9 @@ ylt
 omz
 vil
 lhp
-vHf
+gwj
 ldt
-tbP
+fmH
 ekl
 svQ
 nxb
@@ -135293,7 +135344,7 @@ evL
 bOA
 saw
 tVQ
-kWx
+vHf
 jwK
 svQ
 vxf
@@ -135548,15 +135599,15 @@ wtC
 ijY
 evL
 lhp
-qqe
+qrL
 bks
-mOm
+oNQ
 mkl
 svQ
 vxf
 kiL
-xrX
-mKy
+pHu
+bQR
 hzm
 vaP
 wwp
@@ -135805,9 +135856,9 @@ wtC
 hBT
 npX
 fbt
-bur
+muH
 bks
-kWx
+vHf
 fte
 uly
 vxf
@@ -135826,7 +135877,7 @@ snA
 nmq
 jVk
 jVk
-lte
+qhJ
 jVk
 dNy
 due
@@ -136062,15 +136113,15 @@ dyG
 bwi
 evL
 lhp
-bur
+muH
 bks
-kWx
+vHf
 mkl
 svQ
 vxf
 kiL
-ccg
-vVR
+cCO
+mKy
 blq
 syE
 qbC
@@ -136078,7 +136129,7 @@ mvv
 iVU
 agq
 wFq
-ufk
+tHy
 pNy
 khz
 cpL
@@ -136321,7 +136372,7 @@ lud
 bOA
 saw
 bks
-kWx
+vHf
 bYy
 svQ
 vxf
@@ -136576,9 +136627,9 @@ oZa
 daK
 pPD
 lhp
-vJX
-jnv
-cBG
+sxT
+kMa
+pWt
 vmY
 svQ
 jHw
@@ -136860,7 +136911,7 @@ xom
 xom
 cOy
 esc
-esc
+baj
 esc
 mYj
 eFM
@@ -138920,10 +138971,10 @@ mYj
 wRj
 mYj
 qom
-kVW
+lhd
 wRs
 vcL
-kVW
+lhd
 vRC
 hhG
 dGh

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -483,9 +483,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/carpet{
-	icon_state = "carpet10-8"
-	},
+/turf/simulated/floor/carpet,
 /area/station/bridge/captain_quarters)
 "acM" = (
 /obj/structure/closet/athletic_mixed,
@@ -1538,9 +1536,7 @@
 	c_tag = "Bridge";
 	dir = 1
 	},
-/turf/simulated/floor/carpet{
-	icon_state = "carpet5-1"
-	},
+/turf/simulated/floor/carpet,
 /area/station/bridge)
 "akg" = (
 /obj/machinery/door/firedoor,
@@ -2094,9 +2090,7 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "apV" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet5-1"
-	},
+/turf/simulated/floor/carpet,
 /area/station/bridge/meeting_room)
 "apX" = (
 /turf/simulated/wall,
@@ -2443,9 +2437,7 @@
 /obj/structure/stool/bed/chair/comfy/black{
 	dir = 1
 	},
-/turf/simulated/floor/carpet{
-	icon_state = "carpet13-5"
-	},
+/turf/simulated/floor/carpet,
 /area/station/bridge/meeting_room)
 "atv" = (
 /turf/simulated/floor{
@@ -4131,9 +4123,7 @@
 /obj/machinery/computer/communications{
 	dir = 4
 	},
-/turf/simulated/floor/carpet{
-	icon_state = "carpet5-1"
-	},
+/turf/simulated/floor/carpet,
 /area/station/bridge/captain_quarters)
 "aNW" = (
 /obj/machinery/smartfridge/chemistry,
@@ -4706,7 +4696,7 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "dark"
 	},
 /area/station/civilian/chapel/mass_driver)
 "aUN" = (
@@ -5852,9 +5842,7 @@
 /area/station/maintenance/science)
 "bhv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/simulated/floor/carpet/blue2{
-	icon_state = "blue2carpet15-15"
-	},
+/turf/simulated/floor/carpet/blue2,
 /area/station/medical/psych)
 "bhy" = (
 /obj/item/weapon/flora/random,
@@ -5908,9 +5896,7 @@
 "biC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/carpet/blue2{
-	icon_state = "blue2carpet13-5"
-	},
+/turf/simulated/floor/carpet/blue2,
 /area/station/medical/psych)
 "biE" = (
 /obj/structure/cable{
@@ -6701,9 +6687,7 @@
 /area/station/storage/primary)
 "bre" = (
 /obj/structure/dresser,
-/turf/simulated/floor/carpet{
-	icon_state = "carpet9-4"
-	},
+/turf/simulated/floor/carpet,
 /area/station/bridge/captain_quarters)
 "brg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
@@ -8462,9 +8446,7 @@
 "bIZ" = (
 /obj/machinery/computer/security/wooden_tv,
 /obj/structure/table/woodentable,
-/turf/simulated/floor/carpet{
-	icon_state = "carpet11-12"
-	},
+/turf/simulated/floor/carpet,
 /area/station/bridge/captain_quarters)
 "bJb" = (
 /obj/machinery/turretid/stun{
@@ -11391,9 +11373,7 @@
 /area/station/civilian/chapel)
 "cqG" = (
 /obj/structure/filingcabinet/security,
-/turf/simulated/floor/carpet{
-	icon_state = "carpet5-1"
-	},
+/turf/simulated/floor/carpet,
 /area/station/bridge/captain_quarters)
 "cqJ" = (
 /obj/structure/table/woodentable,
@@ -11742,6 +11722,10 @@
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "siding_thinplating_line";
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/station/civilian/chapel/mass_driver)
 "cvX" = (
@@ -13086,10 +13070,14 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "cKN" = (
-/turf/simulated/floor/carpet/blue2{
-	icon_state = "blue2carpet11-12"
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "box_corners_white";
+	dir = 4
 	},
-/area/station/medical/psych)
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/chapel/mass_driver)
 "cKQ" = (
 /obj/machinery/door/window/eastleft{
 	name = "Shrubbery";
@@ -13559,10 +13547,14 @@
 	},
 /area/station/hallway/primary/fore)
 "cPN" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet9-4"
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 9
 	},
-/area/station/bridge/captain_quarters)
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/chapel)
 "cPY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
@@ -14653,9 +14645,7 @@
 	},
 /area/station/engineering/atmos)
 "dfg" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet10-8"
-	},
+/turf/simulated/floor/carpet,
 /area/station/bridge)
 "dfo" = (
 /obj/machinery/power/apc{
@@ -18117,9 +18107,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet{
-	icon_state = "carpet14-10"
-	},
+/turf/simulated/floor/carpet,
 /area/station/bridge/meeting_room)
 "dVF" = (
 /obj/machinery/vending/cigarette,
@@ -20362,9 +20350,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/carpet{
-	icon_state = "carpet7-3"
-	},
+/turf/simulated/floor/carpet,
 /area/station/bridge/meeting_room)
 "ewN" = (
 /obj/machinery/computer/general_air_control{
@@ -21311,6 +21297,10 @@
 	pixel_x = -28;
 	pixel_y = -6
 	},
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "siding_thinplating_line";
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/station/civilian/chapel/mass_driver)
 "eIE" = (
@@ -22120,9 +22110,7 @@
 	},
 /area/station/rnd/xenobiology)
 "eRo" = (
-/turf/simulated/floor/carpet/blue2{
-	icon_state = "blue2carpet7-3"
-	},
+/turf/simulated/floor/carpet/blue2,
 /area/station/medical/psych)
 "eRS" = (
 /obj/machinery/hologram/holopad,
@@ -23496,8 +23484,12 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/decal/turf_decal/alpha/gray{
+/obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -29826,6 +29818,10 @@
 "gEt" = (
 /obj/structure/table/woodentable/fancy,
 /obj/item/device/flashlight/lantern,
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 8
+	},
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -30167,9 +30163,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet{
-	icon_state = "carpet13-5"
-	},
+/turf/simulated/floor/carpet,
 /area/station/bridge/meeting_room)
 "gIl" = (
 /obj/machinery/door/window/eastleft{
@@ -30424,9 +30418,7 @@
 /area/station/maintenance/medbay)
 "gLL" = (
 /obj/structure/stool/bed/chair/comfy/brown,
-/turf/simulated/floor/carpet/blue2{
-	icon_state = "blue2carpet10-8"
-	},
+/turf/simulated/floor/carpet/blue2,
 /area/station/medical/psych)
 "gLY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/high_volume/on{
@@ -30941,6 +30933,16 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/armoury)
+"gSp" = (
+/obj/structure/table/woodentable/fancy,
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/chapel)
 "gSy" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -34029,7 +34031,7 @@
 	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "dark"
 	},
 /area/station/civilian/chapel/mass_driver)
 "hAs" = (
@@ -38002,6 +38004,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "siding_thinplating_line";
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/station/civilian/chapel/mass_driver)
 "ivk" = (
@@ -38999,9 +39005,7 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/turf/simulated/floor/carpet{
-	icon_state = "carpet10-8"
-	},
+/turf/simulated/floor/carpet,
 /area/station/bridge/meeting_room)
 "iGx" = (
 /obj/machinery/door/firedoor,
@@ -40815,15 +40819,6 @@
 /obj/structure/window/thin,
 /turf/simulated/floor/grass,
 /area/station/hallway/primary/fore)
-"jbe" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 5
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/hallway/secondary/exit)
 "jbl" = (
 /obj/structure/closet/secure_closet/scientist,
 /obj/item/device/cardpay{
@@ -41498,9 +41493,7 @@
 /obj/machinery/door/window/brigdoor/northleft{
 	req_access = list(20)
 	},
-/turf/simulated/floor/carpet{
-	icon_state = "carpet14-10"
-	},
+/turf/simulated/floor/carpet,
 /area/station/bridge/captain_quarters)
 "jjk" = (
 /obj/structure/cable{
@@ -42425,6 +42418,15 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/lobby)
+"jtX" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/hallway/secondary/exit)
 "jug" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
@@ -42624,10 +42626,14 @@
 	},
 /area/station/cargo/lobby)
 "jvL" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet6-2"
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "box_corners_white";
+	dir = 1
 	},
-/area/station/bridge)
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/chapel/mass_driver)
 "jvV" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -45640,9 +45646,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/carpet{
-	icon_state = "carpet14-10"
-	},
+/turf/simulated/floor/carpet,
 /area/station/bridge/meeting_room)
 "kdA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -45783,9 +45787,7 @@
 /obj/machinery/alarm{
 	pixel_y = 22
 	},
-/turf/simulated/floor/carpet/blue2{
-	icon_state = "blue2carpet6-2"
-	},
+/turf/simulated/floor/carpet/blue2,
 /area/station/medical/psych)
 "keN" = (
 /obj/random/vending/snack,
@@ -46345,9 +46347,6 @@
 /turf/simulated/floor/engine/phoron,
 /area/station/engineering/atmos)
 "kkt" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot_right"
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -47859,6 +47858,10 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 1
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -48582,6 +48585,15 @@
 "kJs" = (
 /turf/simulated/floor,
 /area/station/security/brig)
+"kJC" = (
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 5
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/chapel)
 "kJD" = (
 /turf/simulated/floor{
 	icon_state = "greenblue"
@@ -48925,9 +48937,7 @@
 /turf/simulated/floor/grass,
 /area/station/civilian/kitchen)
 "kMA" = (
-/turf/simulated/floor/carpet{
-	icon_state = "carpet6-2"
-	},
+/turf/simulated/floor/carpet,
 /area/station/bridge/captain_quarters)
 "kMJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -49113,6 +49123,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"kPt" = (
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/chapel)
 "kQf" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/crowbar,
@@ -52731,7 +52749,8 @@
 /area/station/storage/tools)
 "lHw" = (
 /obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot_left"
+	icon_state = "box_corners_white";
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -55767,15 +55786,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/storage/tech)
-"msg" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/hallway/secondary/exit)
 "msk" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -57414,6 +57424,10 @@
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -22
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -60226,9 +60240,7 @@
 	icon_state = "4-8"
 	},
 /obj/item/weapon/folder/white,
-/turf/simulated/floor/carpet{
-	icon_state = "carpet15-15"
-	},
+/turf/simulated/floor/carpet,
 /area/station/bridge/meeting_room)
 "ntM" = (
 /obj/structure/cable{
@@ -62344,9 +62356,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/carpet{
-	icon_state = "carpet9-4"
-	},
+/turf/simulated/floor/carpet,
 /area/station/bridge)
 "nSC" = (
 /obj/structure/rack,
@@ -63248,7 +63258,7 @@
 	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "dark"
 	},
 /area/station/civilian/chapel/mass_driver)
 "ocs" = (
@@ -64876,6 +64886,15 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/tox_launch)
+"oAm" = (
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/chapel)
 "oAn" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -65383,6 +65402,16 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
+"oGE" = (
+/obj/structure/table/woodentable/fancy,
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/chapel)
 "oGF" = (
 /obj/structure/table/reinforced,
 /obj/item/device/gps/engineering{
@@ -65990,6 +66019,10 @@
 	pixel_x = 12
 	},
 /obj/structure/window/thin{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "siding_thinplating_line";
 	dir = 1
 	},
 /turf/simulated/floor,
@@ -67644,9 +67677,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet{
-	icon_state = "carpet13-5"
-	},
+/turf/simulated/floor/carpet,
 /area/station/bridge/captain_quarters)
 "pis" = (
 /obj/structure/cable{
@@ -68731,6 +68762,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "siding_thinplating_line";
+	dir = 1
+	},
 /turf/simulated/floor,
 /area/station/civilian/chapel/mass_driver)
 "pug" = (
@@ -68755,9 +68790,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/carpet{
-	icon_state = "carpet6-2"
-	},
+/turf/simulated/floor/carpet,
 /area/station/bridge/meeting_room)
 "puz" = (
 /obj/machinery/door/firedoor,
@@ -70521,6 +70554,10 @@
 "pOE" = (
 /obj/machinery/light/smart{
 	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/red{
+	icon_state = "arrows_white";
+	dir = 1
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -75217,9 +75254,7 @@
 	icon_state = "4-8"
 	},
 /obj/item/toy/figure/dsquad,
-/turf/simulated/floor/carpet{
-	icon_state = "carpet15-15"
-	},
+/turf/simulated/floor/carpet,
 /area/station/bridge/meeting_room)
 "qSZ" = (
 /obj/machinery/door/firedoor,
@@ -75757,7 +75792,7 @@
 "qZH" = (
 /obj/machinery/hologram/holopad,
 /obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/yellow{
+/obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "bot"
 	},
 /turf/simulated/floor,
@@ -79328,9 +79363,7 @@
 /obj/structure/table/woodentable,
 /obj/item/weapon/clipboard,
 /obj/item/weapon/pen,
-/turf/simulated/floor/carpet{
-	icon_state = "carpet9-4"
-	},
+/turf/simulated/floor/carpet,
 /area/station/bridge/meeting_room)
 "rOC" = (
 /obj/machinery/airlock_sensor{
@@ -79474,9 +79507,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet{
-	icon_state = "carpet15-15"
-	},
+/turf/simulated/floor/carpet,
 /area/station/bridge/captain_quarters)
 "rPS" = (
 /obj/effect/landmark/start/roboticist,
@@ -84010,9 +84041,7 @@
 /obj/structure/window/thin/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/carpet{
-	icon_state = "carpet10-8"
-	},
+/turf/simulated/floor/carpet,
 /area/station/bridge/captain_quarters)
 "sTZ" = (
 /obj/machinery/photocopier,
@@ -86065,7 +86094,7 @@
 "tvu" = (
 /obj/structure/morgue,
 /turf/simulated/floor{
-	icon_state = "vaultfull"
+	icon_state = "dark"
 	},
 /area/station/civilian/chapel/mass_driver)
 "tvw" = (
@@ -86586,15 +86615,6 @@
 	icon_state = "white"
 	},
 /area/station/rnd/hallway)
-"tAZ" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/hallway/secondary/exit)
 "tBc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -86745,10 +86765,14 @@
 	},
 /area/station/bridge/meeting_room)
 "tCY" = (
-/turf/simulated/floor/carpet/blue2{
-	icon_state = "blue2carpet9-4"
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 5
 	},
-/area/station/medical/psych)
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/hallway/secondary/exit)
 "tDb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -87627,6 +87651,14 @@
 	icon_state = "wooden-2"
 	},
 /area/station/civilian/gym)
+"tNU" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/chapel/mass_driver)
 "tNX" = (
 /obj/item/stack/rods{
 	amount = 23
@@ -88272,9 +88304,7 @@
 	dir = 1
 	},
 /obj/item/toy/plushie/tuxedo_cat,
-/turf/simulated/floor/carpet/blue2{
-	icon_state = "blue2carpet14-10"
-	},
+/turf/simulated/floor/carpet/blue2,
 /area/station/medical/psych)
 "tXo" = (
 /obj/structure/object_wall/pod{
@@ -88979,6 +89009,9 @@
 	dir = 8
 	},
 /obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -89181,9 +89214,7 @@
 	dir = 4
 	},
 /obj/item/device/radio/intercom,
-/turf/simulated/floor/carpet{
-	icon_state = "carpet11-12"
-	},
+/turf/simulated/floor/carpet,
 /area/station/bridge/meeting_room)
 "uiQ" = (
 /obj/structure/cable{
@@ -89369,6 +89400,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
+"uku" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/hallway/secondary/exit)
 "ukD" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -89727,9 +89767,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/carpet{
-	icon_state = "carpet15-15"
-	},
+/turf/simulated/floor/carpet,
 /area/station/bridge/meeting_room)
 "unL" = (
 /obj/effect/decal/cleanable/dirt,
@@ -94221,6 +94259,17 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor,
 /area/station/security/prison)
+"vuh" = (
+/obj/structure/table/woodentable/fancy,
+/obj/item/device/flashlight/lantern,
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/chapel)
 "vuj" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 29
@@ -94735,9 +94784,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/carpet{
-	icon_state = "carpet13-5"
-	},
+/turf/simulated/floor/carpet,
 /area/station/bridge)
 "vBe" = (
 /obj/effect/decal/turf_decal{
@@ -97428,6 +97475,10 @@
 	c_tag = "Chapel Office";
 	dir = 4
 	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 1
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -98285,9 +98336,7 @@
 /obj/machinery/keycard_auth{
 	pixel_x = -28
 	},
-/turf/simulated/floor/carpet{
-	icon_state = "carpet7-3"
-	},
+/turf/simulated/floor/carpet,
 /area/station/bridge/captain_quarters)
 "wtW" = (
 /obj/machinery/deployable/barrier,
@@ -101910,9 +101959,7 @@
 	pixel_y = -5
 	},
 /obj/effect/landmark/start/psychiatrist,
-/turf/simulated/floor/carpet/blue2{
-	icon_state = "blue2carpet5-1"
-	},
+/turf/simulated/floor/carpet/blue2,
 /area/station/medical/psych)
 "xnP" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
@@ -102010,6 +102057,15 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
+"xoK" = (
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/chapel)
 "xoM" = (
 /mob/living/simple_animal/chicken{
 	name = "Commander Clucky"
@@ -102991,9 +103047,7 @@
 /obj/structure/window/thin/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/carpet{
-	icon_state = "carpet6-2"
-	},
+/turf/simulated/floor/carpet,
 /area/station/bridge/captain_quarters)
 "xze" = (
 /obj/effect/decal/cleanable/dirt,
@@ -104217,6 +104271,15 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
+"xNt" = (
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 10
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/chapel)
 "xNJ" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /turf/simulated/floor/engine,
@@ -104866,9 +104929,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/carpet{
-	icon_state = "carpet14-10"
-	},
+/turf/simulated/floor/carpet,
 /area/station/bridge)
 "xVm" = (
 /obj/machinery/alarm{
@@ -144897,7 +144958,7 @@ gCE
 imK
 lEC
 wnY
-jvL
+dfg
 akc
 lZx
 gWd
@@ -147732,7 +147793,7 @@ ibm
 adM
 sTY
 bIZ
-cPN
+kMA
 iaL
 cHR
 jKD
@@ -148316,9 +148377,9 @@ xQo
 ukM
 rmY
 kbr
-jbe
-tAZ
-msg
+tCY
+jtX
+uku
 ryF
 nGt
 djc
@@ -149069,8 +149130,8 @@ omM
 gUd
 kdH
 gLL
-cKN
-tCY
+eRo
+eRo
 sOe
 fFv
 qxl
@@ -151917,10 +151978,10 @@ eCe
 mMq
 eCe
 wZE
-cUU
-mtw
+cPN
+oGE
 gEt
-cUU
+xNt
 huZ
 mUR
 mUR
@@ -152174,10 +152235,10 @@ sAQ
 tvk
 sAQ
 qus
-cUU
+oAm
 mtw
 cUU
-cUU
+kPt
 huZ
 kqE
 mUR
@@ -152431,10 +152492,10 @@ bYd
 nix
 nix
 bHx
-cUU
+oAm
 iih
 jjD
-cUU
+kPt
 pKo
 oJJ
 eiH
@@ -152688,10 +152749,10 @@ eCe
 mMq
 eCe
 wZE
-cUU
+oAm
 mtw
 cUU
-cUU
+kPt
 huZ
 kqE
 mUR
@@ -152945,10 +153006,10 @@ sAQ
 tvk
 sAQ
 qus
-cUU
-mtw
-gEt
-cUU
+kJC
+gSp
+vuh
+xoK
 huZ
 mUR
 mUR
@@ -155238,9 +155299,9 @@ bhy
 dLG
 iIt
 pne
+cKN
 kkt
-kkt
-kkt
+tNU
 ptR
 rKR
 mWg
@@ -155752,8 +155813,8 @@ thM
 dLG
 iIt
 pne
-lHw
-lHw
+jvL
+kkt
 lHw
 ivc
 fXD

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -1274,16 +1274,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/misc_lab)
-"ahM" = (
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "ahQ" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/snacks/pie,
@@ -1668,15 +1658,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/bridge/hop_office)
-"alx" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "alz" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -1717,6 +1698,18 @@
 	icon_state = "redyellowfull"
 	},
 /area/station/hallway/primary/fore)
+"alW" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "amg" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 4
@@ -2408,14 +2401,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/tox_launch)
-"asp" = (
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "yellow"
-	},
-/area/station/engineering/break_room)
 "asq" = (
 /obj/structure/object_wall/pod{
 	dir = 4;
@@ -2854,6 +2839,19 @@
 	icon_state = "whitehall"
 	},
 /area/station/rnd/hallway/lobby)
+"axC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "axI" = (
 /obj/machinery/camera{
 	c_tag = "Mining Shuttle Dock";
@@ -3944,6 +3942,18 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/chapel/office)
+"aJZ" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "aKa" = (
 /obj/effect/landmark/start/station_engineer,
 /obj/effect/decal/turf_decal{
@@ -5562,6 +5572,15 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/locker)
+"bdl" = (
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "bdo" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -6888,15 +6907,6 @@
 	},
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
-"brm" = (
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
 "brv" = (
 /obj/machinery/optable,
 /obj/machinery/requests_console/forensic{
@@ -6998,27 +7008,6 @@
 	icon_state = "caution"
 	},
 /area/station/engineering/break_room)
-"bsC" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Antechamber";
-	req_one_access = list(66)
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/aisat/teleport)
 "bsD" = (
 /turf/simulated/floor{
 	icon_state = "cafeteria"
@@ -7578,6 +7567,23 @@
 	icon_state = "dark"
 	},
 /area/station/medical/virology)
+"byD" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "caution"
+	},
+/area/station/engineering/atmos/distribution)
 "byG" = (
 /obj/machinery/photocopier,
 /obj/effect/decal/turf_decal/alpha/white{
@@ -8194,6 +8200,25 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/chapel/crematorium)
+"bEi" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/main)
 "bEB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -9241,6 +9266,15 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
+"bOE" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "bOJ" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -9299,16 +9333,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
-"bPP" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SEE-FC";
-	location = "SE-FC"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "bPT" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -10164,18 +10188,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/hallway/primary/fore)
-"bYW" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "bYY" = (
 /turf/simulated/floor{
 	icon_state = "grimy"
@@ -11020,15 +11032,18 @@
 /turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
 "cij" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
 	dir = 1
 	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "cin" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -11218,6 +11233,12 @@
 	icon_state = "darkbluefull"
 	},
 /area/station/security/blueshield)
+"cjO" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "cjS" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/alarm{
@@ -11291,23 +11312,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
-"ckT" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "caution"
-	},
-/area/station/engineering/atmos/distribution)
 "clc" = (
 /obj/machinery/computer/mech_bay_power_console,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -11703,14 +11707,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/rnd/xenobiology)
-"cpv" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/civilian/gym)
 "cpy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on/atmos{
 	dir = 4;
@@ -11720,6 +11716,21 @@
 	},
 /turf/simulated/floor/engine/airmix,
 /area/station/engineering/atmos)
+"cpA" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/engineering/monitoring)
 "cpL" = (
 /obj/machinery/light/smart{
 	dir = 4
@@ -12351,19 +12362,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/qm)
-"cyq" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "cyt" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -12436,15 +12434,6 @@
 	icon_state = "caution"
 	},
 /area/station/medical/chemistry)
-"cyL" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Security";
-	location = "S-C"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "cyQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -12949,6 +12938,19 @@
 	icon_state = "darkbrown"
 	},
 /area/station/medical/virology)
+"cEM" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "cEO" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/green,
 /turf/simulated/floor{
@@ -13046,19 +13048,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/aisat/antechamber_interior)
-"cFl" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "cFp" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/light/smart{
@@ -13210,6 +13199,15 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/hor)
+"cGU" = (
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "cHg" = (
 /obj/machinery/atmospherics/components/binary/pump,
 /obj/effect/decal/turf_decal{
@@ -13541,6 +13539,23 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"cLH" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Entry Shuttle Airlock";
+	req_one_access = list(13)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "cLM" = (
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway South-East";
@@ -13818,6 +13833,18 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/chapel)
+"cNS" = (
+/obj/structure/stool/bed/chair/metal/black{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "cNU" = (
 /obj/effect/decal/turf_decal{
 	dir = 10;
@@ -14240,6 +14267,16 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
+"cSk" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SE-FC";
+	location = "SW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "cSl" = (
 /obj/structure/stool/bed/chair/office/dark,
 /obj/effect/landmark/start/internal_affairs_agent,
@@ -14414,17 +14451,6 @@
 	icon_state = "red"
 	},
 /area/station/security/prison)
-"cTS" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "cUf" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -14628,13 +14654,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/incinerator)
-"cWB" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-FC";
-	location = "SSW-FC"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/starboard)
 "cWE" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/visuals/surgery/full,
@@ -14690,18 +14709,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
-"cXM" = (
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Labor Camp Shuttle Airlock";
-	req_access = list(2)
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/brig)
 "cXP" = (
 /obj/machinery/vending/chinese,
 /turf/simulated/floor{
@@ -14783,17 +14790,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/miningoffice)
-"cZu" = (
-/obj/structure/stool/bed/chair/metal/black{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "cZC" = (
 /obj/machinery/shieldwallgen,
 /turf/simulated/floor,
@@ -14940,14 +14936,6 @@
 /obj/item/weapon/storage/toolbox/electrical,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
-"dbV" = (
-/obj/machinery/atm{
-	pixel_y = -28
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "dcn" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -16634,12 +16622,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
-"dus" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "browncorner"
-	},
-/area/station/cargo/storage)
 "duu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -16708,6 +16690,17 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/lobby)
+"dvu" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "loadingarea"
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "arrow"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "dvy" = (
 /obj/effect/landmark/start/bartender,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -18307,6 +18300,16 @@
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/engineering/atmos)
+"dRw" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-FC";
+	location = "DS"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
+/area/station/hallway/primary/central)
 "dRG" = (
 /obj/machinery/door/window/brigdoor{
 	id = "cargocell";
@@ -19564,15 +19567,6 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor,
 /area/station/maintenance/incinerator)
-"efn" = (
-/obj/structure/closet/emcloset,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "efo" = (
 /obj/machinery/computer/cargo{
 	dir = 4
@@ -19865,23 +19859,17 @@
 	},
 /area/station/hallway/primary/starboard)
 "ejv" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
+/obj/machinery/door_timer/cell_3{
+	pixel_x = 32;
+	pixel_y = 0;
+	dir = 4;
+	id = "Cell 3 perma"
 	},
 /turf/simulated/floor{
-	icon_state = "neutralfull"
+	dir = 8;
+	icon_state = "redcorner"
 	},
-/area/station/hallway/primary/fore)
+/area/station/security/prison)
 "ejG" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 1
@@ -20464,19 +20452,6 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
-"epA" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/powered/pump,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "arrival"
-	},
-/area/station/hallway/primary/port)
 "eqn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
@@ -21728,6 +21703,10 @@
 	pixel_x = 32
 	},
 /obj/item/weapon/reagent_containers/blood/APlus,
+/obj/machinery/vending/wallmed1{
+	name = "Emergency NanoMed";
+	pixel_y = 28
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -22142,15 +22121,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/armoury)
-"eKx" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Central Access"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "eKz" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -22261,16 +22231,6 @@
 	icon_state = "dark"
 	},
 /area/station/cargo/recycleroffice)
-"eLE" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "eLM" = (
 /mob/living/carbon/monkey{
 	name = "Stanley"
@@ -22968,15 +22928,6 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
-"eTb" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "eTg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -23152,6 +23103,16 @@
 	icon_state = "red"
 	},
 /area/station/security/checkpoint/medbay)
+"eUX" = (
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "eUY" = (
 /obj/machinery/power/apc{
 	name = "apc down";
@@ -24913,14 +24874,6 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/station/engineering/atmos)
-"fqW" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "frk" = (
 /obj/structure/transit_tube{
 	icon_state = "N-SE"
@@ -25716,6 +25669,16 @@
 	icon_state = "blackchecker"
 	},
 /area/station/security/interrogation)
+"fzc" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NEE-FC";
+	location = "S-SV"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "fzd" = (
 /obj/effect/decal/turf_decal{
 	dir = 1;
@@ -26028,6 +25991,26 @@
 	icon_state = "purple"
 	},
 /area/station/engineering/atmos)
+"fCx" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "fCz" = (
 /obj/structure/table,
 /turf/simulated/floor{
@@ -26524,6 +26507,18 @@
 	icon_state = "vaultfull"
 	},
 /area/station/engineering/atmos)
+"fJq" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "fJr" = (
 /obj/structure/closet{
 	name = "evidence closet"
@@ -26889,6 +26884,11 @@
 	icon_state = "darkbrown"
 	},
 /area/station/medical/virology)
+"fNv" = (
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "fNA" = (
 /obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "box_corners_white";
@@ -26898,19 +26898,6 @@
 	icon_state = "dark"
 	},
 /area/station/medical/morgue)
-"fNB" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "fNC" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/folder/blue,
@@ -26932,21 +26919,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "fOp" = (
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Entry Shuttle Airlock";
-	req_one_access = list(13)
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
 	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
+/turf/simulated/floor{
+	icon_state = "neutralfull"
 	},
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
+/area/station/engineering/atmos)
 "fOF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
@@ -27665,6 +27646,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"fXu" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/security/prison)
 "fXD" = (
 /obj/structure/closet/wardrobe/black,
 /obj/item/device/radio/intercom{
@@ -27689,6 +27678,16 @@
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
+"fXH" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-C";
+	location = "CS-AR"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "fXS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -28607,15 +28606,6 @@
 	icon_state = "dark"
 	},
 /area/station/ai_monitored/storage_secure)
-"giQ" = (
-/obj/effect/decal/turf_decal/alpha/blue{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "giU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -29331,23 +29321,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/brig)
-"goL" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "goT" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -29533,6 +29506,16 @@
 "gqV" = (
 /turf/simulated/wall/r_wall,
 /area/station/rnd/scibreak)
+"gqY" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "grm" = (
 /obj/machinery/power/solar_control{
 	dir = 8;
@@ -30604,6 +30587,20 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/port)
+"gBu" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 10;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "gBw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -30679,6 +30676,7 @@
 	icon_state = "delivery"
 	},
 /obj/effect/decal/turf_decal{
+	dir = 4;
 	icon_state = "warn_corner"
 	},
 /turf/simulated/floor{
@@ -31648,6 +31646,26 @@
 	icon_state = "foam_plating"
 	},
 /area/station/maintenance/science)
+"gPn" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "gPx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -31813,6 +31831,17 @@
 	},
 /turf/environment/space,
 /area/shuttle/supply/station)
+"gRl" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "gRp" = (
 /obj/effect/decal/turf_decal{
 	dir = 8;
@@ -32121,13 +32150,6 @@
 	icon_state = "bluefull"
 	},
 /area/station/hallway/primary/central)
-"gUk" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=N-MB";
-	location = "NNW-B"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "gUl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /turf/simulated/floor/engine,
@@ -32691,6 +32713,17 @@
 	},
 /turf/simulated/floor,
 /area/station/security/checkpoint/engi)
+"gZZ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "had" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -32708,15 +32741,6 @@
 	icon_state = "darkred"
 	},
 /area/station/security/brig)
-"hae" = (
-/obj/effect/decal/turf_decal{
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "ham" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -34389,6 +34413,14 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/lab)
+"htR" = (
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/break_room)
 "htY" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
@@ -34450,6 +34482,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"hum" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/simulated/floor{
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "hur" = (
 /obj/effect/decal/turf_decal{
 	dir = 8;
@@ -34635,19 +34675,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
-"hwB" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/flasher{
-	id = "Cell 1 perma";
-	pixel_y = -28
-	},
-/turf/simulated/floor,
-/area/station/security/prison)
 "hwC" = (
 /obj/machinery/light/smart{
 	dir = 4
@@ -34675,7 +34702,7 @@
 	req_access = list(2)
 	},
 /obj/effect/decal/turf_decal{
-	dir = 8;
+	dir = 4;
 	icon_state = "warn"
 	},
 /turf/simulated/floor/plating,
@@ -35340,6 +35367,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"hCk" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/hallway/secondary/entry)
 "hCo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -35446,25 +35483,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/hallway/primary/starboard)
-"hDt" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/main)
 "hDy" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -35701,11 +35719,11 @@
 	req_one_access = list(13)
 	},
 /obj/effect/decal/turf_decal{
-	dir = 2;
+	dir = 1;
 	icon_state = "warn"
 	},
 /obj/effect/decal/turf_decal{
-	dir = 1;
+	dir = 2;
 	icon_state = "warn"
 	},
 /turf/simulated/floor/plating,
@@ -36154,16 +36172,6 @@
 	icon_state = "yellowpatch"
 	},
 /area/station/engineering/atmos/supermatter)
-"hLt" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "hLL" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -36180,6 +36188,19 @@
 	icon_state = "vaultfull"
 	},
 /area/station/bridge/cmf_room)
+"hLM" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/flasher{
+	id = "Cell 1 perma";
+	pixel_y = -28
+	},
+/turf/simulated/floor,
+/area/station/security/prison)
 "hLO" = (
 /obj/effect/landmark/start/paramedic,
 /obj/structure/cable{
@@ -36424,18 +36445,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/medbay)
-"hOV" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "hPa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -37694,6 +37703,16 @@
 	icon_state = "bluefull"
 	},
 /area/station/security/checkpoint/escape_custom_desk)
+"idg" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "idn" = (
 /obj/effect/landmark/start/assistant/test_subject,
 /obj/structure/stool/bed/chair/metal/black{
@@ -38126,32 +38145,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/hor)
-"ihJ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/engineering/monitoring)
-"ihO" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "yellow"
-	},
-/area/station/engineering/atmos)
 "ihP" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -39007,6 +39000,19 @@
 	icon_state = "dark"
 	},
 /area/station/aisat/ai_chamber)
+"irH" = (
+/obj/machinery/light/smart{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NE-FC";
+	location = "NEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "irL" = (
 /obj/machinery/light/smart{
 	dir = 4
@@ -39093,6 +39099,15 @@
 	icon_state = "darkblue"
 	},
 /area/station/security/iaa_office)
+"isL" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 29
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "blackcorner"
+	},
+/area/station/hallway/primary/starboard)
 "isO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -39465,6 +39480,16 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/brig/storage)
+"ixt" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/station/security/brig)
 "ixC" = (
 /obj/item/target/syndicate,
 /turf/simulated/floor{
@@ -39996,7 +40021,7 @@
 "iDw" = (
 /obj/item/weapon/flora/random,
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_left"
+	icon_state = "bot_right"
 	},
 /turf/simulated/floor,
 /area/station/storage/tech)
@@ -40048,7 +40073,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
+	icon_state = "siding_line";
 	dir = 8
 	},
 /turf/simulated/floor,
@@ -40991,6 +41016,16 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/locker)
+"iNX" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "iOa" = (
 /obj/item/stack/cable_coil,
 /turf/simulated/floor/plating/airless/catwalk,
@@ -41001,18 +41036,6 @@
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/station/civilian/dormitories)
-"iOd" = (
-/obj/structure/stool/bed/chair/metal/black{
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "iOl" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -42373,6 +42396,21 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/medical/chemistry)
+"jdZ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "jee" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass,
@@ -43245,6 +43283,12 @@
 	},
 /turf/simulated/floor/engine,
 /area/station/rnd/mixing)
+"joo" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "cafeteria"
+	},
+/area/station/security/prison)
 "jor" = (
 /obj/effect/landmark{
 	name = "carpspawn"
@@ -44032,16 +44076,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/mine_sci_shuttle)
-"jws" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "jwD" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -44345,15 +44379,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
-"jzh" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "jzl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
@@ -44592,6 +44617,19 @@
 	icon_state = "vaultfull"
 	},
 /area/station/rnd/robotics)
+"jBy" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "jBD" = (
 /turf/simulated/floor,
 /area/station/maintenance/science)
@@ -46599,6 +46637,27 @@
 	icon_state = "whitebluecorner"
 	},
 /area/station/medical/reception)
+"jXm" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "jXo" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -46861,6 +46920,22 @@
 /obj/item/weapon/wrench,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"kar" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "kav" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
@@ -47458,14 +47533,18 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "kgH" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 5
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_corner"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "arrows_white";
+	dir = 4
 	},
 /turf/simulated/floor{
-	icon_state = "grimy"
+	dir = 4;
+	icon_state = "black"
 	},
-/area/station/security/hos)
+/area/station/hallway/secondary/entry)
 "khm" = (
 /obj/machinery/power/apc{
 	name = "apc down";
@@ -47676,23 +47755,16 @@
 	icon_state = "black"
 	},
 /area/station/civilian/gym)
-"kjh" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Entry Shuttle Airlock";
-	req_one_access = list(13)
+"kjq" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
 	},
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
+/turf/simulated/floor{
+	icon_state = "grimy"
 	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
+/area/station/security/hos)
 "kjv" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -47756,12 +47828,6 @@
 	icon_state = "grimy"
 	},
 /area/station/maintenance/medbay)
-"kjV" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
-	},
-/turf/simulated/floor/carpet/red,
-/area/station/security/detectives_office)
 "kjX" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -48720,6 +48786,18 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
+"kub" = (
+/obj/structure/stool/bed/chair/metal/black{
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "kuh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor{
@@ -49007,6 +49085,24 @@
 	icon_state = "grimy"
 	},
 /area/station/bridge/captain_quarters)
+"kyE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "kyV" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -49217,6 +49313,16 @@
 	icon_state = "showroomfloor"
 	},
 /area/station/civilian/cold_room)
+"kAT" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SWW-FC";
+	location = "SW-FC"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "kAU" = (
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
@@ -49596,11 +49702,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/supermatter)
-"kFv" = (
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "kFI" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -49916,6 +50017,15 @@
 	},
 /turf/environment/space,
 /area/shuttle/mining/station)
+"kIh" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "kIq" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -50146,6 +50256,13 @@
 	icon_state = "grimy"
 	},
 /area/station/maintenance/chapel)
+"kKa" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "kKb" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/pickaxe/drill{
@@ -51407,19 +51524,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
-"kXK" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "kXQ" = (
 /obj/structure/table/woodentable/fancy,
 /obj/machinery/door/window/northright{
@@ -51595,18 +51699,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/cargo/miningoffice)
-"kZk" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "kZp" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -52520,6 +52612,18 @@
 	icon_state = "vaultfull"
 	},
 /area/station/rnd/xenobiology)
+"llL" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "llM" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -52835,20 +52939,6 @@
 	icon_state = "whitepurplefull"
 	},
 /area/station/rnd/misc_lab)
-"lqh" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_corner";
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "arrows_white";
-	dir = 8
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "black"
-	},
-/area/station/hallway/secondary/entry)
 "lqr" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -53235,18 +53325,6 @@
 "ltP" = (
 /turf/simulated/floor/plating,
 /area/station/cargo/office)
-"ltR" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "lud" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -54611,6 +54689,27 @@
 	icon_state = "barber"
 	},
 /area/station/medical/cmo)
+"lKx" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Antechamber";
+	req_one_access = list(66)
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/aisat/teleport)
 "lKD" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/turf_decal/alpha/blue{
@@ -55231,16 +55330,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
-"lQq" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SWW-FC";
-	location = "SW-FC"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "lQz" = (
 /obj/machinery/door_control{
 	id = "teleporter_in_shutter";
@@ -55825,6 +55914,19 @@
 	icon_state = "darkblue"
 	},
 /area/station/engineering/minisat_secure_area)
+"lYy" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "lYB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -55887,17 +55989,6 @@
 "lZx" = (
 /turf/simulated/wall/r_wall,
 /area/station/tcommsat/computer)
-"lZE" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos/atmos_office)
 "lZT" = (
 /obj/machinery/status_display{
 	pixel_x = -32
@@ -56042,6 +56133,16 @@
 	icon_state = "vaultfull"
 	},
 /area/station/hallway/primary/central)
+"mbB" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NNW-B";
+	location = "NW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "mbI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56218,6 +56319,16 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/armoury)
+"mdR" = (
+/obj/machinery/light/smart,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "mev" = (
 /obj/structure/displaycase_chassis,
 /obj/effect/decal/cleanable/dirt,
@@ -57298,26 +57409,6 @@
 /obj/structure/sign/warning/airlock,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/escape)
-"mqg" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "mql" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -57831,6 +57922,15 @@
 	icon_state = "purplecorner"
 	},
 /area/station/rnd/hor)
+"mvz" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "mvD" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -58839,19 +58939,6 @@
 	icon_state = "red"
 	},
 /area/station/security/brig/equipment)
-"mGP" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 9
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "mHj" = (
 /obj/machinery/computer/card,
 /turf/simulated/floor{
@@ -58881,16 +58968,16 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/library)
-"mIq" = (
+"mIh" = (
 /obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SE-FC";
-	location = "SW-B"
+	codes_txt = "patrol;next_patrol=SEE-FC";
+	location = "SE-FC"
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
+	dir = 8;
+	icon_state = "yellowcorner"
 	},
-/area/station/hallway/primary/central)
+/area/station/hallway/primary/port)
 "mIw" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/simulated/wall,
@@ -59223,26 +59310,6 @@
 	icon_state = "white"
 	},
 /area/station/medical/sleeper)
-"mNa" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "mNo" = (
 /obj/machinery/vending/eva,
 /turf/simulated/floor{
@@ -59388,6 +59455,15 @@
 	icon_state = "whitepurplecorner"
 	},
 /area/station/rnd/hor)
+"mPj" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-B";
+	location = "S-MB"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry)
 "mPo" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -61161,13 +61237,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
-"niI" = (
-/obj/item/weapon/flora/random,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_right"
-	},
-/turf/simulated/floor,
-/area/station/storage/tech)
 "niP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -61461,27 +61530,19 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
-"nmW" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
+"nmY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 9
 	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "nna" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -61577,6 +61638,15 @@
 /obj/item/weapon/reagent_containers/food/drinks/bottle/wine,
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories)
+"nol" = (
+/obj/item/weapon/flora/random,
+/obj/machinery/light/smart{
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/station/rnd/hallway/lobby)
 "non" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -61698,15 +61768,6 @@
 	icon_state = "green"
 	},
 /area/station/engineering/atmos)
-"npp" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-B";
-	location = "S-MB"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/secondary/entry)
 "npv" = (
 /obj/structure/table/glass,
 /obj/item/weapon/folder/white,
@@ -61775,6 +61836,17 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/atmos)
+"npO" = (
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "npW" = (
 /obj/machinery/gateway,
 /obj/effect/decal/turf_decal/alpha/gray{
@@ -61873,6 +61945,15 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/break_room)
+"nqC" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_right"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/cold_room)
 "nqD" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -62047,16 +62128,6 @@
 /obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor/wood,
 /area/station/storage/tools)
-"nsw" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NEE-FC";
-	location = "S-SV"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "nsz" = (
 /turf/environment/space,
 /area/station/cargo/miningoffice)
@@ -62135,6 +62206,17 @@
 /obj/item/weapon/folder/white,
 /turf/simulated/floor/carpet,
 /area/station/bridge/meeting_room)
+"ntx" = (
+/obj/machinery/light/smart,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DS";
+	location = "DN-W"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "purplecorner"
+	},
+/area/station/hallway/primary/central)
 "ntM" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -64140,19 +64222,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/main)
-"nRd" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_corner"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "arrows_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "black"
-	},
-/area/station/hallway/secondary/entry)
 "nRf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
@@ -64271,7 +64340,7 @@
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "box_corners_white";
-	dir = 4
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -64957,6 +65026,13 @@
 	icon_state = "darkred"
 	},
 /area/station/security/execution)
+"nZw" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=N-MB";
+	location = "NNW-B"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "nZA" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/directions/science{
@@ -65936,6 +66012,15 @@
 /obj/item/device/violin,
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"olJ" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "olO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
@@ -66096,19 +66181,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
-"ooE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "ooG" = (
 /obj/effect/decal/turf_decal{
 	dir = 5;
@@ -66491,6 +66563,17 @@
 	icon_state = "black"
 	},
 /area/station/civilian/chapel)
+"otD" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "otI" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -66903,14 +66986,6 @@
 	},
 /turf/simulated/wall,
 /area/station/civilian/kitchen)
-"oAd" = (
-/obj/machinery/atm{
-	pixel_y = -28
-	},
-/turf/simulated/floor{
-	icon_state = "redyellowfull"
-	},
-/area/station/hallway/primary/fore)
 "oAi" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 4
@@ -67252,19 +67327,6 @@
 	icon_state = "purple"
 	},
 /area/station/rnd/xenobiology)
-"oEm" = (
-/obj/machinery/light/smart{
-	dir = 4
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NE-FC";
-	location = "NEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "oEo" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
@@ -67386,17 +67448,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
-"oFB" = (
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
 "oFJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -67924,6 +67975,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/hallway)
+"oLC" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-FC";
+	location = "SSW-FC"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/starboard)
 "oLD" = (
 /obj/machinery/meter,
 /obj/structure/cable{
@@ -68235,7 +68293,7 @@
 	icon_state = "bot"
 	},
 /turf/simulated/floor{
-	dir = 5;
+	dir = 4;
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
@@ -68993,7 +69051,8 @@
 /obj/structure/table/glass,
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/clothing/mask/muzzle,
-/obj/machinery/vending/wallmed2{
+/obj/machinery/vending/wallmed1{
+	name = "Emergency NanoMed";
 	pixel_y = 28
 	},
 /turf/simulated/floor{
@@ -69301,6 +69360,13 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/chapel)
+"pbU" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=CS-AR";
+	location = "SWW-FC"
+	},
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "pbV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/stool/bed/chair/office/dark,
@@ -69662,12 +69728,6 @@
 	icon_state = "darkred"
 	},
 /area/station/security/checkpoint/escape)
-"pge" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "cafeteria"
-	},
-/area/station/security/prison)
 "pgo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/command{
@@ -70582,15 +70642,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/aisat/antechamber_interior)
-"ppT" = (
-/obj/item/weapon/flora/random,
-/obj/machinery/light/smart{
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "white"
-	},
-/area/station/rnd/hallway/lobby)
 "pqf" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/camera{
@@ -71266,24 +71317,6 @@
 /obj/item/device/flashlight/lamp,
 /turf/simulated/floor/carpet/red,
 /area/station/civilian/dormitories/service_bedrooms)
-"pyg" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkred"
-	},
-/area/station/security/brig)
-"pyi" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/turf/simulated/floor{
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "pyk" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -71632,25 +71665,14 @@
 	},
 /area/station/engineering/atmos)
 "pBf" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn_corner"
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "redcorner"
+	icon_state = "vaultfull"
 	},
-/area/station/security/prison)
+/area/station/security/blueshield)
 "pBn" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -72432,6 +72454,26 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/main)
+"pKG" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "pKL" = (
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
@@ -73799,13 +73841,6 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/engineering/atmos)
-"qaX" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "qaY" = (
 /obj/item/stack/rods{
 	amount = 23
@@ -74022,6 +74057,18 @@
 /obj/item/clothing/glasses/sunglasses,
 /turf/simulated/floor/carpet/red,
 /area/station/security/vacantoffice)
+"qco" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "qcD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -74215,16 +74262,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
-"qfa" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "black"
-	},
-/area/station/hallway/secondary/entry)
 "qfb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/requests_console/eva{
@@ -74323,11 +74360,11 @@
 	req_one_access = list(13)
 	},
 /obj/effect/decal/turf_decal{
-	dir = 1;
+	dir = 2;
 	icon_state = "warn"
 	},
 /obj/effect/decal/turf_decal{
-	dir = 2;
+	dir = 1;
 	icon_state = "warn"
 	},
 /turf/simulated/floor/plating,
@@ -74896,16 +74933,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/storage/tech)
-"qmz" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-B";
-	location = "SSW-B"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "qmP" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -75307,17 +75334,6 @@
 	},
 /turf/environment/space,
 /area/shuttle/escape_pod6/station)
-"qrJ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "qrL" = (
 /obj/effect/decal/turf_decal{
 	dir = 1;
@@ -75722,14 +75738,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/misc_lab)
-"qvl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/security/prison)
 "qvQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -75785,6 +75793,16 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/misc_lab)
+"qwQ" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSE-FC";
+	location = "SEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "qxf" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -76145,6 +76163,15 @@
 	icon_state = "wooden-2"
 	},
 /area/station/civilian/gym)
+"qCu" = (
+/obj/structure/closet/emcloset,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "qCA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -76153,16 +76180,6 @@
 	icon_state = "redchecker"
 	},
 /area/station/hallway/primary/fore)
-"qCB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "qCK" = (
 /obj/structure/closet/lasertag/red,
 /turf/simulated/floor{
@@ -76256,18 +76273,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet/black,
 /area/station/civilian/chapel/office)
-"qDx" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "qDB" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -77061,6 +77066,17 @@
 	icon_state = "red"
 	},
 /area/station/security/brig/equipment)
+"qMd" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos/atmos_office)
 "qMt" = (
 /obj/structure/morgue,
 /obj/structure/extinguisher_cabinet{
@@ -77924,18 +77940,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/chapel)
-"qWB" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "qWH" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -78361,16 +78365,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
-"rbT" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NNW-B";
-	location = "NW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "rbU" = (
 /obj/item/weapon/rack_parts,
 /turf/simulated/floor/plating,
@@ -79286,6 +79280,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison)
+"rod" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 5
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "rot" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -79883,6 +79886,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
+"rvn" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_left"
+	},
+/turf/simulated/floor,
+/area/station/storage/tech)
 "rvt" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -80260,6 +80270,13 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/reception)
+"ryB" = (
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/prison)
 "ryD" = (
 /obj/structure/object_wall/pod{
 	dir = 4;
@@ -81627,6 +81644,15 @@
 	},
 /turf/environment/space,
 /area/shuttle/supply/station)
+"rLR" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Security";
+	location = "S-C"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "rLY" = (
 /obj/machinery/power/terminal{
 	dir = 8
@@ -82264,6 +82290,15 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
+"rUa" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DN";
+	location = "SSE-FC"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "rUh" = (
 /obj/machinery/alarm{
 	pixel_x = 29;
@@ -82972,6 +83007,18 @@
 	icon_state = "vaultfull"
 	},
 /area/station/engineering/chiefs_office)
+"scZ" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/engineering/atmos/atmos_office)
 "sda" = (
 /obj/structure/stool/bar,
 /turf/simulated/floor/wood,
@@ -83035,6 +83082,16 @@
 	icon_state = "neutral"
 	},
 /area/station/maintenance/medbay)
+"sej" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Central Access"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "seo" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
@@ -83172,16 +83229,6 @@
 "sfm" = (
 /turf/simulated/wall,
 /area/station/maintenance/chapel)
-"sfo" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-C";
-	location = "CS-AR"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "sfr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -83250,15 +83297,6 @@
 	},
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
-"sgd" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 29
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "blackcorner"
-	},
-/area/station/hallway/primary/starboard)
 "sgg" = (
 /obj/effect/landmark/start/quartermaster,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -83300,15 +83338,6 @@
 	icon_state = "neutral"
 	},
 /area/station/hallway/primary/fore)
-"sgN" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_left"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/civilian/cold_room)
 "sgR" = (
 /obj/machinery/camera{
 	c_tag = "Escape Shuttle Hallway North"
@@ -84449,6 +84478,20 @@
 /obj/structure/cable,
 /turf/simulated/floor/plating,
 /area/station/security/brig)
+"sty" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_corner";
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "arrows_white";
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/hallway/secondary/entry)
 "stz" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -84916,13 +84959,6 @@
 	icon_state = "gcircuit"
 	},
 /area/station/maintenance/science)
-"szM" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-MB";
-	location = "N-MB"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "szQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -86818,15 +86854,6 @@
 	icon_state = "dark"
 	},
 /area/station/maintenance/engineering)
-"sXf" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DN";
-	location = "SSE-FC"
-	},
-/turf/simulated/floor{
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "sXj" = (
 /obj/machinery/firealarm{
 	pixel_y = 22
@@ -87219,12 +87246,16 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "tci" = (
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
+/obj/structure/stool/bed/chair/metal/black{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
-/area/station/security/prison)
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "tcq" = (
 /obj/structure/sign/nanotrasen{
 	pixel_y = -32
@@ -87336,17 +87367,6 @@
 	icon_state = "red"
 	},
 /area/station/security/brig/equipment)
-"tdG" = (
-/obj/machinery/light/smart,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DS";
-	location = "DN-W"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "purplecorner"
-	},
-/area/station/hallway/primary/central)
 "tdH" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass{
@@ -88369,6 +88389,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/prison)
+"tqN" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "tqX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/stool/bed/chair{
@@ -88638,16 +88667,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/engineering/minisat_secure_area)
-"tuI" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-FC";
-	location = "DS"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "bluecorner"
-	},
-/area/station/hallway/primary/central)
 "tvg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -89124,6 +89143,14 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/library)
+"tAe" = (
+/obj/machinery/atm{
+	pixel_y = -28
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "tAg" = (
 /obj/effect/landmark/start/clown,
 /obj/structure/stool,
@@ -89895,6 +89922,14 @@
 "tJr" = (
 /turf/simulated/wall/r_wall,
 /area/station/rnd/server)
+"tJB" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/civilian/gym)
 "tJH" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -90659,15 +90694,6 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/chapel/office)
-"tUa" = (
-/obj/item/weapon/flora/random,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "tUg" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
@@ -90945,15 +90971,6 @@
 	temperature = 80
 	},
 /area/station/tcommsat/chamber)
-"tXf" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "tXl" = (
 /obj/structure/stool/bed/chair/comfy/brown,
 /obj/machinery/light/smart{
@@ -91375,17 +91392,17 @@
 	},
 /area/station/rnd/hallway)
 "ucx" = (
-/obj/machinery/door_timer/cell_3{
-	pixel_x = 32;
-	pixel_y = 0;
-	dir = 4;
-	id = "Cell 3 perma"
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 8;
-	icon_state = "redcorner"
+	icon_state = "neutralfull"
 	},
-/area/station/security/prison)
+/area/station/engineering/atmos)
 "ucF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -92946,7 +92963,6 @@
 	name = "Central Access"
 	},
 /turf/simulated/floor{
-	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/station/security/lobby)
@@ -93006,18 +93022,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/mine_sci_shuttle)
-"uuB" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/engineering/atmos/atmos_office)
 "uuG" = (
 /obj/structure/table,
 /obj/item/device/tagger/shop,
@@ -93051,6 +93055,12 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/escape)
+"uvh" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "browncorner"
+	},
+/area/station/cargo/storage)
 "uvm" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -93283,22 +93293,25 @@
 	icon_state = "grimy"
 	},
 /area/station/security/hos)
-"uyn" = (
-/obj/machinery/light/smart,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "uyt" = (
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "neutral"
 	},
 /area/station/hallway/primary/central)
+"uyu" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/pump,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "arrival"
+	},
+/area/station/hallway/primary/port)
 "uyI" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/decal/cleanable/dirt,
@@ -93886,26 +93899,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
-"uGH" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "uGN" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 1
@@ -93949,12 +93942,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "uHN" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=CS-AR";
-	location = "SWW-FC"
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 4
 	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "uHX" = (
 /turf/simulated/floor/wood,
 /area/station/maintenance/chapel)
@@ -94001,6 +93994,12 @@
 "uJi" = (
 /turf/simulated/wall,
 /area/station/rnd/chargebay)
+"uJw" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
+	},
+/turf/simulated/floor/carpet/red,
+/area/station/security/detectives_office)
 "uJK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/binary/valve,
@@ -94349,19 +94348,21 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "uNw" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Entry Shuttle Airlock";
+	req_one_access = list(13)
 	},
 /obj/effect/decal/turf_decal{
-	dir = 10;
+	dir = 2;
 	icon_state = "warn"
 	},
-/turf/simulated/floor{
-	icon_state = "dark"
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
 	},
-/area/station/security/brig)
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "uNx" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -94430,20 +94431,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/brig)
-"uOo" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "escape"
-	},
-/area/station/hallway/primary/port)
 "uOv" = (
 /obj/structure/window/thin/reinforced{
 	dir = 8
@@ -95147,6 +95134,18 @@
 	icon_state = "purple"
 	},
 /area/station/rnd/xenobiology)
+"uXj" = (
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Labor Camp Shuttle Airlock";
+	req_access = list(2)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
 "uXz" = (
 /obj/structure/closet/emcloset,
 /turf/simulated/floor{
@@ -96356,13 +96355,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
-"vmc" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "vme" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -99058,12 +99050,15 @@
 	},
 /area/station/bridge/teleporter)
 "vTX" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 4
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-B";
+	location = "SSW-B"
 	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "vUe" = (
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
@@ -100835,20 +100830,10 @@
 	icon_state = "neutralfull"
 	},
 /area/station/cargo/office)
-"wpj" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "loadingarea"
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "arrow"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "wpm" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
+	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/station/security/lobby)
@@ -102312,7 +102297,7 @@
 "wHb" = (
 /obj/structure/kitchenspike,
 /obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_right"
+	icon_state = "bot_left"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -102994,6 +102979,14 @@
 	icon_state = "white"
 	},
 /area/station/rnd/hallway)
+"wPX" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "wQz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
@@ -103275,18 +103268,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
-"wUy" = (
-/obj/structure/stool/bed/chair/metal/black{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "wUB" = (
 /obj/structure/rack,
 /obj/item/weapon/gun/plasma{
@@ -104723,16 +104704,6 @@
 	},
 /turf/environment/space,
 /area/shuttle/mining/station)
-"xmG" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSE-FC";
-	location = "SEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "xmJ" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -106547,6 +106518,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/break_room)
+"xEG" = (
+/obj/machinery/atm{
+	pixel_y = -28
+	},
+/turf/simulated/floor{
+	icon_state = "redyellowfull"
+	},
+/area/station/hallway/primary/fore)
 "xEL" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/light/small{
@@ -106865,6 +106844,20 @@
 	icon_state = "greenblue"
 	},
 /area/station/hallway/primary/fore)
+"xJt" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "escape"
+	},
+/area/station/hallway/primary/port)
 "xJv" = (
 /obj/effect/landmark{
 	name = "xeno_spawn";
@@ -107386,6 +107379,13 @@
 	icon_state = "darkredcorners"
 	},
 /area/station/security/checkpoint/escape)
+"xPL" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-MB";
+	location = "N-MB"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "xPO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/weapon/table_parts/wood,
@@ -107599,21 +107599,6 @@
 	icon_state = "dark"
 	},
 /area/station/security/warden)
-"xRA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
 "xRL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -109082,6 +109067,26 @@
 	icon_state = "dark"
 	},
 /area/station/bridge)
+"yjr" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "yjy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -118674,7 +118679,7 @@ eXX
 pGn
 fBB
 pGn
-bsC
+lKx
 pGn
 pGn
 oer
@@ -132029,7 +132034,7 @@ xFF
 xFG
 flb
 uDn
-asp
+htR
 ude
 ehA
 geB
@@ -132286,7 +132291,7 @@ qnQ
 hEd
 fDg
 owf
-asp
+htR
 hkb
 ehA
 fUz
@@ -132524,7 +132529,7 @@ bOJ
 oKV
 dup
 dup
-cFl
+nRV
 bOD
 cmG
 xqQ
@@ -132789,7 +132794,7 @@ oLJ
 kFc
 kFc
 cEO
-ihO
+gRl
 azQ
 pfp
 imT
@@ -133035,7 +133040,7 @@ qSk
 qdn
 naA
 kdJ
-nRV
+jBy
 xqQ
 fmh
 mNB
@@ -133043,8 +133048,8 @@ bfy
 cmG
 dup
 htY
-jws
-jws
+fOp
+fOp
 nwM
 tCz
 gRR
@@ -133299,7 +133304,7 @@ nLs
 bTE
 tUm
 oPF
-fNB
+cEM
 rSb
 umn
 svw
@@ -134063,17 +134068,17 @@ bsZ
 fZH
 cTK
 whA
+scZ
 iDO
-uuB
-uuB
-uuB
+iDO
+iDO
 xnu
 vCV
 lFG
 waB
 fMO
-qDx
-bYW
+ucx
+llL
 kHT
 vPk
 vPk
@@ -134322,7 +134327,7 @@ qcT
 mrP
 daq
 daq
-lZE
+qMd
 egG
 iEf
 hrT
@@ -134864,9 +134869,9 @@ hdV
 bhn
 evV
 oKM
-ltR
+qco
 wCx
-hOV
+fJq
 oDZ
 bau
 nkc
@@ -135121,9 +135126,9 @@ moL
 ojN
 enq
 bgZ
-goL
-tRh
 gCp
+tRh
+kar
 oyx
 mRP
 eZT
@@ -135877,7 +135882,7 @@ adw
 adw
 adw
 wjD
-ihJ
+cpA
 cgv
 owM
 ekM
@@ -136380,7 +136385,7 @@ jlK
 tEF
 tne
 cEZ
-ckT
+byD
 iGS
 ciX
 jau
@@ -136915,7 +136920,7 @@ qTx
 qTx
 lGc
 rjD
-pyi
+hum
 uSc
 uib
 uSc
@@ -137162,13 +137167,13 @@ tEF
 sHQ
 dpc
 sHQ
-uOo
+xJt
 blv
 sqb
 uck
 sqb
 hQQ
-epA
+uyu
 qTx
 bUU
 iky
@@ -137434,7 +137439,7 @@ doE
 doE
 doE
 lgU
-bPP
+mIh
 mhm
 doE
 mnD
@@ -137932,7 +137937,7 @@ wwi
 aYN
 wwi
 lfm
-xmG
+qwQ
 tZn
 oyb
 nAM
@@ -137950,7 +137955,7 @@ oyb
 bzt
 bzt
 rcq
-sXf
+rUa
 tYK
 wtC
 wtC
@@ -138966,7 +138971,7 @@ xNR
 rMP
 nAi
 vfr
-iDw
+rvn
 rDd
 jcO
 iNE
@@ -139480,7 +139485,7 @@ xNR
 oYv
 cGN
 vzT
-niI
+iDw
 oVN
 cdA
 jTf
@@ -139723,7 +139728,7 @@ tRk
 vdt
 rwG
 srt
-wHb
+nqC
 dOS
 rfL
 qsE
@@ -139980,7 +139985,7 @@ aSY
 uum
 lVS
 srt
-sgN
+wHb
 uos
 gTB
 kst
@@ -140183,14 +140188,14 @@ kHU
 kHU
 kHU
 yaE
-fOp
+hGn
 yaE
 kHU
 plf
 plf
 kHU
 yaE
-fOp
+hGn
 yaE
 kHU
 kHU
@@ -140697,14 +140702,14 @@ yaE
 ffS
 aev
 yaE
-qgt
+cLH
 yaE
 aqg
 aqg
 aqg
 mlH
 yaE
-qgt
+cLH
 yaE
 eeB
 ffS
@@ -140751,7 +140756,7 @@ kBq
 biv
 pED
 bNa
-cij
+idg
 kIU
 lBN
 yeY
@@ -141008,7 +141013,7 @@ dtM
 fty
 abG
 vLv
-cij
+idg
 kIU
 jVV
 ekm
@@ -141725,7 +141730,7 @@ yaE
 ffS
 eeB
 yaE
-qgt
+cLH
 yaE
 mlH
 nhe
@@ -142084,7 +142089,7 @@ oZa
 xyx
 dJC
 gjY
-ppT
+nol
 kdp
 xfI
 eIi
@@ -142239,7 +142244,7 @@ kHU
 kHU
 kHU
 yaE
-fOp
+hGn
 yaE
 kHU
 plf
@@ -142776,11 +142781,11 @@ dbB
 idn
 fRR
 ofi
-tUa
+mvz
 miI
 ffS
 jjY
-efn
+qCu
 wwi
 pkS
 wwi
@@ -143329,7 +143334,7 @@ iSv
 xXt
 vAu
 ogP
-qmz
+vTX
 bAS
 nvi
 rnH
@@ -143345,7 +143350,7 @@ qbj
 qbj
 tmk
 ldb
-mIq
+cSk
 ogP
 iSi
 amv
@@ -143372,7 +143377,7 @@ vpT
 xei
 bFh
 vpT
-tdG
+ntx
 vIl
 olx
 frM
@@ -143540,7 +143545,7 @@ plf
 brw
 mko
 jsL
-npp
+mPj
 ffX
 hbE
 sTt
@@ -143809,7 +143814,7 @@ gHT
 alc
 vDr
 fDL
-rbT
+mbB
 iwy
 xXt
 gNR
@@ -144315,8 +144320,8 @@ fYS
 slo
 ffS
 pLB
-tUa
-iOd
+mvz
+kub
 acf
 dDs
 aSq
@@ -144590,17 +144595,17 @@ hXb
 hXb
 hXb
 che
-brm
-ejv
-brm
-brm
-brm
-brm
-brm
-brm
-brm
-xRA
-brm
+cGU
+kyE
+cGU
+cGU
+cGU
+cGU
+cGU
+cGU
+cGU
+jdZ
+cGU
 vos
 did
 did
@@ -144809,7 +144814,7 @@ kHU
 kHU
 kHU
 yaE
-hGn
+uNw
 yaE
 kHU
 plf
@@ -144857,7 +144862,7 @@ fjB
 qSx
 dtr
 czE
-oAd
+xEG
 tJq
 gIl
 rdY
@@ -145094,7 +145099,7 @@ kHU
 yaE
 hkD
 fYS
-hae
+bdl
 wts
 mge
 qed
@@ -145323,7 +145328,7 @@ yaE
 ffS
 aev
 yaE
-kjh
+qgt
 yaE
 ygh
 cPq
@@ -145374,13 +145379,13 @@ mpN
 uQg
 tJq
 oFm
-vTX
+uHN
 xsb
-vTX
-vTX
-vTX
+uHN
+uHN
+uHN
 mtf
-vTX
+uHN
 jpq
 bsc
 mfI
@@ -145608,7 +145613,7 @@ plf
 yaE
 vDr
 fYS
-ahM
+eUX
 tEo
 nIB
 iEL
@@ -145865,7 +145870,7 @@ kHU
 yaE
 csG
 fYS
-uyn
+mdR
 wts
 npC
 txi
@@ -145888,13 +145893,13 @@ cCx
 mES
 tJq
 ikZ
-mGP
+nmY
 oki
-vmc
-vmc
-kXK
+kKa
+kKa
+axC
 tWH
-kXK
+axC
 qcF
 bRX
 qSi
@@ -146122,7 +146127,7 @@ kHU
 yaE
 csG
 fYS
-dbV
+tAe
 wts
 bCJ
 euO
@@ -146145,7 +146150,7 @@ tJq
 ucP
 tJq
 fSC
-ooE
+cij
 ktM
 uuo
 djH
@@ -146351,14 +146356,14 @@ yaE
 ffS
 eeB
 yaE
-kjh
+qgt
 yaE
 mlH
 iOK
 iOK
 iOK
 yaE
-kjh
+qgt
 yaE
 aev
 ffS
@@ -146628,10 +146633,10 @@ fYS
 jNI
 ffS
 ylK
-wUy
+cNS
 cmX
 fRR
-cZu
+tci
 ryG
 ffS
 uAC
@@ -146865,14 +146870,14 @@ xjr
 xjr
 kHU
 dhU
-hGn
+uNw
 yaE
 kHU
 plf
 plf
 kHU
 yaE
-hGn
+uNw
 yaE
 plf
 plf
@@ -147653,7 +147658,7 @@ yaE
 yaE
 csG
 fYS
-szM
+xPL
 alc
 gHT
 gHT
@@ -147662,7 +147667,7 @@ gHT
 gHT
 gHT
 alc
-gUk
+nZw
 fYS
 sEX
 srs
@@ -147912,12 +147917,12 @@ lrr
 fYS
 wtr
 sDu
-nRd
-qfa
-qfa
-qfa
-qfa
-lqh
+kgH
+hCk
+hCk
+hCk
+hCk
+sty
 xao
 csG
 fYS
@@ -148921,14 +148926,14 @@ xjr
 xjr
 kHU
 dhU
-hGn
+uNw
 yaE
 kHU
 plf
 plf
 kHU
 yaE
-hGn
+uNw
 yaE
 plf
 plf
@@ -149178,14 +149183,14 @@ xjr
 xjr
 plf
 yaE
-oFB
+npO
 yaE
 yaE
 yaE
 yaE
 yaE
 yaE
-oFB
+npO
 yaE
 plf
 plf
@@ -149435,14 +149440,14 @@ yaE
 ffS
 aev
 yaE
-kjh
+qgt
 yaE
 aqg
 aqg
 aqg
 mlH
 yaE
-kjh
+qgt
 yaE
 eeB
 ffS
@@ -151121,7 +151126,7 @@ sbN
 uKh
 sHC
 npd
-sgd
+isL
 xQo
 mUL
 rmY
@@ -152597,7 +152602,7 @@ mXl
 mXl
 mXl
 wLD
-nsw
+fzc
 iwm
 mXl
 pRS
@@ -152615,7 +152620,7 @@ oNU
 mXl
 uxx
 xMc
-lQq
+kAT
 nvi
 rnH
 cLM
@@ -152624,7 +152629,7 @@ nvi
 tOH
 mfI
 ogP
-tuI
+dRw
 sBG
 wjc
 wjc
@@ -152927,7 +152932,7 @@ xQo
 xQo
 xQo
 nKU
-cWB
+oLC
 xQo
 oPI
 mRu
@@ -153094,7 +153099,7 @@ cpR
 gtK
 cpR
 pxL
-oEm
+irH
 ffJ
 ape
 fZz
@@ -153113,7 +153118,7 @@ hRd
 ckx
 fZz
 lMB
-cyL
+rLR
 kzb
 vAu
 psV
@@ -153127,7 +153132,7 @@ vAu
 kRo
 vAu
 kCI
-sfo
+fXH
 ogP
 lwr
 mLS
@@ -153368,9 +153373,9 @@ erD
 erD
 cmN
 act
-uuf
+sej
 xsY
-eKx
+uuf
 jTW
 jTW
 jTW
@@ -153850,7 +153855,7 @@ fnT
 miA
 ojm
 lPc
-dus
+uvh
 gaF
 rpV
 qSe
@@ -154107,11 +154112,11 @@ nkb
 adb
 hzP
 cpR
+iNX
 oOk
-eLE
 uXI
-eLE
-hLt
+oOk
+gqY
 xqF
 aAF
 iqI
@@ -157218,8 +157223,8 @@ plf
 xyC
 cFp
 klH
-kjV
-kjV
+uJw
+uJw
 hGr
 aRu
 xyC
@@ -157722,11 +157727,11 @@ plf
 plf
 plf
 uRO
-cXM
+hwE
 uRO
 plf
 uRO
-cXM
+hwE
 uRO
 plf
 xyC
@@ -157743,8 +157748,8 @@ dnn
 aEr
 wPw
 jQy
-giQ
-kFv
+pBf
+fNv
 jcX
 fJg
 nPU
@@ -158236,11 +158241,11 @@ plf
 cHH
 cHH
 jxX
-hwE
+uXj
 bjt
 stv
 jxX
-hwE
+uXj
 jxX
 adp
 kMq
@@ -158251,9 +158256,9 @@ xyC
 xyC
 xyC
 xyC
-qaX
-jtG
 wpm
+jtG
+cjO
 fJg
 fJg
 fJg
@@ -158493,7 +158498,7 @@ wVt
 cHH
 cjS
 bNB
-uNw
+gBu
 kms
 cHH
 eow
@@ -158750,7 +158755,7 @@ leA
 cHH
 adG
 iGB
-pyg
+ixt
 tTk
 qMX
 aZz
@@ -159011,7 +159016,7 @@ ikW
 qXE
 rjb
 utF
-wpj
+dvu
 uLd
 lat
 nsn
@@ -159810,7 +159815,7 @@ kIM
 vst
 mDV
 vKG
-uHN
+pbU
 xoq
 tAM
 uQA
@@ -160529,14 +160534,14 @@ fAF
 fgx
 diq
 fAF
-ucx
+ejv
 eTq
 fAF
 wNM
 oPD
 tif
 rHZ
-uGH
+gPn
 czU
 tqK
 hsq
@@ -160793,7 +160798,7 @@ qZx
 qZx
 fXG
 qZx
-mNa
+pKG
 czU
 uvV
 kMw
@@ -161305,7 +161310,7 @@ fBm
 bvC
 hlv
 vqQ
-hwB
+hLM
 qZx
 tnw
 fLE
@@ -162323,7 +162328,7 @@ aXC
 bZu
 pLw
 unD
-qvl
+fXu
 oAx
 ulK
 eyO
@@ -162877,7 +162882,7 @@ sxG
 uOc
 hur
 hur
-cyq
+lYy
 ekd
 lZw
 gqC
@@ -163131,7 +163136,7 @@ ixl
 mme
 uKd
 gRX
-kZk
+aJZ
 sRa
 nUj
 wUB
@@ -163160,13 +163165,13 @@ ncp
 ncp
 hbR
 mWz
-qWB
+alW
 kLd
 syX
 tHk
 tHk
 dbf
-nmW
+jXm
 ram
 mWz
 lNQ
@@ -163630,7 +163635,7 @@ afw
 nDf
 mZo
 qUR
-hDt
+bEi
 mzV
 aSh
 mpR
@@ -163931,13 +163936,13 @@ ncp
 ncp
 hbR
 mWz
-cTS
+otD
 sIY
 qls
 uOM
 uOM
 aeG
-mqg
+fCx
 ram
 mWz
 hPr
@@ -164127,7 +164132,7 @@ lhK
 wVg
 aFN
 jKZ
-pge
+joo
 rBo
 hlv
 qxh
@@ -164391,7 +164396,7 @@ xIO
 jps
 xIO
 qZx
-pBf
+yjr
 tbS
 sZR
 kHU
@@ -164403,7 +164408,7 @@ fwH
 qoH
 vOW
 qoH
-fqW
+wPX
 umQ
 gYp
 kHU
@@ -164641,7 +164646,7 @@ jvm
 hlv
 fVW
 fPH
-pge
+joo
 rnI
 hlv
 pHz
@@ -164656,11 +164661,11 @@ kHU
 plf
 cYc
 ueE
-qCB
+kjq
 wcJ
 iRz
 nez
-qrJ
+gZZ
 hlh
 gYp
 plf
@@ -164913,11 +164918,11 @@ kHU
 kHU
 cYc
 nfj
-jzh
+olJ
 eaE
 nRk
 rZh
-alx
+bOE
 hmN
 gYp
 kHU
@@ -164961,7 +164966,7 @@ dJL
 nRG
 oXA
 oXA
-cpv
+tJB
 dJL
 plf
 cdR
@@ -165170,11 +165175,11 @@ plf
 kHU
 huz
 sIx
-kgH
-tXf
+rod
+kIh
 kjv
-tXf
-eTb
+kIh
+tqN
 tEU
 huz
 plf
@@ -167219,7 +167224,7 @@ plf
 kHU
 hlv
 lrm
-tci
+ryB
 jno
 hlv
 cBu
@@ -168299,7 +168304,7 @@ kHU
 fMh
 plf
 dJL
-cpv
+tJB
 oXA
 oXA
 nJn

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -1274,6 +1274,16 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/misc_lab)
+"ahM" = (
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "ahQ" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/snacks/pie,
@@ -1658,6 +1668,15 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/bridge/hop_office)
+"alx" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "alz" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -2077,23 +2096,6 @@
 /obj/random/tools/tool,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
-"apc" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Entry Shuttle Airlock";
-	req_one_access = list(13)
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
 "ape" = (
 /obj/machinery/door/firedoor,
 /obj/structure/sign/directions/security{
@@ -2406,6 +2408,14 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/tox_launch)
+"asp" = (
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/break_room)
 "asq" = (
 /obj/structure/object_wall/pod{
 	dir = 4;
@@ -3300,26 +3310,6 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/minisat_secure_area)
-"aDK" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "aDL" = (
 /obj/item/weapon/caution,
 /turf/simulated/floor/plating,
@@ -5028,16 +5018,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
-"aXu" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SEE-FC";
-	location = "SE-FC"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "aXC" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/decal/cleanable/cobweb,
@@ -5496,6 +5476,9 @@
 /obj/item/weapon/pen/red,
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 28
 	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -6004,15 +5987,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/maintenance/science)
-"bhs" = (
-/obj/structure/closet/emcloset,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "bhv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor/carpet/blue2,
@@ -6914,6 +6888,15 @@
 	},
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
+"brm" = (
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "brv" = (
 /obj/machinery/optable,
 /obj/machinery/requests_console/forensic{
@@ -7015,6 +6998,27 @@
 	icon_state = "caution"
 	},
 /area/station/engineering/break_room)
+"bsC" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "MiniSat Antechamber";
+	req_one_access = list(66)
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/aisat/teleport)
 "bsD" = (
 /turf/simulated/floor{
 	icon_state = "cafeteria"
@@ -7880,18 +7884,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/security/lobby)
-"bBp" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "bBu" = (
 /obj/structure/table/woodentable,
 /obj/item/device/taperecorder,
@@ -8358,13 +8350,6 @@
 /obj/structure/stool/bed/chair/metal/white{
 	dir = 1
 	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
 /obj/effect/decal/turf_decal/alpha/white{
 	icon_state = "siding_line";
 	dir = 1
@@ -8767,13 +8752,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/starboard)
-"bJm" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-MB";
-	location = "N-MB"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "bJr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9228,15 +9206,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/science)
-"bOv" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 5
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "bOy" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/turretid/stun/AI_special{
@@ -9330,6 +9299,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
+"bPP" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SEE-FC";
+	location = "SE-FC"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "bPT" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -9397,13 +9376,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/engineering/chiefs_office)
-"bQA" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=CS-AR";
-	location = "SWW-FC"
-	},
-/turf/simulated/floor,
-/area/station/civilian/locker)
 "bQI" = (
 /obj/machinery/hydroponics/constructable,
 /turf/simulated/floor,
@@ -9485,17 +9457,6 @@
 	icon_state = "dark"
 	},
 /area/station/medical/virology)
-"bRn" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "yellow"
-	},
-/area/station/engineering/atmos)
 "bRy" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -10203,6 +10164,18 @@
 	icon_state = "vaultfull"
 	},
 /area/station/hallway/primary/fore)
+"bYW" = (
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "bYY" = (
 /turf/simulated/floor{
 	icon_state = "grimy"
@@ -11046,6 +11019,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
+"cij" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 5;
+	icon_state = "cafeteria"
+	},
+/area/station/civilian/kitchen)
 "cin" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -11308,6 +11291,23 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"ckT" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "caution"
+	},
+/area/station/engineering/atmos/distribution)
 "clc" = (
 /obj/machinery/computer/mech_bay_power_console,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -11392,16 +11392,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/port)
-"clM" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=S-C";
-	location = "CS-AR"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "clN" = (
 /obj/structure/table,
 /obj/item/device/tagger/shop,
@@ -11713,6 +11703,14 @@
 	icon_state = "vaultfull"
 	},
 /area/station/rnd/xenobiology)
+"cpv" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/civilian/gym)
 "cpy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on/atmos{
 	dir = 4;
@@ -11722,15 +11720,6 @@
 	},
 /turf/simulated/floor/engine/airmix,
 /area/station/engineering/atmos)
-"cpB" = (
-/obj/effect/decal/turf_decal{
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "cpL" = (
 /obj/machinery/light/smart{
 	dir = 4
@@ -12107,18 +12096,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/engi)
-"cvM" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "cvO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -12374,6 +12351,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/qm)
+"cyq" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "cyt" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -12446,6 +12436,15 @@
 	icon_state = "caution"
 	},
 /area/station/medical/chemistry)
+"cyL" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=Security";
+	location = "S-C"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "cyQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -13047,6 +13046,19 @@
 	icon_state = "vaultfull"
 	},
 /area/station/aisat/antechamber_interior)
+"cFl" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "cFp" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/light/smart{
@@ -13334,14 +13346,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
-"cIf" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/civilian/gym)
 "cIm" = (
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Antechamber";
@@ -13712,12 +13716,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
-"cMP" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "cafeteria"
-	},
-/area/station/security/prison)
 "cMW" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -14006,13 +14004,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/hallway/primary/fore)
-"cPJ" = (
-/obj/machinery/door/firedoor,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "cPN" = (
 /obj/structure/table/woodentable/fancy,
 /obj/effect/decal/turf_decal/metal{
@@ -14423,6 +14414,17 @@
 	icon_state = "red"
 	},
 /area/station/security/prison)
+"cTS" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "cUf" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -14626,6 +14628,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/incinerator)
+"cWB" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-FC";
+	location = "SSW-FC"
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/starboard)
 "cWE" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/visuals/surgery/full,
@@ -14665,19 +14674,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/civilian/locker)
-"cWX" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_corner"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "arrows_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "black"
-	},
-/area/station/hallway/secondary/entry)
 "cXg" = (
 /obj/structure/table/woodentable,
 /obj/item/device/flashlight/lamp{
@@ -14694,6 +14690,18 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"cXM" = (
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Labor Camp Shuttle Airlock";
+	req_access = list(2)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
 "cXP" = (
 /obj/machinery/vending/chinese,
 /turf/simulated/floor{
@@ -14775,6 +14783,17 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/miningoffice)
+"cZu" = (
+/obj/structure/stool/bed/chair/metal/black{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "cZC" = (
 /obj/machinery/shieldwallgen,
 /turf/simulated/floor,
@@ -14921,6 +14940,14 @@
 /obj/item/weapon/storage/toolbox/electrical,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"dbV" = (
+/obj/machinery/atm{
+	pixel_y = -28
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "dcn" = (
 /obj/structure/cable,
 /obj/machinery/power/apc{
@@ -16607,6 +16634,12 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
+"dus" = (
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "browncorner"
+	},
+/area/station/cargo/storage)
 "duu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -16932,6 +16965,11 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
+/obj/machinery/status_display{
+	layer = 3.3;
+	pixel_x = -32;
+	supply_display = 1
+	},
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "brown"
@@ -17215,7 +17253,7 @@
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "box_corners_white";
-	dir = 1
+	dir = 8
 	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -17346,19 +17384,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/space)
-"dED" = (
-/obj/machinery/light/smart{
-	dir = 4
-	},
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NE-FC";
-	location = "NEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "dEP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -18097,17 +18122,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/bridge)
-"dOQ" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "dOS" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -19550,6 +19564,15 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor,
 /area/station/maintenance/incinerator)
+"efn" = (
+/obj/structure/closet/emcloset,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "efo" = (
 /obj/machinery/computer/cargo{
 	dir = 4
@@ -19842,15 +19865,23 @@
 	},
 /area/station/hallway/primary/starboard)
 "ejv" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SE-FC";
-	location = "SW-B"
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
 	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
+	icon_state = "neutralfull"
 	},
-/area/station/hallway/primary/central)
+/area/station/hallway/primary/fore)
 "ejG" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 1
@@ -20433,6 +20464,19 @@
 	icon_state = "redcorner"
 	},
 /area/station/security/prison)
+"epA" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/pump,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "arrival"
+	},
+/area/station/hallway/primary/port)
 "eqn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
@@ -22098,6 +22142,15 @@
 	icon_state = "dark"
 	},
 /area/station/security/armoury)
+"eKx" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass{
+	name = "Central Access"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "eKz" = (
 /obj/machinery/firealarm{
 	dir = 4;
@@ -22208,6 +22261,16 @@
 	icon_state = "dark"
 	},
 /area/station/cargo/recycleroffice)
+"eLE" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "eLM" = (
 /mob/living/carbon/monkey{
 	name = "Stanley"
@@ -22474,15 +22537,6 @@
 	icon_state = "caution"
 	},
 /area/station/medical/chemistry)
-"eOm" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-B";
-	location = "S-MB"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/secondary/entry)
 "eOt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -22914,6 +22968,15 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
+"eTb" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "eTg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -24572,6 +24635,8 @@
 /area/station/rnd/telesci)
 "fmI" = (
 /obj/structure/table,
+/obj/item/weapon/folder,
+/obj/item/weapon/pen,
 /obj/item/device/paicard,
 /turf/simulated/floor{
 	icon_state = "white"
@@ -24848,6 +24913,14 @@
 	},
 /turf/simulated/wall/r_wall,
 /area/station/engineering/atmos)
+"fqW" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "frk" = (
 /obj/structure/transit_tube{
 	icon_state = "N-SE"
@@ -25139,17 +25212,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/engineering/minisat_secure_area)
-"ftt" = (
-/obj/machinery/light/smart,
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DS";
-	location = "DN-W"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "purplecorner"
-	},
-/area/station/hallway/primary/central)
 "fty" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -26827,11 +26889,6 @@
 	icon_state = "darkbrown"
 	},
 /area/station/medical/virology)
-"fNh" = (
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "fNA" = (
 /obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "box_corners_white";
@@ -26841,6 +26898,19 @@
 	icon_state = "dark"
 	},
 /area/station/medical/morgue)
+"fNB" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "fNC" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/folder/blue,
@@ -26862,14 +26932,21 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "fOp" = (
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Entry Shuttle Airlock";
+	req_one_access = list(13)
 	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
 	},
-/area/station/hallway/primary/fore)
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "fOF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
@@ -28530,6 +28607,15 @@
 	icon_state = "dark"
 	},
 /area/station/ai_monitored/storage_secure)
+"giQ" = (
+/obj/effect/decal/turf_decal/alpha/blue{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "giU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -28697,11 +28783,8 @@
 	},
 /area/station/civilian/dormitories/courtroom)
 "gjY" = (
-/obj/structure/table,
-/obj/item/weapon/folder,
-/obj/item/weapon/pen,
-/obj/machinery/light/smart{
-	dir = 8
+/obj/machinery/atm{
+	pixel_x = -28
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -29248,6 +29331,23 @@
 	icon_state = "dark"
 	},
 /area/station/security/brig)
+"goL" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "goT" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -30336,15 +30436,6 @@
 	icon_state = "dark"
 	},
 /area/station/aisat)
-"gzK" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "gzO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -30588,7 +30679,6 @@
 	icon_state = "delivery"
 	},
 /obj/effect/decal/turf_decal{
-	dir = 4;
 	icon_state = "warn_corner"
 	},
 /turf/simulated/floor{
@@ -30700,17 +30790,6 @@
 /obj/item/weapon/table_parts,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
-"gEQ" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "loadingarea"
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "arrow"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
 "gER" = (
 /obj/structure/closet/secure_closet/hop,
 /obj/item/device/cardpay{
@@ -31697,7 +31776,7 @@
 	dir = 4
 	},
 /obj/machinery/flasher{
-	id = "Cell 1 perma";
+	id = "Cell 3 perma";
 	pixel_y = -28
 	},
 /turf/simulated/floor,
@@ -32042,6 +32121,13 @@
 	icon_state = "bluefull"
 	},
 /area/station/hallway/primary/central)
+"gUk" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=N-MB";
+	location = "NNW-B"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "gUl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /turf/simulated/floor/engine,
@@ -32359,16 +32445,6 @@
 /obj/item/weapon/caution,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
-"gXt" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NEE-FC";
-	location = "S-SV"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "gXw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -32632,6 +32708,15 @@
 	icon_state = "darkred"
 	},
 /area/station/security/brig)
+"hae" = (
+/obj/effect/decal/turf_decal{
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "ham" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -34550,6 +34635,19 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"hwB" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/flasher{
+	id = "Cell 1 perma";
+	pixel_y = -28
+	},
+/turf/simulated/floor,
+/area/station/security/prison)
 "hwC" = (
 /obj/machinery/light/smart{
 	dir = 4
@@ -35220,18 +35318,6 @@
 	icon_state = "white"
 	},
 /area/station/medical/reception)
-"hBR" = (
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Labor Camp Shuttle Airlock";
-	req_access = list(2)
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/brig)
 "hBT" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
@@ -35360,6 +35446,25 @@
 	icon_state = "vaultfull"
 	},
 /area/station/hallway/primary/starboard)
+"hDt" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/main)
 "hDy" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -35596,11 +35701,11 @@
 	req_one_access = list(13)
 	},
 /obj/effect/decal/turf_decal{
-	dir = 1;
+	dir = 2;
 	icon_state = "warn"
 	},
 /obj/effect/decal/turf_decal{
-	dir = 2;
+	dir = 1;
 	icon_state = "warn"
 	},
 /turf/simulated/floor/plating,
@@ -35884,19 +35989,6 @@
 /obj/item/target,
 /turf/simulated/floor/plating/airless,
 /area/station/rnd/test_area)
-"hIV" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/powered/pump,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "arrival"
-	},
-/area/station/hallway/primary/port)
 "hJf" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
@@ -36062,6 +36154,16 @@
 	icon_state = "yellowpatch"
 	},
 /area/station/engineering/atmos/supermatter)
+"hLt" = (
+/obj/structure/closet/secure_closet/cargotech,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	dir = 6;
+	icon_state = "brown"
+	},
+/area/station/cargo/storage)
 "hLL" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -36322,6 +36424,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/medbay)
+"hOV" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "hPa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -36436,9 +36550,11 @@
 	},
 /area/station/security/checkpoint/escape_custom_desk)
 "hQj" = (
-/obj/item/weapon/flora/random,
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
+	},
+/obj/machinery/atm{
+	pixel_y = -28
 	},
 /turf/simulated/floor{
 	icon_state = "neutralfull"
@@ -36816,15 +36932,6 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/chapel/office)
-"hVd" = (
-/obj/effect/decal/turf_decal/alpha/blue{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/blueshield)
 "hVg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -38019,6 +38126,32 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/hor)
+"ihJ" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/engineering/monitoring)
+"ihO" = (
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "yellow"
+	},
+/area/station/engineering/atmos)
 "ihP" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -38477,24 +38610,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/mixing)
-"imA" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
 "imK" = (
 /turf/simulated/floor{
 	icon_state = "vaultfull"
@@ -39538,17 +39653,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/gateway)
-"izh" = (
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
 "izp" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -39870,16 +39974,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/aisat/teleport)
-"iDl" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SWW-FC";
-	location = "SW-FC"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "iDo" = (
 /obj/structure/stool/bed/chair/office/light{
 	dir = 8
@@ -40067,19 +40161,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/simulated/floor/wood,
 /area/station/maintenance/medbay)
-"iFk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "iFl" = (
 /turf/simulated/floor/engine/phoron,
 /area/station/engineering/atmos)
@@ -40920,6 +41001,18 @@
 	},
 /turf/simulated/floor/carpet/blue2,
 /area/station/civilian/dormitories)
+"iOd" = (
+/obj/structure/stool/bed/chair/metal/black{
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "iOl" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -42564,19 +42657,6 @@
 	icon_state = "white"
 	},
 /area/station/rnd/robotics)
-"jgM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 1
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "jgS" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -42713,19 +42793,6 @@
 /obj/item/weapon/packageWrap,
 /turf/simulated/floor/plating,
 /area/station/storage/tools)
-"jiJ" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/flasher{
-	id = "Cell 3 perma";
-	pixel_y = -28
-	},
-/turf/simulated/floor,
-/area/station/security/prison)
 "jiS" = (
 /obj/machinery/light/smart{
 	dir = 8
@@ -43965,6 +44032,16 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/mine_sci_shuttle)
+"jws" = (
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "jwD" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -44268,6 +44345,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
+"jzh" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "jzl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
@@ -44752,13 +44838,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/civilian/bar)
-"jFB" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-FC";
-	location = "SSW-FC"
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/starboard)
 "jFP" = (
 /obj/machinery/power/terminal{
 	dir = 1
@@ -47162,21 +47241,6 @@
 	icon_state = "gcircuit"
 	},
 /area/station/rnd/xenobiology)
-"kff" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/hallway/primary/fore)
 "kfj" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/computer/general_air_control/large_tank_control{
@@ -47395,7 +47459,8 @@
 /area/station/maintenance/cargo)
 "kgH" = (
 /obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
+	icon_state = "siding_line";
+	dir = 5
 	},
 /turf/simulated/floor{
 	icon_state = "grimy"
@@ -47611,6 +47676,23 @@
 	icon_state = "black"
 	},
 /area/station/civilian/gym)
+"kjh" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/external{
+	locked = 1;
+	name = "Entry Shuttle Airlock";
+	req_one_access = list(13)
+	},
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "kjv" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -47674,6 +47756,12 @@
 	icon_state = "grimy"
 	},
 /area/station/maintenance/medbay)
+"kjV" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "bot"
+	},
+/turf/simulated/floor/carpet/red,
+/area/station/security/detectives_office)
 "kjX" = (
 /obj/machinery/alarm{
 	pixel_y = 22
@@ -48728,18 +48816,6 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/library)
-"kww" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/engineering/atmos/atmos_office)
 "kwC" = (
 /obj/structure/morgue,
 /obj/effect/decal/turf_decal/alpha/gray{
@@ -48809,25 +48885,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/maintenance/cargo)
-"kxn" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/security/main)
 "kxp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
@@ -49475,19 +49532,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
-"kEG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 9
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "kEH" = (
 /obj/machinery/life_assist/artificial_ventilation,
 /turf/simulated/floor/plating,
@@ -49552,6 +49596,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/supermatter)
+"kFv" = (
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/security/blueshield)
 "kFI" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -50507,19 +50556,6 @@
 	icon_state = "grimy"
 	},
 /area/station/security/hos)
-"kOc" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "kOe" = (
 /obj/structure/grille,
 /obj/structure/sign/warning/securearea{
@@ -51080,18 +51116,6 @@
 	icon_state = "redyellowfull"
 	},
 /area/station/maintenance/cargo)
-"kVe" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "kVf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -51150,18 +51174,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
-/area/station/security/prison)
-"kVQ" = (
-/obj/machinery/door_timer/cell_3{
-	pixel_x = 32;
-	pixel_y = 0;
-	dir = 4;
-	id = "Cell 3 perma"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "redcorner"
-	},
 /area/station/security/prison)
 "kVV" = (
 /obj/structure/cable{
@@ -51395,6 +51407,19 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
+"kXK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "kXQ" = (
 /obj/structure/table/woodentable/fancy,
 /obj/machinery/door/window/northright{
@@ -51570,6 +51595,18 @@
 	icon_state = "neutralfull"
 	},
 /area/station/cargo/miningoffice)
+"kZk" = (
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/armoury)
 "kZp" = (
 /obj/structure/window/thin/reinforced{
 	dir = 1
@@ -52356,17 +52393,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
-"lku" = (
-/obj/structure/stool/bed/chair/metal/black{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "lkv" = (
 /obj/structure/stool/bed/chair{
 	dir = 1
@@ -52591,19 +52617,6 @@
 	icon_state = "darkred"
 	},
 /area/station/security/execution)
-"lmy" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "lmF" = (
 /obj/machinery/computer/crew{
 	dir = 8
@@ -52776,27 +52789,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/monitoring)
-"lpA" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/hatch{
-	name = "MiniSat Antechamber";
-	req_one_access = list(66)
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/aisat/teleport)
 "lpN" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -52843,6 +52835,20 @@
 	icon_state = "whitepurplefull"
 	},
 /area/station/rnd/misc_lab)
+"lqh" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_corner";
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "arrows_white";
+	dir = 8
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/hallway/secondary/entry)
 "lqr" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -53229,6 +53235,18 @@
 "ltP" = (
 /turf/simulated/floor/plating,
 /area/station/cargo/office)
+"ltR" = (
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/engineering/engine)
 "lud" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -53244,13 +53262,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
-"lum" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=N-MB";
-	location = "NNW-B"
-	},
-/turf/simulated/floor,
-/area/station/hallway/secondary/entry)
 "luA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -55000,21 +55011,6 @@
 /obj/item/stack/medical/bruise_pack,
 /turf/simulated/floor,
 /area/station/civilian/gym)
-"lNR" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 8
-	},
-/turf/simulated/floor,
-/area/station/engineering/monitoring)
 "lNS" = (
 /obj/machinery/power/apc{
 	name = "apc down";
@@ -55235,6 +55231,16 @@
 	icon_state = "neutralfull"
 	},
 /area/station/engineering/atmos)
+"lQq" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SWW-FC";
+	location = "SW-FC"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "lQz" = (
 /obj/machinery/door_control{
 	id = "teleporter_in_shutter";
@@ -55335,16 +55341,6 @@
 	},
 /turf/simulated/floor,
 /area/station/medical/storage)
-"lRJ" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 6;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "lRS" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -55441,23 +55437,6 @@
 /obj/item/weapon/paper_bin,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/escape)
-"lTk" = (
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "caution"
-	},
-/area/station/engineering/atmos/distribution)
 "lTn" = (
 /obj/structure/closet/crate/freezer,
 /obj/item/weapon/reagent_containers/food/drinks/bottle/beer,
@@ -55680,7 +55659,10 @@
 /area/station/engineering/atmos)
 "lWC" = (
 /obj/structure/stool,
-/obj/machinery/light/small,
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -32
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -55824,17 +55806,6 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
-"lXW" = (
-/obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_corner";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos/atmos_office)
 "lXY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -55916,6 +55887,17 @@
 "lZx" = (
 /turf/simulated/wall/r_wall,
 /area/station/tcommsat/computer)
+"lZE" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red,
+/obj/structure/disposalpipe/segment,
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_corner";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos/atmos_office)
 "lZT" = (
 /obj/machinery/status_display{
 	pixel_x = -32
@@ -56060,15 +56042,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/hallway/primary/central)
-"mbB" = (
-/obj/structure/kitchenspike,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_left"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/civilian/cold_room)
 "mbI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57325,6 +57298,26 @@
 /obj/structure/sign/warning/airlock,
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/escape)
+"mqg" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white"
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "mql" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -58846,6 +58839,19 @@
 	icon_state = "red"
 	},
 /area/station/security/brig/equipment)
+"mGP" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "mHj" = (
 /obj/machinery/computer/card,
 /turf/simulated/floor{
@@ -58875,6 +58881,16 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/library)
+"mIq" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SE-FC";
+	location = "SW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "mIw" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/simulated/wall,
@@ -59207,6 +59223,26 @@
 	icon_state = "white"
 	},
 /area/station/medical/sleeper)
+"mNa" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "mNo" = (
 /obj/machinery/vending/eva,
 /turf/simulated/floor{
@@ -59337,13 +59373,6 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/sleeper)
-"mOx" = (
-/obj/item/weapon/flora/random,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot_right"
-	},
-/turf/simulated/floor,
-/area/station/storage/tech)
 "mOU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -59430,18 +59459,6 @@
 	},
 /turf/simulated/floor,
 /area/station/bridge/teleporter)
-"mPY" = (
-/obj/structure/stool/bed/chair/metal/white,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/turf/simulated/floor,
-/area/station/civilian/gym)
 "mQa" = (
 /obj/structure/stool/bed/chair{
 	dir = 8
@@ -59874,19 +59891,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/qm)
-"mTD" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "mTN" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -59984,8 +59988,8 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/hop_office)
 "mUL" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
+/obj/machinery/atm{
+	pixel_y = -28
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -60726,13 +60730,6 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/library)
-"ndp" = (
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/security/prison)
 "nds" = (
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
 /obj/machinery/light/small{
@@ -61164,6 +61161,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"niI" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_right"
+	},
+/turf/simulated/floor,
+/area/station/storage/tech)
 "niP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -61457,6 +61461,27 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
+"nmW" = (
+/obj/structure/stool/bed/chair/metal/white{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "black"
+	},
+/area/station/civilian/gym)
 "nna" = (
 /obj/structure/cable{
 	d2 = 8;
@@ -61673,6 +61698,15 @@
 	icon_state = "green"
 	},
 /area/station/engineering/atmos)
+"npp" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-B";
+	location = "S-MB"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/secondary/entry)
 "npv" = (
 /obj/structure/table/glass,
 /obj/item/weapon/folder/white,
@@ -62013,6 +62047,16 @@
 /obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor/wood,
 /area/station/storage/tools)
+"nsw" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NEE-FC";
+	location = "S-SV"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "nsz" = (
 /turf/environment/space,
 /area/station/cargo/miningoffice)
@@ -62551,26 +62595,6 @@
 	icon_state = "whitepurple"
 	},
 /area/station/rnd/hallway)
-"nyX" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 4;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
 "nza" = (
 /obj/machinery/constructable_frame/machine_frame,
 /turf/simulated/floor,
@@ -63326,16 +63350,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
-"nHt" = (
-/obj/structure/closet/secure_closet/cargotech,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "bot"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "brown"
-	},
-/area/station/cargo/storage)
 "nHx" = (
 /turf/simulated/floor{
 	dir = 4;
@@ -64015,6 +64029,9 @@
 /area/station/hallway/secondary/entry)
 "nQr" = (
 /obj/machinery/light/smart,
+/obj/machinery/atm{
+	pixel_y = -28
+	},
 /turf/simulated/floor{
 	icon_state = "brown"
 	},
@@ -64123,6 +64140,19 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/main)
+"nRd" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_corner"
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "arrows_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/hallway/secondary/entry)
 "nRf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor{
@@ -65840,12 +65870,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
-"okz" = (
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "browncorner"
-	},
-/area/station/cargo/storage)
 "okM" = (
 /turf/environment/space,
 /area/shuttle/syndicate/northeast)
@@ -66072,6 +66096,19 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"ooE" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 1
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "ooG" = (
 /obj/effect/decal/turf_decal{
 	dir = 5;
@@ -66107,7 +66144,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/turf_decal{
-	dir = 10;
+	dir = 9;
 	icon_state = "warn"
 	},
 /turf/simulated/floor{
@@ -66866,6 +66903,14 @@
 	},
 /turf/simulated/wall,
 /area/station/civilian/kitchen)
+"oAd" = (
+/obj/machinery/atm{
+	pixel_y = -28
+	},
+/turf/simulated/floor{
+	icon_state = "redyellowfull"
+	},
+/area/station/hallway/primary/fore)
 "oAi" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 4
@@ -67207,6 +67252,19 @@
 	icon_state = "purple"
 	},
 /area/station/rnd/xenobiology)
+"oEm" = (
+/obj/machinery/light/smart{
+	dir = 4
+	},
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NE-FC";
+	location = "NEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "oEo" = (
 /obj/item/weapon/flora/random,
 /turf/simulated/floor{
@@ -67230,15 +67288,13 @@
 	},
 /area/station/civilian/dormitories/service_bedrooms)
 "oEB" = (
-/obj/machinery/status_display{
-	layer = 3.3;
-	pixel_x = -32;
-	supply_display = 1
-	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/atm{
+	pixel_x = -28
 	},
 /turf/simulated/floor{
 	dir = 8;
@@ -67330,6 +67386,17 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
+"oFB" = (
+/obj/effect/decal/turf_decal{
+	dir = 2;
+	icon_state = "warn"
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "oFJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -69595,6 +69662,12 @@
 	icon_state = "darkred"
 	},
 /area/station/security/checkpoint/escape)
+"pge" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "cafeteria"
+	},
+/area/station/security/prison)
 "pgo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/command{
@@ -70041,18 +70114,6 @@
 /obj/effect/decal/cleanable/blood/xeno,
 /turf/simulated/floor,
 /area/station/maintenance/cargo)
-"ple" = (
-/obj/structure/stool/bed/chair/metal/black{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "plf" = (
 /turf/environment/space,
 /area/space)
@@ -70521,6 +70582,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/aisat/antechamber_interior)
+"ppT" = (
+/obj/item/weapon/flora/random,
+/obj/machinery/light/smart{
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/station/rnd/hallway/lobby)
 "pqf" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/camera{
@@ -70591,16 +70661,6 @@
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
-"prm" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSW-FC";
-	location = "DS"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "bluecorner"
-	},
-/area/station/hallway/primary/central)
 "prx" = (
 /obj/machinery/door_control{
 	id = "east_science_hazard";
@@ -71206,6 +71266,24 @@
 /obj/item/device/flashlight/lamp,
 /turf/simulated/floor/carpet/red,
 /area/station/civilian/dormitories/service_bedrooms)
+"pyg" = (
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "darkred"
+	},
+/area/station/security/brig)
+"pyi" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
+/turf/simulated/floor{
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "pyk" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -71554,9 +71632,25 @@
 	},
 /area/station/engineering/atmos)
 "pBf" = (
-/obj/structure/sign/nanotrasen,
-/turf/simulated/wall,
-/area/station/cargo/lobby)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "pBn" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -72554,18 +72648,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/cargo/miningoffice)
-"pMZ" = (
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
 "pNq" = (
 /obj/structure/sign/poster/official/ion_rifle{
 	pixel_x = 32
@@ -72999,22 +73081,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/xenobiology)
-"pQW" = (
-/obj/machinery/door/airlock/external{
-	locked = 1;
-	name = "Entry Shuttle Airlock";
-	req_one_access = list(13)
-	},
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/turf/simulated/floor/plating,
-/area/station/hallway/secondary/entry)
 "pRe" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/structure/disposalpipe/segment{
@@ -73371,14 +73437,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/warden)
-"pWh" = (
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "yellow"
-	},
-/area/station/engineering/break_room)
 "pWn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -73741,6 +73799,13 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/engineering/atmos)
+"qaX" = (
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/security/lobby)
 "qaY" = (
 /obj/item/stack/rods{
 	amount = 23
@@ -74150,6 +74215,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"qfa" = (
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "black"
+	},
+/area/station/hallway/secondary/entry)
 "qfb" = (
 /obj/structure/table/reinforced,
 /obj/machinery/requests_console/eva{
@@ -74248,11 +74323,11 @@
 	req_one_access = list(13)
 	},
 /obj/effect/decal/turf_decal{
-	dir = 2;
+	dir = 1;
 	icon_state = "warn"
 	},
 /obj/effect/decal/turf_decal{
-	dir = 1;
+	dir = 2;
 	icon_state = "warn"
 	},
 /turf/simulated/floor/plating,
@@ -74582,16 +74657,6 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
-"qjF" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "qjH" = (
 /obj/machinery/light/smart{
 	dir = 1
@@ -74831,6 +74896,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/storage/tech)
+"qmz" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SW-B";
+	location = "SSW-B"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "qmP" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -75232,6 +75307,17 @@
 	},
 /turf/environment/space,
 /area/shuttle/escape_pod6/station)
+"qrJ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "qrL" = (
 /obj/effect/decal/turf_decal{
 	dir = 1;
@@ -75636,6 +75722,14 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/misc_lab)
+"qvl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/effect/decal/cleanable/dirt,
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/security/prison)
 "qvQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
@@ -76059,6 +76153,16 @@
 	icon_state = "redchecker"
 	},
 /area/station/hallway/primary/fore)
+"qCB" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 1
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "qCK" = (
 /obj/structure/closet/lasertag/red,
 /turf/simulated/floor{
@@ -76152,6 +76256,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet/black,
 /area/station/civilian/chapel/office)
+"qDx" = (
+/obj/machinery/atmospherics/pipe/simple/visible/red{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/engineering/atmos)
 "qDB" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -76410,16 +76526,6 @@
 	icon_state = "redyellowfull"
 	},
 /area/station/maintenance/cargo)
-"qGd" = (
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "qGe" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
@@ -77818,6 +77924,18 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/chapel)
+"qWB" = (
+/obj/structure/stool/bed/chair/metal/white,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/station/civilian/gym)
 "qWH" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -77854,24 +77972,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
-"qXe" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/security/prison)
-"qXq" = (
-/obj/machinery/light/smart,
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "qXu" = (
 /obj/machinery/portable_atmospherics/powered/pump,
 /obj/machinery/atmospherics/components/unary/portables_connector{
@@ -78261,6 +78361,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
+"rbT" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=NNW-B";
+	location = "NW-B"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "rbU" = (
 /obj/item/weapon/rack_parts,
 /turf/simulated/floor/plating,
@@ -79350,16 +79460,6 @@
 	},
 /turf/simulated/floor,
 /area/station/medical/cmo)
-"rqs" = (
-/obj/effect/decal/turf_decal{
-	dir = 2;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "rqx" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -81879,19 +81979,6 @@
 	icon_state = "whitehall"
 	},
 /area/station/rnd/robotics)
-"rPW" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/effect/decal/turf_decal/alpha/orange{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralfull"
-	},
-/area/station/engineering/atmos)
 "rPX" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
@@ -82240,15 +82327,6 @@
 	icon_state = "vaultfull"
 	},
 /area/station/maintenance/science)
-"rVa" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "rVd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -83094,6 +83172,16 @@
 "sfm" = (
 /turf/simulated/wall,
 /area/station/maintenance/chapel)
+"sfo" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-C";
+	location = "CS-AR"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "sfr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -83162,6 +83250,15 @@
 	},
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
+"sgd" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 29
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "blackcorner"
+	},
+/area/station/hallway/primary/starboard)
 "sgg" = (
 /obj/effect/landmark/start/quartermaster,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -83203,6 +83300,15 @@
 	icon_state = "neutral"
 	},
 /area/station/hallway/primary/fore)
+"sgN" = (
+/obj/structure/kitchenspike,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot_left"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/cold_room)
 "sgR" = (
 /obj/machinery/camera{
 	c_tag = "Escape Shuttle Hallway North"
@@ -83275,16 +83381,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories)
-"shz" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=NNW-B";
-	location = "NW-B"
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/entry)
 "shE" = (
 /obj/machinery/hydroponics/soil,
 /obj/item/weapon/shovel/spade,
@@ -84820,6 +84916,13 @@
 	icon_state = "gcircuit"
 	},
 /area/station/maintenance/science)
+"szM" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=S-MB";
+	location = "N-MB"
+	},
+/turf/simulated/floor,
+/area/station/hallway/secondary/entry)
 "szQ" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -86339,18 +86442,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/maintenance/incinerator)
-"sSA" = (
-/obj/structure/stool/bed/chair/metal/black{
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "sSE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -86727,6 +86818,15 @@
 	icon_state = "dark"
 	},
 /area/station/maintenance/engineering)
+"sXf" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DN";
+	location = "SSE-FC"
+	},
+/turf/simulated/floor{
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "sXj" = (
 /obj/machinery/firealarm{
 	pixel_y = 22
@@ -87118,6 +87218,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"tci" = (
+/obj/effect/decal/turf_decal{
+	dir = 4;
+	icon_state = "warn"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/prison)
 "tcq" = (
 /obj/structure/sign/nanotrasen{
 	pixel_y = -32
@@ -87229,6 +87336,17 @@
 	icon_state = "red"
 	},
 /area/station/security/brig/equipment)
+"tdG" = (
+/obj/machinery/light/smart,
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=DS";
+	location = "DN-W"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "purplecorner"
+	},
+/area/station/hallway/primary/central)
 "tdH" = (
 /obj/structure/table,
 /obj/item/stack/sheet/glass{
@@ -87810,15 +87928,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
-"tlj" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "tlq" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -88324,20 +88433,6 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/primary/starboard)
-"tsL" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/powered/scrubber,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "escape"
-	},
-/area/station/hallway/primary/port)
 "tsT" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -88543,6 +88638,16 @@
 	icon_state = "darkblue"
 	},
 /area/station/engineering/minisat_secure_area)
+"tuI" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSW-FC";
+	location = "DS"
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
+/area/station/hallway/primary/central)
 "tvg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -89247,15 +89352,6 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/atmos)
-"tCE" = (
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line";
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "tCI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -90563,6 +90659,15 @@
 	icon_state = "grimy"
 	},
 /area/station/civilian/chapel/office)
+"tUa" = (
+/obj/item/weapon/flora/random,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "delivery"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "tUg" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/dirt,
@@ -90840,6 +90945,15 @@
 	temperature = 80
 	},
 /area/station/tcommsat/chamber)
+"tXf" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/security/hos)
 "tXl" = (
 /obj/structure/stool/bed/chair/comfy/brown,
 /obj/machinery/light/smart{
@@ -91261,12 +91375,17 @@
 	},
 /area/station/rnd/hallway)
 "ucx" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 4
+/obj/machinery/door_timer/cell_3{
+	pixel_x = 32;
+	pixel_y = 0;
+	dir = 4;
+	id = "Cell 3 perma"
 	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "ucF" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -92827,6 +92946,7 @@
 	name = "Central Access"
 	},
 /turf/simulated/floor{
+	dir = 4;
 	icon_state = "neutralcorner"
 	},
 /area/station/security/lobby)
@@ -92886,6 +93006,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/mine_sci_shuttle)
+"uuB" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/station/engineering/atmos/atmos_office)
 "uuG" = (
 /obj/structure/table,
 /obj/item/device/tagger/shop,
@@ -93151,6 +93283,16 @@
 	icon_state = "grimy"
 	},
 /area/station/security/hos)
+"uyn" = (
+/obj/machinery/light/smart,
+/obj/effect/decal/turf_decal{
+	dir = 8;
+	icon_state = "warn_corner"
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "uyt" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -93238,17 +93380,6 @@
 	icon_state = "darkblue"
 	},
 /area/station/bridge)
-"uzS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/dark_red{
-	icon_state = "siding_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/security/hos)
 "uAq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -93755,6 +93886,26 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
+"uGH" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal{
+	dir = 1;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "redcorner"
+	},
+/area/station/security/prison)
 "uGN" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 1
@@ -93799,14 +93950,11 @@
 /area/station/maintenance/atmos)
 "uHN" = (
 /obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SW-B";
-	location = "SSW-B"
+	codes_txt = "patrol;next_patrol=CS-AR";
+	location = "SWW-FC"
 	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
+/turf/simulated/floor,
+/area/station/civilian/locker)
 "uHX" = (
 /turf/simulated/floor/wood,
 /area/station/maintenance/chapel)
@@ -93865,18 +94013,6 @@
 	icon_state = "caution"
 	},
 /area/station/storage/emergency)
-"uJO" = (
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn"
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/armoury)
 "uJP" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -94213,11 +94349,19 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "uNw" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "bot"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/carpet/red,
-/area/station/security/detectives_office)
+/obj/effect/decal/turf_decal{
+	dir = 10;
+	icon_state = "warn"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "uNx" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/effect/spawner/lootdrop/maintenance/three,
@@ -94286,6 +94430,20 @@
 	icon_state = "dark"
 	},
 /area/station/security/brig)
+"uOo" = (
+/obj/machinery/atmospherics/components/unary/portables_connector{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/powered/scrubber,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "escape"
+	},
+/area/station/hallway/primary/port)
 "uOv" = (
 /obj/structure/window/thin/reinforced{
 	dir = 8
@@ -94609,16 +94767,6 @@
 	icon_state = "purple"
 	},
 /area/station/medical/hallway)
-"uSL" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 5;
-	icon_state = "cafeteria"
-	},
-/area/station/civilian/kitchen)
 "uSN" = (
 /turf/simulated/floor{
 	icon_state = "redyellowfull"
@@ -95498,29 +95646,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/mixing)
-"vde" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/effect/decal/turf_decal{
-	dir = 9;
-	icon_state = "warn"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/security/brig)
-"vdh" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=Security";
-	location = "S-C"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/primary/central)
 "vdj" = (
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
@@ -96026,16 +96151,6 @@
 	icon_state = "neutralfull"
 	},
 /area/station/cargo/storage)
-"vji" = (
-/obj/effect/decal/turf_decal{
-	dir = 8;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	dir = 8;
-	icon_state = "darkred"
-	},
-/area/station/security/brig)
 "vjq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -96241,22 +96356,13 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/office)
-"vlT" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+"vmc" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
 	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/obj/effect/decal/turf_decal{
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/engineering/engine)
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "vme" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -96380,13 +96486,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
-"vnA" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/station/civilian/theatre)
 "vnU" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1;
@@ -96450,10 +96549,6 @@
 	},
 /area/station/maintenance/science)
 "vos" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 22
-	},
 /obj/machinery/light/smart{
 	dir = 4
 	},
@@ -98385,16 +98480,6 @@
 	icon_state = "greencorner"
 	},
 /area/station/hallway/primary/fore)
-"vMb" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Central Access"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "neutralcorner"
-	},
-/area/station/security/lobby)
 "vMc" = (
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32
@@ -98973,25 +99058,12 @@
 	},
 /area/station/bridge/teleporter)
 "vTX" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/effect/decal/turf_decal{
-	dir = 1;
-	icon_state = "warn_corner"
-	},
-/turf/simulated/floor{
-	icon_state = "redcorner"
-	},
-/area/station/security/prison)
+/turf/simulated/floor/wood,
+/area/station/civilian/theatre)
 "vUe" = (
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
@@ -99301,8 +99373,8 @@
 	},
 /area/station/hallway/secondary/entry)
 "vXG" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_y = 29
+/obj/machinery/atm{
+	pixel_y = 28
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -100763,6 +100835,17 @@
 	icon_state = "neutralfull"
 	},
 /area/station/cargo/office)
+"wpj" = (
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "loadingarea"
+	},
+/obj/effect/decal/turf_decal/alpha/dark_red{
+	icon_state = "arrow"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/security/brig)
 "wpm" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -101043,16 +101126,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/miningoffice)
-"wth" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=SSE-FC";
-	location = "SEE-FC"
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "wtl" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -101122,10 +101195,8 @@
 /obj/machinery/light/smart{
 	dir = 4
 	},
-/obj/item/device/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 28;
-	pixel_y = -5
+/obj/machinery/atm{
+	pixel_x = 28
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -103204,6 +103275,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"wUy" = (
+/obj/structure/stool/bed/chair/metal/black{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "box_corners_white";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/hallway/secondary/entry)
 "wUB" = (
 /obj/structure/rack,
 /obj/item/weapon/gun/plasma{
@@ -104445,16 +104528,6 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/dormitories/service_bedrooms)
-"xji" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "black"
-	},
-/area/station/hallway/secondary/entry)
 "xjp" = (
 /obj/structure/stool/bed/chair{
 	dir = 8
@@ -104650,6 +104723,16 @@
 	},
 /turf/environment/space,
 /area/shuttle/mining/station)
+"xmG" = (
+/obj/machinery/navbeacon{
+	codes_txt = "patrol;next_patrol=SSE-FC";
+	location = "SEE-FC"
+	},
+/turf/simulated/floor{
+	dir = 4;
+	icon_state = "yellowcorner"
+	},
+/area/station/hallway/primary/port)
 "xmJ" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -106309,15 +106392,6 @@
 /obj/structure/sign/nanotrasen,
 /turf/simulated/wall/r_wall,
 /area/station/bridge/teleporter)
-"xCK" = (
-/obj/item/weapon/flora/random,
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "delivery"
-	},
-/turf/simulated/floor{
-	icon_state = "vaultfull"
-	},
-/area/station/hallway/secondary/entry)
 "xCL" = (
 /obj/structure/stool/bed/chair{
 	dir = 4
@@ -106380,27 +106454,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/mixing)
-"xDG" = (
-/obj/structure/stool/bed/chair/metal/white{
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	dir = 1;
-	icon_state = "black"
-	},
-/area/station/civilian/gym)
 "xDJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
@@ -106960,20 +107013,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
-"xLb" = (
-/obj/effect/decal/turf_decal/alpha/white{
-	icon_state = "siding_corner";
-	dir = 4
-	},
-/obj/effect/decal/turf_decal/alpha/yellow{
-	icon_state = "arrows_white";
-	dir = 8
-	},
-/turf/simulated/floor{
-	dir = 4;
-	icon_state = "black"
-	},
-/area/station/hallway/secondary/entry)
 "xLe" = (
 /obj/machinery/portable_atmospherics/powered/pump,
 /obj/machinery/light/smart{
@@ -107560,6 +107599,21 @@
 	icon_state = "dark"
 	},
 /area/station/security/warden)
+"xRA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/orange{
+	icon_state = "siding_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/fore)
 "xRL" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -108210,15 +108264,6 @@
 	},
 /turf/simulated/floor,
 /area/station/rnd/misc_lab)
-"xYt" = (
-/obj/machinery/navbeacon{
-	codes_txt = "patrol;next_patrol=DN";
-	location = "SSE-FC"
-	},
-/turf/simulated/floor{
-	icon_state = "yellowcorner"
-	},
-/area/station/hallway/primary/port)
 "xYy" = (
 /obj/machinery/computer/mech_bay_power_console{
 	dir = 8
@@ -118629,7 +118674,7 @@ eXX
 pGn
 fBB
 pGn
-lpA
+bsC
 pGn
 pGn
 oer
@@ -131984,7 +132029,7 @@ xFF
 xFG
 flb
 uDn
-pWh
+asp
 ude
 ehA
 geB
@@ -132241,7 +132286,7 @@ qnQ
 hEd
 fDg
 owf
-pWh
+asp
 hkb
 ehA
 fUz
@@ -132479,7 +132524,7 @@ bOJ
 oKV
 dup
 dup
-mTD
+cFl
 bOD
 cmG
 xqQ
@@ -132744,7 +132789,7 @@ oLJ
 kFc
 kFc
 cEO
-bRn
+ihO
 azQ
 pfp
 imT
@@ -132998,8 +133043,8 @@ bfy
 cmG
 dup
 htY
-qGd
-qGd
+jws
+jws
 nwM
 tCz
 gRR
@@ -133254,7 +133299,7 @@ nLs
 bTE
 tUm
 oPF
-rPW
+fNB
 rSb
 umn
 svw
@@ -134019,16 +134064,16 @@ fZH
 cTK
 whA
 iDO
-kww
-kww
-kww
+uuB
+uuB
+uuB
 xnu
 vCV
 lFG
 waB
 fMO
-kVe
-cvM
+qDx
+bYW
 kHT
 vPk
 vPk
@@ -134277,7 +134322,7 @@ qcT
 mrP
 daq
 daq
-lXW
+lZE
 egG
 iEf
 hrT
@@ -134819,9 +134864,9 @@ hdV
 bhn
 evV
 oKM
-bBp
+ltR
 wCx
-pMZ
+hOV
 oDZ
 bau
 nkc
@@ -135076,9 +135121,9 @@ moL
 ojN
 enq
 bgZ
-gCp
+goL
 tRh
-vlT
+gCp
 oyx
 mRP
 eZT
@@ -135832,7 +135877,7 @@ adw
 adw
 adw
 wjD
-lNR
+ihJ
 cgv
 owM
 ekM
@@ -136335,7 +136380,7 @@ jlK
 tEF
 tne
 cEZ
-lTk
+ckT
 iGS
 ciX
 jau
@@ -136870,7 +136915,7 @@ qTx
 qTx
 lGc
 rjD
-tYK
+pyi
 uSc
 uib
 uSc
@@ -137117,13 +137162,13 @@ tEF
 sHQ
 dpc
 sHQ
-tsL
+uOo
 blv
 sqb
 uck
 sqb
 hQQ
-hIV
+epA
 qTx
 bUU
 iky
@@ -137389,7 +137434,7 @@ doE
 doE
 doE
 lgU
-aXu
+bPP
 mhm
 doE
 mnD
@@ -137887,7 +137932,7 @@ wwi
 aYN
 wwi
 lfm
-wth
+xmG
 tZn
 oyb
 nAM
@@ -137905,7 +137950,7 @@ oyb
 bzt
 bzt
 rcq
-xYt
+sXf
 tYK
 wtC
 wtC
@@ -139435,7 +139480,7 @@ xNR
 oYv
 cGN
 vzT
-mOx
+niI
 oVN
 cdA
 jTf
@@ -139935,7 +139980,7 @@ aSY
 uum
 lVS
 srt
-mbB
+sgN
 uos
 gTB
 kst
@@ -140138,14 +140183,14 @@ kHU
 kHU
 kHU
 yaE
-hGn
+fOp
 yaE
 kHU
 plf
 plf
 kHU
 yaE
-hGn
+fOp
 yaE
 kHU
 kHU
@@ -140652,14 +140697,14 @@ yaE
 ffS
 aev
 yaE
-apc
+qgt
 yaE
 aqg
 aqg
 aqg
 mlH
 yaE
-apc
+qgt
 yaE
 eeB
 ffS
@@ -140706,7 +140751,7 @@ kBq
 biv
 pED
 bNa
-uSL
+cij
 kIU
 lBN
 yeY
@@ -140963,7 +141008,7 @@ dtM
 fty
 abG
 vLv
-uSL
+cij
 kIU
 jVV
 ekm
@@ -141680,7 +141725,7 @@ yaE
 ffS
 eeB
 yaE
-apc
+qgt
 yaE
 mlH
 nhe
@@ -142039,7 +142084,7 @@ oZa
 xyx
 dJC
 gjY
-eIi
+ppT
 kdp
 xfI
 eIi
@@ -142194,7 +142239,7 @@ kHU
 kHU
 kHU
 yaE
-hGn
+fOp
 yaE
 kHU
 plf
@@ -142731,11 +142776,11 @@ dbB
 idn
 fRR
 ofi
-xCK
+tUa
 miI
 ffS
 jjY
-bhs
+efn
 wwi
 pkS
 wwi
@@ -143284,7 +143329,7 @@ iSv
 xXt
 vAu
 ogP
-uHN
+qmz
 bAS
 nvi
 rnH
@@ -143300,7 +143345,7 @@ qbj
 qbj
 tmk
 ldb
-ejv
+mIq
 ogP
 iSi
 amv
@@ -143327,7 +143372,7 @@ vpT
 xei
 bFh
 vpT
-ftt
+tdG
 vIl
 olx
 frM
@@ -143495,7 +143540,7 @@ plf
 brw
 mko
 jsL
-eOm
+npp
 ffX
 hbE
 sTt
@@ -143764,7 +143809,7 @@ gHT
 alc
 vDr
 fDL
-shz
+rbT
 iwy
 xXt
 gNR
@@ -144270,10 +144315,10 @@ fYS
 slo
 ffS
 pLB
-xCK
-dDs
+tUa
+iOd
 acf
-sSA
+dDs
 aSq
 ffS
 gvF
@@ -144545,17 +144590,17 @@ hXb
 hXb
 hXb
 che
-fOp
-imA
-fOp
-fOp
-fOp
-fOp
-fOp
-fOp
-fOp
-kff
-fOp
+brm
+ejv
+brm
+brm
+brm
+brm
+brm
+brm
+brm
+xRA
+brm
 vos
 did
 did
@@ -144764,7 +144809,7 @@ kHU
 kHU
 kHU
 yaE
-pQW
+hGn
 yaE
 kHU
 plf
@@ -144812,7 +144857,7 @@ fjB
 qSx
 dtr
 czE
-uSN
+oAd
 tJq
 gIl
 rdY
@@ -145049,7 +145094,7 @@ kHU
 yaE
 hkD
 fYS
-cpB
+hae
 wts
 mge
 qed
@@ -145278,7 +145323,7 @@ yaE
 ffS
 aev
 yaE
-qgt
+kjh
 yaE
 ygh
 cPq
@@ -145329,13 +145374,13 @@ mpN
 uQg
 tJq
 oFm
-ucx
+vTX
 xsb
-ucx
-ucx
-ucx
+vTX
+vTX
+vTX
 mtf
-ucx
+vTX
 jpq
 bsc
 mfI
@@ -145563,7 +145608,7 @@ plf
 yaE
 vDr
 fYS
-rqs
+ahM
 tEo
 nIB
 iEL
@@ -145820,7 +145865,7 @@ kHU
 yaE
 csG
 fYS
-qXq
+uyn
 wts
 npC
 txi
@@ -145843,13 +145888,13 @@ cCx
 mES
 tJq
 ikZ
-kEG
+mGP
 oki
-vnA
-vnA
-iFk
+vmc
+vmc
+kXK
 tWH
-iFk
+kXK
 qcF
 bRX
 qSi
@@ -146077,7 +146122,7 @@ kHU
 yaE
 csG
 fYS
-wtr
+dbV
 wts
 bCJ
 euO
@@ -146100,7 +146145,7 @@ tJq
 ucP
 tJq
 fSC
-jgM
+ooE
 ktM
 uuo
 djH
@@ -146306,14 +146351,14 @@ yaE
 ffS
 eeB
 yaE
-qgt
+kjh
 yaE
 mlH
 iOK
 iOK
 iOK
 yaE
-qgt
+kjh
 yaE
 aev
 ffS
@@ -146583,10 +146628,10 @@ fYS
 jNI
 ffS
 ylK
-ple
+wUy
 cmX
 fRR
-lku
+cZu
 ryG
 ffS
 uAC
@@ -146820,14 +146865,14 @@ xjr
 xjr
 kHU
 dhU
-pQW
+hGn
 yaE
 kHU
 plf
 plf
 kHU
 yaE
-pQW
+hGn
 yaE
 plf
 plf
@@ -147608,7 +147653,7 @@ yaE
 yaE
 csG
 fYS
-bJm
+szM
 alc
 gHT
 gHT
@@ -147617,7 +147662,7 @@ gHT
 gHT
 gHT
 alc
-lum
+gUk
 fYS
 sEX
 srs
@@ -147867,12 +147912,12 @@ lrr
 fYS
 wtr
 sDu
-cWX
-xji
-xji
-xji
-xji
-xLb
+nRd
+qfa
+qfa
+qfa
+qfa
+lqh
 xao
 csG
 fYS
@@ -148677,7 +148722,7 @@ mXC
 cSn
 mXC
 mXC
-pBf
+mXC
 xdk
 bzv
 lMB
@@ -148876,14 +148921,14 @@ xjr
 xjr
 kHU
 dhU
-pQW
+hGn
 yaE
 kHU
 plf
 plf
 kHU
 yaE
-pQW
+hGn
 yaE
 plf
 plf
@@ -149133,14 +149178,14 @@ xjr
 xjr
 plf
 yaE
-izh
+oFB
 yaE
 yaE
 yaE
 yaE
 yaE
 yaE
-izh
+oFB
 yaE
 plf
 plf
@@ -149390,14 +149435,14 @@ yaE
 ffS
 aev
 yaE
-qgt
+kjh
 yaE
 aqg
 aqg
 aqg
 mlH
 yaE
-qgt
+kjh
 yaE
 eeB
 ffS
@@ -151076,7 +151121,7 @@ sbN
 uKh
 sHC
 npd
-syl
+sgd
 xQo
 mUL
 rmY
@@ -152552,7 +152597,7 @@ mXl
 mXl
 mXl
 wLD
-gXt
+nsw
 iwm
 mXl
 pRS
@@ -152570,7 +152615,7 @@ oNU
 mXl
 uxx
 xMc
-iDl
+lQq
 nvi
 rnH
 cLM
@@ -152579,7 +152624,7 @@ nvi
 tOH
 mfI
 ogP
-prm
+tuI
 sBG
 wjc
 wjc
@@ -152882,7 +152927,7 @@ xQo
 xQo
 xQo
 nKU
-jFB
+cWB
 xQo
 oPI
 mRu
@@ -153049,7 +153094,7 @@ cpR
 gtK
 cpR
 pxL
-dED
+oEm
 ffJ
 ape
 fZz
@@ -153068,7 +153113,7 @@ hRd
 ckx
 fZz
 lMB
-vdh
+cyL
 kzb
 vAu
 psV
@@ -153082,7 +153127,7 @@ vAu
 kRo
 vAu
 kCI
-clM
+sfo
 ogP
 lwr
 mLS
@@ -153090,7 +153135,7 @@ vAu
 vAu
 vAu
 vAu
-xQn
+vAu
 kpD
 qDF
 koY
@@ -153323,9 +153368,9 @@ erD
 erD
 cmN
 act
-vMb
-xsY
 uuf
+xsY
+eKx
 jTW
 jTW
 jTW
@@ -153805,7 +153850,7 @@ fnT
 miA
 ojm
 lPc
-okz
+dus
 gaF
 rpV
 qSe
@@ -154063,10 +154108,10 @@ adb
 hzP
 cpR
 oOk
-nHt
+eLE
 uXI
-nHt
-lRJ
+eLE
+hLt
 xqF
 aAF
 iqI
@@ -157173,8 +157218,8 @@ plf
 xyC
 cFp
 klH
-uNw
-uNw
+kjV
+kjV
 hGr
 aRu
 xyC
@@ -157677,11 +157722,11 @@ plf
 plf
 plf
 uRO
-hBR
+cXM
 uRO
 plf
 uRO
-hBR
+cXM
 uRO
 plf
 xyC
@@ -157698,8 +157743,8 @@ dnn
 aEr
 wPw
 jQy
-hVd
-fNh
+giQ
+kFv
 jcX
 fJg
 nPU
@@ -158206,7 +158251,7 @@ xyC
 xyC
 xyC
 xyC
-cPJ
+qaX
 jtG
 wpm
 fJg
@@ -158448,11 +158493,11 @@ wVt
 cHH
 cjS
 bNB
-opt
+uNw
 kms
 cHH
 eow
-vde
+opt
 goK
 hYT
 nsn
@@ -158705,7 +158750,7 @@ leA
 cHH
 adG
 iGB
-vji
+pyg
 tTk
 qMX
 aZz
@@ -158966,7 +159011,7 @@ ikW
 qXE
 rjb
 utF
-gEQ
+wpj
 uLd
 lat
 nsn
@@ -159765,7 +159810,7 @@ kIM
 vst
 mDV
 vKG
-bQA
+uHN
 xoq
 tAM
 uQA
@@ -160484,14 +160529,14 @@ fAF
 fgx
 diq
 fAF
-kVQ
+ucx
 eTq
 fAF
 wNM
 oPD
 tif
 rHZ
-aDK
+uGH
 czU
 tqK
 hsq
@@ -160748,7 +160793,7 @@ qZx
 qZx
 fXG
 qZx
-vTX
+mNa
 czU
 uvV
 kMw
@@ -161254,13 +161299,13 @@ blh
 cra
 hlv
 dVr
-jiJ
+gQC
 hlv
 fBm
 bvC
 hlv
 vqQ
-gQC
+hwB
 qZx
 tnw
 fLE
@@ -162278,7 +162323,7 @@ aXC
 bZu
 pLw
 unD
-qXe
+qvl
 oAx
 ulK
 eyO
@@ -162832,7 +162877,7 @@ sxG
 uOc
 hur
 hur
-kOc
+cyq
 ekd
 lZw
 gqC
@@ -163086,7 +163131,7 @@ ixl
 mme
 uKd
 gRX
-uJO
+kZk
 sRa
 nUj
 wUB
@@ -163115,13 +163160,13 @@ ncp
 ncp
 hbR
 mWz
-mPY
+qWB
 kLd
 syX
 tHk
 tHk
 dbf
-xDG
+nmW
 ram
 mWz
 lNQ
@@ -163378,7 +163423,7 @@ eFl
 aRb
 nDG
 jjN
-lmy
+bFL
 ram
 mWz
 ucd
@@ -163585,7 +163630,7 @@ afw
 nDf
 mZo
 qUR
-kxn
+hDt
 mzV
 aSh
 mpR
@@ -163886,13 +163931,13 @@ ncp
 ncp
 hbR
 mWz
-dOQ
+cTS
 sIY
 qls
 uOM
 uOM
 aeG
-bFL
+mqg
 ram
 mWz
 hPr
@@ -164082,7 +164127,7 @@ lhK
 wVg
 aFN
 jKZ
-cMP
+pge
 rBo
 hlv
 qxh
@@ -164346,7 +164391,7 @@ xIO
 jps
 xIO
 qZx
-nyX
+pBf
 tbS
 sZR
 kHU
@@ -164358,7 +164403,7 @@ fwH
 qoH
 vOW
 qoH
-kgH
+fqW
 umQ
 gYp
 kHU
@@ -164596,7 +164641,7 @@ jvm
 hlv
 fVW
 fPH
-cMP
+pge
 rnI
 hlv
 pHz
@@ -164611,11 +164656,11 @@ kHU
 plf
 cYc
 ueE
-qjF
+qCB
 wcJ
 iRz
 nez
-uzS
+qrJ
 hlh
 gYp
 plf
@@ -164868,11 +164913,11 @@ kHU
 kHU
 cYc
 nfj
-rVa
+jzh
 eaE
 nRk
 rZh
-tlj
+alx
 hmN
 gYp
 kHU
@@ -164916,7 +164961,7 @@ dJL
 nRG
 oXA
 oXA
-cIf
+cpv
 dJL
 plf
 cdR
@@ -165125,11 +165170,11 @@ plf
 kHU
 huz
 sIx
-bOv
-gzK
+kgH
+tXf
 kjv
-gzK
-tCE
+tXf
+eTb
 tEU
 huz
 plf
@@ -167174,7 +167219,7 @@ plf
 kHU
 hlv
 lrm
-ndp
+tci
 jno
 hlv
 cBu
@@ -168254,7 +168299,7 @@ kHU
 fMh
 plf
 dJL
-cIf
+cpv
 oXA
 oXA
 nJn

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -11224,15 +11224,6 @@
 	icon_state = "dark"
 	},
 /area/station/medical/morgue)
-"cnE" = (
-/obj/effect/decal/turf_decal/metal{
-	icon_state = "siding_thinplating_line";
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/civilian/chapel)
 "cnS" = (
 /obj/machinery/conveyor{
 	dir = 10;
@@ -11633,11 +11624,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
-"cuQ" = (
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/civilian/chapel/mass_driver)
 "cuX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -13395,6 +13381,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"cNP" = (
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 5
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/chapel)
 "cNU" = (
 /obj/effect/decal/turf_decal{
 	dir = 10;
@@ -13445,9 +13440,13 @@
 	},
 /area/station/civilian/dormitories/courtroom)
 "cOt" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 6
+	},
 /turf/simulated/floor{
-	dir = 6;
-	icon_state = "whitered"
+	dir = 9;
+	icon_state = "redfull"
 	},
 /area/station/civilian/library)
 "cOy" = (
@@ -13573,14 +13572,15 @@
 	},
 /area/station/hallway/primary/fore)
 "cPN" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 5
+/obj/structure/table/woodentable/fancy,
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 8
 	},
 /turf/simulated/floor{
-	icon_state = "wooden"
+	icon_state = "grimy"
 	},
-/area/station/hallway/secondary/exit)
+/area/station/civilian/chapel)
 "cPY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor{
@@ -14671,14 +14671,8 @@
 	},
 /area/station/engineering/atmos)
 "dfg" = (
-/obj/effect/decal/turf_decal/metal{
-	icon_state = "siding_thinplating_line";
-	dir = 10
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/civilian/chapel)
+/turf/simulated/floor/carpet,
+/area/station/bridge)
 "dfo" = (
 /obj/machinery/power/apc{
 	dir = 1;
@@ -15085,20 +15079,14 @@
 	},
 /area/station/security/prison)
 "diz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/turf/simulated/floor{
+	icon_state = "grimy"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/maintenance/chapel)
+/area/station/civilian/chapel)
 "diA" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "maint_contraption";
@@ -16851,6 +16839,16 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"dFi" = (
+/obj/structure/table/woodentable/fancy,
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/chapel)
 "dFp" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -18420,6 +18418,7 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
 "dZk" = (
@@ -19148,9 +19147,13 @@
 	},
 /area/station/medical/virology)
 "eib" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 1
+	},
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "whitered"
+	dir = 9;
+	icon_state = "redfull"
 	},
 /area/station/civilian/library)
 "eig" = (
@@ -19833,6 +19836,9 @@
 "eqn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/hologram/holopad,
+/obj/effect/decal/turf_decal/alpha/white{
+	icon_state = "bot"
+	},
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -22142,15 +22148,14 @@
 	},
 /area/station/rnd/xenobiology)
 "eRo" = (
-/obj/structure/table/woodentable/fancy,
-/obj/effect/decal/turf_decal/metal{
-	icon_state = "siding_thinplating_line";
-	dir = 8
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "box_corners_white";
+	dir = 1
 	},
 /turf/simulated/floor{
-	icon_state = "grimy"
+	icon_state = "dark"
 	},
-/area/station/civilian/chapel)
+/area/station/civilian/chapel/mass_driver)
 "eRS" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -23242,6 +23247,9 @@
 	pixel_x = 28;
 	pixel_y = -5
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -30
+	},
 /turf/simulated/floor{
 	icon_state = "wooden"
 	},
@@ -24157,6 +24165,15 @@
 	icon_state = "red"
 	},
 /area/station/security/brig)
+"fqL" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "box_corners_white";
+	dir = 8
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/chapel/mass_driver)
 "fqN" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8;
@@ -24844,9 +24861,13 @@
 /area/station/security/main)
 "fxk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 9
+	},
 /turf/simulated/floor{
 	dir = 9;
-	icon_state = "whitered"
+	icon_state = "redfull"
 	},
 /area/station/civilian/library)
 "fxw" = (
@@ -25468,6 +25489,9 @@
 	dir = 4
 	},
 /obj/machinery/light,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -29346,6 +29370,10 @@
 "gyi" = (
 /obj/item/device/flashlight/lamp,
 /obj/structure/table/woodentable,
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "gyl" = (
@@ -29850,6 +29878,14 @@
 	},
 /turf/simulated/floor,
 /area/station/storage/tech)
+"gEm" = (
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/chapel)
 "gEt" = (
 /obj/structure/table/woodentable/fancy,
 /obj/item/device/flashlight/lantern,
@@ -31486,6 +31522,15 @@
 	icon_state = "neutral"
 	},
 /area/station/civilian/locker)
+"gXx" = (
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 10
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/chapel)
 "gXI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -32717,15 +32762,6 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/secondary/entry)
-"hng" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/hallway/secondary/exit)
 "hno" = (
 /turf/simulated/floor{
 	dir = 9;
@@ -33488,6 +33524,24 @@
 	icon_state = "dark"
 	},
 /area/station/civilian/hydroponics)
+"huT" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/library)
 "huZ" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -36045,15 +36099,6 @@
 	icon_state = "grimy"
 	},
 /area/station/storage/tools)
-"hXB" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "box_corners_white";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/civilian/chapel/mass_driver)
 "hXC" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
@@ -36740,9 +36785,7 @@
 	pixel_y = 6
 	},
 /obj/item/weapon/storage/fancy/crayons,
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
+/turf/simulated/floor/carpet/blue2,
 /area/station/civilian/library)
 "ifQ" = (
 /obj/effect/landmark/start/station_engineer,
@@ -36929,6 +36972,10 @@
 /obj/machinery/alarm{
 	pixel_x = 29;
 	pixel_y = -6
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 1
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
@@ -37986,6 +38033,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
 "iuj" = (
@@ -41700,15 +41751,6 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/storage)
-"jld" = (
-/obj/effect/decal/turf_decal/metal{
-	icon_state = "siding_thinplating_line";
-	dir = 5
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/civilian/chapel)
 "jle" = (
 /obj/structure/table/woodentable,
 /obj/item/device/flashlight/lamp/green,
@@ -42682,8 +42724,14 @@
 	},
 /area/station/cargo/lobby)
 "jvL" = (
-/turf/simulated/floor/carpet,
-/area/station/bridge)
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/hallway/secondary/exit)
 "jvV" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -43423,17 +43471,6 @@
 	oxygen = 0.01
 	},
 /area/station/engineering/atmos)
-"jEJ" = (
-/obj/structure/table/woodentable/fancy,
-/obj/item/device/flashlight/lantern,
-/obj/effect/decal/turf_decal/metal{
-	icon_state = "siding_thinplating_line";
-	dir = 4
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/civilian/chapel)
 "jEM" = (
 /obj/machinery/camera{
 	c_tag = "Bridge East";
@@ -44992,15 +45029,6 @@
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
-"jUD" = (
-/obj/effect/decal/turf_decal/metal{
-	icon_state = "siding_thinplating_line";
-	dir = 9
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/civilian/chapel)
 "jUE" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 8
@@ -45538,6 +45566,15 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/dormitories/courtroom)
+"kaL" = (
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 9
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/chapel)
 "kaM" = (
 /obj/structure/table/woodentable,
 /obj/structure/cable{
@@ -46414,7 +46451,8 @@
 /area/station/engineering/atmos)
 "kkt" = (
 /obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "box_corners_white"
+	icon_state = "box_corners_white";
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -48282,14 +48320,6 @@
 "kGI" = (
 /turf/simulated/wall,
 /area/station/hallway/primary/port)
-"kGJ" = (
-/obj/effect/decal/turf_decal/metal{
-	icon_state = "siding_thinplating_line"
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/civilian/chapel)
 "kGN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
@@ -49944,6 +49974,7 @@
 	req_access = list(12)
 	},
 /obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "kXQ" = (
@@ -51090,6 +51121,17 @@
 	icon_state = "darkred"
 	},
 /area/station/security/checkpoint/medbay)
+"lms" = (
+/obj/structure/table/woodentable/fancy,
+/obj/item/device/flashlight/lantern,
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/chapel)
 "lmu" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -52820,10 +52862,6 @@
 /turf/simulated/floor/wood,
 /area/station/storage/tools)
 "lHw" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "box_corners_white";
-	dir = 1
-	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -53164,7 +53202,9 @@
 /obj/item/canvas/twentythree_twentythree,
 /obj/item/canvas/twentythree_twentythree,
 /obj/item/canvas/twentythree_nineteen,
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/civilian/library)
 "lLN" = (
 /obj/structure/cable{
@@ -53832,6 +53872,10 @@
 /obj/machinery/camera{
 	c_tag = "Library Art Studio";
 	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor{
 	icon_state = "grimy"
@@ -54902,6 +54946,18 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/hallway/primary/port)
+"mhs" = (
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
+/area/station/civilian/library)
 "mhH" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
@@ -58889,6 +58945,15 @@
 /obj/structure/bookcase,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
+"nbF" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "wooden"
+	},
+/area/station/hallway/secondary/exit)
 "nbP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/computerframe{
@@ -59147,7 +59212,12 @@
 /area/station/ai_monitored/storage_secure)
 "nfV" = (
 /obj/machinery/bookbinder,
-/turf/simulated/floor/wood,
+/obj/effect/decal/turf_decal/alpha/yellow{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/civilian/library)
 "nfW" = (
 /obj/machinery/atmospherics/components/binary/valve/digital,
@@ -63248,9 +63318,7 @@
 "obo" = (
 /obj/item/weapon/clipboard,
 /obj/structure/table/woodentable,
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
+/turf/simulated/floor/carpet/blue2,
 /area/station/civilian/library)
 "obx" = (
 /obj/machinery/door/poddoor{
@@ -64146,6 +64214,14 @@
 "onb" = (
 /turf/simulated/floor/plating,
 /area/station/security/prison)
+"onn" = (
+/obj/machinery/firealarm{
+	pixel_y = 22
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/library)
 "onz" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/brig/equipment)
@@ -64984,6 +65060,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor,
 /area/station/security/prison)
+"oAE" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 9
+	},
+/turf/simulated/floor/wood,
+/area/station/civilian/library)
 "oAI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/turf_decal{
@@ -69487,6 +69570,14 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
+"pAL" = (
+/obj/effect/decal/turf_decal/alpha/gray{
+	icon_state = "box_corners_white"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/civilian/chapel/mass_driver)
 "pAM" = (
 /obj/machinery/processor,
 /turf/simulated/floor/plating,
@@ -70161,6 +70252,15 @@
 	},
 /turf/environment/space,
 /area/shuttle/mining/station)
+"pIi" = (
+/obj/effect/decal/turf_decal/metal{
+	icon_state = "siding_thinplating_line";
+	dir = 6
+	},
+/turf/simulated/floor{
+	icon_state = "grimy"
+	},
+/area/station/civilian/chapel)
 "pIp" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -73367,9 +73467,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 10
+	},
 /turf/simulated/floor{
-	dir = 10;
-	icon_state = "whitered"
+	dir = 9;
+	icon_state = "redfull"
 	},
 /area/station/civilian/library)
 "quk" = (
@@ -74471,15 +74575,6 @@
 	icon_state = "blackcorner"
 	},
 /area/station/hallway/primary/starboard)
-"qIy" = (
-/obj/effect/decal/turf_decal/alpha/gray{
-	icon_state = "box_corners_white";
-	dir = 8
-	},
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
-/area/station/civilian/chapel/mass_driver)
 "qIC" = (
 /obj/structure/window/fulltile/reinforced/phoron{
 	grilled = 1;
@@ -75622,15 +75717,6 @@
 	icon_state = "grimy"
 	},
 /area/station/maintenance/science)
-"qVZ" = (
-/obj/effect/decal/turf_decal/metal{
-	icon_state = "siding_thinplating_line";
-	dir = 1
-	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
-/area/station/civilian/chapel)
 "qWc" = (
 /obj/machinery/hologram/holopad,
 /obj/effect/decal/turf_decal/alpha/yellow{
@@ -78041,7 +78127,12 @@
 /area/station/rnd/hor)
 "rzL" = (
 /obj/random/vending/snack,
-/turf/simulated/floor/wood,
+/obj/effect/decal/turf_decal/alpha/red{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/civilian/library)
 "rzN" = (
 /obj/machinery/biogenerator,
@@ -83066,9 +83157,7 @@
 	amount = 50;
 	pixel_y = -11
 	},
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
+/turf/simulated/floor/carpet/blue2,
 /area/station/civilian/library)
 "sGA" = (
 /obj/structure/table/reinforced,
@@ -86388,7 +86477,12 @@
 /area/station/security/prison)
 "txv" = (
 /obj/random/vending/cola,
-/turf/simulated/floor/wood,
+/obj/effect/decal/turf_decal/alpha/red{
+	icon_state = "bot"
+	},
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/civilian/library)
 "txw" = (
 /obj/machinery/camera{
@@ -86462,15 +86556,6 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
-"tyg" = (
-/obj/effect/decal/turf_decal/wood/dark{
-	icon_state = "siding_wood_line";
-	dir = 6
-	},
-/turf/simulated/floor{
-	icon_state = "wooden"
-	},
-/area/station/hallway/secondary/exit)
 "tyn" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -86866,15 +86951,14 @@
 	},
 /area/station/bridge/meeting_room)
 "tCY" = (
-/obj/structure/table/woodentable/fancy,
-/obj/effect/decal/turf_decal/metal{
-	icon_state = "siding_thinplating_line";
-	dir = 4
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 5
 	},
 /turf/simulated/floor{
-	icon_state = "grimy"
+	icon_state = "wooden"
 	},
-/area/station/civilian/chapel)
+/area/station/hallway/secondary/exit)
 "tDb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -86941,7 +87025,9 @@
 /obj/item/canvas/twentythree_twentythree,
 /obj/item/canvas/twentythree_twentythree,
 /obj/item/canvas/nineteen_nineteen,
-/turf/simulated/floor/wood,
+/turf/simulated/floor{
+	icon_state = "vaultfull"
+	},
 /area/station/civilian/library)
 "tDN" = (
 /obj/structure/cable{
@@ -87211,8 +87297,12 @@
 	},
 /area/station/aisat/ai_chamber)
 "tGQ" = (
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line"
+	},
 /turf/simulated/floor{
-	icon_state = "whitered"
+	dir = 9;
+	icon_state = "redfull"
 	},
 /area/station/civilian/library)
 "tGX" = (
@@ -87768,6 +87858,10 @@
 "tOa" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/box,
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
+	},
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "tOH" = (
@@ -89343,6 +89437,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
 "uja" = (
@@ -89963,6 +90060,10 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -90446,9 +90547,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 5
+	},
 /turf/simulated/floor{
-	dir = 5;
-	icon_state = "whitered"
+	dir = 9;
+	icon_state = "redfull"
 	},
 /area/station/civilian/library)
 "uvF" = (
@@ -91173,9 +91278,7 @@
 	pixel_y = 6
 	},
 /obj/structure/table/woodentable,
-/turf/simulated/floor{
-	icon_state = "grimy"
-	},
+/turf/simulated/floor/carpet/blue2,
 /area/station/civilian/library)
 "uFH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -92441,6 +92544,9 @@
 	dir = 4
 	},
 /obj/random/foods/food_trash,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "uWE" = (
@@ -94270,6 +94376,9 @@
 /area/station/maintenance/medbay)
 "vtk" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_y = 32
+	},
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -98453,6 +98562,10 @@
 /obj/item/weapon/storage/pill_bottle/dice{
 	pixel_x = 4;
 	pixel_y = 3
+	},
+/obj/effect/decal/turf_decal/wood/dark{
+	icon_state = "siding_wood_line";
+	dir = 8
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
@@ -105103,6 +105216,9 @@
 	name = "Station Intercom (General)";
 	pixel_y = -32
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "grimy"
 	},
@@ -105648,7 +105764,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/junction,
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
 "ycu" = (
@@ -145027,7 +145143,7 @@ gCE
 imK
 lEC
 wnY
-jvL
+dfg
 akc
 lZx
 gWd
@@ -145541,7 +145657,7 @@ gCE
 imK
 lEC
 mrs
-jvL
+dfg
 nSo
 lZx
 oay
@@ -148446,9 +148562,9 @@ xQo
 ukM
 rmY
 kbr
-cPN
-hng
-tyg
+tCY
+jvL
+nbF
 ryF
 nGt
 djc
@@ -152047,10 +152163,10 @@ eCe
 mMq
 eCe
 wZE
-jUD
-eRo
+kaL
+cPN
 gEt
-dfg
+gXx
 huZ
 mUR
 mUR
@@ -152304,10 +152420,10 @@ sAQ
 tvk
 sAQ
 qus
-qVZ
+diz
 mtw
 cUU
-kGJ
+gEm
 huZ
 kqE
 mUR
@@ -152561,10 +152677,10 @@ bYd
 nix
 nix
 bHx
-qVZ
+diz
 iih
 jjD
-kGJ
+gEm
 pKo
 oJJ
 eiH
@@ -152818,10 +152934,10 @@ eCe
 mMq
 eCe
 wZE
-qVZ
+diz
 mtw
 cUU
-kGJ
+gEm
 huZ
 kqE
 mUR
@@ -153075,10 +153191,10 @@ sAQ
 tvk
 sAQ
 qus
-jld
-tCY
-jEJ
-cnE
+cNP
+dFi
+lms
+pIi
 huZ
 mUR
 mUR
@@ -154325,7 +154441,7 @@ bmM
 iJz
 akS
 gAj
-bZx
+mhs
 nfV
 tDB
 lLH
@@ -154582,9 +154698,9 @@ hyO
 fuB
 hGA
 lIF
-hyO
-fuB
-fuB
+huT
+twW
+twW
 lSs
 kbS
 eXa
@@ -155096,7 +155212,7 @@ bmM
 kkN
 ikj
 kbS
-bmM
+onn
 ifP
 uFD
 fGa
@@ -155368,9 +155484,9 @@ bhy
 dLG
 iIt
 pne
-hXB
-cuQ
 kkt
+lHw
+pAL
 ptR
 rKR
 mWg
@@ -155610,13 +155726,13 @@ lCq
 oGh
 kbS
 rzL
-bZx
+oAE
 gyi
 tOa
 wun
 kbS
 mUb
-diz
+xRL
 dLG
 fnI
 jVl
@@ -155882,9 +155998,9 @@ thM
 dLG
 iIt
 pne
+eRo
 lHw
-cuQ
-qIy
+fqL
 ivc
 fXD
 pne
@@ -156387,7 +156503,7 @@ rNY
 sfm
 uWh
 bwO
-diz
+xRL
 rZi
 xAc
 rNY


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Обновлены плиточки и декали на Дельте под ТГ-стайл.
Добавлены вариации цветов сайдинга в ТГ-цветах, пример в барбершопе или в офисе по центру станции.
Автолат находится далеко от лабы учёных [✓] Перенесён непосредственно в отсек.
К половине КПП СБ нет возможности пройти офицерам [✓] Шлюзам выставлены доступы на проход СБ через главные входы.
У детектива есть доступ к отделам, хотя он не офицер [✓] Доступ скорректирован только для офицеров.
Нет банкоматов на станции [✓] Увеличено их колличество и расставлены в уголках станции.
У офицеров нет боевых ножей [✓] Добавлено колличество ножей в оружейную как на Боксе.
Переделайте пермабриг на обычный бриг с таймерами [✓] Временно переделан.
В медпункте СБ нет бинтиков [✓] Добавлен наномед.
Датчики СМ не подвязаны к консоли [?] Тест не показал отсутствия связи датчиков и вент с консолями, нужно больше подробностей.
Центральный коридор не имеет АПЦ [✓] Зоны перекроены корректно.
Кейкард девайс у ХоПа некрасиво расположен [✓] Перенесено на 4 тайла выше.
Бипски не бегает на патруле [✓] Метки для путешествия Бипски выставлены.
Бар отбытия пустоват [✓] Проложена новая плиточка для сглаживания вида.
В техах ксенобио Эррорки [✓] Заменены неправильные плитки.
У капитана огнетушитель, а на Боксе нет - сложнее подпалить офис кэпа [✓] Удалён огнетушитель из офиса капитана. Проведено небольшое ревью по огнетушителям в коридорах.

Если ваш багрепорт/пропосал не появился здесь, то значит я ещё работаю/обдумываю над ним
## Почему и что этот ПР улучшит
![2023-08-11 12 58 30](https://github.com/TauCetiStation/TauCetiClassic/assets/96499407/1d446c9f-c467-4d8b-af67-8be788592170)

## Авторство

## Чеинжлог
