### PR TITLE
Контролклик по кухонной машинерии активирует её.

### DIFF
--- a/code/game/machinery/kitchen/kitchen_machines.dm
+++ b/code/game/machinery/kitchen/kitchen_machines.dm
@@ -427,6 +427,19 @@
 			dispose()
 	updateUsrDialog()
 
+/obj/machinery/kitchen_machine/CtrlClick(mob/user)
+	if(!Adjacent(user))
+		return ..()
+	if(user.incapacitated())
+		return
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='warning'>You can not comprehend what to do with this.</span>")
+		return
+	if(operating || panel_open)
+		return ..()
+
+	cook()
+
 /*******************
 *   Microwave
 ********************/


### PR DESCRIPTION
## Описание изменений
Кухонная машинерия включается на CTRL+Click

Я хотел сделать что-то элегантнее, хотел, возможно, убрать интерфейс или сделать его необязательным для взаимодействия, хотел добавить возможность "в мире" увидеть что внутри микроволновки по наведению на неё мыши и всякое такое, но понял что Волас всё равно не замержит ничего сложнее пары строчек кода. Потому довольствуйтесь Контрл-Кликом. Уже проверил на локалке. Удобно.

## Почему и что этот ПР улучшит
Удобство работы поваром.

## Авторство
AndreyGysev и никто не помогал мне в дискорде.

## Чеинжлог
 :cl:
  - tweak: Кухонная машинерия включается на CTRL+Click