### PR TITLE
Блоб наносит больше урона халкам

### DIFF
--- a/code/modules/mob/living/simple_animal/hulk.dm
+++ b/code/modules/mob/living/simple_animal/hulk.dm
@@ -51,6 +51,9 @@
 	attack_sound = SOUNDIN_PUNCH_HEAVY
 	. = ..()
 
+/mob/living/simple_animal/hulk/blob_act()
+	adjustBruteLoss(120) //+- 40 damage for hulks
+
 /mob/living/simple_animal/hulk/human
 	hulk_powers = list(/obj/effect/proc_holder/spell/aoe_turf/hulk_jump,
 						/obj/effect/proc_holder/spell/aoe_turf/hulk_dash,


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Удары блоба теперь наносят халкам примерно 35-40 урона (всего у халков 300 здоровья и регенерация в размере 2 hp в секунду), вместо 10.
## Почему и что этот ПР улучшит
Блоб будет не беззащитен против халков.
## Авторство

## Чеинжлог
🆑 Simbaka
- balance: Блоб наносит намного больше урона халкам.