### PR TITLE
Улучшение вывода данных мед. сканера ПДА

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -251,151 +251,134 @@
 		return TRUE
 	return FALSE
 
-/proc/health_analyze(mob/living/M, mob/living/user, mode, output_to_chat, is_PDA_scan=FALSE)
+/proc/health_analyze(mob/living/M, mob/living/user, mode, output_to_chat, hide_advanced_information)
 	var/message = ""
+	var/insurance_type
+	
+	if(ishuman(M))
+		insurance_type = get_insurance_type(M)
 
-	if(!is_PDA_scan)
-		var/insurance_type
-		if(ishuman(M))
-			insurance_type = get_insurance_type(M)
+	if(!output_to_chat)
+		message += "<HTML><head><meta http-equiv='Content-Type' content='text/html; charset=utf-8'><title>[M.name]'s scan results</title></head><BODY>"
 
-		if(!output_to_chat)
-			message += "<HTML><head><meta http-equiv='Content-Type' content='text/html; charset=utf-8'><title>[M.name]'s scan results</title></head><BODY>"
-
-		if(user.ClumsyProbabilityCheck(50) || (user.getBrainLoss() >= 60 && prob(50)))
-			user.visible_message("<span class='warning'>[user] has analyzed the floor's vitals!</span>", "<span class = 'warning'>You try to analyze the floor's vitals!</span>")
-			message += "<span class='notice'>Analyzing Results for The floor:\n&emsp; Overall Status: Healthy</span><br>"
-			message += "<span class='notice'>&emsp; Damage Specifics: [0]-[0]-[0]-[0]</span><br>"
-			message += "<span class='notice'>Key: Suffocation/Toxin/Burns/Brute</span><br>"
-			message += "<span class='notice'>Body Temperature: ???</span>"
-			if(!output_to_chat)
-				message += "</BODY></HTML>"
-			return message
-		user.visible_message("<span class='notice'>[user] has analyzed [M]'s vitals.</span>","<span class='notice'>You have analyzed [M]'s vitals.</span>")
-
-		var/fake_oxy = max(rand(1,40), M.getOxyLoss(), (300 - (M.getToxLoss() + M.getFireLoss() + M.getBruteLoss())))
-		var/OX = M.getOxyLoss() > 50 	? 	"<b>[M.getOxyLoss()]</b>" 		: M.getOxyLoss()
-		var/TX = M.getToxLoss() > 50 	? 	"<b>[M.getToxLoss()]</b>" 		: M.getToxLoss()
-		var/BU = M.getFireLoss() > 50 	? 	"<b>[M.getFireLoss()]</b>" 		: M.getFireLoss()
-		var/BR = M.getBruteLoss() > 50 	? 	"<b>[M.getBruteLoss()]</b>" 	: M.getBruteLoss()
-		if(M.status_flags & FAKEDEATH)
-			OX = fake_oxy > 50 			? 	"<b>[fake_oxy]</b>" 			: fake_oxy
-			message += "<span class='notice'>Analyzing Results for [M]:\n&emsp; Overall Status: dead</span><br>"
-		else
-			message += "<span class='notice'>Analyzing Results for [M]:\n&emsp; Overall Status: [M.stat > 1 ? "dead" : "[M.health - M.halloss]% healthy"]</span><br>"
-		message += "&emsp; Key: <font color='blue'>Suffocation</font>/<font color='green'>Toxin</font>/<font color='#FFA500'>Burns</font>/<font color='red'>Brute</font><br>"
-		message += "&emsp; Damage Specifics: <font color='blue'>[OX]</font> - <font color='green'>[TX]</font> - <font color='#FFA500'>[BU]</font> - <font color='red'>[BR]</font><br>"
-		message += "<span class='notice'>Body Temperature: [M.bodytemperature-T0C]&deg;C ([M.bodytemperature*1.8-459.67]&deg;F)</span><br>"
-		if(M.tod && (M.stat == DEAD || (M.status_flags & FAKEDEATH)))
-			message += "<span class='notice'>Time of Death: [M.tod]</span><br>"
-		if(ishuman(M) && mode)
-			var/mob/living/carbon/human/H = M
-			var/list/damaged = H.get_damaged_bodyparts(1, 1)
-			message += "<span class='notice'>Localized Damage, Brute/Burn:</span><br>"
-			if(length(damaged))
-				for(var/obj/item/organ/external/BP in damaged)
-					message += "<span class='notice'>&emsp; [capitalize(BP.name)]: [(BP.brute_dam > 0) ? "<span class='warning'>[BP.brute_dam]</span>" : 0][(BP.status & ORGAN_BLEEDING) ? "<span class='warning bold'>\[Bleeding\]</span>" : "&emsp;"] - [(BP.burn_dam > 0) ? "<font color='#FFA500'>[BP.burn_dam]</font>" : 0]</span><br>"
-			else
-				message += "<span class='notice'>&emsp; Limbs are OK.</span><br>"
-
-		OX = M.getOxyLoss() > 50 ? "<font color='blue'><b>Severe oxygen deprivation detected</b></font>" : "Subject bloodstream oxygen level normal"
-		TX = M.getToxLoss() > 50 ? "<font color='green'><b>Dangerous amount of toxins detected</b></font>" : "Subject bloodstream toxin level minimal"
-		BU = M.getFireLoss() > 50 ? "<font color='#FFA500'><b>Severe burn damage detected</b></font>" : "Subject burn injury status O.K"
-		BR = M.getBruteLoss() > 50 ? "<font color='red'><b>Severe anatomical damage detected</b></font>" : "Subject brute-force injury status O.K"
-		if(M.status_flags & FAKEDEATH)
-			OX = fake_oxy > 50 ? 		"<span class='warning'>Severe oxygen deprivation detected</span>" : "Subject bloodstream oxygen level normal"
-		message += "[OX]<br>[TX]<br>[BU]<br>[BR]<br>"
-		if(iscarbon(M))
-			var/mob/living/carbon/C = M
-			if(C.reagents.total_volume || C.is_infected_with_zombie_virus())
-				message += "<span class='warning'>Warning: Unknown substance detected in subject's blood.</span><br>"
-			if(C.virus2.len)
-				for (var/ID in C.virus2)
-					if (ID in virusDB)
-						var/datum/data/record/V = virusDB[ID]
-						message += "<span class='warning'>Warning: Pathogen [V.fields["name"]] detected in subject's blood. Known antigen : [V.fields["antigen"]]</span><br>"
-	//			user.oldshow_message(text("<span class='warning'>Warning: Unknown pathogen detected in subject's blood.</span>"))
-			if(C.roundstart_quirks.len)
-				message += "\t<span class='info'>Subject has the following physiological traits: [C.get_trait_string()].</span><br>"
-		if(M.getCloneLoss())
-			to_chat(user, "<span class='warning'>Subject appears to have been imperfectly cloned.</span>")
-		if(M.reagents && M.reagents.get_reagent_amount("inaprovaline"))
-			message += "<span class='notice'>Bloodstream Analysis located [M.reagents:get_reagent_amount("inaprovaline")] units of rejuvenation chemicals.</span><br>"
-		if(M.has_brain_worms())
-			message += "<span class='warning'>Subject suffering from aberrant brain activity. Recommend further scanning.</span><br>"
-		else if(M.getBrainLoss() >= 100 || (ishuman(M) && !M:has_brain() && M:should_have_organ(O_BRAIN)))
-			message += "<span class='warning'>Subject is brain dead.</span>"
-		else if(M.getBrainLoss() >= 60)
-			message += "<span class='warning'>Severe brain damage detected. Subject likely to have mental retardation.</span><br>"
-		else if(M.getBrainLoss() >= 10)
-			message += "<span class='warning'>Significant brain damage detected. Subject may have had a concussion.</span><br>"
-		if(ishuman(M))
-			var/mob/living/carbon/human/H = M
-			var/found_bleed
-			var/found_broken
-			for(var/obj/item/organ/external/BP in H.bodyparts)
-				if(BP.status & ORGAN_BROKEN)
-					if(((BP.body_zone == BP_L_ARM) || (BP.body_zone == BP_R_ARM) || (BP.body_zone == BP_L_LEG) || (BP.body_zone == BP_R_LEG)) && !(BP.status & ORGAN_SPLINTED))
-						message += "<span class='warning'>Unsecured fracture in subject [BP.name]. Splinting recommended for transport.</span><br>"
-					if(!found_broken)
-						found_broken = TRUE
-
-				if(!found_bleed && (BP.status & ORGAN_ARTERY_CUT))
-					found_bleed = TRUE
-
-				if(BP.has_infected_wound())
-					message += "<span class='warning'>Infected wound detected in subject [BP.name]. Disinfection recommended.</span><br>"
-
-			if(found_bleed)
-				message += "<span class='warning'>Arterial bleeding detected. Advanced scanner required for location.</span><br>"
-			if(found_broken)
-				message += "<span class='warning'>Bone fractures detected. Advanced scanner required for location.</span><br>"
-
-			var/blood_volume = H.blood_amount()
-			var/blood_percent =  100.0 * blood_volume / BLOOD_VOLUME_NORMAL
-			var/blood_type = H.dna.b_type
-			if(blood_volume <= BLOOD_VOLUME_SAFE && blood_volume > BLOOD_VOLUME_OKAY)
-				message += "<span class='warning bold'>Warning: Blood Level LOW: [blood_percent]% [blood_volume]cl.</span><span class='notice'>Type: [blood_type]</span><br>"
-			else if(blood_volume <= BLOOD_VOLUME_OKAY)
-				message += "<span class='warning bold'>Warning: Blood Level CRITICAL: [blood_percent]% [blood_volume]cl.</span><span class='notice bold'>Type: [blood_type]</span><br>"
-			else
-				message += "<span class='notice'>Blood Level Normal: [blood_percent]% [blood_volume]cl. Type: [blood_type]</span><br>"
-
-			var/obj/item/organ/internal/heart/Heart = H.organs_by_name[O_HEART]
-			if(Heart)
-				switch(Heart.heart_status)
-					if(HEART_FAILURE)
-						message += "<span class='notice'><font color='red'>Warning! Subject's heart stopped!</font></span><br>"
-					if(HEART_FIBR)
-						message += "<span class='notice'>Subject's Heart status: <font color='blue'>Attention! Subject's heart fibrillating.</font></span><br>"
-				message += "<span class='notice'>Subject's pulse: <font color='[H.pulse == PULSE_THREADY || H.pulse == PULSE_NONE ? "red" : "blue"]'>[H.get_pulse(GETPULSE_TOOL)] bpm.</font></span><br>"
-
-		if(insurance_type)
-			message += "<span class='notice'><font color='blue'>Страховка: [insurance_type]</font></span><br>"
-
+	if(user.ClumsyProbabilityCheck(50) || (user.getBrainLoss() >= 60 && prob(50)))
+		user.visible_message("<span class='warning'>[user] has analyzed the floor's vitals!</span>", "<span class = 'warning'>You try to analyze the floor's vitals!</span>")
+		message += "<span class='notice'>Analyzing Results for The floor:\n&emsp; Overall Status: Healthy</span><br>"
+		message += "<span class='notice'>&emsp; Damage Specifics: [0]-[0]-[0]-[0]</span><br>"
+		message += "<span class='notice'>Key: Suffocation/Toxin/Burns/Brute</span><br>"
+		message += "<span class='notice'>Body Temperature: ???</span>"
 		if(!output_to_chat)
 			message += "</BODY></HTML>"
+		return message
+	user.visible_message("<span class='notice'>[user] has analyzed [M]'s vitals.</span>","<span class='notice'>You have analyzed [M]'s vitals.</span>")
+
+	var/fake_oxy = max(rand(1,40), M.getOxyLoss(), (300 - (M.getToxLoss() + M.getFireLoss() + M.getBruteLoss())))
+	var/OX = M.getOxyLoss() > 50 	? 	"<b>[M.getOxyLoss()]</b>" 		: M.getOxyLoss()
+	var/TX = M.getToxLoss() > 50 	? 	"<b>[M.getToxLoss()]</b>" 		: M.getToxLoss()
+	var/BU = M.getFireLoss() > 50 	? 	"<b>[M.getFireLoss()]</b>" 		: M.getFireLoss()
+	var/BR = M.getBruteLoss() > 50 	? 	"<b>[M.getBruteLoss()]</b>" 	: M.getBruteLoss()
+	if(M.status_flags & FAKEDEATH)
+		OX = fake_oxy > 50 			? 	"<b>[fake_oxy]</b>" 			: fake_oxy
+		message += "<span class='notice'>Analyzing Results for [M]:\n&emsp; Overall Status: dead</span><br>"
 	else
-		var/mob/living/C = M
-		message += "<span class='notice'>Analyzing Results for [C]:</span>"
-		message += "<span class='notice'>&emsp; Overall Status: [C.stat > 1 ? "dead" : "[C.health - C.halloss]% healthy"]</span>"
-		message += "<span class='notice'>&emsp; Body Temperature: [C.bodytemperature-T0C]&deg;C ([C.bodytemperature*1.8-459.67]&deg;F)</span><br>"
-		message += "&emsp; Damage Specifics: <font color='blue'>[C.getOxyLoss()]</font> - <font color='green'>[C.getToxLoss()]</font> - <font color='#FFA500'>[C.getFireLoss()]</font> - <font color='red'>[C.getBruteLoss()]</font>"
-		message += "&emsp; Key: <font color='blue'>Suffocation</font>/<font color='green'>Toxin</font>/<font color='#FFA500'>Burns</font>/<font color='red'>Brute</font><br>"
+		message += "<span class='notice'>Analyzing Results for [M]:\n&emsp; Overall Status: [M.stat > 1 ? "dead" : "[M.health - M.halloss]% healthy"]</span><br>"
+	message += "&emsp; Key: <font color='blue'>Suffocation</font>/<font color='green'>Toxin</font>/<font color='#FFA500'>Burns</font>/<font color='red'>Brute</font><br>"
+	message += "&emsp; Damage Specifics: <font color='blue'>[OX]</font> - <font color='green'>[TX]</font> - <font color='#FFA500'>[BU]</font> - <font color='red'>[BR]</font><br>"
+	message += "<span class='notice'>Body Temperature: [M.bodytemperature-T0C]&deg;C ([M.bodytemperature*1.8-459.67]&deg;F)</span><br>"
+	if(M.tod && (M.stat == DEAD || (M.status_flags & FAKEDEATH)))
+		message += "<span class='notice'>Time of Death: [M.tod]</span><br>"
+	if(ishuman(M) && mode)
+		var/mob/living/carbon/human/H = M
+		var/list/damaged = H.get_damaged_bodyparts(1, 1)
+		message += "<span class='notice'>Localized Damage, Brute/Burn:</span><br>"
+		if(length(damaged))
+			for(var/obj/item/organ/external/BP in damaged)
+				message += "<span class='notice'>&emsp; [capitalize(BP.name)]: [(BP.brute_dam > 0) ? "<span class='warning'>[BP.brute_dam]</span>" : 0][(BP.status & ORGAN_BLEEDING) ? "<span class='warning bold'>\[Bleeding\]</span>" : "&emsp;"] - [(BP.burn_dam > 0) ? "<font color='#FFA500'>[BP.burn_dam]</font>" : 0]</span><br>"
+		else
+			message += "<span class='notice'>&emsp; Limbs are OK.</span><br>"
+	
+	if(hide_advanced_information)
+		if(!output_to_chat)
+			message += "</BODY></HTML>"
+		
+		return message
+	
+	OX = M.getOxyLoss() > 50 ? "<font color='blue'><b>Severe oxygen deprivation detected</b></font>" : "Subject bloodstream oxygen level normal"
+	TX = M.getToxLoss() > 50 ? "<font color='green'><b>Dangerous amount of toxins detected</b></font>" : "Subject bloodstream toxin level minimal"
+	BU = M.getFireLoss() > 50 ? "<font color='#FFA500'><b>Severe burn damage detected</b></font>" : "Subject burn injury status O.K"
+	BR = M.getBruteLoss() > 50 ? "<font color='red'><b>Severe anatomical damage detected</b></font>" : "Subject brute-force injury status O.K"
+	if(M.status_flags & FAKEDEATH)
+		OX = fake_oxy > 50 ? 		"<span class='warning'>Severe oxygen deprivation detected</span>" : "Subject bloodstream oxygen level normal"
+	message += "[OX]<br>[TX]<br>[BU]<br>[BR]<br>"
+	if(iscarbon(M))
+		var/mob/living/carbon/C = M
+		if(C.reagents.total_volume || C.is_infected_with_zombie_virus())
+			message += "<span class='warning'>Warning: Unknown substance detected in subject's blood.</span><br>"
+		if(C.virus2.len)
+			for (var/ID in C.virus2)
+				if (ID in virusDB)
+					var/datum/data/record/V = virusDB[ID]
+					message += "<span class='warning'>Warning: Pathogen [V.fields["name"]] detected in subject's blood. Known antigen : [V.fields["antigen"]]</span><br>"
+//			user.oldshow_message(text("<span class='warning'>Warning: Unknown pathogen detected in subject's blood.</span>"))
+		if(C.roundstart_quirks.len)
+			message += "\t<span class='info'>Subject has the following physiological traits: [C.get_trait_string()].</span><br>"
+	if(M.getCloneLoss())
+		to_chat(user, "<span class='warning'>Subject appears to have been imperfectly cloned.</span>")
+	if(M.reagents && M.reagents.get_reagent_amount("inaprovaline"))
+		message += "<span class='notice'>Bloodstream Analysis located [M.reagents:get_reagent_amount("inaprovaline")] units of rejuvenation chemicals.</span><br>"
+	if(M.has_brain_worms())
+		message += "<span class='warning'>Subject suffering from aberrant brain activity. Recommend further scanning.</span><br>"
+	else if(M.getBrainLoss() >= 100 || (ishuman(M) && !M:has_brain() && M:should_have_organ(O_BRAIN)))
+		message += "<span class='warning'>Subject is brain dead.</span>"
+	else if(M.getBrainLoss() >= 60)
+		message += "<span class='warning'>Severe brain damage detected. Subject likely to have mental retardation.</span><br>"
+	else if(M.getBrainLoss() >= 10)
+		message += "<span class='warning'>Significant brain damage detected. Subject may have had a concussion.</span><br>"
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		var/found_bleed
+		var/found_broken
+		for(var/obj/item/organ/external/BP in H.bodyparts)
+			if(BP.status & ORGAN_BROKEN)
+				if(((BP.body_zone == BP_L_ARM) || (BP.body_zone == BP_R_ARM) || (BP.body_zone == BP_L_LEG) || (BP.body_zone == BP_R_LEG)) && !(BP.status & ORGAN_SPLINTED))
+					message += "<span class='warning'>Unsecured fracture in subject [BP.name]. Splinting recommended for transport.</span><br>"
+				if(!found_broken)
+					found_broken = TRUE
 
-		if(C.tod && (C.stat == DEAD || (C.status_flags & FAKEDEATH)))
-			message += "<span class='notice'>&emsp; Time of Death: [C.tod]</span>"
+			if(!found_bleed && (BP.status & ORGAN_ARTERY_CUT))
+				found_bleed = TRUE
 
-		if(ishuman(C))
-			var/mob/living/carbon/human/H = C
-			var/list/damaged = H.get_damaged_bodyparts(1, 1)
-			message += "<span class='notice'>Localized Damage, <font color='red'>Brute</font>/<font color='#FFA500'>Burn</font>:</span><br>"
-			if(length(damaged)>0)
-				for(var/obj/item/organ/external/BP in damaged)
-					message += text("<span class='notice'>&emsp; []: [][] - []</span>",capitalize(BP.name), (BP.brute_dam > 0) ? "<span class='warning'>[BP.brute_dam]</span>" : 0, (BP.status & ORGAN_BLEEDING) ? "<span class='warning bold'>\[Bleeding\]</span>" : "&emsp;", (BP.burn_dam > 0) ? "<font color='#FFA500'>[BP.burn_dam]</font>" : 0)
-			else
-				message += "<span class='notice'>&emsp; Limbs are OK.</span>"
+			if(BP.has_infected_wound())
+				message += "<span class='warning'>Infected wound detected in subject [BP.name]. Disinfection recommended.</span><br>"
 
-		user.visible_message("<span class='notice'>[user] has analyzed [M]'s vitals.</span>","<span class='notice'>You have analyzed [M]'s vitals.</span>")
+		if(found_bleed)
+			message += "<span class='warning'>Arterial bleeding detected. Advanced scanner required for location.</span><br>"
+		if(found_broken)
+			message += "<span class='warning'>Bone fractures detected. Advanced scanner required for location.</span><br>"
 
+		var/blood_volume = H.blood_amount()
+		var/blood_percent =  100.0 * blood_volume / BLOOD_VOLUME_NORMAL
+		var/blood_type = H.dna.b_type
+		if(blood_volume <= BLOOD_VOLUME_SAFE && blood_volume > BLOOD_VOLUME_OKAY)
+			message += "<span class='warning bold'>Warning: Blood Level LOW: [blood_percent]% [blood_volume]cl.</span><span class='notice'>Type: [blood_type]</span><br>"
+		else if(blood_volume <= BLOOD_VOLUME_OKAY)
+			message += "<span class='warning bold'>Warning: Blood Level CRITICAL: [blood_percent]% [blood_volume]cl.</span><span class='notice bold'>Type: [blood_type]</span><br>"
+		else
+			message += "<span class='notice'>Blood Level Normal: [blood_percent]% [blood_volume]cl. Type: [blood_type]</span><br>"
+
+		var/obj/item/organ/internal/heart/Heart = H.organs_by_name[O_HEART]
+		if(Heart)
+			switch(Heart.heart_status)
+				if(HEART_FAILURE)
+					message += "<span class='notice'><font color='red'>Warning! Subject's heart stopped!</font></span><br>"
+				if(HEART_FIBR)
+					message += "<span class='notice'>Subject's Heart status: <font color='blue'>Attention! Subject's heart fibrillating.</font></span><br>"
+			message += "<span class='notice'>Subject's pulse: <font color='[H.pulse == PULSE_THREADY || H.pulse == PULSE_NONE ? "red" : "blue"]'>[H.get_pulse(GETPULSE_TOOL)] bpm.</font></span><br>"
+
+	if(insurance_type)
+		message += "<span class='notice'><font color='blue'>Страховка: [insurance_type]</font></span><br>"
+
+	if(!output_to_chat)
+		message += "</BODY></HTML>"
+		
 	return message

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -251,126 +251,151 @@
 		return TRUE
 	return FALSE
 
-/proc/health_analyze(mob/living/M, mob/living/user, mode, output_to_chat)
-	var/insurance_type
-	if(ishuman(M))
-		insurance_type = get_insurance_type(M)
-
+/proc/health_analyze(mob/living/M, mob/living/user, mode, output_to_chat, is_PDA_scan=FALSE)
 	var/message = ""
-	if(!output_to_chat)
-		message += "<HTML><head><meta http-equiv='Content-Type' content='text/html; charset=utf-8'><title>[M.name]'s scan results</title></head><BODY>"
 
-	if(user.ClumsyProbabilityCheck(50) || (user.getBrainLoss() >= 60 && prob(50)))
-		user.visible_message("<span class='warning'>[user] has analyzed the floor's vitals!</span>", "<span class = 'warning'>You try to analyze the floor's vitals!</span>")
-		message += "<span class='notice'>Analyzing Results for The floor:\n&emsp; Overall Status: Healthy</span><br>"
-		message += "<span class='notice'>&emsp; Damage Specifics: [0]-[0]-[0]-[0]</span><br>"
-		message += "<span class='notice'>Key: Suffocation/Toxin/Burns/Brute</span><br>"
-		message += "<span class='notice'>Body Temperature: ???</span>"
+	if(!is_PDA_scan)
+		var/insurance_type
+		if(ishuman(M))
+			insurance_type = get_insurance_type(M)
+
+		if(!output_to_chat)
+			message += "<HTML><head><meta http-equiv='Content-Type' content='text/html; charset=utf-8'><title>[M.name]'s scan results</title></head><BODY>"
+
+		if(user.ClumsyProbabilityCheck(50) || (user.getBrainLoss() >= 60 && prob(50)))
+			user.visible_message("<span class='warning'>[user] has analyzed the floor's vitals!</span>", "<span class = 'warning'>You try to analyze the floor's vitals!</span>")
+			message += "<span class='notice'>Analyzing Results for The floor:\n&emsp; Overall Status: Healthy</span><br>"
+			message += "<span class='notice'>&emsp; Damage Specifics: [0]-[0]-[0]-[0]</span><br>"
+			message += "<span class='notice'>Key: Suffocation/Toxin/Burns/Brute</span><br>"
+			message += "<span class='notice'>Body Temperature: ???</span>"
+			if(!output_to_chat)
+				message += "</BODY></HTML>"
+			return message
+		user.visible_message("<span class='notice'>[user] has analyzed [M]'s vitals.</span>","<span class='notice'>You have analyzed [M]'s vitals.</span>")
+
+		var/fake_oxy = max(rand(1,40), M.getOxyLoss(), (300 - (M.getToxLoss() + M.getFireLoss() + M.getBruteLoss())))
+		var/OX = M.getOxyLoss() > 50 	? 	"<b>[M.getOxyLoss()]</b>" 		: M.getOxyLoss()
+		var/TX = M.getToxLoss() > 50 	? 	"<b>[M.getToxLoss()]</b>" 		: M.getToxLoss()
+		var/BU = M.getFireLoss() > 50 	? 	"<b>[M.getFireLoss()]</b>" 		: M.getFireLoss()
+		var/BR = M.getBruteLoss() > 50 	? 	"<b>[M.getBruteLoss()]</b>" 	: M.getBruteLoss()
+		if(M.status_flags & FAKEDEATH)
+			OX = fake_oxy > 50 			? 	"<b>[fake_oxy]</b>" 			: fake_oxy
+			message += "<span class='notice'>Analyzing Results for [M]:\n&emsp; Overall Status: dead</span><br>"
+		else
+			message += "<span class='notice'>Analyzing Results for [M]:\n&emsp; Overall Status: [M.stat > 1 ? "dead" : "[M.health - M.halloss]% healthy"]</span><br>"
+		message += "&emsp; Key: <font color='blue'>Suffocation</font>/<font color='green'>Toxin</font>/<font color='#FFA500'>Burns</font>/<font color='red'>Brute</font><br>"
+		message += "&emsp; Damage Specifics: <font color='blue'>[OX]</font> - <font color='green'>[TX]</font> - <font color='#FFA500'>[BU]</font> - <font color='red'>[BR]</font><br>"
+		message += "<span class='notice'>Body Temperature: [M.bodytemperature-T0C]&deg;C ([M.bodytemperature*1.8-459.67]&deg;F)</span><br>"
+		if(M.tod && (M.stat == DEAD || (M.status_flags & FAKEDEATH)))
+			message += "<span class='notice'>Time of Death: [M.tod]</span><br>"
+		if(ishuman(M) && mode)
+			var/mob/living/carbon/human/H = M
+			var/list/damaged = H.get_damaged_bodyparts(1, 1)
+			message += "<span class='notice'>Localized Damage, Brute/Burn:</span><br>"
+			if(length(damaged))
+				for(var/obj/item/organ/external/BP in damaged)
+					message += "<span class='notice'>&emsp; [capitalize(BP.name)]: [(BP.brute_dam > 0) ? "<span class='warning'>[BP.brute_dam]</span>" : 0][(BP.status & ORGAN_BLEEDING) ? "<span class='warning bold'>\[Bleeding\]</span>" : "&emsp;"] - [(BP.burn_dam > 0) ? "<font color='#FFA500'>[BP.burn_dam]</font>" : 0]</span><br>"
+			else
+				message += "<span class='notice'>&emsp; Limbs are OK.</span><br>"
+
+		OX = M.getOxyLoss() > 50 ? "<font color='blue'><b>Severe oxygen deprivation detected</b></font>" : "Subject bloodstream oxygen level normal"
+		TX = M.getToxLoss() > 50 ? "<font color='green'><b>Dangerous amount of toxins detected</b></font>" : "Subject bloodstream toxin level minimal"
+		BU = M.getFireLoss() > 50 ? "<font color='#FFA500'><b>Severe burn damage detected</b></font>" : "Subject burn injury status O.K"
+		BR = M.getBruteLoss() > 50 ? "<font color='red'><b>Severe anatomical damage detected</b></font>" : "Subject brute-force injury status O.K"
+		if(M.status_flags & FAKEDEATH)
+			OX = fake_oxy > 50 ? 		"<span class='warning'>Severe oxygen deprivation detected</span>" : "Subject bloodstream oxygen level normal"
+		message += "[OX]<br>[TX]<br>[BU]<br>[BR]<br>"
+		if(iscarbon(M))
+			var/mob/living/carbon/C = M
+			if(C.reagents.total_volume || C.is_infected_with_zombie_virus())
+				message += "<span class='warning'>Warning: Unknown substance detected in subject's blood.</span><br>"
+			if(C.virus2.len)
+				for (var/ID in C.virus2)
+					if (ID in virusDB)
+						var/datum/data/record/V = virusDB[ID]
+						message += "<span class='warning'>Warning: Pathogen [V.fields["name"]] detected in subject's blood. Known antigen : [V.fields["antigen"]]</span><br>"
+	//			user.oldshow_message(text("<span class='warning'>Warning: Unknown pathogen detected in subject's blood.</span>"))
+			if(C.roundstart_quirks.len)
+				message += "\t<span class='info'>Subject has the following physiological traits: [C.get_trait_string()].</span><br>"
+		if(M.getCloneLoss())
+			to_chat(user, "<span class='warning'>Subject appears to have been imperfectly cloned.</span>")
+		if(M.reagents && M.reagents.get_reagent_amount("inaprovaline"))
+			message += "<span class='notice'>Bloodstream Analysis located [M.reagents:get_reagent_amount("inaprovaline")] units of rejuvenation chemicals.</span><br>"
+		if(M.has_brain_worms())
+			message += "<span class='warning'>Subject suffering from aberrant brain activity. Recommend further scanning.</span><br>"
+		else if(M.getBrainLoss() >= 100 || (ishuman(M) && !M:has_brain() && M:should_have_organ(O_BRAIN)))
+			message += "<span class='warning'>Subject is brain dead.</span>"
+		else if(M.getBrainLoss() >= 60)
+			message += "<span class='warning'>Severe brain damage detected. Subject likely to have mental retardation.</span><br>"
+		else if(M.getBrainLoss() >= 10)
+			message += "<span class='warning'>Significant brain damage detected. Subject may have had a concussion.</span><br>"
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			var/found_bleed
+			var/found_broken
+			for(var/obj/item/organ/external/BP in H.bodyparts)
+				if(BP.status & ORGAN_BROKEN)
+					if(((BP.body_zone == BP_L_ARM) || (BP.body_zone == BP_R_ARM) || (BP.body_zone == BP_L_LEG) || (BP.body_zone == BP_R_LEG)) && !(BP.status & ORGAN_SPLINTED))
+						message += "<span class='warning'>Unsecured fracture in subject [BP.name]. Splinting recommended for transport.</span><br>"
+					if(!found_broken)
+						found_broken = TRUE
+
+				if(!found_bleed && (BP.status & ORGAN_ARTERY_CUT))
+					found_bleed = TRUE
+
+				if(BP.has_infected_wound())
+					message += "<span class='warning'>Infected wound detected in subject [BP.name]. Disinfection recommended.</span><br>"
+
+			if(found_bleed)
+				message += "<span class='warning'>Arterial bleeding detected. Advanced scanner required for location.</span><br>"
+			if(found_broken)
+				message += "<span class='warning'>Bone fractures detected. Advanced scanner required for location.</span><br>"
+
+			var/blood_volume = H.blood_amount()
+			var/blood_percent =  100.0 * blood_volume / BLOOD_VOLUME_NORMAL
+			var/blood_type = H.dna.b_type
+			if(blood_volume <= BLOOD_VOLUME_SAFE && blood_volume > BLOOD_VOLUME_OKAY)
+				message += "<span class='warning bold'>Warning: Blood Level LOW: [blood_percent]% [blood_volume]cl.</span><span class='notice'>Type: [blood_type]</span><br>"
+			else if(blood_volume <= BLOOD_VOLUME_OKAY)
+				message += "<span class='warning bold'>Warning: Blood Level CRITICAL: [blood_percent]% [blood_volume]cl.</span><span class='notice bold'>Type: [blood_type]</span><br>"
+			else
+				message += "<span class='notice'>Blood Level Normal: [blood_percent]% [blood_volume]cl. Type: [blood_type]</span><br>"
+
+			var/obj/item/organ/internal/heart/Heart = H.organs_by_name[O_HEART]
+			if(Heart)
+				switch(Heart.heart_status)
+					if(HEART_FAILURE)
+						message += "<span class='notice'><font color='red'>Warning! Subject's heart stopped!</font></span><br>"
+					if(HEART_FIBR)
+						message += "<span class='notice'>Subject's Heart status: <font color='blue'>Attention! Subject's heart fibrillating.</font></span><br>"
+				message += "<span class='notice'>Subject's pulse: <font color='[H.pulse == PULSE_THREADY || H.pulse == PULSE_NONE ? "red" : "blue"]'>[H.get_pulse(GETPULSE_TOOL)] bpm.</font></span><br>"
+
+		if(insurance_type)
+			message += "<span class='notice'><font color='blue'>Страховка: [insurance_type]</font></span><br>"
+
 		if(!output_to_chat)
 			message += "</BODY></HTML>"
-		return message
-	user.visible_message("<span class='notice'>[user] has analyzed [M]'s vitals.</span>","<span class='notice'>You have analyzed [M]'s vitals.</span>")
-
-	var/fake_oxy = max(rand(1,40), M.getOxyLoss(), (300 - (M.getToxLoss() + M.getFireLoss() + M.getBruteLoss())))
-	var/OX = M.getOxyLoss() > 50 	? 	"<b>[M.getOxyLoss()]</b>" 		: M.getOxyLoss()
-	var/TX = M.getToxLoss() > 50 	? 	"<b>[M.getToxLoss()]</b>" 		: M.getToxLoss()
-	var/BU = M.getFireLoss() > 50 	? 	"<b>[M.getFireLoss()]</b>" 		: M.getFireLoss()
-	var/BR = M.getBruteLoss() > 50 	? 	"<b>[M.getBruteLoss()]</b>" 	: M.getBruteLoss()
-	if(M.status_flags & FAKEDEATH)
-		OX = fake_oxy > 50 			? 	"<b>[fake_oxy]</b>" 			: fake_oxy
-		message += "<span class='notice'>Analyzing Results for [M]:\n&emsp; Overall Status: dead</span><br>"
 	else
-		message += "<span class='notice'>Analyzing Results for [M]:\n&emsp; Overall Status: [M.stat > 1 ? "dead" : "[M.health - M.halloss]% healthy"]</span><br>"
-	message += "&emsp; Key: <font color='blue'>Suffocation</font>/<font color='green'>Toxin</font>/<font color='#FFA500'>Burns</font>/<font color='red'>Brute</font><br>"
-	message += "&emsp; Damage Specifics: <font color='blue'>[OX]</font> - <font color='green'>[TX]</font> - <font color='#FFA500'>[BU]</font> - <font color='red'>[BR]</font><br>"
-	message += "<span class='notice'>Body Temperature: [M.bodytemperature-T0C]&deg;C ([M.bodytemperature*1.8-459.67]&deg;F)</span><br>"
-	if(M.tod && (M.stat == DEAD || (M.status_flags & FAKEDEATH)))
-		message += "<span class='notice'>Time of Death: [M.tod]</span><br>"
-	if(ishuman(M) && mode)
-		var/mob/living/carbon/human/H = M
-		var/list/damaged = H.get_damaged_bodyparts(1, 1)
-		message += "<span class='notice'>Localized Damage, Brute/Burn:</span><br>"
-		if(length(damaged))
-			for(var/obj/item/organ/external/BP in damaged)
-				message += "<span class='notice'>&emsp; [capitalize(BP.name)]: [(BP.brute_dam > 0) ? "<span class='warning'>[BP.brute_dam]</span>" : 0][(BP.status & ORGAN_BLEEDING) ? "<span class='warning bold'>\[Bleeding\]</span>" : "&emsp;"] - [(BP.burn_dam > 0) ? "<font color='#FFA500'>[BP.burn_dam]</font>" : 0]</span><br>"
-		else
-			message += "<span class='notice'>&emsp; Limbs are OK.</span><br>"
+		var/mob/living/C = M
+		message += "<span class='notice'>Analyzing Results for [C]:</span>"
+		message += "<span class='notice'>&emsp; Overall Status: [C.stat > 1 ? "dead" : "[C.health - C.halloss]% healthy"]</span>"
+		message += "<span class='notice'>&emsp; Body Temperature: [C.bodytemperature-T0C]&deg;C ([C.bodytemperature*1.8-459.67]&deg;F)</span><br>"
+		message += "&emsp; Damage Specifics: <font color='blue'>[C.getOxyLoss()]</font> - <font color='green'>[C.getToxLoss()]</font> - <font color='#FFA500'>[C.getFireLoss()]</font> - <font color='red'>[C.getBruteLoss()]</font>"
+		message += "&emsp; Key: <font color='blue'>Suffocation</font>/<font color='green'>Toxin</font>/<font color='#FFA500'>Burns</font>/<font color='red'>Brute</font><br>"
 
-	OX = M.getOxyLoss() > 50 ? "<font color='blue'><b>Severe oxygen deprivation detected</b></font>" : "Subject bloodstream oxygen level normal"
-	TX = M.getToxLoss() > 50 ? "<font color='green'><b>Dangerous amount of toxins detected</b></font>" : "Subject bloodstream toxin level minimal"
-	BU = M.getFireLoss() > 50 ? "<font color='#FFA500'><b>Severe burn damage detected</b></font>" : "Subject burn injury status O.K"
-	BR = M.getBruteLoss() > 50 ? "<font color='red'><b>Severe anatomical damage detected</b></font>" : "Subject brute-force injury status O.K"
-	if(M.status_flags & FAKEDEATH)
-		OX = fake_oxy > 50 ? 		"<span class='warning'>Severe oxygen deprivation detected</span>" : "Subject bloodstream oxygen level normal"
-	message += "[OX]<br>[TX]<br>[BU]<br>[BR]<br>"
-	if(iscarbon(M))
-		var/mob/living/carbon/C = M
-		if(C.reagents.total_volume || C.is_infected_with_zombie_virus())
-			message += "<span class='warning'>Warning: Unknown substance detected in subject's blood.</span><br>"
-		if(C.virus2.len)
-			for (var/ID in C.virus2)
-				if (ID in virusDB)
-					var/datum/data/record/V = virusDB[ID]
-					message += "<span class='warning'>Warning: Pathogen [V.fields["name"]] detected in subject's blood. Known antigen : [V.fields["antigen"]]</span><br>"
-//			user.oldshow_message(text("<span class='warning'>Warning: Unknown pathogen detected in subject's blood.</span>"))
-		if(C.roundstart_quirks.len)
-			message += "\t<span class='info'>Subject has the following physiological traits: [C.get_trait_string()].</span><br>"
-	if(M.getCloneLoss())
-		to_chat(user, "<span class='warning'>Subject appears to have been imperfectly cloned.</span>")
-	if(M.reagents && M.reagents.get_reagent_amount("inaprovaline"))
-		message += "<span class='notice'>Bloodstream Analysis located [M.reagents:get_reagent_amount("inaprovaline")] units of rejuvenation chemicals.</span><br>"
-	if(M.has_brain_worms())
-		message += "<span class='warning'>Subject suffering from aberrant brain activity. Recommend further scanning.</span><br>"
-	else if(M.getBrainLoss() >= 100 || (ishuman(M) && !M:has_brain() && M:should_have_organ(O_BRAIN)))
-		message += "<span class='warning'>Subject is brain dead.</span>"
-	else if(M.getBrainLoss() >= 60)
-		message += "<span class='warning'>Severe brain damage detected. Subject likely to have mental retardation.</span><br>"
-	else if(M.getBrainLoss() >= 10)
-		message += "<span class='warning'>Significant brain damage detected. Subject may have had a concussion.</span><br>"
-	if(ishuman(M))
-		var/mob/living/carbon/human/H = M
-		var/found_bleed
-		var/found_broken
-		for(var/obj/item/organ/external/BP in H.bodyparts)
-			if(BP.status & ORGAN_BROKEN)
-				if(((BP.body_zone == BP_L_ARM) || (BP.body_zone == BP_R_ARM) || (BP.body_zone == BP_L_LEG) || (BP.body_zone == BP_R_LEG)) && !(BP.status & ORGAN_SPLINTED))
-					message += "<span class='warning'>Unsecured fracture in subject [BP.name]. Splinting recommended for transport.</span><br>"
-				if(!found_broken)
-					found_broken = TRUE
+		if(C.tod && (C.stat == DEAD || (C.status_flags & FAKEDEATH)))
+			message += "<span class='notice'>&emsp; Time of Death: [C.tod]</span>"
 
-			if(!found_bleed && (BP.status & ORGAN_ARTERY_CUT))
-				found_bleed = TRUE
+		if(ishuman(C))
+			var/mob/living/carbon/human/H = C
+			var/list/damaged = H.get_damaged_bodyparts(1, 1)
+			message += "<span class='notice'>Localized Damage, <font color='red'>Brute</font>/<font color='#FFA500'>Burn</font>:</span><br>"
+			if(length(damaged)>0)
+				for(var/obj/item/organ/external/BP in damaged)
+					message += text("<span class='notice'>&emsp; []: [][] - []</span>",capitalize(BP.name), (BP.brute_dam > 0) ? "<span class='warning'>[BP.brute_dam]</span>" : 0, (BP.status & ORGAN_BLEEDING) ? "<span class='warning bold'>\[Bleeding\]</span>" : "&emsp;", (BP.burn_dam > 0) ? "<font color='#FFA500'>[BP.burn_dam]</font>" : 0)
+			else
+				message += "<span class='notice'>&emsp; Limbs are OK.</span>"
 
-			if(BP.has_infected_wound())
-				message += "<span class='warning'>Infected wound detected in subject [BP.name]. Disinfection recommended.</span><br>"
+		user.visible_message("<span class='notice'>[user] has analyzed [M]'s vitals.</span>","<span class='notice'>You have analyzed [M]'s vitals.</span>")
 
-		if(found_bleed)
-			message += "<span class='warning'>Arterial bleeding detected. Advanced scanner required for location.</span><br>"
-		if(found_broken)
-			message += "<span class='warning'>Bone fractures detected. Advanced scanner required for location.</span><br>"
-
-		var/blood_volume = H.blood_amount()
-		var/blood_percent =  100.0 * blood_volume / BLOOD_VOLUME_NORMAL
-		var/blood_type = H.dna.b_type
-		if(blood_volume <= BLOOD_VOLUME_SAFE && blood_volume > BLOOD_VOLUME_OKAY)
-			message += "<span class='warning bold'>Warning: Blood Level LOW: [blood_percent]% [blood_volume]cl.</span><span class='notice'>Type: [blood_type]</span><br>"
-		else if(blood_volume <= BLOOD_VOLUME_OKAY)
-			message += "<span class='warning bold'>Warning: Blood Level CRITICAL: [blood_percent]% [blood_volume]cl.</span><span class='notice bold'>Type: [blood_type]</span><br>"
-		else
-			message += "<span class='notice'>Blood Level Normal: [blood_percent]% [blood_volume]cl. Type: [blood_type]</span><br>"
-
-		var/obj/item/organ/internal/heart/Heart = H.organs_by_name[O_HEART]
-		if(Heart)
-			switch(Heart.heart_status)
-				if(HEART_FAILURE)
-					message += "<span class='notice'><font color='red'>Warning! Subject's heart stopped!</font></span><br>"
-				if(HEART_FIBR)
-					message += "<span class='notice'>Subject's Heart status: <font color='blue'>Attention! Subject's heart fibrillating.</font></span><br>"
-			message += "<span class='notice'>Subject's pulse: <font color='[H.pulse == PULSE_THREADY || H.pulse == PULSE_NONE ? "red" : "blue"]'>[H.get_pulse(GETPULSE_TOOL)] bpm.</font></span><br>"
-
-	if(insurance_type)
-		message += "<span class='notice'><font color='blue'>Страховка: [insurance_type]</font></span><br>"
-		
-	if(!output_to_chat)
-		message += "</BODY></HTML>"
 	return message

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1687,11 +1687,6 @@
 				data_message += "<span class='notice'>Analyzing Results for [C]:</span>"
 				data_message += "<span class='notice'>&emsp; Overall Status: [C.stat > 1 ? "dead" : "[C.health - C.halloss]% healthy"]</span>"
 				data_message += "<span class='notice'>&emsp; Body Temperature: [C.bodytemperature-T0C]&deg;C ([C.bodytemperature*1.8-459.67]&deg;F)</span><br>"
-/*				var/has_oxy_damage = (C.getOxyLoss() > 50)
-				var/has_tox_damage = (C.getToxLoss() > 50)
-				var/has_fire_damage = (C.getFireLoss() > 50)
-				var/has_brute_damage = (C.getBruteLoss() > 50)
-*/
 				data_message += "&emsp; Damage Specifics: <font color='blue'>[C.getOxyLoss()]</font> - <font color='green'>[C.getToxLoss()]</font> - <font color='#FFA500'>[C.getFireLoss()]</font> - <font color='red'>[C.getBruteLoss()]</font>"
 				data_message += "&emsp; Key: <font color='blue'>Suffocation</font>/<font color='green'>Toxin</font>/<font color='#FFA500'>Burns</font>/<font color='red'>Brute</font><br>"
 

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1679,30 +1679,12 @@
 		return ..()
 
 /obj/item/device/pda/attack(mob/living/L, mob/living/user)
-	if (iscarbon(L))
+	if(iscarbon(L))
 		var/mob/living/carbon/C = L
 		var/data_message = ""
 		switch(scanmode)
 			if(1)
-				data_message += "<span class='notice'>Analyzing Results for [C]:</span>"
-				data_message += "<span class='notice'>&emsp; Overall Status: [C.stat > 1 ? "dead" : "[C.health - C.halloss]% healthy"]</span>"
-				data_message += "<span class='notice'>&emsp; Body Temperature: [C.bodytemperature-T0C]&deg;C ([C.bodytemperature*1.8-459.67]&deg;F)</span><br>"
-				data_message += "&emsp; Damage Specifics: <font color='blue'>[C.getOxyLoss()]</font> - <font color='green'>[C.getToxLoss()]</font> - <font color='#FFA500'>[C.getFireLoss()]</font> - <font color='red'>[C.getBruteLoss()]</font>"
-				data_message += "&emsp; Key: <font color='blue'>Suffocation</font>/<font color='green'>Toxin</font>/<font color='#FFA500'>Burns</font>/<font color='red'>Brute</font><br>"
-
-				if(C.tod && (C.stat == DEAD || (C.status_flags & FAKEDEATH)))
-					data_message += "<span class='notice'>&emsp; Time of Death: [C.tod]</span>"
-				if(ishuman(C))
-					var/mob/living/carbon/human/H = C
-					var/list/damaged = H.get_damaged_bodyparts(1, 1)
-					data_message += "<span class='notice'>Localized Damage, <font color='red'>Brute</font>/<font color='#FFA500'>Burn</font>:</span><br>"
-					if(length(damaged)>0)
-						for(var/obj/item/organ/external/BP in damaged)
-							data_message += text("<span class='notice'>&emsp; []: [][] - []</span>",capitalize(BP.name), (BP.brute_dam > 0) ? "<span class='warning'>[BP.brute_dam]</span>" : 0, (BP.status & ORGAN_BLEEDING) ? "<span class='warning bold'>\[Bleeding\]</span>" : "&emsp;", (BP.burn_dam > 0) ? "<font color='#FFA500'>[BP.burn_dam]</font>" : 0)
-					else
-						data_message += "<span class='notice'>&emsp; Limbs are OK.</span>"
-
-				visible_message("<span class='warning'>[user] has analyzed [C]'s vitals!</span>")
+				data_message = health_analyze(L, user, TRUE, TRUE, TRUE)
 				to_chat(user, data_message)
 
 			if(2)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -1686,22 +1686,24 @@
 			if(1)
 				data_message += "<span class='notice'>Analyzing Results for [C]:</span>"
 				data_message += "<span class='notice'>&emsp; Overall Status: [C.stat > 1 ? "dead" : "[C.health - C.halloss]% healthy"]</span>"
-				var/has_oxy_damage = (C.getOxyLoss() > 50)
+				data_message += "<span class='notice'>&emsp; Body Temperature: [C.bodytemperature-T0C]&deg;C ([C.bodytemperature*1.8-459.67]&deg;F)</span><br>"
+/*				var/has_oxy_damage = (C.getOxyLoss() > 50)
 				var/has_tox_damage = (C.getToxLoss() > 50)
 				var/has_fire_damage = (C.getFireLoss() > 50)
 				var/has_brute_damage = (C.getBruteLoss() > 50)
-				data_message += "<span class='notice'>&emsp; Damage Specifics: <span class='[has_oxy_damage ? "warning" : "notice"]'>[C.getOxyLoss()]</span>-<span class='[has_tox_damage ? "warning" : "notice"]'>[C.getToxLoss()]</span>-<span class='[has_fire_damage ? "warning" : "notice"]'>[C.getFireLoss()]</span>-<span class='[has_brute_damage ? "warning" : "notice"]'>[C.getBruteLoss()]</span></span>"
-				data_message += "<span class='notice'>&emsp; Key: Suffocation/Toxin/Burns/Brute</span>"
-				data_message += "<span class='notice'>&emsp; Body Temperature: [C.bodytemperature-T0C]&deg;C ([C.bodytemperature*1.8-459.67]&deg;F)</span>"
+*/
+				data_message += "&emsp; Damage Specifics: <font color='blue'>[C.getOxyLoss()]</font> - <font color='green'>[C.getToxLoss()]</font> - <font color='#FFA500'>[C.getFireLoss()]</font> - <font color='red'>[C.getBruteLoss()]</font>"
+				data_message += "&emsp; Key: <font color='blue'>Suffocation</font>/<font color='green'>Toxin</font>/<font color='#FFA500'>Burns</font>/<font color='red'>Brute</font><br>"
+
 				if(C.tod && (C.stat == DEAD || (C.status_flags & FAKEDEATH)))
 					data_message += "<span class='notice'>&emsp; Time of Death: [C.tod]</span>"
 				if(ishuman(C))
 					var/mob/living/carbon/human/H = C
 					var/list/damaged = H.get_damaged_bodyparts(1, 1)
-					data_message += "<span class='notice'>Localized Damage, Brute/Burn:</span>"
+					data_message += "<span class='notice'>Localized Damage, <font color='red'>Brute</font>/<font color='#FFA500'>Burn</font>:</span><br>"
 					if(length(damaged)>0)
 						for(var/obj/item/organ/external/BP in damaged)
-							data_message += text("<span class='notice'>&emsp; []: []-[]</span>",capitalize(BP.name),(BP.brute_dam > 0)?"<span class='warning'>[BP.brute_dam]</span>":0,(BP.burn_dam > 0)?"<span class='warning'>[BP.burn_dam]</span>":0)
+							data_message += text("<span class='notice'>&emsp; []: [][] - []</span>",capitalize(BP.name), (BP.brute_dam > 0) ? "<span class='warning'>[BP.brute_dam]</span>" : 0, (BP.status & ORGAN_BLEEDING) ? "<span class='warning bold'>\[Bleeding\]</span>" : "&emsp;", (BP.burn_dam > 0) ? "<font color='#FFA500'>[BP.burn_dam]</font>" : 0)
 					else
 						data_message += "<span class='notice'>&emsp; Limbs are OK.</span>"
 

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -25,6 +25,7 @@
 	var/nanoUI[0]
 
 	//Secondary variables
+	var/output_to_chat = TRUE //will print scan results (for medical scanner) in chat?
 	var/scanmode = 0 //1 is medical scanner, 2 is forensics, 3 is reagent scanner.
 	var/fon = 0 //Is the flashlight function on?
 	var/f_lum = 2 //Luminosity for the flashlight function
@@ -1684,8 +1685,13 @@
 		var/data_message = ""
 		switch(scanmode)
 			if(1)
-				data_message = health_analyze(L, user, TRUE, TRUE, TRUE)
-				to_chat(user, data_message)
+				data_message = health_analyze(L, user, TRUE, output_to_chat, TRUE)
+				if(!output_to_chat)
+					var/datum/browser/popup = new(user, "[L.name]_scan_report", "[L.name]'s scan results", 400, 400, ntheme = CSS_THEME_LIGHT)
+					popup.set_content(data_message)
+					popup.open()
+				else
+					to_chat(user, data_message)
 
 			if(2)
 				if (!istype(C.dna, /datum/dna))


### PR DESCRIPTION
## Описание изменений
Улучшил вывод мед. сканера из ПДА по примеру обычного сканера: поменял цвета и расположение выводимых данных.

Было (взято из иссуя #10201):
![194636642-ee6ce6fc-1a44-4577-93cf-9f949dc45c7d](https://github.com/TauCetiStation/TauCetiClassic/assets/142721261/044b8d95-3f87-4569-99d5-b600860984e5)
Стало:
![изображение](https://github.com/TauCetiStation/TauCetiClassic/assets/142721261/a3cbab06-bf13-4ac5-b23b-1849ec8f90b0)


Closes #10201
## Почему и что этот ПР улучшит
 Читабельность и удобство пользования ПДА с мед. сканером 
<details> 
  (конечно, если им кто-то пользуется)
</details>

## Чеинжлог
:cl:
- spellcheck: Более удобный вывод данных медицинским сканером из ПДА.