### PR TITLE
Rounstart events now respect server config

### DIFF
--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -44,6 +44,9 @@ SUBSYSTEM_DEF(events)
 		EC.process()
 
 /datum/controller/subsystem/events/proc/start_roundstart_event()
+	if(!config.allow_random_events)
+		message_admins("RoundStart Event: No event, random events has been disabled by SERVER.")
+		return
 	var/datum/event_container/feature/EC = event_containers[EVENT_LEVEL_FEATURE]
 	for(var/i in 1 to rand(1, 3))
 		EC.start_event()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Заходишь свет потестить, а через раунд все лампы выбиты. Пофиксил.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
