### PR TITLE
Access related fixes

### DIFF
--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -164,7 +164,7 @@
 		if(Machine.emagged)
 			return TRUE
 
-	if(!req_access.len && !req_one_access.len) //no requirements
+	if(!length(req_access) && !length(req_one_access)) //no requirements
 		return TRUE
 	if(!AM)
 		return FALSE

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -162,12 +162,12 @@ var/global/list/wedge_image_cache = list()
 			return
 
 	user.SetNextMove(CLICK_CD_INTERACT)
-	var/atom/check_access = user
 
-	if(!requiresID())
-		check_access = null
+	if(!requiresID() && !check_access(null))
+		do_animate("deny")
+		return
 
-	if(allowed(check_access))
+	if(allowed(user))
 		if(density)
 			open()
 		else


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
1) Теперь, в случае если маппер забыл установить доступ, или сделал это неправильно (см. панель турелек на ЦК и холодильник на Дельте), то к предмету подойдёт любой доступ.
```
Примеры игнорирования доступа:

/obj/machinery/turretid{
	~...~
	req_access = 109
	},

/obj/structure/closet/secure_closet/freezer/kitchen{
	req_access = null
	},
```
```
[19:30:08] Runtime in access.dm:167 : Cannot read null.len
  proc name: check access (/obj/proc/check_access)
  usr: Izmail Mackentosh (ckey) (/mob/living/carbon/human)
  usr.loc: The plating  (216,167,2) (/turf/simulated/floor/plating)
  src: Kitchen Cabinet (/obj/structure/closet/secure_closet/freezer/kitchen)
  src.loc: the floor (216,168,2) (/turf/simulated/floor)
  call stack:
  Kitchen Cabinet (/obj/structure/closet/secure_closet/freezer/kitchen): check access(null)
```
2) В случае отключения сканера карт у шлюза, а также при условии необходимости доступа к оному, он не будет открываться
```
[17:35:57] Runtime in access.dm:110 : Cannot execute null.try access().
  proc name: allowed (/obj/proc/allowed)
  usr: Kasmut Stars (ckey) (/mob/living/carbon/human)
  usr.loc: The floor  (77,183,6) (/turf/simulated/floor/airless)
  src: the glass mutitile airlock (/obj/machinery/door/airlock/multi_tile/glass)
  src.loc: the floor (76,182,6) (/turf/simulated/floor)
  call stack:
  the glass mutitile airlock (/obj/machinery/door/airlock/multi_tile/glass): allowed(null)
  the glass mutitile airlock (/obj/machinery/door/airlock/multi_tile/glass): allowed(null)
```
## Почему и что этот ПР улучшит
Рантаймы на цепи
## Авторство

## Чеинжлог
:cl: 
- bugfix: Рантаймов связанных с шлюзами будет чуть меньше
