### PR TITLE
Changeling Biodegrade Tweak

### DIFF
--- a/code/game/gamemodes/modes_gameplays/changeling/powers/absorb.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/absorb.dm
@@ -3,7 +3,6 @@
 	desc = "Absorb the DNA of our victim."
 	chemical_cost = 0
 	genomecost = 0
-	req_human = 1
 	max_genetic_damage = 100
 
 /obj/effect/proc_holder/changeling/absorbDNA/can_sting(mob/living/carbon/user)

--- a/code/game/gamemodes/modes_gameplays/changeling/powers/absorb.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/absorb.dm
@@ -3,6 +3,7 @@
 	desc = "Absorb the DNA of our victim."
 	chemical_cost = 0
 	genomecost = 0
+	req_human = 1
 	max_genetic_damage = 100
 
 /obj/effect/proc_holder/changeling/absorbDNA/can_sting(mob/living/carbon/user)

--- a/code/game/gamemodes/modes_gameplays/changeling/powers/biodegrade.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/biodegrade.dm
@@ -1,8 +1,7 @@
 /obj/effect/proc_holder/changeling/biodegrade
 	name = "Biodegrade"
 	desc = "Dissolves restraints or other objects preventing free movement."
-	helptext = "This is obvious to nearby people, and can destroy \
-		standard restraints and closets."
+	helptext = "This is obvious to nearby people, and can destroy standard restraints and closets."
 	chemical_cost = 30 //High cost to prevent spam
 	genomecost = 1
 	req_human = 1
@@ -10,62 +9,64 @@
 	max_genetic_damage = 5
 	req_stat = UNCONSCIOUS
 
-
 /obj/effect/proc_holder/changeling/biodegrade/sting_action(mob/living/carbon/human/user)
-	var/used = FALSE // only one form of shackles removed per use
+	var/used = FALSE
 	if(user.back && istype(user.back, /obj/item/device/radio/electropack))
-		user.visible_message("<span class='warning'>[user] vomits a glob of \
-			acid on \his [user.back]!</span>", \
-			"<span class='warning'>We vomit acidic ooze onto our \
-			electropack!</span>")
+		user.visible_message("<span class='warning'>[user] vomits a glob of acid on \his [user.back]!</span>",
+			                 "<span class='warning'>We vomit acidic ooze onto our electropack!</span>")
 		addtimer(CALLBACK(src, PROC_REF(dissolve_electropack), user, user.back), 30)
 		used = TRUE
 
-	if(!used && user.wear_mask && (istype(user.wear_mask, /obj/item/clothing/mask/horsehead)|| \
-		istype(user.wear_mask, /obj/item/clothing/mask/pig) || istype(user.wear_mask, /obj/item/clothing/mask/cowmask) \
-		|| istype(user.wear_mask, /obj/item/clothing/head/chicken)))
-		user.visible_message("<span class='warning'>[user] vomits a glob of \
-			acid on \his [user.wear_mask ]!</span>", \
-			"<span class='warning'>We vomit acidic ooze onto our \
-			mask!</span>")
+	if(user.wear_mask && (istype(user.wear_mask, /obj/item/clothing/mask/horsehead) || \
+		                  istype(user.wear_mask, /obj/item/clothing/mask/pig) || \
+		                  istype(user.wear_mask, /obj/item/clothing/mask/cowmask) || \
+		                  istype(user.wear_mask, /obj/item/clothing/head/chicken)
+						  ))
+		user.visible_message("<span class='warning'>[user] vomits a glob of acid on \his [user.wear_mask]!</span>",
+		                     "<span class='warning'>We vomit acidic ooze onto our mask!</span>")
 		addtimer(CALLBACK(src, PROC_REF(dissolve_horsehead), user, user.wear_mask), 30)
+		used = TRUE
+
+	if(user.handcuffed)
+		var/obj/item/weapon/handcuffs/O = user.handcuffed
+		user.visible_message("<span class='warning'>[user] vomits a glob of acid on \his [O]!</span>",
+		                     "<span class='warning'>We vomit acidic ooze onto our restraints!</span>")
+		addtimer(CALLBACK(src, PROC_REF(dissolve_handcuffs), user, O), 30)
+		used = TRUE
+
+	if(user.wear_suit && istype(user.wear_suit, /obj/item/clothing/suit/straight_jacket))
+		user.visible_message("<span class='warning'>[user] vomits a glob of acid across the front of \his [user.wear_suit]!</span>",
+		                     "<span class='warning'>We vomit acidic ooze onto our straight jacket!</span>")
+		addtimer(CALLBACK(src, PROC_REF(dissolve_straightjacket), user, user.wear_suit), 30)
+		used = TRUE
+
+
+	if(istype(user.loc, /obj/structure/closet))
+		user.loc.visible_message("<span class='warning'>[user.loc]'s hinges suddenly begin to melt and run!</span>")
+		to_chat(user,"<span class='warning'>We vomit acidic goop onto the interior of [user.loc]!</span>")
+		addtimer(CALLBACK(src, PROC_REF(open_closet), user, user.loc), 70)
+		used = TRUE
+
+	if(istype(user.loc, /obj/structure/spider/cocoon))
+		user.loc.visible_message("<span class='warning'>[user.loc] shifts and starts to fall apart!</span>")
+		to_chat(user,"<span class='warning'>We secrete acidic enzymes from our skin and begin melting our cocoon...</span>")
+		addtimer(CALLBACK(src, PROC_REF(dissolve_cocoon), user, user.loc), 25) //Very short because it's just webs
+		used = TRUE
+
+	if(user.grabbed_by.len)
+		for(var/obj/item/weapon/grab/G in user.grabbed_by)
+			user.visible_message("<span class='warning'>[user]'s vomits a glob of acid on [G.assailant]!</span>",
+			                     "<span class='warning'>We vomit acidic ooze onto [G.assailant]!</span>")
+			G.assailant.apply_damage(10, BURN)
+			qdel(G)
+		// there is no option to disable Stun(10) from third grab, so disable all stuns
+		user.AdjustStunned(-10)
+		user.update_canmove()
 		used = TRUE
 
 	if(!user.restrained() && istype(user.loc, /turf) && !used)
 		to_chat(user,"<span class='warning'>We are already free!</span>")
 		return FALSE
-
-	if(user.handcuffed && !used)
-		var/obj/item/weapon/handcuffs/O = user.handcuffed
-		user.visible_message("<span class='warning'>[user] vomits a glob of \
-			acid on \his [O]!</span>", \
-			"<span class='warning'>We vomit acidic ooze onto our \
-			restraints!</span>")
-		addtimer(CALLBACK(src, PROC_REF(dissolve_handcuffs), user, O), 30)
-		used = TRUE
-
-	if(user.wear_suit && istype(user.wear_suit, /obj/item/clothing/suit/straight_jacket) && !used)
-		user.visible_message("<span class='warning'>[user] vomits a glob \
-			of acid across the front of \his [user.wear_suit]!</span>", \
-			"<span class='warning'>We vomit acidic ooze onto our straight \
-			jacket!</span>")
-		addtimer(CALLBACK(src, PROC_REF(dissolve_straightjacket), user, user.wear_suit), 30)
-		used = TRUE
-
-
-	if(istype(user.loc, /obj/structure/closet) && !used)
-		user.loc.visible_message("<span class='warning'>[user.loc]'s hinges suddenly \
-			begin to melt and run!</span>")
-		to_chat(user,"<span class='warning'>We vomit acidic goop onto the \
-			interior of [user.loc]!</span>")
-		addtimer(CALLBACK(src, PROC_REF(open_closet), user, user.loc), 70)
-		used = TRUE
-
-	if(istype(user.loc, /obj/structure/spider/cocoon) && !used)
-		user.loc.visible_message("<span class='warning'>[user.loc] shifts and starts to fall apart!</span>")
-		to_chat(user,"<span class='warning'>We secrete acidic enzymes from our skin and begin melting our cocoon...</span>")
-		addtimer(CALLBACK(src, PROC_REF(dissolve_cocoon), user, user.loc), 25) //Very short because it's just webs
-		used = TRUE
 
 	if(used)
 		feedback_add_details("changeling_powers","BD")
@@ -102,8 +103,10 @@
 		qdel(O)
 
 /obj/effect/proc_holder/changeling/biodegrade/proc/dissolve_horsehead(mob/living/carbon/human/user, obj/item/clothing/mask/O)
-	if(user.wear_mask == O && (istype(O, /obj/item/clothing/mask/horsehead)|| \
-		istype(O, /obj/item/clothing/mask/pig) || istype(O, /obj/item/clothing/mask/cowmask) \
-		|| istype(O, /obj/item/clothing/head/chicken)))
+	if(user.wear_mask == O && (istype(O, /obj/item/clothing/mask/horsehead) || \
+		                       istype(O, /obj/item/clothing/mask/pig) || \
+		                       istype(O, /obj/item/clothing/mask/cowmask) || \
+		                       istype(O, /obj/item/clothing/head/chicken)
+		))
 		O.visible_message("<span class='warning'>[O] dissolves into a puddle of sizzling goop.</span>")
 		qdel(O)

--- a/code/game/gamemodes/modes_gameplays/changeling/powers/biodegrade.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/powers/biodegrade.dm
@@ -17,11 +17,7 @@
 		addtimer(CALLBACK(src, PROC_REF(dissolve_electropack), user, user.back), 30)
 		used = TRUE
 
-	if(user.wear_mask && (istype(user.wear_mask, /obj/item/clothing/mask/horsehead) || \
-		                  istype(user.wear_mask, /obj/item/clothing/mask/pig) || \
-		                  istype(user.wear_mask, /obj/item/clothing/mask/cowmask) || \
-		                  istype(user.wear_mask, /obj/item/clothing/head/chicken)
-						  ))
+	if(user.wear_mask && is_animal_head(user.wear_mask))
 		user.visible_message("<span class='warning'>[user] vomits a glob of acid on \his [user.wear_mask]!</span>",
 		                     "<span class='warning'>We vomit acidic ooze onto our mask!</span>")
 		addtimer(CALLBACK(src, PROC_REF(dissolve_horsehead), user, user.wear_mask), 30)
@@ -103,10 +99,12 @@
 		qdel(O)
 
 /obj/effect/proc_holder/changeling/biodegrade/proc/dissolve_horsehead(mob/living/carbon/human/user, obj/item/clothing/mask/O)
-	if(user.wear_mask == O && (istype(O, /obj/item/clothing/mask/horsehead) || \
-		                       istype(O, /obj/item/clothing/mask/pig) || \
-		                       istype(O, /obj/item/clothing/mask/cowmask) || \
-		                       istype(O, /obj/item/clothing/head/chicken)
-		))
+	if(user.wear_mask == O && is_animal_head(O))
 		O.visible_message("<span class='warning'>[O] dissolves into a puddle of sizzling goop.</span>")
 		qdel(O)
+
+/obj/effect/proc_holder/changeling/biodegrade/proc/is_animal_head(obj/item/clothing/mask/O)
+	return (istype(O, /obj/item/clothing/mask/horsehead) || \
+		    istype(O, /obj/item/clothing/mask/pig) || \
+		    istype(O, /obj/item/clothing/mask/cowmask) || \
+		    istype(O, /obj/item/clothing/head/chicken))


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Как сделать так, чтобы генокрада было сложно поймать навсегда и вывести из раунда? Закрыть как можно больше возможностей поймать навсегда оборотня среди экипажа.

Теперь биодегрейд снимает всё тоже, что и раньше ЗА ОДНО ИСПОЛЬЗОВАНИЕ.
Теперь биодегрейд позволяет выйти из вечного стана красного захвата без танца ~~с бубном~~ с адреналин овердозом.

Бафф этой способности улучшит её статистику, что определённо даст какой-то боланс

![1x](https://github.com/TauCetiStation/TauCetiClassic/assets/96499407/808902e9-054c-478c-a5f4-cd9e6048f800)

## Почему и что этот ПР улучшит
Меньше абузов против генок = больше минут активности генок в раунде, следовательно хорошо.
## Авторство

## Чеинжлог
:cl: Deahaka
- tweak: Biodegrade генокрадов теперь позволяет намного эффективнее вырываться из скованного состояния.