### PR TITLE
Фикс мута дедчата. Мут стал работать на всех мертвых, не только на обсерверов

### DIFF
--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -6,14 +6,6 @@
 
 	log_say("Ghost/[key_name(src)] : [message]")
 
-	if (src.client)
-		if(src.client.prefs.muted & MUTE_DEADCHAT)
-			to_chat(src, "<span class='alert'>You cannot talk in deadchat (muted).</span>")
-			return
-
-		if (client.handle_spam_prevention(message,MUTE_DEADCHAT))
-			return
-
 	. = say_dead(message)
 
 

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -62,9 +62,17 @@
 			to_chat(src, "<span class='red'> Deadchat is globally muted.</span>")
 			return
 
-	if(client && !(client.prefs.chat_toggles & CHAT_DEAD))
-		to_chat(usr, "<span class='red'> You have deadchat muted.</span>")
-		return
+	if(client)
+		if (!(client.prefs.chat_toggles & CHAT_DEAD)) // User preference check
+			to_chat(src, "<span class='red'> You have deadchat muted.</span>")
+			return
+
+		if(client.prefs.muted & MUTE_DEADCHAT) // Admin/autospam mute check
+			to_chat(src, "<span class='alert'>You cannot talk in deadchat (muted).</span>")
+			return
+
+		if (client.handle_spam_prevention(message, MUTE_DEADCHAT)) // Autospam
+			return
 
 	if(mind && mind.name)
 		name = "[mind.name]"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Раньше админский мут дедчата проверялся только для обсерверов. Подвинул проверку в общий say_dead. Проверил на локалке, все работает и не рантаймит.
## Почему и что этот ПР улучшит
Я надеюсь что мне за такое дадут поблажку и снимут муты

closes #11996 
## Авторство
AirBlack
## Чеинжлог
:cl: AirBlack
 - bugfix: Админский мут дедчата и защита от спама дедчата теперь работает на всех мертвых, а не только обсерверов.