### PR TITLE
Фикс стражей улья

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/humanoid/caste/sentinel.dm
+++ b/code/modules/mob/living/carbon/xenomorph/humanoid/caste/sentinel.dm
@@ -15,7 +15,7 @@
 	R.my_atom = src
 	name = "alien sentinel ([rand(1, 1000)])"
 	real_name = name
-	verbs.Add(/mob/living/carbon/xenomorph/humanoid/proc/corrosive_acid, TYPE_PROC_REF(/mob/living/carbon/xenomorph/humanoid, neurotoxin))
+	verbs.Add(/mob/living/carbon/xenomorph/humanoid/proc/corrosive_acid, /mob/living/carbon/xenomorph/humanoid/proc/neurotoxin)
 	alien_list[ALIEN_SENTINEL] += src
 	. = ..()
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Синтелы не понимали своих, не считались в улье и не могли использовать способность плеваться нейротоксином \ кислотой
## Почему и что этот ПР улучшит
Fixes #11940
## Авторство
Pirsnya
## Чеинжлог
:cl: 
 - bugfix: Стражи улья снова понимают своих, считаются в улье и могут использовать свои способности.