### PR TITLE
Fixes camera console filters

### DIFF
--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -22,6 +22,10 @@
 	SHOULD_CALL_PARENT(TRUE)
 	if(!isnull(render_relay_plane))
 		relay_render_to_plane(mymob, render_relay_plane)
+	apply_effects(mymob)
+
+/atom/movable/screen/plane_master/proc/apply_effects(mob/mymob)
+	return
 
 ///Contains just the floor
 /atom/movable/screen/plane_master/floor
@@ -39,8 +43,7 @@
 	blend_mode = BLEND_OVERLAY
 	render_relay_plane = RENDER_PLANE_GAME
 
-/atom/movable/screen/plane_master/game_world/backdrop(mob/mymob)
-	. = ..()
+/atom/movable/screen/plane_master/game_world/apply_effects(mob/mymob)
 	remove_filter("AO")
 	if(istype(mymob) && mymob?.client?.prefs?.ambientocclusion)
 		add_filter("AO", 1, drop_shadow_filter(x = 0, y = -2, size = 4, color = "#04080FAA"))
@@ -65,8 +68,7 @@
 	plane = GHOST_ILLUSION_PLANE
 	render_relay_plane = RENDER_PLANE_ABOVE_GAME
 
-/atom/movable/screen/plane_master/ghost_illusion/backdrop(mob/mymob)
-	. = ..()
+/atom/movable/screen/plane_master/ghost_illusion/apply_effects(mob/mymob)
 	remove_filter("ghost_illusion")
 	add_filter("ghost_illusion", 1, motion_blur_filter(x = 3, y = 3))
 
@@ -108,8 +110,7 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	render_relay_plane = RENDER_PLANE_GAME
 
-/atom/movable/screen/plane_master/exposure/backdrop(mob/mymob) // todo: prefs
-	. = ..()
+/atom/movable/screen/plane_master/exposure/apply_effects(mob/mymob) // todo: prefs
 	remove_filter("blur_exposure")
 	if(istype(mymob) && mymob?.client?.prefs?.old_lighting)
 		return
@@ -124,8 +125,7 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	render_relay_plane = RENDER_PLANE_GAME
 
-/atom/movable/screen/plane_master/lamps_selfglow/backdrop(mob/mymob) // todo: prefs
-	. = ..()
+/atom/movable/screen/plane_master/lamps_selfglow/apply_effects(mob/mymob) // todo: prefs
 	remove_filter("add_lamps_to_selfglow")
 	remove_filter("lamps_selfglow_bloom")
 
@@ -170,8 +170,7 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	render_relay_plane = RENDER_PLANE_GAME
 
-/atom/movable/screen/plane_master/lamps_glare/backdrop(mob/mymob)
-	. = ..()
+/atom/movable/screen/plane_master/lamps_glare/apply_effects(mob/mymob)
 	remove_filter("add_lamps_to_glare")
 	remove_filter("lamps_glare")
 	if(istype(mymob) && mymob?.client?.prefs?.old_lighting || !mymob?.client?.prefs?.lampsglare)

--- a/code/_onclick/hud/rendering/render_plate.dm
+++ b/code/_onclick/hud/rendering/render_plate.dm
@@ -40,13 +40,12 @@
 	plane = RENDER_PLANE_GAME
 	render_relay_plane = RENDER_PLANE_MASTER
 
-/atom/movable/screen/plane_master/rendering_plate/game_world/atom_init(mapload, ...)
-	. = ..()
-	apply_singularity_effects()
-
-	add_filter("anomaly", 5, displacement_map_filter(render_source = ANOMALY_RENDER_TARGET, size = 10))
-
-/atom/movable/screen/plane_master/rendering_plate/game_world/proc/apply_singularity_effects()
+/atom/movable/screen/plane_master/rendering_plate/game_world/apply_effects(mob/mymob)
+	// singularity
+	remove_filter("singularity_0")
+	remove_filter("singularity_1")
+	remove_filter("singularity_2")
+	remove_filter("singularity_3")
 	add_filter("singularity_0", 1, displacement_map_filter(render_source = SINGULO_RENDER_TARGET_0, size = -40))
 	add_filter("singularity_1", 2, displacement_map_filter(render_source = SINGULO_RENDER_TARGET_1, size = 75))
 	add_filter("singularity_2", 3, displacement_map_filter(render_source = SINGULO_RENDER_TARGET_2, size = 400))
@@ -63,6 +62,10 @@
 
 	animate(get_filter("singularity_3"), size = 750, time = 10, easing = LINEAR_EASING, loop = -1, flags = ANIMATION_PARALLEL)
 	animate(size = 600, time = 10, easing = LINEAR_EASING, loop = -1)
+
+	// anomalys: gravity pulse, maybe something else
+	remove_filter("anomaly")
+	add_filter("anomaly", 5, displacement_map_filter(render_source = ANOMALY_RENDER_TARGET, size = 10))
 
 ///everything that should be above game world. (for example, singularity, nar-si)
 /atom/movable/screen/plane_master/rendering_plate/above_game_world

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -97,7 +97,8 @@
 			use_power(active_power_usage)
 		// Register map objects
 		user.client.register_map_obj(cam_screen)
-		for(var/plane in cam_plane_masters)
+		for(var/atom/movable/screen/plane_master/plane in cam_plane_masters)
+			plane.apply_effects(user)
 			user.client.register_map_obj(plane)
 		user.client.register_map_obj(cam_background)
 		// Open UI

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -46,13 +46,7 @@
 	cam_screen.screen_loc = "[map_name]:1,1"
 	cam_plane_masters = list()
 	for(var/plane in subtypesof(/atom/movable/screen/plane_master) - /atom/movable/screen/plane_master/blackness)
-		var/atom/movable/screen/plane_master/instance = new plane()
-		if(instance.blend_mode_override)
-			instance.blend_mode = instance.blend_mode_override
-		instance.assigned_map = map_name
-		instance.del_on_map_removal = FALSE
-		instance.screen_loc = "[map_name]:CENTER"
-		cam_plane_masters += instance
+		cam_plane_masters += plane
 	cam_background = new
 	cam_background.assigned_map = map_name
 	cam_background.del_on_map_removal = FALSE
@@ -97,9 +91,19 @@
 			use_power(active_power_usage)
 		// Register map objects
 		user.client.register_map_obj(cam_screen)
-		for(var/atom/movable/screen/plane_master/plane in cam_plane_masters)
-			plane.apply_effects(user)
-			user.client.register_map_obj(plane)
+
+		for(var/plane in cam_plane_masters)
+			var/atom/movable/screen/plane_master/instance = new plane()
+
+			if(instance.blend_mode_override)
+				instance.blend_mode = instance.blend_mode_override
+			instance.assigned_map = map_name
+			instance.del_on_map_removal = FALSE
+			instance.screen_loc = "[map_name]:CENTER"
+
+			instance.apply_effects(user)
+			user.client.register_map_obj(instance)
+
 		user.client.register_map_obj(cam_background)
 		// Open UI
 		ui = new(user, src, "CameraConsole", name)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Фильтры обычных плейнов корректно применяются к виду из камеры. 

Сингулярность не чинится, видимо какие-то особенности из-за того, что фильтр применяется к game_world plate.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог

:cl:
 - bugfix: Поправлено отображение нового света в консоли камер.