### PR TITLE
Lighting prefs

### DIFF
--- a/code/__DEFINES/preferences.dm
+++ b/code/__DEFINES/preferences.dm
@@ -20,10 +20,10 @@
 
 #define TOGGLES_DEFAULT_CHAT (CHAT_OOC|CHAT_DEAD|CHAT_NOCLIENT_ATTACK|CHAT_GHOSTEARS|CHAT_PRAYER|CHAT_RADIO|CHAT_GHOSTRADIO|CHAT_GHOSTNPC|CHAT_ATTACKLOGS|CHAT_LOOC|CHAT_CKEY)
 
-#define BLOOM_HIGH    0
-#define BLOOM_MED     1 //default.
-#define BLOOM_LOW     2
-#define BLOOM_DISABLE 3 //this option must be the highest number
+#define GLOW_HIGH    0
+#define GLOW_MED     1 //default.
+#define GLOW_LOW     2
+#define GLOW_DISABLE 3 //this option must be the highest number
 
 #define PARALLAX_INSANE -1 //for show offs
 #define PARALLAX_HIGH    0 //default.

--- a/code/_onclick/hud/rendering/plane_master.dm
+++ b/code/_onclick/hud/rendering/plane_master.dm
@@ -24,6 +24,7 @@
 		relay_render_to_plane(mymob, render_relay_plane)
 	apply_effects(mymob)
 
+//For filters and other effects
 /atom/movable/screen/plane_master/proc/apply_effects(mob/mymob)
 	return
 
@@ -112,9 +113,16 @@
 
 /atom/movable/screen/plane_master/exposure/apply_effects(mob/mymob) // todo: prefs
 	remove_filter("blur_exposure")
-	if(istype(mymob) && mymob?.client?.prefs?.old_lighting)
+	if(!istype(mymob))
 		return
-	add_filter("blur_exposure", 1, gauss_blur_filter(size = 20)) // by refs such blur is heavy, but tests were okay and this allow us more flexibility with setup
+
+	var/enabled = mymob?.client?.prefs?.lampsexposure || FALSE
+
+	if(enabled)
+		alpha = 255
+		add_filter("blur_exposure", 1, gauss_blur_filter(size = 20)) // by refs such blur is heavy, but tests were okay and this allow us more flexibility with setup. Possible point for improvements
+	else
+		alpha = 0
 
 /atom/movable/screen/plane_master/lamps_selfglow
 	name = "lamps selfglow plane master"
@@ -125,28 +133,32 @@
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 	render_relay_plane = RENDER_PLANE_GAME
 
-/atom/movable/screen/plane_master/lamps_selfglow/apply_effects(mob/mymob) // todo: prefs
+/atom/movable/screen/plane_master/lamps_selfglow/apply_effects(mob/mymob)
 	remove_filter("add_lamps_to_selfglow")
 	remove_filter("lamps_selfglow_bloom")
 
 	if(!istype(mymob))
 		return
-	if(mymob?.client?.prefs?.old_lighting)
+
+	var/level = mymob?.client?.prefs?.glowlevel || FALSE
+
+	if(isnull(level))
 		return
+
 	var/bloomsize = 0
 	var/bloomoffset = 0
-	switch(mymob?.client?.prefs?.bloomlevel)
-		if(BLOOM_DISABLE)
-			return
-		if(BLOOM_LOW)
+	switch(level)
+		if(GLOW_LOW)
 			bloomsize = 2
 			bloomoffset = 1
-		if(BLOOM_MED)
+		if(GLOW_MED)
 			bloomsize = 3
 			bloomoffset = 2
-		if(BLOOM_HIGH)
+		if(GLOW_HIGH)
 			bloomsize = 5
 			bloomoffset = 3
+		else
+			return
 
 	add_filter("add_lamps_to_selfglow", 1, layering_filter(render_source = LIGHTING_LAMPS_RENDER_TARGET, blend_mode = BLEND_OVERLAY))
 	add_filter("lamps_selfglow_bloom", 1, bloom_filter(threshold = "#aaaaaa", size = bloomsize, offset = bloomoffset, alpha = 100))
@@ -173,10 +185,15 @@
 /atom/movable/screen/plane_master/lamps_glare/apply_effects(mob/mymob)
 	remove_filter("add_lamps_to_glare")
 	remove_filter("lamps_glare")
-	if(istype(mymob) && mymob?.client?.prefs?.old_lighting || !mymob?.client?.prefs?.lampsglare)
+
+	if(!istype(mymob))
 		return
-	add_filter("add_lamps_to_glare", 1, layering_filter(render_source = LIGHTING_LAMPS_RENDER_TARGET, blend_mode = BLEND_OVERLAY))
-	add_filter("lamps_glare", 1, radial_blur_filter(size = 0.05))
+
+	var/enabled = mymob?.client?.prefs?.lampsglare || FALSE
+
+	if(enabled)
+		add_filter("add_lamps_to_glare", 1, layering_filter(render_source = LIGHTING_LAMPS_RENDER_TARGET, blend_mode = BLEND_OVERLAY))
+		add_filter("lamps_glare", 1, radial_blur_filter(size = 0.05))
 
 /atom/movable/screen/plane_master/above_lighting
 	name = "above lighting plane master"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -163,12 +163,13 @@ var/global/list/preferences_datums = list()
 	// jukebox volume
 	var/volume = 100
 	var/parallax = PARALLAX_HIGH
-	var/bloomlevel = BLOOM_MED
-	var/old_lighting = FALSE
-	var/lampsglare = FALSE
 	var/ambientocclusion = TRUE
 	var/auto_fit_viewport = TRUE
 	var/lobbyanimation = FALSE
+	// lighting settings
+	var/glowlevel = GLOW_MED // or bloom
+	var/lampsexposure = TRUE // idk how we should name it
+	var/lampsglare = FALSE // aka lens flare
 
   //custom loadout
 	var/list/gear = list()

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -359,6 +359,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["permamuted"]        >> muted
 	S["parallax"]          >> parallax
 	S["ambientocclusion"]  >> ambientocclusion
+	S["glowlevel"]         >> glowlevel
+	S["lampsexposure"]     >> lampsexposure
+	S["lampsglare"]        >> lampsglare
 	S["auto_fit_viewport"] >> auto_fit_viewport
 	S["lobbyanimation"]    >> lobbyanimation
 	S["tooltip"]           >> tooltip
@@ -414,6 +417,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	tgui_lock		= sanitize_integer(tgui_lock, 0, 1, initial(tgui_lock))
 	parallax		= sanitize_integer(parallax, PARALLAX_INSANE, PARALLAX_DISABLE, PARALLAX_HIGH)
 	ambientocclusion	= sanitize_integer(ambientocclusion, 0, 1, initial(ambientocclusion))
+	glowlevel		= sanitize_integer(glowlevel, GLOW_HIGH, GLOW_DISABLE, initial(glowlevel))
+	lampsexposure	= sanitize_integer(lampsexposure, 0, 1, initial(lampsexposure))
+	lampsglare		= sanitize_integer(lampsglare, 0, 1, initial(lampsglare))
 	lobbyanimation	= sanitize_integer(lobbyanimation, 0, 1, initial(lobbyanimation))
 	auto_fit_viewport	= sanitize_integer(auto_fit_viewport, 0, 1, initial(auto_fit_viewport))
 	tooltip = sanitize_integer(tooltip, 0, 1, initial(tooltip))
@@ -483,6 +489,9 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["permamuted"]        << permamuted
 	S["parallax"]          << parallax
 	S["ambientocclusion"]  << ambientocclusion
+	S["glowlevel"]         << glowlevel
+	S["lampsexposure"]     << lampsexposure
+	S["lampsglare"]        << lampsglare
 	S["lobbyanimation"]    << lobbyanimation
 	S["auto_fit_viewport"] << auto_fit_viewport
 	S["tooltip"]           << tooltip

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -209,72 +209,58 @@
 	prefs.ambientocclusion = !prefs.ambientocclusion
 	to_chat(src, "Ambient Occlusion: [prefs.ambientocclusion ? "Enabled" : "Disabled"].")
 	prefs.save_preferences()
-	if(screen && screen.len)
+	if(length(screen))
 		var/atom/movable/screen/plane_master/game_world/PM = locate() in screen
-		PM.backdrop(mob)
+		PM.apply_effects(mob)
 	feedback_add_details("admin_verb","TAC")
 
-/client/verb/set_bloom_level()
-	set name = "LIGHTING: Set Bloom Level"
+/client/verb/set_glow_level()
+	set name = "Lighting: Glow Level"
 	set category = "Preferences"
-	set desc = "Set bloom level near lamps."
 
-	var/new_setting = input(src, "LIGHTING: Bloom Level:") as null|anything in list("Disable", "Low", "Medium (Default)", "High")
+	var/new_setting = input(src, "Set glow level of light sources:") as null|anything in list("Disable", "Low", "Medium (Default)", "High")
 	if(!new_setting)
 		return
 
 	switch(new_setting)
 		if("Disable")
-			prefs.bloomlevel = BLOOM_DISABLE
+			prefs.glowlevel = GLOW_DISABLE
 		if("Low")
-			prefs.bloomlevel = BLOOM_LOW
+			prefs.glowlevel = GLOW_LOW
 		if("Medium (Default)")
-			prefs.bloomlevel = BLOOM_MED
+			prefs.glowlevel = GLOW_MED
 		if("High")
-			prefs.bloomlevel = BLOOM_HIGH
+			prefs.glowlevel = GLOW_HIGH
 
-	to_chat(src, "Bloom: [new_setting].")
+	to_chat(src, "Glow level: [new_setting].")
 	prefs.save_preferences()
-	if(screen && screen.len)
+	if(length(screen))
 		var/atom/movable/screen/plane_master/lamps_selfglow/PM = locate() in screen
-		PM.backdrop(mob)
-	feedback_add_details("admin_verb","BLM")
+		PM.apply_effects(mob)
+	feedback_add_details("admin_verb","LGL")
 
-/client/verb/toggle_oldnew_lighting()
-	set name = "LIGHTING: Toggle Old/New Lighting"
+/client/verb/toggle_lamp_exposure()
+	set name = "Lighting: Lamp Exposure"
 	set category = "Preferences"
-	set desc = "Toggle lighting variant."
 
-	prefs.old_lighting = !prefs.old_lighting
-	to_chat(src, "Lighting: [prefs.old_lighting ? "Old" : "New"].")
+	prefs.lampsexposure = !prefs.lampsexposure
+	to_chat(src, "Lamp exposure: [prefs.lampsexposure ? "Enabled" : "Disabled"].")
 	prefs.save_preferences()
-	if(screen && screen.len)
+	if(length(screen))
 		var/atom/movable/screen/plane_master/exposure/EXP = locate() in screen
-		var/atom/movable/screen/plane_master/lamps_selfglow/BLM = locate() in screen
-		var/atom/movable/screen/plane_master/lamps_glare/GLR = locate() in screen
+		EXP.apply_effects(mob)
+	feedback_add_details("admin_verb","GLR")
 
-		if(prefs.old_lighting)
-			EXP.alpha = 0
-		else
-			EXP.alpha = 255
-
-		EXP.backdrop(mob)
-		BLM.backdrop(mob)
-		GLR.backdrop(mob)
-	feedback_add_details("admin_verb","OLGHT")
-
-/client/verb/toggle_glare()
-	set name = "LIGHTING: Toggle Glare"
+/client/verb/toggle_lamps_glare()
+	set name = "Lighting: Lamp Glare"
 	set category = "Preferences"
-	set desc = "Toggle glare of lamps."
 
 	prefs.lampsglare = !prefs.lampsglare
-	to_chat(src, "Glare: [prefs.old_lighting ? "Enabled" : "Disabled"].")
+	to_chat(src, "Glare: [prefs.lampsglare ? "Enabled" : "Disabled"].")
 	prefs.save_preferences()
-	if(screen && screen.len)
+	if(length(screen))
 		var/atom/movable/screen/plane_master/lamps_glare/PM = locate() in screen
-
-		PM.backdrop(mob)
+		PM.apply_effects(mob)
 	feedback_add_details("admin_verb","GLR")
 
 /client/verb/set_parallax_quality()

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -249,7 +249,7 @@
 	if(length(screen))
 		var/atom/movable/screen/plane_master/exposure/EXP = locate() in screen
 		EXP.apply_effects(mob)
-	feedback_add_details("admin_verb","GLR")
+	feedback_add_details("admin_verb","LEXP")
 
 /client/verb/toggle_lamps_glare()
 	set name = "Lighting: Lamp Glare"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Немного переименований и сделал, что они теперь сохраняются. Я забыл их добавить в окно сетапа, видимо в следующий раз, сейчас лезть туда максимально лень.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог

:cl: 
 - tweak: Индивидуальные настройки света были окончательно обновлены и теперь сохраняются между раундами. Использовать нужно через вкладку Preferences, в сетапе персонажа появятся позже.