### PR TITLE
Часть 1.3 Джетпаки для всех модулей

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -127,18 +127,14 @@
 	return 1
 
 /obj/item/borg/upgrade/jetpack
-	name = "mining robot jetpack"
-	desc = "A carbon dioxide jetpack suitable for low-gravity mining operations."
+	name = "robot jetpack"
+	desc = "A carbon dioxide jetpack suitable for low-gravity operations."
 	icon_state = "cyborg_upgrade3"
 	require_module = 1
 
 /obj/item/borg/upgrade/jetpack/action(mob/living/silicon/robot/R)
 	if(..()) return 0
 
-	if(!istype(R.module, /obj/item/weapon/robot_module/miner))
-		to_chat(R, "Upgrade mounting error!  No suitable hardpoint detected!")
-		to_chat(usr, "There's no mounting point for the module!")
-		return 0
 	for(var/obj/item/weapon/tank/jetpack/J in R.module.modules)
 		if(J && istype(J, /obj/item/weapon/tank/jetpack))
 			to_chat(usr, "There's no room for another jetpack!")

--- a/code/modules/mob/living/silicon/robot/robot_upgrades.dm
+++ b/code/modules/mob/living/silicon/robot/robot_upgrades.dm
@@ -124,19 +124,14 @@
 	return TRUE
 
 /obj/item/borg/upgrade/jetpack
-	name = "Mining Borg Jetpack"
-	desc = "A carbon dioxide jetpack suitable for low-gravity mining operations."
+	name = "Borg Jetpack"
+	desc = "A carbon dioxide jetpack suitable for low-gravity operations."
 	icon_state = "cyborg_upgrade3"
 	require_module = TRUE
 
 /obj/item/borg/upgrade/jetpack/action(mob/living/silicon/robot/R)
-	if(!istype(R.module, /obj/item/weapon/robot_module/miner))
-		to_chat(R, "Upgrade mounting error!  No suitable hardpoint detected!")
-		to_chat(usr, "There's no mounting point for the module!")
-		return FALSE
 	var/obj/item/weapon/tank/jetpack/carbondioxide/J = new(R.module)
 	R.module.add_item(J)
 	for(var/obj/item/weapon/tank/jetpack/carbondioxide in R.module.modules)
 		R.internals = src
-	R.icon_state="Miner+j"
 	return TRUE

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -934,7 +934,7 @@
 	category = list("Cyborg Upgrade Modules")
 
 /datum/design/borg_upgrade_jetpack
-	name = "Cyborg Upgrade Module (Mining Jetpack)"
+	name = "Cyborg Upgrade Module (Cyborg Jetpack)"
 	id = "borg_upgrade_jetpack"
 	build_type = MECHFAB
 	build_path = /obj/item/borg/upgrade/jetpack


### PR DESCRIPTION
## Описание изменений
- Джетпаки теперь доступны всем модулям (Повысит смысл добычи форона для установки джетпака на борга и реиграбельность самой платы). 
![image](https://github.com/TauCetiStation/TauCetiClassic/assets/74739991/a2019ec1-1851-4cd5-af44-872d968aa118)
**Однако** - если модуль сменят, плата сгорает и нужно джетпак делать по новой

## Почему и что этот ПР улучшит
По мотивам распила ПРа #11679 : 
![image](https://github.com/TauCetiStation/TauCetiClassic/assets/74739991/3b530217-b25e-4c5f-a964-abc586c990f1)

Так как улучшение есть, а шахтерному боргу улучшения данное не сдалось, то время попробовать открыть джетпаки для других модулей боргов и посмотреть, что из этого выйдет.

## Авторство
Я вновь выложил ПР, а ранее Бася сделал это. 
## Чеинжлог
:cl: Azzy.Dreemurr, Basia
- balance: Модуль джетпака доступен для всех модулей юнитов, через плату улучшения.