### PR TITLE
repair wheelchairs

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -139,6 +139,9 @@
 		move_delay = world.time + add_delay //set move delay
 
 		//Relaymoves
+		if(istype(mob.pulledby, /obj/structure/stool/bed/chair/wheelchair))
+			return mob.pulledby.relaymove(mob, direct)
+		
 		if(mob.buckled) // Wheelchair driving!
 			if(isspaceturf(mob.loc))
 				return // No wheelchair driving in space


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
https://github.com/TauCetiStation/TauCetiClassic/pull/10057 удалил возможность пулить инвалидное кресло случайно.
## Почему и что этот ПР улучшит

close #12041
## Авторство

## Чеинжлог
:cl: Deahaka
- fix: Инвалидное кресло вновь можно толкать сзади, взявшись за него.