### PR TITLE
теперь можно ставить стартовые лэндмарки для альт проф

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -451,7 +451,7 @@ SUBSYSTEM_DEF(job)
 
 	if(!joined_late)
 		var/obj/effect/landmark/start/spawn_mark
-		var/list/rank_landmarks = landmarks_list[rank]
+		var/list/rank_landmarks = landmarks_list[H.mind.role_alt_title]
 		if(length(rank_landmarks))
 			for(var/obj/effect/landmark/start/landmark as anything in rank_landmarks)
 				if(!(locate(/mob/living) in landmark.loc))


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
тайтл, на боксе есть спавн официанта в баре, но он не работал
## Почему и что этот ПР улучшит
больше рпшки там.... возможностей... для мапперов...
## Авторство
я
## Чеинжлог
:cl:
- bugfix: Официант спавнится в баре, а не в ассистентской.