### PR TITLE
исправляем рандомный раундстартовый рантайм

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -277,14 +277,15 @@
 	for(var/datum/smartlight_preset/type as anything in subtypesof(/datum/smartlight_preset))
 		smartlight_presets[initial(type.name)] = type
 
-	global.virus_by_pool = list()
+	global.virus_types_by_pool = list()
 	for(var/e in subtypesof(/datum/disease2/effect))
 		var/datum/disease2/effect/f = new e
 		var/list/L = f.pools
+		qdel(f)
 		if(!L.len)
 			continue
 		for(var/pool in L)
-			LAZYADD(virus_by_pool[pool], f)
+			LAZYADD(virus_types_by_pool[pool], e)
 
 /proc/init_joblist() // Moved here because we need to load map config to edit jobs, called from SSjobs
 	//List of job. I can't believe this was calculated multiple times per tick!

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -98,7 +98,6 @@ var/global/list/virus_types_by_pool
 		return get_random_effect_total(max(minlvl - 1, 1), maxlvl + 1, pickedpool)
 	var/datum/disease2/effectholder/holder = new /datum/disease2/effectholder
 	var/datum/disease2/effect/effect = pick(effects_pool_list)
-	//create a copy of effect
 	effects_pool_list -= effect
 	holder.effect = effect
 	for(var/effect as anything in effects_pool_list)

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -100,8 +100,8 @@ var/global/list/virus_types_by_pool
 	var/datum/disease2/effect/effect = pick(effects_pool_list)
 	effects_pool_list -= effect
 	holder.effect = effect
-	for(var/effect as anything in effects_pool_list)
-		qdel(effect)
+	for(var/eff as anything in effects_pool_list)
+		qdel(eff)
 	holder.chance = rand(holder.effect.chance_minm, holder.effect.chance_maxm)
 	return holder
 

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -1,7 +1,7 @@
 #define POOL_POSITIVE_VIRUS "pool_positive_virus"
 #define POOL_NEUTRAL_VIRUS "pool_neutral_virus"
 #define POOL_NEGATIVE_VIRUS "pool_negative_virus"
-var/global/list/virus_by_pool
+var/global/list/virus_types_by_pool
 
 /datum/disease2/disease
 	var/infectionchance = 70
@@ -82,7 +82,10 @@ var/global/list/virus_by_pool
 		POOL_NEGATIVE_VIRUS = 50,
 	)
 	var/pickedpool = pool_name ? pool_name : pickweight(pool_distribution)
-	var/list/effects_pool_list = global.virus_by_pool[pickedpool]
+	var/list/effects_pool_list = list()
+	for(var/type as anything in global.virus_types_by_pool[pickedpool])
+		var/datum/disease2/effect/e = new type
+		effects_pool_list += e
 	for(var/datum/disease2/effect/e as anything in effects_pool_list)
 		if(e.level > maxlvl)
 			effects_pool_list -= e
@@ -96,8 +99,10 @@ var/global/list/virus_by_pool
 	var/datum/disease2/effectholder/holder = new /datum/disease2/effectholder
 	var/datum/disease2/effect/effect = pick(effects_pool_list)
 	//create a copy of effect
-	var/datum/disease2/effect/f = new effect.type
-	holder.effect = f
+	effects_pool_list -= effect
+	holder.effect = effect
+	for(var/effect as anything in effects_pool_list)
+		qdel(effect)
 	holder.chance = rand(holder.effect.chance_minm, holder.effect.chance_maxm)
 	return holder
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
closes #12034
прок гет_рандом_эффект должен копировать датумы из глобального листа, но копирует ссылки на них
из-за чего они и удаляются оттуда, что вызывает бесконечную рекурсию и рантайм, на который злится гитхаб и который почему-то не отображается в логах (следующим пром это исправлю)

чтобы это произошло нужно нескольким вирусам выбить один и тот же пул, потому и через раз происходило
## Почему и что этот ПР улучшит
я надеюсь я ничего не сломал...
## Авторство

## Чеинжлог
