### PR TITLE
Удешевление боевой мини аптечки

### DIFF
--- a/code/datums/uplinks_items.dm
+++ b/code/datums/uplinks_items.dm
@@ -816,7 +816,7 @@
 	name = "Syndicate Medical Small Kit"
 	desc = "The syndicate medkit. Included is a combat stimulant injector for rapid healing."
 	item = /obj/item/weapon/storage/firstaid/small_firstaid_kit/combat
-	cost = 5
+	cost = 2
 	uplink_types = list("nuclear", "traitor", "dealer")
 
 /datum/uplink_item/device_tools/bonepen


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Выравнивает стоимость мини аптечки с адреналин имплантом по восстанавливаемому урону за одно использование 
![2023-09-09_13-13-36](https://github.com/TauCetiStation/TauCetiClassic/assets/109436132/964301b4-c17a-485c-9b89-09f79684d4a7)

## Почему и что этот ПР улучшит
Благодаря статистике можно узнать, что адреналин имплант покупают в 10 раз чаще, чем боевую аптечку
![2023-09-09_12-53-55](https://github.com/TauCetiStation/TauCetiClassic/assets/109436132/8a144bd6-a1bd-4f0a-99e1-7c0dac3c120c)
![2023-09-09_12-54-27](https://github.com/TauCetiStation/TauCetiClassic/assets/109436132/e168a336-a805-4fdf-a764-85884680b9a5)
Почему так
Во-первых адреналин - это в первую очередь защита от стан ту вин, а уже после хилка
Во-вторых адреналином очень просто пользоваться, клик по иконке и всё, а не: 1 освободить  руку. 2 открыть сумку с аптечкой. 3 открыть аптечку. 4 подумать какой автоинжектор надо сейчас кольнуть. 5 попасть по иконке. 6 активировать по себе. 7 выбросить и взять оружие. осознать что тебя зарабастили 
В третьих мини аптечка очень дорогая: зачем покупать неудобную одноразку за 5 тк, когда можно потраться на 1 тк больше и купить 3х разовый адреналин с защитой от станов, который можно использовать в один клик с занятыми руками без значительного переключения внимания

А ещё триторы смогут позволить дешевую лечилку доступную в любых ситуациях и не сковывающих геймплей тратой четверти бюджета 

## Авторство

## Чеинжлог
:cl:
 - balance: Удешевление боевой мини аптечки до 2 тк