### PR TITLE
добавление падежей сумкам

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -5,6 +5,7 @@
 
 /obj/item/weapon/storage/backpack
 	name = "backpack"
+	cases = list("рюкзака", "рюкзаку", "рюкзак", "рюкзаком", "рюкзаке")
 	desc = "You wear this on your back and put items into it."
 	icon_state = "backpack"
 	item_state = "backpack"
@@ -79,6 +80,7 @@
 
 /obj/item/weapon/storage/backpack/santabag
 	name = "Santa's Gift Bag"
+	cases = list("мешка", "мешку", "мешок", "мешком", "мешке")
 	desc = "Space Santa uses this to deliver toys to all the nice children in space in Christmas! Wow, it's pretty big!"
 	icon_state = "giftbag0"
 	item_state = "giftbag"
@@ -128,6 +130,7 @@
 
 /obj/item/weapon/storage/backpack/satchel
 	name = "leather satchel"
+	cases = list("сумки", "сумке", "сумку", "сумкой", "сумке")
 	desc = "It's a very fancy satchel made with fine leather."
 	icon_state = "satchel"
 	item_state = "satchel"
@@ -236,6 +239,7 @@
 
 /obj/item/weapon/storage/backpack/kitbag
 	name = "kitbag"
+	cases = list("вещмешка", "вещмешку", "вещмешок", "вещмешком", "вещмешке")
 	icon_state = "kitbag"
 
 /obj/item/weapon/storage/backpack/medbag
@@ -342,6 +346,7 @@
 
 /obj/item/weapon/storage/backpack/dufflebag
 	name = "suspicious looking dufflebag"
+	cases = list("вещмешка", "вещмешку", "вещмешок", "вещмешком", "вещмешке")
 	desc = "A large dufflebag for holding extra tactical supplies."
 	icon_state = "duffle-syndie"
 	item_state = "duffle-syndie"
@@ -398,6 +403,7 @@
 
 /obj/item/weapon/storage/backpack/henchmen
 	name = "wings"
+	cases = list("крыльев", "крыльям", "крылья", "крыльями", "крыльях")
 	desc = "Granted to the henchmen who deserve it. This probably doesn't include you."
 	icon_state = "henchmen"
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
у сумок теперь есть падежи

возникла единственная проблема:
у нас есть так называемые dufflebags, которые можно перевести как спортивная сумка (что неправильно, у нас же их носят синдикатовцы и морпехи, а не баскетболисты), и как вещмешок (уже хорошо, я на педивикии нагуглил, что вещмешком называются точно такие же сумки у морпехов сша). но так же у нас есть старый советский вещмешок, который респрайт рюкзака - пока что я сделал им одинаковый перевод падежей. этот старый вещмешок достать можно только из мусора и не то чтобы сильно отсвечивает. в общем да
## Почему и что этот ПР улучшит
перевод
## Авторство
я
## Чеинжлог
