### PR TITLE
Del light preset hardcode

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1313,20 +1313,6 @@
 	if(custom_smartlight_preset)
 		var/type = smartlight_presets[custom_smartlight_preset]
 		smartlight_preset = new type
-
-	// temp code before we replace all station APC
-	else if(istype(my_area, /area/station/rnd) || istype(my_area, /area/asteroid/research_outpost))
-		smartlight_preset = new /datum/smartlight_preset/rnd
-	else if(istype(my_area, /area/station/medical))
-		smartlight_preset = new /datum/smartlight_preset/medbay
-	else if(istype(my_area, /area/station/security))
-		smartlight_preset = new /datum/smartlight_preset/brig
-	else if(istype(my_area, /area/station/engineering))
-		smartlight_preset = new /datum/smartlight_preset/engineering
-	else if(istype(my_area, /area/station/cargo) || istype(my_area, /area/asteroid/mine/production))
-		smartlight_preset = new /datum/smartlight_preset/cargo
-	// temp code end
-
 	else
 		smartlight_preset = new
 

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1309,7 +1309,6 @@
 	return APC_CHANNEL_OFF
 
 /obj/machinery/power/apc/proc/init_smartlight()
-	var/area/my_area = get_area(src)
 	if(custom_smartlight_preset)
 		var/type = smartlight_presets[custom_smartlight_preset]
 		smartlight_preset = new type


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Yashark заборол апц на картах в соответствии с #11981, так что теперь можно попробовать убрать хардкод.

Если где-то были ошибки с прописью зон, оно всплывет сейчас.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
