### PR TITLE
изификс пулла кухонной машинерии

### DIFF
--- a/code/game/machinery/kitchen/kitchen_machines.dm
+++ b/code/game/machinery/kitchen/kitchen_machines.dm
@@ -435,7 +435,7 @@
 	if(!user.IsAdvancedToolUser())
 		to_chat(user, "<span class='warning'>You can not comprehend what to do with this.</span>")
 		return
-	if(operating || panel_open)
+	if(!anchored || operating || panel_open)
 		return ..()
 
 	cook()


### PR DESCRIPTION
## Описание изменений
Оказывается, кухонную машинерию можно открутить и таскать. Теперь точно можно.

## Почему и что этот ПР улучшит
Фикс бага, что я и создал.

## Авторство
AndreyGysev и все все все, кто помогал в дискорде.

## Чеинжлог
 :cl: 
  - bugfix: Микроволновку и прочую кухонную машинерию снова можно пуллить.