### PR TITLE
Разгоняем скреллов

### DIFF
--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -464,7 +464,7 @@
 	has_gendered_icons = FALSE
 
 	speed_mod = 1.5
-	speed_mod_no_shoes = -1.6
+	speed_mod_no_shoes = -2.2
 
 	flags = list(
 	 IS_WHITELISTED = TRUE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
В бухгалтерии все как обычно перепутали
Скреллы в данный момент медленней унатхов без обуви, уступая место разве что дионам
![image](https://github.com/TauCetiStation/TauCetiClassic/assets/89906909/9c53a835-b0cb-4fc7-86fa-4273fcfb187b)
В обуви же они теперь медленней унатхов, без обуви - медленней хуманов, но быстрее унатхов
## Почему и что этот ПР улучшит
Скреллы вновь играбельная раса
## Авторство

## Чеинжлог
пока немногие заметили эту ошибку, наверное не стоит писать?