### PR TITLE
СПУ разучились в бессмертие

### DIFF
--- a/code/modules/surgery/ribcage.dm
+++ b/code/modules/surgery/ribcage.dm
@@ -543,6 +543,7 @@
 	target.SetStunned(0)
 	target.SetWeakened(0)
 	target.SetParalysis(0)
+	target.timeofdeath = 0
 
 
 //////////////////////////////////////////////////////////////////


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
closes #11799 
closes #8542 
время смерти не сбрасывается при реанимации СПУ
эта строчка отключает тяжелые проки(в том числе и обновление статуса), если тело лежит больше десяти минут
https://github.com/TauCetiStation/TauCetiClassic/blob/4f9e54ee7a30d280b9215a4d377a4d04fe43745e/code/modules/mob/living/carbon/human/life.dm#L75-L76
итог: живые спу имеют время смерти, и если разница больше десяти минут, то они просто перестают умирать
## Почему и что этот ПР улучшит
готовимся к выпуску спу на свет
## Авторство

## Чеинжлог
