### PR TITLE
Бафф ловушек мага

### DIFF
--- a/code/datums/spells/wizard.dm
+++ b/code/datums/spells/wizard.dm
@@ -250,10 +250,10 @@
 	invocation_type = "shout"
 	range = 3
 	summon_type = list(
-		/obj/structure/trap/stun,
-		/obj/structure/trap/fire,
-		/obj/structure/trap/chill,
-		/obj/structure/trap/damage,
+		/obj/structure/trap/wizard/stun,
+		/obj/structure/trap/wizard/fire,
+		/obj/structure/trap/wizard/chill,
+		/obj/structure/trap/wizard/damage,
 					)
 	summon_lifespan = 3000
 	summon_amt = 5

--- a/code/game/objects/structures/traps.dm
+++ b/code/game/objects/structures/traps.dm
@@ -124,7 +124,7 @@
 	name = "IT'S A WIZARD TRAP"
 
 /obj/structure/trap/wizard/Crossed()
-	if(ishuman(AM)
+	if(ishuman(AM))
 		var/mob/living/carbon/human/H = AM
 		 if(iswizard(H))
 			return

--- a/code/game/objects/structures/traps.dm
+++ b/code/game/objects/structures/traps.dm
@@ -123,7 +123,7 @@
 /obj/structure/trap/wizard
 	name = "IT'S A WIZARD TRAP"
 
-/obj/structure/trap/wizard/Crossed()
+/obj/structure/trap/wizard/Crossed(atom/movable/AM)
 	if(ishuman(AM))
 		var/mob/living/carbon/human/H = AM
 		 if(iswizard(H))

--- a/code/game/objects/structures/traps.dm
+++ b/code/game/objects/structures/traps.dm
@@ -119,3 +119,62 @@
 	. = ..()
 	QDEL_IN(src, time_between_triggers)
 
+
+/obj/structure/trap/wizard
+	name = "IT'S A WIZARD TARP"
+	alpha = 20
+
+/obj/structure/trap/wizard/Crossed()
+	if(ishuman(AM)
+		var/mob/living/carbon/human/H = AM
+		 if(iswizard(H))
+			return
+		 return ..()
+
+/obj/structure/trap/wizard/stun
+	name = "shock trap"
+	desc = "A trap that will shock and render you immobile. You'd better avoid it."
+	icon_state = "trap-shock"
+
+/obj/structure/trap/wizard/stun/trap_effect(mob/living/L)
+	L.electrocute_act(30, src) // electrocute act does a message.
+	L.Stun(5)
+	L.Weaken(5)
+
+/obj/structure/trap/wizard/fire
+	name = "flame trap"
+	desc = "A trap that will set you ablaze. You'd better avoid it."
+	icon_state = "trap-fire"
+
+/obj/structure/trap/wizard/fire/trap_effect(mob/living/L)
+	to_chat(L, "<span class='danger'>Spontaneous combustion!</span>")
+	L.fire_act()
+	L.adjust_fire_stacks(5)
+	L.Weaken(1)
+
+/obj/structure/trap/wizard/chill
+	name = "frost trap"
+	desc = "A trap that will chill you to the bone. You'd better avoid it."
+	icon_state = "trap-frost"
+
+/obj/structure/trap/wizard/chill/trap_effect(mob/living/L)
+	to_chat(L, "<span class='danger'>You're frozen solid!</span>")
+	L.Stun(1)
+	L.Weaken(1)
+	L.adjust_bodytemperature(-300)
+	L.reagents.add_reagent("frostoil", 15)
+
+/obj/structure/trap/wizard/damage
+	name = "earth trap"
+	desc = "A trap that will summon a small earthquake, just for you. You'd better avoid it."
+	icon_state = "trap-earth"
+
+/obj/structure/trap/wizard/damage/trap_effect(mob/living/L)
+	to_chat(L, "<span class='danger'>The ground quakes beneath your feet!</span>")
+	L.Weaken(5)
+	L.adjustBruteLoss(35)
+
+/obj/structure/trap/wizard/damage/flare()
+	..()
+	var/obj/structure/rock/giant_rock = new (get_turf(src))
+	QDEL_IN(giant_rock, 200)

--- a/code/game/objects/structures/traps.dm
+++ b/code/game/objects/structures/traps.dm
@@ -128,7 +128,7 @@
 		var/mob/living/carbon/human/H = AM
 		if(iswizard(H))
 			return
-		 return ..()
+	return ..()
 
 /obj/structure/trap/wizard/stun
 	name = "shock trap"

--- a/code/game/objects/structures/traps.dm
+++ b/code/game/objects/structures/traps.dm
@@ -121,8 +121,7 @@
 
 
 /obj/structure/trap/wizard
-	name = "IT'S A WIZARD TARP"
-	alpha = 20
+	name = "IT'S A WIZARD TRAP"
 
 /obj/structure/trap/wizard/Crossed()
 	if(ishuman(AM)

--- a/code/game/objects/structures/traps.dm
+++ b/code/game/objects/structures/traps.dm
@@ -126,7 +126,7 @@
 /obj/structure/trap/wizard/Crossed(atom/movable/AM)
 	if(ishuman(AM))
 		var/mob/living/carbon/human/H = AM
-		 if(iswizard(H))
+		if(iswizard(H))
 			return
 		 return ..()
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Ловушки мага не подрывают мага


## Почему и что этот ПР улучшит
Спелл ловушек мага событие редкое, так как страдает в первую очередь сам маг, так как он невероятно сильно зависит от мобильности и возможности дать дёру куда угодно и когда угодно
Если офицер, зачастую, имеет возможность постоять и подумать(чем не всегда пользуются), а его ошибка прощается отступлением в медом или карго, то маг не имеет права на ошибку, любая значимая оплошность отправит его в госты, а использование ловушек - это создание себе дополнительных трудностей не нарваться на них и не быть застреленным во время стана.
Возможность не подорваться на ловушках позволит создавать их, не боясь заруинить себе игру.

## Авторство
Дехака помогал
## Чеинжлог
:cl:
 - add: Ловушки мага не подрывают мага
 