### PR TITLE
Bad qdel fix

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -60,7 +60,7 @@
 
 /obj/machinery/computer/security/Destroy()
 	qdel(cam_screen)
-	QDEL_LIST(cam_plane_masters)
+	cam_plane_masters.Cut()
 	qdel(cam_background)
 	return ..()
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

После #11999 это не список объектов, а просто список, qdel был не нужен.

```
Runtime in code/controllers/subsystem/garbage.dm:291 : bad del
  proc name: qdel (/proc/qdel)
  usr:
  usr.loc: The floor  (123,173,2) (/turf/simulated/floor)
  src: null
  call stack:
  qdel(null, 0)
  the security camera monitor (/obj/machinery/computer/security): Destroy(0)
  qdel(the security camera monitor (/obj/machinery/computer/security), 0)
  the security camera monitor (/obj/machinery/computer/security): deconstruct(1, null)
```

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
