### PR TITLE
Fix #12131 Игрушечный арбалет теперь тоже на русском

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -349,7 +349,7 @@
 
 /obj/item/toy/crossbow
 	name = "foam dart crossbow"
-	desc = "A weapon favored by many overactive children. Ages 8 and up."
+	desc = "Оружие, любимое многими гиперактивными детьми. Возрастной рейтинг 8+."
 	icon = 'icons/obj/gun.dmi'
 	icon_state = "crossbow"
 	item_state = "crossbow"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
fix #12131  , Фикс, описания у игрушечного оружия. 
## Почему и что этот ПР улучшит
Исправление описание локализации ранее, где забыли к игрушечному арбалету также докинуть описание. 
![image](https://github.com/TauCetiStation/TauCetiClassic/assets/74739991/3217dfbb-5097-4efc-b14d-90c8b130b27e)
Что начало выдавать тритаров с патрохами, если кто-то особо хитрый знал, что игрушечный арбалет на английском, а настоящий на русском. Теперь это исправлено.
## Авторство
Исправил я
## Чеинжлог
:cl:  
- bugfix: Исправили описание игрушечного Арбалета