### PR TITLE
одиночные световые мечи светятся

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -472,6 +472,21 @@
 /obj/item/toy/sword/atom_init()
 	. = ..()
 	blade_color = pick("red", "blue", "green", "purple", "yellow", "pink", "black")
+	switch(blade_color)
+		if("red")
+			light_color = COLOR_RED
+		if("blue")
+			light_color = COLOR_BLUE
+		if("green")
+			light_color = COLOR_GREEN
+		if("purple")
+			light_color = COLOR_PURPLE
+		if("yellow")
+			light_color = COLOR_YELLOW
+		if("pink")
+			light_color = COLOR_PINK
+		if("black")
+			light_color = COLOR_GRAY
 
 /obj/item/toy/sword/attack_self(mob/user)
 	active = !active
@@ -482,6 +497,7 @@
 		item_state = icon_state
 		w_class = SIZE_NORMAL
 		hitsound = list('sound/weapons/blade1.ogg')
+		set_light(2)
 	else
 		to_chat(user, "<span class='notice'>You push the plastic blade back down into the handle.</span>")
 		playsound(user, 'sound/weapons/saberoff.ogg', VOL_EFFECTS_MASTER)
@@ -489,6 +505,7 @@
 		item_state = "sword0"
 		w_class = SIZE_TINY
 		hitsound = initial(hitsound)
+		set_light(0)
 
 	update_inv_mob()
 

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -30,6 +30,21 @@
 /obj/item/weapon/melee/energy/sword/atom_init()
 	. = ..()
 	blade_color = pick("red","blue","green","purple","yellow","pink","black")
+	switch(blade_color)
+		if("red")
+			light_color = COLOR_RED
+		if("blue")
+			light_color = COLOR_BLUE
+		if("green")
+			light_color = COLOR_GREEN
+		if("purple")
+			light_color = COLOR_PURPLE
+		if("yellow")
+			light_color = COLOR_YELLOW
+		if("pink")
+			light_color = COLOR_PINK
+		if("black")
+			light_color = COLOR_GRAY
 
 /obj/item/weapon/melee/energy/sword/attack_self(mob/living/user)
 	if (user.ClumsyProbabilityCheck(50))
@@ -50,7 +65,7 @@
 		w_class = SIZE_SMALL
 		playsound(user, 'sound/weapons/saberon.ogg', VOL_EFFECTS_MASTER)
 		to_chat(user, "<span class='notice'>[src] is now active.</span>")
-
+		set_light(2)
 	else
 		qualities = null
 		sharp = FALSE
@@ -64,6 +79,7 @@
 		w_class = SIZE_TINY
 		playsound(user, 'sound/weapons/saberoff.ogg', VOL_EFFECTS_MASTER)
 		to_chat(user, "<span class='notice'>[src] can now be concealed.</span>")
+		set_light(0)
 
 	update_inv_mob()
 	add_fingerprint(user)
@@ -234,30 +250,37 @@
 /obj/item/weapon/melee/energy/sword/green/atom_init()
 	. = ..()
 	blade_color = "green"
+	light_color = COLOR_GREEN
 
 /obj/item/weapon/melee/energy/sword/red/atom_init()
 	. = ..()
 	blade_color = "red"
+	light_color = COLOR_RED
 
 /obj/item/weapon/melee/energy/sword/blue/atom_init()
 	. = ..()
 	blade_color = "blue"
+	light_color = COLOR_BLUE
 
 /obj/item/weapon/melee/energy/sword/purple/atom_init()
 	. = ..()
 	blade_color = "purple"
+	light_color = COLOR_PURPLE
 
 /obj/item/weapon/melee/energy/sword/yellow/atom_init()
 	. = ..()
 	blade_color = "yellow"
+	light_color = COLOR_YELLOW
 
 /obj/item/weapon/melee/energy/sword/pink/atom_init()
 	. = ..()
 	blade_color = "pink"
+	light_color = COLOR_PINK
 
 /obj/item/weapon/melee/energy/sword/black/atom_init()
 	. = ..()
 	blade_color = "black"
+	light_color = COLOR_GRAY
 
 
 /obj/item/weapon/melee/energy/blade/atom_init()

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -175,6 +175,22 @@
 /obj/item/weapon/pen/edagger/atom_init()
 	. = ..()
 	blade_color = pick("blue", "red", "green", "purple", "yellow", "pink", "black")
+	switch(blade_color)
+		if("red")
+			light_color = COLOR_RED
+		if("blue")
+			light_color = COLOR_BLUE
+		if("green")
+			light_color = COLOR_GREEN
+		if("purple")
+			light_color = COLOR_PURPLE
+		if("yellow")
+			light_color = COLOR_YELLOW
+		if("pink")
+			light_color = COLOR_PINK
+		if("black")
+			light_color = COLOR_GRAY
+
 
 /obj/item/weapon/pen/edagger/attack_self(mob/living/user)
 	..()
@@ -195,6 +211,7 @@
 		playsound(user, 'sound/weapons/saberoff.ogg', VOL_EFFECTS_MASTER, 5)
 		to_chat(user, "<span class='warning'>[src] can now be concealed.</span>")
 		qualities = null
+		set_light(0)
 	else
 		on = 1
 		force = 18
@@ -211,6 +228,7 @@
 		qualities = list(
 			QUALITY_CUTTING = 1
 			)
+		set_light(1)
 	update_icon()
 
 /obj/item/weapon/pen/edagger/attackby(obj/item/I, mob/user, params)
@@ -242,30 +260,37 @@
 /obj/item/weapon/pen/edagger/blue/atom_init()
 	. = ..()
 	blade_color = "blue"
+	light_color = COLOR_BLUE
 
 /obj/item/weapon/pen/edagger/red/atom_init()
 	. = ..()
 	blade_color = "red"
+	light_color = COLOR_RED
 
 /obj/item/weapon/pen/edagger/green/atom_init()
 	. = ..()
 	blade_color = "green"
+	light_color = COLOR_GREEN
 
 /obj/item/weapon/pen/edagger/purple/atom_init()
 	. = ..()
 	blade_color = "purple"
+	light_color = COLOR_PURPLE
 
 /obj/item/weapon/pen/edagger/yellow/atom_init()
 	. = ..()
 	blade_color = "yellow"
+	light_color = COLOR_YELLOW
 
 /obj/item/weapon/pen/edagger/pink/atom_init()
 	. = ..()
 	blade_color = "pink"
+	light_color = COLOR_PINK
 
 /obj/item/weapon/pen/edagger/black/atom_init()
 	. = ..()
 	blade_color = "black"
+	light_color = COLOR_GRAY
 
 /*
  * Legit edagger for NT boys
@@ -277,6 +302,7 @@
 /obj/item/weapon/pen/edagger/legitimate/atom_init()
 	. = ..()
 	blade_color = "blue"
+	light_color = COLOR_BLUE
 
 /*
  * Chameleon pen


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
![image](https://github.com/TauCetiStation/TauCetiClassic/assets/84613249/e8c7a877-c41c-4453-b12c-acb73e5dd806)
![image](https://github.com/TauCetiStation/TauCetiClassic/assets/84613249/06ec1fb0-73b7-4a9c-8f14-2e24aab969c7)

и игрушечные тож
## Почему и что этот ПР улучшит
fix #10921
## Авторство

## Чеинжлог
🆑 Simbaka
- fix: Обычные энергетические мечи не светились в темноте. 