### PR TITLE
Guns tweaks

### DIFF
--- a/code/modules/projectiles/firing.dm
+++ b/code/modules/projectiles/firing.dm
@@ -22,7 +22,6 @@
 			newshot()
 			BB.pixel_x += rand(-8, 8) // so they will look more spreaded and not all in one (good for shotguns).
 			BB.pixel_y += rand(-8, 8)
-	user.next_move = world.time + 4
 	update_icon()
 	return 1
 

--- a/code/modules/projectiles/guns/plasma/plasma.dm
+++ b/code/modules/projectiles/guns/plasma/plasma.dm
@@ -16,7 +16,7 @@
 	desc = "Стандартный плазменный карабин типа булл-пап обладающий высокой скорострельностью."
 	icon_state = "plasma10_car"
 	item_state = "plasma10_car"
-	fire_delay = 1
+	fire_delay = 2
 	origin_tech = "combat=3;magnets=2"
 	fire_sound = 'sound/weapons/guns/plasma10_shot.ogg'
 	recoil = FALSE
@@ -85,7 +85,7 @@
 		fire_sound = initial(fire_sound)
 	else
 		shot = ammo_type[PLASMAGUN_OVERCHARGE_TYPE]
-		fire_delay = 0
+		fire_delay = 1
 		fire_sound = overcharge_fire_sound
 		max_projectile_per_fire = 1
 

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -5,7 +5,7 @@
 	origin_tech = "combat=2;materials=2"
 	w_class = SIZE_SMALL
 	m_amt = 1000
-	fire_delay = 0
+	fire_delay = 4
 	recoil = 1
 	var/bolt_slide_sound = 'sound/weapons/guns/TargetOn.ogg'
 	var/initial_mag = /obj/item/ammo_box/magazine/stechkin

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -13,6 +13,7 @@
 	var/has_cover = FALSE //does this gun has cover
 	var/cover_open = FALSE //does gun cover is open
 	var/obj/item/ammo_box/magazine/magazine
+	var/has_ammo_counter = FALSE
 
 /obj/item/weapon/gun/projectile/atom_init()
 	. = ..()
@@ -111,7 +112,7 @@
 
 /obj/item/weapon/gun/projectile/examine(mob/user)
 	..()
-	if(src in view(1, user))
+	if(src in view(1, user) && has_ammo_counter)
 		to_chat(user, "Has [get_ammo()] round\s remaining.")
 
 /obj/item/weapon/gun/projectile/proc/get_ammo(countchambered = 1)

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -6,6 +6,7 @@
 	w_class = SIZE_SMALL
 	origin_tech = "combat=4;materials=2"
 	initial_mag = /obj/item/ammo_box/magazine/smg
+	ammo_counter = TRUE
 	can_be_holstered = FALSE
 	var/alarmed = FALSE
 	var/should_alarm_when_empty = FALSE
@@ -68,6 +69,7 @@
 	fire_sound = 'sound/weapons/guns/gunshot_light.ogg'
 	should_alarm_when_empty = TRUE
 	can_be_silenced = TRUE
+	ammo_counter = TRUE
 
 /obj/item/weapon/gun/projectile/automatic/l6_saw
 	name = "L6 SAW"
@@ -80,6 +82,7 @@
 	fire_sound = 'sound/weapons/guns/Gunshot2.ogg'
 	has_cover = TRUE
 	two_hand_weapon = ONLY_TWOHAND
+	ammo_counter = TRUE
 
 /obj/item/weapon/gun/projectile/automatic/l6_saw/update_icon()
 	icon_state = "l6[cover_open ? "open" : "closed"][magazine ? CEIL(get_ammo(0) / 12.5) * 25 : "-empty"]"
@@ -163,6 +166,7 @@
 	icon_state = "borg_smg"
 	initial_mag = /obj/item/ammo_box/magazine/borg45
 	fire_sound = 'sound/weapons/guns/gunshot_medium.ogg'
+	ammo_counter = TRUE
 
 /obj/item/weapon/gun/projectile/automatic/borg/update_icon()
 	return

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -6,7 +6,7 @@
 	w_class = SIZE_SMALL
 	origin_tech = "combat=4;materials=2"
 	initial_mag = /obj/item/ammo_box/magazine/smg
-	ammo_counter = TRUE
+	has_ammo_counter = TRUE
 	can_be_holstered = FALSE
 	var/alarmed = FALSE
 	var/should_alarm_when_empty = FALSE
@@ -69,7 +69,7 @@
 	fire_sound = 'sound/weapons/guns/gunshot_light.ogg'
 	should_alarm_when_empty = TRUE
 	can_be_silenced = TRUE
-	ammo_counter = TRUE
+	has_ammo_counter = TRUE
 
 /obj/item/weapon/gun/projectile/automatic/l6_saw
 	name = "L6 SAW"
@@ -82,7 +82,7 @@
 	fire_sound = 'sound/weapons/guns/Gunshot2.ogg'
 	has_cover = TRUE
 	two_hand_weapon = ONLY_TWOHAND
-	ammo_counter = TRUE
+	has_ammo_counter = TRUE
 
 /obj/item/weapon/gun/projectile/automatic/l6_saw/update_icon()
 	icon_state = "l6[cover_open ? "open" : "closed"][magazine ? CEIL(get_ammo(0) / 12.5) * 25 : "-empty"]"
@@ -166,7 +166,7 @@
 	icon_state = "borg_smg"
 	initial_mag = /obj/item/ammo_box/magazine/borg45
 	fire_sound = 'sound/weapons/guns/gunshot_medium.ogg'
-	ammo_counter = TRUE
+	has_ammo_counter = TRUE
 
 /obj/item/weapon/gun/projectile/automatic/borg/update_icon()
 	return


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
убирает захардкоженную задержку при выстрелах в 4 тика, переносит её в fire_delay для того, чтобы можно было делать пушки, стреляющее прям супер быстро! как например л10с, которая сейчас практически бесполезна, но с удалением хардкода может заиметь какую-никакую нишу (была задумана с делеем в 1 тик, а при оверчарже - в 0)
убирает возможность точно узнавать сколько патронов в магазине через экзамин пушки, в которой это сделать невозможно. накидал всяким пушкам с открытыми магазинами аммо каунтер.
## Почему и что этот ПР улучшит
интересный контент!
## Авторство
я
## Чеинжлог
:cl:
- balance: Л10-С теперь ужасно скорострельна.
- tweak: У пушек с закрытыми магазинами нельзя посмотреть количество патронов.