### PR TITLE
нерф разгерм

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -424,7 +424,6 @@ var/global/list/tourette_bad_words= list(
 	//Moved pressure calculations here for use in skip-processing check.
 	var/pressure = environment.return_pressure()
 	var/adjusted_pressure = calculate_affecting_pressure(pressure)
-	var/is_in_space = isspaceturf(get_turf(src))
 
 	if(environment.total_moles) //space is not meant to change your body temperature.
 		var/loc_temp = get_temperature(environment)
@@ -494,7 +493,6 @@ var/global/list/tourette_bad_words= list(
 			pressure_alert = -1
 		else
 			pressure_alert = -2
-			apply_effect(is_in_space ? 15 : 7, AGONY, 0)
 			take_overall_damage(burn=LOW_PRESSURE_DAMAGE, used_weapon = "Low Pressure")
 
 	//Check for contaminants before anything else because we don't want to skip it.


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
разгермы больше не наносят голоурон изниоткуда
кукда теперь падает на пол через минуту вместо тридцати секунд (в два раза дольше!)
## Почему и что этот ПР улучшит
меньший импакт отстойной механики, больше забавных ситуаций с побегом из брига по космосу, а сам факт так называемого area denial не убирается, для нормальной войнушки в разгерме всё равно придётся идти за ригом
## Авторство
я
## Чеинжлог
:cl:
- experiment: Урон от разгермы больше не наносит дополнительной боли - бегайте по космосу в четыре раза дольше!