### PR TITLE
бафф бол

### DIFF
--- a/code/game/objects/items/weapons/legcuffs.dm
+++ b/code/game/objects/items/weapons/legcuffs.dm
@@ -87,19 +87,6 @@
 		                "<span class='userdanger'>\The [src] ensnares you!</span>",
 						"<span class='notice'>You hear something flying at a very fast speed.</span>")
 		feedback_add_details("handcuffs","B")
-		var/chances_to_fault = 100
-		if(ishuman(C))
-			var/mob/living/carbon/human/H = C
-			var/BP_armor = 0
-			for(var/leg in list(BP_L_LEG, BP_R_LEG))
-				var/obj/item/organ/external/BP = H.get_bodypart(leg)
-				if(BP)
-					var/leg_armor = H.getarmor(BP, MELEE)
-					if(leg_armor > BP_armor)
-						BP_armor = leg_armor
-			chances_to_fault = clamp((BP_armor - weaken * 10), 0, 100)
-		if(prob(chances_to_fault))
-			return
 		C.Weaken(weaken)
 
 //traitor variant


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
шанс того что бола оглушит кого-то теперь не зависит от защищённости цели
## Почему и что этот ПР улучшит
сейчас со 100% шансом можно защититься от болы просто включив режим БРОСКА, не вижу смысла в том, чтобы ещё и броня (с шансом, что мне очень не нравится) защищала от стана
## Авторство

## Чеинжлог
🆑 Simbaka
- balance: Броня больше не защищает от оглушения с помощью болы.