### PR TITLE
Вес голосов гостов, глав, антагов немного изменен

### DIFF
--- a/code/controllers/subsystem/voting/poll.dm
+++ b/code/controllers/subsystem/voting/poll.dm
@@ -4,9 +4,9 @@
 	If you are an antag or a head of staff, you get 2 votes
 */
 #define VOTE_WEIGHT_NONE   0
-#define VOTE_WEIGHT_LOW    0.3
+#define VOTE_WEIGHT_LOW    0.5
 #define VOTE_WEIGHT_NORMAL 1
-#define VOTE_WEIGHT_HIGH   2
+#define VOTE_WEIGHT_HIGH   1.5
 #define MINIMUM_VOTE_LIFETIME 15 MINUTES
 
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Вес голосов гостов, новых игроков и т.п. изменен с 0,3 до 0,5
Вес глав, ролей изменен с 2 до 1,5
## Почему и что этот ПР улучшит
Баланс. Равенство. Я бы вообще всем 1 поставил, но думаю партия такое не одобрит
## Авторство

## Чеинжлог
:cl:
- tweak: Вес голосов разных групп игроков немного уравнен