### PR TITLE
делает бинты и мази менее требовательными к скиллам

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -103,7 +103,7 @@
 	repeating = TRUE
 	heal_brute = 1
 
-	required_skills = list(/datum/skill/medical = SKILL_LEVEL_NOVICE)
+	required_skills = list(/datum/skill/medical = SKILL_LEVEL_NONE)
 
 /obj/item/stack/medical/bruise_pack/announce_heal(mob/living/L, mob/user)
 	..()
@@ -169,7 +169,7 @@
 	repeating = FALSE
 	heal_burn = 1
 
-	required_skills = list(/datum/skill/medical = SKILL_LEVEL_NOVICE)
+	required_skills = list(/datum/skill/medical = SKILL_LEVEL_NONE)
 
 /obj/item/stack/medical/ointment/can_heal(mob/living/L, mob/living/user)
 	. = ..()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
уменьшил требования к мед скиллам у обычных бинтов и мазей до 0
## Почему и что этот ПР улучшит
Одна из причин существования скиллов - усложнить кражу работки, замедлив взаимодействия с теми вещами, с которыми нная профессия не должна взаимодействовать.
Базовые медикаменты являются общедоступными предметами, они лежат у многих гражданских профессий без медицинских скиллов. Исходя из этого, ими должны мочь пользоваться абсолютно все.
## Авторство

## Чеинжлог
:cl: Simbaka
- balance: Убраны требования к медицинским умениям у базовых медикаментов, по типу бинтов и мазей.