### PR TITLE
Imposters gamemode probabilities

### DIFF
--- a/code/game/gamemodes/modes_declares/imposters.dm
+++ b/code/game/gamemodes/modes_declares/imposters.dm
@@ -1,7 +1,7 @@
 /datum/game_mode/imposter
 	name = "Imposter"
 	config_name = "imposter"
-	probability = 70
+	probability = 35
 	factions_allowed = list(/datum/faction/traitor/auto/imposter)
 	minimum_player_count = 1
 	minimum_players_bundles = 1


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Задумка была сделать этот режим редким. Оказалось что редкость на уровне шадоулингов, мага или ревы это больше чем 1-2 раунда за день. Согласно опросу, 90% участников не против уменьшить его вероятность.
https://forum.taucetistation.org/t/golosovanie-fidbek-imposterov/40934
## Почему и что этот ПР улучшит
уменьшаем вдвое шанс выпадения для режима, задуманного как редкого.
## Авторство

## Чеинжлог
:cl: Deahaka
- tweak: Шанс появления режима Самозванцы (Imposters) уменьшен вдвое