### PR TITLE
Только главы, СБ, БЩ и КМ смогут стать импостерами

### DIFF
--- a/code/game/gamemodes/roles/traitor.dm
+++ b/code/game/gamemodes/roles/traitor.dm
@@ -151,8 +151,8 @@
 	name = IMPOSTER
 	id = IMPOSTER
 	required_pref = ROLE_IMPOSTER
-	//No restricts, everyone can be a imposter
-	restricted_jobs = list()
+	//only heads and quartermaster can have imposter role
+	restricted_jobs = list("Chaplain", "Cargo Technician", "Shaft Miner", "Recycler", "Bartender", "Chef", "Botanist", "Janitor", "Barber", "Librarian", "Clown", "Mime", "Station Engineer", "Atmospheric Technician", "Technical Assistant", "Medical Doctor", "Paramedic", "Chemist", "Geneticist", "Virologist", "Psychiatrist", "Medical Intern", "Scientist", "Xenoarchaeologist", "Xenobiologist", "Roboticist",  "Research Assistant")
 	//Challenge
 	give_uplink = FALSE
 	telecrystals = 0

--- a/code/game/gamemodes/roles/traitor.dm
+++ b/code/game/gamemodes/roles/traitor.dm
@@ -151,7 +151,7 @@
 	name = IMPOSTER
 	id = IMPOSTER
 	required_pref = ROLE_IMPOSTER
-	//only heads and quartermaster can have imposter role
+	//only heads, quartermaster and blueshield officer can have imposter role
 	restricted_jobs = list("Chaplain", "Cargo Technician", "Shaft Miner", "Recycler", "Bartender", "Chef", "Botanist", "Janitor", "Barber", "Librarian", "Clown", "Mime", "Station Engineer", "Atmospheric Technician", "Technical Assistant", "Medical Doctor", "Paramedic", "Chemist", "Geneticist", "Virologist", "Psychiatrist", "Medical Intern", "Scientist", "Xenoarchaeologist", "Xenobiologist", "Roboticist",  "Research Assistant")
 	//Challenge
 	give_uplink = FALSE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
тайтл
## Почему и что этот ПР улучшит
Импостеры, которые не являются главы / СБ / агентом БЩ ничем не отличаются от игроков, поставивших отсутствие апплинка в сетапе. КМ не включён в список, так-как по сути является главой отдела Карго (не считая ГП)

Несмотря на отсутствие активности по выбору местоположения апплинка, не считаю, что этот механ должен быть удалён, потому что лучше иметь в билде две _нормально_ работающие механики, чем одну.
## Авторство
maleyvich
## Чеинжлог
:cl:
- tweak: Роль импостера теперь смогут получить только главы, СБ и завхоз.