### PR TITLE
Продолжение отлова Error-турфов.  asteroid.dmm and centcom.dmm

### DIFF
--- a/maps/asteroid/asteroid.dmm
+++ b/maps/asteroid/asteroid.dmm
@@ -3314,12 +3314,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/simulated/floor{
-	dir = 1;
-	icon_state = "vault";
-	name = "Mainframe floor";
-	nitrogen = 100;
-	oxygen = 0;
-	temperature = 80
+	icon_state = "dark"
 	},
 /area/asteroid/research_outpost/tempstorage)
 "hd" = (
@@ -8195,7 +8190,7 @@
 	icon_state = "gr_window_reinforced"
 	},
 /turf/simulated/floor/airless{
-	icon_state = "circuit"
+	icon_state = "wood"
 	},
 /area/asteroid/mine/explored)
 "rZ" = (

--- a/maps/centcom/centcom.dmm
+++ b/maps/centcom/centcom.dmm
@@ -6647,7 +6647,7 @@
 /area/space)
 "apz" = (
 /turf/unsimulated/floor{
-	icon_state = "floor5"
+	icon_state = "floor"
 	},
 /area/custom/alien)
 "apA" = (
@@ -6815,7 +6815,7 @@
 	dir = 4
 	},
 /turf/unsimulated/floor{
-	icon_state = "floor5"
+	icon_state = "floor"
 	},
 /area/custom/alien)
 "apT" = (
@@ -15381,7 +15381,7 @@
 	name = "Arrival Airlock"
 	},
 /turf/unsimulated/floor{
-	icon_state = "floor5"
+	icon_state = "floor"
 	},
 /area/centcom/evac)
 "aHK" = (
@@ -15785,15 +15785,6 @@
 "aII" = (
 /turf/unsimulated/floor,
 /area/centcom/evac)
-"aIJ" = (
-/obj/machinery/door/airlock/external{
-	name = "Arrival Airlock";
-	dir = 4
-	},
-/turf/unsimulated/floor{
-	icon_state = "floor5"
-	},
-/area/centcom/evac)
 "aIK" = (
 /turf/unsimulated/floor{
 	dir = 4;
@@ -15822,11 +15813,6 @@
 	icon_state = "warn"
 	},
 /turf/unsimulated/floor,
-/area/centcom/evac)
-"aIP" = (
-/turf/unsimulated/floor{
-	icon_state = "floor5"
-	},
 /area/centcom/evac)
 "aIQ" = (
 /obj/structure/stool/bed,
@@ -23271,7 +23257,7 @@
 	dir = 4
 	},
 /turf/unsimulated/floor{
-	icon_state = "floor5"
+	icon_state = "floor"
 	},
 /area/centcom/evac)
 "bOb" = (
@@ -24987,7 +24973,7 @@
 	dir = 4
 	},
 /turf/unsimulated/floor{
-	icon_state = "floor5"
+	icon_state = "floor"
 	},
 /area/centcom/evac)
 "eOb" = (
@@ -25444,7 +25430,7 @@
 	name = "Arrival Airlock"
 	},
 /turf/unsimulated/floor{
-	icon_state = "floor5"
+	icon_state = "floor"
 	},
 /area/centcom/evac)
 "fLb" = (
@@ -27769,7 +27755,7 @@
 	name = "Arrival Airlock"
 	},
 /turf/unsimulated/floor{
-	icon_state = "floor5"
+	icon_state = "floor"
 	},
 /area/centcom/evac)
 "ksb" = (
@@ -29797,7 +29783,7 @@
 	dir = 4
 	},
 /turf/unsimulated/floor{
-	icon_state = "floor5"
+	icon_state = "floor"
 	},
 /area/centcom/evac)
 "pgb" = (
@@ -49939,7 +49925,7 @@ aaM
 aaM
 aaM
 abn
-aIP
+aIy
 abn
 aaM
 aaM
@@ -50964,7 +50950,7 @@ hyb
 aIy
 hOb
 hSb
-aIP
+aIy
 hZb
 hyb
 aIy
@@ -51738,7 +51724,7 @@ aHv
 aaM
 aHv
 aHv
-aIJ
+pdb
 aHv
 aHv
 aaM


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Убраны Error-турфы на ЦК(Зона доков) и астеройде(Один на научке, один под стеклом у структуры на западе)
## Почему и что этот ПР улучшит
Продолжаем работать над иммерсивностью окружения
## Авторство
Ястарк
## Чеинжлог
