### PR TITLE
Toggle Ghost Icon verb without fluff

### DIFF
--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -429,11 +429,9 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	if(!length(custom_sprites))
 		if(config.customitems_info_url)
-			to_chat(src, "<span class='notice'>You don't have any ghost sprites. <a href='[config.customitems_info_url]'>Read more about Fluff</a> and how to get them.</span>")
+			to_chat(src, "<span class='notice'>You don't have any custom ghost sprites. <a href='[config.customitems_info_url]'>Read more about Fluff</a> and how to get them.</span>")
 		else
-			to_chat(src, "<span class='notice'>You don't have any ghost sprites.</span>")
-
-		return
+			to_chat(src, "<span class='notice'>You don't have any custom ghost sprites.</span>")
 
 	if(body_icon)
 		custom_sprites += "--body--"


### PR DESCRIPTION
## Описание изменений
Игроки, у которых есть флафф иконка призрака могли переключаться между: Простым спрайтом призрака / Призрачным спрайтом тела из которого гостанулись / Флаффом. Игроки без флаффа не могли переключаться вообще. Теперь игроки без флаффа могут переключаться между обычным призраком и призраком тела. Ссылка на статью про флафф при его отсутствии осталась
## Почему и что этот ПР улучшит
индивидуальное эстетическое удовольствие
## Авторство

## Чеинжлог
:cl:
- rscadd: Кнопка Toggle Ghost Icon в вкладке Ghost переключает спрайт призрака и тела.