### PR TITLE
Move speed damage/pain rebalance

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -24,6 +24,11 @@
 
 // =============================================
 
+/mob/living/carbon/human/proc/getTotalLoss()
+	return getOxyLoss() + getFireLoss() + getBruteLoss() + getToxLoss() + getCloneLoss()
+
+// =============================================
+
 /mob/living/carbon/human/getBrainLoss()
 	if(status_flags & GODMODE)
 		return 0

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -33,9 +33,8 @@
 		if(embedded_flag)
 			handle_embedded_objects() // Moving with objects stuck in you can cause bad times.
 
-		var/health_deficiency = (100 - health + halloss)
-		if(health_deficiency >= 40)
-			tally += health_deficiency / 25
+		tally += (getTotalLoss() / 100) * 2.5 + (getHalLoss() / 100) * 4.5
+		//slowdown per precent of damage on human or pain, pain most effectivy but can be more 100
 
 		var/hungry = 500 - get_satiation()
 		if(hungry >= 350) // Slow down if nutrition <= 150


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Изменен принцип подсчета коэффициента замедления у куклы.

Раньше он зависит от порога в 40 урона сподвигая на использование летального оружия (лазеров) для получения максимального эффекта от замедления, за один выстрел. В то время как не летальное оружие имело недостаточно урона для того, чтобы перейти порог.

В ПРе предлагается отойти от принципа порога урона для замедления, используя вместо этого процентное замедление от количества урона нанесенного кукле. *(Как болью, так и обычного, в том числе урона от клонирования.)*

Предложенные коэффициенты эффективности примерны и могут быть изменены.
На момент создания ПРа:
2.5 для всех типов урона, кроме галоурона *(немного слабее чем было)*
4.5 для галоурона *(Немного сильнее чем было)*

По цифрам и подсчетам:
При нанесении 40 урона цели, она получит замедление в 1. *(Было 1.6 для любого урона после перехода порога в 40 урона)*
При нанесении 35 галоурона цели, она получит замедление в 1.57~.

## Почему и что этот ПР улучшит
Баланс?
## Авторство
Я, чур Димшик обосновывает
## Чеинжлог
:cl:
- balance[link]: Изменен принцип замедления куклы при получении урона.