### PR TITLE
Nuke RIg modules update

### DIFF
--- a/code/datums/outfits/nuclear.dm
+++ b/code/datums/outfits/nuclear.dm
@@ -45,6 +45,9 @@
 /datum/outfit/nuclear/skrell_equip()
 	backpack_contents += list(/obj/item/device/modkit/skrell)
 
+/datum/outfit/nuclear/ipc_equip()
+	backpack_contents += list(/obj/item/rig_module/cooling_unit/advanced)
+
 /datum/outfit/nuclear/vox_equip()
 	backpack_contents += list(/obj/item/device/modkit/vox)
 	l_hand = /obj/item/weapon/tank/nitrogen

--- a/code/datums/outfits/outfit.dm
+++ b/code/datums/outfits/outfit.dm
@@ -116,6 +116,9 @@
 /datum/outfit/proc/skrell_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	return
 
+/datum/outfit/proc/ipc_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	return
+
 /datum/outfit/proc/vox_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	return
 

--- a/code/modules/clothing/spacesuits/rig/modules/ai.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ai.dm
@@ -344,11 +344,22 @@
 		return
 
 	var/obj/item/rig_module/chem_dispenser/chem_disp = holder.find_module(/obj/item/rig_module/chem_dispenser)
-	if(!chem_disp)
+	var/obj/item/rig_module/selfrepair/adv/repairModule = holder.find_module(/obj/item/rig_module/selfrepair/adv)
+
+	if(!chem_disp && !repairModule)
 		return
 
-	if(H.getOxyLoss() > 40)
+	for(var/obj/item/organ/external/BP in H.bodyparts)
+		if(BP.is_robotic())
+			if(BP.brute_dam || BP.burn_dam)
+				if(!repairModule.active)
+					repairModule.activate()
+
+	if(H.getOxyLoss() > 40 && H.species != VOX)
 		if(try_inject(H, chem_disp, list("dexalin plus", "dexalin", "inaprovaline", "tricordrazine")))
+			return
+	else if(H.getOxyLoss() > 40)
+		if(try_inject(H, chem_disp, list("tricordrazine")))
 			return
 	if(H.getFireLoss() > 40)
 		if(try_inject(H, chem_disp, list("dermaline", "kelotane", "tricordrazine")))

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -495,6 +495,67 @@
 
 	return FALSE
 
+/obj/item/rig_module/selfrepair/adv
+	name = "hardsuit advanced self-repair module"
+
+/obj/item/rig_module/selfrepair/adv/process_module()
+	if(!active)
+		return passive_power_cost
+
+	var/mob/living/carbon/human/H = holder.wearer
+	var/obj/item/organ/external/DBP
+
+	for(var/obj/item/organ/external/BP in H.bodyparts)
+		if(BP.is_robotic())
+			if(BP.brute_dam)
+				DBP = BP
+			else if(BP.burn_dam)
+				DBP = BP
+
+	if(!holder.brute_damage && !holder.burn_damage && !DBP)
+		deactivate()
+		to_chat(H, "<span class='notice'>Self-repair is completed</span>")
+		return passive_power_cost
+
+	var/datum/rig_charge/charge = charges["metal"]
+
+	if(!charge)
+		deactivate()
+		return FALSE
+
+	active_power_cost = passive_power_cost
+	if(holder.brute_damage && charge.charges > 0)
+		var/chargeuse = min(charge.charges, 2)
+
+		charge.charges -= chargeuse
+		holder.repair_breaches(BRUTE, chargeuse, H, stop_messages = TRUE)
+
+		active_power_cost = chargeuse * 150
+	else if(holder.burn_damage && charge.charges > 0)
+		var/chargeuse = min(charge.charges, 2)
+
+		charge.charges -= chargeuse
+		holder.repair_breaches(BURN, chargeuse, H, stop_messages = TRUE)
+
+		active_power_cost = chargeuse * 150
+	else if(DBP.?brute_dam && charge.charges > 0)
+		var/chargeuse = min(charge.charges, 2)
+		DBP.heal_damage(10, 0, 0, 1)
+		charge.charges -= chargeuse
+
+		active_power_cost = chargeuse * 200
+	else if(DBP.?burn_dam && charge.charges > 0)
+		var/chargeuse = min(charge.charges, 2)
+		DBP.heal_damage(0, 10, 0, 1)
+		charge.charges -= chargeuse
+
+		active_power_cost = chargeuse * 200
+	else
+		deactivate()
+		to_chat(H, "<span class='danger'>Not enough materials to continue self-repair</span>")
+
+	return active_power_cost
+
 /obj/item/rig_module/med_teleport
 	name = "hardsuit medical teleport system"
 	origin_tech = "programming=2;materials=2;bluespace=1"

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -544,7 +544,7 @@
 		charge.charges -= chargeuse
 
 		active_power_cost = chargeuse * 200
-	else if(DBP.?burn_dam && charge.charges > 0)
+	else if(DBP?.burn_dam && charge.charges > 0)
 		var/chargeuse = min(charge.charges, 2)
 		DBP.heal_damage(0, 10, 0, 1)
 		charge.charges -= chargeuse

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -538,7 +538,7 @@
 		holder.repair_breaches(BURN, chargeuse, H, stop_messages = TRUE)
 
 		active_power_cost = chargeuse * 150
-	else if(DBP.?brute_dam && charge.charges > 0)
+	else if(DBP?.brute_dam && charge.charges > 0)
 		var/chargeuse = min(charge.charges, 2)
 		DBP.heal_damage(10, 0, 0, 1)
 		charge.charges -= chargeuse

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -829,7 +829,7 @@
 	               /obj/item/weapon/handcuffs)
 	species_restricted = list("exclude" , UNATHI , TAJARAN , DIONA, VOX)
 	max_mounted_devices = 4
-	initial_modules = list(/obj/item/rig_module/simple_ai, /obj/item/rig_module/selfrepair, /obj/item/rig_module/emp_shield)
+	initial_modules = list(/obj/item/rig_module/simple_ai/advanced, /obj/item/rig_module/selfrepair/adv, /obj/item/rig_module/emp_shield)
 	cell_type = /obj/item/weapon/stock_parts/cell/super
 	var/combat_mode = FALSE
 	var/combat_armor = list(melee = 60, bullet = 65, laser = 55, energy = 45, bomb = 50, bio = 100, rad = 60)
@@ -919,7 +919,7 @@
 	item_state = "syndie_hardsuit"
 	rig_variant = "rig-heavy"
 	slowdown = 1.2
-	initial_modules = list(/obj/item/rig_module/simple_ai/advanced, /obj/item/rig_module/selfrepair, /obj/item/rig_module/chem_dispenser/combat, /obj/item/rig_module/emp_shield)
+	initial_modules = list(/obj/item/rig_module/simple_ai/advanced, /obj/item/rig_module/selfrepair/adv, /obj/item/rig_module/chem_dispenser/combat, /obj/item/rig_module/emp_shield)
 	combat_armor = list(melee = 75, bullet = 80, laser = 70,energy = 55, bomb = 50, bio = 100, rad = 30)
 	space_armor = list(melee = 45, bullet = 30, laser = 30, energy = 45, bomb = 50, bio = 100, rad = 60)
 	combat_slowdown = 0.5
@@ -953,7 +953,7 @@
 	combat_armor = list(melee = 80, bullet = 75, laser = 65, energy = 65, bomb = 70, bio = 70, rad = 70)
 	space_armor = list(melee = 65, bullet = 60, laser = 50, energy = 35, bomb = 50, bio = 100, rad = 70)
 	combat_slowdown = 0.2
-	initial_modules = list(/obj/item/rig_module/simple_ai, /obj/item/rig_module/selfrepair, /obj/item/rig_module/syndiemmessage, /obj/item/rig_module/emp_shield)
+	initial_modules = list(/obj/item/rig_module/simple_ai/advanced, /obj/item/rig_module/selfrepair/adv, /obj/item/rig_module/syndiemmessage, /obj/item/rig_module/emp_shield)
 	can_be_modded = FALSE
 
 /obj/item/clothing/suit/space/rig/syndi/elite/comander
@@ -983,7 +983,7 @@
 	slowdown = 0.7
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	unacidable = TRUE
-	initial_modules = list(/obj/item/rig_module/simple_ai, /obj/item/rig_module/selfrepair, /obj/item/rig_module/emp_shield, /obj/item/rig_module/cooling_unit/advanced)
+	initial_modules = list(/obj/item/rig_module/simple_ai/advanced, /obj/item/rig_module/selfrepair/adv, /obj/item/rig_module/emp_shield, /obj/item/rig_module/cooling_unit/advanced)
 	allowed = list(/obj/item/device/flashlight,
 	               /obj/item/weapon/tank,
 	               /obj/item/device/suit_cooling_unit,


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Добавил улучшенный модуль авторемонта.
Дал его только нюкерам.
Улучшенный модуль авторемонта может чинить робо конечности, а не только сам РИГ, но в первую очередь, будет чинить РИГ и только потом конечности.

Также, изменил модули обычного ИИ на улучшенного в ригах синдиката.

Хим модуль РИГов больше не обкалывае воксов дексалином и тд.

СПУ нюкеры при спавне будут получать улучшенный модуль охлаждения для РИГа.

## Почему и что этот ПР улучшит
Баланс, геймплей. 
Нюкер человек с протезами или СПУ нюкер будут меньше страдать ЭМИ и повреждений, которые они не могут восстановить будучи в РИГах.

А воксы просто перестанут бояться хим модулей, что обкалывают их дексалином до смерти.

СПУ смогут носить не только хазматы, но и други РИГи без перегрева.

## Авторство
Я
## Чеинжлог
:cl:
- balance[link]: Немного изменены модули РИГов Оперативников Ядерной Угрозы.