### PR TITLE
remove channels on no module borg and fix radio

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -751,32 +751,32 @@ var/global/GLOBAL_RADIO_TYPE = 1 // radio type to use
 		return ..()
 
 /obj/item/device/radio/borg/proc/recalculateChannels()
-	src.channels = list()
-	src.syndie = 0
+	channels = list()
+	syndie = 0
 
 	var/mob/living/silicon/robot/D = src.loc
 	if(D.module)
 		for(var/ch_name in D.module.channels)
-			if(ch_name in src.channels)
+			if(ch_name in channels)
 				continue
-			src.channels += ch_name
-			src.channels[ch_name] += D.module.channels[ch_name]
+			channels += ch_name
+			channels[ch_name] += D.module.channels[ch_name]
 	if(keyslot)
 		for(var/ch_name in keyslot.channels)
-			if(ch_name in src.channels)
+			if(ch_name in channels)
 				continue
-			src.channels += ch_name
-			src.channels[ch_name] += keyslot.channels[ch_name]
+			channels += ch_name
+			channels[ch_name] += keyslot.channels[ch_name]
 
 		if(keyslot.syndie)
-			src.syndie = 1
+			syndie = 1
 
 
-	for (var/ch_name in src.channels)
+	for (var/ch_name in channels)
 		if(!radio_controller)
 			sleep(30) // Waiting for the radio_controller to be created.
 		if(!radio_controller)
-			src.name = "broken radio"
+			name = "broken radio"
 			return
 
 		secure_radio_connections[ch_name] = radio_controller.add_object(src, radiochannels[ch_name],  RADIO_CHAT)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -24,9 +24,12 @@
 	require_module = 1
 
 /obj/item/borg/upgrade/reset/action(mob/living/silicon/robot/R)
-	if(..()) return 0
+	if(..())
+		return 0
+
 	R.uneq_all()
 	R.icon_state = "robot"
+	clearlist(R.module.channels)
 	qdel(R.module)
 	R.module = null
 	R.module_icon.update_icon(R)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -337,6 +337,7 @@
 		icon_state = module_sprites[new_icon_state]
 
 	radio.config(module.channels)
+	radio.recalculateChannels()
 
 /mob/living/silicon/robot/proc/build_combat_borg()
 	var/mob/living/silicon/robot/combat/C = new(get_turf(src))

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -5,7 +5,7 @@
 	w_class = SIZE_LARGE
 	item_state = "electronic"
 	flags = CONDUCT
-	var/channels = list()
+	var/list/channels = list()
 	var/list/modules = list()
 	var/obj/item/emag = null
 	var/obj/item/borg/upgrade/jetpack = null


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
При сбросе модуля борга, будучи без модуля у него оставались каналы связи которые он получил от модуля. 

При этом, если вставить ключ шифрования в борга и тот откроет ему новые радиоканалы, если борг сменит модуль, каналы исчезнут до повторной установки ключа шифрования. *(Который остается в борге)*

Этот пр как бы фиксит это.
## Почему и что этот ПР улучшит
Меньше багов?
## Авторство
Я
## Чеинжлог
