### PR TITLE
Повышение КД репульса у мага

### DIFF
--- a/code/datums/spells/repulse.dm
+++ b/code/datums/spells/repulse.dm
@@ -1,7 +1,7 @@
 /obj/effect/proc_holder/spell/aoe_turf/repulse
 	name = "Репульс"
 	desc = "Заклинание отбрасывает все вещи и людей от вас подальше."
-	charge_max = 200
+	charge_max = 60 SECONDS
 	clothes_req = 1
 	invocation = "GITTAH WEIGH"
 	invocation_type = "shout"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
тайтл
## Почему и что этот ПР улучшит
вещь, которая способна застанить на 2 секунды и заweaken-ить на 5 не должна иметь такое низкое КД. Кнопка довольно сильная, поэтому не вижу смысла давать ей маленький кулдаун (текущий ПР подразумевает повышение КД до 60 секунд)
## Авторство
maleyvich
## Чеинжлог
:cl: Maleyvich
- experiment: Кулдаун способности "Repulse" был повышен до 60 секунд