### PR TITLE
Цветные цифры урона в медсканере

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -240,7 +240,7 @@
 					var/arterial_bleeding = ""
 					var/rejecting = ""
 					if(BP.status & ORGAN_ARTERY_CUT)
-						arterial_bleeding = "<font color='red'><br><b>Артериальное кровотечение</b><br><font>"
+						arterial_bleeding = "<font color='red'><br><b>Артериальное кровотечение</b><br></font>"
 					if(BP.status & ORGAN_SPLINTED)
 						splint = "Наложена шина:"
 					if(BP.status & ORGAN_BLEEDING)

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -281,8 +281,8 @@
 					if(!AN && !open && !infected && !imp)
 						AN = "Не обнаружено:"
 					if(!(BP.is_stump))
-						dat += text("<td>[BP.name]</td><td><font color='[]'>[BP.burn_dam]</font></td><td><font color='[]'>[BP.brute_dam]</font></td><td>[robot][bled][AN][splint][open][infected][imp][arterial_bleeding][rejecting]</td>", (BP.burn_dam > 0 ? "orange" : "blue"), (BP.brute_dam > 0 ? "red" : "blue"))
-						storedinfo += text("<td>[BP.name]</td><td><font color='[]'>[BP.burn_dam]</font></td><td><font color='[]'>[BP.brute_dam]</font></td><td>[robot][bled][AN][splint][open][infected][imp][arterial_bleeding][rejecting]</td>", (BP.burn_dam > 0 ? "orange" : "blue"), (BP.brute_dam > 0 ? "red" : "blue"))
+						dat += text("<td>[BP.name]</td><td>[]</td><td>[]</td><td>[robot][bled][AN][splint][open][infected][imp][arterial_bleeding][rejecting]</td>", (BP.burn_dam > 0 ? "<font color='orange'>[BP.burn_dam]</font>" : "-/-"), (BP.brute_dam > 0 ? "<font color='red'>[BP.brute_dam]</font>" : "-/-"))
+						storedinfo += text("<td>[BP.name]</td><td>[]</td><td>[]</td><td>[robot][bled][AN][splint][open][infected][imp][arterial_bleeding][rejecting]</td>", (BP.burn_dam > 0 ? "<font color='orange'>[BP.burn_dam]</font>" : "-/-"), (BP.brute_dam > 0 ? "<font color='red'>[BP.brute_dam]</font>" : "-/-"))
 					else
 						dat += "<td>[parse_zone(BP.body_zone)]</td><td>-</td><td>-</td><td>Not Found</td>"
 						storedinfo += "<td>[parse_zone(BP.body_zone)]</td><td>-</td><td>-</td><td>Not Found</td>"
@@ -334,10 +334,10 @@
 					if(!organ_status && !infection)
 						infection = "Не обнаружено:"
 					dat += "<tr>"
-					dat += text("<td>[IO.name]</td><td>N/A</td><td><font color='[]'>[IO.damage]</font></td><td>[infection][organ_status]|[mech]</td><td></td>", (IO.damage > 0 ? "red" : "blue"))
+					dat += text("<td>[IO.name]</td><td>N/A</td><td>[]</td><td>[infection][organ_status]|[mech]</td><td></td>", (IO.damage > 0 ? "<font color='red'>[IO.damage]</font>" : "-/-"))
 					dat += "</tr>"
 					storedinfo += "<tr>"
-					storedinfo += text("<td>[IO.name]</td><td>N/A</td><td><font color='[]'>[IO.damage]</font></td><td>[infection][organ_status]|[mech]</td><td></td>", (IO.damage > 0 ? "red" : "blue"))
+					storedinfo += text("<td>[IO.name]</td><td>N/A</td><td>[]</td><td>[infection][organ_status]|[mech]</td><td></td>", (IO.damage > 0 ? "<font color='red'>[IO.damage]</font>" : "-/-"))
 					storedinfo += "</tr>"
 				dat += "</table>"
 				storedinfo += "</table>"

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -240,7 +240,7 @@
 					var/arterial_bleeding = ""
 					var/rejecting = ""
 					if(BP.status & ORGAN_ARTERY_CUT)
-						arterial_bleeding = "<font color='red'><br><b>Артериальное кровотечение</b><br></font>"
+						arterial_bleeding = "<span class='red'><br><b>Артериальное кровотечение</b><br></span>"
 					if(BP.status & ORGAN_SPLINTED)
 						splint = "Наложена шина:"
 					if(BP.status & ORGAN_BLEEDING)
@@ -281,8 +281,10 @@
 					if(!AN && !open && !infected && !imp)
 						AN = "Не обнаружено:"
 					if(!(BP.is_stump))
-						dat += text("<td>[BP.name]</td><td>[]</td><td>[]</td><td>[robot][bled][AN][splint][open][infected][imp][arterial_bleeding][rejecting]</td>", (BP.burn_dam > 0 ? "<font color='orange'>[BP.burn_dam]</font>" : "-/-"), (BP.brute_dam > 0 ? "<font color='red'>[BP.brute_dam]</font>" : "-/-"))
-						storedinfo += text("<td>[BP.name]</td><td>[]</td><td>[]</td><td>[robot][bled][AN][splint][open][infected][imp][arterial_bleeding][rejecting]</td>", (BP.burn_dam > 0 ? "<font color='orange'>[BP.burn_dam]</font>" : "-/-"), (BP.brute_dam > 0 ? "<font color='red'>[BP.brute_dam]</font>" : "-/-"))
+						var/burnDamText = BP.burn_dam > 0 ? "<span class='orange'>[BP.burn_dam]</span>" : "-/-"
+						var/bruteDamText = BP.brute_dam > 0 ? "<span class='red'>[BP.brute_dam]</span>" : "-/-"
+						dat += "<td>[BP.name]</td><td>[burnDamText]</td><td>[bruteDamText]</td><td>[robot][bled][AN][splint][open][infected][imp][arterial_bleeding][rejecting]</td>"
+						storedinfo += "<td>[BP.name]</td><td>[burnDamText]</td><td>[bruteDamText]</td><td>[robot][bled][AN][splint][open][infected][imp][arterial_bleeding][rejecting]</td>"
 					else
 						dat += "<td>[parse_zone(BP.body_zone)]</td><td>-</td><td>-</td><td>Not Found</td>"
 						storedinfo += "<td>[parse_zone(BP.body_zone)]</td><td>-</td><td>-</td><td>Not Found</td>"
@@ -333,11 +335,13 @@
 
 					if(!organ_status && !infection)
 						infection = "Не обнаружено:"
+
+					var/organ_damage_text = IO.damage > 0 ? "<span class='red'>[IO.damage]</span>" : "-/-"
 					dat += "<tr>"
-					dat += text("<td>[IO.name]</td><td>N/A</td><td>[]</td><td>[infection][organ_status]|[mech]</td><td></td>", (IO.damage > 0 ? "<font color='red'>[IO.damage]</font>" : "-/-"))
+					dat += "<td>[IO.name]</td><td>N/A</td><td>[organ_damage_text]</td><td>[infection][organ_status]|[mech]</td><td></td>"
 					dat += "</tr>"
 					storedinfo += "<tr>"
-					storedinfo += text("<td>[IO.name]</td><td>N/A</td><td>[]</td><td>[infection][organ_status]|[mech]</td><td></td>", (IO.damage > 0 ? "<font color='red'>[IO.damage]</font>" : "-/-"))
+					storedinfo += "<td>[IO.name]</td><td>N/A</td><td>[organ_damage_text]</td><td>[infection][organ_status]|[mech]</td><td></td>"
 					storedinfo += "</tr>"
 				dat += "</table>"
 				storedinfo += "</table>"

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -281,8 +281,8 @@
 					if(!AN && !open && !infected && !imp)
 						AN = "Не обнаружено:"
 					if(!(BP.is_stump))
-						dat += "<td>[BP.name]</td><td>[BP.burn_dam]</td><td>[BP.brute_dam]</td><td>[robot][bled][AN][splint][open][infected][imp][arterial_bleeding][rejecting]</td>"
-						storedinfo += "<td>[BP.name]</td><td>[BP.burn_dam]</td><td>[BP.brute_dam]</td><td>[robot][bled][AN][splint][open][infected][imp][arterial_bleeding][rejecting]</td>"
+						dat += text("<td>[BP.name]</td><td><font color='[]'>[BP.burn_dam]</font></td><td><font color='[]'>[BP.brute_dam]</font></td><td>[robot][bled][AN][splint][open][infected][imp][arterial_bleeding][rejecting]</td>", (BP.burn_dam > 0 ? "orange" : "blue"), (BP.brute_dam > 0 ? "red" : "blue"))
+						storedinfo += text("<td>[BP.name]</td><td><font color='[]'>[BP.burn_dam]</font></td><td><font color='[]'>[BP.brute_dam]</font></td><td>[robot][bled][AN][splint][open][infected][imp][arterial_bleeding][rejecting]</td>", (BP.burn_dam > 0 ? "orange" : "blue"), (BP.brute_dam > 0 ? "red" : "blue"))
 					else
 						dat += "<td>[parse_zone(BP.body_zone)]</td><td>-</td><td>-</td><td>Not Found</td>"
 						storedinfo += "<td>[parse_zone(BP.body_zone)]</td><td>-</td><td>-</td><td>Not Found</td>"
@@ -334,10 +334,10 @@
 					if(!organ_status && !infection)
 						infection = "Не обнаружено:"
 					dat += "<tr>"
-					dat += "<td>[IO.name]</td><td>N/A</td><td>[IO.damage]</td><td>[infection][organ_status]|[mech]</td><td></td>"
+					dat += text("<td>[IO.name]</td><td>N/A</td><td><font color='[]'>[IO.damage]</font></td><td>[infection][organ_status]|[mech]</td><td></td>", (IO.damage > 0 ? "red" : "blue"))
 					dat += "</tr>"
 					storedinfo += "<tr>"
-					storedinfo += "<td>[IO.name]</td><td>N/A</td><td>[IO.damage]</td><td>[infection][organ_status]|[mech]</td><td></td>"
+					storedinfo += text("<td>[IO.name]</td><td>N/A</td><td><font color='[]'>[IO.damage]</font></td><td>[infection][organ_status]|[mech]</td><td></td>", (IO.damage > 0 ? "red" : "blue"))
 					storedinfo += "</tr>"
 				dat += "</table>"
 				storedinfo += "</table>"
@@ -352,7 +352,7 @@
 	else
 		dat = "<font color='red'> Ошибка: Не подключен сканер тела.</font>"
 
-	var/datum/browser/popup = new(user, "window=scanconsole", src.name, 430, 600, ntheme = CSS_THEME_LIGHT)
+	var/datum/browser/popup = new(user, "window=scanconsole", src.name, 530, 700, ntheme = CSS_THEME_LIGHT)
 	popup.set_content(dat)
 	popup.open()
 

--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -240,7 +240,7 @@
 					var/arterial_bleeding = ""
 					var/rejecting = ""
 					if(BP.status & ORGAN_ARTERY_CUT)
-						arterial_bleeding = "<br>Артериальное кровотечние"
+						arterial_bleeding = "<font color='red'><br><b>Артериальное кровотечение</b><br><font>"
 					if(BP.status & ORGAN_SPLINTED)
 						splint = "Наложена шина:"
 					if(BP.status & ORGAN_BLEEDING)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Теперь вместо чёрных цифр урона будут цветные, что нагляднее будет показывать где болит. Так же теперь это окошко открывается с бОльшей шириной, что бы не приходилось каждый раз его растягивать в ширину что бы всё поместилось.

До:
![before](https://github.com/TauCetiStation/TauCetiClassic/assets/43725089/b4cc5214-7b40-4c2f-b7ac-c461a3753028)



После:
![new](https://github.com/TauCetiStation/TauCetiClassic/assets/43725089/700194c2-45f2-402f-9015-81b8c82abc00)



## Почему и что этот ПР улучшит
Удобно, красиво, наглядно.
## Авторство

## Чеинжлог
🆑 
 - tweak: Цифры урона в медсканере по конечностям и органам стали цветными.
