### PR TITLE
electrified arm nerf

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -14,11 +14,18 @@
 	M.log_combat(user, "stunned with [name]")
 	playsound(src, 'sound/machines/defib_zap.ogg', VOL_EFFECTS_MASTER)
 
-	user.cell.charge -= 30
+	user.cell.charge -= 500
 
-	M.Weaken(5)
-	M.Stuttering(5)
-	M.Stun(5)
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		var/obj/item/organ/external/BP = H.get_bodypart(user.get_targetzone())
+		var/calc_power = 125 // 25% better than stungloves
+		calc_power *= H.get_siemens_coefficient_organ(BP)
+		M.apply_effects(0,0,0,0,2,0,0,calc_power)
+	else
+		M.Weaken(5)
+		M.Stuttering(5)
+		M.Stun(5)
 
 
 	M.visible_message("<span class='warning'><B>[user] has prodded [M] with an electrically-charged arm!</B></span>", blind_message = "<span class='warning'>You hear someone fall</span>")


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
вместо стана на 5 секунд электрорука борга наносит людям 125 болеурона умноженные на сопротивляемость электричеству.
использование электроруки стало тратить в 17 раз больше энергии борга
## Почему и что этот ПР улучшит
баланс
стандубинка которая оглушает на 5 секунд КОГО УГОДНО и которая почти не тратит энергии является имбой думаю не надо объяснять почему
## Авторство

## Чеинжлог
🆑 Simbaka
- balance: Модуль electrified arm инженерных боргов наносит болеурон зависящий от устойчивости к электричеству цели, вместо простого оглушения на 5 секунд.