### PR TITLE
hos shades colormatrix fix

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -285,7 +285,7 @@
 	toggleable = TRUE
 	active = TRUE
 	activation_sound = 'sound/effects/glasses_switch.ogg'
-	sightglassesmod  = "sepia"
+	sightglassesmod  = "hos"
 	darkness_view = 7
 	lighting_alpha = LIGHTING_PLANE_ALPHA_INVISIBLE
 	flash_protection = FLASHES_AMPLIFIER


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
поменял цветоматрицу у очков хоса на ту которая должна быть
<details>
  <summary>Картинки</summary>
до

![image](https://github.com/TauCetiStation/TauCetiClassic/assets/84613249/30fabbf0-303b-4871-bab5-9912a930232a)

после

![image](https://github.com/TauCetiStation/TauCetiClassic/assets/84613249/dcf62eb7-b009-4587-b3b1-9081ab34596f)

без

![image](https://github.com/TauCetiStation/TauCetiClassic/assets/84613249/3ccfc126-d308-4d20-a712-7bff3eb367e1)

</details>

## Почему и что этот ПР улучшит
фикс ошибки
## Авторство

## Чеинжлог
очень маленькое изменение думаю ченджлог не нужен