### PR TITLE
Мелкобыстрофикся анастезических канистр в меде.

### DIFF
--- a/code/modules/atmospheric/machinery/portable/canister.dm
+++ b/code/modules/atmospheric/machinery/portable/canister.dm
@@ -141,7 +141,7 @@
 
 /obj/machinery/portable_atmospherics/canister/anesthetic/create_gas()
 	var/list/air_mix = StandardAirMix()
-	air_contents.adjust_multi("oxygen", air_mix["oxygen"], "sleeping_agent", air_mix["sleeping_agent"])
+	air_contents.adjust_multi("oxygen", air_mix["oxygen"], "sleeping_agent", air_mix["nitrogen"])
 
 #define HOLDING     1
 #define CONNECTED   2


### PR DESCRIPTION
## Описание изменений
Мелкобыстрофикся анастезических канистр в меде.

## Почему и что этот ПР улучшит
Мелкобыстрофикся анастезических канистр в меде.

## Авторство
AndreyGysev и Slavik2001

## Чеинжлог
 :cl: AndreyGysev, Slavik2001
 - bugfix: В канистре с анестетиком не было анестетика.