### PR TITLE
Фикс отрыва головы

### DIFF
--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -344,11 +344,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 		if(BP.parent == src)
 			BP.droplimb(null, clean, disintegrate)
 
-	for(var/obj/item/organ/internal/IO in bodypart_organs)
-		owner.organs -= IO
-		owner.organs_by_name -= IO.organ_tag
-		IO.owner = null
-
 	if(parent && !(parent.is_stump) && disintegrate != DROPLIMB_BURN)
 		if(clean)
 			if(prob(10))
@@ -452,6 +447,11 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 	if(vital)
 		owner.death()
+
+	for(var/obj/item/organ/internal/IO in bodypart_organs)
+		owner.organs -= IO
+		owner.organs_by_name -= IO.organ_tag
+		IO.owner = null
 
 	owner.UpdateDamageIcon(src)
 	if(!clean && leaves_stump)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
ссылка на мозг чистится слишком рано
из-за этого при отрыве головы игрока не перекидывает в мозг
терь все должно работать
## Почему и что этот ПР улучшит

## Авторство
спасибо вальтер что показал это в раунде
## Чеинжлог
