### PR TITLE
Навыки космо-бомжам

### DIFF
--- a/code/modules/scrap/scrap_people.dm
+++ b/code/modules/scrap/scrap_people.dm
@@ -61,4 +61,6 @@ var/global/list/junkyard_bum_list = list()     //list of all bums placements
 	to_chat(host, "<span class='warning'>You are space bum now. Try to survive. Try to cooperate. Try to be friendly. Only remember: there are no rules!</span>")
 	var/area/host_area = get_area(host)
 	SEND_SIGNAL(host_area, COMSIG_AREA_ENTERED, host, null)
+	host.mind.skills.add_available_skillset(/datum/skillset/jack_of_all_trades)
+	host.mind.skills.maximize_active_skills()
 	return host


### PR DESCRIPTION
## Описание изменений
У космо-бомжей появятся все навыки на среднем уровне (как у особки на навыки)
## Почему и что этот ПР улучшит
Неумелые космо-бомжи не успевают построить лачугу перед штормом как они могли до появления навыков, теперь снова успеют. Оперировать переломы от свалко-фауны товарищу бомжу подручными средствами они тоже смогут без огромных задержек.
## Авторство

## Чеинжлог
:cl:
 - tweak: Космо-бездомные со свалки получили навыки - всего понемногу.