### PR TITLE
На боксе в допросной комнате существовал особый стол...

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -3889,14 +3889,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "agH" = (
-/obj/structure/table/reinforced{
-	icon_state = "table"
-	},
 /obj/item/device/flashlight/lamp,
 /obj/item/device/taperecorder,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/structure/table/reinforced,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},


### PR DESCRIPTION
## Описание изменений
На боксе в комнате допроса был стол с Icon_state = "table", что не отображался в редакторе и вообще чзнх, фикс мап ишуя.

## Почему и что этот ПР улучшит
Фикс мап ишуя и, возможно, какой-то фигни что плавит чьи-то гпу.

## Авторство
AndreyGysev и все все все, кто помогал в дискорде.

## Чеинжлог