### PR TITLE
Вселение в кибер хоррора

### DIFF
--- a/code/modules/reagents/reagent_types/Chemistry-Miscellaneous.dm
+++ b/code/modules/reagents/reagent_types/Chemistry-Miscellaneous.dm
@@ -561,9 +561,14 @@
 						to_chat(M, pick( "<b><span class='warning'>Something bursts out from inside you!</span></b>"))
 						message_admins("[key_name(H)] has gibbed and spawned a new cyber horror due to nanobots. (<A HREF='?_src_=holder;adminmoreinfo=\ref[H]'>?</A>) [ADMIN_JMP(H)]")
 						log_game("[key_name(H)] has gibbed and spawned a new cyber horror due to nanobots")
-						new /mob/living/simple_animal/hostile/cyber_horror(H.loc)
+						var/mob/living/simple_animal/hostile/cyber_horror/CH = new(H.loc)
 						spawning_horror = 0
+						var/client/chelik = H.client
 						H.gib()
+						var/answer = tgui_alert(chelik,"Ты хочешь стать кибер хоррором? Потом ты не сможешь вернуться в свою голову.","Кибер хоррор", list("Да","Нет"))
+						if(answer == "Да")
+							CH.key = chelik.key
+							to_chat(CH, "Теперь ты кибер хоррор! Кусай людей пока они не превратятся в твоих сородичей. Чем больше вас - тем вы сильнее!")
 	else
 		holder.del_reagent(id)
 

--- a/code/modules/reagents/reagent_types/Chemistry-Miscellaneous.dm
+++ b/code/modules/reagents/reagent_types/Chemistry-Miscellaneous.dm
@@ -563,11 +563,11 @@
 						log_game("[key_name(H)] has gibbed and spawned a new cyber horror due to nanobots")
 						var/mob/living/simple_animal/hostile/cyber_horror/CH = new(H.loc)
 						spawning_horror = 0
-						var/client/chelik = H.client
+						var/client/player = H.client
 						H.gib()
-						var/answer = tgui_alert(chelik,"Ты хочешь стать кибер хоррором? Потом ты не сможешь вернуться в свою голову.","Кибер хоррор", list("Да","Нет"))
+						var/answer = tgui_alert(player,"Ты хочешь стать кибер хоррором? Потом ты не сможешь вернуться в свою голову.","Кибер хоррор", list("Да","Нет"))
 						if(answer == "Да")
-							CH.key = chelik.key
+							CH.key = player.key
 							to_chat(CH, "Теперь ты кибер хоррор! Кусай людей пока они не превратятся в твоих сородичей. Чем больше вас - тем вы сильнее!")
 	else
 		holder.del_reagent(id)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
После гиба от кибер хоррора появится окно где можно вселиться в нового монстра или не вселяться и остаться в голове как раньше.
## Почему и что этот ПР улучшит
Возможность поиграть за кибер хоррора, обратить всю станцию в них. Симулятор выживания для остальных людей.
## Авторство
AndroBetel - дал идею
Leprekeoner - сделал
## Чеинжлог
:cl:
- tweak: Можно вселиться в нового кибер хоррора после гиба от наноботов
