### PR TITLE
Fitness nutrition removing delete

### DIFF
--- a/code/game/objects/fitness.dm
+++ b/code/game/objects/fitness.dm
@@ -25,7 +25,6 @@
 
 	playsound(user, 'sound/machines/click.ogg', VOL_EFFECTS_MASTER)
 
-	user.nutrition -= 6
 	user.overeatduration -= 8
 
 	var/obj/item/organ/external/chest/C = user.get_bodypart(BP_CHEST)
@@ -134,7 +133,6 @@
 	if(user.is_busy() || !do_after(user, 3, TRUE, src, progress=FALSE))
 		return
 
-	user.nutrition -= 12
 	user.overeatduration -= 16
 
 	var/obj/item/organ/external/l_arm/LA = user.get_bodypart(BP_L_ARM)
@@ -329,5 +327,4 @@
 	SEND_SIGNAL(H, COMSIG_ADD_MOOD_EVENT, "swole", /datum/mood_event/swole, pain_amount)
 	H.update_body()
 
-	H.nutrition -= 2 * mass
 	H.overeatduration -= 2 * mass


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
![112222](https://github.com/TauCetiStation/TauCetiClassic/assets/96499407/9b869062-710b-42fc-bf46-f3ebf717d967)

Этому коду 7 лет и с тех пор многое изменилось, оставлять как есть было бы ошибкой. Вот как я к этому пришёл:

Я поиграл в игру где даже близко не накачался до полной физической мощи, а каждый раз получал красную полоску голода практически до конца игры, что даёт дебаф на скорость. Я начал разбираться и дебажить в чём проблема такого неприятного геймплея и как оно было задумано автором. Проблемы в метаболизме не оказалось, там всё было также, как и задумано #10922 и #11110.

Я не учёл одно - вот этих цифр, которые с 400 (полная полоска) опускают значение голода до 150 (красная полоска) за 20-40 кликов! Это буквально 10 или 20 кача на части тел при максимуме в 60 (!). А восполнить значение назад требует 8 (!) штук нормального фастфуда. И это не считая того что за накачивание значение метаболизма увеличивается, ускоряя пассивный голод.

Это ужасно, это мотивирует вообще не трогать качалку для тех, кто не может себе позволить столько фастфуда на свою зарплату. А ещё это можно легально обойти не качая части тела на тренажёрах, а отрабатывая приёмы на груше... Даёшь качалку всем, а не только офицерам и врачам!
![barerl](https://github.com/TauCetiStation/TauCetiClassic/assets/96499407/3332ecd6-3097-4a21-bc14-625e37a6e791)

## Почему и что этот ПР улучшит
Меньше штрафов за безобидный геймплей тем, для кого он скорее всего и был добавлен, больше удовольствия игроков от игрового процесса и лучше восприятие геймдизайна Тау Сети членами игрового процесса! Автор качалки уведомил что ему всё равно на это изменение, так что надеюсь никаких преград для этого ПРа не будет выставлено.
## Авторство

## Чеинжлог
:cl: Deahaka
- del: Фитнес-снаряды больше не тратят голод за клик-упражнение