### PR TITLE
OOC fix

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -61,7 +61,7 @@ var/global/bridge_secret = null
 	var/automute_on = 0					//enables automuting/spam prevention
 
 	// If true - disable OOC for the duration of a round.
-	var/ooc_round_only = FALSE
+	var/ooc_round_autotoggle = FALSE
 
 	var/registration_panic_bunker_age = null
 	var/allowed_by_bunker_player_age = 60
@@ -691,8 +691,8 @@ var/global/bridge_secret = null
 				if("use_persistent_cache")
 					config.use_persistent_cache = TRUE
 
-				if("ooc_round_only")
-					config.ooc_round_only = TRUE
+				if("ooc_round_only") // todo: ambiguous old name, need to rename for ooc_round_autotoggle or something
+					config.ooc_round_autotoggle = TRUE
 
 				if("minute_topic_limit")
 					config.minutetopiclimit = text2num(value)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -189,8 +189,8 @@ SUBSYSTEM_DEF(ticker)
 	to_chat(world, "<span class='boldannounce'>Starting game...</span>")
 
 	// Discuss your stuff after the round ends.
-	if(config.ooc_round_only)
-		to_chat(world, "<span class='warning bold'>The OOC channel has been globally disabled for the duration of the round!</span>")
+	if(config.ooc_round_autotoggle)
+		to_chat(world, "<span class='warning bold'>The OOC channel for IC clients has been globally disabled for the duration of the round!</span>")
 		ooc_allowed = FALSE
 
 	var/init_start = world.timeofday
@@ -524,7 +524,7 @@ SUBSYSTEM_DEF(ticker)
 //cursed code
 /datum/controller/subsystem/ticker/proc/declare_completion()
 	// Now you all can discuss the game.
-	if(config.ooc_round_only)
+	if(config.ooc_round_autotoggle)
 		to_chat(world, "<span class='notice bold'>The OOC channel has been globally enabled!</span>")
 		ooc_allowed = TRUE
 

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -169,7 +169,17 @@ var/global/bridge_ooc_colour = "#7b804f"
 
 	log_ooc("(LOCAL) [key_name(mob)] : [msg]")
 
-	var/list/heard = get_mobs_in_view(7, src.mob)
+	var/list/heard
+	var/prefix = "LOOC"
+
+	// mobs_in_view doesn't work for lobby mobs and i don't know why, already spend to much time on it
+	// so currently admins can't jump to lobby location for lobby looc
+	if(isnewplayer(mob))
+		heard = new_player_list
+		prefix = "(LOBBY)[prefix]"
+	else
+		heard = get_mobs_in_view(7, src.mob)
+
 	for(var/mob/M in heard)
 
 		if(!M.client)
@@ -181,16 +191,15 @@ var/global/bridge_ooc_colour = "#7b804f"
 		if(C.prefs.chat_toggles & CHAT_LOOC)
 			if(is_fake_key && C.holder)
 				display_name = "[holder.fakekey]/([key])"
-			to_chat(C, "<span class='looc'><span class='prefix'>LOOC:</span> <EM>[display_name]:</EM> <span class='message emojify linkify'>[msg]</span></span>")
+			to_chat(C, "<span class='looc'><span class='prefix'>[prefix]:</span> <EM>[display_name]:</EM> <span class='message emojify linkify'>[msg]</span></span>")
 
 	for(var/client/C as anything in admins)
 		if(C.prefs.chat_toggles & CHAT_LOOC)
 			var/track = ""
-			if(isobserver(C.mob))
+			if(isobserver(C.mob) && !isnewplayer(mob))
 				track = FOLLOW_LINK(C.mob, mob)
-			var/prefix = "(R)LOOC"
-			if (C.mob in heard)
-				prefix = "LOOC"
+			if (!(C.mob in heard))
+				prefix = "(R)[prefix]"
 			to_chat(C, "[track]<span class='looc'><span class='prefix'>[prefix]:</span> <EM>[mob.name]/([key]):</EM> <span class='message emojify linkify'>[msg]</span></span>")
 
 /client/verb/fix_ui()

--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -26,12 +26,25 @@ var/global/bridge_ooc_colour = "#7b804f"
 		return
 
 	if(!holder)
+
 		if(!dooc_allowed && (mob.stat == DEAD))
 			to_chat(usr, "<span class='red'>OOC for dead mobs has been turned off.</span>")
 			return
-		if(!ooc_allowed && !istype(mob, /mob/dead/new_player))
-			to_chat(src, "<span class='red'>OOC is globally muted.[config.ooc_round_only ? " Try again after round end." : ""]</span>")
+		if(!ooc_allowed) // can be disabled globally, or autodisabled for round only
+			var/user_message = "OOC is globally muted."
+
+			if(config.ooc_round_autotoggle && SSticker.current_state == GAME_STATE_PLAYING) //disabled for round only
+				user_message += " Try again after the round ends."
+
+			if(looc_allowed)
+				if(istype(mob, /mob/dead/new_player))
+					user_message += "<br>While in lobby, you can still use LOOC to chat with others people in lobby."
+				else
+					user_message += "<br>You can still use LOOC to chat with others people in view."
+
+			to_chat(src, "<span class='red'>[user_message]</span>")
 			return
+
 		if(handle_spam_prevention(msg,MUTE_OOC))
 			return
 		if(findtext(msg, "byond://"))
@@ -71,10 +84,6 @@ var/global/bridge_ooc_colour = "#7b804f"
 	var/msg_end = "<span class='message emojify linkify'>[msg]</span></font></span>"
 
 	for(var/client/C in clients)
-		// Lobby people can only say in OOC to other lobby people.
-		if(!ooc_allowed && !istype(C.mob, /mob/dead/new_player) && !C.holder)
-			continue
-
 		if(!display_name)
 			display_name = name
 
@@ -89,8 +98,7 @@ var/global/bridge_ooc_colour = "#7b804f"
 					display_name = sender.holder.fakekey
 
 		if(C.prefs.chat_toggles & CHAT_OOC)
-			var/chat_suffix = C.holder && istype(sender, /mob/dead/new_player) && !ooc_allowed ? " (LOBBY)" : ""
-			to_chat(C, "[msg_start][chat_suffix]:</span> [display_name?"<EM>[display_name]:</EM> ":""][msg_end]")
+			to_chat(C, "[msg_start]:</span> [display_name?"<EM>[display_name]:</EM> ":""][msg_end]")
 
 /client/proc/set_global_ooc(newColor as color)
 	set name = "Set Global OOC Colour"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

У меня начали закрадываться подозрения, когда админы в игре вдруг сообщили, что их сообщения никто не видит. Я думал, им показалось, да и как-то никто ничего не репоритил. Потом подозрения укрепились, когда заметил, что игроки как-то совсем не реагируют на технические сообщения, и на сообщения из дискорда.

И вот только сейчас открыл и заметил, что и правда - на *вывод* OOC почему-то стоит проверка ``ooc_allowed``. И мы с этим жили 3 года!

## Почему и что этот ПР улучшит

Исправляет путаницу с флагами, убирает (LOBBY)OOC (который если и работал, то не очевидно) в пользу LOOC.

## Авторство

## Чеинжлог

:cl: 
 - fix: Отключение OOC во время раунда работало не совсем корректно. Игроки вновь смогут видеть технические OOC сообщения и OOC сообщения от администраторов.
 - tweak: Игроки в лобби во время раунда больше не смогут пользоваться ограниченным OOC, если он выключен. Это было слишком запутано и вводило в заблуждение новых игроков. Для тех же целей в лобби можно использовать LOOC.
