### PR TITLE
Однозначный фикс удаления счетов отделов

### DIFF
--- a/code/modules/events/money_lotto.dm
+++ b/code/modules/events/money_lotto.dm
@@ -5,10 +5,11 @@
 
 /datum/event/money_lotto/start()
 	winner_sum = pick(5000, 10000, 50000, 100000, 500000, 1000000, 1500000)
-	var/list/employee_accounts = all_money_accounts
+	var/list/employee_accounts = all_money_accounts.Copy()
 	for(var/i in department_accounts)
 		employee_accounts.Remove(department_accounts[i])
 	employee_accounts.Remove(station_account)
+	employee_accounts.Remove(centcomm_account)
 
 	if(employee_accounts.len)
 		var/datum/money_account/D = pick(employee_accounts)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Однозначный фикс удаления счетов отделов. Уже не в драфте т.к. убедился и проверил
## Почему и что этот ПР улучшит
Карго не будет из-за ебента отпадать. На другие счета отделов как мне, так и всем игрокам абсолютно похуй, я лично разрешаю остальные счета вырезать и дехаку тоже и симбаку и гусева.

За баг спасибо Киборгу Нолевичу Четыреву

closes #12210 
closes #11065 
## Авторство
AirBlack - фикс бага в карго
KIBORG04 - баг удаления счета карго
## Чеинжлог
:cl: AirBlack
 - bugfix: Счета отделов больше не удаляются при рандомивенте на лоттерею.