### PR TITLE
Revert map weight

### DIFF
--- a/code/controllers/subsystem/voting/poll_types.dm
+++ b/code/controllers/subsystem/voting/poll_types.dm
@@ -231,9 +231,6 @@
 		return "Отсутствует конфиг карт"
 
 /datum/poll/nextmap/init_choices()
-	var/list/voteweights = get_voteweights()
-	if(!voteweights)
-		voteweights = list()
 	for (var/map in config.maplist)
 		var/datum/map_config/VM = config.maplist[map]
 
@@ -247,31 +244,12 @@
 			continue
 
 		var/datum/vote_choice/nextmap/vc = new
-		var/map_name = splittext(VM.map_name, " ")[1]
-		if(map_name in voteweights)
-			VM.voteweight = max(0.4, VM.voteweight * voteweights[map_name])
 		vc.text = VM.GetFullMapName()
 		if(VM.voteweight != 1)
 			vc.text += "\[vote weight: [VM.voteweight]\]"
 		vc.mapname = VM.map_name
 		vc.vote_weight = VM.voteweight
 		choices.Add(vc)
-
-
-/datum/poll/nextmap/proc/get_voteweights()
-	if(!establish_db_connection("erro_round"))
-		return FALSE
-	var/list/voteweights = list()
-	var/DBQuery/select_query = dbcon.NewQuery("SELECT map_name FROM erro_round WHERE (end_state = 'proper completion' OR end_state = 'nuke') AND server_port = [sanitize_sql(world.port)] ORDER BY id DESC LIMIT 3")
-	select_query.Execute()
-	var/map_name = ""
-	while(select_query.NextRow())
-		var/list/row = select_query.GetRowData()
-		map_name = splittext(row["map_name"], " ")[1]
-		if(!(map_name in voteweights))
-			voteweights[map_name] = 1
-		voteweights[map_name] -= 0.2
-	return voteweights
 
 /datum/vote_choice/nextmap
 	text = "Box Station"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Откат динамических коефициентов карт
#11849 
## Почему и что этот ПР улучшит
Большинство онлайна решает за меньшинство, тем самым сохраняя своё большинство на сервере. Меньшинство не диктует большинству условия "играй на этих картах или уходи с сервера" а через две недели после того как половина игроков решила уйти — перестать играть из-за низкого онлайна.
## Авторство

## Чеинжлог
:cl:
- del: Коефициенты на голос у карт больше не меняются динамически.