### PR TITLE
Обновление фаердоров: часть вторая

### DIFF
--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -87,7 +87,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
 	name = "Range Access";
@@ -266,7 +268,9 @@
 	dir = 4
 	},
 /obj/machinery/computer/reconstitutor/animal,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/turf_decal{
 	dir = 1;
 	icon_state = "warn"
@@ -316,7 +320,9 @@
 /turf/simulated/floor,
 /area/station/security/range)
 "aaH" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -324,7 +330,9 @@
 /turf/simulated/floor/plating,
 /area/station/security/range)
 "aaI" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/table/reinforced,
 /obj/item/weapon/gun/energy/laser/practice,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -352,7 +360,9 @@
 /turf/simulated/floor,
 /area/station/security/range)
 "aaK" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	id = "Armoury0";
 	name = "Emergency Access";
@@ -808,7 +818,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -1462,7 +1474,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "acz" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	id = "Armoury0";
 	name = "Emergency Access";
@@ -1563,7 +1577,9 @@
 	req_access = list(2);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/security/processing)
 "acK" = (
@@ -1740,7 +1756,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -1935,7 +1953,9 @@
 	req_access = list(2);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -2151,7 +2171,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -2413,7 +2435,9 @@
 	},
 /area/station/medical/virology)
 "aec" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	id = "Armoury";
 	name = "Emergency Access";
@@ -3012,7 +3036,9 @@
 /turf/simulated/wall,
 /area/station/maintenance/dormitory)
 "aff" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -3109,7 +3135,9 @@
 	},
 /area/station/security/warden)
 "afp" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2";
@@ -4013,7 +4041,9 @@
 	},
 /area/station/security/warden)
 "agT" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -4124,7 +4154,9 @@
 	},
 /area/station/security/hos)
 "ahc" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -4177,7 +4209,9 @@
 	name = "Warden's Desk";
 	req_access = list(3)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
@@ -4245,7 +4279,9 @@
 	},
 /area/station/security/main)
 "aho" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -4306,7 +4342,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -4318,7 +4356,9 @@
 /turf/simulated/floor/plating,
 /area/station/construction)
 "ahu" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -4459,7 +4499,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -4532,7 +4574,9 @@
 /turf/simulated/floor/carpet/red,
 /area/station/security/hos)
 "ahI" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2";
@@ -4550,7 +4594,9 @@
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "ahJ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/external{
 	locked = 1;
 	name = "Labor Camp Shuttle Airlock";
@@ -4599,7 +4645,9 @@
 	},
 /area/station/security/brig)
 "ahO" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -4912,7 +4960,9 @@
 	},
 /area/station/security/brig)
 "aio" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/structure/window/fulltile{
 	grilled = 1;
@@ -5198,7 +5248,9 @@
 /turf/environment/space/shuttle,
 /area/shuttle/escape_pod3/station)
 "aiM" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/structure/cable{
 	d1 = 1;
@@ -5594,7 +5646,9 @@
 /turf/simulated/floor/plating,
 /area/station/security/main)
 "ajv" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/computer/guestpass{
 	dir = 1;
 	pixel_y = 28
@@ -5960,7 +6014,9 @@
 	},
 /area/station/security/main)
 "aka" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
@@ -6025,7 +6081,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -6200,7 +6258,9 @@
 /turf/simulated/floor/grass,
 /area/station/hallway/secondary/exit)
 "akt" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -6215,7 +6275,9 @@
 /turf/simulated/wall,
 /area/station/rnd/hallway)
 "akw" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door_control{
 	desc = "A remote control switch for the brig foyer.";
 	id = "cell1";
@@ -6633,7 +6695,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/virology{
 	name = "Virology Break";
 	req_access = list(39);
@@ -6976,7 +7040,9 @@
 /turf/simulated/floor,
 /area/station/security/brig)
 "alM" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -7064,7 +7130,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -7288,7 +7356,9 @@
 /area/station/security/brig)
 "ami" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/window/westright{
 	name = "Brig Desk"
 	},
@@ -7443,7 +7513,9 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "amu" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -7591,7 +7663,9 @@
 	},
 /area/station/security/prison)
 "amH" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/status_display{
 	layer = 4;
 	pixel_y = -32
@@ -7859,7 +7933,9 @@
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
@@ -7963,22 +8039,15 @@
 	},
 /area/station/security/interrogation)
 "ano" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/window/fulltile{
+/obj/structure/window/fulltile/reinforced{
 	grilled = 1;
-	icon_state = "gr_window"
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/maintenance/chapel)
 "anp" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -7987,9 +8056,9 @@
 	name = "Brig Desk"
 	},
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -8403,7 +8472,9 @@
 	req_access = list(66);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -8488,7 +8559,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced/polarized{
 	grilled = 1;
 	icon_state = "gr_window_reinforced_polarized";
@@ -8571,8 +8644,10 @@
 	req_one_access = list(31,48,67);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -8697,7 +8772,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/security{
 	name = "Detective";
 	req_one_access = list(4,68);
@@ -9078,7 +9155,9 @@
 	req_one_access = list(4,68);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -9100,10 +9179,12 @@
 /turf/simulated/floor,
 /area/station/cargo/office)
 "apl" = (
-/obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
@@ -9646,7 +9727,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "aqq" = (
@@ -9842,7 +9925,9 @@
 /area/station/civilian/hydroponics)
 "aqE" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/window/westleft{
 	name = "Brig Desk"
 	},
@@ -9900,7 +9985,9 @@
 	opacity = 0;
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -10332,6 +10419,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "redcorner"
@@ -10350,7 +10442,9 @@
 	opacity = 0;
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -10400,7 +10494,9 @@
 /area/station/security/detectives_office)
 "arJ" = (
 /obj/structure/cable,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced/polarized{
 	grilled = 1;
 	icon_state = "gr_window_reinforced_polarized";
@@ -10672,7 +10768,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -11258,7 +11356,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/engine,
 /area/station/rnd/xenobiology)
 "atk" = (
@@ -11586,7 +11686,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/engine,
 /area/station/rnd/xenobiology)
 "atP" = (
@@ -11594,7 +11696,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -12369,6 +12473,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "redcorner"
@@ -12422,7 +12531,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -12510,7 +12621,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/engine,
 /area/station/rnd/xenobiology)
 "avB" = (
@@ -12559,7 +12672,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/engine,
 /area/station/rnd/xenobiology)
 "avD" = (
@@ -12589,7 +12704,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -12817,7 +12934,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/engine,
 /area/station/rnd/xenobiology)
 "awa" = (
@@ -12844,7 +12963,9 @@
 	opacity = 0;
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/engine,
 /area/station/rnd/xenobiology)
 "awb" = (
@@ -13209,7 +13330,9 @@
 	req_access = list(28);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -13476,10 +13599,12 @@
 	},
 /area/station/rnd/xenobiology)
 "axr" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Hardsuits";
 	req_access = list(1);
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -13881,7 +14006,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "ayf" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -13890,10 +14014,12 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/eva)
 "ayg" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -13901,6 +14027,9 @@
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/eva)
@@ -13943,12 +14072,14 @@
 /turf/simulated/floor/wood,
 /area/station/maintenance/eva)
 "ayl" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
 /obj/machinery/door/airlock{
 	name = "Firefighting equipment";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -14006,7 +14137,9 @@
 	icon_state = "0-2";
 	pixel_y = 1
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -14199,7 +14332,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/medical/surgery2)
 "ayI" = (
@@ -14599,7 +14734,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "azw" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2";
@@ -15090,7 +15227,9 @@
 	opacity = 0;
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -15194,8 +15333,10 @@
 	name = "Brig Restroom";
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/security/prison)
 "aAA" = (
@@ -15209,7 +15350,6 @@
 	name = "Hydroponics Pasture";
 	req_access = list(35)
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor,
 /area/station/civilian/hydroponics)
 "aAC" = (
@@ -15303,7 +15443,9 @@
 /obj/machinery/door/window/southright{
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/rnd/tox_launch)
 "aAN" = (
@@ -15332,7 +15474,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
@@ -15790,7 +15934,6 @@
 /turf/simulated/floor/plating,
 /area/station/security/prison/toilet)
 "aBI" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -15803,6 +15946,9 @@
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/eva)
@@ -15868,7 +16014,9 @@
 	},
 /area/station/civilian/kitchen)
 "aBO" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -16514,6 +16662,16 @@
 /obj/structure/table/glass,
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
+"aDd" = (
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/kitchen)
 "aDe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -17373,9 +17531,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "aER" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
 	name = "Firefighting equipment";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -17429,7 +17589,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -17446,7 +17608,9 @@
 /obj/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "aEY" = (
@@ -17733,7 +17897,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "aFy" = (
@@ -17755,7 +17921,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "aFz" = (
@@ -17955,7 +18123,9 @@
 	opacity = 0;
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -18018,7 +18188,9 @@
 	name = "Holodeck Control";
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/civilian/fitness)
 "aGb" = (
@@ -18080,7 +18252,9 @@
 	},
 /area/station/civilian/toilet)
 "aGi" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock{
 	name = "Unisex Showers";
 	dir = 4
@@ -18141,11 +18315,13 @@
 	name = "Arrival Airlock";
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -18457,7 +18633,9 @@
 	},
 /area/station/hallway/secondary/exit)
 "aGU" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -18475,22 +18653,15 @@
 /turf/simulated/wall,
 /area/station/storage/tools)
 "aGX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor{
-	icon_state = "neutralcorner"
-	},
-/area/station/hallway/secondary/arrival)
+/turf/simulated/floor/plating,
+/area/station/medical/virology)
 "aGY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -18638,7 +18809,9 @@
 	name = "Unisex Restrooms";
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -18724,13 +18897,8 @@
 	},
 /area/station/medical/storage)
 "aHw" = (
-/obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
 /obj/structure/sign/directions/dock_tablo/tablo2,
-/turf/simulated/floor/plating,
+/turf/simulated/wall,
 /area/station/hallway/secondary/entry)
 "aHx" = (
 /obj/machinery/door/airlock/maintenance{
@@ -18748,7 +18916,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "aHy" = (
@@ -19109,11 +19279,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "aIm" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -19124,6 +19295,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
@@ -19190,7 +19364,6 @@
 /turf/simulated/floor/wood,
 /area/station/security/vacantoffice)
 "aIs" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -19201,6 +19374,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
@@ -19436,7 +19612,9 @@
 	req_access = list(5);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -19447,7 +19625,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "aIO" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12);
 	dir = 4
@@ -19582,7 +19762,9 @@
 	},
 /area/station/security/armoury)
 "aJc" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -19785,7 +19967,9 @@
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "bluecorner"
@@ -19973,7 +20157,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "aJO" = (
@@ -20013,7 +20199,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "aJS" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -20026,6 +20211,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -20241,7 +20429,9 @@
 /turf/simulated/floor/carpet/orange,
 /area/station/maintenance/escape)
 "aKj" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/port)
 "aKk" = (
@@ -20355,15 +20545,15 @@
 	},
 /area/station/security/main)
 "aKz" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/station/hallway/primary/central)
+/turf/simulated/floor/plating,
+/area/station/rnd/xenobiology)
 "aKA" = (
 /obj/item/weapon/flora/random,
 /obj/machinery/computer/shop{
@@ -20402,7 +20592,9 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "aKE" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -20745,7 +20937,9 @@
 /turf/simulated/floor,
 /area/station/rnd/storage)
 "aLi" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -21284,7 +21478,9 @@
 	req_one_access = list(11,24);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -21849,10 +22045,12 @@
 	},
 /area/station/civilian/fitness)
 "aNk" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/window/eastright{
 	name = "Kitchen";
 	req_access = list(28)
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -22167,7 +22365,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "aNS" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
 	icon_state = "shutter0";
@@ -22177,6 +22374,9 @@
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
@@ -22429,7 +22629,9 @@
 	req_access = list(12);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/storage/tools)
 "aOs" = (
@@ -22827,7 +23029,6 @@
 /turf/simulated/floor,
 /area/station/rnd/mixing)
 "aPf" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/window/brigdoor{
 	dir = 4
 	},
@@ -22839,6 +23040,9 @@
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/security/checkpoint)
@@ -23054,7 +23258,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "aPx" = (
@@ -23062,11 +23268,13 @@
 	name = "Diner";
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/structure/grille{
 	destroyed = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -23806,7 +24014,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
 "aQR" = (
@@ -24255,7 +24465,9 @@
 	req_access = list(27);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -24469,7 +24681,9 @@
 /turf/simulated/floor,
 /area/station/cargo/storage)
 "aSd" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/oil,
 /turf/simulated/floor/plating,
@@ -24701,7 +24915,6 @@
 	opacity = 0;
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -24713,16 +24926,21 @@
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/bridge)
 "aSE" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -24917,11 +25135,13 @@
 	},
 /area/station/civilian/chapel/office)
 "aSY" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -24945,7 +25165,6 @@
 	opacity = 0;
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -24959,6 +25178,9 @@
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/bridge)
@@ -24998,7 +25220,6 @@
 /turf/simulated/floor,
 /area/station/bridge)
 "aTd" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -25011,6 +25232,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -25050,9 +25274,11 @@
 	opacity = 0;
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/bridge)
@@ -25517,12 +25743,14 @@
 	},
 /area/station/civilian/playroom)
 "aTX" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/effect/decal/turf_decal/wood{
-	dir = 10;
-	icon_state = "spline_fancy"
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
 	},
-/turf/simulated/floor/grass,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
 /area/station/civilian/garden)
 "aTY" = (
 /obj/item/device/radio/intercom{
@@ -25557,14 +25785,15 @@
 	},
 /area/station/medical/sleeper)
 "aUb" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/lavendergrass,
-/obj/effect/decal/turf_decal/wood{
-	dir = 8;
-	icon_state = "spline_fancy"
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
 	},
-/turf/simulated/floor/grass,
-/area/station/civilian/garden)
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "aUc" = (
 /obj/structure/flora/junglebush/b,
 /obj/effect/decal/turf_decal/wood{
@@ -26329,7 +26558,9 @@
 	req_access = list(47);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -26451,7 +26682,9 @@
 /obj/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "aVK" = (
@@ -26470,7 +26703,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -26493,7 +26728,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -26559,7 +26796,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -26590,13 +26829,14 @@
 	},
 /area/station/gateway)
 "aVT" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2";
 	pixel_y = 1
 	},
-/obj/structure/cable,
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -26616,7 +26856,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -26689,11 +26931,13 @@
 /turf/simulated/floor/plating,
 /area/station/rnd/misc_lab)
 "aWa" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable,
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/ai_monitored/eva)
@@ -26898,7 +27142,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -26940,7 +27186,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -27154,7 +27402,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -27415,7 +27665,9 @@
 	},
 /area/station/medical/cmo)
 "aXl" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -27642,7 +27894,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced_phoron"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/rnd/mixing)
 "aXG" = (
@@ -27695,7 +27949,9 @@
 	dir = 1;
 	name = "Confession Booth"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/station/civilian/chapel/office)
 "aXM" = (
@@ -27831,7 +28087,9 @@
 /turf/environment/space,
 /area/shuttle/transport1/station)
 "aYa" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -27956,7 +28214,6 @@
 /turf/simulated/floor,
 /area/station/gateway)
 "aYk" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -27968,6 +28225,9 @@
 	pixel_x = -6;
 	pixel_y = 26;
 	req_access = list(57)
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 1;
@@ -28146,13 +28406,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "aYA" = (
-/obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
 /obj/structure/sign/warning/airlock,
-/turf/simulated/floor/plating,
+/turf/simulated/wall,
 /area/station/hallway/secondary/exit)
 "aYB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -28429,7 +28684,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -28642,7 +28899,9 @@
 /turf/environment/space/shuttle,
 /area/shuttle/escape_pod1/station)
 "aZv" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -28718,19 +28977,15 @@
 	},
 /area/station/rnd/hallway)
 "aZA" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
 /turf/simulated/floor/plating,
-/area/station/rnd/hor)
+/area/station/maintenance/engineering)
 "aZB" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -29120,7 +29375,9 @@
 	req_access = list(47);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -29128,7 +29385,6 @@
 /turf/simulated/floor,
 /area/station/rnd/misc_lab)
 "bam" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/mass_driver{
 	dir = 4;
 	id = "chapelgun"
@@ -29445,13 +29701,13 @@
 /area/station/hallway/secondary/entry)
 "baN" = (
 /obj/structure/flora/junglebush/b,
-/obj/machinery/camera{
-	c_tag = "Garden East";
-	dir = 9
-	},
 /obj/effect/decal/turf_decal/wood{
 	dir = 8;
 	icon_state = "spline_fancy"
+	},
+/obj/machinery/camera{
+	c_tag = "Garden East";
+	dir = 9
 	},
 /turf/simulated/floor/grass,
 /area/station/civilian/garden)
@@ -29552,9 +29808,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
 	name = "Diner";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -29879,7 +30137,9 @@
 	},
 /area/station/hallway/secondary/entry)
 "bbD" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "redcorner"
@@ -30305,7 +30565,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -30318,13 +30580,15 @@
 	},
 /area/station/hallway/secondary/entry)
 "bcq" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/effect/decal/turf_decal/wood{
-	dir = 9;
-	icon_state = "spline_fancy"
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
 	},
-/turf/simulated/floor/grass,
-/area/station/civilian/garden)
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics)
 "bcr" = (
 /obj/structure/disposalpipe/sortjunction/flipped{
 	dir = 4;
@@ -30537,7 +30801,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/rnd/mixing)
 "bcN" = (
@@ -30742,7 +31008,9 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "yellowcorner"
@@ -30818,6 +31086,9 @@
 	name = "Chapel Launcher Door";
 	dir = 4
 	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/mass_driver)
 "bdn" = (
@@ -30875,7 +31146,7 @@
 "bdw" = (
 /obj/structure/flora/rock/jungle,
 /obj/effect/decal/turf_decal/wood{
-	dir = 1;
+	dir = 5;
 	icon_state = "spline_fancy"
 	},
 /turf/simulated/floor/grass,
@@ -30954,7 +31225,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -30982,13 +31255,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "bdE" = (
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/effect/decal/turf_decal/wood{
-	dir = 1;
-	icon_state = "spline_fancy"
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/turf/simulated/floor/grass,
-/area/station/civilian/garden)
+/turf/simulated/floor/plating,
+/area/station/maintenance/cargo)
 "bdF" = (
 /obj/effect/landmark{
 	name = "blobstart"
@@ -31328,7 +31599,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "bek" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "neutralcorner"
@@ -31386,7 +31659,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -31622,13 +31897,15 @@
 	},
 /area/station/hallway/primary/central)
 "beG" = (
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/bar)
@@ -31762,7 +32039,9 @@
 	name = "Station Intercom (General)";
 	pixel_y = 20
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "bluecorner"
@@ -32090,7 +32369,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -32119,7 +32400,9 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/bridge/meeting_room)
 "bft" = (
@@ -32266,7 +32549,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -32449,7 +32734,9 @@
 	},
 /area/station/medical/hallway)
 "bgb" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
@@ -32736,7 +33023,9 @@
 	icon_state = "0-2"
 	},
 /obj/structure/cable,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/bridge/meeting_room)
 "bgB" = (
@@ -32758,7 +33047,9 @@
 	icon_state = "gr_window_reinforced"
 	},
 /obj/structure/cable,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/bridge/meeting_room)
 "bgD" = (
@@ -32989,7 +33280,9 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "bgZ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -33266,7 +33559,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/civilian/library)
 "bhE" = (
@@ -33540,7 +33835,6 @@
 /area/station/tcommsat/computer)
 "bie" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -34260,7 +34554,9 @@
 	req_access = list(5);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -34352,7 +34648,9 @@
 	id = "Captain_private";
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/bridge/captain_quarters)
 "bjX" = (
@@ -34479,7 +34777,9 @@
 	id = "Captain_private";
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/bridge/captain_quarters)
 "bkj" = (
@@ -34824,7 +35124,6 @@
 /turf/simulated/floor/plating,
 /area/station/construction/assembly_line)
 "bkQ" = (
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -34987,7 +35286,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "blf" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Science Maintenance";
 	req_access = list(47);
@@ -34999,7 +35300,9 @@
 /turf/simulated/floor/plating,
 /area/station/rnd/hallway)
 "blg" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -35679,7 +35982,9 @@
 	dir = 4
 	},
 /obj/structure/cable,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/bridge/captain_quarters)
 "bmf" = (
@@ -35929,9 +36234,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
 	name = "Diner";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -36223,7 +36530,9 @@
 /obj/structure/window/thin/reinforced{
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/thin/reinforced{
 	dir = 1
 	},
@@ -36369,7 +36678,9 @@
 	},
 /area/station/tcommsat/computer)
 "bns" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "whitecorner"
 	},
@@ -36549,7 +36860,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/bridge/nuke_storage)
 "bnN" = (
@@ -36708,13 +37021,8 @@
 /turf/simulated/floor,
 /area/station/civilian/locker)
 "bod" = (
-/obj/machinery/door/firedoor,
 /obj/structure/sign/departments/botany,
-/obj/structure/window/fulltile{
-	grilled = 1;
-	icon_state = "gr_window"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall,
 /area/station/civilian/hydroponics)
 "boe" = (
 /turf/simulated/shuttle/floor/mining{
@@ -36896,12 +37204,14 @@
 	opacity = 0;
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
 /obj/item/weapon/bell,
 /obj/item/device/cardpay{
 	dir = 8;
 	pixel_x = -3;
 	pixel_y = 15
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/bridge/hop_office)
@@ -37364,7 +37674,9 @@
 	},
 /area/station/rnd/telesci)
 "bpn" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/curtain/medical,
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
@@ -37390,7 +37702,9 @@
 /turf/simulated/floor,
 /area/station/medical/cryo)
 "bpp" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/medical{
 	name = "Operating Theatre 2";
 	req_access = list(45);
@@ -37404,7 +37718,9 @@
 	},
 /area/station/medical/surgery2)
 "bpq" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
 	icon_state = "shutter0";
@@ -37485,7 +37801,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/bridge)
 "bpy" = (
@@ -37627,7 +37945,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "bpO" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/glass{
 	name = "Chapel";
 	dir = 4
@@ -38126,7 +38446,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/maintenance{
 	name = "Medbay Maintenance";
 	req_access = list(5,6);
@@ -38222,7 +38544,9 @@
 	},
 /area/station/hallway/secondary/exit)
 "bqP" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/external{
 	name = "Escape Airlock";
 	req_access = list(1);
@@ -38928,7 +39252,9 @@
 	},
 /area/station/civilian/chapel)
 "bsf" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/structure/window/fulltile/polarized{
 	grilled = 1;
@@ -39002,7 +39328,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "bso" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
 	name = "Teleport Access";
 	req_access = list(17);
@@ -39012,6 +39337,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -39364,7 +39692,9 @@
 	opacity = 0;
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/bridge/hop_office)
 "bsX" = (
@@ -40431,7 +40761,9 @@
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel)
 "buR" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -40458,9 +40790,11 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
 "buT" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
 	name = "Arrival Access";
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -40711,7 +41045,6 @@
 	req_access = list(67);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -40719,6 +41052,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -40786,7 +41122,6 @@
 	req_access = list(67);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -40794,6 +41129,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -40900,7 +41238,6 @@
 	req_access = list(67);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -40910,6 +41247,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -41066,13 +41406,15 @@
 	},
 /area/station/hallway/secondary/arrival)
 "bvV" = (
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
@@ -41083,7 +41425,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
 	name = "Arrival Access";
 	dir = 4
@@ -41092,6 +41433,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
@@ -41706,7 +42050,9 @@
 	req_access = list(60);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -41897,7 +42243,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -42466,7 +42814,6 @@
 	},
 /area/station/hallway/primary/port)
 "byl" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -42486,6 +42833,9 @@
 	buildable_sign = 0;
 	dir = 8;
 	pixel_y = 24
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 4;
@@ -42623,7 +42973,9 @@
 	},
 /area/station/bridge/nuke_storage)
 "byz" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/window/westleft{
 	name = "Server Room";
 	opacity = 1;
@@ -42944,7 +43296,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -43339,10 +43693,12 @@
 /turf/simulated/floor,
 /area/station/bridge/hop_office)
 "bzN" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/highsecurity{
 	name = "CMF altering";
 	req_access = list(57);
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -43394,7 +43750,9 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -43931,7 +44289,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -44721,7 +45081,9 @@
 	},
 /area/station/rnd/hallway)
 "bCt" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -44781,7 +45143,9 @@
 	req_access = list(29,47);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -44898,6 +45262,11 @@
 	pixel_x = -6;
 	pixel_y = 6
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -44946,7 +45315,9 @@
 	pixel_y = 8
 	},
 /obj/item/weapon/reagent_containers/food/snacks/grown/harebell,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -45269,14 +45640,15 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "bDp" = (
 /turf/simulated/wall,
 /area/station/civilian/cold_room)
 "bDq" = (
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/sortjunction/wildcard{
 	dir = 8
 	},
@@ -45397,7 +45769,9 @@
 /turf/simulated/floor/carpet/blue,
 /area/station/bridge/captain_quarters)
 "bDE" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -45612,7 +45986,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "bDX" = (
@@ -45676,7 +46052,9 @@
 /turf/simulated/floor/carpet/purple,
 /area/station/civilian/theatre)
 "bEd" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
@@ -46082,7 +46460,6 @@
 	req_access = list(12);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -46098,6 +46475,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -46397,11 +46777,13 @@
 	req_one_access = list(50,70);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -46557,7 +46939,9 @@
 /turf/simulated/floor,
 /area/station/rnd/lab)
 "bFG" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -46600,7 +46984,9 @@
 	},
 /area/shuttle/escape_pod2/station)
 "bFL" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -46612,7 +46998,9 @@
 	req_access = list(72);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -46861,7 +47249,6 @@
 	},
 /area/station/bridge)
 "bGl" = (
-/obj/machinery/door/firedoor,
 /obj/structure/table/reinforced,
 /obj/item/weapon/paper_bin,
 /obj/machinery/door/window/westright{
@@ -46880,6 +47267,9 @@
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/cargo/office)
@@ -46991,7 +47381,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
 	name = "Barbershop";
 	dir = 4
@@ -47000,6 +47389,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -47268,7 +47660,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/civilian/theatre)
 "bGR" = (
@@ -47294,7 +47688,9 @@
 /turf/simulated/floor/carpet/green,
 /area/station/medical/patients_rooms)
 "bGT" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -47422,10 +47818,12 @@
 	icon_state = "medium"
 	},
 /obj/item/weapon/shard,
-/obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
@@ -47471,7 +47869,9 @@
 	},
 /area/station/civilian/chapel/office)
 "bHn" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock{
 	name = "Confession Booth";
@@ -47540,10 +47940,12 @@
 	},
 /area/station/civilian/barbershop)
 "bHu" = (
-/obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/civilian/barbershop)
@@ -47805,19 +48207,11 @@
 	},
 /area/station/medical/medbreak)
 "bHR" = (
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "atmos";
-	name = "Atmos Blast Door";
-	opacity = 0
+/obj/item/weapon/flora/random,
+/turf/simulated/floor{
+	dir = 9;
+	icon_state = "caution"
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/window/fulltile{
-	grilled = 1;
-	icon_state = "gr_window"
-	},
-/turf/simulated/floor/plating,
 /area/station/engineering/monitoring)
 "bHS" = (
 /obj/machinery/door/firedoor,
@@ -48075,12 +48469,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
 	name = "Firefighting equipment";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -48194,7 +48590,9 @@
 	req_access = list(19,23);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -48220,8 +48618,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -48541,7 +48941,9 @@
 /turf/simulated/floor,
 /area/station/rnd/robotics)
 "bJg" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -48745,8 +49147,10 @@
 	req_access = list(12);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -48758,7 +49162,9 @@
 	},
 /area/station/civilian/chapel)
 "bJB" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "bluecorner"
 	},
@@ -49919,7 +50325,9 @@
 	},
 /area/station/medical/virology)
 "bLR" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -50212,7 +50620,9 @@
 	},
 /area/station/civilian/dormitories)
 "bMt" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -50234,9 +50644,11 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/monitoring)
 "bMu" = (
-/obj/machinery/door/firedoor,
 /obj/structure/sign/departments/chemistry{
 	pixel_y = -32
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
@@ -50569,7 +50981,9 @@
 	req_access = list(5);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -50801,7 +51215,9 @@
 	req_access = list(12);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -50844,7 +51260,9 @@
 	},
 /area/station/hallway/primary/fore)
 "bNu" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "purplecorner"
@@ -51078,7 +51496,9 @@
 	req_access = list(12);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -51390,7 +51810,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -51399,6 +51818,9 @@
 /obj/effect/decal/turf_decal{
 	dir = 1;
 	icon_state = "warn"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/secondary/mine_sci_shuttle)
@@ -51424,7 +51846,9 @@
 	},
 /area/station/rnd/hallway)
 "bOw" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -51432,18 +51856,14 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/starboard)
 "bOx" = (
-/obj/machinery/door/airlock/external{
-	name = "Arrival Airlock";
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor,
+/turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "bOy" = (
 /obj/structure/disposalpipe/segment,
@@ -51611,11 +52031,13 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/starboard)
 "bOR" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -51751,8 +52173,10 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "bPe" = (
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -51866,7 +52290,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "bPo" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/starboard)
 "bPp" = (
@@ -51886,7 +52312,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock{
 	id_tag = "Dorm2";
 	name = "Dorm 2";
@@ -52117,6 +52545,9 @@
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/monitoring)
@@ -52593,6 +53024,7 @@
 /area/station/hallway/primary/starboard)
 "bQB" = (
 /obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	icon_state = "browncorner"
 	},
@@ -52631,7 +53063,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/civilian/dormitories)
 "bQG" = (
@@ -53064,7 +53498,9 @@
 	freq = 1400;
 	location = "Engineering"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -53130,7 +53566,9 @@
 	},
 /area/station/medical/cryo)
 "bRQ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/sign/warning/securearea,
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
@@ -53367,11 +53805,13 @@
 	},
 /area/station/hallway/primary/starboard)
 "bSt" = (
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -53427,7 +53867,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
@@ -53641,7 +54083,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -53769,7 +54213,9 @@
 "bTv" = (
 /obj/structure/barricade/wooden,
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/construction/assembly_line)
 "bTw" = (
@@ -54038,7 +54484,9 @@
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "bUv" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -54097,7 +54545,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/station/medical/psych)
 "bUA" = (
@@ -54222,18 +54672,22 @@
 /area/station/construction/assembly_line)
 "bUX" = (
 /obj/structure/barricade/wooden,
-/obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
 	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/construction/assembly_line)
 "bVa" = (
-/obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
@@ -54451,6 +54905,9 @@
 	req_access = list(71);
 	dir = 4
 	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
 "bVL" = (
@@ -54544,7 +55001,9 @@
 	req_access = list(24);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -54628,7 +55087,9 @@
 	},
 /area/station/rnd/brainstorm_center)
 "bWd" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -54978,7 +55439,9 @@
 	},
 /area/station/engineering/break_room)
 "bXl" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -55631,12 +56094,12 @@
 	},
 /area/station/engineering/atmos)
 "bZa" = (
-/obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
+/obj/structure/stool/bed/chair/metal/yellow{
+	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/garden{
+	icon_state = "asteroid6"
+	},
 /area/station/civilian/garden)
 "bZb" = (
 /turf/simulated/floor/grass,
@@ -55902,7 +56365,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/construction/assembly_line)
 "cah" = (
@@ -56019,7 +56484,9 @@
 	name = "Altar";
 	req_access = list(22)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -56323,7 +56790,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
@@ -57090,7 +57559,9 @@
 	req_access = list(12);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -57179,7 +57650,9 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/chiefs_office)
 "cfk" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	d2 = 2;
 	icon_state = "0-2"
@@ -57213,7 +57686,9 @@
 	req_access = list(71)
 	},
 /obj/item/weapon/bell,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/item/device/cardpay{
 	dir = 8;
 	pixel_x = -3;
@@ -57305,7 +57780,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "yellow"
@@ -57847,13 +58324,15 @@
 	},
 /area/station/medical/medbreak)
 "chc" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
 	name = "Assembly Line (KEEP OUT)";
 	req_access = list(32);
 	dir = 4
 	},
 /obj/structure/barricade/wooden,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/construction/assembly_line)
 "chd" = (
@@ -57984,7 +58463,9 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "chq" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -58121,7 +58602,9 @@
 /turf/simulated/floor,
 /area/station/engineering/break_room)
 "chI" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/sign/departments/engineering,
 /obj/structure/window/fulltile{
 	grilled = 1;
@@ -58207,7 +58690,9 @@
 	req_access = list(12);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "chZ" = (
@@ -58680,7 +59165,9 @@
 /turf/simulated/floor,
 /area/station/engineering/engine)
 "cjF" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -58730,7 +59217,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -59015,7 +59504,9 @@
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
@@ -59192,7 +59683,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "clm" = (
@@ -59218,7 +59711,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/eva)
 "clp" = (
@@ -59371,7 +59866,9 @@
 	req_one_access = list(66);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
@@ -59426,7 +59923,9 @@
 	req_one_access = list(66);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -60196,7 +60695,9 @@
 	req_access = list(12);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -60207,7 +60708,6 @@
 	req_access = list(12);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -60218,6 +60718,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
@@ -61017,7 +61520,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
 "cpL" = (
@@ -61026,7 +61531,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -61034,6 +61538,9 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor,
@@ -61239,7 +61746,9 @@
 /turf/simulated/floor,
 /area/station/rnd/robotics)
 "cqi" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
@@ -62022,7 +62531,9 @@
 	req_one_access = list(66);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -62370,7 +62881,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -62702,6 +63215,9 @@
 /obj/effect/decal/turf_decal/alpha/black{
 	dir = 4;
 	icon_state = "arrow"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
@@ -63111,7 +63627,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/starboard)
 "cuJ" = (
@@ -63347,7 +63865,9 @@
 	},
 /area/station/bridge/hop_office)
 "cvo" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -63439,7 +63959,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
 "cvR" = (
@@ -63590,7 +64112,6 @@
 /turf/simulated/floor,
 /area/station/medical/reception)
 "cwD" = (
-/obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -63598,6 +64119,9 @@
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
@@ -63919,13 +64443,8 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "cxD" = (
-/obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
 /obj/structure/sign/directions/dock_tablo/tablo4,
-/turf/simulated/floor/plating,
+/turf/simulated/wall,
 /area/station/hallway/secondary/entry)
 "cxE" = (
 /obj/structure/cable{
@@ -64040,7 +64559,9 @@
 	pixel_x = 5;
 	pixel_y = -32
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -64077,7 +64598,9 @@
 /turf/simulated/floor/engine,
 /area/station/rnd/xenobiology)
 "cxW" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -64787,7 +65310,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
@@ -64966,7 +65491,9 @@
 	req_access = list(5);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -65067,7 +65594,9 @@
 /turf/simulated/floor/plating,
 /area/station/storage/emergency3)
 "cAM" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -65160,7 +65689,9 @@
 	req_access = list(40);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -65213,7 +65744,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -65587,7 +66120,9 @@
 	},
 /area/station/solar/starboard)
 "cCb" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -66297,7 +66832,9 @@
 /turf/environment/space,
 /area/space)
 "cEe" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
 	icon_state = "shutter0";
@@ -66717,7 +67254,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "cFP" = (
@@ -67303,7 +67842,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "cHG" = (
@@ -67611,7 +68152,9 @@
 	},
 /area/station/civilian/garden)
 "cIK" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "green"
@@ -67849,7 +68392,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "cJZ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -68066,7 +68611,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -68332,7 +68879,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "cLH" = (
@@ -68586,7 +69135,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "cMu" = (
@@ -68787,7 +69338,9 @@
 	},
 /area/station/medical/hallway)
 "cNh" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -68806,7 +69359,9 @@
 /area/station/engineering/drone_fabrication)
 "cOb" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -69166,12 +69721,22 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/singularity)
+"diy" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "dka" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "dkb" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/medical{
 	name = "Morgue";
 	req_access = list(9);
@@ -69253,7 +69818,9 @@
 	req_access = list(10);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -69302,7 +69869,9 @@
 	},
 /area/station/medical/morgue)
 "drM" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/morgue{
 	name = "Confession Booth (Chaplain)";
 	req_access = list(22)
@@ -69447,9 +70016,11 @@
 	},
 /area/station/civilian/bar)
 "dyF" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12);
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -69477,7 +70048,9 @@
 	name = "Escape Pod 5";
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "dBb" = (
@@ -69563,10 +70136,7 @@
 	},
 /area/station/security/armoury)
 "dFc" = (
-/obj/structure/closet/emcloset,
-/turf/simulated/floor{
-	icon_state = "dark"
-	},
+/turf/simulated/wall/r_wall,
 /area/station/hallway/primary/aft)
 "dFe" = (
 /obj/effect/decal/cleanable/dirt,
@@ -69621,8 +70191,20 @@
 	icon_state = "vaultfull"
 	},
 /area/station/engineering/drone_fabrication)
+"dLf" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/library)
 "dMb" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -69812,7 +70394,9 @@
 	opacity = 0;
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -70152,10 +70736,12 @@
 	},
 /area/station/engineering/break_room)
 "eqq" = (
-/obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
@@ -70184,6 +70770,27 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/mine_sci_shuttle)
+"erw" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/gateway)
+"etD" = (
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/decal/turf_decal/wood{
+	dir = 10;
+	icon_state = "spline_fancy"
+	},
+/turf/simulated/floor/grass,
+/area/station/civilian/garden)
 "etF" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -70286,6 +70893,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"ezi" = (
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK"
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "ezx" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
@@ -70295,7 +70916,9 @@
 /turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
 "eAb" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
 	icon_state = "shutter0";
@@ -70359,6 +70982,19 @@
 	icon_state = "blue"
 	},
 /area/station/medical/genetics)
+"eEh" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 10
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos)
 "eGb" = (
 /obj/item/stack/medical/ointment{
 	pixel_y = 4
@@ -70447,9 +71083,11 @@
 	},
 /area/station/medical/reception)
 "eKs" = (
-/obj/machinery/door/firedoor,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -30
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
@@ -70479,6 +71117,14 @@
 	icon_state = "bluecorner"
 	},
 /area/station/engineering/engine)
+"eNO" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "bluecorner"
+	},
+/area/station/hallway/primary/central)
 "ePa" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/simulated/floor/plating,
@@ -70520,6 +71166,24 @@
 	icon_state = "dark"
 	},
 /area/station/medical/morgue)
+"eQF" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/station/civilian/garden)
+"eQG" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/arrival)
 "eQY" = (
 /obj/machinery/door/firedoor,
 /turf/simulated/floor{
@@ -70546,7 +71210,9 @@
 /obj/machinery/door/morgue{
 	name = "Dressing Room"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -70590,7 +71256,9 @@
 /turf/simulated/floor,
 /area/station/cargo/storage)
 "eUb" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -70790,7 +71458,9 @@
 	},
 /area/station/civilian/hydroponics)
 "flb" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -70811,6 +71481,13 @@
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
+/area/station/civilian/hydroponics)
+"fmP" = (
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
 "fmS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -71008,7 +71685,9 @@
 	req_access = list(5);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -71232,6 +71911,9 @@
 	dir = 8;
 	icon_state = "arrow"
 	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "fFV" = (
@@ -71374,12 +72056,14 @@
 	opacity = 0;
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/bridge)
@@ -71452,7 +72136,9 @@
 	},
 /area/station/medical/cmo)
 "fSs" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "yellow"
@@ -71593,7 +72279,9 @@
 	req_access = list(1);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "redfull"
@@ -71703,6 +72391,16 @@
 	icon_state = "dark"
 	},
 /area/station/cargo/recycleroffice)
+"giA" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/mine_sci_shuttle)
 "gjb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -71815,6 +72513,16 @@
 	icon_state = "dark"
 	},
 /area/station/ai_monitored/storage_secure)
+"gqE" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/fitness)
 "gqW" = (
 /obj/structure/rack,
 /obj/structure/cable{
@@ -72051,7 +72759,9 @@
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/port)
 "gFL" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -72076,6 +72786,15 @@
 	},
 /turf/simulated/floor,
 /area/station/maintenance/incinerator)
+"gGe" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/secondary/entry)
 "gGO" = (
 /obj/structure/sign/warning/docking,
 /turf/simulated/wall,
@@ -72120,6 +72839,21 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"gHx" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
+"gHG" = (
+/obj/structure/stool/bed/chair/metal/yellow,
+/turf/simulated/floor/garden{
+	icon_state = "asteroid"
+	},
+/area/station/civilian/garden)
 "gIb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -72214,7 +72948,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -72598,6 +73334,16 @@
 	icon_state = "2-3"
 	},
 /area/shuttle/mining/station)
+"hgi" = (
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/bar)
 "hgJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -72704,6 +73450,17 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/engine)
+"hmP" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos)
 "hmR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/stool/bed/chair/metal{
@@ -72726,6 +73483,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/cargo/storage)
+"hnr" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/recycler)
 "hob" = (
 /obj/machinery/door/airlock/external{
 	name = "Arrival Airlock"
@@ -72799,7 +73566,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/civilian/library)
 "hsb" = (
@@ -72811,6 +73580,17 @@
 	icon_state = "4-3"
 	},
 /area/shuttle/mining/station)
+"htg" = (
+/obj/item/weapon/storage/fancy/crayons{
+	pixel_x = -8;
+	pixel_y = 6
+	},
+/obj/item/weapon/storage/fancy/cigarettes/menthol,
+/obj/structure/table/glass,
+/turf/simulated/floor/garden{
+	icon_state = "asteroid"
+	},
+/area/station/civilian/garden)
 "huy" = (
 /turf/simulated/shuttle/floor/cargo{
 	icon_state = "1,3"
@@ -73032,7 +73812,9 @@
 	name = "Escape Airlock";
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "hIf" = (
@@ -73256,7 +74038,9 @@
 /obj/structure/window/thin/reinforced{
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/closet/coffin,
 /turf/simulated/floor{
 	icon_state = "dark"
@@ -73275,7 +74059,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "hUF" = (
@@ -73805,6 +74591,16 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/starboard)
+"ixi" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/rnd/tox_launch)
 "ixO" = (
 /obj/structure/grille,
 /obj/structure/window/thin/reinforced,
@@ -73961,7 +74757,6 @@
 	},
 /area/station/hallway/primary/aft)
 "iEb" = (
-/obj/machinery/door/firedoor,
 /obj/structure/sign/directions/security{
 	buildable_sign = 0;
 	dir = 4;
@@ -73974,6 +74769,9 @@
 /obj/structure/sign/directions/command{
 	buildable_sign = 0;
 	pixel_y = -40
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
@@ -74060,6 +74858,9 @@
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/monitoring)
@@ -74171,7 +74972,9 @@
 	name = "HIGH VOLTAGE";
 	pixel_y = 32
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "blue"
@@ -74201,9 +75004,11 @@
 /obj/structure/sign/warning/securearea{
 	pixel_x = 32
 	},
-/obj/machinery/door/firedoor,
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/bridge)
@@ -74219,9 +75024,11 @@
 /obj/structure/sign/warning/securearea{
 	pixel_x = -32
 	},
-/obj/machinery/door/firedoor,
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/bridge)
@@ -74249,7 +75056,9 @@
 	name = "HIGH VOLTAGE";
 	pixel_y = 32
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "blue"
@@ -74396,7 +75205,9 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "iZb" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 6;
 	icon_state = "blue"
@@ -74432,7 +75243,6 @@
 	req_access = list(32);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -74443,6 +75253,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/construction)
@@ -74574,13 +75387,26 @@
 	req_access = list(12);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "jib" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"jir" = (
+/obj/structure/barricade/wooden,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/engineering)
 "jjN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -74609,6 +75435,14 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/engineering/engine)
+"jkG" = (
+/obj/structure/stool/bed/chair/metal/yellow{
+	dir = 4
+	},
+/turf/simulated/floor/garden{
+	icon_state = "asteroid"
+	},
+/area/station/civilian/garden)
 "jlb" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 1
@@ -74725,6 +75559,12 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/chapel/mass_driver)
+"jpO" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/medbay)
 "jqb" = (
 /obj/item/weapon/reagent_containers/syringe,
 /obj/item/weapon/reagent_containers/pill/methylphenidate,
@@ -74922,6 +75762,16 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/starboard)
+"jBg" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/chapel/mass_driver)
 "jBx" = (
 /obj/machinery/power/grounding_rod,
 /obj/structure/cable{
@@ -75004,7 +75854,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -75036,7 +75888,9 @@
 	req_access = list(1);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 9;
 	icon_state = "redfull"
@@ -75064,7 +75918,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "yellow"
 	},
@@ -75322,10 +76178,12 @@
 	},
 /area/shuttle/supply/station)
 "jYz" = (
-/obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
@@ -75824,7 +76682,9 @@
 	opacity = 0;
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/bridge/hop_office)
 "kwS" = (
@@ -75898,7 +76758,9 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/mine_sci_shuttle)
 "kAR" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced/polarized{
 	grilled = 1;
 	icon_state = "gr_window_reinforced_polarized";
@@ -76003,10 +76865,12 @@
 	req_access = list(12);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/structure/barricade/wooden{
 	layer = 2.8;
 	name = "doorway barricade"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
@@ -76041,6 +76905,16 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/genetics)
+"kJn" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics)
 "kKb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -76101,12 +76975,25 @@
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "bluecorner"
 	},
 /area/station/hallway/primary/central)
+"kPt" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor{
+	dir = 1;
+	icon_state = "red"
+	},
+/area/station/security/lobby)
 "kPR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -76121,6 +77008,13 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/chapel/mass_driver)
+"kQj" = (
+/obj/effect/decal/turf_decal/wood{
+	dir = 10;
+	icon_state = "spline_fancy"
+	},
+/turf/simulated/wall,
+/area/station/civilian/garden)
 "kQm" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -76301,6 +77195,14 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
+"lck" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/turf_decal/wood{
+	dir = 4;
+	icon_state = "spline_fancy"
+	},
+/turf/simulated/floor/grass,
+/area/station/civilian/garden)
 "lcB" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
@@ -76325,7 +77227,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "lcO" = (
@@ -76542,7 +77446,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	d2 = 8;
 	icon_state = "0-8"
@@ -76716,7 +77622,9 @@
 	},
 /area/station/medical/morgue)
 "lAA" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
 	icon_state = "shutter0";
@@ -76996,7 +77904,9 @@
 	req_access = list(12);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -77122,7 +78032,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "lUb" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -77251,6 +78163,15 @@
 	icon_state = "barber"
 	},
 /area/station/medical/cmo)
+"mbQ" = (
+/obj/structure/sign/nanotrasen{
+	pixel_y = -32
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
+/area/station/hallway/primary/central)
 "mcb" = (
 /obj/structure/rack,
 /obj/item/weapon/reagent_containers/spray/extinguisher,
@@ -77282,6 +78203,30 @@
 	icon_state = "white"
 	},
 /area/station/medical/morgue)
+"mdr" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	dir = 8
+	},
+/turf/simulated/floor/plating,
+/area/station/rnd/hor)
+"mdC" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/central)
 "meb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -77346,6 +78291,15 @@
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"mhC" = (
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK"
+	},
+/turf/simulated/wall,
+/area/station/hallway/secondary/entry)
 "mib" = (
 /obj/structure/stool/bed/roller,
 /obj/machinery/alarm{
@@ -77647,7 +78601,6 @@
 	req_one_access = list(31,48,67);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -77661,6 +78614,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/station/cargo/storage)
@@ -77761,15 +78717,34 @@
 	icon_state = "whiteblue"
 	},
 /area/station/medical/genetics)
+"mGx" = (
+/obj/machinery/door/firedoor,
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/turf/simulated/floor/plating,
+/area/station/rnd/hor)
 "mHb" = (
 /obj/structure/closet/toolcloset,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "mHR" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
 	name = "E.V.A.";
 	req_one_access = list(1,5,11,18,24);
+	dir = 4
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
 /turf/simulated/floor{
@@ -77855,12 +78830,24 @@
 	},
 /turf/simulated/floor,
 /area/station/civilian/janitor)
+"mLE" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/gateway)
 "mMb" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access = list(12);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "mMv" = (
@@ -78196,7 +79183,9 @@
 	req_access = list(12);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
@@ -78209,12 +79198,21 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "nmb" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"nmu" = (
+/obj/effect/decal/turf_decal/wood{
+	dir = 8;
+	icon_state = "spline_fancy_corner"
+	},
+/turf/simulated/wall,
+/area/station/civilian/garden)
 "nnb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -78455,15 +79453,25 @@
 /area/station/engineering/engine)
 "nyA" = (
 /obj/structure/cable{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "redcorner"
 	},
 /area/station/security/lobby)
+"nyJ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/reception)
 "nzb" = (
 /obj/structure/sign/warning/securearea,
 /obj/machinery/door/firedoor,
@@ -78613,6 +79621,14 @@
 	icon_state = "green"
 	},
 /area/station/civilian/hydroponics)
+"nHY" = (
+/obj/effect/decal/turf_decal/wood{
+	dir = 9;
+	icon_state = "spline_fancy"
+	},
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/grass,
+/area/station/civilian/garden)
 "nIb" = (
 /obj/structure/mineral_door/wood,
 /turf/simulated/floor/wood,
@@ -78789,6 +79805,14 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/civilian/fitness)
+"nVQ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "white"
+	},
+/area/station/rnd/hallway)
 "nWb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -78949,6 +79973,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"ocg" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/medbay)
 "ocr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor,
@@ -79070,7 +80104,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "oib" = (
@@ -79218,6 +80254,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating/airless,
 /area/station/maintenance/incinerator)
+"ouo" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/genetics_cloning)
 "ovb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -79393,7 +80439,6 @@
 /area/station/civilian/hydroponics)
 "oGL" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
 /obj/machinery/door/window/westleft{
 	dir = 4;
 	name = "Kitchen";
@@ -79402,6 +80447,9 @@
 /obj/machinery/door/window/westleft{
 	name = "Hydroponics";
 	req_access = list(35)
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -79423,7 +80471,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "oIb" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 10;
 	icon_state = "blue"
@@ -79434,7 +80484,9 @@
 	name = "Gym";
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "wooden-2"
 	},
@@ -79494,7 +80546,9 @@
 /area/station/civilian/garden)
 "oMQ" = (
 /obj/machinery/smartfridge,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -79554,6 +80608,10 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
+"oUF" = (
+/obj/structure/lattice,
+/turf/simulated/wall,
+/area/space)
 "oUI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -79648,7 +80706,9 @@
 /turf/simulated/floor,
 /area/station/cargo/storage)
 "pcJ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -80110,6 +81170,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/maintenance/incinerator)
+"pDK" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/virology)
 "pEt" = (
 /obj/machinery/hydroponics/constructable,
 /obj/machinery/status_display{
@@ -80638,6 +81708,14 @@
 	},
 /turf/environment/space,
 /area/shuttle/supply/station)
+"qnY" = (
+/obj/structure/stool/bed/chair/metal/yellow{
+	dir = 1
+	},
+/turf/simulated/floor/garden{
+	icon_state = "asteroid"
+	},
+/area/station/civilian/garden)
 "qob" = (
 /obj/item/seeds/potatoseed,
 /turf/simulated/floor/plating,
@@ -80700,6 +81778,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/singularity)
+"qqg" = (
+/obj/structure/stool/bed/chair/metal/yellow{
+	dir = 8
+	},
+/obj/structure/sign/poster/random{
+	pixel_x = 32
+	},
+/turf/simulated/floor/garden{
+	icon_state = "asteroid3"
+	},
+/area/station/civilian/garden)
 "qrb" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -80793,12 +81882,24 @@
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"qwn" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/engine)
 "qwt" = (
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	d2 = 2;
 	icon_state = "0-2"
@@ -80964,6 +82065,15 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/aft)
+"qHR" = (
+/obj/effect/decal/turf_decal/wood{
+	dir = 8;
+	icon_state = "spline_fancy"
+	},
+/obj/structure/flora/junglebush/c,
+/obj/effect/decal/cleanable/cobweb2,
+/turf/simulated/floor/grass,
+/area/station/civilian/garden)
 "qJb" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -81006,6 +82116,10 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/singularity)
+"qKQ" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/simulated/floor/grass,
+/area/station/civilian/garden)
 "qLl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/tools/tool,
@@ -81138,7 +82252,6 @@
 	},
 /area/station/medical/genetics_cloning)
 "qRb" = (
-/obj/machinery/door/firedoor,
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -81146,6 +82259,9 @@
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
 	name = "KEEP CLEAR: DOCKING AREA"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/arrival)
@@ -81278,7 +82394,9 @@
 	name = "Librarian";
 	req_access = list(37)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "cult"
 	},
@@ -81293,6 +82411,16 @@
 	icon_state = "barber"
 	},
 /area/station/civilian/locker)
+"qXB" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/exit)
 "qYi" = (
 /obj/structure/disposalpipe/junction{
 	icon_state = "pipe-j2"
@@ -81408,6 +82536,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor,
 /area/station/maintenance/incinerator)
+"rfW" = (
+/obj/structure/flora/ausbushes/genericbush,
+/obj/effect/decal/turf_decal/wood{
+	dir = 4;
+	icon_state = "spline_fancy"
+	},
+/turf/simulated/floor/grass,
+/area/station/civilian/garden)
 "rgb" = (
 /obj/item/stack/cable_coil/random,
 /obj/item/device/radio/intercom{
@@ -81473,6 +82609,13 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
+"rjK" = (
+/obj/effect/decal/turf_decal/wood{
+	dir = 4;
+	icon_state = "spline_fancy_corner"
+	},
+/turf/simulated/wall,
+/area/station/civilian/garden)
 "rjR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -81532,6 +82675,15 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
+"rlQ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "bluecorner"
+	},
+/area/station/hallway/primary/central)
 "rlZ" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -82061,6 +83213,20 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"rOr" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
+	name = "KEEP CLEAR: DOCKING AREA"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/exit)
 "rPb" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -82514,6 +83680,16 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/singularity)
+"snv" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos)
 "snG" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -82611,6 +83787,16 @@
 	icon_state = "freezerfloor"
 	},
 /area/station/medical/virology)
+"srJ" = (
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/office)
 "ssb" = (
 /obj/structure/table/glass,
 /obj/item/weapon/reagent_containers/glass/beaker,
@@ -82771,7 +83957,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/virology/glass{
 	name = "Isolation B";
 	req_access = list(39);
@@ -82889,7 +84077,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/virology/glass{
 	name = "Monkey Pen";
 	req_access = list(39);
@@ -83053,7 +84243,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/virology/glass{
 	name = "Isolation A";
 	req_access = list(39);
@@ -83328,6 +84520,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
+"tdv" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/dormitory)
 "teb" = (
 /obj/machinery/light/smart{
 	dir = 1
@@ -83361,6 +84563,14 @@
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"tfZ" = (
+/obj/effect/decal/turf_decal/wood{
+	dir = 8;
+	icon_state = "spline_fancy"
+	},
+/obj/structure/flora/rock/jungle,
+/turf/simulated/floor/grass,
+/area/station/civilian/garden)
 "tgb" = (
 /obj/decal/boxingrope{
 	dir = 5
@@ -83378,7 +84588,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "thb" = (
@@ -83412,6 +84624,15 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/tcommsat/computer)
+"tiS" = (
+/obj/structure/table/glass,
+/obj/item/trash/popcorn,
+/obj/item/weapon/paper/lovenote,
+/obj/item/weapon/wrapping_paper,
+/turf/simulated/floor/garden{
+	icon_state = "asteroid"
+	},
+/area/station/civilian/garden)
 "tkb" = (
 /obj/machinery/shower{
 	dir = 1
@@ -83525,6 +84746,12 @@
 	icon_state = "greencorner"
 	},
 /area/station/hallway/primary/port)
+"tqo" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor,
+/area/station/hallway/primary/central)
 "tso" = (
 /obj/effect/decal/turf_decal{
 	dir = 6;
@@ -83683,6 +84910,16 @@
 	icon_state = "green"
 	},
 /area/station/civilian/hydroponics)
+"tJh" = (
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/fitness)
 "tKb" = (
 /obj/structure/stool,
 /obj/effect/decal/cleanable/dirt,
@@ -83830,6 +85067,17 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
+"ubH" = (
+/obj/structure/window/fulltile,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal)
 "ucb" = (
 /obj/structure/filingcabinet/chestdrawer{
 	dir = 1
@@ -83936,7 +85184,9 @@
 	},
 /area/station/medical/genetics)
 "uhz" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock{
 	name = "Firefighting equipment";
 	dir = 4
@@ -83958,10 +85208,12 @@
 /turf/simulated/floor,
 /area/station/security/range)
 "ujL" = (
-/obj/machinery/door/firedoor,
 /obj/structure/table/reinforced/stall,
 /obj/item/weapon/storage/fancy/donut_box{
 	pixel_y = 8
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor{
 	dir = 5;
@@ -84138,6 +85390,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"uBq" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/eva)
 "uBz" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/structure/disposalpipe/segment{
@@ -84267,6 +85525,16 @@
 	icon_state = "vaultfull"
 	},
 /area/station/civilian/chapel/mass_driver)
+"uIO" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/storage)
 "uMv" = (
 /obj/machinery/door/firedoor,
 /obj/structure/window/fulltile{
@@ -84363,7 +85631,9 @@
 	name = "Library";
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "vbU" = (
@@ -84372,6 +85642,16 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/break_room)
+"vbW" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/central)
 "vcK" = (
 /obj/effect/decal/turf_decal{
 	icon_state = "warn"
@@ -84426,6 +85706,14 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"vql" = (
+/obj/structure/flora/ausbushes/leafybush,
+/obj/effect/decal/turf_decal/wood{
+	dir = 4;
+	icon_state = "spline_fancy_corner"
+	},
+/turf/simulated/floor/grass,
+/area/station/civilian/garden)
 "vsv" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -84564,11 +85852,15 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/cargo/qm)
 "vJB" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/command{
 	name = "Chief Engineer";
 	req_access = list(56);
@@ -84669,13 +85961,15 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "vWz" = (
-/obj/machinery/door/firedoor,
 /obj/item/weapon/bell,
 /obj/item/device/cardpay{
 	dir = 4;
 	pixel_y = 15
 	},
 /obj/structure/table/reinforced/stall,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -84695,6 +85989,14 @@
 	icon_state = "green"
 	},
 /area/station/hallway/primary/port)
+"vXA" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "whitebluefull"
+	},
+/area/station/medical/sleeper)
 "vXW" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/components/unary/portables_connector,
@@ -84733,6 +86035,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
+"wcY" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/processing)
 "wdR" = (
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the singularity chamber.";
@@ -84862,7 +86174,9 @@
 	},
 /area/shuttle/supply/station)
 "wjJ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = 20
@@ -84958,7 +86272,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/engineering/break_room)
 "woS" = (
@@ -85012,6 +86328,16 @@
 	},
 /turf/environment/space,
 /area/shuttle/supply/station)
+"wtw" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/chapel/mass_driver)
 "wuI" = (
 /obj/item/weapon/cigbutt,
 /turf/simulated/floor/plating,
@@ -85202,6 +86528,18 @@
 "wLi" = (
 /turf/simulated/wall,
 /area/station/civilian/chapel/mass_driver)
+"wLY" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/aisat)
 "wMu" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
@@ -85274,7 +86612,9 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "wYU" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock{
 	name = "Unisex Restrooms";
 	dir = 4
@@ -85355,7 +86695,9 @@
 	name = "Arrival Airlock";
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "xoA" = (
@@ -85574,6 +86916,14 @@
 	icon_state = "green"
 	},
 /area/station/civilian/hydroponics)
+"xJo" = (
+/obj/effect/decal/turf_decal/wood{
+	dir = 8;
+	icon_state = "spline_fancy_corner"
+	},
+/obj/structure/flora/junglebush/large,
+/turf/simulated/floor/grass,
+/area/station/civilian/garden)
 "xKE" = (
 /obj/effect/decal/turf_decal{
 	dir = 10;
@@ -85659,6 +87009,24 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/engine)
+"xOQ" = (
+/obj/structure/stool/bed/chair/metal/yellow{
+	dir = 8
+	},
+/turf/simulated/floor/garden{
+	icon_state = "asteroid6"
+	},
+/area/station/civilian/garden)
+"xPD" = (
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/qm)
 "xQr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -85775,6 +87143,14 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/cargo/recycler)
+"xYD" = (
+/obj/structure/sign/nanotrasen{
+	pixel_y = -32
+	},
+/turf/simulated/floor{
+	icon_state = "bluecorner"
+	},
+/area/station/hallway/primary/central)
 "xZb" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -89830,8 +91206,8 @@ aJO
 hsb
 bjc
 inL
-hib
-hib
+giA
+giA
 inL
 fgF
 aaa
@@ -92144,7 +93520,7 @@ aaa
 aaa
 odL
 aGU
-aGX
+aIm
 odL
 aaa
 aaa
@@ -92398,8 +93774,8 @@ aGy
 aGy
 aGy
 qRb
-iur
-iur
+eQG
+eQG
 iCC
 aGY
 hPU
@@ -92911,9 +94287,9 @@ aGy
 aGy
 aGy
 aGy
-iur
-iur
-iur
+eQG
+eQG
+eQG
 hIf
 aGY
 odL
@@ -93956,8 +95332,8 @@ aXZ
 bdz
 apT
 apT
-aDy
-aDy
+bOx
+bOx
 hVb
 aah
 avy
@@ -94228,9 +95604,9 @@ bgj
 bgj
 bgj
 apo
-aEb
-aEb
-aEb
+bOx
+bOx
+bOx
 btD
 btD
 btD
@@ -94453,9 +95829,9 @@ aGy
 aGy
 aGy
 aGy
-iur
-iur
-iur
+eQG
+eQG
+eQG
 aFz
 hSb
 odL
@@ -94968,8 +96344,8 @@ aGy
 aGy
 aGy
 qRb
-iur
-iur
+eQG
+eQG
 hIf
 aGY
 hPU
@@ -95228,7 +96604,7 @@ aaa
 aaa
 odL
 aGU
-aGX
+aIm
 odL
 aaa
 aaa
@@ -95759,15 +97135,15 @@ bMi
 baM
 apT
 aah
-icb
+ezi
 bZz
-aEb
+aDy
 aah
 apT
 aaa
-icb
+mhC
 wYt
-aEb
+apT
 aaa
 apT
 cMC
@@ -96011,21 +97387,21 @@ aXZ
 aXZ
 aXZ
 aXZ
-aDy
-aDy
+apT
+apT
 aGj
 apT
-aEb
-aEb
-bLZ
-aEb
-aEb
 apT
-aEb
-aEb
+aDy
 bLZ
-aEb
-aEb
+aDy
+apT
+apT
+apT
+apT
+bLZ
+apT
+apT
 apT
 dCb
 aml
@@ -96269,8 +97645,8 @@ aXZ
 aXZ
 aXZ
 aXZ
-icb
-bOx
+mhC
+aGp
 apT
 aYx
 bWv
@@ -96281,7 +97657,7 @@ apT
 aYx
 cxD
 xnL
-aEb
+apT
 aYx
 cKo
 bwe
@@ -96526,13 +97902,13 @@ aXZ
 aXZ
 aXZ
 aXZ
-aEb
+apT
 aGj
 apT
 bWw
 bTo
 bTo
-bTo
+gGe
 bie
 phy
 jyQ
@@ -96774,22 +98150,22 @@ bvW
 bwv
 bDi
 apT
-aEb
-aEb
-aEb
-aEb
-aEb
-aEb
-aEb
-aEb
+bOx
+bOx
+bOx
+bOx
+bOx
+bOx
+bOx
+bOx
 aHw
-aEb
+apT
 aGp
 apT
 wwg
 xLk
 atE
-atE
+aqN
 bkQ
 qtj
 atE
@@ -97556,9 +98932,9 @@ bHe
 bHe
 bHe
 pwb
-uMv
+srJ
 bFr
-uMv
+srJ
 bGl
 bHe
 blq
@@ -98601,7 +99977,7 @@ bJI
 bcB
 biq
 bio
-ccP
+ubH
 bio
 bgf
 bsn
@@ -98841,8 +100217,8 @@ jOv
 qlZ
 qlZ
 qlZ
-lNB
-lNB
+xPD
+xPD
 vIs
 qlZ
 qlZ
@@ -99840,7 +101216,7 @@ apW
 aaa
 apW
 aBb
-gSb
+apw
 aKJ
 aKJ
 aaa
@@ -100097,15 +101473,15 @@ apW
 aaa
 apW
 bwT
-apW
+aRn
 aah
 aah
 aah
 aah
 aRn
-apW
-apW
-gSb
+qXB
+qXB
+rOr
 aRn
 aRn
 aRn
@@ -100351,10 +101727,10 @@ apW
 aXX
 aXX
 apW
-apW
+qXB
 apW
 aXX
-apW
+aRn
 aRn
 aRn
 aRn
@@ -100604,12 +101980,12 @@ aaa
 aYA
 hIb
 hIb
-apW
+aRn
 hIb
 hIb
-apW
+aRn
 dDb
-apW
+aRn
 bqP
 aYA
 bqO
@@ -100656,8 +102032,8 @@ bFS
 bxC
 byS
 bzs
-mJL
-mJL
+uIO
+uIO
 bCt
 wnL
 nMG
@@ -101427,9 +102803,9 @@ bFS
 bxz
 bFS
 bAh
-mJL
-mJL
-mJL
+uIO
+uIO
+uIO
 vQD
 gWa
 euT
@@ -102198,8 +103574,8 @@ bFS
 byq
 bze
 bAl
-mJL
-mJL
+uIO
+uIO
 bCt
 lcO
 kZC
@@ -103197,7 +104573,7 @@ aWC
 aFG
 bbD
 aJS
-bfZ
+diy
 aSP
 aRV
 aZK
@@ -105481,13 +106857,13 @@ aaa
 aaa
 aaa
 aah
-awz
-awz
-awz
-awz
-awz
-awz
-awz
+avp
+gqE
+gqE
+gqE
+gqE
+gqE
+gqE
 avp
 avp
 avp
@@ -105512,15 +106888,15 @@ bdv
 bdZ
 ipb
 bod
-aqD
-aqD
+kJn
+aNi
 gKG
 aVg
 jmV
 nNV
-aqD
-aqD
-aqD
+fmP
+bcq
+bcq
 aNi
 aNi
 aNi
@@ -106286,7 +107662,7 @@ aMZ
 aMZ
 aMZ
 aMZ
-ezx
+aDd
 oMQ
 oGL
 aMZ
@@ -106557,7 +107933,7 @@ bIM
 bJX
 rnx
 bDp
-usn
+bdE
 tgJ
 bNk
 bsT
@@ -107548,8 +108924,8 @@ awh
 awh
 awh
 awh
-vwg
-vwg
+avp
+tJh
 aGa
 avp
 aIF
@@ -107615,25 +108991,25 @@ aaa
 aaa
 aaa
 aaa
-bvY
-bvY
-bvY
-bvY
-bvY
-bvY
-bvY
+bIZ
+aUb
+aUb
+aUb
+aUb
+aUb
+aUb
 bIZ
 bIZ
 bIZ
-bvY
+aZA
 bIZ
 bIZ
 bQl
 cMI
 chX
 bIZ
-bvY
-bvY
+aZA
+aZA
 cAW
 cib
 okb
@@ -108308,13 +109684,13 @@ aaa
 aaa
 aaa
 aah
-awz
-awz
-awz
-awz
-awz
-awz
-awz
+avp
+gqE
+gqE
+gqE
+gqE
+gqE
+gqE
 avp
 avp
 avp
@@ -108855,7 +110231,7 @@ npd
 aMZ
 aMZ
 awO
-ezx
+aDd
 aMZ
 aET
 bmx
@@ -110098,7 +111474,7 @@ aaa
 aah
 aah
 aah
-acO
+wcY
 ahJ
 acJ
 amu
@@ -110128,11 +111504,11 @@ aHz
 aUZ
 aUZ
 aUZ
-bag
-bag
 aCq
-bag
-bag
+mLE
+aCq
+mLE
+erw
 aCq
 bdj
 aKd
@@ -110431,11 +111807,11 @@ sOh
 cap
 cap
 cap
-bHa
-bHa
+hnr
+hnr
 cap
 cap
-bHa
+hnr
 cap
 cFO
 bIZ
@@ -110612,10 +111988,10 @@ aaa
 aah
 alm
 alm
-acO
+wcY
 ahJ
 acJ
-acO
+wcY
 alm
 agO
 alZ
@@ -110627,7 +112003,7 @@ alZ
 alZ
 cfP
 agO
-bzA
+uBq
 agO
 axm
 aNh
@@ -110961,8 +112337,8 @@ bIZ
 bIZ
 bIZ
 bIZ
-tlE
-tlE
+jir
+jir
 aPx
 bIZ
 bIZ
@@ -111677,12 +113053,12 @@ aCq
 aCq
 aCq
 byl
-aFE
+tqo
 iEb
 aGn
-ayv
-ayv
-ayv
+hgi
+hgi
+hgi
 aGn
 aRj
 bau
@@ -111739,7 +113115,7 @@ cpc
 aNI
 bIZ
 cJZ
-bPe
+gHx
 bIZ
 lcG
 crH
@@ -112706,11 +114082,11 @@ aMD
 aCu
 bex
 aKx
-bbo
-aGZ
-aGZ
-aGZ
-aGZ
+xYD
+aNU
+vbW
+vbW
+aNU
 aPv
 aKx
 iYb
@@ -112738,11 +114114,11 @@ aKx
 cxF
 bIZ
 bIZ
-bvY
-bvY
-bvY
-bvY
-bvY
+aUb
+aUb
+aUb
+aUb
+aUb
 bIZ
 bIZ
 bJc
@@ -113719,7 +115095,7 @@ axN
 axN
 axN
 axN
-bzA
+uBq
 clo
 aCu
 aCy
@@ -113762,7 +115138,7 @@ bzK
 cvc
 bra
 bFG
-aKz
+bDW
 bEd
 aMR
 aaa
@@ -114276,7 +115652,7 @@ bzM
 cvm
 bra
 kOb
-aKz
+bDW
 bEd
 bLW
 bKl
@@ -115019,7 +116395,7 @@ aOq
 aNU
 aJv
 bDW
-aGs
+eNO
 aNV
 bnh
 bqi
@@ -115347,8 +116723,8 @@ crH
 dWu
 crH
 crH
-cBT
-cBT
+qwn
+crH
 cpU
 cCx
 aaa
@@ -116787,7 +118163,7 @@ alj
 adM
 ami
 aqE
-ano
+adJ
 arC
 ati
 ati
@@ -116889,8 +118265,8 @@ crH
 czV
 crH
 crH
-cBT
-cBT
+qwn
+crH
 oMx
 cCx
 aaa
@@ -117045,7 +118421,7 @@ alu
 amh
 anY
 anp
-aom
+kPt
 ati
 ati
 aAs
@@ -117328,8 +118704,8 @@ awT
 awT
 aeJ
 aef
-aGZ
-aGZ
+aMR
+aMR
 aMN
 aKx
 aRR
@@ -118103,7 +119479,7 @@ aMR
 aMR
 beU
 bDW
-aGq
+rlQ
 aGZ
 aaa
 aUG
@@ -118388,7 +119764,7 @@ bzZ
 bBT
 byE
 bek
-aKz
+bDW
 bgZ
 bJe
 bAL
@@ -118902,7 +120278,7 @@ bAa
 bGu
 byE
 bek
-aKz
+bDW
 cxQ
 bJe
 ckL
@@ -119902,11 +121278,11 @@ crb
 aEa
 clq
 aKx
-aRR
-aGZ
-aGZ
-aGZ
-aGZ
+mbQ
+aNU
+mdC
+mdC
+aNU
 aPv
 bau
 iYb
@@ -120462,10 +121838,10 @@ cJQ
 cJQ
 cbX
 bSV
-bRe
-bRe
-bRe
-bRe
+snv
+snv
+snv
+snv
 bVS
 bSV
 kif
@@ -120941,7 +122317,7 @@ bjy
 bjy
 bjy
 bFG
-aKz
+bDW
 bEd
 bkE
 bkE
@@ -122177,7 +123553,7 @@ afl
 gNb
 aef
 aef
-ajr
+tdv
 aef
 aaa
 aef
@@ -122472,7 +123848,7 @@ aXg
 agl
 agP
 aSN
-bct
+nVQ
 blg
 bok
 bqE
@@ -122518,25 +123894,25 @@ cdS
 cce
 bPY
 bSV
-bTq
-cli
+eEh
+hmP
 bUv
-cli
+hmP
 bWd
 bXl
 bUv
-cli
+hmP
 bWd
-cli
+hmP
 bUv
-cli
+hmP
 bWd
-cli
+hmP
 bUv
-cli
+hmP
 bWd
-cli
-cli
+hmP
+hmP
 eec
 wHJ
 cli
@@ -123841,9 +125217,9 @@ aaa
 aaa
 aaa
 cnR
-cnR
-cnR
-cnR
+wLY
+wLY
+wLY
 cCW
 cnp
 cCW
@@ -124267,10 +125643,10 @@ bAU
 bAU
 bAU
 aVT
-aVT
-aZA
+mdr
+bAU
 cAM
-bct
+nVQ
 bmI
 bmI
 bmI
@@ -124525,7 +125901,7 @@ aSS
 aUn
 bCK
 bCJ
-aZB
+mGx
 bqe
 boO
 biD
@@ -124588,7 +125964,7 @@ aaa
 ckA
 ckA
 ckA
-cfJ
+aGX
 ckA
 ckA
 ckA
@@ -124838,9 +126214,9 @@ aaa
 aaa
 ckA
 ckA
-cfJ
+aGX
 ckA
-cfJ
+aGX
 ckA
 ckA
 slb
@@ -125056,9 +126432,9 @@ bNd
 bcb
 coo
 bjk
-lmV
-lmV
-lmV
+nyJ
+nyJ
+nyJ
 gab
 bjk
 bjk
@@ -125325,7 +126701,7 @@ aIq
 bjl
 kBb
 bza
-mQb
+vXA
 bjl
 bkV
 bkV
@@ -125358,9 +126734,9 @@ rRb
 rZb
 ckA
 ckA
-oax
+pDK
 sIb
-oax
+pDK
 ckA
 ckA
 aaa
@@ -126352,7 +127728,7 @@ cGB
 mWb
 bqm
 bvR
-bsz
+ouo
 bvR
 bvR
 aIt
@@ -126385,11 +127761,11 @@ aky
 rUb
 sdb
 ckA
-oax
+pDK
 sCb
 ckA
 sPb
-oax
+pDK
 ckA
 aaa
 aaa
@@ -126819,7 +128195,7 @@ aah
 aah
 aah
 bRf
-bMf
+ixi
 aAM
 aBz
 agM
@@ -127414,9 +128790,9 @@ rTb
 sgb
 ckA
 ckA
-cfJ
+aGX
 ckA
-cfJ
+aGX
 ckA
 ckA
 aaa
@@ -128101,9 +129477,9 @@ aaa
 cbD
 cbD
 cbD
-axY
-axY
-axY
+aKz
+aKz
+aKz
 cbD
 cbD
 aCM
@@ -130986,7 +132362,7 @@ bLp
 aKs
 bFo
 bFo
-mUb
+jpO
 bFo
 bFo
 jGb
@@ -131961,8 +133337,8 @@ cbD
 aaa
 aaa
 aup
-aLy
-aLy
+ano
+ano
 aup
 aup
 aup
@@ -133286,7 +134662,7 @@ ebb
 aKs
 aKs
 bSC
-cjY
+dLf
 vaf
 aKs
 aKs
@@ -135315,7 +136691,7 @@ aRx
 aKM
 aPt
 aup
-aYO
+jBg
 bnc
 hUb
 bCM
@@ -136375,8 +137751,8 @@ cxs
 cxu
 cuE
 bdw
-bZp
-bWu
+lck
+rfW
 bFo
 iJb
 aVF
@@ -136621,8 +137997,8 @@ aaa
 aaa
 aaa
 aaa
-bZa
-cdn
+eQF
+cHi
 clU
 cwV
 cxz
@@ -136631,8 +138007,8 @@ avn
 cuE
 cuN
 cuE
-bdE
-bZb
+cuE
+cuE
 bZa
 bFo
 aCV
@@ -136878,27 +138254,27 @@ aaa
 aaa
 aaa
 aaa
-bZa
-bZa
-bZa
-aTX
+eQF
+jkG
+cuE
+cuE
 cuN
 cxu
 cuE
 cuE
 cuE
-bcq
-bZa
-bZa
-bZa
-cak
+cuE
+cuN
+gHG
+tiS
+bFo
 aUX
 cak
 bqR
 bFz
 bqV
 aVF
-bMQ
+ocg
 bFo
 bFo
 bFo
@@ -137117,9 +138493,9 @@ aah
 aaa
 aaa
 wLi
-oRh
-oRh
-oRh
+wtw
+wtw
+wtw
 wLi
 aah
 aaa
@@ -137135,20 +138511,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-bZa
-bZa
-aUb
+bWu
+htg
+qnY
+cuN
+bWu
 aWJ
 aXM
 baN
 bbj
-bZa
-bZa
-aaa
-aaa
-aah
+bWu
+cuE
+cuE
+xOQ
+oUF
 aah
 aah
 aaa
@@ -137392,20 +138768,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-bZa
-bZa
-bZa
-bZa
-bZa
-bZa
-bZa
-aaa
-aaa
-aaa
-aaa
+bWu
+qqg
+cuN
+nHY
+rjK
+bZn
+bWu
+bWu
+cdd
+kQj
+etD
+cuE
+cuN
+bkb
 aaa
 aaa
 aaa
@@ -137649,20 +139025,20 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bWu
+bWu
+qHR
+vql
+bWu
+bZp
+qKQ
+bZp
+bZc
+nmu
+xJo
+tfZ
+bWu
+bkb
 aaa
 aaa
 aaa
@@ -137907,18 +139283,18 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+bWu
+aTX
+aTX
+bWu
+aTX
+aTX
+aTX
+aTX
+bWu
+aTX
+aTX
+bWu
 aaa
 aaa
 aaa
@@ -138430,7 +139806,7 @@ aaa
 aaa
 aaa
 aaa
-aag
+aaa
 aaa
 aaa
 aaa
@@ -139201,7 +140577,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aag
 aaa
 aaa
 aaa

--- a/maps/boxstation/boxstation.dmm
+++ b/maps/boxstation/boxstation.dmm
@@ -27370,14 +27370,6 @@
 	icon_state = "neutral"
 	},
 /area/station/storage/primary)
-"aWJ" = (
-/obj/structure/flora/junglebush/b,
-/obj/effect/decal/turf_decal/wood{
-	dir = 8;
-	icon_state = "spline_fancy"
-	},
-/turf/simulated/floor/grass,
-/area/station/civilian/garden)
 "aWK" = (
 /obj/structure/table,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -27955,14 +27947,14 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/chapel/office)
 "aXM" = (
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/machinery/light/smart{
-	dir = 4
-	},
 /obj/effect/decal/turf_decal/wood{
 	dir = 8;
 	icon_state = "spline_fancy"
 	},
+/obj/machinery/light/smart{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/grass,
 /area/station/civilian/garden)
 "aXN" = (
@@ -29700,7 +29692,6 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/entry)
 "baN" = (
-/obj/structure/flora/junglebush/b,
 /obj/effect/decal/turf_decal/wood{
 	dir = 8;
 	icon_state = "spline_fancy"
@@ -29709,6 +29700,7 @@
 	c_tag = "Garden East";
 	dir = 9
 	},
+/obj/structure/flora/ausbushes/ywflowers,
 /turf/simulated/floor/grass,
 /area/station/civilian/garden)
 "baO" = (
@@ -29944,11 +29936,11 @@
 	},
 /area/station/medical/chemistry)
 "bbj" = (
-/obj/structure/flora/ausbushes/fullgrass,
 /obj/effect/decal/turf_decal/wood{
 	dir = 8;
 	icon_state = "spline_fancy"
 	},
+/obj/structure/flora/ausbushes/sunnybush,
 /turf/simulated/floor/grass,
 /area/station/civilian/garden)
 "bbk" = (
@@ -31146,7 +31138,7 @@
 "bdw" = (
 /obj/structure/flora/rock/jungle,
 /obj/effect/decal/turf_decal/wood{
-	dir = 5;
+	dir = 1;
 	icon_state = "spline_fancy"
 	},
 /turf/simulated/floor/grass,
@@ -56094,12 +56086,14 @@
 	},
 /area/station/engineering/atmos)
 "bZa" = (
-/obj/structure/stool/bed/chair/metal/yellow{
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor{
 	dir = 4
 	},
-/turf/simulated/floor/garden{
-	icon_state = "asteroid6"
-	},
+/turf/simulated/wall,
 /area/station/civilian/garden)
 "bZb" = (
 /turf/simulated/floor/grass,
@@ -70783,14 +70777,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/gateway)
-"etD" = (
-/obj/structure/flora/ausbushes/brflowers,
-/obj/effect/decal/turf_decal/wood{
-	dir = 10;
-	icon_state = "spline_fancy"
-	},
-/turf/simulated/floor/grass,
-/area/station/civilian/garden)
 "etF" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -72849,10 +72835,12 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "gHG" = (
-/obj/structure/stool/bed/chair/metal/yellow,
-/turf/simulated/floor/garden{
-	icon_state = "asteroid"
+/obj/effect/decal/turf_decal/wood{
+	dir = 8;
+	icon_state = "spline_fancy"
 	},
+/obj/structure/flora/junglebush/b,
+/turf/simulated/floor/grass,
 /area/station/civilian/garden)
 "gIb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -73581,15 +73569,12 @@
 	},
 /area/shuttle/mining/station)
 "htg" = (
-/obj/item/weapon/storage/fancy/crayons{
-	pixel_x = -8;
-	pixel_y = 6
+/obj/effect/decal/turf_decal/wood{
+	dir = 10;
+	icon_state = "spline_fancy"
 	},
-/obj/item/weapon/storage/fancy/cigarettes/menthol,
-/obj/structure/table/glass,
-/turf/simulated/floor/garden{
-	icon_state = "asteroid"
-	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
 /area/station/civilian/garden)
 "huy" = (
 /turf/simulated/shuttle/floor/cargo{
@@ -75435,14 +75420,6 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/engineering/engine)
-"jkG" = (
-/obj/structure/stool/bed/chair/metal/yellow{
-	dir = 4
-	},
-/turf/simulated/floor/garden{
-	icon_state = "asteroid"
-	},
-/area/station/civilian/garden)
 "jlb" = (
 /obj/machinery/atmospherics/components/unary/portables_connector{
 	dir = 1
@@ -77010,10 +76987,11 @@
 /area/station/civilian/chapel/mass_driver)
 "kQj" = (
 /obj/effect/decal/turf_decal/wood{
-	dir = 10;
+	dir = 1;
 	icon_state = "spline_fancy"
 	},
-/turf/simulated/wall,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/simulated/floor/grass,
 /area/station/civilian/garden)
 "kQm" = (
 /obj/structure/cable{
@@ -77195,14 +77173,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
-"lck" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/effect/decal/turf_decal/wood{
-	dir = 4;
-	icon_state = "spline_fancy"
-	},
-/turf/simulated/floor/grass,
-/area/station/civilian/garden)
 "lcB" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
@@ -79206,13 +79176,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
-"nmu" = (
-/obj/effect/decal/turf_decal/wood{
-	dir = 8;
-	icon_state = "spline_fancy_corner"
-	},
-/turf/simulated/wall,
-/area/station/civilian/garden)
 "nnb" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -80608,10 +80571,6 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
-"oUF" = (
-/obj/structure/lattice,
-/turf/simulated/wall,
-/area/space)
 "oUI" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -81708,14 +81667,6 @@
 	},
 /turf/environment/space,
 /area/shuttle/supply/station)
-"qnY" = (
-/obj/structure/stool/bed/chair/metal/yellow{
-	dir = 1
-	},
-/turf/simulated/floor/garden{
-	icon_state = "asteroid"
-	},
-/area/station/civilian/garden)
 "qob" = (
 /obj/item/seeds/potatoseed,
 /turf/simulated/floor/plating,
@@ -81778,17 +81729,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/singularity)
-"qqg" = (
-/obj/structure/stool/bed/chair/metal/yellow{
-	dir = 8
-	},
-/obj/structure/sign/poster/random{
-	pixel_x = 32
-	},
-/turf/simulated/floor/garden{
-	icon_state = "asteroid3"
-	},
-/area/station/civilian/garden)
 "qrb" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -82065,15 +82005,6 @@
 	},
 /turf/simulated/floor,
 /area/station/hallway/primary/aft)
-"qHR" = (
-/obj/effect/decal/turf_decal/wood{
-	dir = 8;
-	icon_state = "spline_fancy"
-	},
-/obj/structure/flora/junglebush/c,
-/obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/grass,
-/area/station/civilian/garden)
 "qJb" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -82116,10 +82047,6 @@
 	},
 /turf/simulated/floor/plating/airless,
 /area/station/engineering/singularity)
-"qKQ" = (
-/obj/structure/flora/ausbushes/sunnybush,
-/turf/simulated/floor/grass,
-/area/station/civilian/garden)
 "qLl" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/tools/tool,
@@ -82538,10 +82465,6 @@
 /area/station/maintenance/incinerator)
 "rfW" = (
 /obj/structure/flora/ausbushes/genericbush,
-/obj/effect/decal/turf_decal/wood{
-	dir = 4;
-	icon_state = "spline_fancy"
-	},
 /turf/simulated/floor/grass,
 /area/station/civilian/garden)
 "rgb" = (
@@ -82609,13 +82532,6 @@
 	icon_state = "whitegreen"
 	},
 /area/station/medical/virology)
-"rjK" = (
-/obj/effect/decal/turf_decal/wood{
-	dir = 4;
-	icon_state = "spline_fancy_corner"
-	},
-/turf/simulated/wall,
-/area/station/civilian/garden)
 "rjR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -84624,15 +84540,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/station/tcommsat/computer)
-"tiS" = (
-/obj/structure/table/glass,
-/obj/item/trash/popcorn,
-/obj/item/weapon/paper/lovenote,
-/obj/item/weapon/wrapping_paper,
-/turf/simulated/floor/garden{
-	icon_state = "asteroid"
-	},
-/area/station/civilian/garden)
 "tkb" = (
 /obj/machinery/shower{
 	dir = 1
@@ -85706,14 +85613,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
-"vql" = (
-/obj/structure/flora/ausbushes/leafybush,
-/obj/effect/decal/turf_decal/wood{
-	dir = 4;
-	icon_state = "spline_fancy_corner"
-	},
-/turf/simulated/floor/grass,
-/area/station/civilian/garden)
 "vsv" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -86916,14 +86815,6 @@
 	icon_state = "green"
 	},
 /area/station/civilian/hydroponics)
-"xJo" = (
-/obj/effect/decal/turf_decal/wood{
-	dir = 8;
-	icon_state = "spline_fancy_corner"
-	},
-/obj/structure/flora/junglebush/large,
-/turf/simulated/floor/grass,
-/area/station/civilian/garden)
 "xKE" = (
 /obj/effect/decal/turf_decal{
 	dir = 10;
@@ -87009,14 +86900,6 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/engine)
-"xOQ" = (
-/obj/structure/stool/bed/chair/metal/yellow{
-	dir = 8
-	},
-/turf/simulated/floor/garden{
-	icon_state = "asteroid6"
-	},
-/area/station/civilian/garden)
 "xPD" = (
 /obj/structure/window/fulltile{
 	grilled = 1;
@@ -137751,7 +137634,7 @@ cxs
 cxu
 cuE
 bdw
-lck
+bZp
 rfW
 bFo
 iJb
@@ -137998,7 +137881,7 @@ aaa
 aaa
 aaa
 eQF
-cHi
+cdn
 clU
 cwV
 cxz
@@ -138007,9 +137890,9 @@ avn
 cuE
 cuN
 cuE
-cuE
-cuE
-bZa
+kQj
+cdd
+bWu
 bFo
 aCV
 aVF
@@ -138254,20 +138137,20 @@ aaa
 aaa
 aaa
 aaa
-eQF
-jkG
-cuE
-cuE
+bWu
+aTX
+bWu
+htg
 cuN
 cxu
 cuE
 cuE
 cuE
-cuE
-cuN
-gHG
-tiS
-bFo
+nHY
+bWu
+aTX
+bWu
+aUX
 aUX
 cak
 bqR
@@ -138511,20 +138394,20 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
 bWu
-htg
-qnY
-cuN
 bWu
-aWJ
+gHG
+tfZ
 aXM
 baN
 bbj
 bWu
-cuE
-cuE
-xOQ
-oUF
+bWu
+aaa
+aaa
+aah
 aah
 aah
 aaa
@@ -138768,20 +138651,20 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
 bWu
-qqg
-cuN
-nHY
-rjK
-bZn
+aTX
+aTX
+aTX
+aTX
+bZa
 bWu
-bWu
-cdd
-kQj
-etD
-cuE
-cuN
-bkb
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -139025,20 +138908,20 @@ aaa
 aaa
 aaa
 aaa
-bWu
-bWu
-qHR
-vql
-bWu
-bZp
-qKQ
-bZp
-bZc
-nmu
-xJo
-tfZ
-bWu
-bkb
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -139283,18 +139166,18 @@ aaa
 aaa
 aaa
 aaa
-bWu
-aTX
-aTX
-bWu
-aTX
-aTX
-aTX
-aTX
-bWu
-aTX
-aTX
-bWu
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -140060,7 +139943,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aag
 aaa
 aaa
 aaa
@@ -140577,7 +140460,7 @@ aaa
 aaa
 aaa
 aaa
-aag
+aaa
 aaa
 aaa
 aaa

--- a/maps/delta/delta.dmm
+++ b/maps/delta/delta.dmm
@@ -217,7 +217,9 @@
 /turf/simulated/floor,
 /area/station/maintenance/brig)
 "aas" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/external{
 	dir = 4
 	},
@@ -375,7 +377,9 @@
 	name = "Escape Bar Backroom";
 	req_access = list(25)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -396,11 +400,15 @@
 	name = "Emergency Storage";
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "aaI" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/maintenance{
 	dir = 4;
 	name = "Medbay Maintenance";
@@ -595,7 +603,9 @@
 	id = "Secure Storage";
 	name = "Secure Storage"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/turf_decal{
 	dir = 10;
 	icon_state = "warn"
@@ -647,7 +657,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -706,7 +718,9 @@
 	},
 /area/station/hallway/primary/central)
 "abk" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/glass{
 	dir = 4;
 	name = "Library"
@@ -730,7 +744,9 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/meeting_room)
 "abm" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -761,7 +777,9 @@
 	name = "Vacant Room";
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -832,7 +850,9 @@
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
 "abt" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
 	dir = 8;
@@ -924,7 +944,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/vault{
 	dir = 4;
 	locked = 1;
@@ -1056,7 +1078,9 @@
 	},
 /area/station/bridge/nuke_storage)
 "abI" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/security{
 	dir = 4;
 	name = "Security Transferring Center";
@@ -1282,7 +1306,9 @@
 	},
 /area/station/engineering/chiefs_office)
 "acd" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -1469,7 +1495,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
 "acx" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/security/glass{
 	dir = 4;
 	name = "Gear Room";
@@ -1593,7 +1621,9 @@
 	},
 /area/station/rnd/mixing)
 "acF" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/engineering/glass{
 	dir = 4;
 	name = "Engine Room";
@@ -2122,7 +2152,9 @@
 	},
 /area/station/security/detectives_office)
 "adV" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock{
 	dir = 4;
 	name = "Locker Room"
@@ -2264,7 +2296,9 @@
 /turf/simulated/floor,
 /area/station/maintenance/science)
 "aeD" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -2337,7 +2371,9 @@
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
 "afh" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/medical/glass{
 	dir = 4;
 	id_tag = "MedbayFoyerOut";
@@ -2380,7 +2416,9 @@
 	name = "Brig";
 	req_access = list(63)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -2904,7 +2942,9 @@
 /turf/simulated/floor/carpet,
 /area/station/bridge)
 "akg" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/medical/glass{
 	dir = 4;
 	id_tag = "med_second_ex";
@@ -3022,7 +3062,9 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/hop_office)
 "alz" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -3128,6 +3170,16 @@
 	icon_state = "yellow"
 	},
 /area/station/engineering/break_room)
+"amx" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/exit)
 "amy" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/cable_coil,
@@ -3273,7 +3325,9 @@
 	},
 /area/station/engineering/atmos)
 "anG" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -3308,8 +3362,21 @@
 	},
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/auxstarboard)
+"anV" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/gym)
 "anX" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -3582,7 +3649,9 @@
 	name = "Chapel Maintenance";
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "aqy" = (
@@ -3608,6 +3677,16 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/robotics)
+"aqD" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos)
 "aqF" = (
 /obj/item/weapon/table_parts,
 /turf/simulated/floor/plating,
@@ -3619,7 +3698,9 @@
 	},
 /area/station/security/hos)
 "aqK" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
 	},
@@ -3890,6 +3971,12 @@
 	icon_state = "gcircuit"
 	},
 /area/station/rnd/xenobiology)
+"atD" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/wall,
+/area/station/civilian/gym)
 "atL" = (
 /obj/structure/cable{
 	d2 = 4;
@@ -3963,7 +4050,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
 "auc" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
@@ -4169,7 +4258,9 @@
 	},
 /area/station/medical/virology)
 "axg" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -4195,6 +4286,20 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/mine_sci_shuttle)
+"axJ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/checkpoint/medbay)
 "axK" = (
 /obj/structure/object_wall/pod{
 	icon_state = "3,1";
@@ -4204,7 +4309,9 @@
 /turf/environment/space/shuttle,
 /area/shuttle/escape_pod2/station)
 "ayd" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/security/glass{
 	dir = 4;
 	name = "Security Office";
@@ -4384,7 +4491,9 @@
 	},
 /area/station/aisat/ai_chamber)
 "aAw" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/security/glass{
 	dir = 4;
 	name = "Security Transferring Control";
@@ -4532,7 +4641,9 @@
 	name = "Bar";
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/barricade/wooden{
 	layer = 2.8;
 	name = "doorway barricade"
@@ -4540,7 +4651,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "aBD" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -4952,6 +5065,16 @@
 	icon_state = "brown"
 	},
 /area/station/cargo/storage)
+"aGb" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos/atmos_office)
 "aGi" = (
 /obj/machinery/power/solar{
 	id = "auxsolareast";
@@ -5333,7 +5456,9 @@
 	},
 /area/station/hallway/primary/central)
 "aJW" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/glass{
 	dir = 4;
 	name = "Chapel Office";
@@ -5480,7 +5605,9 @@
 /obj/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
 "aMd" = (
@@ -5600,7 +5727,9 @@
 	freq = 1400;
 	location = "Medbay"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/medical/storage)
 "aNa" = (
@@ -6375,7 +6504,9 @@
 /turf/simulated/floor/plating/airless,
 /area/station/rnd/test_area)
 "aVI" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -6551,7 +6682,9 @@
 	},
 /area/station/rnd/misc_lab)
 "aYm" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -6981,7 +7114,9 @@
 	},
 /area/station/medical/cryo)
 "bcG" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/glass{
 	dir = 4;
 	name = "Chapel"
@@ -7018,7 +7153,9 @@
 	},
 /area/shuttle/mining/station)
 "bcW" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced/phoron{
 	grilled = 1;
 	icon_state = "gr_window_reinforced_phoron"
@@ -7103,7 +7240,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/barricade/wooden{
 	layer = 2.8;
 	name = "doorway barricade"
@@ -7111,7 +7250,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "bed" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/glass{
 	dir = 4;
 	name = "Central Access"
@@ -7373,7 +7514,9 @@
 	},
 /area/station/storage/tools)
 "bgs" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/table/reinforced/stall,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
@@ -7386,7 +7529,9 @@
 /turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
 "bgu" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/command{
 	dir = 4;
 	name = "Chief Engineer's Office";
@@ -7525,7 +7670,9 @@
 	},
 /area/station/rnd/tox_launch)
 "bhH" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/glass{
 	dir = 4;
 	name = "Central Access"
@@ -7610,7 +7757,9 @@
 	},
 /area/station/bridge/nuke_storage)
 "biZ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/research{
 	dir = 4;
 	name = "Circuits Lab";
@@ -7661,29 +7810,19 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "bjt" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/hallway/secondary/entry)
 "bjB" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -7797,7 +7936,9 @@
 /turf/simulated/floor/engine,
 /area/station/rnd/telesci)
 "bkz" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/security{
 	dir = 4;
 	name = "Shooting Range";
@@ -8110,7 +8251,9 @@
 	},
 /area/station/security/execution)
 "bmZ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -8128,6 +8271,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/chiefs_office)
+"bni" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/storage)
 "bnp" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
@@ -8163,7 +8316,9 @@
 	},
 /area/station/security/hos)
 "bnx" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/table/woodentable,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
@@ -8213,11 +8368,6 @@
 "bor" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
@@ -8243,7 +8393,9 @@
 	name = "Arrival Maintenance";
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "boL" = (
@@ -8561,7 +8713,9 @@
 	},
 /area/station/security/prison)
 "bsO" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -8901,7 +9055,9 @@
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
 "bwm" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -9422,6 +9578,20 @@
 	icon_state = "neutralcorner"
 	},
 /area/station/hallway/primary/central)
+"bAU" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/checkpoint/engi)
 "bBe" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/window/thin{
@@ -9660,6 +9830,25 @@
 	icon_state = "yellowcorner"
 	},
 /area/station/engineering/atmos)
+"bDl" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/storage)
 "bDu" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/toolbox/electrical,
@@ -9746,7 +9935,9 @@
 	},
 /area/station/civilian/chapel/mass_driver)
 "bEf" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -9980,7 +10171,9 @@
 	},
 /area/station/cargo/miningoffice)
 "bGi" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/virology{
 	dir = 4;
 	name = "Virology Access";
@@ -10305,7 +10498,9 @@
 	id = "Secure Storage";
 	name = "Secure Storage"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/turf_decal{
 	dir = 9;
 	icon_state = "warn"
@@ -11055,7 +11250,9 @@
 /turf/simulated/floor/carpet/black,
 /area/station/civilian/chapel/office)
 "bQW" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
@@ -11078,7 +11275,9 @@
 	},
 /area/station/medical/virology)
 "bRy" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -11140,7 +11339,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "bSa" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
 	},
@@ -11271,7 +11472,9 @@
 	},
 /area/station/medical/reception)
 "bUn" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -11350,7 +11553,9 @@
 	},
 /area/station/engineering/break_room)
 "bUU" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "caution"
@@ -11516,7 +11721,9 @@
 /turf/simulated/floor,
 /area/station/maintenance/cargo)
 "bWo" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/security/glass{
 	dir = 4;
 	name = "Security Post - Medbay";
@@ -11714,7 +11921,9 @@
 	},
 /area/station/civilian/chapel)
 "bYk" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -11829,7 +12038,9 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "bZz" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
@@ -12054,7 +12265,9 @@
 /turf/simulated/floor,
 /area/station/cargo/storage)
 "cbP" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -12657,7 +12870,9 @@
 /area/station/cargo/recycleroffice)
 "cin" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/item/weapon/folder/red,
 /obj/item/weapon/pen,
 /obj/machinery/door/window/brigdoor{
@@ -12799,7 +13014,9 @@
 	dir = 4;
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/barricade/wooden{
 	layer = 2.8;
 	name = "doorway barricade"
@@ -13224,7 +13441,9 @@
 	name = "Atmospherics Maintenance";
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "coi" = (
@@ -13286,7 +13505,9 @@
 /area/station/security/prison)
 "coI" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/item/weapon/bell,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
@@ -13409,7 +13630,9 @@
 	},
 /area/station/security/prison)
 "crx" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -13686,7 +13909,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -13704,7 +13929,9 @@
 /turf/simulated/floor/plating,
 /area/station/cargo/recycleroffice)
 "cvI" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
@@ -13960,22 +14187,15 @@
 	},
 /area/station/medical/hallway)
 "cym" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "QM Lockdown Blast Doors";
-	name = "QM Lockdown Blast Doors";
-	opacity = 0
-	},
 /turf/simulated/floor/plating,
-/area/station/cargo/qm)
+/area/station/civilian/gym)
 "cyt" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -14252,6 +14472,19 @@
 	icon_state = "wooden"
 	},
 /area/station/civilian/library)
+"cAy" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/gym)
 "cAF" = (
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
@@ -14316,7 +14549,9 @@
 	name = "Mining Maintenance";
 	req_one_access = list(12,48)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/cargo/miningoffice)
 "cBu" = (
@@ -15236,7 +15471,9 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/mine_sci_shuttle)
 "cMd" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -15880,7 +16117,9 @@
 	name = "Cargo Maintenance";
 	req_one_access = list(12,31,48)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -16237,7 +16476,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/maintenance/cargo)
 "cWu" = (
@@ -17181,7 +17422,9 @@
 	},
 /area/station/engineering/engine)
 "dim" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 5
 	},
@@ -17739,7 +17982,9 @@
 	},
 /area/station/hallway/primary/port)
 "dpc" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
@@ -17771,7 +18016,9 @@
 	name = "Cargo Warehouse";
 	req_access = list(31)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -17890,7 +18137,9 @@
 	},
 /area/station/bridge/teleporter)
 "dqO" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -18539,7 +18788,9 @@
 	},
 /area/station/security/armoury)
 "dxt" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/security{
 	dir = 4;
 	name = "Interrogation";
@@ -18728,7 +18979,9 @@
 	},
 /area/shuttle/supply/station)
 "dAf" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -19049,7 +19302,9 @@
 	id = "Secure Storage";
 	name = "Secure Storage"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/turf_decal{
 	dir = 8;
 	icon_state = "warn"
@@ -19067,7 +19322,9 @@
 	},
 /area/station/civilian/chapel)
 "dFp" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -19260,7 +19517,9 @@
 	name = "Kitchen";
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/barricade/wooden{
 	layer = 2.8;
 	name = "doorway barricade"
@@ -20167,7 +20426,9 @@
 	},
 /area/station/medical/chemistry)
 "dTZ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
@@ -20178,7 +20439,9 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/distribution)
 "dUa" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
@@ -20309,7 +20572,9 @@
 	name = "Botany";
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/barricade/wooden{
 	layer = 2.8;
 	name = "doorway barricade"
@@ -20518,15 +20783,10 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories/service_bedrooms)
 "dXZ" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall,
 /area/station/civilian/gym)
 "dYl" = (
 /obj/structure/stool/bed/chair/office/dark,
@@ -20968,7 +21228,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "ecA" = (
@@ -21047,7 +21309,9 @@
 	},
 /area/station/cargo/qm)
 "edA" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -21391,7 +21655,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "ehM" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -22343,7 +22609,9 @@
 	},
 /area/station/cargo/storage)
 "etj" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced/phoron{
 	grilled = 1;
 	icon_state = "gr_window_reinforced_phoron"
@@ -22780,7 +23048,9 @@
 /turf/simulated/floor,
 /area/station/civilian/hydroponics)
 "exw" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -23053,7 +23323,9 @@
 /area/station/security/prison)
 "eAq" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/window/northleft{
 	dir = 8;
 	name = "Engineering Desk";
@@ -23244,7 +23516,9 @@
 /turf/environment/space,
 /area/shuttle/supply/station)
 "eBS" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/glass{
 	dir = 4;
 	name = "Service Bedrooms"
@@ -23354,7 +23628,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "eDZ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/glass{
 	dir = 4;
 	name = "Central Access"
@@ -23431,7 +23707,9 @@
 	},
 /area/station/rnd/hallway)
 "eFu" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	dir = 4;
 	id = "Skynet_launch";
@@ -23536,7 +23814,9 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "eGo" = (
@@ -23756,7 +24036,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
 	id = "Cell 5 perma";
@@ -23907,7 +24189,9 @@
 /area/station/medical/virology)
 "eKQ" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/window/brigdoor{
 	base_state = "rightsecure";
 	dir = 4;
@@ -24083,7 +24367,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "eMn" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
@@ -24124,7 +24410,9 @@
 /turf/simulated/floor,
 /area/station/rnd/xenobiology)
 "eNj" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	dir = 4;
 	id = "cell3";
@@ -24142,7 +24430,9 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/barricade/wooden,
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
@@ -24165,7 +24455,9 @@
 	},
 /area/station/engineering/minisat_secure_area)
 "eNy" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -24548,7 +24840,9 @@
 	},
 /area/station/rnd/hallway)
 "eRc" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -24620,6 +24914,16 @@
 	icon_state = "blackchoco"
 	},
 /area/station/civilian/barbershop)
+"eRX" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/chapel)
 "eSi" = (
 /obj/machinery/telecomms/processor/preset_one,
 /turf/simulated/floor/bluegrid{
@@ -24852,7 +25156,9 @@
 	},
 /area/station/civilian/gym)
 "eUv" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/medical{
 	dir = 4;
 	id_tag = "psych_ex";
@@ -24963,7 +25269,9 @@
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/auxstarboard)
 "eWN" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -25508,7 +25816,9 @@
 /area/station/hallway/secondary/entry)
 "fcg" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -25585,7 +25895,9 @@
 	},
 /area/station/bridge)
 "fcL" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -25983,7 +26295,9 @@
 	name = "Atmospherics Maintenance";
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "fgA" = (
@@ -26079,7 +26393,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/external{
 	dir = 4;
 	locked = 1;
@@ -26367,7 +26683,9 @@
 	},
 /area/station/engineering/minisat_secure_area)
 "fls" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -26617,6 +26935,16 @@
 	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
+"fpn" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/library)
 "fpT" = (
 /obj/structure/table/woodentable/poker,
 /obj/item/toy/cards,
@@ -26717,7 +27045,9 @@
 	name = "Second Emergency Storage";
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "fqK" = (
@@ -26895,11 +27225,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "fsv" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/medical/glass{
 	dir = 4;
 	name = "Medbay Treatment Center";
@@ -27450,7 +27784,9 @@
 	},
 /area/station/engineering/atmos)
 "fxe" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/security/glass{
 	dir = 4;
 	name = "Security Office";
@@ -27615,7 +27951,9 @@
 	},
 /area/station/civilian/locker)
 "fzx" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -27931,7 +28269,9 @@
 /turf/simulated/floor/wood,
 /area/station/engineering/break_room)
 "fDm" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -29226,7 +29566,9 @@
 	id_tag = "Dorm2";
 	name = "Dorm 2"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -29441,7 +29783,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/turf_decal{
 	dir = 8;
 	icon_state = "warn"
@@ -29451,7 +29795,9 @@
 	},
 /area/station/rnd/mixing)
 "fWu" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -29560,7 +29906,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
 	id = "Cell 1 perma";
@@ -29705,6 +30053,15 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/plating,
 /area/station/maintenance/incinerator)
+"fYX" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "fYZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -30029,8 +30386,20 @@
 /obj/effect/landmark/start/assistant/test_subject,
 /turf/simulated/floor/plating,
 /area/station/storage/tools)
+"gdp" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/atmos)
 "gdx" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -30066,7 +30435,9 @@
 	name = "Auxiliary Tool Storage";
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -30133,7 +30504,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
@@ -30482,7 +30855,9 @@
 /turf/simulated/floor/plating,
 /area/station/civilian/dormitories)
 "giP" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/hatch{
 	dir = 4;
 	name = "MiniSat Antechamber";
@@ -30789,7 +31164,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "glc" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -30864,7 +31241,9 @@
 	name = "Chemistry";
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/barricade/wooden{
 	layer = 2.8;
 	name = "doorway barricade"
@@ -30872,7 +31251,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "glx" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -30898,7 +31279,9 @@
 	name = "Owl House";
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "glO" = (
@@ -30912,7 +31295,9 @@
 	locked = 1;
 	name = "Arrival Airlock"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/sign/directions/engineering{
 	desc = "A sign that shows there are doors here. There are doors everywhere!";
 	icon_state = "doors";
@@ -31001,7 +31386,9 @@
 /turf/simulated/wall,
 /area/station/security/forensic_office)
 "gmU" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
@@ -31541,7 +31928,9 @@
 	name = "Supply Dock Airlock";
 	req_access = list(31)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "gte" = (
@@ -31803,7 +32192,9 @@
 	name = "Supply Dock Loading Door"
 	},
 /obj/structure/plasticflaps/mining,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "QMLoad"
@@ -32393,7 +32784,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -32542,7 +32935,9 @@
 	name = "Emergency Storage";
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "gBH" = (
@@ -32912,7 +33307,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
 "gGu" = (
@@ -32936,7 +33333,9 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories)
 "gHh" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -33876,7 +34275,9 @@
 	},
 /area/station/security/armoury)
 "gSy" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -34075,7 +34476,9 @@
 /turf/simulated/floor/engine,
 /area/station/engineering/atmos/supermatter)
 "gUo" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "yellowcorner"
 	},
@@ -34368,7 +34771,9 @@
 	},
 /area/station/engineering/chiefs_office)
 "gWR" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -34617,7 +35022,9 @@
 /turf/simulated/floor/engine,
 /area/station/rnd/mixing)
 "gZU" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/mining{
 	dir = 4;
 	req_one_access = list(23,65,48)
@@ -34741,7 +35148,9 @@
 	},
 /area/station/security/main)
 "hbu" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/mining/glass{
 	dir = 4;
 	name = "Delivery Office";
@@ -34815,7 +35224,9 @@
 /turf/simulated/floor,
 /area/station/maintenance/medbay)
 "hbZ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -35270,6 +35681,16 @@
 /obj/structure/sign/warning/nosmoking,
 /turf/simulated/wall,
 /area/station/engineering/break_room)
+"hiM" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/barbershop)
 "hjc" = (
 /turf/simulated/floor{
 	dir = 9;
@@ -36077,7 +36498,9 @@
 	},
 /area/station/bridge/captain_quarters)
 "hro" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 1
 	},
@@ -36109,7 +36532,9 @@
 	name = "Air Storage";
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -37385,7 +37810,9 @@
 	name = "Engineering Maintenance";
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "hDc" = (
@@ -38198,7 +38625,9 @@
 	},
 /area/station/medical/storage)
 "hLX" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -38434,7 +38863,9 @@
 /turf/simulated/floor,
 /area/station/maintenance/science)
 "hOR" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -38511,7 +38942,9 @@
 	},
 /area/station/bridge/captain_quarters)
 "hPN" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -39083,7 +39516,9 @@
 	},
 /area/station/security/brig)
 "hWH" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/glass{
 	dir = 4;
 	name = "Library"
@@ -39270,7 +39705,9 @@
 	},
 /area/station/maintenance/medbay)
 "hXM" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -39735,7 +40172,9 @@
 	},
 /area/station/hallway/primary/central)
 "icU" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
 	req_access = list(19)
@@ -40385,7 +40824,9 @@
 /turf/simulated/floor,
 /area/station/engineering/atmos/distribution)
 "iky" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -40616,7 +41057,9 @@
 /turf/simulated/floor/plating,
 /area/station/storage/tools)
 "imr" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/glass{
 	dir = 4;
 	name = "Central Access"
@@ -41632,7 +42075,9 @@
 	},
 /area/station/cargo/storage)
 "iyw" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -41893,7 +42338,9 @@
 /turf/simulated/floor,
 /area/station/maintenance/brig)
 "iBy" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/command{
 	dir = 4;
 	name = "Chief Medical Officer's Quarters";
@@ -42350,7 +42797,9 @@
 /turf/simulated/floor/carpet,
 /area/station/bridge/meeting_room)
 "iGx" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -42629,7 +43078,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "iIZ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -42964,7 +43415,9 @@
 	name = "Engineering External Access";
 	req_access = list(13)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
@@ -43285,7 +43738,9 @@
 	},
 /area/station/bridge)
 "iQz" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/security{
 	dir = 4;
 	name = "Evidence Storage";
@@ -43433,7 +43888,9 @@
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
 "iRZ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/command/glass{
 	dir = 4;
 	name = "Bridge Access";
@@ -43636,7 +44093,9 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/hop_office)
 "iUF" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -43852,15 +44311,10 @@
 	},
 /area/station/security/brig)
 "iWS" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall,
 /area/station/civilian/gym)
 "iWT" = (
 /obj/machinery/mineral/equipment_vendor,
@@ -43917,7 +44371,9 @@
 	},
 /area/station/civilian/dormitories)
 "iXE" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	dir = 4;
@@ -43958,7 +44414,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "iYt" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -44059,6 +44517,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
+"iZM" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor{
+	dir = 8;
+	icon_state = "purplecorner"
+	},
+/area/station/hallway/primary/central)
 "iZP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -44230,7 +44697,9 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/mine_sci_shuttle)
 "jbF" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
@@ -44300,7 +44769,9 @@
 	name = "Upper Atmospherics";
 	req_access = list(24)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -45145,7 +45616,9 @@
 	},
 /area/station/rnd/server)
 "jlx" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -45515,7 +45988,9 @@
 	name = "Distribution Loop";
 	req_access = list(24)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -45567,7 +46042,9 @@
 /turf/simulated/floor,
 /area/station/security/hos)
 "jqQ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -45693,7 +46170,9 @@
 	id_tag = "Dorm4";
 	name = "Dorm 4"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -45844,7 +46323,9 @@
 /turf/simulated/floor/engine/airmix,
 /area/station/engineering/atmos)
 "jtD" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/research{
 	dir = 4;
 	name = "Ordnance Launch Site";
@@ -45874,7 +46355,9 @@
 	},
 /area/station/rnd/tox_launch)
 "jtG" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -46145,7 +46628,9 @@
 	},
 /area/station/security/vacantoffice)
 "jwq" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	dir = 8;
 	id = "mine_shuttes";
@@ -46440,7 +46925,9 @@
 	name = "Engineering Auxiliary Storage";
 	req_access = list(12,71)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -46587,7 +47074,9 @@
 	},
 /area/station/security/brig)
 "jAD" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -47526,7 +48015,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
 "jKI" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -47803,7 +48294,9 @@
 	},
 /area/station/engineering/engine)
 "jNo" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
@@ -47815,7 +48308,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/glass{
 	dir = 4;
 	name = "Cryogenic Storage"
@@ -48020,7 +48515,9 @@
 	},
 /area/station/civilian/barbershop)
 "jPt" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/research{
 	dir = 4;
 	name = "Xenobiology Lab";
@@ -48151,7 +48648,9 @@
 	name = "Honk Office";
 	req_access = list(46)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/civilian/theatre)
 "jQh" = (
@@ -48241,7 +48740,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
@@ -48294,7 +48795,9 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "jSj" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -48504,7 +49007,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
 	id = "Cell 4 perma";
@@ -48659,7 +49164,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -49582,7 +50089,9 @@
 /turf/simulated/floor,
 /area/station/rnd/lab)
 "kfX" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -50214,7 +50723,9 @@
 	},
 /area/station/security/warden)
 "kmW" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/medical{
 	dir = 4;
 	id_tag = "MedTransOut";
@@ -50702,6 +51213,16 @@
 	icon_state = "neutralchoco"
 	},
 /area/station/medical/reception)
+"krQ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced/phoron{
+	grilled = 1;
+	icon_state = "gr_window_reinforced_phoron"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/engine)
 "krR" = (
 /turf/simulated/floor{
 	icon_state = "wooden"
@@ -50777,7 +51298,9 @@
 	},
 /area/station/rnd/hallway)
 "ksB" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -51310,7 +51833,9 @@
 	name = "Security E.V.A. Storage";
 	req_access = list(1)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -51427,7 +51952,9 @@
 	},
 /area/station/engineering/minisat_secure_area)
 "kAA" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -51568,7 +52095,9 @@
 	name = "Engineering External Access";
 	req_access = list(13)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -51677,7 +52206,9 @@
 	name = "Recycler Office";
 	req_access = list(67)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -51834,7 +52365,9 @@
 	name = "Mime's Backstage Room";
 	req_access = list(46)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -52023,7 +52556,9 @@
 	},
 /area/station/security/checkpoint/cargo)
 "kHq" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/command{
 	dir = 4;
 	name = "Chief Engineer's Quarters";
@@ -52355,7 +52890,9 @@
 	name = "Supermatter Shutters";
 	opacity = 0
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -52443,7 +52980,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/mine_sci_shuttle)
 "kKi" = (
@@ -52838,7 +53377,9 @@
 	},
 /area/station/security/hos)
 "kOb" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -52883,7 +53424,9 @@
 /turf/simulated/floor/plating,
 /area/station/rnd/misc_lab)
 "kOM" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -52974,7 +53517,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -52983,7 +53528,9 @@
 	},
 /area/station/bridge/hop_office)
 "kRe" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -53195,7 +53742,9 @@
 	},
 /area/station/storage/tech)
 "kSN" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/engineering/glass{
 	dir = 4;
 	name = "Engineering Storage";
@@ -53576,7 +54125,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "kXb" = (
@@ -53591,7 +54142,9 @@
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
 "kXd" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -53711,7 +54264,9 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories)
 "kYb" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/research{
 	dir = 4;
 	name = "Xenobiology Lab";
@@ -53994,7 +54549,9 @@
 	name = "Bar";
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/barricade/wooden{
 	layer = 2.8;
 	name = "doorway barricade"
@@ -54318,7 +54875,9 @@
 	},
 /area/station/hallway/primary/fore)
 "lfJ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/glass{
 	dir = 4;
 	name = "Service Bedrooms"
@@ -55130,7 +55689,9 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "purplechoco"
 	},
@@ -55371,7 +55932,9 @@
 /turf/simulated/floor,
 /area/station/ai_monitored/eva)
 "lrZ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -55396,6 +55959,20 @@
 /obj/item/device/plant_analyzer,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
+"lsu" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/minisat_secure_area)
 "lsw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/woodentable,
@@ -55450,7 +56027,9 @@
 	name = "Mech Bay";
 	req_access = list(29)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/rnd/chargebay)
 "lsP" = (
@@ -55852,6 +56431,16 @@
 	icon_state = "blackcorner"
 	},
 /area/station/hallway/primary/starboard)
+"lxj" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/storage/primary)
 "lxv" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor{
@@ -56514,7 +57103,9 @@
 	},
 /area/station/engineering/atmos)
 "lFK" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced/tinted{
 	grilled = 1;
 	icon_state = "gr_window_reinforced_tinted"
@@ -56736,7 +57327,9 @@
 	name = "Virology";
 	req_access = list(39)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/medical/virology)
 "lIj" = (
@@ -56860,7 +57453,9 @@
 	},
 /area/station/aisat/ai_chamber)
 "lJb" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -57144,7 +57739,9 @@
 	name = "Kitchen";
 	req_access = list(28)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -57173,7 +57770,9 @@
 	name = "Supermatter Shutters";
 	opacity = 0
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -57599,7 +58198,9 @@
 /turf/environment/space,
 /area/shuttle/mining/station)
 "lQI" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/security{
 	dir = 4;
 	name = "Armoury";
@@ -58101,7 +58702,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
@@ -58489,7 +59092,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "mcr" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	dir = 4;
 	id = "Skynet_launch";
@@ -59236,7 +59841,9 @@
 	name = "Robotics";
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/barricade/wooden{
 	layer = 2.8;
 	name = "doorway barricade"
@@ -59398,7 +60005,9 @@
 	},
 /area/station/medical/hallway)
 "mmP" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced/tinted{
 	grilled = 1;
 	icon_state = "gr_window_reinforced_tinted"
@@ -59436,7 +60045,9 @@
 	name = "Botany";
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/barricade/wooden{
 	layer = 2.8;
 	name = "doorway barricade"
@@ -59762,7 +60373,6 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "mre" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -59772,11 +60382,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall/r_wall,
 /area/station/engineering/break_room)
 "mrj" = (
 /obj/machinery/atmospherics/components/trinary/tvalve/mirrored/digital/bypass{
@@ -59791,7 +60397,9 @@
 	dir = 4;
 	name = "Auxiliary Tool Storage"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -59831,7 +60439,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -59876,29 +60486,15 @@
 	},
 /area/station/storage/tech)
 "msk" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "QM Lockdown Blast Doors";
-	name = "QM Lockdown Blast Doors";
-	opacity = 0
-	},
 /turf/simulated/floor/plating,
-/area/station/cargo/qm)
+/area/station/hallway/secondary/arrival)
 "mso" = (
 /turf/simulated/floor{
 	dir = 2;
@@ -59926,7 +60522,9 @@
 	},
 /area/station/engineering/minisat_secure_area)
 "msR" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced/phoron{
 	grilled = 1;
 	icon_state = "gr_window_reinforced_phoron"
@@ -60063,7 +60661,9 @@
 	name = "Engineering External Access";
 	req_access = list(10,13)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
@@ -60398,7 +60998,9 @@
 	},
 /area/station/storage/emergency)
 "mye" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/table/woodentable,
 /obj/item/weapon/book/manual/wiki/barman_recipes{
 	pixel_y = 10
@@ -60562,7 +61164,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "mzT" = (
@@ -61124,6 +61728,17 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/engine)
+"mFf" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/sign/plaques/kiddie/library,
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/library)
 "mFh" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -61339,7 +61954,9 @@
 	},
 /area/station/maintenance/science)
 "mIU" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -61376,7 +61993,9 @@
 	},
 /area/station/medical/surgeryobs)
 "mJd" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced/phoron{
 	grilled = 1;
 	icon_state = "gr_window_reinforced_phoron"
@@ -61924,7 +62543,9 @@
 /turf/simulated/floor/engine/n20,
 /area/station/engineering/atmos)
 "mQn" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/research{
 	dir = 4;
 	name = "Firing Range";
@@ -62398,7 +63019,9 @@
 	name = "Security Checkpoint";
 	req_access = list(1)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -62684,7 +63307,9 @@
 	},
 /area/station/rnd/hallway)
 "mWU" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -62696,7 +63321,9 @@
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "mWZ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/medical{
 	dir = 4;
 	req_access = list(6)
@@ -63227,7 +63854,9 @@
 	},
 /area/station/medical/hallway)
 "ndF" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -63859,7 +64488,9 @@
 	name = "Bar";
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/barricade/wooden{
 	layer = 2.8;
 	name = "doorway barricade"
@@ -63936,7 +64567,9 @@
 /area/station/cargo/lobby)
 "nmF" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -63995,7 +64628,9 @@
 	},
 /area/station/hallway/secondary/entry)
 "nnf" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -64069,7 +64704,9 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories)
 "non" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -64132,7 +64769,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboardsolar)
 "noW" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	dir = 4;
 	id = "pr_kitch_shuttes"
@@ -65738,7 +66377,9 @@
 /turf/simulated/floor,
 /area/station/engineering/atmos/atmos_office)
 "nFQ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -65887,7 +66528,9 @@
 /turf/simulated/floor/plating,
 /area/station/bridge/corp_lounge)
 "nHj" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/glass{
 	dir = 4;
 	name = "Recreation Room"
@@ -66096,7 +66739,9 @@
 	},
 /area/station/rnd/xenobiology)
 "nJt" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -66143,7 +66788,9 @@
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
 "nKg" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/glass{
 	dir = 4;
 	name = "Recreation Room"
@@ -66196,7 +66843,9 @@
 /area/station/hallway/primary/starboard)
 "nLd" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66326,7 +66975,9 @@
 	},
 /area/station/medical/chemistry)
 "nNa" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -66367,7 +67018,9 @@
 	},
 /area/station/bridge)
 "nNM" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -66628,7 +67281,9 @@
 /area/station/storage/primary)
 "nQy" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -66919,7 +67574,9 @@
 	},
 /area/station/security/brig/storage)
 "nSF" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "yellowcorner"
@@ -67048,7 +67705,9 @@
 	},
 /area/station/rnd/mixing)
 "nUd" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
@@ -67147,7 +67806,9 @@
 	},
 /area/station/medical/virology)
 "nVF" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -67178,7 +67839,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "nVJ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/engineering/glass{
 	dir = 4;
 	name = "Primary Tool Storage"
@@ -67262,7 +67925,9 @@
 	},
 /area/station/hallway/primary/port)
 "nWN" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -67359,7 +68024,9 @@
 	},
 /area/station/cargo/office)
 "nXA" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced/phoron{
 	grilled = 1;
 	icon_state = "gr_window_reinforced_phoron"
@@ -67421,7 +68088,9 @@
 /area/station/hallway/secondary/entry)
 "nYh" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/item/weapon/bell{
 	pixel_x = 4
 	},
@@ -67541,7 +68210,9 @@
 	name = "Departures Customs Desk";
 	req_access = list(19)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint/escape_custom_desk)
 "nYQ" = (
@@ -67922,6 +68593,19 @@
 	icon_state = "blackchoco"
 	},
 /area/station/medical/morgue)
+"odh" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/gym)
 "odu" = (
 /obj/machinery/computer/atmoscontrol{
 	dir = 4
@@ -68958,7 +69642,9 @@
 	},
 /area/station/cargo/storage)
 "osk" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/mining{
 	dir = 4;
 	name = "Cargo Bay";
@@ -69252,6 +69938,20 @@
 	icon_state = "floor"
 	},
 /area/shuttle/escape_pod2/station)
+"ouX" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/minisat_secure_area)
 "ouZ" = (
 /obj/machinery/door/airlock{
 	name = "Theater Backstage";
@@ -69477,7 +70177,9 @@
 	dir = 4;
 	name = "Escape Airlock"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "ozn" = (
@@ -69852,7 +70554,9 @@
 	name = "Library External Access";
 	req_one_access = list(13,45,1)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
@@ -70973,7 +71677,9 @@
 	name = "Engineering External Access";
 	req_access = list(13)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -71156,7 +71862,9 @@
 /turf/simulated/wall,
 /area/station/rnd/hallway)
 "oRS" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -71357,7 +72065,9 @@
 	},
 /area/station/civilian/gym)
 "oUf" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/engineering/glass{
 	dir = 4;
 	name = "Engineering Foyer";
@@ -71814,7 +72524,9 @@
 	name = "Chapel Maintenance";
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "oZK" = (
@@ -71967,7 +72679,9 @@
 /turf/simulated/wall,
 /area/station/civilian/barbershop)
 "pbQ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock{
 	dir = 4;
 	name = "Chapel Mass Driver"
@@ -72088,7 +72802,9 @@
 	},
 /area/station/medical/surgeryobs)
 "pdZ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
@@ -72307,7 +73023,9 @@
 	},
 /area/station/civilian/gym)
 "pfC" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -72322,7 +73040,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "pfR" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	dir = 4;
 	id = "cell4";
@@ -72586,26 +73306,17 @@
 	},
 /area/station/storage/primary)
 "pjq" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall/r_wall,
 /area/station/engineering/break_room)
 "pjw" = (
 /obj/structure/table/reinforced,
@@ -72755,7 +73466,9 @@
 	name = "Atmospherics Maintenance";
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "pkU" = (
@@ -73060,7 +73773,9 @@
 /turf/simulated/floor,
 /area/station/maintenance/engineering)
 "pnY" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -73475,26 +74190,17 @@
 	},
 /area/station/security/prison)
 "pss" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall/r_wall,
 /area/station/engineering/break_room)
 "pst" = (
 /turf/simulated/floor/plating,
@@ -73634,7 +74340,9 @@
 	name = "Coldroom";
 	req_access = list(28)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/civilian/cold_room)
 "pux" = (
@@ -73644,7 +74352,9 @@
 /turf/simulated/floor/carpet,
 /area/station/bridge/meeting_room)
 "puz" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/security{
 	dir = 4;
 	name = "Armoury";
@@ -73835,7 +74545,9 @@
 	},
 /area/station/rnd/scibreak)
 "pwK" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -74327,7 +75039,9 @@
 /turf/simulated/floor,
 /area/station/engineering/break_room)
 "pAS" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/glass{
 	dir = 4;
 	name = "Central Access"
@@ -74742,7 +75456,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/bridge)
 "pFf" = (
@@ -74776,7 +75492,9 @@
 	name = "Medsci Airlock";
 	req_one_access = list(2,47)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	dir = 4;
@@ -74876,7 +75594,9 @@
 	},
 /area/station/medical/reception)
 "pGM" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 5
 	},
@@ -75206,7 +75926,9 @@
 	},
 /area/station/civilian/hydroponics)
 "pLs" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -75500,7 +76222,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
@@ -75529,7 +76253,9 @@
 	},
 /area/station/security/checkpoint)
 "pPo" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -75567,7 +76293,9 @@
 /area/station/maintenance/engineering)
 "pPK" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/item/weapon/bell,
 /obj/machinery/door/window/eastleft{
 	dir = 8;
@@ -75644,7 +76372,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "pPY" = (
@@ -75973,7 +76703,9 @@
 	name = "Security Checkpoint";
 	req_access = list(1)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/security/checkpoint)
 "pTm" = (
@@ -76568,7 +77300,9 @@
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "qbh" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/command{
 	dir = 4;
 	name = "Research Director's Office";
@@ -76678,7 +77412,9 @@
 	},
 /area/station/engineering/atmos)
 "qbA" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
@@ -76861,7 +77597,9 @@
 	},
 /area/station/hallway/primary/central)
 "qea" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -76977,7 +77715,9 @@
 /turf/simulated/floor,
 /area/station/civilian/toilet)
 "qfC" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -77009,7 +77749,9 @@
 	},
 /area/station/engineering/engine)
 "qfR" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/glass{
 	dir = 4;
 	name = "Central Access"
@@ -77048,7 +77790,9 @@
 	},
 /area/station/rnd/robotics)
 "qgt" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/external{
 	dir = 4;
 	locked = 1;
@@ -77361,7 +78105,9 @@
 /obj/machinery/door/morgue{
 	name = "Confession Booth"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -77471,7 +78217,9 @@
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
 "qkR" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -78020,6 +78768,16 @@
 	icon_state = "blackchoco"
 	},
 /area/station/aisat/teleport)
+"qrc" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/break_room)
 "qrj" = (
 /turf/simulated/wall,
 /area/station/bridge/meeting_room)
@@ -78108,7 +78866,9 @@
 	},
 /area/station/security/brig/storage)
 "qsp" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/tinted{
 	grilled = 1;
 	icon_state = "gr_window_tinted"
@@ -78183,7 +78943,9 @@
 	},
 /area/station/security/prison)
 "qsS" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -78331,7 +79093,9 @@
 	},
 /area/station/security/prison)
 "qup" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/snacks/candy/cash,
 /obj/structure/sign/monkey_painting{
@@ -78422,7 +79186,9 @@
 	},
 /area/station/engineering/atmos/distribution)
 "quV" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/table/woodentable,
 /obj/item/weapon/bell,
 /obj/machinery/door/poddoor/shutters{
@@ -78461,7 +79227,9 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/hop_office)
 "qvQ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/glass{
 	dir = 4;
 	name = "Holodeck Door"
@@ -78826,7 +79594,9 @@
 	},
 /area/station/rnd/hallway)
 "qBN" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -78923,7 +79693,9 @@
 /turf/environment/space,
 /area/shuttle/escape_pod6/station)
 "qDg" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	dir = 4;
@@ -79014,7 +79786,9 @@
 	},
 /area/station/rnd/hallway)
 "qDH" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -79147,7 +79921,9 @@
 /turf/simulated/floor,
 /area/station/engineering/engine)
 "qEV" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/glass{
 	dir = 4;
 	name = "Central Access"
@@ -79212,7 +79988,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "qFs" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -79244,7 +80022,9 @@
 	},
 /area/station/maintenance/cargo)
 "qGe" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/command/glass{
 	dir = 4;
 	name = "Customs Post";
@@ -79491,7 +80271,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "qIP" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -79595,7 +80377,9 @@
 	},
 /area/station/aisat/ai_chamber)
 "qJX" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/command{
 	dir = 4;
 	name = "Quartermaster's Office";
@@ -79653,6 +80437,14 @@
 	icon_state = "graychoco"
 	},
 /area/station/storage/emergency2)
+"qKf" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralcorner"
+	},
+/area/station/hallway/primary/central)
 "qKo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -79720,7 +80512,9 @@
 	name = "Drawing Room";
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "qLu" = (
@@ -79760,7 +80554,9 @@
 	},
 /area/station/rnd/hallway/lobby)
 "qLM" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -80152,7 +80948,9 @@
 	},
 /area/station/medical/hallway)
 "qQL" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/research{
 	dir = 4;
 	name = "Science Break Room";
@@ -81103,15 +81901,10 @@
 /turf/simulated/floor,
 /area/station/engineering/atmos/supermatter)
 "rbK" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall,
 /area/station/civilian/gym)
 "rbL" = (
 /obj/structure/curtain/open/shower/security,
@@ -81128,7 +81921,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "rbW" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -81197,14 +81992,16 @@
 	},
 /area/station/engineering/atmos)
 "rcM" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/sign/warning/vacuum,
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
 /turf/simulated/floor/plating,
-/area/station/hallway/primary/central)
+/area/station/hallway/secondary/entry)
 "rcQ" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -82026,7 +82823,9 @@
 /turf/simulated/floor/plating,
 /area/station/civilian/toilet)
 "roF" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "roG" = (
@@ -82185,7 +82984,9 @@
 	},
 /area/station/medical/cmo)
 "rqx" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -82312,7 +83113,9 @@
 /turf/simulated/floor/plating,
 /area/space)
 "rrY" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -82424,7 +83227,9 @@
 	},
 /area/station/hallway/primary/port)
 "rtq" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -82467,7 +83272,9 @@
 /area/station/maintenance/atmos)
 "rtx" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
 	dir = 4;
@@ -82499,7 +83306,9 @@
 	},
 /area/station/engineering/engine)
 "rtQ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -82617,16 +83426,11 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "rvh" = (
-/obj/machinery/door/firedoor,
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'KEEP CLEAR OF DOCKING AREA'.";
 	name = "KEEP CLEAR: DOCKING AREA"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall/r_wall,
 /area/station/maintenance/auxsolarstarboard)
 "rvt" = (
 /obj/structure/cable{
@@ -82705,7 +83509,9 @@
 	},
 /area/station/hallway/primary/central)
 "rwb" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/glass{
 	dir = 4;
 	name = "Dormitory"
@@ -83211,7 +84017,9 @@
 	},
 /area/station/storage/primary)
 "rAm" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -83587,7 +84395,9 @@
 	},
 /area/station/hallway/primary/central)
 "rEs" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/command{
 	dir = 4;
 	name = "Quartermaster's Office";
@@ -83687,7 +84497,9 @@
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
 "rFp" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	dir = 4;
 	id = "cell1";
@@ -83956,7 +84768,9 @@
 	},
 /area/station/civilian/library)
 "rIs" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -84077,7 +84891,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock{
 	dir = 4;
 	name = "Hydroponics Pasture";
@@ -84270,7 +85086,9 @@
 	},
 /area/station/cargo/lobby)
 "rKA" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/structure/window/fulltile/reinforced/tinted{
 	grilled = 1;
@@ -84436,7 +85254,9 @@
 	},
 /area/station/security/prison)
 "rMM" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -84996,7 +85816,9 @@
 	},
 /area/station/hallway/primary/fore)
 "rSY" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/table/woodentable,
 /obj/item/weapon/storage/wallet/random,
 /obj/machinery/door/poddoor/shutters{
@@ -85227,6 +86049,16 @@
 	},
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories/service_bedrooms)
+"rWm" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/central)
 "rWn" = (
 /obj/machinery/gateway{
 	dir = 1
@@ -85707,7 +86539,9 @@
 	name = "Clown's Backstage Room";
 	req_access = list(46)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -86263,7 +87097,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
 	id = "Cell 2 perma";
@@ -86401,7 +87237,9 @@
 	},
 /area/station/security/checkpoint)
 "sjL" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -86511,7 +87349,9 @@
 	},
 /area/station/security/range)
 "sku" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/medical/glass{
 	dir = 4;
 	name = "Medbay Treatment Center";
@@ -86879,7 +87719,9 @@
 	},
 /area/station/security/armoury)
 "soF" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 2;
 	icon_state = "bluecorner"
@@ -86932,7 +87774,9 @@
 	},
 /area/station/hallway/primary/fore)
 "sps" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -87164,7 +88008,9 @@
 	name = "Robotics Lab";
 	req_access = list(29)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/rnd/robotics)
 "sse" = (
@@ -87245,14 +88091,16 @@
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
 "stv" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable,
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/structure/cable,
 /turf/simulated/floor/plating,
-/area/station/security/brig)
+/area/station/security/checkpoint/medbay)
 "stz" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -87489,6 +88337,19 @@
 	icon_state = "bluefull"
 	},
 /area/station/civilian/locker)
+"swr" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/gym)
 "sws" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -87524,7 +88385,9 @@
 	},
 /area/station/bridge/nuke_storage)
 "swO" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock{
 	dir = 4;
 	name = "Courtroom"
@@ -87648,7 +88511,9 @@
 	},
 /area/station/security/brig)
 "syV" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -88114,7 +88979,9 @@
 	},
 /area/station/civilian/chapel)
 "sEr" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -89087,7 +89954,9 @@
 	},
 /area/station/engineering/engine)
 "sPV" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -89120,6 +89989,16 @@
 	},
 /turf/simulated/floor/grass,
 /area/station/hallway/primary/fore)
+"sQu" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/storage)
 "sQv" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -89477,26 +90356,17 @@
 	},
 /area/station/civilian/dormitories)
 "sUX" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall/r_wall,
 /area/station/engineering/break_room)
 "sUZ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -89735,7 +90605,9 @@
 /area/space)
 "sYm" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -89748,7 +90620,9 @@
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
 "sYu" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -90238,7 +91112,9 @@
 	},
 /area/shuttle/supply/station)
 "tfj" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -90400,6 +91276,16 @@
 	icon_state = "bluecorner"
 	},
 /area/station/hallway/primary/starboard)
+"tgJ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/locker)
 "tgM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -91138,7 +92024,9 @@
 	},
 /area/station/civilian/chapel)
 "tqo" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/security/glass{
 	dir = 4;
 	name = "Prison Wing";
@@ -91242,7 +92130,9 @@
 	name = "Bar Backroom";
 	req_access = list(25)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -91567,7 +92457,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "twd" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/security/glass{
 	dir = 4;
 	name = "Prison Wing";
@@ -91762,7 +92654,9 @@
 	},
 /area/station/hallway/primary/port)
 "txP" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "browncorner"
@@ -91871,6 +92765,16 @@
 /obj/machinery/atmospherics/components/unary/portables_connector,
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos/supermatter)
+"tze" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/medbay)
 "tzh" = (
 /obj/machinery/alarm{
 	pixel_x = 29;
@@ -92105,7 +93009,9 @@
 	name = "Chapel Maintenance";
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -92395,7 +93301,9 @@
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/atmos)
 "tEG" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -92748,7 +93656,9 @@
 	},
 /area/station/cargo/storage)
 "tIQ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -92826,7 +93736,9 @@
 	},
 /area/station/bridge/teleporter)
 "tJV" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -92964,7 +93876,9 @@
 	},
 /area/station/tcommsat/computer)
 "tLU" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/glass{
 	dir = 4;
 	name = "Central Access"
@@ -94310,7 +95224,9 @@
 	},
 /area/station/engineering/chiefs_office)
 "ucP" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock{
 	dir = 4;
 	name = "Bar Backroom";
@@ -94393,7 +95309,9 @@
 	},
 /area/station/security/checkpoint/escape_custom_desk)
 "udW" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/table/reinforced,
 /obj/item/weapon/bell,
 /obj/machinery/door/window/westright{
@@ -94463,7 +95381,9 @@
 	name = "Engineering External Access";
 	req_one_access = list(10,11,13,24)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
@@ -94518,7 +95438,9 @@
 	},
 /area/station/engineering/atmos)
 "ufI" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/security{
 	dir = 4;
 	name = "Security Post - Cargo";
@@ -94847,7 +95769,9 @@
 /turf/simulated/floor,
 /area/station/maintenance/chapel)
 "uja" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -94997,7 +95921,9 @@
 /turf/environment/space,
 /area/shuttle/escape_pod3/station)
 "uks" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 1
 	},
@@ -95043,7 +95969,9 @@
 	},
 /area/station/hallway/primary/starboard)
 "ukX" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/command{
 	dir = 4;
 	name = "Research Director's Quarters";
@@ -95108,7 +96036,9 @@
 	name = "Brig Maintenance";
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "ulr" = (
@@ -95165,7 +96095,9 @@
 /turf/simulated/floor/plating,
 /area/station/security/prison)
 "ulV" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	dir = 8;
 	id = "vac_offic";
@@ -95207,7 +96139,9 @@
 	dir = 4;
 	name = "Locker Room"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -95325,22 +96259,15 @@
 /turf/simulated/floor/plating,
 /area/station/rnd/xenobiology)
 "unp" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
 /turf/simulated/floor/plating,
-/area/station/bridge/nuke_storage)
+/area/station/maintenance/chapel)
 "uns" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -95642,7 +96569,9 @@
 	},
 /area/station/cargo/storage)
 "urd" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
@@ -95880,7 +96809,9 @@
 	},
 /area/station/cargo/recycleroffice)
 "uuf" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/glass{
 	dir = 4;
 	name = "Central Access"
@@ -96200,7 +97131,9 @@
 	},
 /area/station/hallway/primary/central)
 "uxZ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -96349,7 +97282,9 @@
 	},
 /area/station/aisat)
 "uAU" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -96853,7 +97788,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "uHN" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -96959,7 +97896,9 @@
 /turf/environment/space/shuttle,
 /area/shuttle/escape_pod3/station)
 "uJZ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -96991,6 +97930,20 @@
 "uKd" = (
 /turf/simulated/wall/r_wall,
 /area/station/security/armoury)
+"uKe" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/brig)
 "uKh" = (
 /turf/simulated/floor{
 	icon_state = "blackchoco"
@@ -97089,6 +98042,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/bridge/corp_lounge)
+"uLv" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/reception)
 "uLI" = (
 /obj/structure/sign/warning,
 /turf/simulated/wall/r_wall,
@@ -97212,7 +98175,9 @@
 	},
 /area/station/civilian/dormitories)
 "uNl" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -97283,7 +98248,9 @@
 	},
 /area/station/gateway)
 "uOm" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -97705,7 +98672,9 @@
 /area/station/security/vacantoffice)
 "uTw" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/window/westleft{
 	name = "Hydroponics";
 	req_access = list(35)
@@ -98101,7 +99070,9 @@
 	name = "Dining Room";
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/barricade/wooden{
 	layer = 2.8;
 	name = "doorway barricade"
@@ -98138,7 +99109,9 @@
 	name = "Atmospherics Desk";
 	req_access = list(24)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -98156,29 +99129,15 @@
 	},
 /area/station/engineering/monitoring)
 "uYs" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	icon_state = "pdoor0";
-	id = "QM Lockdown Blast Doors";
-	name = "QM Lockdown Blast Doors";
-	opacity = 0
-	},
 /turf/simulated/floor/plating,
-/area/station/cargo/qm)
+/area/station/hallway/secondary/mine_sci_shuttle)
 "uYM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -98413,7 +99372,9 @@
 	id_tag = "Dorm3";
 	name = "Dorm 3"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -98743,7 +99704,9 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/meeting_room)
 "vgk" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -99230,7 +100193,9 @@
 	pixel_y = 28
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
 	dir = 4;
@@ -99398,7 +100363,9 @@
 	name = "Engineering External Access";
 	req_one_access = list(13,45,1)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "vnU" = (
@@ -99613,6 +100580,14 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"vpM" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor{
+	icon_state = "neutralfull"
+	},
+/area/station/hallway/primary/central)
 "vpT" = (
 /turf/simulated/floor{
 	dir = 8;
@@ -99754,7 +100729,9 @@
 	},
 /area/station/medical/medbreak)
 "vrC" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/engineering{
 	dir = 4;
 	name = "Engineering Break Room";
@@ -99841,7 +100818,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "vsI" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/engineering/glass{
 	dir = 4;
 	name = "Engineering Break Room";
@@ -100069,25 +101048,20 @@
 	},
 /area/station/security/main)
 "vvv" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/sign/directions/engineering{
+	desc = "A sign that shows there are doors here. There are doors everywhere!";
+	icon_state = "doors";
+	name = "WARNING: EXTERNAL AIRLOCK"
 	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/poddoor{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id = "QM Lockdown Blast Doors";
-	name = "QM Lockdown Blast Doors";
-	opacity = 0
-	},
 /turf/simulated/floor/plating,
-/area/station/cargo/qm)
+/area/station/hallway/secondary/entry)
 "vvy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -100120,7 +101094,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -100291,7 +101267,9 @@
 /turf/simulated/floor,
 /area/station/maintenance/brig)
 "vys" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 8;
 	icon_state = "neutralcorner"
@@ -100499,7 +101477,9 @@
 	},
 /area/station/hallway/primary/central)
 "vAK" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -101178,7 +102158,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/window/brigdoor{
 	dir = 4;
 	id = "Cell 3 perma";
@@ -101247,7 +102229,9 @@
 	},
 /area/station/cargo/storage)
 "vKC" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/medical{
 	dir = 4;
 	name = "Paramedic Dispatch";
@@ -101484,7 +102468,9 @@
 	name = "Departures Customs Desk";
 	req_access = list(19)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "bluechoco"
 	},
@@ -102989,7 +103975,9 @@
 	},
 /area/station/civilian/barbershop)
 "wfw" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/external{
 	dir = 4;
 	name = "Escape Airlock";
@@ -103606,7 +104594,9 @@
 	},
 /area/station/security/prison)
 "wmj" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -103857,7 +104847,9 @@
 	},
 /area/station/cargo/office)
 "wpm" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "neutralcorner"
@@ -104135,7 +105127,9 @@
 	},
 /area/station/security/warden)
 "wsS" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/glass{
 	dir = 4;
 	name = "Hydroponics";
@@ -104664,7 +105658,9 @@
 /turf/simulated/floor,
 /area/station/engineering/engine)
 "wAr" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -104791,7 +105787,9 @@
 	},
 /area/station/hallway/secondary/entry)
 "wBa" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -104909,7 +105907,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "wBR" = (
@@ -105046,7 +106046,9 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
 "wDB" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -105072,7 +106074,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/gateway)
 "wDG" = (
@@ -105210,7 +106214,9 @@
 /turf/simulated/floor,
 /area/station/maintenance/atmos)
 "wFU" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/mining{
 	dir = 4;
 	name = "Cargo Bay";
@@ -105228,7 +106234,9 @@
 /turf/simulated/floor/wood,
 /area/station/maintenance/atmos)
 "wFY" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -105758,7 +106766,9 @@
 	grilled = 1;
 	icon_state = "gr_window"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/barricade/wooden,
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
@@ -105838,7 +106848,9 @@
 	name = "Drawing Room";
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "wOp" = (
@@ -105981,7 +106993,9 @@
 	},
 /area/station/hallway/primary/central)
 "wPK" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	dir = 4;
 	id = "warehouse_shuttes";
@@ -106077,7 +107091,9 @@
 /turf/simulated/floor/engine,
 /area/station/rnd/mixing)
 "wRk" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -106419,7 +107435,9 @@
 	},
 /area/station/engineering/atmos/supermatter)
 "wVt" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -106543,6 +107561,16 @@
 	icon_state = "bluechecker"
 	},
 /area/station/medical/storage)
+"wXb" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/rnd/hallway/lobby)
 "wXp" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -106588,7 +107616,9 @@
 	},
 /area/station/civilian/dormitories/courtroom)
 "wXX" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -106844,7 +107874,9 @@
 	},
 /area/station/civilian/cold_room)
 "xau" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -106910,7 +107942,9 @@
 	},
 /area/station/hallway/secondary/exit)
 "xbd" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -106944,7 +107978,9 @@
 	},
 /area/station/civilian/chapel/mass_driver)
 "xbG" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/window/brigdoor{
 	dir = 4
 	},
@@ -107020,7 +108056,9 @@
 	name = "Atmospherics Project Closet";
 	req_access = list(24)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/barricade/wooden{
 	layer = 2.8;
 	name = "doorway barricade"
@@ -107227,7 +108265,9 @@
 	},
 /area/station/aisat)
 "xeH" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	dir = 4;
 	id = "teleporter_in_shutter";
@@ -107319,7 +108359,9 @@
 	},
 /area/station/engineering/minisat_secure_area)
 "xgd" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -107428,7 +108470,9 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "xhv" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -107482,6 +108526,16 @@
 /obj/random/tools/tool,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"xii" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/science)
 "xim" = (
 /obj/effect/landmark/start/chemist,
 /obj/structure/stool/bed/chair/office/light{
@@ -107809,7 +108863,9 @@
 	id_tag = "Dorm1";
 	name = "Dorm 1"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "graychoco"
 	},
@@ -107928,7 +108984,9 @@
 /area/station/rnd/storage)
 "xob" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/window/eastright{
 	base_state = "left";
 	dir = 8;
@@ -108159,7 +109217,9 @@
 	name = "CMF altering";
 	req_access = list(60)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "blackchoco"
 	},
@@ -108321,7 +109381,9 @@
 	},
 /area/station/rnd/tox_launch)
 "xrB" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -108510,7 +109572,9 @@
 	},
 /area/station/medical/chemistry)
 "xsY" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -108539,7 +109603,9 @@
 	name = "Engine Room";
 	req_access = list(10)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -108911,7 +109977,9 @@
 /turf/simulated/wall/r_wall,
 /area/station/medical/hallway)
 "xxp" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -109076,7 +110144,9 @@
 /turf/environment/space,
 /area/space)
 "xzg" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -109114,7 +110184,9 @@
 	},
 /area/station/engineering/chiefs_office)
 "xzz" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/glass{
 	dir = 4;
 	name = "Central Access"
@@ -109193,7 +110265,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "xAi" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/security/glass{
 	dir = 4;
 	id_tag = "InnerBrig";
@@ -109206,13 +110280,17 @@
 	},
 /area/station/security/brig)
 "xAl" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "neutralcorner"
 	},
 /area/station/security/lobby)
 "xAm" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
@@ -109633,21 +110711,12 @@
 	},
 /area/station/engineering/chiefs_office)
 "xEE" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/structure/window/fulltile/reinforced{
-	grilled = 1;
-	icon_state = "gr_window_reinforced"
-	},
-/turf/simulated/floor/plating,
+/turf/simulated/wall/r_wall,
 /area/station/engineering/break_room)
 "xEL" = (
 /obj/item/weapon/flora/random,
@@ -109722,7 +110791,9 @@
 	name = "Supply Dock Loading Door"
 	},
 /obj/structure/plasticflaps/mining,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/conveyor{
 	dir = 8;
 	id = "QMLoad2"
@@ -110111,7 +111182,9 @@
 	},
 /area/station/security/brig)
 "xKv" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/external{
 	dir = 4;
 	locked = 1;
@@ -110586,7 +111659,9 @@
 	},
 /area/station/civilian/dormitories/service_bedrooms)
 "xPZ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -110646,7 +111721,9 @@
 	},
 /area/station/engineering/atmos/supermatter)
 "xQz" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -110723,7 +111800,9 @@
 	},
 /area/station/engineering/break_room)
 "xRz" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/security/glass{
 	dir = 4;
 	name = "Warden's Office";
@@ -111092,7 +112171,9 @@
 /turf/simulated/floor/grass,
 /area/station/civilian/kitchen)
 "xVn" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -111339,7 +112420,9 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/fore)
 "xXy" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/research{
 	dir = 4;
 	name = "Mech Bay";
@@ -111686,7 +112769,9 @@
 /area/station/hallway/secondary/mine_sci_shuttle)
 "ybJ" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/item/weapon/storage/fancy/donut_box{
 	pixel_y = 8
 	},
@@ -111743,7 +112828,9 @@
 /turf/simulated/floor/wood,
 /area/station/maintenance/science)
 "yce" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/security/glass{
 	dir = 4;
 	name = "Gear Room";
@@ -112225,7 +113312,9 @@
 /turf/simulated/floor/grass,
 /area/station/civilian/kitchen)
 "yhM" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
@@ -112453,7 +113542,9 @@
 	},
 /area/station/civilian/chapel)
 "ylh" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -130164,13 +131255,13 @@ kHU
 plf
 cjx
 cjx
-vee
-vee
-vee
-vee
-vee
-vee
-vee
+xii
+xii
+xii
+xii
+xii
+xii
+xii
 cjx
 cjx
 plf
@@ -131155,13 +132246,13 @@ xXN
 rOC
 xkv
 tvt
-hbP
-hbP
-hbP
+lsu
+lsu
+lsu
 sEx
 pLs
-hbP
-hbP
+lsu
+lsu
 tvt
 tvt
 kHU
@@ -131701,7 +132792,7 @@ cjx
 aQr
 vnx
 cjx
-vee
+xii
 rrY
 cjx
 lUT
@@ -132751,10 +133842,10 @@ gZk
 cjx
 fUZ
 fUZ
-vee
+xii
 fUZ
-vee
-vee
+fUZ
+fUZ
 plf
 lgc
 kHU
@@ -133268,9 +134359,9 @@ irt
 ezW
 oMd
 lRm
-vee
 fUZ
-vee
+fUZ
+xii
 fUZ
 fUZ
 kHU
@@ -133986,9 +135077,9 @@ tvt
 tvt
 tvt
 tvt
-idM
+ouX
 tvt
-idM
+ouX
 tvt
 tvt
 fzd
@@ -134300,9 +135391,9 @@ hUv
 gjC
 xGR
 ilA
-vee
-vee
-vee
+fUZ
+xii
+fUZ
 plf
 plf
 kHU
@@ -134816,7 +135907,7 @@ eKr
 pJk
 lRm
 xQx
-fUZ
+vee
 kHU
 kHU
 kHU
@@ -135330,7 +136421,7 @@ eKr
 oIO
 lRm
 qCM
-fUZ
+vee
 kHU
 kHU
 kHU
@@ -135769,13 +136860,13 @@ isX
 gVm
 rYi
 vPk
-pte
-pte
+aqD
+aqD
 vPk
 vPk
 vPk
-ifq
-ifq
+qrc
+qrc
 qlj
 eCF
 qJk
@@ -135794,9 +136885,9 @@ mBg
 qDT
 nsa
 nsa
-bKu
-bKu
-bKu
+krQ
+krQ
+krQ
 bKu
 iPv
 vqL
@@ -135804,9 +136895,9 @@ mTb
 bAA
 gnl
 bKu
-bKu
-bKu
-bKu
+krQ
+krQ
+krQ
 nsa
 nsa
 aIU
@@ -135842,9 +136933,9 @@ stP
 gjC
 gmu
 uvN
-vee
-vee
-vee
+fUZ
+xii
+fUZ
 plf
 plf
 kHU
@@ -136291,7 +137382,7 @@ rwr
 sQF
 dWt
 qlj
-ifq
+qrc
 vsI
 qlj
 ehA
@@ -136785,9 +137876,9 @@ itq
 itq
 itq
 itq
-dKG
+aGb
 itq
-dKG
+aGb
 itq
 itq
 hnu
@@ -138870,7 +139961,7 @@ mFv
 jUm
 oVp
 oVp
-rwR
+bAU
 ndF
 cvI
 oVp
@@ -139940,7 +141031,7 @@ sLj
 pAm
 nPD
 fUZ
-vee
+xii
 fUZ
 fbF
 kNm
@@ -140234,11 +141325,11 @@ plf
 kHU
 plf
 kHU
-xcZ
+ifo
 xcZ
 kBR
 xcZ
-xcZ
+ifo
 kHU
 pka
 plf
@@ -140618,10 +141709,10 @@ plf
 plf
 plf
 wwi
-obm
+gdp
 wwi
 wwi
-obm
+gdp
 tEF
 kqh
 bec
@@ -143677,10 +144768,10 @@ plf
 yaE
 qYg
 yaE
-yaE
-yaE
-yaE
-yaE
+bjt
+bjt
+bjt
+bjt
 yaE
 qYg
 yaE
@@ -143690,11 +144781,11 @@ plf
 plf
 plf
 ffS
-yaE
-yaE
-yaE
+bjt
+bjt
+bjt
 wwi
-obm
+gdp
 wwi
 maK
 aHs
@@ -143927,10 +145018,10 @@ ffS
 ffS
 ffS
 ffS
-yaE
-yaE
+bjt
+bjt
 ffS
-aev
+rcM
 yaE
 xKv
 yaE
@@ -143941,11 +145032,11 @@ cmk
 yaE
 xKv
 yaE
-eeB
+vvv
 ffS
-yaE
-yaE
-yaE
+bjt
+bjt
+bjt
 ffS
 hkD
 hkD
@@ -144955,10 +146046,10 @@ ffS
 ffS
 ffS
 ffS
-yaE
-yaE
+bjt
+bjt
 ffS
-eeB
+vvv
 yaE
 xKv
 yaE
@@ -144968,11 +146059,11 @@ nnd
 cmk
 ffS
 ffS
-yaE
-aev
+bjt
+rcM
 ffS
-yaE
-yaE
+bjt
+bjt
 ffS
 fAi
 lNi
@@ -145219,7 +146310,7 @@ plf
 yaE
 qYg
 yaE
-yaE
+bjt
 ffS
 ffS
 ffS
@@ -145487,8 +146578,8 @@ mTn
 mTn
 mTn
 acd
-byS
-byS
+msk
+msk
 csG
 fYS
 gUH
@@ -145634,7 +146725,7 @@ nba
 tIo
 tIo
 tIo
-gjJ
+tze
 tIo
 tIo
 plf
@@ -146000,9 +147091,9 @@ mTn
 mTn
 mTn
 mTn
-byS
-byS
-byS
+msk
+msk
+msk
 hkD
 fYS
 oOy
@@ -146141,7 +147232,7 @@ aaF
 hqd
 tIo
 tIo
-gjJ
+tze
 tIo
 tIo
 kHU
@@ -146315,20 +147406,20 @@ eza
 urf
 aVs
 aVs
-dka
-dka
+lxj
+lxj
 nVJ
 nVJ
-dka
-dka
+lxj
+lxj
 aVs
 aVs
 tLU
 bed
 iYt
 pbn
-pHa
-pHa
+hiM
+hiM
 pbn
 yhw
 ugS
@@ -146344,12 +147435,12 @@ oZa
 oZa
 oZa
 oZa
-ugI
+wXb
 veM
-ugI
+wXb
 wBa
 jlx
-ugI
+wXb
 vIl
 vIl
 vNW
@@ -147542,9 +148633,9 @@ mTn
 mTn
 mTn
 mTn
-byS
-byS
-byS
+msk
+msk
+msk
 gQw
 fYS
 slo
@@ -147594,9 +148685,9 @@ fIn
 ogP
 kXR
 hBZ
-rPX
-rPX
-rPX
+rWm
+rWm
+rWm
 lYH
 jxu
 gNf
@@ -147806,12 +148897,12 @@ aaD
 fYS
 mZi
 ffS
-yaE
-yaE
-yaE
-yaE
-yaE
-yaE
+bjt
+bjt
+bjt
+bjt
+bjt
+bjt
 ffS
 eQO
 fDL
@@ -147891,8 +148982,8 @@ aZe
 amN
 aVg
 pwK
-aBP
-bbt
+vpM
+iZM
 fAY
 bZk
 kOb
@@ -148057,8 +149148,8 @@ mTn
 mTn
 mTn
 acd
-byS
-byS
+msk
+msk
 rCP
 fYS
 rEz
@@ -148303,7 +149394,7 @@ plf
 yaE
 qYg
 yaE
-yaE
+bjt
 ffS
 ffS
 ffS
@@ -148553,10 +149644,10 @@ ffS
 ffS
 ffS
 ffS
-yaE
-yaE
+bjt
+bjt
 ffS
-aev
+rcM
 yaE
 qgt
 yaE
@@ -148566,11 +149657,11 @@ bix
 cmk
 ffS
 ffS
-yaE
-eeB
+bjt
+vvv
 ffS
-yaE
-yaE
+bjt
+bjt
 ffS
 fAi
 coT
@@ -149581,10 +150672,10 @@ ffS
 ffS
 ffS
 ffS
-yaE
-yaE
+bjt
+bjt
 ffS
-eeB
+vvv
 yaE
 qgt
 yaE
@@ -149595,22 +150686,22 @@ uSg
 yaE
 qgt
 yaE
-aev
+rcM
 ffS
-yaE
-yaE
+bjt
+bjt
 ffS
 ffS
 upq
 fYS
 wjU
 ffS
-yaE
-yaE
-yaE
-yaE
-yaE
-yaE
+bjt
+bjt
+bjt
+bjt
+bjt
+bjt
 ffS
 wii
 fYS
@@ -149648,7 +150739,7 @@ jQg
 bRX
 bSa
 uNl
-kRo
+qKf
 oVk
 kHU
 kHU
@@ -149845,10 +150936,10 @@ plf
 yaE
 qYg
 yaE
-yaE
-yaE
-yaE
-yaE
+bjt
+bjt
+bjt
+bjt
 yaE
 qYg
 yaE
@@ -150883,9 +151974,9 @@ plf
 plf
 plf
 plf
-yaE
-yaE
-yaE
+bjt
+bjt
+bjt
 csG
 fYS
 iMr
@@ -150991,9 +152082,9 @@ map
 qGQ
 kEm
 rSa
-msA
+axJ
 bWo
-cEh
+stv
 rSa
 rSa
 uqj
@@ -151397,8 +152488,8 @@ plf
 plf
 plf
 plf
-yaE
-yaE
+bjt
+bjt
 glx
 oDk
 fYS
@@ -151769,10 +152860,10 @@ mne
 vTJ
 sBD
 aMR
-sbr
+bni
 sBD
 sBD
-sbr
+bni
 sBD
 sBD
 sXj
@@ -152415,10 +153506,10 @@ plf
 yaE
 ruV
 yaE
-yaE
-yaE
-yaE
-yaE
+bjt
+bjt
+bjt
+bjt
 yaE
 ruV
 yaE
@@ -152664,11 +153755,11 @@ lgc
 kHU
 kHU
 ffS
-yaE
+bjt
 glU
-yaE
+bjt
 ffS
-aev
+rcM
 yaE
 qgt
 yaE
@@ -152679,10 +153770,10 @@ cmk
 yaE
 qgt
 yaE
-eeB
+vvv
 ffS
-yaE
-yaE
+bjt
+bjt
 ffS
 cmm
 nsh
@@ -153246,7 +154337,7 @@ lBT
 mXC
 txP
 aeD
-wLD
+fYX
 oVk
 kHU
 kHU
@@ -154726,7 +155817,7 @@ tYn
 jQK
 sGc
 tYn
-nRr
+uYs
 lgb
 wLU
 oPi
@@ -154985,15 +156076,15 @@ uWL
 tYn
 kHU
 lgb
-nRr
-nRr
-nRr
-nRr
-nRr
+uYs
+uYs
+uYs
+uYs
+uYs
 lgb
-nRr
+uYs
 kKg
-nRr
+uYs
 lgb
 pnq
 srs
@@ -155304,9 +156395,9 @@ bzv
 mij
 hAU
 hBZ
-rPX
-rPX
-rPX
+rWm
+rWm
+rWm
 lYH
 jxu
 pBI
@@ -155601,13 +156692,13 @@ rZn
 rZn
 rZn
 alz
-aBP
+vpM
 soF
 icJ
-tDl
+uLv
 imr
 imr
-tDl
+uLv
 icJ
 nPb
 nPb
@@ -155749,7 +156840,7 @@ plf
 plf
 pka
 kHU
-kmD
+tYn
 kmD
 iNl
 kmD
@@ -156321,9 +157412,9 @@ vEp
 gng
 cpR
 cpR
-tiC
-tiC
-tiC
+sQu
+sQu
+sQu
 cpR
 cpR
 gtK
@@ -156589,11 +157680,11 @@ cBp
 lGt
 hBZ
 hBZ
-rNH
+hBZ
 bor
 abz
-unp
-rcM
+bor
+hBZ
 hBZ
 hBZ
 cmN
@@ -156635,11 +157726,11 @@ kbS
 kbS
 kbS
 kbS
-exA
+fpn
 abk
-fSl
+mFf
 abm
-exA
+fpn
 kbS
 kbS
 aac
@@ -156939,11 +158030,11 @@ rmY
 rmY
 rmY
 rmY
-sug
-sug
-sug
-sug
-sug
+amx
+amx
+amx
+amx
+amx
 rmY
 plf
 kHU
@@ -158354,8 +159445,8 @@ nSZ
 nSZ
 oWa
 fTz
-sDU
-sDU
+bDl
+bDl
 cpR
 sDU
 sbg
@@ -158365,8 +159456,8 @@ fJP
 kTj
 sDU
 cpR
-sDU
-sDU
+bDl
+bDl
 cpR
 cpR
 twC
@@ -159961,7 +161052,7 @@ vst
 vst
 sXW
 rwb
-mFY
+tgJ
 dFp
 bYH
 bYH
@@ -160168,12 +161259,12 @@ kHU
 plf
 plf
 plf
-rlx
+gtE
 eaH
 oOv
 xRi
 uYY
-rlx
+gtE
 kHU
 plf
 plf
@@ -160272,9 +161363,9 @@ pbQ
 eiH
 eiH
 eiH
-mUR
-mUR
-mUR
+eRX
+eRX
+eRX
 eiH
 nHC
 plf
@@ -160425,12 +161516,12 @@ kHU
 kHU
 kHU
 kHU
-uYs
-cym
 twC
 twC
-vvv
-msk
+twC
+twC
+twC
+twC
 kHU
 plf
 plf
@@ -161472,8 +162563,8 @@ cHH
 cHH
 jxX
 hwE
-bjt
-stv
+jxX
+cHH
 jxX
 hwE
 jxX
@@ -161518,11 +162609,11 @@ xRq
 kbS
 kbS
 kbS
-exA
+fpn
 eRc
-fSl
+mFf
 hWH
-exA
+fpn
 kbS
 kbS
 vtk
@@ -163287,7 +164378,7 @@ jlg
 xhv
 adp
 uOm
-uRO
+uKe
 xAi
 adp
 xhv
@@ -165380,7 +166471,7 @@ bwO
 voI
 glO
 sfm
-xsw
+unp
 sfm
 sfm
 gBw
@@ -165655,11 +166746,11 @@ fLI
 ord
 geE
 sfm
-xsw
+unp
 sfm
 sfm
 sfm
-xsw
+unp
 sfm
 sfm
 plf
@@ -166160,7 +167251,7 @@ hCo
 mUb
 xsw
 hFR
-xsw
+sfm
 xPO
 sTg
 geE
@@ -166409,16 +167500,16 @@ mWz
 wNb
 adB
 plf
-xsw
-xsw
-xsw
-xsw
-xsw
-xsw
-xsw
+sfm
+unp
+unp
+unp
+unp
+unp
+sfm
 nna
-xsw
-xsw
+sfm
+unp
 sfm
 geE
 hHz
@@ -167931,20 +169022,20 @@ kDn
 ncp
 wrs
 dJL
-adB
-adB
-htC
-adB
-adB
+cym
+cym
+swr
+cym
+cym
 wxA
 hyY
 hyY
 wxA
-adB
-adB
-lMz
-adB
-adB
+cym
+cym
+cAy
+cym
+cym
 dJL
 mxx
 mTv
@@ -168184,9 +169275,9 @@ plf
 lgc
 plf
 dJL
-adB
+cym
 aLD
-adB
+cym
 dJL
 plf
 kHU
@@ -168448,14 +169539,14 @@ dJL
 kHU
 rbK
 fcL
-adB
-adB
+cym
+cym
 qvQ
-adB
-adB
+cym
+cym
 qvQ
-adB
-adB
+cym
+cym
 auc
 dXZ
 kHU
@@ -168698,9 +169789,9 @@ plf
 kHU
 tcq
 dJL
-adB
+cym
 sDk
-adB
+cym
 dJL
 plf
 htC
@@ -168717,9 +169808,9 @@ aEX
 lMz
 plf
 dJL
-adB
-adB
-adB
+cym
+cym
+cym
 dJL
 kHU
 kHU
@@ -171275,16 +172366,16 @@ adB
 plf
 iWS
 uxZ
-adB
-adB
+cym
+cym
 qvQ
-adB
-adB
+cym
+cym
 qvQ
-adB
-adB
+cym
+cym
 xxp
-dUa
+atD
 plf
 adB
 kHU
@@ -171786,20 +172877,20 @@ plf
 plf
 kHU
 dJL
-adB
+cym
 dJL
-iWS
+odh
 jNo
-jNo
+anV
 xbd
-adB
-adB
+cym
+cym
 yhM
 xAm
 xAm
 dUa
 dJL
-adB
+cym
 dJL
 kHU
 kHU
@@ -172047,12 +173138,12 @@ kHU
 kHU
 kHU
 kHU
-adB
+dJL
 vjZ
 eqo
 rjz
 fXb
-adB
+dJL
 kHU
 kHU
 kHU
@@ -172561,12 +173652,12 @@ plf
 plf
 lgc
 kHU
-adB
+dJL
 oOj
 qRr
 bqG
 duP
-adB
+dJL
 kHU
 lgc
 plf
@@ -172818,12 +173909,12 @@ plf
 plf
 plf
 kHU
-adB
+dJL
 adB
 dJL
 dJL
 adB
-adB
+dJL
 kHU
 plf
 plf

--- a/maps/falcon/falcon.dmm
+++ b/maps/falcon/falcon.dmm
@@ -389,7 +389,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/turf_decal/set_burned,
 /turf/simulated/floor/plating,
 /area/station/medical/surgery)
@@ -463,7 +465,9 @@
 	},
 /area/station/tcommsat/computer)
 "aaN" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
 	icon_state = "shutter0";
@@ -621,7 +625,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -800,7 +806,9 @@
 	req_access = list(50);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "abt" = (
@@ -1039,7 +1047,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -1080,7 +1090,9 @@
 	opacity = 1;
 	req_access = list(30)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -1319,7 +1331,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -4203,7 +4217,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
@@ -4665,7 +4681,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -4783,7 +4801,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "black"
@@ -4950,7 +4970,9 @@
 	name = "Escape Hall";
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 4;
 	icon_state = "dark"
@@ -4981,7 +5003,9 @@
 /turf/simulated/floor,
 /area/station/hallway/secondary/exit)
 "aiU" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "black"
 	},
@@ -5848,7 +5872,9 @@
 "akL" = (
 /obj/structure/barricade/wooden,
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/construction/assembly_line)
 "akM" = (
@@ -5983,7 +6009,9 @@
 /turf/simulated/floor/plating,
 /area/station/construction/assembly_line)
 "alh" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/engineering/glass{
 	locked = 1;
 	name = "Assembly Line (KEEP OUT)";
@@ -5993,7 +6021,9 @@
 /turf/simulated/floor/plating,
 /area/station/construction/assembly_line)
 "ali" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -6168,7 +6198,9 @@
 /area/station/construction/assembly_line)
 "alB" = (
 /obj/structure/barricade/wooden,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -6180,7 +6212,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "alD" = (
@@ -6375,7 +6409,9 @@
 /turf/simulated/floor,
 /area/station/construction/assembly_line)
 "alX" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -7210,7 +7246,9 @@
 	},
 /area/station/civilian/kitchen)
 "anC" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
@@ -7633,7 +7671,9 @@
 	name = "Test Chamber Blast Doors";
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -7850,7 +7890,9 @@
 	req_access = list(12);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "apc" = (
@@ -8437,7 +8479,9 @@
 	icon_state = "engineering_door"
 	},
 /obj/structure/barricade/wooden,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "aqg" = (
@@ -8586,7 +8630,9 @@
 /turf/simulated/floor,
 /area/station/construction/assembly_line)
 "aqr" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/engineering/glass{
 	locked = 1;
 	name = "Assembly Line (KEEP OUT)";
@@ -8651,7 +8697,9 @@
 	name = "Escape Airlock";
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "aqx" = (
@@ -9585,7 +9633,9 @@
 /turf/environment/space,
 /area/space)
 "arV" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/turf_decal/set_burned,
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
@@ -9646,7 +9696,9 @@
 /area/station/hallway/primary/central)
 "asb" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "asc" = (
@@ -9756,6 +9808,16 @@
 	icon_state = "asteroid2"
 	},
 /area/station/maintenance/science)
+"axa" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/hydroponics)
 "axd" = (
 /obj/structure/bookcase/manuals/security,
 /obj/machinery/alarm{
@@ -10002,7 +10064,9 @@
 /obj/structure/window/thin/reinforced{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/item/weapon/storage/fancy/donut_box,
 /turf/simulated/floor{
 	dir = 5;
@@ -10349,7 +10413,9 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/hop_office)
 "aXo" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -10657,7 +10723,9 @@
 	},
 /area/shuttle/supply/station)
 "ble" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/status_display{
 	layer = 4;
 	pixel_y = -32
@@ -10719,7 +10787,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering";
 	req_access = list(10);
@@ -11006,7 +11076,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "bCq" = (
@@ -11177,7 +11249,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -11732,7 +11806,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -11771,7 +11847,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
 "cnv" = (
@@ -11806,7 +11884,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -11831,7 +11911,9 @@
 /area/station/civilian/kitchen)
 "cra" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -11978,7 +12060,9 @@
 	req_access = list(12);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/civilian/gym)
 "cDq" = (
@@ -12190,7 +12274,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -12372,7 +12458,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "cWy" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -12417,7 +12505,9 @@
 	req_access = list(12);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "cZW" = (
@@ -12820,7 +12910,9 @@
 	req_access = list(5);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -12912,7 +13004,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/station/bridge/captain_quarters)
 "dxD" = (
@@ -13209,7 +13303,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "prisonentry";
 	name = "Brig Entry";
@@ -13366,7 +13462,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "dRK" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -13746,7 +13844,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "eln" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -13838,7 +13938,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -13900,7 +14002,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -14043,7 +14147,9 @@
 	req_one_access = list(22,12);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/turf_decal/set_burned,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
@@ -14099,7 +14205,9 @@
 	req_access = list(7);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -14288,7 +14396,9 @@
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "ePz" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -14492,7 +14602,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -14621,7 +14733,9 @@
 	req_access = list(12);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -14661,7 +14775,9 @@
 	opacity = 0;
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -14974,7 +15090,9 @@
 	req_access = list(72);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/medical/storage)
 "fES" = (
@@ -15292,7 +15410,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
 "fVM" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
 	icon_state = "shutter0";
@@ -15604,7 +15724,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "vaultfull"
 	},
@@ -16132,6 +16254,16 @@
 	icon_state = "black"
 	},
 /area/station/security/lobby)
+"gKF" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/checkpoint)
 "gKV" = (
 /obj/machinery/camera{
 	c_tag = "RnD North";
@@ -16693,7 +16825,9 @@
 	},
 /area/station/hallway/primary/central)
 "hht" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -16725,7 +16859,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -17052,7 +17188,9 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
 "hHC" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -17088,7 +17226,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "hNU" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "black"
@@ -17276,7 +17416,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -17312,7 +17454,9 @@
 	},
 /area/station/bridge/nuke_storage)
 "hYy" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -17370,7 +17514,9 @@
 	},
 /area/station/hallway/primary/central)
 "iao" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
 	icon_state = "shutter0";
@@ -17403,7 +17549,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "ibB" = (
@@ -17604,7 +17752,9 @@
 	},
 /area/station/hallway/secondary/arrival)
 "ikw" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/sign/directions/security{
 	buildable_sign = 0;
 	dir = 4;
@@ -17697,7 +17847,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -17966,7 +18118,9 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/drone_fabrication)
 "iDh" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -18006,7 +18160,9 @@
 /turf/environment/space,
 /area/shuttle/escape_pod1/station)
 "iGg" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/camera{
 	c_tag = "Central Hallway North-East";
 	dir = 6
@@ -18664,6 +18820,22 @@
 	icon_state = "blackcorner"
 	},
 /area/station/hallway/primary/central)
+"jsn" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/structure/sign/warning/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK"
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/storage)
 "juX" = (
 /turf/simulated/shuttle/floor/cargo{
 	icon_state = "1,4"
@@ -18681,7 +18853,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -18816,7 +18990,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -19103,7 +19279,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 5;
 	icon_state = "cafeteria"
@@ -19122,7 +19300,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -19412,7 +19592,9 @@
 /turf/simulated/floor,
 /area/station/maintenance/auxsolarstarboard)
 "jUL" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -19452,7 +19634,9 @@
 	req_access = list(7);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -19497,7 +19681,9 @@
 /turf/simulated/floor/plating/airless/asteroid,
 /area/asteroid/mine/unexplored)
 "jXF" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -19696,7 +19882,9 @@
 	id = "Captain_private";
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -19801,7 +19989,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "wooden-2"
 	},
@@ -20267,7 +20457,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
 "kLq" = (
@@ -20353,7 +20545,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -20405,7 +20599,9 @@
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
@@ -20705,7 +20901,9 @@
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/auxstarboard)
 "lfk" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -20829,7 +21027,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -20897,7 +21097,9 @@
 	},
 /area/station/medical/reception)
 "lqE" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -21121,7 +21323,9 @@
 	req_access = list(12);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -21177,7 +21381,9 @@
 	req_access = list(1);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -21708,7 +21914,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/office)
 "mhv" = (
@@ -21761,7 +21969,9 @@
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
 "mlr" = (
@@ -21809,7 +22019,9 @@
 	id = "Captain_private";
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
@@ -21907,7 +22119,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -22062,7 +22276,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/turf_decal/set_burned,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
@@ -22334,7 +22550,9 @@
 	},
 /area/station/hallway/secondary/arrival)
 "mQs" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/external{
 	name = "Escape Airlock";
 	req_access = list(1);
@@ -22851,7 +23069,9 @@
 /turf/simulated/floor,
 /area/station/medical/surgeryobs)
 "nkO" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -22901,7 +23121,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "whitebluefull"
 	},
@@ -22988,7 +23210,9 @@
 	},
 /area/station/hallway/primary/central)
 "npp" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -23116,7 +23340,9 @@
 /turf/simulated/floor/plating,
 /area/station/civilian/dormitories)
 "ntn" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -23533,7 +23759,9 @@
 /turf/simulated/floor/wood,
 /area/station/bridge/hop_office)
 "nMG" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
@@ -24351,7 +24579,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -25461,7 +25691,9 @@
 	name = "Unisex Restrooms";
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor"
 	},
@@ -25552,7 +25784,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/sign/warning/securearea{
 	pixel_y = -32
 	},
@@ -26550,7 +26784,9 @@
 	},
 /area/station/engineering/atmos)
 "qxr" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "black"
 	},
@@ -26613,7 +26849,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -26688,7 +26926,9 @@
 	},
 /area/station/civilian/toilet)
 "qBV" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
 	icon_state = "shutter0";
@@ -27034,7 +27274,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -27152,7 +27394,9 @@
 	req_access = list(28)
 	},
 /obj/item/weapon/bell,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/random/foods/food_snack,
 /turf/simulated/floor{
 	dir = 5;
@@ -27213,6 +27457,16 @@
 	icon_state = "darkpurple"
 	},
 /area/asteroid/research_outpost/spectro)
+"qVS" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/dormitories)
 "qWs" = (
 /obj/structure/stool/bed/chair/office/dark{
 	dir = 4
@@ -27489,7 +27743,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
 "rox" = (
@@ -27554,7 +27810,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "rsc" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/structure/window/fulltile{
 	grilled = 1;
@@ -27728,7 +27986,9 @@
 	},
 /area/station/medical/cmo)
 "rzZ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/sign/directions/engineering{
 	buildable_sign = 0;
 	dir = 8;
@@ -27859,7 +28119,9 @@
 	},
 /area/station/bridge)
 "rGb" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -28139,7 +28401,9 @@
 /turf/simulated/floor/grass,
 /area/station/civilian/kitchen)
 "rTQ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -28454,7 +28718,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -28756,7 +29022,9 @@
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "sCU" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -29167,7 +29435,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -29200,7 +29470,9 @@
 	req_access = list(57);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -29474,6 +29746,14 @@
 /obj/item/stack/rods,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
+"try" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/effect/decal/turf_decal/set_burned,
+/turf/simulated/floor/plating,
+/area/station/maintenance/science)
 "tsN" = (
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -29570,7 +29850,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/hallway/primary/central)
 "tAD" = (
@@ -29703,7 +29985,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -29720,7 +30004,9 @@
 	opacity = 0;
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -30029,7 +30315,9 @@
 	},
 /area/station/hallway/primary/central)
 "tTE" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -30524,7 +30812,9 @@
 	name = "Escape Pod 5";
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "upz" = (
@@ -30638,7 +30928,9 @@
 	},
 /area/shuttle/supply/station)
 "uyd" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -30951,7 +31243,9 @@
 	req_access = list(30);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -30989,7 +31283,9 @@
 /turf/simulated/floor/plating,
 /area/asteroid/mine/dwarf)
 "uND" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -31032,7 +31328,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "uPO" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
 	icon_state = "shutter0";
@@ -31175,7 +31473,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	icon_state = "pdoor0";
@@ -31541,7 +31841,9 @@
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "vrd" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -31674,7 +31976,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/station/civilian/chapel/office)
 "vzv" = (
@@ -31792,7 +32096,9 @@
 /turf/environment/space,
 /area/space)
 "vFF" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -32254,7 +32560,9 @@
 	req_access = list(25);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -32381,7 +32689,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/civilian/kitchen)
 "wjV" = (
@@ -32456,7 +32766,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "wmc" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -32581,7 +32893,9 @@
 /turf/environment/space,
 /area/shuttle/supply/station)
 "wrg" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -32728,7 +33042,9 @@
 /obj/structure/window/thin/reinforced{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/sign/poster/contraband/eat{
 	pixel_y = 32
 	},
@@ -32758,6 +33074,16 @@
 	icon_state = "vault"
 	},
 /area/station/civilian/chapel)
+"wAl" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/exit)
 "wAS" = (
 /turf/simulated/shuttle/floor/cargo{
 	icon_state = "0,3"
@@ -32904,7 +33230,9 @@
 	},
 /area/station/hallway/primary/central)
 "wJX" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -33004,7 +33332,9 @@
 /turf/environment/space/shuttle,
 /area/shuttle/escape_pod4/station)
 "wMu" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -33202,6 +33532,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/central)
+"wXL" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/storage)
 "wYk" = (
 /turf/simulated/wall/r_wall,
 /area/station/maintenance/auxsolarstarboard)
@@ -33699,7 +34039,9 @@
 	opacity = 0;
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -33779,7 +34121,9 @@
 	},
 /area/station/rnd/chargebay)
 "xxK" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/turf_decal/set_burned,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
@@ -33804,7 +34148,9 @@
 	opacity = 0;
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -34024,12 +34370,24 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/vomit{
 	icon_state = "vomit_4"
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
+"xJI" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/gym)
 "xKi" = (
 /turf/simulated/wall,
 /area/station/medical/reception)
@@ -34178,7 +34536,9 @@
 /turf/simulated/floor,
 /area/station/cargo/storage)
 "xQL" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/sign/directions/medical{
 	buildable_sign = 0;
 	dir = 8;
@@ -34572,7 +34932,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -53007,9 +53369,9 @@ aqw
 qcu
 aqw
 aqw
-xbS
+wAl
 pNu
-nsB
+gKF
 mQs
 rTQ
 pNu
@@ -58918,12 +59280,12 @@ aiC
 aiU
 qcu
 aik
-aij
-aij
+xJI
+xJI
 aik
 knb
-aij
-aij
+xJI
+xJI
 aik
 akL
 alh
@@ -62796,9 +63158,9 @@ sFn
 kOm
 acW
 sFn
-scr
-scr
-scr
+wXL
+wXL
+wXL
 sFn
 ohE
 pxZ
@@ -63794,7 +64156,7 @@ acR
 uUx
 uUx
 gmO
-oRV
+qVS
 uUx
 uUx
 wsK
@@ -63826,7 +64188,7 @@ arq
 mvQ
 gfQ
 scr
-scr
+wXL
 scr
 vgT
 juX
@@ -64596,9 +64958,9 @@ wxP
 lVK
 uYJ
 sFn
-scr
-scr
-nhT
+wXL
+wXL
+jsn
 jaz
 uwE
 qEE
@@ -64836,7 +65198,7 @@ kpo
 kpo
 kpo
 hkb
-ews
+axa
 kpo
 aeu
 dIJ
@@ -71285,7 +71647,7 @@ jcg
 isF
 isF
 asb
-eTS
+try
 lUt
 hvD
 hvD

--- a/maps/prometheus/prometheus.dmm
+++ b/maps/prometheus/prometheus.dmm
@@ -20,7 +20,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "aad" = (
@@ -370,7 +372,9 @@
 	},
 /area/station/engineering/equip)
 "aaA" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -779,7 +783,9 @@
 	},
 /area/station/tcommsat/chamber)
 "abg" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/medical/glass{
 	dir = 4;
 	name = "Medbay"
@@ -795,7 +801,9 @@
 	name = "Medbay";
 	req_access = list(5)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -964,7 +972,9 @@
 	name = "Research Shuttle Dock"
 	})
 "abu" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -2369,7 +2379,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -2384,7 +2396,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
@@ -3083,7 +3097,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/barricade/wooden{
 	layer = 2.8;
 	name = "doorway barricade"
@@ -3126,7 +3142,9 @@
 	},
 /area/station/security/checkpoint)
 "ajj" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -3203,7 +3221,9 @@
 	},
 /area/station/hallway/primary/port)
 "ajQ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -3233,7 +3253,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
@@ -3300,7 +3322,9 @@
 	},
 /area/station/security/brig)
 "akX" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -3351,7 +3375,9 @@
 	dir = 4;
 	name = "Play Room"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -3384,7 +3410,9 @@
 	dir = 4;
 	name = "Bedroom"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -3699,7 +3727,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	dir = 4;
@@ -4161,7 +4191,9 @@
 	name = "Genetics Lab Maintenance";
 	req_access = list(9)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -4251,7 +4283,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "awq" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -4446,7 +4480,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "ayD" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -4499,7 +4535,9 @@
 	dir = 4;
 	name = "Chapel"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -4758,7 +4796,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "aBM" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/security{
 	dir = 4;
 	name = "Procedural";
@@ -4942,7 +4982,9 @@
 	name = "E.V.A.";
 	req_one_access = list(1,5,11,18,24)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -5202,7 +5244,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "aGK" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	dir = 4;
 	id = "Armoury0";
@@ -5440,7 +5484,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "aJH" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/glass{
 	dir = 4;
 	name = "Play Room"
@@ -5568,7 +5614,9 @@
 	},
 /area/station/medical/hallway)
 "aLw" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
 	dir = 4;
@@ -6328,7 +6376,9 @@
 	name = "Hydroponics";
 	req_access = list(35)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -6809,7 +6859,9 @@
 	name = "Gateway Access";
 	req_access = list(62)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -6885,7 +6937,9 @@
 	name = "Research Shuttle Dock"
 	})
 "bfO" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -7667,7 +7721,9 @@
 	dir = 8;
 	id = "Captain_private"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/bridge/captain_quarters)
 "bpx" = (
@@ -7827,7 +7883,9 @@
 	},
 /area/station/cargo/office)
 "bqU" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
 	dir = 8;
@@ -8091,7 +8149,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "bty" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "btE" = (
@@ -8176,7 +8236,9 @@
 	name = "Delivery Office";
 	req_access = list(50)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -8923,7 +8985,9 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "bFk" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -9196,7 +9260,9 @@
 "bIC" = (
 /obj/structure/grille,
 /obj/structure/barricade/wooden,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "bIL" = (
@@ -10043,7 +10109,9 @@
 	},
 /area/station/civilian/chapel/mass_driver)
 "bTi" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	dir = 4;
@@ -10184,7 +10252,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "bUJ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -10327,6 +10397,16 @@
 	icon_state = "vaultfull"
 	},
 /area/station/security/lobby)
+"bXF" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/rnd/tox_launch)
 "bXG" = (
 /obj/machinery/atmospherics/components/unary/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
@@ -10385,7 +10465,9 @@
 	name = "Research Shuttle Dock"
 	})
 "bZl" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -10949,7 +11031,9 @@
 	name = "Brig Medical Checkpoint";
 	req_one_access = list(5,63)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -10961,7 +11045,9 @@
 	},
 /area/station/security/prison)
 "ciV" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -11118,7 +11204,9 @@
 	},
 /area/station/engineering/atmos)
 "clJ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
@@ -11331,7 +11419,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "cnI" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -11540,7 +11630,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
 "cqL" = (
@@ -12151,7 +12243,9 @@
 /obj/structure/sign/departments/medbay/alt{
 	pixel_y = 32
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -12723,7 +12817,9 @@
 	},
 /area/station/medical/hallway)
 "cHo" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/structure/cable{
 	d1 = 1;
@@ -12745,7 +12841,9 @@
 /turf/simulated/floor/plating,
 /area/station/rnd/hor)
 "cHJ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -12803,7 +12901,9 @@
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "cIj" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/sign/departments/holy,
 /obj/structure/window/fulltile{
 	grilled = 1;
@@ -13016,7 +13116,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -13481,7 +13583,9 @@
 	name = "Crematorium";
 	req_access = list(27)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -13582,6 +13686,16 @@
 	icon_state = "white"
 	},
 /area/station/medical/sleeper)
+"cTH" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/security/prison)
 "cTP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -13672,6 +13786,16 @@
 	icon_state = "darkblue"
 	},
 /area/station/bridge)
+"cVb" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/brig)
 "cVd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -14167,7 +14291,9 @@
 	dir = 4;
 	req_access = list(28)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -14230,7 +14356,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "dbT" = (
@@ -14462,7 +14590,9 @@
 	name = "Warden's Office";
 	req_access = list(3)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -14645,7 +14775,9 @@
 	dir = 1;
 	name = "Confession Booth"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/station/civilian/chapel)
 "dgz" = (
@@ -14663,7 +14795,9 @@
 /area/station/security/interrogation)
 "dgD" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/window/southright{
 	dir = 4;
 	name = "Robotics Desk";
@@ -14738,7 +14872,9 @@
 	dir = 4;
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -15079,7 +15215,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
 "dkV" = (
@@ -15521,7 +15659,9 @@
 	},
 /area/station/security/checkpoint)
 "drX" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -15639,7 +15779,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "dtL" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -15869,7 +16011,9 @@
 	},
 /area/station/cargo/storage)
 "dwf" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	dir = 4;
@@ -16058,7 +16202,9 @@
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/port)
 "dxo" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -16363,7 +16509,9 @@
 	},
 /area/station/rnd/telesci)
 "dAS" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -17243,7 +17391,9 @@
 	dir = 4;
 	name = "Garden"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -17260,7 +17410,9 @@
 	name = "Shrubbery";
 	req_access = list(9)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -17994,7 +18146,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "dSZ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
@@ -18198,7 +18352,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -18247,6 +18403,16 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/carpet/green,
 /area/station/medical/virology)
+"dVO" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/storage)
 "dWb" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Security Office";
@@ -18699,7 +18865,9 @@
 	name = "Medbay";
 	req_access = list(5)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -19020,7 +19188,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "ehC" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -19119,7 +19289,9 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	dir = 4;
 	id = "Skynet_launch";
@@ -19516,7 +19688,9 @@
 	},
 /area/station/medical/storage)
 "enF" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -19711,7 +19885,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "ept" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
@@ -19778,7 +19954,9 @@
 	name = "Honk Office";
 	req_access = list(46)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -19827,7 +20005,9 @@
 	name = "Honk Office";
 	req_access = list(46)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -19881,6 +20061,16 @@
 	icon_state = "blue"
 	},
 /area/station/medical/reception)
+"eqT" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/primary/central)
 "eqZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/foods/food_trash,
@@ -19973,7 +20163,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "esl" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
 	icon_state = "shutter0";
@@ -19987,7 +20179,9 @@
 /turf/simulated/floor/plating,
 /area/station/bridge/hop_office)
 "esq" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -20153,7 +20347,9 @@
 	name = "Delivery Office";
 	req_access = list(50)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -20273,7 +20469,9 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/theatre)
 "evO" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -20362,7 +20560,9 @@
 	name = "Washroom";
 	req_one_access = list(1,4)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -20459,7 +20659,9 @@
 /turf/simulated/floor,
 /area/station/engineering/engine)
 "exM" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -20917,7 +21119,9 @@
 	},
 /area/station/medical/hallway)
 "eDs" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/sign/departments/botany,
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
@@ -21227,7 +21431,9 @@
 	},
 /area/station/medical/surgeryobs)
 "eGP" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "brown"
 	},
@@ -21375,7 +21581,9 @@
 	name = "Kitchen";
 	req_access = list(28)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/item/weapon/bell{
 	pixel_y = -3
 	},
@@ -21542,7 +21750,9 @@
 	},
 /area/station/medical/virology)
 "eLP" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -21572,7 +21782,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	dir = 4;
@@ -21846,7 +22058,9 @@
 /turf/simulated/floor,
 /area/station/engineering/engine)
 "ePy" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	dir = 4;
 	id = "Armoury";
@@ -21942,7 +22156,9 @@
 /turf/simulated/wall,
 /area/station/civilian/chapel/crematorium)
 "eQK" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/medical/glass{
 	dir = 4;
 	name = "Medbay"
@@ -22074,7 +22290,9 @@
 /turf/simulated/wall,
 /area/station/medical/storage)
 "eSd" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -22098,7 +22316,9 @@
 /area/station/security/execution)
 "eSo" = (
 /obj/structure/barricade/wooden,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -22106,7 +22326,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "eSw" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
 	dir = 8;
@@ -22606,7 +22828,9 @@
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "eYl" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -22834,7 +23058,9 @@
 /turf/simulated/floor,
 /area/station/medical/cryo)
 "faY" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -22863,7 +23089,9 @@
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
@@ -24004,7 +24232,9 @@
 	},
 /area/station/security/checkpoint)
 "foG" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -24378,7 +24608,9 @@
 	},
 /area/station/rnd/xenobiology)
 "fsV" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -24435,7 +24667,9 @@
 	dir = 4;
 	name = "Prison"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -24572,7 +24806,9 @@
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "fuY" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -24812,7 +25048,9 @@
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	dir = 4;
@@ -24829,7 +25067,9 @@
 /turf/simulated/floor,
 /area/station/civilian/garden)
 "fxS" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	dir = 4;
 	id = "Gateway_shutters";
@@ -25177,7 +25417,9 @@
 	name = "Tech Storage";
 	req_access = list(23)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -25492,7 +25734,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	dir = 4;
@@ -25768,7 +26012,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced_phoron"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/rnd/mixing)
 "fIO" = (
@@ -25898,7 +26144,9 @@
 	name = "Aft Port Solar Access";
 	req_access = list(10)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
 "fKn" = (
@@ -26032,7 +26280,9 @@
 	name = "Server Room";
 	req_access = list(30)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -26224,7 +26474,9 @@
 	name = "Quartermaster";
 	req_access = list(41)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -27107,7 +27359,9 @@
 	name = "Medbay Reception";
 	req_access = list(5)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -27560,7 +27814,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboardsolar)
 "gfb" = (
@@ -27709,7 +27965,9 @@
 	name = "Containment Pen";
 	req_access = list(55)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/engine,
 /area/station/rnd/xenobiology)
 "ggo" = (
@@ -28459,7 +28717,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/mass_driver)
 "gpb" = (
@@ -28558,7 +28818,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
@@ -28673,7 +28935,9 @@
 	id = "HoP_private";
 	opacity = 0
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 8;
@@ -28891,7 +29155,9 @@
 	},
 /area/station/hallway/primary/central)
 "gtZ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -29192,6 +29458,16 @@
 	},
 /turf/simulated/floor,
 /area/station/security/prison)
+"gxy" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/genetics)
 "gxE" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 28
@@ -29218,7 +29494,9 @@
 	name = "Mining Shuttle Dock";
 	req_one_access = list(48,65)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -29281,6 +29559,16 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
+"gyS" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/exit)
 "gyW" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -29372,7 +29660,9 @@
 	dir = 4;
 	name = "Primary Tool Storage"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -29387,7 +29677,9 @@
 	},
 /area/station/storage/primary)
 "gzU" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
 	dir = 4;
@@ -29421,7 +29713,9 @@
 /obj/structure/sign/nanotrasen{
 	pixel_y = 32
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -29470,7 +29764,9 @@
 	name = "Operating Theatre"
 	})
 "gAS" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -29694,7 +29990,9 @@
 	},
 /area/station/rnd/telesci)
 "gEn" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/medical/glass{
 	dir = 4;
 	name = "Medbay"
@@ -29863,7 +30161,9 @@
 	name = "Bar Backroom";
 	req_access = list(25)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -30352,7 +30652,9 @@
 	name = "Virology Interior Airlock";
 	req_access = list(39)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -30454,7 +30756,9 @@
 	name = "Virology Exterior Airlock";
 	req_access = list(39)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -30697,7 +31001,9 @@
 	dir = 4;
 	name = "Holodeck Control"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -30779,7 +31085,9 @@
 	},
 /area/station/medical/hallway)
 "gQA" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -31114,7 +31422,9 @@
 	},
 /area/station/bridge)
 "gVn" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -31450,7 +31760,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/construction)
 "gYO" = (
@@ -31536,7 +31848,9 @@
 	name = "Containment Pen";
 	req_access = list(55)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/engine,
 /area/station/rnd/xenobiology)
 "gZP" = (
@@ -31595,7 +31909,9 @@
 	name = "Morgue Maintenance";
 	req_one_access = list(6,28)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -32220,7 +32536,9 @@
 	},
 /area/station/engineering/atmos)
 "hgZ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -32950,6 +33268,16 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"hoL" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/virology)
 "hoS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -32965,7 +33293,9 @@
 	name = "Disposal Access";
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
@@ -33719,7 +34049,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboardsolar)
 "hBe" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -33896,7 +34228,9 @@
 	},
 /area/station/civilian/playroom)
 "hDq" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -34122,7 +34456,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	dir = 4;
@@ -34144,7 +34480,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -34165,7 +34503,9 @@
 	layer = 2.8;
 	name = "doorway barricade"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "hHL" = (
@@ -34354,7 +34694,9 @@
 	},
 /area/station/hallway/secondary/exit)
 "hJt" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/maintenance{
 	dir = 4;
 	req_access = list(12)
@@ -35024,7 +35366,9 @@
 	name = "Execution Chamber";
 	req_access = list(1)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -35227,7 +35571,9 @@
 	name = "Chapel Office Maintenance";
 	req_one_access = list(22)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -35485,7 +35831,9 @@
 	id = "HoP_queue";
 	opacity = 0
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -35957,7 +36305,9 @@
 /area/station/civilian/bar)
 "iem" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
@@ -36749,7 +37099,9 @@
 /turf/simulated/floor/wood,
 /area/station/civilian/cafeteria)
 "iov" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/maintenance{
 	dir = 4;
 	name = "Hydroponics Maintenance";
@@ -37207,7 +37559,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "iwd" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/maintenance{
 	dir = 4;
@@ -37231,7 +37585,9 @@
 	dir = 4;
 	name = "Chapel"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -37440,7 +37796,9 @@
 	name = "Atmos Blast Door";
 	opacity = 0
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/station/engineering/monitoring)
 "iyE" = (
@@ -37621,7 +37979,9 @@
 	},
 /area/station/medical/morgue)
 "iAo" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
@@ -37757,7 +38117,9 @@
 	name = "doorway barricade"
 	},
 /obj/structure/grille,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "iCa" = (
@@ -38201,7 +38563,9 @@
 	},
 /area/station/medical/chemistry)
 "iIp" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -38811,7 +39175,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -38980,7 +39346,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/structure/sign/nanotrasen,
 /obj/machinery/door/poddoor/shutters{
@@ -39142,7 +39510,9 @@
 /turf/simulated/floor/carpet/black,
 /area/station/civilian/chapel)
 "iVC" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "white"
 	},
@@ -39478,7 +39848,9 @@
 	name = "Tribunal"
 	})
 "iZa" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -39539,7 +39911,9 @@
 /turf/simulated/floor,
 /area/station/security/prison)
 "iZV" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/medical/glass{
 	dir = 4;
 	id_tag = "Medbay";
@@ -39557,7 +39931,9 @@
 	},
 /area/station/medical/hallway)
 "jaa" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -39840,7 +40216,9 @@
 	name = "Bar Maintenance";
 	req_one_access = list(25)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/civilian/bar)
 "jdr" = (
@@ -40571,7 +40949,9 @@
 	},
 /area/station/rnd/storage)
 "joS" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	dir = 8;
 	id = "qm_warehouse";
@@ -40934,7 +41314,9 @@
 	},
 /area/station/security/secconfhall)
 "jtc" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -40995,7 +41377,9 @@
 /turf/simulated/floor,
 /area/station/cargo/storage)
 "jtS" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/barricade/wooden{
 	layer = 2.8;
 	name = "doorway barricade"
@@ -41031,7 +41415,9 @@
 	dir = 4;
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "jtV" = (
@@ -41426,7 +41812,9 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -41507,6 +41895,16 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/misc_lab)
+"jAF" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/storage)
 "jAG" = (
 /obj/effect/decal/turf_decal{
 	dir = 5;
@@ -41706,7 +42104,9 @@
 	name = "MiniSat Access";
 	req_access = list(66)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -41771,7 +42171,9 @@
 	dir = 4;
 	name = "Prison"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -41864,7 +42266,9 @@
 	name = "Miscellaneous Research";
 	req_access = list(47)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -42799,7 +43203,9 @@
 	dir = 4;
 	name = "Escape Hall"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -43617,7 +44023,9 @@
 	},
 /area/station/cargo/storage)
 "kcX" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/wood,
 /area/station/civilian/dormitories)
@@ -43683,7 +44091,9 @@
 /obj/structure/window/thin/reinforced{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/item/weapon/storage/fancy/donut_box,
 /obj/structure/table/reinforced/stall,
 /turf/simulated/floor/wood,
@@ -43878,7 +44288,9 @@
 	},
 /area/station/security/execution)
 "kip" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -44727,7 +45139,9 @@
 /obj/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
 "kup" = (
@@ -45092,7 +45506,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "kzA" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	dir = 4;
@@ -45586,7 +46002,9 @@
 	name = "Gateway Access";
 	req_access = list(62)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -45635,7 +46053,9 @@
 	dir = 4;
 	name = "Primary Tool Storage"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -45744,7 +46164,9 @@
 	dir = 4;
 	name = "Chapel"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -45812,7 +46234,9 @@
 	},
 /area/station/tcommsat/computer)
 "kIF" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -46012,7 +46436,9 @@
 	name = "Security Maintenance";
 	req_access = list(63)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/security/brig)
 "kLo" = (
@@ -46478,7 +46904,9 @@
 /turf/simulated/floor/grass,
 /area/station/civilian/hydroponics)
 "kSB" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -46576,7 +47004,9 @@
 	name = "Kitchen";
 	req_access = list(28)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -46632,7 +47062,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "kUn" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
@@ -46782,7 +47214,9 @@
 "kVU" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood/oil,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -47083,6 +47517,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
+"kYI" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/arrival)
 "kYJ" = (
 /obj/structure/table/glass,
 /obj/item/weapon/paper_bin{
@@ -47466,7 +47910,9 @@
 /turf/simulated/floor/engine,
 /area/station/engineering/engine)
 "ldp" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -48319,7 +48765,9 @@
 	},
 /area/station/security/forensic_office)
 "lmx" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	dir = 4;
@@ -48460,12 +48908,12 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
 /obj/structure/sign/warning/electricshock,
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/tcommsat/computer)
 "loA" = (
@@ -48481,7 +48929,9 @@
 	},
 /area/station/rnd/misc_lab)
 "loC" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
@@ -49194,6 +49644,16 @@
 	icon_state = "dark"
 	},
 /area/station/medical/morgue)
+"lyx" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/qm)
 "lzb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
@@ -49460,7 +49920,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -49501,7 +49963,9 @@
 /turf/simulated/floor/carpet/green,
 /area/station/medical/patients_rooms)
 "lCW" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -49908,7 +50372,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -50863,7 +51329,9 @@
 /turf/environment/space,
 /area/shuttle/arrival/station)
 "lUd" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	dir = 4;
@@ -51101,7 +51569,9 @@
 	},
 /area/station/security/brig)
 "lXr" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -51147,7 +51617,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "lXE" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
@@ -51718,7 +52190,9 @@
 	name = "Interrogation";
 	req_one_access = list(1,4)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -51957,7 +52431,9 @@
 	dir = 4;
 	name = "Escape Pod 5"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "mhJ" = (
@@ -51989,7 +52465,9 @@
 /area/station/security/armoury)
 "mhZ" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
@@ -52105,7 +52583,9 @@
 	},
 /area/station/cargo/recycleroffice)
 "miR" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -52157,7 +52637,9 @@
 	},
 /area/station/hallway/secondary/entry)
 "mjw" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/random/foods/food_trash,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -52710,7 +53192,9 @@
 	dir = 4;
 	name = "Central Access"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
 "mqg" = (
@@ -52719,7 +53203,9 @@
 	name = "Morgue";
 	req_one_access = list(6,28)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -53097,7 +53583,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "mwc" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -53801,7 +54289,9 @@
 	name = "E.V.A.";
 	req_one_access = list(1,5,11,18,24)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -54026,7 +54516,9 @@
 /turf/simulated/floor/wood,
 /area/station/medical/psych)
 "mGh" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -54535,7 +55027,9 @@
 	},
 /area/station/medical/virology)
 "mMb" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -55069,7 +55563,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/civilian/theatre)
 "mTX" = (
@@ -55150,7 +55646,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
 "mUD" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -55319,6 +55817,16 @@
 /obj/machinery/shieldgen,
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
+"mXi" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/medbreak)
 "mXq" = (
 /turf/simulated/floor{
 	dir = 1;
@@ -55920,7 +56428,9 @@
 	id = "HoP_private";
 	opacity = 0
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/item/weapon/bell,
 /obj/machinery/door/window/northleft{
 	dir = 4;
@@ -56155,7 +56665,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "nik" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -56312,7 +56824,9 @@
 	},
 /area/station/hallway/primary/central)
 "njL" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -56684,7 +57198,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced_phoron"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/engine,
 /area/station/engineering/engine)
 "nox" = (
@@ -57053,7 +57569,9 @@
 	},
 /area/station/engineering/chiefs_office)
 "nuF" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -57736,7 +58254,9 @@
 /turf/simulated/floor/plating/airless/catwalk,
 /area/station/solar/auxport)
 "nDy" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -57811,7 +58331,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
@@ -57927,7 +58449,9 @@
 /turf/simulated/floor,
 /area/station/rnd/chargebay)
 "nFV" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/camera{
 	c_tag = "Brig South East";
 	network = list("SS13","Security")
@@ -57948,7 +58472,9 @@
 	dir = 4;
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -58118,7 +58644,9 @@
 	},
 /area/station/bridge)
 "nHY" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -58329,7 +58857,9 @@
 	name = "Teleport Access";
 	req_access = list(17)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -58512,7 +59042,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "nOb" = (
@@ -58691,7 +59223,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -58796,7 +59330,9 @@
 /turf/simulated/floor/carpet/green,
 /area/station/medical/patients_rooms)
 "nSO" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -58970,7 +59506,9 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "nUR" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door_timer/cell_6{
 	dir = 2;
 	pixel_x = 0;
@@ -59129,7 +59667,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
@@ -59165,7 +59705,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarport)
 "nWW" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	dir = 4;
@@ -59404,7 +59946,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "oaY" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -59573,7 +60117,9 @@
 /turf/environment/space,
 /area/shuttle/supply/station)
 "ocK" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -59581,7 +60127,9 @@
 /turf/simulated/floor/plating,
 /area/station/civilian/hydroponics)
 "odc" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/glass{
 	dir = 4;
 	name = "Play Room"
@@ -60134,7 +60682,9 @@
 /turf/simulated/floor/plating,
 /area/station/medical/patients_rooms)
 "ojQ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -60667,7 +61217,9 @@
 	},
 /area/station/civilian/holodeck)
 "orb" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -60704,7 +61256,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -60878,7 +61432,9 @@
 	dir = 4;
 	name = "Arrival Airlock"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/entry)
 "otj" = (
@@ -60976,7 +61532,9 @@
 /turf/simulated/floor,
 /area/station/maintenance/incinerator)
 "our" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -61003,7 +61561,9 @@
 	dir = 4;
 	name = "Sauna"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -61064,7 +61624,9 @@
 	},
 /area/station/ai_monitored/eva)
 "ouQ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/sign/directions/medical{
 	buildable_sign = 0;
 	dir = 8
@@ -61349,7 +61911,9 @@
 	name = "Kitchen Cold Room";
 	req_access = list(28)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -62157,7 +62721,9 @@
 	name = "Toxins Launch Room";
 	req_access = list(8)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -62228,7 +62794,9 @@
 	},
 /area/station/civilian/bar)
 "oJT" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -62401,7 +62969,9 @@
 	dir = 4;
 	name = "Private Restroom"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "freezerfloor2"
 	},
@@ -63067,7 +63637,9 @@
 	name = "Solitary Confinement flash";
 	pixel_y = 28
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "red"
@@ -63400,7 +63972,9 @@
 	name = "Brig Escape Hall";
 	req_access = list(1)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -63715,7 +64289,9 @@
 	dir = 4;
 	name = "Library"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -63764,7 +64340,9 @@
 	},
 /area/station/security/secconfhall)
 "pfO" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/table/reinforced/stall,
 /obj/structure/window/thin/reinforced{
 	dir = 4
@@ -63791,7 +64369,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/incinerator)
 "pfZ" = (
@@ -64051,7 +64631,9 @@
 /turf/simulated/floor/plating,
 /area/station/hallway/primary/port)
 "piZ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/sign/departments/medbay,
 /obj/structure/window/fulltile{
 	grilled = 1;
@@ -64092,7 +64674,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -64247,7 +64831,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboardsolar)
 "pmK" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -64397,7 +64983,9 @@
 /turf/simulated/floor,
 /area/station/cargo/storage)
 "poQ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/window/westleft{
 	dir = 4;
 	name = "Hydroponics";
@@ -64618,7 +65206,9 @@
 /area/station/security/brig)
 "psY" = (
 /obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	dir = 4;
@@ -64759,7 +65349,9 @@
 /turf/simulated/floor,
 /area/station/medical/storage)
 "ptX" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -64776,7 +65368,9 @@
 	dir = 4;
 	name = "Chapel"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -64879,7 +65473,9 @@
 	},
 /area/station/civilian/janitor)
 "pvF" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -64920,7 +65516,9 @@
 	},
 /area/station/security/interrogation)
 "pws" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/sign/departments/holy,
 /obj/structure/window/fulltile{
 	grilled = 1;
@@ -65096,7 +65694,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/bluegrid{
 	icon_state = "dark";
 	name = "Server Walkway";
@@ -65210,7 +65810,9 @@
 	},
 /area/station/civilian/gym)
 "pAb" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
@@ -65261,12 +65863,12 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
 /obj/structure/sign/warning/server_room,
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/station/tcommsat/computer)
 "pAT" = (
@@ -65588,7 +66190,9 @@
 	},
 /area/station/cargo/recycleroffice)
 "pFn" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	density = 0;
 	dir = 4;
@@ -66128,7 +66732,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "pMi" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
@@ -66285,7 +66891,9 @@
 	},
 /area/station/rnd/robotics)
 "pOF" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastright{
 	dir = 8;
@@ -66719,6 +67327,16 @@
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/plating,
 /area/station/maintenance/dormitory)
+"pUB" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/entry)
 "pUD" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -67370,6 +67988,16 @@
 	icon_state = "darkblue"
 	},
 /area/station/aisat)
+"qbN" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/recycleroffice)
 "qbP" = (
 /obj/structure/closet/secure_closet/security,
 /obj/item/device/radio/intercom{
@@ -67521,7 +68149,9 @@
 	name = "Drone Fabrication";
 	req_access = list(32)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -67658,7 +68288,9 @@
 	},
 /area/station/cargo/storage)
 "qfm" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/turf_decal/set_burned,
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
@@ -68093,7 +68725,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboardsolar)
 "qkG" = (
@@ -68305,7 +68939,9 @@
 	dir = 4;
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
@@ -68799,7 +69435,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/storage/emergency3)
 "quZ" = (
@@ -68812,7 +69450,9 @@
 	},
 /area/station/civilian/garden)
 "qvj" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -68935,7 +69575,9 @@
 	dir = 4;
 	name = "Escape Airlock"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/hallway/secondary/exit)
 "qwq" = (
@@ -69067,7 +69709,9 @@
 "qyg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/scrap/safe_even,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/turf_decal/set_burned,
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
@@ -69459,7 +70103,9 @@
 	},
 /area/station/hallway/secondary/exit)
 "qCI" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/medical/glass{
 	dir = 4;
 	name = "Medbay"
@@ -69758,7 +70404,6 @@
 	},
 /area/station/medical/hallway)
 "qHG" = (
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Telecoms Server Access";
@@ -69779,6 +70424,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -69966,6 +70612,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/chapel)
+"qKj" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/auxsolarport)
 "qKm" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
@@ -70008,7 +70664,9 @@
 	dir = 4;
 	name = "Play Room"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -70046,7 +70704,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance_hatch{
 	dir = 4;
 	name = "Telecoms Server Access";
@@ -70056,6 +70713,9 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
 /turf/simulated/floor/bluegrid{
 	icon_state = "dark";
@@ -70086,7 +70746,9 @@
 /turf/simulated/floor/plating,
 /area/station/gateway)
 "qMz" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -70262,7 +70924,9 @@
 /turf/simulated/floor/plating,
 /area/station/civilian/chapel/altar)
 "qOY" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -70416,7 +71080,9 @@
 /turf/simulated/floor/carpet/red,
 /area/station/security/detectives_office)
 "qRA" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -70436,6 +71102,16 @@
 	icon_state = "purplechecker"
 	},
 /area/station/civilian/barbershop)
+"qRP" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/fitness)
 "qSg" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -70459,6 +71135,16 @@
 	icon_state = "dark"
 	},
 /area/station/security/main)
+"qSF" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/engine)
 "qSL" = (
 /obj/structure/grille{
 	destroyed = 1
@@ -71137,7 +71823,9 @@
 	dir = 8;
 	id = "Captain_private"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/sign/warning/electricshock,
 /turf/simulated/floor/plating,
 /area/station/bridge/captain_quarters)
@@ -71178,7 +71866,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
@@ -71301,7 +71991,9 @@
 	name = "Drone Fabrication";
 	req_access = list(32)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -71390,7 +72082,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -71683,7 +72377,9 @@
 	dir = 4;
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -71863,7 +72559,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "rkm" = (
@@ -72406,7 +73104,9 @@
 	id = "HoP_queue";
 	opacity = 0
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -72875,7 +73575,9 @@
 	},
 /area/station/bridge)
 "rye" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	dir = 4;
@@ -73272,7 +73974,9 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
 "rCV" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -73953,7 +74657,9 @@
 /obj/structure/window/thin/reinforced{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/random/foods/donuts,
 /turf/simulated/floor/wood,
 /area/station/civilian/kitchen)
@@ -73961,7 +74667,9 @@
 /obj/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "rNv" = (
@@ -74088,7 +74796,9 @@
 	dir = 4;
 	name = "Escape Hall"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -74173,7 +74883,9 @@
 	name = "Bridge Blast Doors";
 	opacity = 0
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -74237,7 +74949,9 @@
 	name = "Xenoarchaeologist office";
 	req_access = list(65)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -74530,7 +75244,9 @@
 	},
 /area/station/rnd/telesci)
 "rTa" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	dir = 4;
 	id = "Gateway_shutters_entrance";
@@ -74558,7 +75274,9 @@
 	},
 /area/station/rnd/mixing)
 "rUa" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/maintenance{
 	dir = 4;
 	req_access = list(12)
@@ -74775,7 +75493,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -75203,7 +75923,9 @@
 	},
 /area/station/cargo/qm)
 "scx" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -75286,7 +76008,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/auxsolarstarboard)
 "sdi" = (
@@ -75435,7 +76159,9 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "seL" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -75857,7 +76583,9 @@
 	name = "Research and Development";
 	req_access = list(7)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -76607,6 +77335,16 @@
 	icon_state = "red"
 	},
 /area/station/security/lobby)
+"svI" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/recycler)
 "svN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -77107,7 +77845,9 @@
 	name = "Tribunal"
 	})
 "sBo" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -77387,7 +78127,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "sDz" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -77511,7 +78253,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
@@ -77626,7 +78370,9 @@
 	name = "Librarian";
 	req_access = list(37)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -77781,12 +78527,26 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/office)
+"sIf" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor{
+	icon_state = "dark"
+	},
+/area/station/aisat)
 "sIh" = (
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
@@ -77934,7 +78694,9 @@
 	},
 /area/station/cargo/office)
 "sLz" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -78039,7 +78801,9 @@
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "bot"
 	},
@@ -78480,7 +79244,9 @@
 /turf/simulated/floor/plating/airless,
 /area/station/cargo/recycler)
 "sSX" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -78846,7 +79612,9 @@
 	name = "Firing Range";
 	req_access = list(1)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -78983,6 +79751,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/incinerator)
+"sZq" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/office)
 "sZs" = (
 /obj/structure/closet/bombcloset,
 /obj/machinery/firealarm{
@@ -79852,7 +80630,9 @@
 	dir = 4;
 	name = "Garden"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -79970,7 +80750,9 @@
 	},
 /area/station/medical/genetics_cloning)
 "tnb" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -80385,7 +81167,9 @@
 	},
 /area/station/rnd/telesci)
 "ttz" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -80459,7 +81243,9 @@
 /turf/simulated/floor/carpet/green,
 /area/station/civilian/dormitories)
 "tuC" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -81526,7 +82312,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/disposal)
 "tIj" = (
@@ -81731,7 +82519,9 @@
 	name = "Equipment Storage";
 	req_access = list(1)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -81831,7 +82621,9 @@
 	},
 /area/station/medical/reception)
 "tKW" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/machinery/door/poddoor{
 	density = 0;
@@ -82828,7 +83620,9 @@
 	},
 /area/station/hallway/secondary/entry)
 "tXj" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/maintenance{
 	dir = 4;
 	req_access = list(12)
@@ -83215,7 +84009,9 @@
 	name = "Research Shuttle Dock"
 	})
 "uem" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "brown"
@@ -83587,7 +84383,9 @@
 	name = "Tribunal"
 	})
 "uiP" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -83614,7 +84412,9 @@
 	name = "Warden's Office";
 	req_access = list(3)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -83746,7 +84546,9 @@
 	},
 /area/station/security/range)
 "ukK" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -84005,7 +84807,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "uoN" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -84237,7 +85041,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "urM" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/barricade/wooden,
 /obj/structure/window/fulltile{
 	grilled = 1;
@@ -84450,7 +85256,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "utQ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -84483,7 +85291,9 @@
 /turf/simulated/wall/r_wall,
 /area/station/rnd/hor)
 "uud" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -84530,7 +85340,9 @@
 /turf/simulated/floor/carpet/blue2,
 /area/station/bridge/hop_office)
 "uuQ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/external{
 	dir = 4;
 	name = "Escape Airlock";
@@ -85041,7 +85853,9 @@
 	},
 /area/station/civilian/chapel/crematorium)
 "uCx" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -85300,7 +86114,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/incinerator)
 "uGG" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -86000,7 +86816,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/incinerator)
 "uOj" = (
@@ -86196,7 +87014,9 @@
 	},
 /area/station/aisat/antechamber_interior)
 "uRC" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/sign/nanotrasen,
 /obj/structure/cable,
 /obj/structure/cable{
@@ -86409,7 +87229,9 @@
 	},
 /area/station/engineering/break_room)
 "uTy" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -86652,7 +87474,9 @@
 	dir = 4;
 	name = "Unisex Restrooms"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -87856,7 +88680,9 @@
 	},
 /area/station/cargo/qm)
 "vlu" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/structure/window/fulltile{
 	grilled = 1;
@@ -88014,7 +88840,9 @@
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "vnx" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
@@ -88219,7 +89047,9 @@
 	dir = 4;
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -88454,6 +89284,16 @@
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/wood,
 /area/station/civilian/library)
+"vtP" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/civilian/kitchen)
 "vtZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor{
@@ -88792,6 +89632,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
+"vyG" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/medical/virology)
 "vyP" = (
 /obj/structure/cable,
 /obj/item/solar_assembly,
@@ -88923,7 +89773,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 8
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "vAv" = (
@@ -89200,7 +90052,9 @@
 	name = "Hydroponics Pasture";
 	req_access = list(35)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -89452,7 +90306,9 @@
 	name = "Bridge Blast Doors";
 	opacity = 0
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -89967,6 +90823,16 @@
 /obj/random/tools/tool,
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboardsolar)
+"vNK" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/disposal)
 "vNL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -90372,7 +91238,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -90738,7 +91606,9 @@
 	},
 /area/station/civilian/garden)
 "vXy" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -90893,7 +91763,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/portsolar)
 "vZe" = (
@@ -92614,7 +93486,9 @@
 	dir = 4;
 	name = "Central Access"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -92866,7 +93740,9 @@
 	},
 /area/station/civilian/garden)
 "wxr" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -92935,7 +93811,9 @@
 	},
 /area/station/storage/primary)
 "wxJ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -92971,7 +93849,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "wyJ" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -93008,7 +93888,9 @@
 /area/station/gateway)
 "wyW" = (
 /obj/item/weapon/scrap_lump,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/engineering)
 "wyX" = (
@@ -93381,7 +94263,9 @@
 	dir = 4;
 	req_access = list(12)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -93560,7 +94444,9 @@
 /area/station/maintenance/medbay)
 "wHc" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -93588,7 +94474,9 @@
 	name = "Brig Entry";
 	req_access = list(2)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -93969,7 +94857,9 @@
 	dir = 4;
 	name = "Library"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -94005,7 +94895,9 @@
 	name = "MiniSat Antechamber";
 	req_one_access = list(66)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -94357,7 +95249,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/atmos)
 "wPX" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/medical/glass{
 	dir = 4;
 	name = "Medbay"
@@ -94703,7 +95597,9 @@
 /obj/structure/window/thin/reinforced{
 	dir = 1
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/science)
 "wVk" = (
@@ -94935,7 +95831,9 @@
 	},
 /area/station/civilian/fitness)
 "wYU" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -94966,7 +95864,9 @@
 	},
 /area/station/security/warden)
 "wYY" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	dir = 4;
@@ -95243,7 +96143,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/starboardsolar)
 "xcp" = (
@@ -95273,7 +96175,9 @@
 	name = "Custodial Closet";
 	req_access = list(26)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -95370,7 +96274,9 @@
 	},
 /area/station/bridge/hop_office)
 "xdY" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -95483,7 +96389,9 @@
 	id = "HoP_private";
 	opacity = 0
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
 	icon_state = "shock";
@@ -95598,7 +96506,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "xgc" = (
@@ -95629,7 +96539,9 @@
 	dir = 4
 	},
 /obj/structure/mineral_door/wood,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/medbay)
 "xgz" = (
@@ -96106,7 +97018,9 @@
 	name = "Custodial Closet";
 	req_access = list(26)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -96279,7 +97193,9 @@
 /turf/simulated/floor/wood,
 /area/station/medical/psych)
 "xpw" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -96654,7 +97570,9 @@
 	},
 /area/station/bridge/ai_upload)
 "xvH" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor{
 	density = 0;
 	dir = 4;
@@ -96766,7 +97684,9 @@
 	},
 /area/station/ai_monitored/eva)
 "xwz" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/maintenance{
 	dir = 4;
 	req_access = list(12)
@@ -96807,7 +97727,9 @@
 	},
 /area/station/medical/reception)
 "xwM" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -96855,7 +97777,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/escape)
 "xxs" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
@@ -97116,7 +98040,9 @@
 	range = 10;
 	req_access = list(2)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "red"
 	},
@@ -97378,6 +98304,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
+"xFZ" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos)
 "xGa" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
@@ -98029,7 +98965,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced_phoron"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/sign/warning/fire,
 /turf/simulated/floor/engine,
 /area/station/engineering/engine)
@@ -98490,7 +99428,9 @@
 	freq = 1400;
 	location = "Bar"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/plasticflaps{
 	opacity = 1
 	},
@@ -98943,7 +99883,9 @@
 	},
 /area/station/civilian/gym)
 "xZW" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -99008,7 +99950,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/brig)
 "yax" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -99247,7 +100191,9 @@
 	name = "Telecoms Control Room";
 	req_access = list(61)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -99517,7 +100463,9 @@
 	name = "Virology Access";
 	req_access = list(5)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -99665,7 +100613,9 @@
 /turf/simulated/floor/plating,
 /area/station/maintenance/cargo)
 "yjx" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -114352,7 +115302,7 @@ cJy
 cJy
 vaI
 vaI
-wDR
+vyG
 nSO
 vaI
 vaI
@@ -114613,8 +115563,8 @@ eVt
 fCy
 hdK
 vaI
-wDR
-wDR
+vyG
+vyG
 vaI
 cJy
 dYE
@@ -115650,9 +116600,9 @@ cJy
 cJy
 cJy
 jeg
-bfr
-bfr
-bfr
+gyS
+gyS
+gyS
 jeg
 jeg
 qwk
@@ -115898,14 +116848,14 @@ bHn
 aey
 ilQ
 bFm
-soF
-soF
-soF
+hoL
+hoL
+hoL
 vaI
 cJy
 cJy
 jeg
-bfr
+gyS
 jeg
 aOP
 aCS
@@ -117239,8 +118189,8 @@ adA
 otf
 mfJ
 vlL
-lqA
-lqA
+pUB
+pUB
 vlL
 xBl
 xBl
@@ -118701,8 +119651,8 @@ jfO
 bsG
 wTK
 dNx
-fol
-fol
+gxy
+gxy
 dKR
 blV
 blV
@@ -119190,9 +120140,9 @@ iRy
 cJy
 iRy
 lCM
-qha
-qha
-qha
+bXF
+bXF
+bXF
 rsA
 spn
 rUt
@@ -120044,23 +120994,23 @@ vlL
 vlL
 vlL
 vlL
-lqA
-lqA
-lqA
+pUB
+pUB
+pUB
 vlL
 vlL
 mjv
 aea
 mjv
 vlL
-lqA
+pUB
 vlL
 adz
 otf
 lqA
 vlL
-lqA
-lqA
+pUB
+pUB
 vlL
 uem
 enF
@@ -120068,15 +121018,15 @@ eGP
 vlL
 vlL
 vlL
-lqA
-lqA
-lqA
+pUB
+pUB
+pUB
 vlL
-lqA
-lqA
+pUB
+pUB
 vlL
-lqA
-lqA
+pUB
+pUB
 vlL
 rbr
 rbr
@@ -121100,8 +122050,8 @@ uCB
 gyW
 vRU
 cDK
-lqA
-lqA
+pUB
+pUB
 vlL
 cJy
 cJy
@@ -121745,8 +122695,8 @@ cJy
 cJy
 iRy
 etl
-dIj
-dIj
+qKj
+qKj
 etl
 lgk
 rhQ
@@ -121845,8 +122795,8 @@ vlN
 juX
 oDy
 oDy
-tfb
-tfb
+svI
+svI
 oDy
 oIb
 baM
@@ -121867,9 +122817,9 @@ oIb
 oIb
 cDK
 tIi
-eZa
-eZa
-eZa
+vNK
+vNK
+vNK
 cDK
 cJy
 cJy
@@ -123079,8 +124029,8 @@ xbN
 xbN
 aSM
 eSb
-knP
-knP
+dVO
+dVO
 cLr
 eSb
 eSb
@@ -126163,9 +127113,9 @@ wnD
 nXZ
 lhj
 wnD
-dmE
+mXi
 fYg
-dmE
+mXi
 wnD
 wnD
 aMO
@@ -126724,9 +127674,9 @@ iUm
 dhu
 vks
 ozg
-lwk
+qbN
 kIF
-lwk
+qbN
 ozg
 dps
 abD
@@ -126971,7 +127921,7 @@ rKK
 sIb
 lfU
 hTs
-rmK
+sZq
 etV
 buX
 hTs
@@ -126990,7 +127940,7 @@ reN
 hHL
 iOC
 wlk
-wlk
+jAF
 gep
 peb
 wzM
@@ -127747,9 +128697,9 @@ jPL
 lfW
 lUh
 nIe
-xwN
+lyx
 fOt
-xwN
+lyx
 nIe
 abB
 hxa
@@ -128532,7 +129482,7 @@ mfF
 kPD
 dvS
 wlk
-wlk
+jAF
 gep
 rLR
 ifZ
@@ -130601,9 +131551,9 @@ oQV
 oSS
 cJy
 pKw
-qUW
-qUW
-qUW
+xFZ
+xFZ
+xFZ
 pKw
 cJy
 cJy
@@ -131248,8 +132198,8 @@ lUa
 lUa
 lUa
 uiP
-eCj
-eCj
+kYI
+kYI
 oPc
 wYa
 aQh
@@ -131548,11 +132498,11 @@ tYj
 wWZ
 tGa
 cnp
-dRV
+eqT
 kSB
 yax
 bfO
-dRV
+eqT
 acc
 jUH
 iRy
@@ -131761,9 +132711,9 @@ lUa
 lUa
 lUa
 lUa
-eCj
+kYI
 exM
-eCj
+kYI
 rSg
 lFI
 wox
@@ -133303,9 +134253,9 @@ lUa
 lUa
 lUa
 lUa
-eCj
+kYI
 exM
-eCj
+kYI
 rSg
 lFI
 puv
@@ -133342,7 +134292,7 @@ rbG
 rNj
 eJh
 kdX
-vwE
+vtP
 kTI
 rbG
 cnp
@@ -133576,9 +134526,9 @@ ufp
 lmc
 wbk
 woH
-pUW
+qRP
 gPp
-pUW
+qRP
 woH
 doO
 mTV
@@ -137537,11 +138487,11 @@ pKw
 nEb
 pKw
 sFy
-qUW
+xFZ
 nWE
 pKw
 sFy
-qUW
+xFZ
 nWE
 pKw
 uIq
@@ -137749,7 +138699,7 @@ aHv
 aHv
 piZ
 ciy
-oHh
+cTH
 aHv
 njA
 uRZ
@@ -140577,9 +141527,9 @@ npE
 eWy
 veM
 aHv
-oHh
+cTH
 ami
-oHh
+cTH
 vdJ
 vdJ
 oTW
@@ -142067,9 +143017,9 @@ iRy
 iRy
 sQT
 sQT
-jpr
-jpr
-jpr
+cVb
+cVb
+cVb
 sQT
 sQT
 cJy
@@ -142155,8 +143105,8 @@ tye
 jDd
 tye
 tye
-wpz
-wpz
+qSF
+qSF
 tye
 cJy
 iRy
@@ -142374,8 +143324,8 @@ aHv
 aHv
 aHv
 aHv
-oHh
-oHh
+cTH
+cTH
 aHv
 ftA
 jEk
@@ -142681,8 +143631,8 @@ iRy
 cJy
 cJy
 gvI
-xAc
-xAc
+sIf
+sIf
 gvI
 aKR
 gvI
@@ -143180,8 +144130,8 @@ iRy
 cJy
 cJy
 tye
-wpz
-wpz
+qSF
+qSF
 tye
 cJy
 iRy

--- a/maps/prometheus_asteroid/prometheus_asteroid.dmm
+++ b/maps/prometheus_asteroid/prometheus_asteroid.dmm
@@ -1375,7 +1375,9 @@
 	name = "Bathroom";
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "showroomfloor"
 	},
@@ -1802,6 +1804,16 @@
 	icon_state = "wood"
 	},
 /area/asteroid/mine/explored)
+"gg" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/asteroid/mine/living_quarters)
 "gh" = (
 /obj/structure/grille,
 /obj/item/weapon/scrap_lump,
@@ -2071,7 +2083,9 @@
 	req_access = list(65);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -2434,7 +2448,9 @@
 	req_one_access = list(65,10,24);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 8
 	},
@@ -2909,7 +2925,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -3279,7 +3297,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced_phoron"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
@@ -3437,7 +3457,9 @@
 	},
 /area/asteroid/mine/explored)
 "mF" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -3568,7 +3590,9 @@
 	req_one_access = list(65,10,24);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -3946,7 +3970,9 @@
 	name = "Mining outpost";
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -4631,7 +4657,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/engine,
 /area/asteroid/research_outpost/iso2)
 "so" = (
@@ -4700,7 +4728,9 @@
 /turf/simulated/floor,
 /area/asteroid/mine/dwarf)
 "sE" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable,
 /obj/machinery/power/apc/largecell{
 	name = "RnD largecell apc down";
@@ -4857,7 +4887,9 @@
 	name = "Long Term Storage";
 	req_access = list(65)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -4916,7 +4948,9 @@
 /turf/simulated/wall,
 /area/asteroid/research_outpost/hallway)
 "tF" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -4979,13 +5013,25 @@
 	},
 /turf/simulated/floor/plating,
 /area/asteroid/research_outpost/atmos)
+"tQ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/asteroid/mine/production)
 "tU" = (
 /obj/machinery/door/airlock/mining{
 	name = "Mining Storage";
 	req_access = list(48);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -5455,7 +5501,9 @@
 	name = "Mining External Access";
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
@@ -5678,7 +5726,9 @@
 /turf/simulated/floor/engine,
 /area/asteroid/mine/abandoned)
 "xp" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	dir = 1;
 	icon_state = "whitepurple"
@@ -5920,7 +5970,9 @@
 	},
 /area/asteroid/research_outpost/hallway)
 "yx" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/sign/departments/chemistry{
 	desc = "A warning sign which reads 'SAMPLE PREPARATION'";
 	name = "\improper SAMPLE PREPARATION";
@@ -6302,7 +6354,9 @@
 	req_access = list(65);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -6341,7 +6395,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -6519,9 +6575,21 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/asteroid/mine/maintenance)
+"AY" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/asteroid/research_outpost/hallway)
 "Bb" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -6670,7 +6738,9 @@
 	req_one_access = list(48);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -6895,7 +6965,9 @@
 	req_access = list(65);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -6944,7 +7016,9 @@
 	name = "Mining Outpost"
 	})
 "Da" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -6997,7 +7071,9 @@
 	req_access = list(65);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -7260,6 +7336,16 @@
 /obj/random/vending/snack,
 /turf/simulated/floor/wood,
 /area/asteroid/research_outpost/hallway)
+"EJ" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/asteroid/research_outpost/anomaly)
 "EK" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable,
@@ -7566,7 +7652,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -7916,7 +8004,9 @@
 	name = "Mining Outpost"
 	})
 "Ic" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -7967,7 +8057,9 @@
 /area/asteroid/mine/eva)
 "Ir" = (
 /obj/machinery/mineral/unloading_machine,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor,
 /area/asteroid/mine/west_outpost{
 	name = "Mining Outpost"
@@ -8118,7 +8210,9 @@
 	name = "Mining Station EVA";
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -8181,7 +8275,9 @@
 	},
 /area/asteroid/research_outpost/hallway)
 "Jv" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/light/small,
 /turf/simulated/floor{
 	icon_state = "whitepurple"
@@ -8290,7 +8386,9 @@
 /turf/simulated/floor/plating,
 /area/asteroid/mine/eva)
 "JS" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -9043,7 +9141,9 @@
 /turf/environment/space,
 /area/space)
 "Nv" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock{
 	id_tag = "mbath";
 	name = "Bathroom";
@@ -9495,7 +9595,9 @@
 /turf/simulated/floor/bluegrid,
 /area/asteroid/research_outpost/iso1)
 "PW" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -9810,6 +9912,18 @@
 	icon_state = "vaultfull"
 	},
 /area/asteroid/mine/eva)
+"Rt" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/asteroid/mine/west_outpost{
+	name = "Mining Outpost"
+	})
 "Rx" = (
 /obj/structure/dispenser/oxygen,
 /obj/machinery/firealarm{
@@ -9907,7 +10021,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -9934,7 +10050,9 @@
 	req_access = list(61);
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -10097,7 +10215,9 @@
 	id = "mining_internal"
 	},
 /obj/structure/plasticflaps,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/asteroid/mine/production)
 "SR" = (
@@ -10693,7 +10813,9 @@
 	},
 /area/asteroid/research_outpost/iso1)
 "Vs" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -10812,7 +10934,9 @@
 	id = "mining_internal"
 	},
 /obj/structure/plasticflaps,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/turf_decal{
 	icon_state = "warn_corner"
 	},
@@ -10901,7 +11025,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
@@ -11008,7 +11134,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
@@ -11210,6 +11338,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/asteroid/mine/dwarf)
+"Yi" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/asteroid/mine/eva)
 "Yk" = (
 /obj/machinery/mining/brace{
 	dir = 4
@@ -11604,7 +11742,9 @@
 /turf/simulated/floor/plating,
 /area/asteroid/mine/dwarf)
 "ZG" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/newscaster{
 	pixel_y = 28
 	},
@@ -39762,9 +39902,9 @@ EK
 Lz
 fP
 Wf
-jG
-jG
-jG
+tQ
+tQ
+tQ
 MT
 SQ
 MT
@@ -41817,10 +41957,10 @@ Bx
 FP
 zJ
 yH
-oF
+Yi
 Jh
-oF
-oF
+Yi
+Yi
 yH
 VL
 VL
@@ -42069,9 +42209,9 @@ es
 hc
 zA
 zA
-jG
+tQ
 tU
-jG
+tQ
 yH
 yH
 mK
@@ -43863,9 +44003,9 @@ WW
 db
 zA
 zA
-vv
+gg
 tF
-vv
+gg
 zA
 zA
 nZ
@@ -44382,9 +44522,9 @@ lm
 lm
 MT
 MT
-jG
+tQ
 BM
-jG
+tQ
 yH
 yH
 XM
@@ -46948,8 +47088,8 @@ db
 db
 vU
 Ic
-nP
-nP
+AY
+AY
 vU
 vG
 EB
@@ -47728,8 +47868,8 @@ Da
 Jv
 Qn
 Qn
-Iv
-Iv
+EJ
+EJ
 zK
 Qn
 Qn
@@ -49270,9 +49410,9 @@ PW
 sE
 Qn
 Ug
-Iv
+EJ
 hx
-Iv
+EJ
 Qn
 Vd
 jg
@@ -49830,10 +49970,10 @@ aK
 IC
 gZ
 gZ
-of
+Rt
 oL
-of
-of
+Rt
+Rt
 gZ
 gZ
 gZ

--- a/maps/stroechka/stroechka.dmm
+++ b/maps/stroechka/stroechka.dmm
@@ -169,7 +169,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced_phoron"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/meter{
 	layer = 3.2
 	},
@@ -186,7 +188,9 @@
 	pixel_y = -28;
 	req_access = list(71)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	id = "Out";
 	dir = 4
@@ -225,7 +229,9 @@
 	pixel_y = -28;
 	req_access = list(71)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "bot"
 	},
@@ -633,7 +639,9 @@
 	name = "Escape Airlock";
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/turf_decal/alpha/yellow{
 	icon_state = "delivery"
 	},
@@ -883,7 +891,9 @@
 	dir = 4
 	},
 /obj/structure/fans/tiny,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/effect/decal/turf_decal/alpha/gray{
 	icon_state = "bot"
 	},
@@ -896,7 +906,9 @@
 	},
 /area/station/hallway/secondary/arrival)
 "bP" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -2326,7 +2338,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -2842,7 +2856,9 @@
 /turf/simulated/floor/plating/airless,
 /area/station/cargo/recycler)
 "fh" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -2918,7 +2934,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -3583,6 +3601,16 @@
 	icon_state = "dark"
 	},
 /area/station/hallway/secondary/exit)
+"gY" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/cargo/storage)
 "he" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/atmospherics/components/unary/portables_connector{
@@ -3653,7 +3681,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -3963,7 +3993,9 @@
 /turf/simulated/floor,
 /area/station/rnd/chargebay)
 "jR" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	id = "Skynet_launch";
 	name = "Mech Bay";
@@ -4182,7 +4214,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/station/rnd/lab)
 "lT" = (
@@ -4203,6 +4237,16 @@
 	icon_state = "dark"
 	},
 /area/station/rnd/lab)
+"mk" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/hallway/secondary/arrival)
 "mm" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -4607,7 +4651,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced_phoron"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 8
 	},
@@ -4741,6 +4787,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/cargo/storage)
+"rL" = (
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos)
 "rN" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 8
@@ -4821,6 +4877,16 @@
 	icon_state = "caution"
 	},
 /area/station/engineering/atmos)
+"sx" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/atmos)
 "sB" = (
 /obj/machinery/atmospherics/components/unary/tank/nitrogen{
 	dir = 8;
@@ -4882,7 +4948,9 @@
 /turf/simulated/floor,
 /area/station/engineering/equip)
 "sS" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/sign/departments/science,
 /obj/structure/window/fulltile{
 	grilled = 1;
@@ -5509,6 +5577,16 @@
 	},
 /turf/simulated/floor/plating,
 /area/station/engineering/atmos)
+"yU" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/equip)
 "yW" = (
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering EVA";
@@ -5643,6 +5721,16 @@
 	icon_state = "dark"
 	},
 /area/station/engineering/equip)
+"zX" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/engineering/engine)
 "Ab" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
@@ -6292,7 +6380,9 @@
 	name = "Escape Hall";
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -6575,7 +6665,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engine Room";
 	req_access = list(71);
@@ -6672,7 +6764,9 @@
 /turf/environment/space,
 /area/shuttle/supply/station)
 "FL" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/sign/departments/engineering,
 /obj/structure/window/fulltile{
 	grilled = 1;
@@ -6749,7 +6843,9 @@
 /turf/simulated/wall,
 /area/station/engineering/atmos)
 "Gn" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -6856,7 +6952,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -7419,6 +7517,16 @@
 	},
 /turf/environment/space,
 /area/shuttle/supply/station)
+"JY" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/maintenance/auxsolarport)
 "Kb" = (
 /obj/effect/decal/turf_decal{
 	dir = 9;
@@ -7560,13 +7668,15 @@
 /turf/simulated/floor/plating,
 /area/station/engineering/engine)
 "LZ" = (
-/obj/structure/window/fulltile/reinforced/phoron{
-	grilled = 1;
-	icon_state = "gr_window_reinforced_phoron"
+/obj/machinery/door/firedoor{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor/engine/vacuum,
-/area/station/engineering/engine)
+/obj/structure/window/fulltile{
+	grilled = 1;
+	icon_state = "gr_window"
+	},
+/turf/simulated/floor/plating,
+/area/station/rnd/lab)
 "Mb" = (
 /obj/structure/stool/bed/chair/office/light,
 /obj/effect/landmark/start/chief_engineer,
@@ -7766,7 +7876,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
@@ -7786,7 +7898,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced_phoron"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 8
 	},
@@ -8002,7 +8116,9 @@
 /turf/simulated/floor,
 /area/station/engineering/atmos)
 "PR" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile{
 	grilled = 1;
 	icon_state = "gr_window"
@@ -8264,7 +8380,9 @@
 	pixel_y = 28;
 	req_access = list(71)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	id = "Out2";
 	dir = 4
@@ -8501,7 +8619,9 @@
 	pixel_y = 28;
 	req_access = list(71)
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	id = "Out";
 	dir = 4
@@ -8712,7 +8832,9 @@
 	},
 /area/station/engineering/atmos)
 "Vv" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/window/fulltile/reinforced{
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
@@ -8803,6 +8925,16 @@
 	},
 /turf/simulated/floor,
 /area/station/engineering/atmos)
+"VY" = (
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
+/obj/structure/window/fulltile/reinforced{
+	grilled = 1;
+	icon_state = "gr_window_reinforced"
+	},
+/turf/simulated/floor/plating,
+/area/station/rnd/lab)
 "Wc" = (
 /obj/effect/decal/turf_decal{
 	dir = 1;
@@ -8833,7 +8965,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /turf/simulated/floor{
 	icon_state = "dark"
 	},
@@ -9092,7 +9226,9 @@
 	dir = 4
 	},
 /obj/structure/fans/tiny,
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/door/poddoor/shutters{
 	id = "Out";
 	dir = 4
@@ -9109,7 +9245,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
@@ -9304,7 +9442,9 @@
 	grilled = 1;
 	icon_state = "gr_window_reinforced_phoron"
 	},
-/obj/machinery/door/firedoor,
+/obj/machinery/door/firedoor{
+	dir = 4
+	},
 /obj/structure/sign/warning/fire,
 /turf/simulated/floor/engine/vacuum,
 /area/station/engineering/engine)
@@ -31314,7 +31454,7 @@ gN
 gN
 bP
 bP
-LZ
+OI
 am
 TD
 ar
@@ -31553,9 +31693,9 @@ MC
 MC
 MC
 BH
-BY
-BY
-BY
+JY
+JY
+JY
 BH
 XB
 aF
@@ -32838,9 +32978,9 @@ MC
 MC
 MC
 BH
-BY
-BY
-BY
+JY
+JY
+JY
 BH
 Zy
 Dw
@@ -33123,12 +33263,12 @@ io
 gN
 gN
 bA
-si
-si
+gY
+gY
 fo
 SY
-si
-si
+gY
+gY
 bi
 ez
 eA
@@ -33612,8 +33752,8 @@ Zw
 Zw
 Zw
 fh
-YY
-YY
+mk
+mk
 qv
 vN
 fG
@@ -33907,7 +34047,7 @@ Kb
 yK
 VQ
 si
-si
+gY
 ZS
 Df
 jw
@@ -34125,9 +34265,9 @@ Zw
 Zw
 Zw
 Zw
-YY
+mk
 Vv
-YY
+mk
 ks
 cd
 fP
@@ -34140,11 +34280,11 @@ Fu
 gN
 gN
 gN
-Hk
-Hk
+zX
+zX
 gN
-Hk
-Hk
+zX
+zX
 gN
 gN
 gN
@@ -35449,7 +35589,7 @@ cW
 CV
 Nc
 si
-si
+gY
 ZS
 JV
 fD
@@ -35667,9 +35807,9 @@ Zw
 Zw
 Zw
 Zw
-YY
+mk
 Vv
-YY
+mk
 GD
 cB
 Lt
@@ -35688,10 +35828,10 @@ qs
 qs
 Wn
 qs
-sJ
+yU
 FL
-sJ
-sJ
+yU
+yU
 qs
 qs
 qs
@@ -36182,8 +36322,8 @@ Zw
 Zw
 Zw
 fh
-YY
-YY
+mk
+mk
 nK
 Lx
 cl
@@ -36964,9 +37104,9 @@ Zi
 Zi
 GM
 Zi
-EI
-EI
-EI
+LZ
+LZ
+LZ
 Zi
 Zi
 fx
@@ -36976,9 +37116,9 @@ Az
 qs
 Gl
 Gl
-rm
-rm
-rm
+sx
+sx
+sx
 Gl
 XG
 XG
@@ -38505,9 +38645,9 @@ MC
 MC
 MC
 Zi
-il
-il
-il
+VY
+VY
+VY
 lS
 Zi
 Zi
@@ -38775,8 +38915,8 @@ wQ
 ap
 ap
 Gl
-NR
-NR
+rL
+rL
 Gl
 Vz
 Yi
@@ -39294,7 +39434,7 @@ MC
 MC
 Gl
 YI
-NR
+rL
 YI
 NO
 NO
@@ -39808,7 +39948,7 @@ MC
 SW
 VK
 YS
-NR
+rL
 YS
 VK
 pb


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Обновление диров фаердоров на Коробке, Фалькольне, Прометее, астеройде Прометея и на Строечке.
Upd: так же добрался до Дельты
Upd2: отменены изменения в саду коробки
Нужно будет продумать уменьшение стекол которые стоят рядом с друг другом и делают выпирающие части станций. 
## Почему и что этот ПР улучшит
Уменьшение санити мапера и улучшение визуала игры и карты, окончательное решение вопроса по closes #12290
## Авторство
Ястарк
## Чеинжлог
