### PR TITLE
blob and canisters

### DIFF
--- a/code/modules/atmospheric/machinery/portable/canister.dm
+++ b/code/modules/atmospheric/machinery/portable/canister.dm
@@ -128,6 +128,9 @@
 	create_gas()
 	update_icon()
 
+/obj/machinery/portable_atmospherics/canister/blob_act()
+	qdel(src)
+
 /obj/machinery/portable_atmospherics/canister/proc/create_gas()
 	if(gas_type && start_pressure)
 		air_contents.adjust_gas(gas_type, MolesForPressure())


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Удары блоба удаляют канистры с газами, а не ломают их
## Почему и что этот ПР улучшит
Баланс 
Убьёт унылую и невероятно эффективную стратегию со спавном на складе токсинов, ведь там стоит целых 4 канистры с фороном, от которого может защитить лишь разгерма помещения или риг с модулем охлаждения.
## Авторство

## Чеинжлог
🆑 Simbaka
- balance: Удары блоба полностью удаляют канистры с газами.