### PR TITLE
Выпил дубликата кода откручивания смартхолодильников

### DIFF
--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -222,15 +222,6 @@
 
 	default_deconstruction_crowbar(O)
 
-	if(isscrewing(O))
-		panel_open = !panel_open
-		to_chat(user, "You [panel_open ? "open" : "close"] the maintenance panel.")
-		cut_overlays()
-		if(panel_open)
-			add_overlay(image(icon, icon_panel))
-		nanomanager.update_uis(src)
-		return
-
 	if(is_wire_tool(O) && panel_open && wires.interact(user))
 		return
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Это ломает спрайт, выпилил дублирующийся код чтобы не ломало.
## Почему и что этот ПР улучшит
closes #12354
## Авторство

## Чеинжлог
:cl: Deahaka
- fix: Холодильники теперь не теряют стекло при взаимодействии с отвёрткой.