### PR TITLE
Крч огонь и взрывы с аномалиями переместились на плейн ламп.

### DIFF
--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -70,6 +70,7 @@
 /obj/effect/anomaly/grav
 	name = "gravitational anomaly"
 	icon_state = "grav"
+	plane = LIGHTING_LAMPS_PLANE
 	density = TRUE
 	var/boing = 0
 	///Warp effect holder for displacement filter to "pulse" the anomaly
@@ -120,6 +121,7 @@
 
 /obj/effect/anomaly/flux
 	name = "flux wave anomaly"
+	plane = LIGHTING_LAMPS_PLANE
 	icon_state = "flux2"
 	light_color = "#ffe194"
 
@@ -132,6 +134,7 @@
 /obj/effect/anomaly/bluespace
 	name = "bluespace anomaly"
 	icon_state = "bluespace"
+	plane = LIGHTING_LAMPS_PLANE
 	density = TRUE
 	light_color = "#009eff"
 

--- a/code/game/objects/effects/anomalies.dm
+++ b/code/game/objects/effects/anomalies.dm
@@ -70,7 +70,6 @@
 /obj/effect/anomaly/grav
 	name = "gravitational anomaly"
 	icon_state = "grav"
-	plane = LIGHTING_LAMPS_PLANE
 	density = TRUE
 	var/boing = 0
 	///Warp effect holder for displacement filter to "pulse" the anomaly
@@ -121,7 +120,6 @@
 
 /obj/effect/anomaly/flux
 	name = "flux wave anomaly"
-	plane = LIGHTING_LAMPS_PLANE
 	icon_state = "flux2"
 	light_color = "#ffe194"
 
@@ -134,7 +132,6 @@
 /obj/effect/anomaly/bluespace
 	name = "bluespace anomaly"
 	icon_state = "bluespace"
-	plane = LIGHTING_LAMPS_PLANE
 	density = TRUE
 	light_color = "#009eff"
 

--- a/code/game/objects/effects/explosion_particles.dm
+++ b/code/game/objects/effects/explosion_particles.dm
@@ -2,6 +2,7 @@
 	name = "explosive particles"
 	icon = 'icons/effects/effects.dmi'
 	icon_state = "explosion_particle"
+	plane = LIGHTING_LAMPS_PLANE
 	opacity = 1
 	anchored = TRUE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
@@ -34,6 +35,7 @@
 	name = "explosive particles"
 	icon = 'icons/effects/96x96.dmi'
 	icon_state = "explosion"
+	plane = LIGHTING_LAMPS_PLANE
 	opacity = 1
 	anchored = TRUE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT

--- a/code/modules/atmospheric/ZAS/Fire.dm
+++ b/code/modules/atmospheric/ZAS/Fire.dm
@@ -129,6 +129,7 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 	icon_state = "1"
 	light_color = LIGHT_COLOR_FIRE
 	layer = OBJ_LAYER
+	plane = LIGHTING_LAMPS_PLANE
 	flags = ABSTRACT
 
 /obj/effect/firewave/atom_init(mapload, temperature = 1000)
@@ -175,6 +176,7 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 	icon_state = "1"
 	light_color = LIGHT_COLOR_FIRE
 	layer = OBJ_LAYER
+	plane = LIGHTING_LAMPS_PLANE
 	flags = ABSTRACT
 
 	var/firelevel = 1 //Calculated by gas_mixture.calculate_firelevel()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -333,6 +333,7 @@ Please contact me on #coderbus IRC. ~Carn x
 		var/image/over = image('icons/mob/OnFire.dmi', "human_overlay", layer = -FIRE_UPPER_LAYER)
 		under = update_height(under)
 		over = update_height(over)
+		over.plane = LIGHTING_LAMPS_PLANE
 		overlays_standing[FIRE_LOWER_LAYER] = under
 		overlays_standing[FIRE_UPPER_LAYER] = over
 

--- a/code/modules/mob/living/carbon/ian/update_icons.dm
+++ b/code/modules/mob/living/carbon/ian/update_icons.dm
@@ -234,7 +234,9 @@
 	update_fire_underlay()
 	if(on_fire)
 		//overlays_standing[LAYERIAN_LOWER_FIRE] = image("icon"='icons/mob/OnFire.dmi', "icon_state"="generic_underlay", "layer"=-LAYERIAN_LOWER_FIRE)
-		overlays_standing[LAYERIAN_UPPER_FIRE] = image("icon"='icons/mob/OnFire.dmi', "icon_state"="generic_overlay", "layer"=-LAYERIAN_UPPER_FIRE)
+		var/image/over = image("icon"='icons/mob/OnFire.dmi', "icon_state"="generic_overlay", "layer"=-LAYERIAN_UPPER_FIRE)
+		over.plane = LIGHTING_LAMPS_PLANE
+		overlays_standing[LAYERIAN_UPPER_FIRE] = over
 
 	//apply_standing_overlay(LAYERIAN_LOWER_FIRE)
 	apply_standing_overlay(LAYERIAN_UPPER_FIRE)

--- a/code/modules/mob/living/carbon/monkey/update_icons.dm
+++ b/code/modules/mob/living/carbon/monkey/update_icons.dm
@@ -161,7 +161,9 @@
 	//cut_overlay(overlays_standing[M_FIRE_LOWER_LAYER])
 	if(on_fire)
 		//overlays_standing[M_FIRE_LOWER_LAYER] = image("icon"='icons/mob/OnFire.dmi', "icon_state"="generic_underlay", layer = -M_FIRE_LOWER_LAYER)
-		overlays_standing[M_FIRE_UPPER_LAYER] = image("icon"='icons/mob/OnFire.dmi', "icon_state"="generic_overlay", layer = -M_FIRE_UPPER_LAYER)
+		var/image/over = image("icon"='icons/mob/OnFire.dmi', "icon_state"="generic_overlay", layer = -M_FIRE_UPPER_LAYER)
+		over.plane = LIGHTING_LAMPS_PLANE
+		overlays_standing[M_FIRE_UPPER_LAYER] = over
 		//add_overlay(overlays_standing[M_FIRE_LOWER_LAYER])
 	//else
 		//overlays_standing[M_FIRE_LOWER_LAYER] = null

--- a/code/modules/mob/living/carbon/xenomorph/humanoid/update_icons.dm
+++ b/code/modules/mob/living/carbon/xenomorph/humanoid/update_icons.dm
@@ -178,7 +178,9 @@
 	remove_standing_overlay(X_FIRE_UPPER_LAYER)
 
 	if(on_fire)
-		overlays_standing[X_FIRE_UPPER_LAYER] = image(icon = 'icons/mob/alienqueen.dmi', icon_state = icon_state + "_fire", layer = -X_FIRE_UPPER_LAYER)
+		var/image/over = image(icon = 'icons/mob/alienqueen.dmi', icon_state = icon_state + "_fire", layer = -X_FIRE_UPPER_LAYER)
+		over.plane = LIGHTING_LAMPS_PLANE
+		overlays_standing[X_FIRE_UPPER_LAYER] = over
 
 	apply_standing_overlay(X_FIRE_UPPER_LAYER)
 
@@ -186,7 +188,9 @@
 	remove_standing_overlay(X_FIRE_UPPER_LAYER)
 
 	if(on_fire)
-		overlays_standing[X_FIRE_UPPER_LAYER] = image(icon = 'icons/mob/alienqueen.dmi', icon_state = replacetext(icon_state, "_old", "") + "_fire", layer = -X_FIRE_UPPER_LAYER)
+		var/image/over = image(icon = 'icons/mob/alienqueen.dmi', icon_state = replacetext(icon_state, "_old", "") + "_fire", layer = -X_FIRE_UPPER_LAYER)
+		over.plane = LIGHTING_LAMPS_PLANE
+		overlays_standing[X_FIRE_UPPER_LAYER] = over
 
 	apply_standing_overlay(X_FIRE_UPPER_LAYER)
 
@@ -199,7 +203,9 @@
 	update_fire_underlay()
 	//cut_overlay(overlays_standing[X_FIRE_LOWER_LAYER])
 	if(on_fire)
-		overlays_standing[X_FIRE_UPPER_LAYER] = image(icon = 'icons/mob/OnFire.dmi', icon_state = "human_overlay", layer = -X_FIRE_UPPER_LAYER)
+		var/image/over = image(icon = 'icons/mob/OnFire.dmi', icon_state = "human_overlay", layer = -X_FIRE_UPPER_LAYER)
+		over.plane = LIGHTING_LAMPS_PLANE
+		overlays_standing[X_FIRE_UPPER_LAYER] = over
 		//overlays_standing[X_FIRE_LOWER_LAYER] = image(icon = 'icons/mob/OnFire.dmi', icon_state = "human_underlay", layer = -X_FIRE_LOWER_LAYER)
 		//add_overlay(overlays_standing[X_FIRE_LOWER_LAYER])
 	//overlays_standing[X_FIRE_LOWER_LAYER] = null
@@ -215,7 +221,9 @@
 	update_fire_underlay()
 	//cut_overlay(overlays_standing[X_FIRE_LOWER_LAYER])
 	if(on_fire)
-		overlays_standing[X_FIRE_UPPER_LAYER] = image(icon = 'icons/mob/OnFire.dmi', icon_state = "generic_overlay", layer = -X_FIRE_UPPER_LAYER)
+		var/image/over = image(icon = 'icons/mob/OnFire.dmi', icon_state = "generic_overlay", layer = -X_FIRE_UPPER_LAYER)
+		over.plane = LIGHTING_LAMPS_PLANE
+		overlays_standing[X_FIRE_UPPER_LAYER] = over
 		//overlays_standing[X_FIRE_LOWER_LAYER] = image(icon = 'icons/mob/OnFire.dmi', icon_state = "generic_underlay", layer = -X_FIRE_LOWER_LAYER)
 		//add_overlay(overlays_standing[X_FIRE_LOWER_LAYER])
 	//overlays_standing[X_FIRE_LOWER_LAYER] = null

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -246,7 +246,9 @@
 /mob/living/silicon/robot/update_fire()
 	if(on_fire)
 		underlays += image("icon"='icons/mob/OnFire.dmi', "icon_state"="generic_underlay")
-		add_overlay(image("icon"='icons/mob/OnFire.dmi', "icon_state"="generic_overlay"))
+		var/image/over = image("icon"='icons/mob/OnFire.dmi', "icon_state"="generic_overlay")
+		over.plane = LIGHTING_LAMPS_PLANE
+		add_overlay(over)
 	else
 		underlays -= image("icon"='icons/mob/OnFire.dmi', "icon_state"="generic_underlay")
 		cut_overlay(image("icon"='icons/mob/OnFire.dmi', "icon_state"="generic_overlay"))

--- a/code/modules/power/fusion/core/core_field.dm
+++ b/code/modules/power/fusion/core/core_field.dm
@@ -11,6 +11,7 @@
 	alpha = 50
 	layer = 4
 	light_color = COLOR_BLUE
+	plane = LIGHTING_LAMPS_PLANE
 	anchored = TRUE
 	var/size = 1
 	var/energy = 0


### PR DESCRIPTION
## Описание изменений
Огонь, взрывы и аномалии переместились на плейн ламп.
![image](https://github.com/TauCetiStation/TauCetiClassic/assets/21008918/1e951fbe-9b6b-4535-9ccc-4c97b380d13e)
![image](https://github.com/TauCetiStation/TauCetiClassic/assets/21008918/7114f52f-1f83-4451-b929-1786c9da7e8e)
![image](https://github.com/TauCetiStation/TauCetiClassic/assets/21008918/6621874f-72e4-43a8-95ac-69f0aa576d60)
![image](https://github.com/TauCetiStation/TauCetiClassic/assets/21008918/66530518-d15f-4cd8-b087-b63b91fdbadb)
![image](https://github.com/TauCetiStation/TauCetiClassic/assets/21008918/2e9e7a20-7260-445c-ba4a-73f901e5775d)
![image](https://github.com/TauCetiStation/TauCetiClassic/assets/21008918/c708e834-3f7b-487b-876b-1cb14c1740d3)
![image](https://github.com/TauCetiStation/TauCetiClassic/assets/21008918/61b46e93-d5e6-41d2-8137-2f346a024acb)

## Почему и что этот ПР улучшит
RTX on.

Но надо респрайтнуть наши взрывы и аномалии уже, лоль.
## Авторство
AndreyGysev

## Чеинжлог
 :cl:
  - tweak: огонь, взрывы, аномалии и поле токамака переместились на плейн ламп и стали светиться.