### PR TITLE
In Mani works clear

### DIFF
--- a/code/datums/spells/in_hand.dm
+++ b/code/datums/spells/in_hand.dm
@@ -377,6 +377,37 @@
 	can_powerup = TRUE
 	max_power = 7
 
+///mob/proc/ClickOn()
+// Ranged
+/obj/item/weapon/magic/heal_touch/afterattack(atom/target, mob/user, proximity, params)
+	if(user.incapacitated())
+		return FALSE
+	if(touch_spell)
+		return
+	var/turf/U = get_turf(user)
+	var/turf/T = get_turf(target)
+	if(U == T)
+		return
+	if(!cast_throw(target, user))
+		return FALSE
+	if(s_fire)
+		playsound(user, s_fire, VOL_EFFECTS_MASTER)
+	if(invoke)
+		user.say(invoke)
+	return TRUE
+
+// Adjacent
+/obj/item/weapon/magic/heal_touch/attack(mob/living/M, mob/living/user, def_zone)
+	if(user.incapacitated())
+		return FALSE
+	if(!cast_touch(M, user))
+		return FALSE
+	if(s_fire)
+		playsound(user, s_fire, VOL_EFFECTS_MASTER)
+	if(invoke)
+		user.say(invoke)
+	return TRUE
+
 /obj/item/weapon/magic/heal_touch/attack_self(mob/user)
 	if(!..())
 		return


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
https://github.com/TauCetiStation/TauCetiClassic/pull/11872 вписался в `/item/` которые не имеют `force` и переопределил для них `/attacked_by()`, который был значением `attackby()`, который в `melee_attack_chain()` должен был заиметь `FALSE` для вызова `afterattack()`, который у `/item/magic` отвечал за лечение. https://github.com/TauCetiStation/TauCetiClassic/blob/68bda575331efd43f7a6424d7e58d94b7ddf62e1/code/_onclick/item_attack.dm#L7C8-L7C8
переписал для In Mani чтобы вызывалось всё когда надо. Потыкал, работает.
Ещё это скрытнобаф магов, так как можно тыкать по себе на 5+ апгрейде, а раньше нельзя было.
## Почему и что этот ПР улучшит
closes #12305
## Авторство

## Чеинжлог
:cl: Deahaka
- fix: Заклинание "Лечение" теперь всегда работает при клике по себе.