### PR TITLE
fix resurrection after suicide

### DIFF
--- a/code/game/objects/items/weapons/defibrillator.dm
+++ b/code/game/objects/items/weapons/defibrillator.dm
@@ -413,7 +413,7 @@
 		H.adjustFireLoss(burn_damage_amt)
 	H.updatehealth()
 
-	if(H.health < config.health_threshold_dead)
+	if((H.health < config.health_threshold_dead) || (H.suiciding))
 		make_announcement("buzzes, \"Defibrillation failed - Patinent's body is too wounded to sustain heart beating.\"")
 		playsound(src, 'sound/items/surgery/defib_failed.ogg', VOL_EFFECTS_MASTER, null, FALSE)
 		return

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -2208,7 +2208,7 @@
 			massages_done_right = 0
 			return_to_body_dialog()
 
-			if((health > config.health_threshold_dead) || (suiciding))
+			if((health > config.health_threshold_dead) || (!suiciding))
 				Heart.heart_fibrillate()
 				to_chat(user, "<span class='notice'>You feel an irregular heartbeat coming form [src]'s body. It is in need of defibrillation you assume!</span>")
 			else

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -2208,7 +2208,7 @@
 			massages_done_right = 0
 			return_to_body_dialog()
 
-			if(health > config.health_threshold_dead)
+			if((health > config.health_threshold_dead) || suiciding)
 				Heart.heart_fibrillate()
 				to_chat(user, "<span class='notice'>You feel an irregular heartbeat coming form [src]'s body. It is in need of defibrillation you assume!</span>")
 			else

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -2208,7 +2208,7 @@
 			massages_done_right = 0
 			return_to_body_dialog()
 
-			if((health > config.health_threshold_dead) || suiciding)
+			if((health > config.health_threshold_dead) || (suiciding))
 				Heart.heart_fibrillate()
 				to_chat(user, "<span class='notice'>You feel an irregular heartbeat coming form [src]'s body. It is in need of defibrillation you assume!</span>")
 			else


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
человечка который использовал команду suicide будет невозможно воскресить с помощью дефиба или массажа
## Почему и что этот ПР улучшит
фикс бага
## Авторство
Я
## Чеинжлог
слишком маленькое изменение, никто не жаловался на баг, а значит никто не заметит изменений...