### PR TITLE
Pyro Anomaly runtime empty turfs

### DIFF
--- a/code/modules/events/anomaly.dm
+++ b/code/modules/events/anomaly.dm
@@ -13,12 +13,12 @@
 	if(!impact_area)
 		CRASH("No valid areas for anomaly found.")
 	var/list/turf_test = get_area_turfs(impact_area)
-	if(!turf_test)
+	if(!turf_test || !turf_test.len)
 		CRASH("Anomaly : No valid turfs found for [impact_area] - [impact_area.type]")
 
 /datum/event/anomaly/start()
 	var/list/turfs = get_area_turfs(impact_area)
-	if(!turfs)
+	if(!turfs || turfs.len)
 		return
 	var/turf/T = pick(turfs)
 	newAnomaly = new anomaly_type(T)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Какая-то зона не смогла выдать турфов для спавна аномалии, из-за чего возникал рантайм попытки взять что-то из пустого списка
## Почему и что этот ПР улучшит
![barerl](https://github.com/TauCetiStation/TauCetiClassic/assets/96499407/c0db01c3-867b-4091-a69a-c07c639815d9)
## Авторство

## Чеинжлог
