### PR TITLE
Revert "Фикс библии священника (#12374)"

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -80,10 +80,7 @@ var/global/list/slot_equipment_priority = list(
 	SLOT_S_STORE,
 	SLOT_TIE,
 	SLOT_L_STORE,
-	SLOT_R_STORE,
-	SLOT_L_HAND,
-	SLOT_R_HAND,
-	SLOT_IN_BACKPACK
+	SLOT_R_STORE
 	)
 
 //puts the item "W" into an appropriate slot in a human's inventory

--- a/code/modules/religion/religion_types/chaplain.dm
+++ b/code/modules/religion/religion_types/chaplain.dm
@@ -130,7 +130,7 @@
 
 	lore = sanitize_safe(input(chaplain, "You can come up with the lore of your god in [new_religion] religion.", "Lore for new god", ""), MAX_MESSAGE_LEN)
 
-	chaplain.equip_to_appropriate_slot(B, TRUE)
+	chaplain.equip_to_slot_or_del(B, SLOT_L_HAND)
 
 	var/list/bible_variants = gen_pos_bible_variants()
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Видимо. придется делать как на ТГ, где есть equip_to_best_slot() для квик_эквипа и equip_to_appropriate_slot().

А еще я заметил, что equip_to_appropriate_slot() не обновляет появившуюся иконку в рюкзаке, когда в него квик_эквипом кладешь предмет

fix https://github.com/TauCetiStation/TauCetiClassic/issues/12400

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
