### PR TITLE
Transfer_actions fix

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -83,11 +83,12 @@
 
 	nanomanager.user_transferred(current, new_character) // transfer active NanoUI instances to new user
 
+	transfer_actions(new_character)
+
 	var/mob/old_character = current
 	current = new_character		//link ourself to our new body
 	new_character.mind = src	//and link our new body to ourself
 
-	transfer_actions(new_character)
 	var/datum/atom_hud/antag/hud_to_transfer = antag_hud
 	transfer_antag_huds(hud_to_transfer)
 


### PR DESCRIPTION
## Описание изменений
Коротко: Персонажи должны при передаче mind копировать акшионы "со старого, на нового", а не с "нового на новый".
Подробно: `/datum/mind/proc/transfer_actions(mob/living/new_character)` берёт за основу `current`а, который переопределяется ниже, т.е. до этого момента новый персонаж сам с себя копировал акшионы, (не)передавая их себе же.

Обнаружил случайно, делая сторонний ПР.
Да, во мне что-то проснулось и я решил делить ПРы, а не лить всё одной массой.
## Почему и что этот ПР улучшит
Баг
## Авторство

## Чеинжлог
Я не знаю, на что оно вообще может повлиять. На тестах у меня только связанное с другим ПРом изменилось.