### PR TITLE
timer.dm:208 : undefined variable world/var/active_timers

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -78,8 +78,7 @@ var/global/it_is_a_snow_day = FALSE
 #endif
 
 	if(config.kick_inactive)
-		spawn(15 MINUTES)
-			KickInactiveClients()
+		addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(KickInactiveClients)), 15 MINUTES)
 
 #undef RECOMMENDED_VERSION
 
@@ -263,13 +262,13 @@ var/global/shutdown_processed = FALSE
 
 	..()
 
-/world/proc/KickInactiveClients()
+/proc/KickInactiveClients()
 	for (var/client/C in clients)
 		if (!(C.holder || C.supporter) && C.is_afk())
 			log_access("AFK: [key_name(C)]")
 			to_chat(C, "<span class='userdanger'>You have been inactive for more than [config.afk_time_bracket / 600] minutes and have been disconnected.</span>")
 			QDEL_IN(C, 2 SECONDS)
-	addtimer(CALLBACK(src, PROC_REF(KickInactiveClients)), 5 MINUTES)
+	addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(KickInactiveClients)), 5 MINUTES)
 
 /world/proc/load_stealth_keys()
 	var/list/keys_list = file2list("config/stealth_keys.txt")


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Таймеры объявлены в датуме, но видимо world не наследуется от датума, и на него мы не можем вешать таймер.

## Почему и что этот ПР улучшит

Исправляет кик инактивов.

## Авторство

## Чеинжлог
