### PR TITLE
возвращение ассистентов

### DIFF
--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -131,7 +131,7 @@ SUBSYSTEM_DEF(job)
 		if(!job)
 			continue
 
-		if(istype(job, GetJob("Test Subject"))) // We don't want to give him assistant, that's boring!
+		if(istype(job, GetJob("Assistant"))) // We don't want to give him assistant, that's boring!
 			continue
 
 		if(job.title in command_positions) //If you want a command position, select it!
@@ -159,8 +159,8 @@ SUBSYSTEM_DEF(job)
 
 	// So we end up here which means every other job is unavailable, lets give him "assistant", since this is the only job without any spawn limit and restrictions.
 	if(player.mind && !player.mind.assigned_role)
-		Debug("GRJ Random job given, Player: [player], Job: Test Subject")
-		AssignRole(player, "Test Subject")
+		Debug("GRJ Random job given, Player: [player], Job: Assistant")
+		AssignRole(player, "Assistant")
 		unassigned -= player
 
 /datum/controller/subsystem/job/proc/ResetOccupations()
@@ -286,7 +286,7 @@ SUBSYSTEM_DEF(job)
 	Debug("AC1, Candidates: [assistant_candidates.len]")
 	for(var/mob/dead/new_player/player in assistant_candidates)
 		Debug("AC1 pass, Player: [player]")
-		AssignRole(player, "Test Subject")
+		AssignRole(player, "Assistant")
 		assistant_candidates -= player
 	Debug("DO, AC1 end")
 
@@ -366,7 +366,7 @@ SUBSYSTEM_DEF(job)
 	for(var/mob/dead/new_player/player in unassigned)
 		if(player.client.prefs.alternate_option == BE_ASSISTANT)
 			Debug("AC2 Assistant located, Player: [player]")
-			AssignRole(player, "Test Subject")
+			AssignRole(player, "Assistant")
 
 	//For ones returning to lobby
 	for(var/mob/dead/new_player/player in unassigned)

--- a/code/datums/outfits/jobs/assistant.dm
+++ b/code/datums/outfits/jobs/assistant.dm
@@ -2,7 +2,7 @@
 /datum/outfit/job/assistant
 	name = OUTFIT_JOB_NAME("Assistant Gear")
 
-	uniform = /obj/item/clothing/under/test_subject
+	uniform = /obj/item/clothing/under/color/grey
 	shoes = /obj/item/clothing/shoes/black
 
 /datum/outfit/job/assistant/lawyer

--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -21,6 +21,7 @@
 	outfit = /datum/outfit/job/assistant
 	skillsets = list(
 		"Assistant"      = /datum/skillset/assistant,
+		"Test Subject"   = /datum/skillset/assistant/test_subject,
 		"Lawyer"         = /datum/skillset/assistant/lawyer,
 		"Mecha Operator" = /datum/skillset/assistant/mecha,
 		"Private Eye"    = /datum/skillset/assistant/detective,

--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -1,5 +1,5 @@
 /datum/job/assistant
-	title = "Test Subject"
+	title = "Assistant"
 	flag = ASSISTANT
 	department_flag = CIVILIAN
 	faction = "Station"
@@ -10,6 +10,7 @@
 	access = list()			//See /datum/job/assistant/get_access()
 	salary = 0
 	alt_titles = list(
+		"Test Subject"   = /datum/outfit/job/assistant/test_subject,
 		"Lawyer"         = /datum/outfit/job/assistant/lawyer,
 		"Private Eye"    = /datum/outfit/job/assistant/private_eye,
 		"Reporter"       = /datum/outfit/job/assistant/reporter,
@@ -17,16 +18,16 @@
 		"Vice Officer"   = /datum/outfit/job/assistant/vice_officer,
 		"Paranormal Investigator" = /datum/outfit/job/assistant/paranormal_investigator
 		)
-	outfit = /datum/outfit/job/assistant/test_subject
+	outfit = /datum/outfit/job/assistant
 	skillsets = list(
-		"Test Subject"   = /datum/skillset/test_subject,
-		"Lawyer"         = /datum/skillset/test_subject/lawyer,
-		"Mecha Operator" = /datum/skillset/test_subject/mecha,
-		"Private Eye"    = /datum/skillset/test_subject/detective,
-		"Reporter"       = /datum/skillset/test_subject/reporter,
-		"Waiter"         = /datum/skillset/test_subject/waiter,
-		"Vice Officer"   = /datum/skillset/test_subject/vice_officer,
-		"Paranormal Investigator" = /datum/skillset/test_subject/paranormal
+		"Assistant"      = /datum/skillset/assistant,
+		"Lawyer"         = /datum/skillset/assistant/lawyer,
+		"Mecha Operator" = /datum/skillset/assistant/mecha,
+		"Private Eye"    = /datum/skillset/assistant/detective,
+		"Reporter"       = /datum/skillset/assistant/reporter,
+		"Waiter"         = /datum/skillset/assistant/waiter,
+		"Vice Officer"   = /datum/skillset/assistant/vice_officer,
+		"Paranormal Investigator" = /datum/skillset/assistant/paranormal
 		)
 	flags = JOB_FLAG_CIVIL
 

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -125,7 +125,7 @@ var/global/list/civilian_positions = list(
 	"Janitor",
 	"Barber",
 	"Librarian",
-	"Test Subject"
+	"Assistant"
 )
 
 var/global/list/nonhuman_positions = list(

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -362,7 +362,7 @@
 					tgui_alert(usr, "Invalid name.")
 					return
 
-				var/u = sanitize_safe(input(user, "What occupation would you like to put on this card?\nNote: This will not grant any access levels other than Maintenance.", "Agent card job assignment", "Test Subject"))
+				var/u = sanitize_safe(input(user, "What occupation would you like to put on this card?\nNote: This will not grant any access levels other than Maintenance.", "Agent card job assignment", "Assistant"))
 				if(!u)
 					tgui_alert(usr, "Invalid assignment.")
 					return

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -522,7 +522,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	else
 		new_character.mind_initialize()
 	if(!new_character.mind.assigned_role)
-		new_character.mind.assigned_role = "Test Subject"//If they somehow got a null assigned role.
+		new_character.mind.assigned_role = "Assistant"//If they somehow got a null assigned role.
 
 	//DNA
 	if(record_found)//Pull up their name from database records if they did have a mind.

--- a/code/modules/client/character_menu/occupation.dm
+++ b/code/modules/client/character_menu/occupation.dm
@@ -59,7 +59,7 @@
 		if(!job.is_species_permitted(user.client.prefs.species))
 			. += "<del>[rank]</del></td><td><b> \[SPECIES RESTRICTED]</b></td></tr>"
 			continue
-		if(job_preferences["Test Subject"] == JP_LOW && (rank != "Test Subject"))
+		if(job_preferences["Assistant"] == JP_LOW && (rank != "Assistant"))
 			. += "<font color=orange>[rank]</font></td><td></td></tr>"
 			continue
 		if((rank in command_positions) || (rank == "AI"))//Bold head jobs
@@ -71,8 +71,8 @@
 
 		. += "<a class='white' href='?_src_=prefs;preference=job;task=setJobLevel;dir=higher;text=[rank]' oncontextmenu='window.location.href=\"?_src_=prefs;preference=job;task=setJobLevel;text=[rank]\";return false;'>"
 
-		if(rank == "Test Subject")//Assistant is special
-			if(job_preferences["Test Subject"])
+		if(rank =="Assistant")//Assistant is special
+			if(job_preferences["Assistant"])
 				. += " <font color=green size=2>Yes</font>"
 			else
 				. += " <font color=red size=2>No</font>"
@@ -157,8 +157,8 @@
 	if(!dir) //RMB case
 		jpval = jpval2
 
-	if(role == "Test Subject")
-		if(job_preferences["Test Subject"] == JP_LOW)
+	if(role == "Assistant")
+		if(job_preferences["Assistant"] == JP_LOW)
 			jpval = null
 		else
 			jpval = JP_LOW

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -190,8 +190,8 @@
 	// Determine what job is marked as 'High' priority, and dress them up as such.
 	var/datum/job/previewJob
 
-	if(job_preferences["Test Subject"] == JP_LOW)
-		previewJob = SSjob.GetJob("Test Subject")
+	if(job_preferences["Assistant"] == JP_LOW)
+		previewJob = SSjob.GetJob("Assistant")
 
 	if(!previewJob)
 		var/highest_pref = 0

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -45,6 +45,7 @@ Note: Must be placed west/left of and R&D console to function.
 	. = ..()
 	component_parts = list()
 	component_parts += new /obj/item/weapon/circuitboard/protolathe(src)
+
 	component_parts += new /obj/item/weapon/stock_parts/matter_bin(src)
 	component_parts += new /obj/item/weapon/stock_parts/matter_bin(src)
 	component_parts += new /obj/item/weapon/stock_parts/manipulator(src)

--- a/code/modules/skills/skillsets/civilian.dm
+++ b/code/modules/skills/skillsets/civilian.dm
@@ -87,50 +87,56 @@
 
 /datum/skillset/janitor
 	name = "Janitor"
-/datum/skillset/test_subject
-	name = "Test Subject"
-/datum/skillset/test_subject/lawyer
+/datum/skillset/assistant
+	name = "Assistant"
+/datum/skillset/assistant/lawyer
 	name = "Lawyer"
 	initial_skills = list(
 		/datum/skill/command = SKILL_LEVEL_NOVICE
 	)
 
-/datum/skillset/test_subject/mecha
+/datum/skillset/assistant/mecha
 	name = "Mecha Operator"
 	initial_skills = list(
 		/datum/skill/civ_mech = SKILL_LEVEL_MASTER,
 		/datum/skill/combat_mech = SKILL_LEVEL_PRO
 	)
 
-/datum/skillset/test_subject/detective
+/datum/skillset/assistant/detective
 	name = "Private Eye"
 	initial_skills = list(
 		/datum/skill/firearms = SKILL_LEVEL_NOVICE
 	)
 
-/datum/skillset/test_subject/reporter
+/datum/skillset/assistant/reporter
 	name = "Reporter"
 	initial_skills = list(
 		/datum/skill/command = SKILL_LEVEL_NOVICE
 	)
 
-/datum/skillset/test_subject/waiter
+/datum/skillset/assistant/waiter
 	name = "Waiter"
 	initial_skills = list(
 		/datum/skill/chemistry = SKILL_LEVEL_NOVICE,
 		/datum/skill/medical = SKILL_LEVEL_NOVICE
 	)
 
-/datum/skillset/test_subject/vice_officer
+/datum/skillset/assistant/vice_officer
 	name = "Vice Officer"
 	initial_skills = list(
 		/datum/skill/command = SKILL_LEVEL_TRAINED,
 		/datum/skill/police = SKILL_LEVEL_NOVICE
 	)
 
-/datum/skillset/test_subject/paranormal
+/datum/skillset/assistant/paranormal
 	name = "Paranormal Investigator"
 	initial_skills = list(
 		/datum/skill/research = SKILL_LEVEL_NOVICE,
 		/datum/skill/medical = SKILL_LEVEL_NOVICE
+	)
+
+/datum/skillset/assistant/test_subject
+	name = "Test Subject"
+	initial_skills = list(
+		/datum/skill/research = SKILL_LEVEL_TRAINED,
 	)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Заменяет тест сабжектов на ассистентов.
Добавляет подпрофу тест сабжект для гражданского ассистента.
## Почему и что этот ПР улучшит
Сама идея подопытных провалилась с треском. Все околонацистские-сцпшнные мечты тех, кто это вводил разбились о реальность, и на практике подопытные ведут себя точно так же, как ассистенты (огого кто бы мог подумать).
Так что не вижу смысла в существовании целой профессии подопытных, пусть они останутся в качестве подпрофессии обычного ассистента.
## Авторство

## Чеинжлог
🆑 Simbaka
- tweak: Подопытные снова ассистенты. "Старые" подопытные остались в качестве подпрофессии гражданского ассистента.