### PR TITLE
Last resort warning

### DIFF
--- a/code/game/gamemodes/modes_gameplays/changeling/headcrab.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/headcrab.dm
@@ -11,6 +11,11 @@
 	max_genetic_damage = 10
 	can_be_used_in_abom_form = FALSE
 
+/obj/effect/proc_holder/changeling/headcrab/can_sting(mob/user, mob/target)
+	. = ..()
+	if(tgui_alert(user, "Are we sure we wish to sacrifice our current body?","Last Resort", list("Yes","No")) == "No")
+		return FALSE
+
 /obj/effect/proc_holder/changeling/headcrab/sting_action(mob/user)
 	var/datum/mind/M = user.mind
 	for(var/mob/living/carbon/human/H in range(2,user))

--- a/code/game/gamemodes/modes_gameplays/changeling/headcrab.dm
+++ b/code/game/gamemodes/modes_gameplays/changeling/headcrab.dm
@@ -13,7 +13,7 @@
 
 /obj/effect/proc_holder/changeling/headcrab/can_sting(mob/user, mob/target)
 	. = ..()
-	if(tgui_alert(user, "Are we sure we wish to sacrifice our current body?","Last Resort", list("Yes","No")) == "No")
+	if(tgui_alert(user, "Are we sure we wish to sacrifice our current body?","Last Resort", list("Yes","No")) != "Yes")
 		return FALSE
 
 /obj/effect/proc_holder/changeling/headcrab/sting_action(mob/user)


### PR DESCRIPTION

## Описание изменений
При использовании ласт резорта нужно подтвердить, что да, ты хочешь суициднуться.

## Почему и что этот ПР улучшит
Исправит ситуации когда из-за миссклика тебя рвёт на кусочки и из охотника, ты становишься мёртвым червяком.
## Авторство

## Чеинжлог
:cl: 
 - tweak: Генокрадский червь теперь спрашивает, хочешь ли ты быть разорванным.