### PR TITLE
Eye blur effect

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -171,6 +171,8 @@ var/global/list/preferences_datums = list()
 	var/glowlevel = GLOW_MED // or bloom
 	var/lampsexposure = TRUE // idk how we should name it
 	var/lampsglare = FALSE // aka lens flare
+	//
+	var/eye_blur_effect = TRUE
 
   //custom loadout
 	var/list/gear = list()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -171,7 +171,7 @@ var/global/list/preferences_datums = list()
 	var/glowlevel = GLOW_MED // or bloom
 	var/lampsexposure = TRUE // idk how we should name it
 	var/lampsglare = FALSE // aka lens flare
-	//
+	//Impacts performance clientside
 	var/eye_blur_effect = TRUE
 
   //custom loadout

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -363,6 +363,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["glowlevel"]         >> glowlevel
 	S["lampsexposure"]     >> lampsexposure
 	S["lampsglare"]        >> lampsglare
+	S["eye_blur_effect"]   >> eye_blur_effect
 	S["auto_fit_viewport"] >> auto_fit_viewport
 	S["lobbyanimation"]    >> lobbyanimation
 	S["tooltip"]           >> tooltip
@@ -419,6 +420,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	parallax		= sanitize_integer(parallax, PARALLAX_INSANE, PARALLAX_DISABLE, PARALLAX_HIGH)
 	ambientocclusion	= sanitize_integer(ambientocclusion, 0, 1, initial(ambientocclusion))
 	glowlevel		= sanitize_integer(glowlevel, GLOW_HIGH, GLOW_DISABLE, initial(glowlevel))
+	eye_blur_effect = sanitize_integer(eye_blur_effect, 0, 1, initial(eye_blur_effect))
 	lampsexposure	= sanitize_integer(lampsexposure, 0, 1, initial(lampsexposure))
 	lampsglare		= sanitize_integer(lampsglare, 0, 1, initial(lampsglare))
 	lobbyanimation	= sanitize_integer(lobbyanimation, 0, 1, initial(lobbyanimation))
@@ -491,6 +493,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["parallax"]          << parallax
 	S["ambientocclusion"]  << ambientocclusion
 	S["glowlevel"]         << glowlevel
+	S["eye_blur_effect"]   << eye_blur_effect
 	S["lampsexposure"]     << lampsexposure
 	S["lampsglare"]        << lampsglare
 	S["lobbyanimation"]    << lobbyanimation

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -268,12 +268,13 @@
 	set category = "Preferences"
 
 	prefs.eye_blur_effect = !prefs.eye_blur_effect
-	to_chat(src, "Blur effect: [prefs.eye_blur_effect ? "Enabled" : "Disabled"].")
+	to_chat(src, "Blur effect: [prefs.eye_blur_effect ? "Enabled" : "Old design"].")
 	prefs.save_preferences()
 	var/atom/movable/plane_master_controller/game_plane_master_controller = mob.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
 	if(mob.eye_blurry)
 		game_plane_master_controller.remove_filter("eye_blur_angular")
 		game_plane_master_controller.remove_filter("eye_blur_gauss")
+		mob.clear_fullscreen("blurry")
 	feedback_add_details("admin_verb","EBE")
 
 /client/verb/set_parallax_quality()

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -271,7 +271,7 @@
 	to_chat(src, "Blur effect: [prefs.eye_blur_effect ? "Enabled" : "Disabled"].")
 	prefs.save_preferences()
 	var/atom/movable/plane_master_controller/game_plane_master_controller = mob.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
-	if(eye_blurry)
+	if(mob.eye_blurry)
 		game_plane_master_controller.remove_filter("eye_blur_angular")
 		game_plane_master_controller.remove_filter("eye_blur_gauss")
 	feedback_add_details("admin_verb","EBE")

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -263,6 +263,19 @@
 		PM.apply_effects(mob)
 	feedback_add_details("admin_verb","GLR")
 
+/client/verb/eye_blur_effect()
+	set name = "Blur effect"
+	set category = "Preferences"
+
+	prefs.eye_blur_effect = !prefs.eye_blur_effect
+	to_chat(src, "Blur effect: [prefs.eye_blur_effect ? "Enabled" : "Disabled"].")
+	prefs.save_preferences()
+	var/atom/movable/plane_master_controller/game_plane_master_controller = mob.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
+	if(eye_blurry)
+		game_plane_master_controller.remove_filter("eye_blur_angular")
+		game_plane_master_controller.remove_filter("eye_blur_gauss")
+	feedback_add_details("admin_verb","EBE")
+
 /client/verb/set_parallax_quality()
 	set name = "Set Parallax Quality"
 	set category = "Preferences"

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -270,10 +270,10 @@
 	prefs.eye_blur_effect = !prefs.eye_blur_effect
 	to_chat(src, "Blur effect: [prefs.eye_blur_effect ? "Enabled" : "Old design"].")
 	prefs.save_preferences()
-	var/atom/movable/plane_master_controller/game_plane_master_controller = mob.hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
+	var/atom/movable/screen/plane_master/game_world/PM = locate(/atom/movable/screen/plane_master/rendering_plate/game_world) in screen
 	if(mob.eye_blurry)
-		game_plane_master_controller.remove_filter("eye_blur_angular")
-		game_plane_master_controller.remove_filter("eye_blur_gauss")
+		PM.remove_filter("eye_blur_angular")
+		PM.remove_filter("eye_blur_gauss")
 		mob.clear_fullscreen("blurry")
 	feedback_add_details("admin_verb","EBE")
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -414,13 +414,13 @@
 		return
 
 	if(client.prefs.eye_blur_effect)
-		var/atom/movable/plane_master_controller/game_plane_master_controller = hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
+		var/atom/movable/screen/plane_master/game_world/PM = locate(/atom/movable/screen/plane_master/rendering_plate/game_world) in client.screen
 		if(eye_blurry)
-			game_plane_master_controller.add_filter("eye_blur_angular", 1, angular_blur_filter(16, 16, clamp(eye_blurry * 0.1, 0.2, 0.6)))
-			game_plane_master_controller.add_filter("eye_blur_gauss", 1, gauss_blur_filter(clamp(eye_blurry * 0.05, 0.1, 0.25)))
+			PM.add_filter("eye_blur_angular", 1, angular_blur_filter(16, 16, clamp(eye_blurry * 0.1, 0.2, 0.6)))
+			PM.add_filter("eye_blur_gauss", 1, gauss_blur_filter(clamp(eye_blurry * 0.05, 0.1, 0.25)))
 		else
-			game_plane_master_controller.remove_filter("eye_blur_angular")
-			game_plane_master_controller.remove_filter("eye_blur_gauss")
+			PM.remove_filter("eye_blur_angular")
+			PM.remove_filter("eye_blur_gauss")
 
 	else
 		if(eye_blurry)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -412,6 +412,8 @@
 /mob/proc/update_eye_blur()
 	if(!client)
 		return
+	if(!client.prefs.eye_blur_effect)
+		return
 	var/atom/movable/plane_master_controller/game_plane_master_controller = hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
 	if(eye_blurry)
 		game_plane_master_controller.add_filter("eye_blur_angular", 1, angular_blur_filter(16, 16, clamp(eye_blurry * 0.1, 0.2, 0.6)))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -412,15 +412,21 @@
 /mob/proc/update_eye_blur()
 	if(!client)
 		return
-	if(!client.prefs.eye_blur_effect)
-		return
-	var/atom/movable/plane_master_controller/game_plane_master_controller = hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
-	if(eye_blurry)
-		game_plane_master_controller.add_filter("eye_blur_angular", 1, angular_blur_filter(16, 16, clamp(eye_blurry * 0.1, 0.2, 0.6)))
-		game_plane_master_controller.add_filter("eye_blur_gauss", 1, gauss_blur_filter(clamp(eye_blurry * 0.05, 0.1, 0.25)))
+
+	if(client.prefs.eye_blur_effect)
+		var/atom/movable/plane_master_controller/game_plane_master_controller = hud_used.plane_master_controllers[PLANE_MASTERS_GAME]
+		if(eye_blurry)
+			game_plane_master_controller.add_filter("eye_blur_angular", 1, angular_blur_filter(16, 16, clamp(eye_blurry * 0.1, 0.2, 0.6)))
+			game_plane_master_controller.add_filter("eye_blur_gauss", 1, gauss_blur_filter(clamp(eye_blurry * 0.05, 0.1, 0.25)))
+		else
+			game_plane_master_controller.remove_filter("eye_blur_angular")
+			game_plane_master_controller.remove_filter("eye_blur_gauss")
+
 	else
-		game_plane_master_controller.remove_filter("eye_blur_angular")
-		game_plane_master_controller.remove_filter("eye_blur_gauss")
+		if(eye_blurry)
+			overlay_fullscreen("blurry", /atom/movable/screen/fullscreen/blurry)
+		else
+			clear_fullscreen("blurry")
 
 // ============================================================
 

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -76,6 +76,13 @@
 	blocker.plane = ABOVE_HUD_PLANE
 	blocker.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
+	//Users with different eye_blur_effect prefs OR client disconnected during eye_blurry effect
+	var/atom/movable/plane_master_controller/game_plane_master_controller = hud_used?.plane_master_controllers[PLANE_MASTERS_GAME]
+	if(game_plane_master_controller)
+		game_plane_master_controller.remove_filter("eye_blur_angular")
+		game_plane_master_controller.remove_filter("eye_blur_gauss")
+	clear_fullscreen("blurry")
+
 	// atom_huds
 	reload_huds()
 

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -76,11 +76,11 @@
 	blocker.plane = ABOVE_HUD_PLANE
 	blocker.mouse_opacity = MOUSE_OPACITY_TRANSPARENT
 
-	//Users with different eye_blur_effect prefs OR client disconnected during eye_blurry effect
-	var/atom/movable/plane_master_controller/game_plane_master_controller = hud_used?.plane_master_controllers[PLANE_MASTERS_GAME]
-	if(game_plane_master_controller)
-		game_plane_master_controller.remove_filter("eye_blur_angular")
-		game_plane_master_controller.remove_filter("eye_blur_gauss")
+	//Users with different eye_blur_effect pref OR client disconnected during eye_blurry effect
+	var/atom/movable/screen/plane_master/game_world/PM = locate(/atom/movable/screen/plane_master/rendering_plate/game_world) in client.screen
+	if(PM)
+		PM.remove_filter("eye_blur_angular")
+		PM.remove_filter("eye_blur_gauss")
 	clear_fullscreen("blurry")
 
 	// atom_huds


### PR DESCRIPTION
## Для игрока
Если у вас начинает сильно фризить игра после попадания с лазера или нескольких сварок, то идёте в преференсы и ищите `Blur effect`, переключаете его и проверяете.
## Описание изменений
Обсуждалась уже проблема с тем, что по попаданию в куклу и какое-то время после этого у некоторых игроков очень лагает. Такое я встречал и у себя на старой машине, при полном отсутствии на более сильной. Пообщался с несколькими игроками, у всех симптомы схожи: помутнение от лазера, 4 сварок.

Итак, данный ПР даёт возможность жмякнуть в вкладке `Preferences` на кнопку `Blur effect`, что отключит этот фильтр для них, используя старый оверлей (туман по всему экрану). По крайней мере у моего ноута лаги пропадают.
## Почему и что этот ПР улучшит
closes #12037
## Авторство
Страдания слабых ПК
## Чеинжлог
:cl:
 - fix[link]: Найдена и оптимизирована проблема, связанная с лагами клиента на слабых машинах при появлении на экране эффекта блюра зрения (после попадания оружием, от сварки). Если проблема с лагом еще присутствует - добавлена опция на переключение на старый фильтр через кнопку "Preferences" -> "Blur effect"