### PR TITLE
Заряд SMES при сборке (замене компонентов) не зависит от заряда батарей

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -109,16 +109,13 @@
 
 	var/IO = 0
 	var/C = 0
-	var/c = 0
 	for(var/obj/item/weapon/stock_parts/capacitor/CP in component_parts)
 		IO += CP.rating
 	input_level_max = 200000 * IO
 	output_level_max = 200000 * IO
 	for(var/obj/item/weapon/stock_parts/cell/PC in component_parts)
 		C += PC.maxcharge
-		c += PC.charge
 	capacity = C * 100
-	charge = c * 100
 
 /obj/machinery/power/smes/attackby(obj/item/I, mob/user)
 	// opening using screwdriver


### PR DESCRIPTION
## Описание изменений
Убрал зависимость заряда SMES от заряда батарей, используемых при его сборке 
Невозможность зарядить SMES с помощью РПЕД
## Почему и что этот ПР улучшит
Легкий и быстрый способ обеспечения энергией более недоступен, ценность инженеров повышается
## Авторство
tgt4
## Чеинжлог
:cl: tgt4
 - tweak: Заряд SMES при сборке (замене компонентов) не зависит от заряда батарей