### PR TITLE
Time to registration delete

### DIFF
--- a/code/datums/spawners_menu/spawners_living.dm
+++ b/code/datums/spawners_menu/spawners_living.dm
@@ -162,12 +162,14 @@
 	desc = "Вы магическим образом ожили на станции"
 	cooldown = 1 MINUTES
 	time_for_registration = null
+	register_only = FALSE
 
 /datum/spawner/living/evil_shade
 	name = "Злой Дух"
 	desc = "Магическая сила призвала вас в мир, отомстите живым за причинённые обиды!"
 	cooldown = 2 MINUTES
 	time_for_registration = null
+	register_only = FALSE
 
 /datum/spawner/living/evil_shade/spawn_body(mob/dead/spectator)
 	..()
@@ -177,6 +179,7 @@
 	name = "Крыса"
 	desc = "Вы появляетесь в своём новом доме"
 	time_for_registration = null
+	register_only = FALSE
 
 /datum/spawner/living/rat/spawn_body(mob/dead/spectator)
 	. = ..()
@@ -196,3 +199,4 @@
 	desc = "Технологически развитое сообщество пришельцев, которые занимаются каталогизированием других существ в Галактике. К сожалению для этих существ, методы похитителей, мягко выражаясь, агрессивны."
 	wiki_ref = "Abductor"
 	time_for_registration = null
+	register_only = FALSE

--- a/code/datums/spawners_menu/spawners_living.dm
+++ b/code/datums/spawners_menu/spawners_living.dm
@@ -161,11 +161,13 @@
 	name = "Оживлённый предмет"
 	desc = "Вы магическим образом ожили на станции"
 	cooldown = 1 MINUTES
+	time_for_registration = null
 
 /datum/spawner/living/evil_shade
 	name = "Злой Дух"
 	desc = "Магическая сила призвала вас в мир, отомстите живым за причинённые обиды!"
 	cooldown = 2 MINUTES
+	time_for_registration = null
 
 /datum/spawner/living/evil_shade/spawn_body(mob/dead/spectator)
 	..()
@@ -174,6 +176,7 @@
 /datum/spawner/living/rat
 	name = "Крыса"
 	desc = "Вы появляетесь в своём новом доме"
+	time_for_registration = null
 
 /datum/spawner/living/rat/spawn_body(mob/dead/spectator)
 	. = ..()
@@ -192,3 +195,4 @@
 	name = "Похититель"
 	desc = "Технологически развитое сообщество пришельцев, которые занимаются каталогизированием других существ в Галактике. К сожалению для этих существ, методы похитителей, мягко выражаясь, агрессивны."
 	wiki_ref = "Abductor"
+	time_for_registration = null


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
https://github.com/TauCetiStation/TauCetiClassic/pull/12409 дал всем ливингам время на регистрацию, а это не нужно для некоторых вакансий, особенно тех которые могут умереть через 5 секунд после спавна, ибо никто не будет ждать пока гост зайдёт за тело антага, которое уже перед глазами.
## Почему и что этот ПР улучшит
авторское виденье сохранено, всё работает как задумано.
## Авторство

## Чеинжлог
:cl: Deahaka
- fix: Некоторые спавнеры у призраков перестали иметь предварительную регистрацию