### PR TITLE
Spawner fixes

### DIFF
--- a/code/datums/spawners_menu/spawners.dm
+++ b/code/datums/spawners_menu/spawners.dm
@@ -151,7 +151,11 @@
 	if(blocked)
 		return
 
+	if(!spectator.client || spectator.client.is_in_spawner)
+		return
+
 	if(!register_only)
+		positions--
 		do_spawn(spectator)
 		return
 
@@ -209,29 +213,35 @@
 
 	for(var/mob/dead/M in filtered_candidates)
 		if(positions > 0)
+			positions--
 			to_chat(M, "<span class='notice'>Вы получили роль \"[name]\"!</span>")
-			do_spawn(M)
+			INVOKE_ASYNC(src, PROC_REF(do_spawn), M)
 		else
 			to_chat(M, "<span class='warning'>К сожалению, вам не выпала роль \"[name]\".</span>")
 
 	//SSrole_spawners.trigger_ui_update()
 
 /datum/spawner/proc/do_spawn(mob/dead/spectator)
-	if(!can_spawn(spectator))
-		return
-
 	if(positions < 1)
 		return
 
-	positions--
+	if(!can_spawn(spectator))
+		return
 
 	var/client/C = spectator.client
+
+	// temporary flag to fight some races because of pre-spawn dialogs in spawn_body of some spawners
+	// we should fight it and first spawn user, so he can't access spawn menu anymore,
+	// and only then allow costumization in separated thread
+	C.is_in_spawner = TRUE
+
 	if(isnewplayer(spectator))
 		var/mob/dead/new_player/NP = spectator
 		spectator = NP.spawn_as_observer() // need to check if we can skip this step
 
 	spawn_body(spectator)
 
+	C.is_in_spawner = FALSE
 	// check if the spectator really moved to a new body
 	if(spectator.client == C)
 		positions++

--- a/code/datums/spawners_menu/spawners_menu.dm
+++ b/code/datums/spawners_menu/spawners_menu.dm
@@ -1,8 +1,6 @@
 /datum/spawners_menu
 	var/mob/dead/owner
 
-	var/role_selected = FALSE
-
 /datum/spawners_menu/New(mob/dead/new_owner)
 	if(!istype(new_owner))
 		qdel(src)
@@ -62,7 +60,7 @@
 	if(.)
 		return
 
-	if(role_selected)
+	if(!owner.client || owner.client.is_in_spawner)
 		to_chat(owner, "<span class='notice'>Вы уже выбрали роль!</span>")
 		return
 
@@ -87,7 +85,5 @@
 			spawner.jump(owner)
 			return TRUE
 		if("spawn")
-			role_selected = TRUE
 			spawner.registration(owner)
-			role_selected = FALSE
 			return TRUE

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -126,3 +126,5 @@
 
 	///Tracks say() usage for ic/dchat while slowmode is enabled
 	COOLDOWN_DECLARE(say_slowmode)
+
+	var/is_in_spawner = FALSE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений

Из-за открытия разных диалоговых окон при спавне, слипающих тред, розыгрыш ролей мог работать криво. ``role_selected`` заменен на флаг в клиенте и блокирует возможный мультиспавн теперь и с очередью.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
:cl: 
 - fix: Исправлены некоторые всплывшие проблемы спавнеров и розыгрыша ролей.