### PR TITLE
Немного привёл в порядок код projectile/Bump

### DIFF
--- a/code/datums/spells/conjure.dm
+++ b/code/datums/spells/conjure.dm
@@ -87,24 +87,6 @@
 	unacidable = 1
 	can_block_air = TRUE
 
-/obj/effect/forcefield/bullet_act(obj/item/projectile/Proj, def_zone)
-	. = ..()
-
-	if(. == PROJECTILE_ABSORBED)
-		return
-
-	// to prevent abuses
-	// todo: should be impossible to abuse so we can remove this hack
-	var/list/mobs = list()
-	for(var/mob/living/M in get_turf(loc))
-		if(M in Proj.permutated)
-			continue
-		mobs += M
-
-	if(length(mobs))
-		var/mob/M = pick(mobs)
-		M.bullet_act(Proj, def_zone)
-
 /obj/effect/forcefield/magic
 	var/mob/wizard
 

--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -125,24 +125,6 @@ for reference:
 	. = ..()
 	global.peacekeeper_shields_count++
 
-/obj/structure/barricade/bubble/bullet_act(obj/item/projectile/Proj, def_zone)
-	. = ..()
-
-	if(. == PROJECTILE_ABSORBED)
-		return
-
-	// to prevent abuses
-	// todo: should be impossible to abuse so we can remove this hack
-	var/list/mobs = list()
-	for(var/mob/living/M in get_turf(loc))
-		if(M in Proj.permutated)
-			continue
-		mobs += M
-
-	if(length(mobs))
-		var/mob/M = pick(mobs)
-		M.bullet_act(Proj, def_zone)
-
 /obj/structure/barricade/bubble/CanPass(atom/movable/mover, turf/target, height=0) //make robots can pass
 	if(isrobot(mover))
 		return TRUE

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -111,43 +111,32 @@
 	zone = check_zone(zone)
 
 	// you can only miss if your target is standing and not restrained
-	if(!target.buckled && !target.lying)
-		var/miss_chance = 10
-		switch(zone)
-			if(BP_HEAD)
-				miss_chance = 50
-			if(BP_GROIN)
-				miss_chance = 50
-			if(BP_L_ARM)
-				miss_chance = 60
-			if(BP_R_ARM)
-				miss_chance = 60
-			if(BP_L_LEG)
-				miss_chance = 60
-			if(BP_R_LEG)
-				miss_chance = 60
-		if(prob(max(miss_chance + miss_chance_mod, 0)))
-			if(prob(max(20, (miss_chance/2))))
-				return null
-			else
-				var/t = rand(1, 100)
-				switch(t)
-					if(1 to 65)
-						return BP_CHEST
-					if(66 to 75)
-						return BP_HEAD
-					if(76 to 80)
-						return BP_L_ARM
-					if(81 to 85)
-						return BP_R_ARM
-					if(86 to 90)
-						return BP_R_LEG
-					if(91 to 95)
-						return BP_L_LEG
-					if(96 to 100)
-						return BP_GROIN
+	if(target.buckled || target.lying)
+		return zone
 
-	return zone
+	var/miss_chance = 10
+	switch(zone)
+		if(BP_HEAD, BP_GROIN)
+			miss_chance = 50
+		if(BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG)
+			miss_chance = 60
+
+	if(!prob(miss_chance + miss_chance_mod)) // chance to hit
+		return zone
+
+	if(prob(max(20, miss_chance / 2))) // chance to fully miss
+		return null
+
+	// redirecting
+	return pick(
+		prob(65); BP_CHEST,
+		prob(10); BP_HEAD,
+		prob(5); BP_L_ARM,
+		prob(5); BP_R_ARM,
+		prob(5); BP_L_LEG,
+		prob(5); BP_R_LEG,
+		prob(5); BP_GROIN,
+	)
 
 /proc/get_zone_with_probabilty(zone, probability = 80)
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -166,18 +166,16 @@
 	var/mob/living/M = isliving(A) ? A : null
 	bumped = 1
 	if(firer && M)
-		if(!isliving(A))
-			loc = A.loc
-			return 0// nope.avi
 		var/distance = get_dist(starting,loc) //More distance = less damage, except for high fire power weapons.
 		var/miss_modifier = 0
 		if(damage && (distance > 7))
-			if(damage < 55)
+			if(damage >= 50)
+				miss_modifier = -100 // so sniper rifle and PTR-rifle projectiles cannot miss
+			else
 				damage = max(1, damage - round(damage * (((distance-6)*3)/100)))
-				miss_modifier = - 100 // so sniper rifle and PTR-rifle projectiles cannot miss
 		if (istype(shot_from,/obj/item/weapon/gun))	//If you aim at someone beforehead, it'll hit more often.
 			var/obj/item/weapon/gun/daddy = shot_from //Kinda balanced by fact you need like 2 seconds to aim
-			if (daddy.target && (original in daddy.target)) //As opposed to no-delay pew pew
+			if (daddy.target && (M in daddy.target)) //As opposed to no-delay pew pew
 				miss_modifier -= 60
 		if(distance > 1)
 			def_zone = get_zone_with_miss_chance(def_zone, M, miss_modifier)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -166,7 +166,7 @@
 			for(var/mob/living/L in A_loc)
 				if(L.stat != DEAD)
 					mobs += L
-			if(mobs.len > 0)
+			if(length(mobs) > 0)
 				A = pick(mobs) // pick random alive mob as target
 				A_loc = A.loc
 		

--- a/code/modules/sports/PedalGen.dm
+++ b/code/modules/sports/PedalGen.dm
@@ -162,13 +162,6 @@
 	else
 		animate(M, pixel_x = M.default_pixel_x, pixel_y = M.default_pixel_y, 2, 1, LINEAR_EASING)
 
-/obj/structure/stool/bed/chair/pedalgen/bullet_act(obj/item/projectile/Proj, def_zone)
-	if(buckled_mob)
-		if(prob(85))
-			return buckled_mob.bullet_act(Proj)
-	visible_message("<span class='warning'>[Proj] ricochets off the [src]!</span>")
-	return ..()
-
 /obj/structure/stool/bed/chair/pedalgen/Destroy()
 	qdel(Generator)
 	return..()


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
get_zone_with_miss_chance просто переписал по человечески, хоть и хотелось изменить.
Вернул check_living_shield
Переписал порядок выбора цели, с преимуществом для живых мобов
Убрал ересь 9-летней давности. Почему-то проджектайлы с уроном < 55 после 8 тайлов начинали стрелять без промахов, заменил на то, что подразумелось комментарием.

Не знаю нужно ли сделать так, что даже если кликнуть по спрайту объекта, то приоритетными будут мобы на одном тайле с ним (в этой версии будут попадать по объекту). Если стрелять за объект, то и сейчас приоритет отдаётся мобам.
В двух места pedalgen и spacebike, есть bullect_act с "защитой buckled", хз как нормально их переписать, но ими и так не пользуются для этого.

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
