### PR TITLE
Respawn verb sets lobby name to key

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -439,6 +439,7 @@
 	client.prefs.selected_quality_name = null
 
 	M.key = key
+	M.name = M.key
 //	M.Login()	//wat
 	return
 


### PR DESCRIPTION
## Описание изменений
после респавна имя в лобби становилось new_player из-за чего случалась такая некрасота 
![image](https://github.com/TauCetiStation/TauCetiClassic/assets/39914744/b6502aa8-224f-48eb-a063-3f58228b9129)
а так имя будет ставиться на кей

## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
