### PR TITLE
экшен-кнопки работают у лежачих

### DIFF
--- a/code/_onclick/hud/action.dm
+++ b/code/_onclick/hud/action.dm
@@ -4,10 +4,9 @@
 #define AB_GENERIC 4
 
 #define AB_CHECK_INCAPACITATED 2
-#define AB_CHECK_LYING 4
-#define AB_CHECK_ALIVE 8
-#define AB_CHECK_INSIDE 16
-#define AB_CHECK_ACTIVE 32
+#define AB_CHECK_ALIVE 4
+#define AB_CHECK_INSIDE 8
+#define AB_CHECK_ACTIVE 16
 
 
 /datum/action
@@ -112,9 +111,6 @@
 		return FALSE
 	if(check_flags & AB_CHECK_INCAPACITATED)
 		if(owner.incapacitated(restrained_check))
-			return FALSE
-	if(check_flags & AB_CHECK_LYING)
-		if(owner.lying)
 			return FALSE
 	if(check_flags & AB_CHECK_ALIVE)
 		if(owner.stat != CONSCIOUS)
@@ -312,7 +308,7 @@
 	return !(target in user)
 
 /datum/action/item_action/hands_free
-	check_flags = AB_CHECK_INCAPACITATED|AB_CHECK_LYING|AB_CHECK_INSIDE|AB_CHECK_ALIVE
+	check_flags = AB_CHECK_INCAPACITATED|AB_CHECK_INSIDE|AB_CHECK_ALIVE
 
 
 //Preset for spells

--- a/code/datums/components/zoom.dm
+++ b/code/datums/components/zoom.dm
@@ -1,12 +1,12 @@
 /datum/action/zoom
 	name = "Toggle Zoom"
 	action_type = AB_INNATE
-	check_flags = AB_CHECK_INCAPACITATED | AB_CHECK_LYING | AB_CHECK_INSIDE | AB_CHECK_ACTIVE
+	check_flags = AB_CHECK_INCAPACITATED | AB_CHECK_INSIDE | AB_CHECK_ACTIVE
 	button_icon_state = "zoom"
 
 /datum/action/zoom/Activate()
 	SEND_SIGNAL(target, COMSIG_ZOOM_TOGGLE, owner)
-	
+
 /datum/component/zoom
 	var/zoom_view_range
 	var/can_move
@@ -16,7 +16,7 @@
 /datum/component/zoom/Initialize(_zoom_view_range, _can_move = FALSE)
 	if(!isitem(parent))
 		return COMPONENT_INCOMPATIBLE
-	
+
 	zoom_view_range = _zoom_view_range
 	can_move = _can_move
 	RegisterSignal(parent, list(COMSIG_ITEM_EQUIPPED), PROC_REF(on_equip))
@@ -57,7 +57,7 @@
 	else
 		reset_zoom()
 	to_chat(user, "<font color='[zoomer ? "notice" : "rose"]'>Zoom mode [zoomer ? "en" : "dis"]abled.</font>")
-	
+
 /datum/component/zoom/proc/reset_zoom()
 	SIGNAL_HANDLER
 	if(!zoomer)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
убрал проверку на лежание у экшен-кнопок
## Почему и что этот ПР улучшит
проверка не имеет более смысла ибо с предметами давно можно интерачить лежа
## Авторство

## Чеинжлог
:cl:
 - bugfix: Экшен-кнопки работают у лежачих