### PR TITLE
чиним неприятный рантайм

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -72,6 +72,14 @@ var/global/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","dama
 	else
 		icon_regular_floor = icon_state
 
+/turf/simulated/floor/ChangeTurf()
+	var/old_holy = holy
+	. = ..()
+	if(istype(src)) // turf is changed, is it still a floor?
+		holy = old_holy
+	else // nope, it's not a floor
+		qdel(old_holy)
+
 /turf/simulated/floor/Destroy()
 	if(floor_type)
 		floor_type = null

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -290,10 +290,6 @@
 	//BEGIN: ECS SHIT (UNTIL SOMEONE MAKES POSSIBLE TO USE QDEL IN THIS PROC FOR TURFS)
 	signal_enabled = FALSE
 
-	if(isfloorturf(src))
-		var/turf/simulated/floor/sf = src
-		QDEL_NULL(sf.holy)
-
 	var/list/dc = datum_components
 	if(dc)
 		var/all_components = dc[/datum/component]

--- a/code/modules/religion/holy_turf.dm
+++ b/code/modules/religion/holy_turf.dm
@@ -45,7 +45,8 @@
 
 	religion.holy_turfs -= turf
 
-	turf.holy = null
+	if(istype(turf))
+		turf.holy = null
 
 	turf = null
 	religion = null


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
ChangeTurf() сбрасывает турфу переменные и не присваивает обратно ``holy``, в котором хранится датум освященного тайла 
из-за чего каждое изменение освещения на этом тайле вызывает рантайм
теперь же все нормально присваивается
## Почему и что этот ПР улучшит
10к рантаймов из-за этого в #61852
![image](https://github.com/TauCetiStation/TauCetiClassic/assets/89906909/178dc85d-0076-4dba-b431-274710f90cdb)

## Авторство

## Чеинжлог
