### PR TITLE
no pain on switching species to NO_PAIN one

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1398,6 +1398,10 @@
 
 	maxHealth = species.total_health
 
+	if(species.flags[NO_PAIN])
+		src.shock_stage = 0
+		src.traumatic_shock = 0
+
 	if(species.base_color && default_colour)
 		//Apply colour.
 		r_skin = HEX_VAL_RED(species.base_color)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1399,8 +1399,8 @@
 	maxHealth = species.total_health
 
 	if(species.flags[NO_PAIN])
-		src.shock_stage = 0
-		src.traumatic_shock = 0
+		shock_stage = 0
+		traumatic_shock = 0
 
 	if(species.base_color && default_colour)
 		//Apply colour.


### PR DESCRIPTION
## Описание изменений
Прок set_species ставит болевой шок на 0 если у целевого гуманоида флаг игнорирования боли, сейчас если раса гуманоида сменяется в течение раунда шок остается навсегда без возможности снять кроме как педально
resolves https://github.com/TauCetiStation/TauCetiClassic/issues/9654
## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
:cl: 
 - bugfix: Превращение в слаймо-человека токсином ксенобиолога больше не чревато вечным замедлением.
 - bugfix: Скелеты больше не замедляются навечно, если были ранены при жизни.