### PR TITLE
чиним поломанный передоз трика и прочего

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -287,7 +287,8 @@ var/global/const/INGEST = 2
 						feedback_add_details("chemical_reaction","[C.result]|[C.result_amount*multiplier]")
 						multiplier = max(multiplier, 1) //this shouldnt happen ...
 						add_reagent(C.result, C.result_amount*multiplier)
-						set_data(C.result, preserved_data)
+						if(preserved_data)
+							set_data(C.result, preserved_data)
 
 						//add secondary products
 						for(var/S in C.secondary_results)


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
при синтезе реагента если никакой даты не получилось сохранить, то дату приравнивает к ``null``, даже если там был уже какой-то лист
и все реагенты использующие эту дату начинают выдавать рантайм
![image](https://github.com/TauCetiStation/TauCetiClassic/assets/89906909/11db856d-8a48-47f7-a810-9c96f0d0ce2b)
https://github.com/TauCetiStation/TauCetiClassic/blob/5f9bb8db4fd053f5f141cb7b0a96869e605c0d15/code/modules/reagents/reagent_types/Chemistry-Medicine.dm#L311
причем в проке перемещения реагента есть эта проверка, поэтому проблема так долго не всплывала
https://github.com/TauCetiStation/TauCetiClassic/blob/5f9bb8db4fd053f5f141cb7b0a96869e605c0d15/code/modules/reagents/Chemistry-Holder.dm#L449-L450

иными словами, нюкеры синтезирующие трик прямо у себя в крови теперь не будут спамить рантаймами
## Почему и что этот ПР улучшит
#61892,  пару тысяч этих рантаймов
## Авторство

## Чеинжлог
