### PR TITLE
Moves all the TC for nukeops to one uplink

### DIFF
--- a/code/game/gamemodes/roles/syndicate.dm
+++ b/code/game/gamemodes/roles/syndicate.dm
@@ -76,8 +76,6 @@
 	nuclear_outfit = /datum/outfit/nuclear/leader
 	skillset_type = /datum/skillset/nuclear_operative_leader
 
-	TC_num = 25
-
 /datum/role/operative/leader/OnPostSetup(laterole)
 	. = ..()
 	var/datum/faction/nuclear/N = faction

--- a/code/game/machinery/computer/tc_station.dm
+++ b/code/game/machinery/computer/tc_station.dm
@@ -118,7 +118,7 @@ var/global/list/possible_uplinker_IDs = list("Alfa","Bravo","Charlie","Delta","E
 	icon_state = "tcboss"
 	var/virgin = 1
 	var/scanrange = 10
-	var/storedcrystals = 30
+	var/storedcrystals = 0
 	var/list/TCstations = list()
 	var/list/transferlog = list()
 

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -198,6 +198,10 @@ A list of items and costs is stored under the datum of every game mode, alongsid
 	. = ..()
 	hidden_uplink.uses = 15
 
+/obj/item/device/radio/uplink/nukeop_leader/atom_init()
+	. = ..()
+	hidden_uplink.uses = 75
+
 /obj/item/device/multitool/uplink/atom_init()
 	. = ..()
 	hidden_uplink = new(src)

--- a/code/game/objects/structures/crates_lockers/closets/secure/syndicate.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/syndicate.dm
@@ -27,4 +27,4 @@
 	new /obj/item/weapon/pinpointer/nukeop(src)
 	new /obj/item/weapon/kitchenknife/combat(src)
 	new /obj/item/clothing/accessory/storage/syndi_vest(src)
-	new /obj/item/device/radio/uplink(src)
+	new /obj/item/device/radio/uplink/nukeop_leader(src)


### PR DESCRIPTION
## Описание изменений
сейчас у нюки телекристаллы в трёх местах: в аплинке в шкафу лидера 20, в консоли команды 30 и в наушнике лидера (или интеркоме если это выбрано в префах) 25. теперь все 75 будут в аплинке из шкафа. 
## Почему и что этот ПР улучшит
лично я очень часто вижу как новички не догадываются взаимодействовать с консолью, а про наушник сейчас забывают вообще почти все, за этот месяц про наушник чаще забывали чем вспоминали, а ещё после открытия аплинка в наушнике нельзя обратно переключить его на частоту нюки чтоб говорить в их канал через ; префикс. 
## Авторство

## Чеинжлог
:cl: 
 - tweak: Все 75 телекристаллов команды ядерных оперативников теперь находятся в аплинке в шкафчике лидера.