### PR TITLE
Hide logo & icon & objectives option for roles

### DIFF
--- a/code/game/gamemodes/role.dm
+++ b/code/game/gamemodes/role.dm
@@ -24,6 +24,7 @@
 	// Logo of role
 	var/logo_state
 
+	var/hide_logo = FALSE
 	// What faction this role is associated with.
 	var/datum/faction/faction
 	// The actual antag mind.
@@ -318,6 +319,19 @@
 
 	return text
 
+/datum/role/proc/print_player_without_icon(datum/mind/mind)
+	var/text = ""
+	var/mob/M = mind.current
+	text += "<b>[mind.key]</b> was <b>[name]</b> ("
+	if(!M)
+		text += "body destroyed"
+	else if(M.stat == DEAD)
+		text += "died"
+	else
+		text += "survived"
+	text += ")"
+	return text
+
 /datum/role/proc/GetObjectiveDescription(datum/objective/objective)
 	return "[objective.explanation_text] [objective.completion_to_string()]"
 
@@ -325,8 +339,10 @@
 	var/win = TRUE
 	var/text = ""
 
-	text = printplayerwithicon(antag)
-
+	if(!hide_logo)
+		text = printplayerwithicon(antag)
+	else
+		text = print_player_without_icon(antag)
 	if(objectives.objectives.len > 0)
 		var/count = 1
 		text += "<ul>"


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
надо для https://github.com/TauCetiStation/TauCetiClassic/pull/12408
Возможность не указывать в титрах лого роли, отображение лого антага и его целей.
## Почему и что этот ПР улучшит
Возможность сохранить в тайне от смотрящих титры вид куклы юзера, картинки его лого и целей. Возможность добавлять отделённые от фракций роли в раунд и не присуждать им много места в титрах, например если нам нужна роль чисто для надписи в Notes для однозначного трактования действий юзера для администраторов.
## Авторство

## Чеинжлог
