### PR TITLE
Customization folderpath of eyes species

### DIFF
--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -8,6 +8,7 @@
 	var/icobase = 'icons/mob/human_races/r_human.dmi'    // Normal icon set.
 	var/deform = 'icons/mob/human_races/r_def_human.dmi' // Mutated icon set.
 	var/damage_mask = TRUE
+	var/eyes_icon = 'icons/mob/human_face.dmi'
 	var/eyes = "eyes"                                    // Icon for eyes.
 	var/eyes_glowing = FALSE                             // To make those eyes gloooow.
 	var/gender_tail_icons = FALSE

--- a/code/modules/organs/organ_external.dm
+++ b/code/modules/organs/organ_external.dm
@@ -586,8 +586,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	//Eyes
 	if(species && species.eyes)
 		var/eyes_layer = -icon_layer
-
-		var/mutable_appearance/img_eyes_s = mutable_appearance('icons/mob/human_face.dmi', species.eyes, eyes_layer)
+		var/mutable_appearance/img_eyes_s = mutable_appearance(species.eyes_icon, species.eyes, eyes_layer)
 		if(species.eyes_glowing)
 			img_eyes_s.plane = LIGHTING_LAMPS_PLANE
 			img_eyes_s.layer = ABOVE_LIGHTING_LAYER


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
надо для https://github.com/TauCetiStation/TauCetiClassic/pull/12408
Файл глаз указывается в расе, а не захардкожен
## Почему и что этот ПР улучшит
возможность переопределять файл глаз для расы, если она имеет нестандартные размеры
## Авторство

## Чеинжлог
