### PR TITLE
Customization specie fire over-/underlays

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -332,9 +332,12 @@ Please contact me on #coderbus IRC. ~Carn x
 	remove_standing_overlay(FIRE_UPPER_LAYER)
 
 	if(on_fire)
-		var/image/under = image('icons/mob/OnFire.dmi', "human_underlay", layer = -FIRE_LOWER_LAYER)
-		var/image/over = image('icons/mob/OnFire.dmi', "human_overlay", layer = -FIRE_UPPER_LAYER)
-		under = update_height(under)
+		var/fire_suffix_icon = "human"
+		var/datum/species/S = species
+		if(S)
+			fire_suffix_icon = S.specie_suffix_fire_icon
+		var/image/under = image('icons/mob/OnFire.dmi', "[fire_suffix_icon]_underlay", layer = -FIRE_LOWER_LAYER)
+		var/image/over = image('icons/mob/OnFire.dmi', "[fire_suffix_icon]_overlay", layer = -FIRE_UPPER_LAYER)
 		over = update_height(over)
 		over.plane = LIGHTING_LAMPS_PLANE
 		overlays_standing[FIRE_LOWER_LAYER] = under

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -76,6 +76,7 @@
 
 	var/list/flags = list()       // Various specific features.
 
+	var/specie_suffix_fire_icon = "human"
 	var/blood_datum_path = /datum/dirt_cover/red_blood //Red.
 	var/datum/dirt_cover/blood_datum // this will contain reference and should only be used as read only.
 	var/flesh_color = "#ffc896" //Pink.


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
надо для https://github.com/TauCetiStation/TauCetiClassic/pull/12408
В расе хранится название стейта для обвивающего куклу огня и его можно изменить чтобы поменять на своё, добавив стейт в файл
## Почему и что этот ПР улучшит
возможность кастомизации отображения огня на куклах для рас имеющих отличные от человека особенности.
## Авторство

## Чеинжлог
