### PR TITLE
Human update_icons() tweak

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -456,7 +456,11 @@ Please contact me on #coderbus IRC. ~Carn x
 		overlays_standing[GLOVES_LAYER] = standing
 	else
 		if(blood_DNA)
-			var/image/bloodsies	= image("icon"='icons/effects/blood.dmi', "icon_state"="bloodyhands")
+			var/blood_icon_hand = "bloodyhands"
+			var/datum/species/S = species
+			if(S)
+				blood_icon_hand = S.specie_hand_blood_state
+			var/image/bloodsies	= image("icon"='icons/effects/blood.dmi', "icon_state" = blood_icon_hand)
 			bloodsies.color = hand_dirt_datum.color
 			bloodsies = human_update_offset(bloodsies, FALSE)
 			overlays_standing[GLOVES_LAYER]	= bloodsies
@@ -519,7 +523,11 @@ Please contact me on #coderbus IRC. ~Carn x
 		overlays_standing[SHOES_LAYER] = standing
 	else
 		if(feet_blood_DNA)
-			var/image/bloodsies = image("icon"='icons/effects/blood.dmi', "icon_state"="shoeblood")
+			var/blood_icon_shoe = "shoeblood"
+			var/datum/species/S = species
+			if(S)
+				blood_icon_shoe = S.specie_shoe_blood_state
+			var/image/bloodsies = image("icon"='icons/effects/blood.dmi', "icon_state" = blood_icon_shoe)
 			bloodsies.color = feet_dirt_color.color
 			overlays_standing[SHOES_LAYER] = bloodsies
 		else
@@ -737,9 +745,6 @@ Please contact me on #coderbus IRC. ~Carn x
 		if(client && hud_used)
 			client.screen += l_hand
 
-		var/t_state = l_hand.item_state
-		if(!t_state)
-			t_state = l_hand.icon_state
 		var/image/standing = l_hand.get_standing_overlay(src, l_hand.lefthand_file, SPRITE_SHEET_HELD, -L_HAND_LAYER, icon_state_appendix = "_l")
 		standing = human_update_offset(standing, FALSE)
 		overlays_standing[L_HAND_LAYER] = standing

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -78,6 +78,8 @@
 
 	var/blood_datum_path = /datum/dirt_cover/red_blood //Red.
 	var/datum/dirt_cover/blood_datum // this will contain reference and should only be used as read only.
+	var/specie_shoe_blood_state = "shoeblood"
+	var/specie_hand_blood_state = "bloodyhands"
 	var/flesh_color = "#ffc896" //Pink.
 	var/base_color      //Used when setting species.
 


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
надо для https://github.com/TauCetiStation/TauCetiClassic/pull/12408
В расах хранится название стейта для оверлея крови на руках и на ногах, что позволяет менять их на свои, добавив в файл соответствующую кастомному названию иконку. Удалён ничего не делающий код у руки.
## Почему и что этот ПР улучшит
возможность кастомизировать отображение оверлеев для рас с непохожими на человека формами тела
## Авторство

## Чеинжлог
