### PR TITLE
Zombie death

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -48,9 +48,6 @@
 
 		update_canmove()
 
-		if(is_infected_with_zombie_virus())
-			handle_infected_death()
-
 	tod = worldtime2text()		//weasellos time of death patch
 	if(mind)	mind.store_memory("Time of death: [tod]", 0)
 	if(SSticker && SSticker.mode)

--- a/code/modules/mob/living/carbon/human/zombie.dm
+++ b/code/modules/mob/living/carbon/human/zombie.dm
@@ -138,16 +138,20 @@
 	if(H.stat != DEAD && prob(10))
 		playsound(H, pick(spooks), VOL_EFFECTS_MASTER)
 
-/datum/species/zombie/handle_death(mob/living/carbon/human/H, gibbed)
+/datum/species/zombie/handle_death(mob/living/carbon/human/H, gibbed) //Death of zombie
 	if(gibbed)
-		H.handle_infected_death()
-
-/mob/living/carbon/human/proc/handle_infected_death()
-	if(species.name in list(HUMAN, UNATHI, TAJARAN, SKRELL))
-		addtimer(CALLBACK(src, PROC_REF(prerevive_zombie)), rand(60,70))
-		to_chat(src, "<span class='cult'>Твоё сердце останавливается, но голод так и не унялся... \
+		return
+	addtimer(CALLBACK(H, TYPE_PROC_REF(/mob/living/carbon/human, prerevive_zombie)), rand(600,700))
+	to_chat(H, "<span class='cult'>Твоё сердце останавливается, но голод так и не унялся... \
 		Как и жизнь не покинула твоё бездыханное тело. Ты чувствуешь лишь ненасытный голод, \
 		который даже сама смерть не способна заглушить, ты восстанешь вновь!</span>")
+
+/mob/living/carbon/human/proc/handle_infected_death() //Death of human
+	if(species.name in list(HUMAN, UNATHI, TAJARAN, SKRELL))
+		addtimer(CALLBACK(src, PROC_REF(prerevive_zombie)), 300)
+		to_chat(src, "<span class='cult'>Твоё сердце останавливается, но голод так и не унялся... \
+			Как и жизнь не покинула твоё бездыханное тело. Ты чувствуешь лишь ненасытный голод, \
+			который даже сама смерть не способна заглушить, ты восстанешь вновь!</span>")
 
 /mob/living/carbon/human/proc/prerevive_zombie()
 	var/obj/item/organ/external/BP = bodyparts_by_name[BP_HEAD]
@@ -192,6 +196,9 @@
 	radiation = 0
 	heal_overall_damage(getBruteLoss(), getFireLoss())
 	restore_blood()
+	// make the icons look correct
+	if(HUSK in mutations)
+		mutations.Remove(HUSK)
 
 	// remove the character from the list of the dead
 	if(stat == DEAD)

--- a/code/modules/mob/living/carbon/human/zombie.dm
+++ b/code/modules/mob/living/carbon/human/zombie.dm
@@ -125,7 +125,6 @@
 		eyes.damage = 0
 	if(brain)
 		brain.damage = 0
-	H.setBrainLoss(0)
 	H.setBlurriness(0)
 	H.eye_blind = 0
 
@@ -140,77 +139,75 @@
 		playsound(H, pick(spooks), VOL_EFFECTS_MASTER)
 
 /datum/species/zombie/handle_death(mob/living/carbon/human/H, gibbed)
-	if(!gibbed)
-		addtimer(CALLBACK(null, PROC_REF(prerevive_zombie), H), rand(600,700))
-		to_chat(H, "<span class='cult'>Твоё сердце останавливается, но голод так и не унялся... \
-			Как и жизнь не покинула твоё бездыханное тело. Ты чувствуешь лишь ненасытный голод, \
-			который даже сама смерть не способна заглушить, ты восстанешь вновь!</span>")
+	if(gibbed)
+		H.handle_infected_death()
 
 /mob/living/carbon/human/proc/handle_infected_death()
 	if(species.name in list(HUMAN, UNATHI, TAJARAN, SKRELL))
-		addtimer(CALLBACK(null, PROC_REF(prerevive_zombie), src), rand(600,700))
-		to_chat(src, "<span class='cult'>Твоё сердце останавливается, но вместе с этим просыпается ненасытный ГОЛОД... \
-					Вот только жизнь не покинула твоё бездыханное тело. Этот голод не отпускает тебя, ты ещё восстанешь, что бы распространять болезнь и сеять смерть!</span>")
+		addtimer(CALLBACK(src, PROC_REF(prerevive_zombie)), rand(60,70))
+		to_chat(src, "<span class='cult'>Твоё сердце останавливается, но голод так и не унялся... \
+		Как и жизнь не покинула твоё бездыханное тело. Ты чувствуешь лишь ненасытный голод, \
+		который даже сама смерть не способна заглушить, ты восстанешь вновь!</span>")
 
-/proc/prerevive_zombie(mob/living/carbon/human/H)
-	var/obj/item/organ/external/BP = H.bodyparts_by_name[BP_HEAD]
-	if(H.organs_by_name[O_BRAIN] && BP && !(BP.is_stump))
-		if(!H.key && H.mind)
+/mob/living/carbon/human/proc/prerevive_zombie()
+	var/obj/item/organ/external/BP = bodyparts_by_name[BP_HEAD]
+	if(organs_by_name[O_BRAIN] && BP && !(BP.is_stump))
+		if(!key && mind)
 			for(var/mob/dead/observer/ghost in player_list)
-				if(ghost.mind == H.mind && ghost.can_reenter_corpse)
+				if(ghost.mind == mind && ghost.can_reenter_corpse)
 					var/answer = tgui_alert(ghost,"You are about to turn into a zombie. Do you want to return to body?","I'm a zombie!", list("Yes","No"))
 					if(answer == "Yes")
 						ghost.reenter_corpse()
 
-		H.visible_message("<span class='danger'>[H]'s body starts to move!</span>")
-		addtimer(CALLBACK(null, PROC_REF(revive_zombie), H), 40)
+		visible_message("<span class='danger'>[src]'s body starts to move!</span>")
+		addtimer(CALLBACK(src, PROC_REF(revive_zombie)), 40)
 
-/proc/revive_zombie(mob/living/carbon/human/H)
-	var/obj/item/organ/external/BP = H.bodyparts_by_name[BP_HEAD]
-	if(!H.organs_by_name[O_BRAIN] || !BP || BP.is_stump)
+/mob/living/carbon/human/proc/revive_zombie()
+	var/obj/item/organ/external/BP = bodyparts_by_name[BP_HEAD]
+	if(!organs_by_name[O_BRAIN] || !BP || BP.is_stump)
 		return
 	//zombie have NO_PAIN and can't adjust/sets halloss
-	H.setHalLoss(0)
+	setHalLoss(0)
 	//remove all blind-blur effects
-	H.cure_nearsighted(list(EYE_DAMAGE_TRAIT, GENETIC_MUTATION_TRAIT, EYE_DAMAGE_TEMPORARY_TRAIT))
-	H.sdisabilities &= ~BLIND
-	H.blinded = FALSE
-	H.setBlurriness(0)
-	H.handle_vision(TRUE)
+	cure_nearsighted(list(EYE_DAMAGE_TRAIT, GENETIC_MUTATION_TRAIT, EYE_DAMAGE_TEMPORARY_TRAIT))
+	sdisabilities &= ~BLIND
+	blinded = FALSE
+	setBlurriness(0)
+	handle_vision(TRUE)
 
-	if(!iszombie(H))
-		H.zombify()
+	if(!iszombie(src))
+		zombify()
 
 	//del wounds and embedded implants in limbs, heal
-	for(var/obj/item/organ/external/limb in H.bad_bodyparts)
+	for(var/obj/item/organ/external/limb in bad_bodyparts)
 		limb.rejuvenate()
 
-	H.setCloneLoss(0)
-	H.setBrainLoss(0)
-	H.SetParalysis(0)
-	H.SetStunned(0)
-	H.SetWeakened(0)
-	H.nutrition = NUTRITION_LEVEL_NORMAL
-	H.SetSleeping(0)
-	H.radiation = 0
-	H.heal_overall_damage(H.getBruteLoss(), H.getFireLoss())
-	H.restore_blood()
+	setCloneLoss(0)
+	setBrainLoss(0)
+	SetParalysis(0)
+	SetStunned(0)
+	SetWeakened(0)
+	nutrition = NUTRITION_LEVEL_NORMAL
+	SetSleeping(0)
+	radiation = 0
+	heal_overall_damage(getBruteLoss(), getFireLoss())
+	restore_blood()
 
 	// remove the character from the list of the dead
-	if(H.stat == DEAD)
-		dead_mob_list -= H
-		alive_mob_list += H
-		H.tod = null
-		H.timeofdeath = 0
-	H.stat = CONSCIOUS
-	H.update_canmove()
-	H.regenerate_icons()
-	H.med_hud_set_health()
-	H.clear_alert("embeddedobject")
+	if(stat == DEAD)
+		dead_mob_list -= src
+		alive_mob_list += src
+		tod = null
+		timeofdeath = 0
+	stat = CONSCIOUS
+	update_canmove()
+	regenerate_icons()
+	med_hud_set_health()
+	clear_alert("embeddedobject")
 
-	playsound(H, pick(list('sound/hallucinations/veryfar_noise.ogg','sound/hallucinations/wail.ogg')), VOL_EFFECTS_MASTER)
-	to_chat(H, "<span class='cult'>Твой голод всё также ненасытен! Пора его утолить!</span>")
-	H.visible_message("<span class='danger'>[H] suddenly wakes up!</span>")
+	playsound(src, pick(list('sound/hallucinations/veryfar_noise.ogg','sound/hallucinations/wail.ogg')), VOL_EFFECTS_MASTER)
+	to_chat(src, "<span class='cult'>Твой голод всё также ненасытен! Пора его утолить!</span>")
+	visible_message("<span class='danger'>[src] suddenly wakes up!</span>")
 
 /mob/living/carbon/proc/is_infected_with_zombie_virus()
 	for(var/ID in virus2)
@@ -261,6 +258,7 @@
 	D.infectionchance = 100
 	D.antigen |= ANTIGEN_Z
 	D.spreadtype = DISEASE_SPREAD_BLOOD // not airborn and not contact, because spreading zombie virus through air or hugs is silly
+	Z.RegisterSignal(src, COMSIG_MOB_DIED, PROC_REF(handle_infected_death))
 
 	infect_virus2(src, D, forced = TRUE, ignore_antibiotics = TRUE)
 

--- a/code/modules/mob/living/carbon/species.dm
+++ b/code/modules/mob/living/carbon/species.dm
@@ -1472,7 +1472,6 @@
 	oxy_mod = 0
 	tox_mod = 0
 	brain_mod = 0
-	speed_mod = -0.2
 	speed_mod_no_shoes = -1
 
 	var/list/spooks = list('sound/voice/growl1.ogg', 'sound/voice/growl2.ogg', 'sound/voice/growl3.ogg')
@@ -1523,7 +1522,7 @@
 
 	brute_mod = 2
 	burn_mod = 1.2
-	speed_mod = -0.8
+	speed_mod = -0.6
 
 	tail = "tajaran_zombie"
 
@@ -1574,7 +1573,7 @@
 
 	brute_mod = 1.6
 	burn_mod = 0.90
-	speed_mod = -0.2
+	speed_mod = 0.1
 
 	tail = "unathi_zombie"
 

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -84,7 +84,7 @@
 			if (!(machine.check_eye(src)))
 				reset_view(null)
 		else
-			if(!client.adminobs && !force_remote_viewing)
+			if(!client?.adminobs && !force_remote_viewing)
 				reset_view(null)
 
 

--- a/code/modules/virus2/effect.dm
+++ b/code/modules/virus2/effect.dm
@@ -102,72 +102,70 @@
 	var/obj/item/organ/external/infected_organ = null //if infected part is removed, destroys itself
 
 /datum/disease2/effect/zombie/activate_mob(mob/living/carbon/A, datum/disease2/effectholder/holder, datum/disease2/disease/disease)
-	if(ishuman(A))
-		var/mob/living/carbon/human/H = A
-		if(iszombie(H))
-			disease.dead = TRUE
-			UnregisterSignal(H, COMSIG_MOB_DIED)
-			return
+	if(!ishuman(A))
+		return
+	var/mob/living/carbon/human/H = A
+	if(iszombie(H) || activated)
+		disease.dead = TRUE
+		UnregisterSignal(H, COMSIG_MOB_DIED)
+		return
 
-		if(!(H.species.name in list(HUMAN, UNATHI, TAJARAN, SKRELL)))
-			return
+	if(!(H.species.name in list(HUMAN, UNATHI, TAJARAN, SKRELL)))
+		return
 
-		if(infected_organ == null && holder.ticks == 0)
-			var/list/organs = list(BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG) // Organs that you can actually cut off are checked first to give a chance
-			organs = shuffle(organs) + shuffle(list(BP_CHEST, BP_GROIN, BP_HEAD))
+	if(infected_organ == null && holder.ticks == 0)
+		var/list/organs = list(BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG) // Organs that you can actually cut off are checked first to give a chance
+		organs = shuffle(organs) + shuffle(list(BP_CHEST, BP_GROIN, BP_HEAD))
+		for(var/o in organs)
+			var/obj/item/organ/external/BP = H.get_bodypart(o)
+			if(BP && BP.is_flesh() && BP.is_usable())
+				infected_organ = BP
+				break
 
-			for(var/o in organs)
-				var/obj/item/organ/external/BP = H.get_bodypart(o)
-				if(BP && BP.is_flesh() && BP.is_usable())
-					infected_organ = BP
-					break
+	if(QDELETED(infected_organ) || !infected_organ || !infected_organ.is_flesh() || infected_organ.is_stump || !infected_organ.is_attached())
+		disease.dead = TRUE
+		UnregisterSignal(A, COMSIG_MOB_DIED)
+		to_chat(H, "<span class='notice'>You suddenly feel better.</span>")
+		return
 
-		if(QDELETED(infected_organ) || !infected_organ || !infected_organ.is_flesh() || infected_organ.is_stump || !infected_organ.is_attached())
-			disease.dead = TRUE
-			UnregisterSignal(A, COMSIG_MOB_DIED)
-			to_chat(H, "<span class='notice'>You suddenly feel better.</span>")
-			return
+	var/tox_damage = 0
+	var/messages_pool = list()
 
-		switch(holder.stage)
-			if(1,2,3) //increased hunger
-				H.nutrition = max(H.nutrition - 20, 0)
-				if(prob(1)) //might never happen and its fine
-					to_chat(H, "<span class='notice'>[pick("You feel an odd gurgle in your stomach.", "You are hungry for something.", "You suddenly feel better.", "You suddenly feel worse.")]</span>")
-			if(4,5,6) //some random stuff
-				H.adjustToxLoss(1)
-				if(prob(70))
-					H.emote(pick("twitch","drool","sneeze","sniff","cough","shiver","giggle","laugh","gasp"))
-				else
-					to_chat(H, "<span class='warning'>[pick("Your [infected_organ.name] seems to become more green...", "Your [infected_organ.name] hurts...")]</span>")
-			if(7,8) //pain
-				to_chat(H, "<span class='danger'>[pick("Your brain hurts.", "Your [infected_organ.name] hurts a lot.", "Your muscles ache.", "Your muscles are sore.")]</span>")
-				H.apply_effect(20, AGONY, 0)
-				H.adjustBrainLoss(5)
-				H.adjustToxLoss(3)
-			if(9) //IT HURTS
-				if(prob(33))
-					to_chat(H, "<span class='danger'>[pick("IT HURTS", "You feel a sharp pain across your whole body!")]</span>")
-					H.adjustBruteLoss(rand(2, 5))
-					H.apply_effect(50, AGONY, 0)
-				else if(prob(33) && H.stat == CONSCIOUS)
-					to_chat(H, "<span class='danger'>[pick("Your heart stop for a second.", "It's hard for you to breathe.")]</span>")
-					H.adjustOxyLoss(rand(10, 40))
-					H.losebreath = rand(10, 20)
-				else
-					to_chat(H, "<span class='danger'>[pick("Your body is paralyzed.")]</span>")
-					H.Stun(4)
-			if(10) //rip
-				if(!activated)
-					activated = TRUE
-					H.visible_message("<span class='danger'>[H] suddenly closes \his eyes. \His body falls lifeless and stops moving. \He seems to stop breathing.</span>")
-					H.suiciding = TRUE
-					H.adjustOxyLoss(max(H.maxHealth * 2 - H.getToxLoss() - H.getFireLoss() - H.getBruteLoss() - H.getOxyLoss(), 0))
-					H.updatehealth()
-					addtimer(CALLBACK(H, TYPE_PROC_REF(/mob/living/carbon/human, prerevive_zombie)), 600)
-					to_chat(H, "<span class='cult'>Твоё сердце останавливается, но вместе с этим просыпается ненасытный ГОЛОД... \
-					Вот только жизнь не покинула твоё бездыханное тело. Этот голод не отпускает тебя, ты ещё восстанешь, что бы распространять болезнь и сеять смерть!</span>")
-					disease.dead = TRUE
-					UnregisterSignal(A, COMSIG_MOB_DIED)
+	H.nutrition = max(H.nutrition - 20, 0)
+	messages_pool += "<span class='notice'>[pick("You feel an odd gurgle in your stomach.", "You are hungry for something.", "You suddenly feel better.", "You suddenly feel worse.")]</span>"
+	if(holder.stage > 3) //some random stuff
+		tox_damage += 1
+		if(prob(10))
+			H.emote(pick("twitch","drool","sneeze","sniff","cough","shiver","giggle","laugh","gasp"))
+		messages_pool += "<span class='warning'>[pick("Your [infected_organ.name] seems to become more green...", "Your [infected_organ.name] hurts...")]</span>"
+	if(holder.stage > 6) //pain
+		messages_pool += "<span class='danger'>[pick("Your brain hurts.", "Your [infected_organ.name] hurts a lot.", "Your muscles ache.", "Your muscles are sore.")]</span>"
+		H.adjustBrainLoss(5)
+		tox_damage += 2
+	if(holder.stage > 8) //IT HURTS
+		if(prob(33))
+			messages_pool += "<span class='danger'>[pick("IT HURTS", "You feel a sharp pain across your whole body!")]</span>"
+			H.adjustBruteLoss(20)
+			H.apply_effect(20, AGONY, 0)
+		else if(prob(33) && H.stat == CONSCIOUS)
+			messages_pool += "<span class='danger'>[pick("Your heart stop for a second.", "It's hard for you to breathe.")]</span>"
+			H.adjustOxyLoss(10)
+			H.losebreath = 5
+		else
+			messages_pool += "<span class='danger'>Your body is paralyzed.</span>"
+			H.Stun(4)
+
+	H.adjustToxLoss(tox_damage)
+	if(prob(50))
+		to_chat(H, pick(messages_pool))
+
+	if(holder.stage > 9) //rip
+		activated = TRUE
+		H.suiciding = TRUE
+		UnregisterSignal(H, COMSIG_MOB_DIED)
+		H.adjustOxyLoss(max(H.maxHealth * 2 - H.getToxLoss() - H.getFireLoss() - H.getBruteLoss() - H.getOxyLoss(), 0))
+		H.updatehealth()
+		disease.dead = TRUE
 
 /datum/disease2/effect/zombie/copy(datum/disease2/effectholder/holder_old, datum/disease2/effectholder/holder_new, datum/disease2/effect/effect_old)
 	var/datum/disease2/effect/zombie/Z = effect_old
@@ -182,15 +180,12 @@
 	SIGNAL_HANDLER
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		H.handle_infected_death()
+		addtimer(CALLBACK(H, TYPE_PROC_REF(/mob/living/carbon/human, prerevive_zombie)), 600)
 		to_chat(H, "<span class='cult'>Твоё сердце останавливается, но вместе с этим просыпается ненасытный ГОЛОД... \
 				Вот только жизнь не покинула твоё бездыханное тело. \
 				Этот голод не отпускает тебя, ты ещё восстанешь, что бы распространять болезнь и сеять смерть!</span>")
 		activated = TRUE
 		UnregisterSignal(H, COMSIG_MOB_DIED)
-//трижды присылает сообщение, ревайвит через 4 секунды
-
-
 
 ////////////////////////STAGE 4/////////////////////////////////
 


### PR DESCRIPTION

## Описание изменений
1) `prerevive_zombie()` и подобные проки перетащены с глобальных в проки человека.
2) У зомби нет возможности получить урон по мозгу из-за `brain_mod = 0`, а каждые 3 тика вызывать `update_health()` не вижу смысла
3) Симптомы болезни с развитием оной нарастают, а не меняются.
4) Исправлен баг с бесконечной смертью зомбя
5) Превращение заражённого человека перенесено со стороны `death()` у хумана на сигнал болезни, подцепленного на смерть моба
## Почему и что этот ПР улучшит
Да, уже какой-то рефактор ради рефактора.
## Авторство

## Чеинжлог
