### PR TITLE
чиним рантайм ии-модуля рига

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/ai.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ai.dm
@@ -350,6 +350,7 @@
 		for(var/obj/item/organ/external/BP in H.bodyparts)
 			if(BP.is_robotic() && (BP.brute_dam || BP.burn_dam))
 				repairModule.activate()
+				break
 
 	if(!chem_disp)
 		return


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
проверки смотрят на отсутствие обоих модулей
если одного из модулей нет - жутко страшный флуд рантаймов
## Почему и что этот ПР улучшит

## Авторство

## Чеинжлог
