### PR TITLE
powered crossbows fixes

### DIFF
--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -49,7 +49,7 @@
 			"[user.name] cuts the [src], turning it into a crossbow bolt.",
 			"<span class='notice'>You cuts the [src], turning it into a crossbow bolt.</span>"
 			)
-		var/obj/item/weapon/arrow/new_item = new(usr.loc, , TRUE)
+		var/obj/item/weapon/arrow/new_item = new(user.loc)
 		use(1)
 		var/replace = (user.get_inactive_hand() == src)
 		if(!QDELETED(src) && replace)

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -44,12 +44,16 @@
 			if(!QDELETED(src) && replace)
 				user.put_in_hands(new_item)
 	if(iscutter(I))
+		if(get_amount() < 2)
+			to_chat(user, "<span class='warning'>You need at least two rods to do this!</span>")
+			return
 		playsound(src, 'sound/items/Wirecutter.ogg', VOL_EFFECTS_MASTER)
 		user.visible_message(
 			"[user.name] cuts the [src], turning it into a crossbow bolt.",
 			"<span class='notice'>You cuts the [src], turning it into a crossbow bolt.</span>"
 			)
 		var/obj/item/weapon/arrow/new_item = new(usr.loc, , TRUE)
+		use(1)
 		var/replace = (user.get_inactive_hand() == src)
 		if(!QDELETED(src) && replace)
 			user.put_in_hands(new_item)

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -44,7 +44,7 @@
 			if(!QDELETED(src) && replace)
 				user.put_in_hands(new_item)
 	if(iscutter(I))
-		if(get_amount() < 2)
+		if(get_amount() < 1)
 			to_chat(user, "<span class='warning'>You need at least two rods to do this!</span>")
 			return
 		playsound(src, 'sound/items/Wirecutter.ogg', VOL_EFFECTS_MASTER)

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -44,9 +44,6 @@
 			if(!QDELETED(src) && replace)
 				user.put_in_hands(new_item)
 	if(iscutter(I))
-		if(get_amount() < 1)
-			to_chat(user, "<span class='warning'>You need at least one rod to do this!</span>")
-			return
 		playsound(src, 'sound/items/Wirecutter.ogg', VOL_EFFECTS_MASTER)
 		user.visible_message(
 			"[user.name] cuts the [src], turning it into a crossbow bolt.",

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -43,6 +43,16 @@
 			use(2)
 			if(!QDELETED(src) && replace)
 				user.put_in_hands(new_item)
+	if(iscutter(I))
+		playsound(src, 'sound/items/Wirecutter.ogg', VOL_EFFECTS_MASTER)
+		user.visible_message(
+			"[user.name] cuts the [src], turning it into a crossbow bolt.",
+			"<span class='notice'>You cuts the [src], turning it into a crossbow bolt.</span>"
+			)
+		var/obj/item/weapon/arrow/new_item = new(usr.loc, , TRUE)
+		var/replace = (user.get_inactive_hand() == src)
+		if(!QDELETED(src) && replace)
+			user.put_in_hands(new_item)
 
 	else
 		return ..()

--- a/code/game/objects/items/stacks/rods.dm
+++ b/code/game/objects/items/stacks/rods.dm
@@ -45,7 +45,7 @@
 				user.put_in_hands(new_item)
 	if(iscutter(I))
 		if(get_amount() < 1)
-			to_chat(user, "<span class='warning'>You need at least two rods to do this!</span>")
+			to_chat(user, "<span class='warning'>You need at least one rod to do this!</span>")
 			return
 		playsound(src, 'sound/items/Wirecutter.ogg', VOL_EFFECTS_MASTER)
 		user.visible_message(

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -13,9 +13,9 @@
 /datum/crafting_recipe/proc/on_craft_completion(mob/user, atom/result)
 	return
 
-/datum/crafting_recipe/can_grenade_igniter
+/datum/crafting_recipe/crossbow_bolt
 	name = "Crossbow Bolt"
-	result = /obj/item/weapon/grenade/cancasing
+	result = /obj/item/weapon/arrow
 	reqs = list(/obj/item/stack/rods = 1)
 	tools = list(/obj/item/weapon/wirecutters)
 	time = 1

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -14,6 +14,15 @@
 	return
 
 /datum/crafting_recipe/can_grenade_igniter
+	name = "Crossbow Bolt"
+	result = /obj/item/weapon/grenade/cancasing
+	reqs = list(/obj/item/stack/rods = 1)
+	tools = list(/obj/item/weapon/wirecutters)
+	time = 1
+	required_proficiency = list(/datum/skill/construction = SKILL_LEVEL_NONE)
+
+
+/datum/crafting_recipe/can_grenade_igniter
 	name = "Can Grenade (igniter)"
 	result = /obj/item/weapon/grenade/cancasing
 	reqs = list(/datum/reagent/fuel = 50,

--- a/code/modules/projectiles/guns/projectile/bow.dm
+++ b/code/modules/projectiles/guns/projectile/bow.dm
@@ -63,7 +63,7 @@
 			to_chat(user, "<span class='notice'>Вы вставляете батарейку в [CASE(src, ACCUSATIVE_CASE)] и подключаете его к катушке зажигания.</span>")
 			if(arrow)
 				if(istype(arrow,/obj/item/weapon/arrow) && arrow.throwforce < 15 && cell.charge >= 500)
-					to_chat(user, "<span class='notice'>[CASE(arrow, ACCUSATIVE_CASE)] мерцает и трещит, раскаляясь докрасна.</span>")
+					to_chat(user, "<span class='notice'>[capitalize(CASE(arrow, ACCUSATIVE_CASE))] мерцает и трещит, раскаляясь докрасна.</span>")
 					arrow.throwforce = 15
 					arrow.icon_state = "metal-rod-superheated"
 					cell.use(500)
@@ -77,7 +77,7 @@
 			cell = null
 			to_chat(user, "<span class='notice'>Вы вынимаете батарейку из [CASE(src, GENITIVE_CASE)] [I].</span>")
 		else
-			to_chat(user, "<span class='notice'>[CASE(src, ACCUSATIVE_CASE)] не имеет батарейки внутри.</span>")
+			to_chat(user, "<span class='notice'>[capitalize(CASE(src, ACCUSATIVE_CASE))] не имеет батарейки внутри.</span>")
 
 	else
 		return ..()

--- a/code/modules/projectiles/guns/projectile/bow.dm
+++ b/code/modules/projectiles/guns/projectile/bow.dm
@@ -123,7 +123,7 @@
 
 	if(tension>=max_tension)
 		tension = max_tension
-		to_chat(user, "Арбалет лязгает, когда вы натягиваете тетиву до максимального натяжения!")
+		to_chat(user, "[capitalize(CASE(src, ACCUSATIVE_CASE))] лязгает, когда вы натягиваете тетиву до максимального натяжения!")
 	else
 		user.visible_message("[user] натягивает тетиву [CASE(src, GENITIVE_CASE)]!", "Вы продолжаете натягивать тетиву [CASE(src, GENITIVE_CASE)]!")
 		spawn(25) increase_tension(user)

--- a/code/modules/projectiles/guns/projectile/bow.dm
+++ b/code/modules/projectiles/guns/projectile/bow.dm
@@ -139,7 +139,7 @@
 		return
 
 	if(!tension)
-		to_chat(user, "Вы не натянули [CASE(arrow, ACCUSATIVE_CASE)] на тетиву!")
+		to_chat(user, "Вы не натянули тетиву!")
 		return 0
 
 	if (!arrow)

--- a/code/modules/projectiles/guns/projectile/bow.dm
+++ b/code/modules/projectiles/guns/projectile/bow.dm
@@ -11,14 +11,6 @@
 	sharp = 1
 	edge = 0
 
-/obj/item/weapon/arrow/proc/removed(mob/user)
-	if(throwforce == 15) // The rod has been superheated - we don't want it to be useable when removed from the bow.
-		to_chat(user, "[src] при выпуске из арбалета разлетается на россыпь осколков из перенапряженного металла.")
-		var/obj/item/weapon/shard/shrapnel/S = new()
-		S.loc = get_turf(src)
-		qdel(src)
-	return
-
 /obj/item/weapon/arrow/quill
 
 	name = "vox quill"
@@ -96,7 +88,6 @@
 			user.visible_message("[user] ослабляет натяжение тетивы [CASE(src, GENITIVE_CASE)] и вытаскивает [CASE(arrow, ACCUSATIVE_CASE)].","Вы ослабляете натяжение тетивы [CASE(src, GENITIVE_CASE)] и вытаскиваете [CASE(arrow, ACCUSATIVE_CASE)].")
 			var/obj/item/weapon/arrow/A = arrow
 			A.loc = get_turf(src)
-			A.removed(user)
 			arrow = null
 		else
 			user.visible_message("[user] ослабляет натяжение тетивы [CASE(src, GENITIVE_CASE)].", "Вы ослабляете натяжение тетивы [CASE(src, GENITIVE_CASE)].")

--- a/code/modules/projectiles/guns/projectile/bow.dm
+++ b/code/modules/projectiles/guns/projectile/bow.dm
@@ -7,11 +7,16 @@
 	icon_state = "bolt"
 	item_state = "bolt"
 	throwforce = 8
-	w_class = SIZE_SMALL
+	w_class = SIZE_TINY
 	sharp = 1
 	edge = 0
 
-/obj/item/weapon/arrow/proc/removed() //Helper for metal rods falling apart.
+/obj/item/weapon/arrow/proc/removed(mob/user)
+	if(throwforce == 15) // The rod has been superheated - we don't want it to be useable when removed from the bow.
+		to_chat(user, "[src] при выпуске из арбалета разлетается на россыпь осколков из перенапряженного металла.")
+		var/obj/item/weapon/shard/shrapnel/S = new()
+		S.loc = get_turf(src)
+		qdel(src)
 	return
 
 /obj/item/weapon/arrow/quill
@@ -23,30 +28,14 @@
 	item_state = "quill"
 	throwforce = 5
 
-/obj/item/weapon/arrow/rod
-
-	name = "metal rod"
-	cases = list("стержень", "стержня", "стержню", "стержень", "стерженем", "стержне")
-	desc = "Не плачь по мне, Орифена."
-	icon_state = "metal-rod"
-
-/obj/item/weapon/arrow/rod/removed(mob/user)
-	if(throwforce == 15) // The rod has been superheated - we don't want it to be useable when removed from the bow.
-		to_chat(user, "[src] при выпуске из арбалета разлетается на россыпь осколков из перенапряженного металла.")
-		var/obj/item/weapon/shard/shrapnel/S = new()
-		S.loc = get_turf(src)
-		qdel(src)
-
 /obj/item/weapon/crossbow
 	name = "powered crossbow"
 	cases = list("арбалет", "арбалета", "арбалету", "арбалет", "арбалетом", "арбалете")
 	icon = 'icons/obj/weapons.dmi'
 	icon_state = "crossbow"
 	item_state = "crossbow-solid"
-	w_class = SIZE_BIG
 	flags =  CONDUCT
 	slot_flags = SLOT_FLAGS_BELT | SLOT_FLAGS_BACK
-
 	w_class = SIZE_SMALL
 
 	var/tension = 0                       // Current draw on the bow.
@@ -67,17 +56,6 @@
 			arrow = I
 			user.visible_message("[user] вставляет [CASE(arrow, ACCUSATIVE_CASE)] в [CASE(src, ACCUSATIVE_CASE)].","Вы вставляете [CASE(arrow, ACCUSATIVE_CASE)] в [CASE(src, ACCUSATIVE_CASE)].")
 			icon_state = "crossbow-nocked"
-			return
-
-		else if(istype(I, /obj/item/stack/rods))
-			var/obj/item/stack/rods/R = I
-			if(!R.use(1))
-				return
-			arrow = new /obj/item/weapon/arrow/rod(src)
-			arrow.fingerprintslast = src.fingerprintslast
-			arrow.forceMove(src)
-			icon_state = "crossbow-nocked"
-			user.visible_message("[user] хаотично вставляет [CASE(arrow, ACCUSATIVE_CASE)] в [CASE(src, ACCUSATIVE_CASE)].","Вы хаотично вставляете [CASE(arrow, ACCUSATIVE_CASE)] в [CASE(src, ACCUSATIVE_CASE)].")
 			if(cell)
 				if(cell.charge >= 500)
 					to_chat(user, "<span class='notice'>В результате [CASE(arrow, ACCUSATIVE_CASE)] начинает раскаляться докрасна.</span>")
@@ -92,7 +70,7 @@
 			cell = I
 			to_chat(user, "<span class='notice'>Вы вставляете батарейку в [CASE(src, ACCUSATIVE_CASE)] и подключаете его к катушке зажигания.</span>")
 			if(arrow)
-				if(istype(arrow,/obj/item/weapon/arrow/rod) && arrow.throwforce < 15 && cell.charge >= 500)
+				if(istype(arrow,/obj/item/weapon/arrow) && arrow.throwforce < 15 && cell.charge >= 500)
 					to_chat(user, "<span class='notice'>[CASE(arrow, ACCUSATIVE_CASE)] мерцает и трещит, раскаляясь докрасна.</span>")
 					arrow.throwforce = 15
 					arrow.icon_state = "metal-rod-superheated"
@@ -154,7 +132,7 @@
 
 	if(tension>=max_tension)
 		tension = max_tension
-		to_chat(user, "[CASE(src, ACCUSATIVE_CASE)] лязгает, когда вы натягиваете тетиву до максимального натяжения!")
+		to_chat(user, "Арбалет лязгает, когда вы натягиваете тетиву до максимального натяжения!")
 	else
 		user.visible_message("[user] натягивает тетиву [CASE(src, GENITIVE_CASE)]!", "Вы продолжаете натягивать тетиву [CASE(src, GENITIVE_CASE)]!")
 		spawn(25) increase_tension(user)
@@ -174,7 +152,7 @@
 		return 0
 
 	if (!arrow)
-		to_chat(user, "[CASE(arrow, ACCUSATIVE_CASE)] отсутствует в арбалете!")
+		to_chat(user, "Болт отсутствует в арбалете!")
 		return 0
 	else
 		spawn(0) Fire(target,user,params)

--- a/maps/templates/space_structures/broken_breacher.dmm
+++ b/maps/templates/space_structures/broken_breacher.dmm
@@ -301,7 +301,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/item/weapon/arrow/rod,
+/obj/item/weapon/arrow,
 /obj/effect/decal/turf_decal{
 	dir = 4;
 	icon_state = "warn"
@@ -1236,7 +1236,7 @@
 /area/space)
 "Vk" = (
 /obj/item/weapon/crossbow/vox,
-/obj/item/weapon/arrow/rod,
+/obj/item/weapon/arrow,
 /obj/effect/decal/turf_decal/set_damaged,
 /turf/simulated/floor/plating/airless,
 /area/space_structures/broken_breacher)
@@ -1255,7 +1255,7 @@
 	},
 /area/space_structures/broken_breacher)
 "Wa" = (
-/obj/item/weapon/arrow/rod,
+/obj/item/weapon/arrow,
 /turf/simulated/floor/plating/airless{
 	icon_state = "podhatchfull"
 	},


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
Фиксит проблему с болтами описанную в #9193 (Третье, если арбалет с батарейкой, то вывалиться не стержень, а шрапнель. Пятое, вставленный металлический стержень в арбалет превращается в почти точно такой же обьект, но гораздо больший в инвентаре и не стакающийся(снаряд). Шестое, стержень (снаряд) при выстреле с арбалета под батарейкой не меняет свой спрайт на раскаленный аналог.)
Арбалет теперь использует специальные болты, которые можно сделать кликнув кусачками по стержням или в крафт меню.
Фикс ошибок допущенных при переводе арбалета (null.cases рантайм и маленькая буква в начале предложения)
## Почему и что этот ПР улучшит
Меньше багов
fixes #9193 остальные баги о которых написано в ишшуе были пофикшены в других ПРах
## Авторство

## Чеинжлог
🆑 Simbaka
- tweak: Арбалет использует специальные болты, которые можно создать в крафт меню или кликнув кусачками по металлическим прутьям.