### PR TITLE
исправляем залипающий трейт броска

### DIFF
--- a/code/controllers/subsystem/throwing.dm
+++ b/code/controllers/subsystem/throwing.dm
@@ -90,7 +90,7 @@ SUBSYSTEM_DEF(throwing)
 
 	SSthrowing.processing -= thrownthing
 	SSthrowing.currentrun -= thrownthing
-	thrownthing.throwing = null
+	thrownthing.throwing = FALSE
 	thrownthing = null
 	target = null
 	thrower = null
@@ -155,7 +155,7 @@ SUBSYSTEM_DEF(throwing)
 /datum/thrownthing/proc/finialize(hit = FALSE, atom/movable/AM)
 	set waitfor = 0
 	//done throwing, either because it hit something or it finished moving
-	if (QDELETED(thrownthing) || !thrownthing.throwing)
+	if(QDELETED(thrownthing))
 		return
 
 	thrownthing.throwing = FALSE


### PR DESCRIPTION
<!--
Читать: https://github.com/TauCetiStation/TauCetiClassic/blob/master/.github/wiki/STYLING_OF_PR.md
-->
## Описание изменений
здесь что-то очень странное происходит 
мы проверяем !throwing, получаем положительный результат, пытаемся завершить полет
https://github.com/TauCetiStation/TauCetiClassic/blob/0316e9bded9f4a02740fa49ccfa230da40712d0e/code/controllers/subsystem/throwing.dm#L110-L114
но встречаем точно такую же проверку (зачем-то) и получаем возврат
https://github.com/TauCetiStation/TauCetiClassic/blob/0316e9bded9f4a02740fa49ccfa230da40712d0e/code/controllers/subsystem/throwing.dm#L155-L159
итог: у нас зацикленный тик
избавился от проверки и все должно быть нормально теперь

если интересно где между тиками может поменяться throwing, то вот
https://github.com/TauCetiStation/TauCetiClassic/blob/0316e9bded9f4a02740fa49ccfa230da40712d0e/code/modules/mob/mob_movement.dm#L214-L215
## Почему и что этот ПР улучшит
#closes #11669
![image](https://github.com/TauCetiStation/TauCetiClassic/assets/89906909/60f2630a-99b0-4684-8fc0-ae1c703104b3)

## Авторство
боже храни разработчика дебаггера
## Чеинжлог
